### PR TITLE
Migrate from repaintRectInLocalCoordinates(Accurate) to direct computation

### DIFF
--- a/Source/WebCore/rendering/svg/SVGBoundingBoxComputation.h
+++ b/Source/WebCore/rendering/svg/SVGBoundingBoxComputation.h
@@ -53,6 +53,7 @@ public:
     static constexpr DecorationOptions strokeBoundingBoxDecoration = { DecorationOption::IncludeFillShape, DecorationOption::IncludeStrokeShape };
     static constexpr DecorationOptions filterBoundingBoxDecoration = { DecorationOption::OverrideBoxWithFilterBox, DecorationOption::OverrideBoxWithFilterBoxForChildren };
     static constexpr DecorationOptions repaintBoundingBoxDecoration = { DecorationOption::IncludeFillShape, DecorationOption::IncludeStrokeShape, DecorationOption::IncludeMarkers, DecorationOption::IncludeClippers, DecorationOption::IncludeMaskers, DecorationOption::OverrideBoxWithFilterBox, DecorationOption::CalculateFastRepaintRect };
+    static constexpr DecorationOptions decoratedBoundingBoxDecoration = { DecorationOption::IncludeFillShape, DecorationOption::IncludeStrokeShape, DecorationOption::IncludeMarkers };
 
     FloatRect computeDecoratedBoundingBox(const DecorationOptions&, bool* boundingBoxValid = nullptr) const;
 
@@ -69,9 +70,7 @@ public:
 
     static FloatRect computeDecoratedBoundingBox(const RenderLayerModelObject& renderer)
     {
-        // FIXME: Compute decorated bounding box directly instead of delegating
-        // to accurate repaint rect.
-        return renderer.repaintRectInLocalCoordinates(RepaintRectCalculation::Accurate);
+        return computeDecoratedBoundingBox(renderer, decoratedBoundingBoxDecoration);
     }
 
     static LayoutRect computeVisualOverflowRect(const RenderLayerModelObject&);

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.h
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.h
@@ -53,8 +53,18 @@ public:
     // Helper function determining wheter overflow is hidden
     static bool isOverflowHidden(const RenderElement&);
 
+    // Applies filter/clipper/masker resource effects to a geometric bounding rect.
+    // This is the preferred API for resource code (masks, gradients, clippers) that needs
+    // to compute bounds for rendering. Unlike intersectRepaintRectWithResources(), this
+    // function is semantically about geometric calculations, not repaint/invalidation.
+    static void applyResourceEffectsToRect(const RenderElement&, FloatRect&);
+
     // Calculates the repaintRect in combination with filter, clipper and masker in local coordinates.
+    // FIXME: After migrating all RepaintRectCalculation::Accurate callers to use applyResourceEffectsToRect
+    // function, we can simplify this to only handle Fast mode.
     static void intersectRepaintRectWithResources(const RenderElement&, FloatRect&, RepaintRectCalculation = RepaintRectCalculation::Fast);
