### PR TITLE
Remove some static_cast in WebCore/Modules/mediastream

### DIFF
--- a/Source/WebCore/Modules/mediastream/RTCRtpReceiverBackend.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpReceiverBackend.h
@@ -42,6 +42,8 @@ public:
     virtual Vector<RTCRtpSynchronizationSource> getSynchronizationSources() const { return { }; }
     virtual Ref<RTCRtpTransformBackend> rtcRtpTransformBackend() = 0;
     virtual std::unique_ptr<RTCDtlsTransportBackend> dtlsTransportBackend() = 0;
+
+    virtual bool isLibWebRTCRtpReceiverBackend() const { return false; }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/RTCRtpSenderBackend.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSenderBackend.h
@@ -54,6 +54,8 @@ public:
     virtual Ref<RTCRtpTransformBackend> rtcRtpTransformBackend() = 0;
     virtual void setMediaStreamIds(const FixedVector<String>&) = 0;
     virtual std::unique_ptr<RTCDtlsTransportBackend> dtlsTransportBackend() = 0;
+
+    virtual bool isLibWebRTCRtpSenderBackend() const { return false; }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/RTCRtpTransceiverBackend.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpTransceiverBackend.h
@@ -46,6 +46,8 @@ public:
     virtual void stop() = 0;
     virtual bool stopped() const = 0;
     virtual ExceptionOr<void> setCodecPreferences(const Vector<RTCRtpCodecCapability>&) = 0;
+
+    virtual bool isLibWebRTCRtpTransceiverBackend() const { return false; }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/RTCRtpTransformableFrame.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpTransformableFrame.h
@@ -79,6 +79,8 @@ public:
     void setTransformer(RTCRtpScriptTransformer&);
     bool isFromTransformer(RTCRtpScriptTransformer& transformer) const { return &transformer == m_transformer.get(); }
 
+    virtual bool isLibWebRTCRtpTransformableFrame() const { return false; }
+
 private:
     WeakPtr<RTCRtpScriptTransformer> m_transformer;
 };

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
@@ -67,7 +67,7 @@ static const std::unique_ptr<PeerConnectionBackend> createLibWebRTCPeerConnectio
     if (!page)
         return nullptr;
 
-    auto& webRTCProvider = static_cast<LibWebRTCProvider&>(page->webRTCProvider());
+    auto& webRTCProvider = downcast<LibWebRTCProvider>(page->webRTCProvider());
     webRTCProvider.setEnableWebRTCEncryption(page->settings().webRTCEncryptionEnabled());
 
     RefPtr endpoint = LibWebRTCMediaEndpoint::create(peerConnection, webRTCProvider, document, configurationFromMediaEndpointConfiguration(WTF::move(configuration)));
@@ -205,7 +205,7 @@ void LibWebRTCPeerConnectionBackend::getStats(Ref<DeferredPromise>&& promise)
 static inline LibWebRTCRtpSenderBackend& backendFromRTPSender(RTCRtpSender& sender)
 {
     ASSERT(!sender.isStopped());
-    return static_cast<LibWebRTCRtpSenderBackend&>(*sender.backend());
+    return downcast<LibWebRTCRtpSenderBackend>(*sender.backend());
 }
 
 static inline Ref<LibWebRTCRtpSenderBackend> protectedBackendFromRTPSender(RTCRtpSender& sender)
