### PR TITLE
[JSC] Treat unused catch binding as optional catch binding

### DIFF
--- a/JSTests/stress/unused-catch-binding.js
+++ b/JSTests/stress/unused-catch-binding.js
@@ -1,0 +1,303 @@
+function shouldBe(actual, expected, message) {
+    if (actual !== expected)
+        throw new Error((message ? message + ": " : "") + "expected " + expected + " but got " + actual);
+}
+
+(function testBasicUnusedCatch() {
+    let executed = false;
+    try {
+        throw new Error("test");
+    } catch (e) {
+        executed = true;
+    }
+    shouldBe(executed, true, "testBasicUnusedCatch");
+})();
+
+(function testUnusedCatchWithReturn() {
+    function f() {
+        try {
+            throw new Error("test");
+        } catch (e) {
+            return "caught";
+        }
+        return "not caught";
+    }
+    shouldBe(f(), "caught", "testUnusedCatchWithReturn");
+})();
+
+(function testUnusedCatchWithFinally() {
+    let catchExecuted = false;
+    let finallyExecuted = false;
+    try {
+        throw new Error("test");
+    } catch (e) {
+        catchExecuted = true;
+    } finally {
+        finallyExecuted = true;
+    }
+    shouldBe(catchExecuted, true, "testUnusedCatchWithFinally - catch");
+    shouldBe(finallyExecuted, true, "testUnusedCatchWithFinally - finally");
+})();
+
+(function testUsedCatchVariable() {
+    let message = null;
+    try {
+        throw new Error("expected message");
+    } catch (e) {
+        message = e.message;
+    }
+    shouldBe(message, "expected message", "testUsedCatchVariable");
+})();
+
+(function testCatchVariableInClosure() {
+    let getter = null;
+    try {
+        throw "captured value";
+    } catch (e) {
+        getter = function() { return e; };
+    }
+    shouldBe(getter(), "captured value", "testCatchVariableInClosure");
+})();
+
+(function testCatchVariableWithEval() {
+    let result = null;
+    try {
+        throw "eval test";
+    } catch (e) {
+        result = eval("e");
+    }
+    shouldBe(result, "eval test", "testCatchVariableWithEval");
+})();
+
+(function testCatchVariableWithEvalExpression() {
+    let result = null;
+    try {
+        throw 42;
+    } catch (e) {
+        result = eval("e + 8");
+    }
+    shouldBe(result, 50, "testCatchVariableWithEvalExpression");
+})();
+
+(function testCatchVariableWithEvalInner() {
+    let result = null;
+    try {
+        throw 42;
+    } catch (e) {
+        function foo() {
+            result = eval("e + 8");
+        }
+        foo();
+    }
+    shouldBe(result, 50, "testCatchVariableWithEvalInner");
+})();
+
+(function testOuterVariableNotAffected() {
+    let e = "outer";
+    try {
+        throw new Error("inner");
+    } catch (e) {
+    }
+    shouldBe(e, "outer", "testOuterVariableNotAffected");
+})();
+
+(function testOuterVariableAccessible() {
+    let outer = "accessible";
+    let result = null;
+    try {
+        throw new Error("test");
+    } catch (e) {
+        result = outer;
+    }
+    shouldBe(result, "accessible", "testOuterVariableAccessible");
+})();
+
+(function testNestedTryCatch() {
+    let innerCaught = false;
+    try {
+        try {
+            throw new Error("inner");
+        } catch (e) {
+            innerCaught = true;
+            throw new Error("rethrow");
+        }
+    } catch (e) {
+    }
+    shouldBe(innerCaught, true, "testNestedTryCatch");
+})();
+
+(function testNestedTryCatchSameName() {
+    let values = [];
+    try {
+        try {
+            throw "first";
+        } catch (e) {
+            values.push(e);
+            throw "second";
+        }
+    } catch (e) {
+        values.push(e);
+    }
+    shouldBe(values[0], "first", "testNestedTryCatchSameName - first");
+    shouldBe(values[1], "second", "testNestedTryCatchSameName - second");
+})();
+
+(function testUnusedCatchInLoop() {
+    let count = 0;
+    for (let i = 0; i < 10000; i++) {
+        try {
+            throw new Error("loop");
+        } catch (e) {
+            count++;
+        }
+    }
+    shouldBe(count, 10000, "testUnusedCatchInLoop");
+})();
+
+(function testUsedCatchInLoop() {
+    let sum = 0;
+    for (let i = 0; i < 1000; i++) {
+        try {
+            throw i;
+        } catch (e) {
+            sum += e;
+        }
+    }
+    shouldBe(sum, 499500, "testUsedCatchInLoop");
+})();
+
+(function testMixedCatchInLoop() {
+    let usedSum = 0;
+    let unusedCount = 0;
+    for (let i = 0; i < 1000; i++) {
+        if (i % 2 === 0) {
+            try {
+                throw i;
+            } catch (e) {
+                usedSum += e;
+            }
+        } else {
+            try {
+                throw i;
+            } catch (e) {
+                unusedCount++;
+            }
+        }
+    }
+    shouldBe(usedSum, 249500, "testMixedCatchInLoop - usedSum");
+    shouldBe(unusedCount, 500, "testMixedCatchInLoop - unusedCount");
+})();
+
+(function testUnderscoreNaming() {
+    let executed = false;
+    try {
+        throw new Error("test");
+    } catch (_) {
+        executed = true;
+    }
+    shouldBe(executed, true, "testUnderscoreNaming");
+})();
+
+(function testUnderscoreUsed() {
+    let result = null;
+    try {
+        throw "underscore value";
+    } catch (_) {
+        result = _;
+    }
+    shouldBe(result, "underscore value", "testUnderscoreUsed");
+})();
+
+(function testThrowNonError() {
+    let results = [];
+    try { throw null; } catch (e) { results.push("null"); }
+    try { throw undefined; } catch (e) { results.push("undefined"); }
+    try { throw 0; } catch (e) { results.push("zero"); }
+    try { throw ""; } catch (e) { results.push("empty string"); }
+    try { throw false; } catch (e) { results.push("false"); }
+    shouldBe(results.length, 5, "testThrowNonError");
+})();
+
+(function testCatchModifiesOuter() {
+    let value = "before";
+    try {
+        throw new Error("test");
+    } catch (e) {
+        value = "after";
+    }
+    shouldBe(value, "after", "testCatchModifiesOuter");
+})();
+
+(function testSequentialCatches() {
+    let count = 0;
+    try { throw 1; } catch (a) { count++; }
+    try { throw 2; } catch (b) { count++; }
+    try { throw 3; } catch (c) { count++; }
+    shouldBe(count, 3, "testSequentialCatches");
+})();
+
+(function testStrictModeUnused() {
+    "use strict";
+    let executed = false;
+    try {
+        throw new Error("strict");
+    } catch (e) {
+        executed = true;
+    }
+    shouldBe(executed, true, "testStrictModeUnused");
+})();
+
+(function testStrictModeWithEval() {
+    "use strict";
+    let result = null;
+    try {
+        throw "strict eval";
+    } catch (e) {
+        result = eval("e");
+    }
+    shouldBe(result, "strict eval", "testStrictModeWithEval");
+})();
+
+(async function testAsyncUnusedCatch() {
+    let executed = false;
+    try {
+        throw new Error("async");
+    } catch (e) {
+        executed = true;
+    }
+    shouldBe(executed, true, "testAsyncUnusedCatch");
+})();
+
+(async function testAsyncUsedCatch() {
+    let message = null;
+    try {
+        throw new Error("async message");
+    } catch (e) {
+        message = e.message;
+    }
+    shouldBe(message, "async message", "testAsyncUsedCatch");
+})();
+
+(function testGeneratorUnusedCatch() {
+    function* gen() {
+        try {
+            throw new Error("gen");
+        } catch (e) {
+            yield "caught";
+        }
+    }
+    let g = gen();
+    shouldBe(g.next().value, "caught", "testGeneratorUnusedCatch");
+})();
+
+(function testGeneratorUsedCatch() {
+    function* gen() {
+        try {
+            throw "gen value";
+        } catch (e) {
+            yield e;
+        }
+    }
+    let g = gen();
+    shouldBe(g.next().value, "gen value", "testGeneratorUsedCatch");
+})();

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -1867,6 +1867,9 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseTryStatement(
             matchOrFail(OPENBRACE, "Expected exception handler to be a block statement");
             catchBlock = parseBlockStatement(context, BlockType::CatchBlock);
             failIfFalse(catchBlock, "Unable to parse 'catch' block");
+            // Handle `try { } catch (/* never used */ error) { }`
+            if (ident && !catchScope->usedVariablesContains(ident->impl()) && !catchScope->usesEval() && !catchScope->hasVariableBeingHoisted(ident->impl()))
+                catchPattern = 0;
             std::tie(catchEnvironment, functionStack) = popScope(catchScope, TreeBuilder::NeedsFreeVariableInfo);
             ASSERT(functionStack.isEmpty());
             RELEASE_ASSERT(!ident || (catchEnvironment.size() == 1 && catchEnvironment.contains(ident->impl())));

--- a/Source/JavaScriptCore/parser/Parser.h
+++ b/Source/JavaScriptCore/parser/Parser.h
@@ -503,6 +503,11 @@ public:
         return m_lexicalVariables.contains(ident);
     }
 
