### PR TITLE
[SwiftUI] Fix WebPage.backForwardList not being observable contrary to the documentation

### DIFF
--- a/Source/WebKit/UIProcess/API/Swift/WebPage+BackForwardList.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+BackForwardList.swift
@@ -160,6 +160,8 @@ extension WebPage {
             wrapped?.forwardList.map(Item.init(_:)) ?? []
         }
 
+        private let id = UUID()
+
         private var wrapped: WKBackForwardList? = nil
 
         /// Accesses the item at the relative offset from the current item.

--- a/Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageTests.swift
@@ -59,22 +59,54 @@ fileprivate class TestNavigationDecider: WebPage.NavigationDeciding {
     }
 }
 
+private struct FakeSchemeHandler: URLSchemeHandler {
+    // This force unwrap is safe because the scheme is a static String.
+    // swift-format-ignore: NeverForceUnwrap
+    @MainActor
+    static let scheme = URLScheme("fake")!
+
+    nonisolated func reply(for request: URLRequest) -> some AsyncSequence<URLSchemeTaskResult, any Error> {
+        AsyncThrowingStream { continuation in
+            // This force unwrap is safe because this HTML is a static String.
+            // swift-format-ignore: NeverForceUnwrap
+            let data = """
+                    <html>
+                    <head>
+                        <title>Title</title>
+                    </head>
+                    <body></body>
+                    </html>
+                """
+                .data(using: .utf8)!
+            guard let url = request.url else {
+                continuation.finish(throwing: URLError(.badURL))
+                return
+            }
+            continuation.yield(
+                .response(
+                    .init(
+                        url: url,
+                        mimeType: "text/html",
+                        expectedContentLength: data.count,
+                        textEncodingName: "utf-8",
+                    )
+                )
+            )
+            continuation.yield(.data(data))
+            continuation.finish()
+        }
+    }
+}
+
 // MARK: Tests
 
 @MainActor
 struct WebPageTests {
     @Test
     func observableProperties() async throws {
-        let page = WebPage()
-
-        let html = """
-        <html>
-        <head>
-            <title>Title</title>
-        </head>
-        <body></body>
-        </html>
-        """
+        var configuration = WebPage.Configuration()
+        configuration.urlSchemeHandlers[FakeSchemeHandler.scheme] = FakeSchemeHandler()
+        let page = WebPage(configuration: configuration)
 
         #expect(page.url == nil)
         #expect(page.title == "")
@@ -83,6 +115,21 @@ struct WebPageTests {
         #expect(page.serverTrust == nil)
         #expect(!page.hasOnlySecureContent)
         #expect(page.themeColor == nil)
+
+        let observablePropertyKeyPaths: [PartialKeyPath<WebPage>] = [
+            \.title,
+            \.backForwardList,
+        ]
+        for (i, keyPath) in observablePropertyKeyPaths.enumerated() {
+            try await confirmation("Observing \(keyPath)", expectedCount: 1) { confirmation async throws in
+                _ = withObservationTracking {
+                    page[keyPath: keyPath]
+                } onChange: {
+                    confirmation()
+                }
+                try await page.load(URL(string: "fake://test/\(i)")).wait()
+            }
+        }
 
         // FIXME: (283456) Make this test more comprehensive once Observation supports observing a stream of changes to properties.
     }


### PR DESCRIPTION
#### cea317e840c136d831f94a34c29408add52f3de5
<pre>
[SwiftUI] Fix WebPage.backForwardList not being observable contrary to the documentation
<a href="https://bugs.webkit.org/show_bug.cgi?id=304698">https://bugs.webkit.org/show_bug.cgi?id=304698</a>

Reviewed by NOBODY (OOPS!).

Storing a private identifier to ensure changes are detected.

Test: Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageTests.swift

* Source/WebKit/UIProcess/API/Swift/WebPage+BackForwardList.swift:
* Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageTests.swift:
(FakeSchemeHandler.reply(for:)):
(WebPageTests.observableProperties):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d788dd9fa8dc6183fcac4fae4224fd8a4ca0159

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139326 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11702 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/828 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147453 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92393 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141199 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12409 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11852 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106666 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77642 "1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142273 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9402 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124790 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87528 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8948 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6715 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7750 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118403 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/691 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150236 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11386 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/709 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115062 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11399 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9639 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115370 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9526 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121139 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/66361 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11429 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/658 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11163 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75095 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11366 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11216 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->