@@ -228,7 +228,7 @@ void LibWebRTCPeerConnectionBackend::getStats(RTCRtpReceiver& receiver, Ref<Defe
 {
     RefPtr<webrtc::RtpReceiverInterface> rtcReceiver;
     if (auto* backend = receiver.backend())
-        rtcReceiver = &static_cast<LibWebRTCRtpReceiverBackend*>(backend)->rtcReceiver();
+        rtcReceiver = downcast<LibWebRTCRtpReceiverBackend>(backend)->rtcReceiver();
 
     if (!rtcReceiver) {
         m_endpoint->getStats(WTF::move(promise));
@@ -376,7 +376,7 @@ void LibWebRTCPeerConnectionBackend::setSenderSourceFromTrack(LibWebRTCRtpSender
 
 static inline LibWebRTCRtpTransceiverBackend& backendFromRTPTransceiver(RTCRtpTransceiver& transceiver)
 {
-    return static_cast<LibWebRTCRtpTransceiverBackend&>(*transceiver.backend());
+    return downcast<LibWebRTCRtpTransceiverBackend>(*transceiver.backend());
 }
 
 RefPtr<RTCRtpTransceiver> LibWebRTCPeerConnectionBackend::existingTransceiver(Function<bool(LibWebRTCRtpTransceiverBackend&)>&& matchingFunction)

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.cpp
@@ -111,7 +111,7 @@ Ref<RealtimeMediaSource> LibWebRTCRtpReceiverBackend::createSource(Document& doc
         webrtc::scoped_refptr<webrtc::AudioTrackInterface> audioTrack { static_cast<webrtc::AudioTrackInterface*>(rtcTrack.get()) };
         Ref source = RealtimeIncomingAudioSource::create(toRef(WTF::move(audioTrack)), fromStdString(rtcTrack->id()));
         if (document.page()) {
-            auto& webRTCProvider = reinterpret_cast<LibWebRTCProvider&>(document.page()->webRTCProvider());
+            auto& webRTCProvider = downcast<LibWebRTCProvider>(document.page()->webRTCProvider());
             source->setAudioModule(webRTCProvider.audioModule());
         }
         return source;

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.h
@@ -47,6 +47,8 @@ public:
     Ref<RealtimeMediaSource> createSource(Document&);
 
 private:
+    bool isLibWebRTCRtpReceiverBackend() const final { return true; }
+
     RTCRtpParameters getParameters() final;
     Vector<RTCRtpContributingSource> getContributingSources() const final;
     Vector<RTCRtpSynchronizationSource> getSynchronizationSources() const final;
@@ -58,5 +60,9 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::LibWebRTCRtpReceiverBackend)
+    static bool isType(const WebCore::RTCRtpReceiverBackend& backend) { return backend.isLibWebRTCRtpReceiverBackend(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(WEB_RTC) && USE(LIBWEBRTC)

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderBackend.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderBackend.h
@@ -69,6 +69,8 @@ private:
     LibWebRTCRtpSenderBackend(LibWebRTCPeerConnectionBackend&, RefPtr<webrtc::RtpSenderInterface>&&, Source&&);
     LibWebRTCRtpSenderBackend(LibWebRTCPeerConnectionBackend&, RefPtr<webrtc::RtpSenderInterface>&&);
 
+    bool isLibWebRTCRtpSenderBackend() const final { return true; }
+
     bool replaceTrack(RTCRtpSender&, MediaStreamTrack*) final;
     RTCRtpSendParameters getParameters() const final;
     void setParameters(const RTCRtpSendParameters&, DOMPromiseDeferred<void>&&) final;
@@ -91,5 +93,9 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::LibWebRTCRtpSenderBackend)
+    static bool isType(const WebCore::RTCRtpSenderBackend& backend) { return backend.isLibWebRTCRtpSenderBackend(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(WEB_RTC) && USE(LIBWEBRTC)

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransceiverBackend.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransceiverBackend.h
@@ -50,6 +50,8 @@ public:
     webrtc::RtpTransceiverInterface* rtcTransceiver() { return m_rtcTransceiver.ptr(); }
 
 private:
+    bool isLibWebRTCRtpTransceiverBackend() const final { return true; }
+
     RTCRtpTransceiverDirection direction() const final;
     std::optional<RTCRtpTransceiverDirection> currentDirection() const final;
     void setDirection(RTCRtpTransceiverDirection) final;
@@ -62,5 +64,9 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::LibWebRTCRtpTransceiverBackend)
+    static bool isType(const WebCore::RTCRtpTransceiverBackend& backend) { return backend.isLibWebRTCRtpTransceiverBackend(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(WEB_RTC) && USE(LIBWEBRTC)

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransformBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransformBackend.cpp
@@ -68,7 +68,7 @@ void LibWebRTCRtpTransformBackend::sendFrameToOutput(std::unique_ptr<webrtc::Tra
 
 void LibWebRTCRtpTransformBackend::processTransformedFrame(RTCRtpTransformableFrame& frame)
 {
-    if (auto rtcFrame = static_cast<LibWebRTCRtpTransformableFrame&>(frame).takeRTCFrame())
+    if (auto rtcFrame = downcast<LibWebRTCRtpTransformableFrame>(frame).takeRTCFrame())
         sendFrameToOutput(WTF::move(rtcFrame));
 }
 

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransformableFrame.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransformableFrame.h
@@ -47,6 +47,8 @@ public:
 private:
     LibWebRTCRtpTransformableFrame(std::unique_ptr<webrtc::TransformableFrameInterface>&&, bool isAudio);
 
+    bool isLibWebRTCRtpTransformableFrame() const final { return true; }
+
     // RTCRtpTransformableFrame
     std::span<const uint8_t> data() const final;
     void setData(std::span<const uint8_t>) final;
@@ -63,5 +65,9 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::LibWebRTCRtpTransformableFrame)
+    static bool isType(const WebCore::RTCRtpTransformableFrame& backend) { return backend.isLibWebRTCRtpTransformableFrame(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(WEB_RTC) && USE(LIBWEBRTC)

--- a/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -4,9 +4,7 @@ Modules/Model/Implementation/ModelDowncastConvertToBackingContext.cpp
 Modules/WebGPU/Implementation/WebGPUBindGroupImpl.cpp
 Modules/WebGPU/Implementation/WebGPUDowncastConvertToBackingContext.cpp
 Modules/WebGPU/Implementation/WebGPUXRBindingImpl.cpp
-Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
 Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.cpp
-Modules/mediastream/libwebrtc/LibWebRTCRtpTransformBackend.cpp
 Modules/mediastream/libwebrtc/LibWebRTCStatsCollector.cpp
 SVGNames.cpp
 TagName.cpp


### PR DESCRIPTION
#### e56c49a1eea15261ba930e5875e459a8647b55b4
<pre>
Remove some static_cast in WebCore/Modules/mediastream
<a href="https://bugs.webkit.org/show_bug.cgi?id=304690">https://bugs.webkit.org/show_bug.cgi?id=304690</a>

Reviewed by Chris Dumez.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

Canonical link: <a href="https://commits.webkit.org/304979@main">https://commits.webkit.org/304979@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1174cc0094c5ee3b204f23e5517a3554e7a1d28

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137086 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9446 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48373 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144829 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90059 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6f8b9280-9c16-40c4-a519-9e4045cb5cb5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138958 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10149 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9573 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104830 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3892c5f9-d71b-436f-838f-c7737929198e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140031 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7461 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122841 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85665 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/560f69a6-64a8-4106-8a31-8013dbffc3ee) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7098 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4804 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5418 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116446 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41009 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147585 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9129 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41575 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113183 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9147 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7673 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113513 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7019 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119105 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63465 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21121 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9177 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37159 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8901 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72743 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9118 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8970 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->