### PR TITLE
Make height-dependent aspect-ratio set width on tables with specified height

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-item-aspect-ratio-justify-self-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-item-aspect-ratio-justify-self-002-expected.txt
@@ -17,36 +17,16 @@
 
 
 
-FAIL .item 1 assert_equals:
-<div class="item start" data-expected-width="16" data-expected-height="32"></div>
-width expected 16 but got 0
-FAIL .item 2 assert_equals:
-<div class="item end" data-expected-width="16" data-expected-height="32"></div>
-width expected 16 but got 0
-FAIL .item 3 assert_equals:
-<div class="item self-start" data-expected-width="16" data-expected-height="32"></div>
-width expected 16 but got 0
-FAIL .item 4 assert_equals:
-<div class="item self-end" data-expected-width="16" data-expected-height="32"></div>
-width expected 16 but got 0
-FAIL .item 5 assert_equals:
-<div class="item flex-start" data-expected-width="16" data-expected-height="32"></div>
-width expected 16 but got 0
-FAIL .item 6 assert_equals:
-<div class="item flex-end" data-expected-width="16" data-expected-height="32"></div>
-width expected 16 but got 0
-FAIL .item 7 assert_equals:
-<div class="item left" data-expected-width="16" data-expected-height="32"></div>
-width expected 16 but got 0
-FAIL .item 8 assert_equals:
-<div class="item right" data-expected-width="16" data-expected-height="32"></div>
-width expected 16 but got 0
-FAIL .item 9 assert_equals:
-<div class="item center" data-expected-width="16" data-expected-height="32"></div>
-width expected 16 but got 0
-FAIL .item 10 assert_equals:
-<div class="item normal" data-expected-width="24" data-expected-height="48"></div>
-width expected 24 but got 0
+PASS .item 1
+PASS .item 2
+PASS .item 3
+PASS .item 4
+PASS .item 5
+PASS .item 6
+PASS .item 7
+PASS .item 8
+PASS .item 9
+PASS .item 10
 PASS .item 11
 PASS .item 12
 PASS .item 13

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -503,8 +503,13 @@ void RenderTable::layout()
 
         LayoutUnit oldLogicalWidth = logicalWidth();
         LayoutUnit oldLogicalHeight = logicalHeight();
-        resetLogicalHeightBeforeLayoutIfNeeded();
+        if (style().hasAspectRatio()) {
+            auto logicalHeightLength = style().logicalHeight();
+            if (logicalHeightLength.isSpecified() && logicalHeightLength.isPossiblyPositive())
+                setLogicalHeight(convertStyleLogicalHeightToComputedHeight(logicalHeightLength));
+        }
         updateLogicalWidth();
+        resetLogicalHeightBeforeLayoutIfNeeded();
 
         if (logicalWidth() != oldLogicalWidth) {
             for (unsigned i = 0; i < m_captions.size(); i++)


### PR DESCRIPTION
#### adf177b90b815cd37c89ed52ac26ced0cb3c16e6
<pre>
Make height-dependent aspect-ratio set width on tables with specified height
<a href="https://bugs.webkit.org/show_bug.cgi?id=304709">https://bugs.webkit.org/show_bug.cgi?id=304709</a>
<a href="https://rdar.apple.com/167214714">rdar://167214714</a>

Reviewed by NOBODY (OOPS!).

In RenderTable::layout() we weren&apos;t setting the computed height onto
m_frameRect before calling updateLogicalWidth(), but updateLogicalWidth()
passes the m_frameRect&apos;s logicalHeight() as the definite height for
calculating a height-dependent width via the aspect-ratio in
RenderBox::computeLogicalWidthFromAspectRation(). This resulted in us
always calculating an aspect-ratio dependent width of zero.

With this change, if there&apos;s an aspect-ratio, we compute the height and
store it onto m_frameRect before calling updateLogicalWidth() so that
an aspect-ratio-dependent width computes correctly.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-item-aspect-ratio-justify-self-002-expected.txt:
* Source/WebCore/rendering/RenderTable.cpp:
(WebCore::RenderTable::layout):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/adf177b90b815cd37c89ed52ac26ced0cb3c16e6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137006 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9366 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48293 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144749 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89979 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e16e287c-559a-4b0d-ad4a-4fb996a1c3d3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138878 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10069 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9493 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104768 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76442 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e7eb44be-d0c2-4125-9588-9e83b5dfb83b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139951 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7390 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122768 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85605 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f9405402-4e10-4a86-be67-fe3ca5c36962) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7027 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4727 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5338 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116368 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40940 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147504 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9049 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41509 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113122 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9067 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7603 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113452 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6950 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119039 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63333 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9097 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37093 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8820 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72663 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9038 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8890 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->