### PR TITLE
SVGPathElement.getTotalLength() should respect CSS 'd' property for display:none elements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getPointAtLength-04-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getPointAtLength-04-expected.txt
@@ -1,7 +1,7 @@
 
 PASS SVGGeometryElement.getPointAtLength: 'display' and a valid path, path with display: default
 PASS SVGGeometryElement.getPointAtLength: 'display' and a valid path, path with display: none
-FAIL SVGGeometryElement.getPointAtLength: 'display' and a valid path, path with display: none and inline style The element's path is empty.
+PASS SVGGeometryElement.getPointAtLength: 'display' and a valid path, path with display: none and inline style
 PASS SVGGeometryElement.getPointAtLength: 'display' and a valid path, rect with display: default
 FAIL SVGGeometryElement.getPointAtLength: 'display' and a valid path, rect with display: none The object is in an invalid state.
 PASS SVGGeometryElement.getPointAtLength: 'display' and a valid path, circle with display: default

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGPathElement.getTotalLength-01-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGPathElement.getTotalLength-01-expected.txt
@@ -1,5 +1,5 @@
 
 PASS SVGPathElement.getTotalLength: 'display:none', path with d attribute specified on element
-FAIL SVGPathElement.getTotalLength: 'display:none', path with d attribute specified as styles assert_equals: expected 100 but got 0
-FAIL SVGPathElement.getTotalLength: 'display:none', path with d attribute specified on element and as styles assert_equals: expected 100 but got 233.1370849609375
+PASS SVGPathElement.getTotalLength: 'display:none', path with d attribute specified as styles
+PASS SVGPathElement.getTotalLength: 'display:none', path with d attribute specified on element and as styles
 

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1691,9 +1691,6 @@ webkit.org/b/222573 media/media-fullscreen-pause-inline.html [ Pass Failure ]
 
 webkit.org/b/222692 inspector/page/empty-or-missing-resources.html [ Pass Timeout ]
 
-# webkit.org/b/223223 these two tests fail on Apple Silicon only
-[ Debug arm64 ] svg/W3C-SVG-1.1/paths-data-03-f.svg [ Failure ]
-
 # webkit.org/b/223043 the following tests have issues only on Apple Silicon
 webrtc/h264-baseline.html  [ Failure Timeout ]
 

--- a/Source/WebCore/svg/SVGPathElement.cpp
+++ b/Source/WebCore/svg/SVGPathElement.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2004, 2005, 2006, 2008 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006, 2007 Rob Buis <buis@kde.org>
- * Copyright (C) 2018-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -238,6 +238,14 @@ RenderPtr<RenderElement> SVGPathElement::createElementRenderer(RenderStyle&& sty
 const SVGPathByteStream& SVGPathElement::pathByteStream() const
 {
     if (document().settings().cssDPropertyEnabled()) {
+        // Try computed style first (works for display:none elements).
+        auto path = const_cast<SVGPathElement*>(this);
+        if (auto* style = path->computedStyle()) {
+            if (auto& pathFunction = style->d().tryPath())
+                return pathFunction->parameters.data.byteStream;
+        }
+
+        // Fallback to renderer style, if no computed style.
         if (CheckedPtr renderer = this->renderer()) {
             if (auto& pathFunction = renderer->style().d().tryPath())
                 return pathFunction->parameters.data.byteStream;


### PR DESCRIPTION
#### fb740fd4160c7a929a26ef4d16302a441f43919c
<pre>
SVGPathElement.getTotalLength() should respect CSS &apos;d&apos; property for display:none elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=304701">https://bugs.webkit.org/show_bug.cgi?id=304701</a>
<a href="https://rdar.apple.com/167195297">rdar://167195297</a>

Reviewed by NOBODY (OOPS!).

Per the SVG specification [1], getTotalLength() should compute the path length
based on the effective path data, which includes CSS &apos;d&apos; property values.
Currently, display:none elements fail to read the CSS &apos;d&apos; property because
pathByteStream() only checks renderer-&gt;style(), which is null for non-rendered
elements.

Fix by checking computedStyle() first before falling back to the renderer,
allowing display:none elements to access their CSS &apos;d&apos; property values.

[1] <a href="https://svgwg.org/svg2-draft/paths.html#InterfaceSVGGeometryElement">https://svgwg.org/svg2-draft/paths.html#InterfaceSVGGeometryElement</a>

* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getPointAtLength-04-expected.txt: Progression
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGPathElement.getTotalLength-01-expected.txt: Ditto
* Source/WebCore/svg/SVGPathElement.cpp:
(WebCore::SVGPathElement::pathByteStream const):
</pre>