### PR TITLE
Remove static_cast in ScriptModuleLoader

### DIFF
--- a/Source/JavaScriptCore/runtime/ScriptFetcher.h
+++ b/Source/JavaScriptCore/runtime/ScriptFetcher.h
@@ -32,6 +32,9 @@ namespace JSC {
 class ScriptFetcher : public RefCounted<ScriptFetcher> {
 public:
     virtual ~ScriptFetcher() { }
+
+    virtual bool isCachedScriptFetcher() const { return false; }
+    virtual bool isWorkerScriptFetcher() const { return false; }
 };
 
 } // namespace JSC

--- a/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -28,7 +28,6 @@ bindings/js/JSWindowProxy.cpp
 bindings/js/JSWindowProxy.h
 bindings/js/JSWorkerGlobalScopeBase.cpp
 bindings/js/JSWorkletGlobalScopeBase.cpp
-bindings/js/ScriptModuleLoader.cpp
 bindings/js/WebCoreTypedArrayController.cpp
 bridge/objc/ObjCRuntimeObject.mm
 bridge/objc/WebScriptObject.mm

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -194,7 +194,6 @@ bindings/js/WebAssemblyScriptBufferSourceProvider.h
 bindings/js/WebCoreJSClientData.cpp
 bindings/js/WebCoreTypedArrayController.cpp
 bindings/js/WindowProxy.cpp
-bindings/js/WorkerModuleScriptLoader.cpp
 bridge/jsc/BridgeJSC.cpp
 bridge/objc/WebScriptObject.mm
 bridge/objc/objc_runtime.mm

--- a/Source/WebCore/bindings/js/CachedModuleScriptLoader.h
+++ b/Source/WebCore/bindings/js/CachedModuleScriptLoader.h
@@ -63,6 +63,8 @@ public:
 private:
     CachedModuleScriptLoader(ModuleScriptLoaderClient&, DeferredPromise&, CachedScriptFetcher&, RefPtr<JSC::ScriptFetchParameters>&&);
 
+    bool isCachedModuleScriptLoader() const final { return true; }
+
     void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) final;
 
     CachedResourceHandle<CachedScript> m_cachedScript;
@@ -70,3 +72,7 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::CachedModuleScriptLoader)
+    static bool isType(const WebCore::ModuleScriptLoader& loader) { return loader.isCachedModuleScriptLoader(); }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/bindings/js/CachedScriptFetcher.h
+++ b/Source/WebCore/bindings/js/CachedScriptFetcher.h
@@ -57,7 +57,7 @@ protected:
     {
     }
 
-    CachedScriptFetcher(const AtomString& charset)
+    explicit CachedScriptFetcher(const AtomString& charset)
         : m_charset(charset)
     {
     }
@@ -65,6 +65,8 @@ protected:
     CachedResourceHandle<CachedScript> requestScriptWithCache(Document&, const URL& sourceURL, FetchOptionsDestination, const String& crossOriginMode, String&& integrity, std::optional<ResourceLoadPriority>, std::optional<ServiceWorkersMode>) const;
 
 private:
+    bool isCachedScriptFetcher() const final { return true; }
+
     String m_nonce;
     AtomString m_charset;
     AtomString m_initiatorType;
@@ -74,3 +76,7 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::CachedScriptFetcher)
+    static bool isType(const JSC::ScriptFetcher& fetcher) { return fetcher.isCachedScriptFetcher(); }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/bindings/js/ModuleScriptLoader.h
+++ b/Source/WebCore/bindings/js/ModuleScriptLoader.h
@@ -47,6 +47,9 @@ public:
     JSC::ScriptFetcher& scriptFetcher() { return m_scriptFetcher.get(); }
     JSC::ScriptFetchParameters* parameters() { return m_parameters.get(); }
 
+    virtual bool isCachedModuleScriptLoader() const { return false; }
+    virtual bool isWorkerModuleScriptLoader() const { return false; }
+
 protected:
     ModuleScriptLoader(ModuleScriptLoaderClient& client, DeferredPromise& promise, JSC::ScriptFetcher& scriptFetcher, RefPtr<JSC::ScriptFetchParameters>&& parameters)
         : m_client(&client)
@@ -59,7 +62,7 @@ protected:
     ModuleScriptLoaderClient* m_client;
     RefPtr<DeferredPromise> m_promise;
     const Ref<JSC::ScriptFetcher> m_scriptFetcher;
-    RefPtr<JSC::ScriptFetchParameters> m_parameters;
+    const RefPtr<JSC::ScriptFetchParameters> m_parameters;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/WorkerModuleScriptLoader.h
+++ b/Source/WebCore/bindings/js/WorkerModuleScriptLoader.h
@@ -70,6 +70,8 @@ public:
 private:
     WorkerModuleScriptLoader(ModuleScriptLoaderClient&, DeferredPromise&, WorkerScriptFetcher&, RefPtr<JSC::ScriptFetchParameters>&&);
 
+    bool isWorkerModuleScriptLoader() const final { return true; }
+
     void didReceiveResponse(ScriptExecutionContextIdentifier, std::optional<ResourceLoaderIdentifier>, const ResourceResponse&) final { }
     void notifyFinished(std::optional<ScriptExecutionContextIdentifier>) final;
 
@@ -85,3 +87,7 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WorkerModuleScriptLoader)
+    static bool isType(const WebCore::ModuleScriptLoader& loader) { return loader.isWorkerModuleScriptLoader(); }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/bindings/js/WorkerScriptFetcher.h
+++ b/Source/WebCore/bindings/js/WorkerScriptFetcher.h
@@ -88,6 +88,8 @@ protected:
     }
 
 private:
+    bool isWorkerScriptFetcher() const final { return true; }
+
     FetchOptions::Credentials m_credentials;
     FetchOptions::Destination m_destination;
     ReferrerPolicy m_referrerPolicy { ReferrerPolicy::EmptyString };
@@ -99,3 +101,7 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WorkerScriptFetcher)
+    static bool isType(const JSC::ScriptFetcher& fetcher) { return fetcher.isWorkerScriptFetcher(); }
+SPECIALIZE_TYPE_TRAITS_END()


### PR DESCRIPTION
#### 05bf547098d5ada6f663cafb7ea8b39f70b5e42d
<pre>
Remove static_cast in ScriptModuleLoader
<a href="https://bugs.webkit.org/show_bug.cgi?id=304689">https://bugs.webkit.org/show_bug.cgi?id=304689</a>

Reviewed by Justin Michaud.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

Canonical link: <a href="https://commits.webkit.org/304960@main">https://commits.webkit.org/304960@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b97620368e5918a9752f7f63f5442ae0cdc8bd9a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137034 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9394 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48321 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144777 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90007 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b007c83d-a786-4f2c-852c-b252901f96bb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138906 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10097 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9521 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104790 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e451701b-9ab2-4cfb-b3a0-8b77026f9ee4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139979 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7412 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122792 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85625 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4d6dc913-b893-4e22-bb67-b900ff0cfbe0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7049 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/4750 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5366 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/128995 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116392 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40962 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147532 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/135520 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9077 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41531 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113144 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9095 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/7624 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113473 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6972 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119061 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63383 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21116 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9125 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37115 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/168301 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8848 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72691 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43918 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9066 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8918 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->