+
+    static FloatRect computeContainerDecoratedBoundingBox(const RenderElement& container);
 
     // Determines whether a container needs to be laid out because it's filtered and a child is being laid out.
     static bool filtersForceContainerLayout(const RenderElement&);

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp
@@ -223,9 +223,7 @@ FloatRect LegacyRenderSVGContainer::repaintRectInLocalCoordinates(RepaintRectCal
 
 FloatRect LegacyRenderSVGContainer::decoratedBoundingBox() const
 {
-    // FIXME: Compute decorated bounding box directly instead of delegating
-    // to accurate repaint rect.
-    return repaintRectInLocalCoordinates(RepaintRectCalculation::Accurate);
+    return SVGRenderSupport::computeContainerDecoratedBoundingBox(*this);
 }
 
 bool LegacyRenderSVGContainer::nodeAtFloatPoint(const HitTestRequest& request, HitTestResult& result, const FloatPoint& pointInParent, HitTestAction hitTestAction)

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.cpp
@@ -67,6 +67,10 @@ auto LegacyRenderSVGResourceMasker::applyResource(RenderElement& renderer, const
     AffineTransform absoluteTransform = SVGRenderingContext::calculateTransformationToOutermostCoordinateSystem(renderer);
     FloatRect decoratedBounds = renderer.decoratedBoundingBox();
 
+    // Masks define a clipping region via x/y/width/height attributes.
+    // We need to get the effective area to mask.
+    SVGRenderSupport::applyResourceEffectsToRect(renderer, decoratedBounds);
+
     // Ignore 2D rotation, as it doesn't affect the size of the mask.
     FloatSize scale(absoluteTransform.xScale(), absoluteTransform.yScale());
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
@@ -515,9 +515,7 @@ FloatRect LegacyRenderSVGRoot::repaintRectInLocalCoordinates(RepaintRectCalculat
 
 FloatRect LegacyRenderSVGRoot::decoratedBoundingBox() const
 {
-    // FIXME: Compute decorated bounding box directly instead of delegating
-    // to accurate repaint rect.
-    return repaintRectInLocalCoordinates(RepaintRectCalculation::Accurate);
+    return SVGRenderSupport::computeContainerDecoratedBoundingBox(*this);
 }
 
 bool LegacyRenderSVGRoot::nodeAtPoint(const HitTestRequest& request, HitTestResult& result, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction hitTestAction)

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
@@ -451,9 +451,10 @@ FloatRect LegacyRenderSVGShape::repaintRectInLocalCoordinates(RepaintRectCalcula
 
 FloatRect LegacyRenderSVGShape::decoratedBoundingBox() const
 {
-    // FIXME: Compute decorated bounding box directly instead of delegating
-    // to accurate repaint rect.
-    return repaintRectInLocalCoordinates(RepaintRectCalculation::Accurate);
+    // FIXME: strokeBoundingBox currently includes markers via adjustStrokeBoundingBoxForMarkersAndZeroLengthLinecaps.
+    // Ideally, strokeBoundingBox should only include stroke. We should refactor to compute
+    // decoratedBoundingBox = strokeBoundingBox() + markers explicitly.
+    return strokeBoundingBox();
 }
 
 float LegacyRenderSVGShape::strokeWidth() const


### PR DESCRIPTION
#### 0193cdc183749bab70ddc698c0862c2d6bb41ec5
<pre>
Migrate from repaintRectInLocalCoordinates(Accurate) to direct computation
<a href="https://bugs.webkit.org/show_bug.cgi?id=304706">https://bugs.webkit.org/show_bug.cgi?id=304706</a>
<a href="https://rdar.apple.com/problem/167205237">rdar://problem/167205237</a>

Reviewed by Simon Fraser.

Follow-up to 304945@main

decoratedBoundingBox() now computes geometric bounds directly instead of
delegating to repaintRectInLocalCoordinates(Accurate).

We introduce applyResourceEffectsToRect() to apply filter/clipper/masker effects
to a geometric rect. This provides semantic clarity: resource code (masks,
gradients) computes bounds for rendering, not for repaint invalidation.

Looking at other callers of repaintRectInLocalCoordinates(Accurate), they
are also computing geometric bounds rather than repaint rects - these should
be migrated to applyResourceEffectsToRect() in follow-up work.

Note: applyResourceEffectsToRect still forwards to intersectRepaintRectWithResources() internally

* Source/WebCore/rendering/svg/SVGBoundingBoxComputation.h:
(WebCore::SVGBoundingBoxComputation::computeDecoratedBoundingBox):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.cpp:
(WebCore::LegacyRenderSVGResourceMasker::applyResource):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp:
(WebCore::LegacyRenderSVGShape::decoratedBoundingBox const):

Canonical link: <a href="https://commits.webkit.org/304965@main">https://commits.webkit.org/304965@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5417cd00b776993a3b44783aacfbaadf3b77075

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137042 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9402 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48329 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144785 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90015 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2c708c57-19d8-45be-965d-7382a880eb03) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138914 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10105 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9529 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104794 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0ec38d53-2f55-4e5d-9d3b-74785af3083f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139987 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7419 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122796 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85629 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7056 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4756 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5374 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116399 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40965 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147540 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9085 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41534 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113148 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9103 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7629 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113477 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28818 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6978 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119064 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63395 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9133 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37118 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8856 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72699 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9074 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8926 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->