+    bool hasVariableBeingHoisted(UniquedStringImpl* ident) const
+    {
+        return m_variablesBeingHoisted.contains(ident);
+    }
+
     bool hasPrivateName(const Identifier& ident)
     {
         return m_lexicalVariables.hasPrivateName(ident);


### PR DESCRIPTION
#### 328cf24b0ded041b2b0c0fd721e48f7ac278de37
<pre>
[JSC] Treat unused catch binding as optional catch binding
<a href="https://bugs.webkit.org/show_bug.cgi?id=304703">https://bugs.webkit.org/show_bug.cgi?id=304703</a>

Reviewed by Yusuke Suzuki.

When a catch clause has a binding that is never used (e.g., `catch (e) {}`
where `e` is not used), treat it the same as optional catch binding (`catch {}`).

This skips emitPushCatchScope and emitPopCatchScope, avoiding unnecessary
SymbolTable creation and bytecode generation.

This benefits legacy code written before ES2019 that couldn&apos;t use the
optional catch binding syntax.

The transformation is skipped when:

- The catch parameter is a destructuring pattern
- The catch block uses eval (which may reference the variable dynamically)

Test: JSTests/stress/unused-catch-binding.js

* JSTests/stress/unused-catch-binding.js: Added.
(shouldBe):
(testUnusedCatchWithReturn.f):
(testUnusedCatchWithReturn):
(testUnusedCatchWithFinally):
(testUsedCatchVariable):
(testCatchVariableInClosure.catch.getter):
(testCatchVariableInClosure):
(testCatchVariableWithEval):
(testCatchVariableWithEvalExpression):
(testCatchVariableWithEvalInner.catch.foo):
(testCatchVariableWithEvalInner):
(testOuterVariableNotAffected):
(testOuterVariableAccessible):
(testNestedTryCatch):
(testNestedTryCatchSameName):
(testUnusedCatchInLoop):
(testUsedCatchInLoop):
(testMixedCatchInLoop):
(testUnderscoreNaming):
(testUnderscoreUsed):
(testThrowNonError):
(testCatchModifiesOuter):
(testSequentialCatches):
(testStrictModeUnused):
(testStrictModeWithEval):
(async testAsyncUnusedCatch):
(async testAsyncUsedCatch):
(testGeneratorUnusedCatch.gen):
(testGeneratorUnusedCatch):
(testGeneratorUsedCatch.gen):
(testGeneratorUsedCatch):
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::parseTryStatement):
* Source/JavaScriptCore/parser/Parser.h:
(JSC::Scope::hasVariableBeingHoisted const):

Canonical link: <a href="https://commits.webkit.org/304974@main">https://commits.webkit.org/304974@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/afeb2d415f01d9bf941d06c173d439eef13894d2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137016 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9376 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48303 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144759 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89989 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10079 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9503 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104779 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139961 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7400 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122778 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85614 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7037 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4737 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5348 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/128977 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116378 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40950 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147514 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/135502 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9059 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41519 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113131 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9077 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7613 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113461 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28827 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6961 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119049 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63351 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9107 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37103 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/168283 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8830 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72673 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43913 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9048 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8900 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->