### PR TITLE
Refactor self-alignment property resolution to manage 'auto' instead of 'normal'

### DIFF
--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -3020,11 +3020,10 @@ bool RenderBox::columnFlexItemHasStretchAlignment() const
     if (style().marginStart().isAuto() || style().marginEnd().isAuto())
         return false;
 
-    auto normalBehavior = containingBlock()->selfAlignmentNormalBehavior();
-
-    if (!style().alignSelf().isAuto())
-        return style().alignSelf().resolve(normalBehavior).position() == ItemPosition::Stretch;
-    return parentStyle.alignItems().resolve(normalBehavior).position() == ItemPosition::Stretch;
+    auto alignment = style().alignSelf().resolve(&parentStyle);
+    if (alignment.isNormal())
+        return ItemPosition::Stretch == containingBlock()->selfAlignmentNormalBehavior();
+    return alignment.isStretch();
 }
 
 bool RenderBox::isStretchingColumnFlexItem() const
@@ -3054,18 +3053,18 @@ bool RenderBox::hasStretchedLogicalHeight() const
         if (auto* grid = dynamicDowncast<RenderGrid>(*this); grid && grid->isSubgridInParentDirection(Style::GridTrackSizingDirection::Columns))
             return true;
 
-        auto normalBehavior = containingBlock->selfAlignmentNormalBehavior(this);
-        if (!style.justifySelf().isAuto())
-            return style.justifySelf().resolve(normalBehavior).position() == ItemPosition::Stretch;
-        return containingBlock->style().justifyItems().resolve(normalBehavior).position() == ItemPosition::Stretch;
+        auto alignment = style.justifySelf().resolve(&containingBlock->style());
+        if (alignment.isNormal())
+            return ItemPosition::Stretch == containingBlock->selfAlignmentNormalBehavior(this);
+        return alignment.isStretch();
     }
     if (auto* grid = dynamicDowncast<RenderGrid>(*this); grid && grid->isSubgridInParentDirection(Style::GridTrackSizingDirection::Rows))
         return true;
 
-    auto normalBehavior = containingBlock->selfAlignmentNormalBehavior(this);
-    if (!style.alignSelf().isAuto())
-        return style.alignSelf().resolve(normalBehavior).position() == ItemPosition::Stretch;
-    return containingBlock->style().alignItems().resolve(normalBehavior).position() == ItemPosition::Stretch;
+    auto alignment = style.alignSelf().resolve(&containingBlock->style());
+    if (alignment.isNormal())
+        return ItemPosition::Stretch == containingBlock->selfAlignmentNormalBehavior(this);
+    return alignment.isStretch();
 }
 
 // FIXME: Can/Should we move this inside specific layout classes (flex. grid)? Can we refactor columnFlexItemHasStretchAlignment logic?
@@ -3080,21 +3079,22 @@ bool RenderBox::hasStretchedLogicalWidth(StretchingMode stretchingMode) const
         // The 'normal' value behaves like 'start' except for Flexbox Items, which obviously should have a container.
         return false;
     }
-    auto normalItemPosition = stretchingMode == StretchingMode::Any ? containingBlock->selfAlignmentNormalBehavior(this) : ItemPosition::Normal;
     if (containingBlock->isHorizontalWritingMode() != isHorizontalWritingMode()) {
         if (auto* grid = dynamicDowncast<RenderGrid>(*this); grid && grid->isSubgridInParentDirection(Style::GridTrackSizingDirection::Rows))
             return true;
 
-        if (!style.alignSelf().isAuto())
-            return style.alignSelf().resolve(normalItemPosition).position() == ItemPosition::Stretch;
-        return containingBlock->style().alignItems().resolve(normalItemPosition).position() == ItemPosition::Stretch;
+        auto alignment = style.alignSelf().resolve(&containingBlock->style());
+        if (StretchingMode::Any == stretchingMode && alignment.isNormal())
+            return ItemPosition::Stretch == containingBlock->selfAlignmentNormalBehavior(this);
+        return alignment.isStretch();
     }
     if (auto* grid = dynamicDowncast<RenderGrid>(*this); grid && grid->isSubgridInParentDirection(Style::GridTrackSizingDirection::Columns))
         return true;
 
-    if (!style.justifySelf().isAuto())
-        return style.justifySelf().resolve(normalItemPosition).position() == ItemPosition::Stretch;
-    return containingBlock->style().justifyItems().resolve(normalItemPosition).position() == ItemPosition::Stretch;
+    auto alignment = style.justifySelf().resolve(&containingBlock->style());
+    if (StretchingMode::Any == stretchingMode && alignment.isNormal())
+        return ItemPosition::Stretch == containingBlock->selfAlignmentNormalBehavior(this);
+    return alignment.isStretch();
 }
 
 bool RenderBox::sizesPreferredLogicalWidthToFitContent() const

--- a/Source/WebCore/rendering/style/StyleSelfAlignmentData.h
+++ b/Source/WebCore/rendering/style/StyleSelfAlignmentData.h
@@ -60,11 +60,21 @@ public:
     ItemPositionType positionType() const { return static_cast<ItemPositionType>(m_positionType); }
     OverflowAlignment overflow() const { return static_cast<OverflowAlignment>(m_overflow); }
 
-    bool isNormal(ItemPosition autoAlignment = ItemPosition::Normal) const
+    bool isNormal() const
     {
-        if (position() == ItemPosition::Auto)
-            return autoAlignment == ItemPosition::Normal;
         return position() == ItemPosition::Normal;
+    }
+
+    bool isStretch() const
+    {
+        return position() == ItemPosition::Stretch;
+    }
+
+    bool isStretchy(ItemPosition normal) const
+    {
+        if (isNormal())
+            return normal == ItemPosition::Stretch;
+        return position() == ItemPosition::Stretch;
     }
 
     // Must resolve Auto before calling. Normal treated as Start.

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -834,7 +834,7 @@ void Adjuster::adjust(RenderStyle& style) const
 
     // If the inherited value of justify-items includes the 'legacy' keyword (plus 'left', 'right' or
     // 'center'), 'legacy' computes to the the inherited value. Otherwise, 'auto' computes to 'normal'.
-    if (m_parentBoxStyle.justifyItems().resolve().positionType() == ItemPositionType::Legacy && style.justifyItems().resolve().position() == ItemPosition::Legacy)
+    if (m_parentBoxStyle.justifyItems().isLegacy() && style.justifyItems().isLegacyNone())
         style.setJustifyItems(m_parentBoxStyle.justifyItems());
 
 #if HAVE(CORE_MATERIAL)

--- a/Source/WebCore/style/values/align/StyleAlignItems.cpp
+++ b/Source/WebCore/style/values/align/StyleAlignItems.cpp
@@ -32,7 +32,7 @@
 namespace WebCore {
 namespace Style {
 
-StyleSelfAlignmentData AlignItems::resolve(std::optional<StyleSelfAlignmentData> valueForNormal) const
+StyleSelfAlignmentData AlignItems::resolve() const
 {
     auto resolveOverflowPosition = [&](auto itemPosition) -> StyleSelfAlignmentData {
         switch (overflowPosition()) {
@@ -48,7 +48,7 @@ StyleSelfAlignmentData AlignItems::resolve(std::optional<StyleSelfAlignmentData>
 
     switch (primary()) {
     case PrimaryKind::Normal:
-        return valueForNormal.value_or(ItemPosition::Normal);
+        return { ItemPosition::Normal };
     case PrimaryKind::Stretch:
         return { ItemPosition::Stretch };
     case PrimaryKind::Baseline:

--- a/Source/WebCore/style/values/align/StyleAlignItems.h
+++ b/Source/WebCore/style/values/align/StyleAlignItems.h
@@ -70,7 +70,7 @@ struct AlignItems {
 
     constexpr bool operator==(const AlignItems&) const = default;
 
-    StyleSelfAlignmentData resolve(std::optional<StyleSelfAlignmentData> = std::nullopt) const;
+    StyleSelfAlignmentData resolve() const;
 
 private:
     enum class PrimaryKind : uint8_t {

--- a/Source/WebCore/style/values/align/StyleAlignSelf.cpp
+++ b/Source/WebCore/style/values/align/StyleAlignSelf.cpp
@@ -28,14 +28,19 @@
 
 #include "AnchorPositionEvaluator.h"
 #include "RenderStyle.h"
+#include "RenderStyle+GettersInlines.h"
+#include "StyleAlignItems.h"
 #include "StyleBuilderChecking.h"
 #include "StylePrimitiveNumericTypes+CSSValueConversion.h"
 
 namespace WebCore {
 namespace Style {
 
-StyleSelfAlignmentData AlignSelf::resolve(std::optional<StyleSelfAlignmentData> valueForNormalOrAuto) const
+StyleSelfAlignmentData AlignSelf::resolve(const RenderStyle* containerStyle) const
 {
+    if (PrimaryKind::Auto == primary())
+        return containerStyle ? containerStyle->alignItems().resolve() : StyleSelfAlignmentData { ItemPosition::Normal };
+
     auto resolveOverflowPosition = [&](auto itemPosition) -> StyleSelfAlignmentData {
         switch (overflowPosition()) {
         case OverflowPositionKind::None:
@@ -43,16 +48,17 @@ StyleSelfAlignmentData AlignSelf::resolve(std::optional<StyleSelfAlignmentData> 
         case OverflowPositionKind::Unsafe:
             return { itemPosition, OverflowAlignment::Unsafe };
         case OverflowPositionKind::Safe:
-            return { itemPosition, OverflowAlignment::Safe, };
+            return { itemPosition, OverflowAlignment::Safe };
         }
         RELEASE_ASSERT_NOT_REACHED();
     };
 
     switch (primary()) {
     case PrimaryKind::Auto:
-        return valueForNormalOrAuto.value_or(ItemPosition::Auto);
+        ASSERT_NOT_REACHED();
+        return { ItemPosition::Auto };
     case PrimaryKind::Normal:
-        return valueForNormalOrAuto.value_or(ItemPosition::Normal);
+        return { ItemPosition::Normal };
     case PrimaryKind::Stretch:
         return { ItemPosition::Stretch };
     case PrimaryKind::Baseline:

--- a/Source/WebCore/style/values/align/StyleAlignSelf.h
+++ b/Source/WebCore/style/values/align/StyleAlignSelf.h
@@ -34,8 +34,7 @@ namespace Style {
 
 // <'align-self'> = auto | normal | stretch | <baseline-position> | <overflow-position>? <self-position>
 // https://drafts.csswg.org/css-align/#propdef-align-self
-// Additional values, `anchor-center` and `dialog` added to <self-position> by CSS Anchor Positioning.
-// FIXME: Add support for `dialog`.
+// Additional values, `anchor-center` added to <self-position> by CSS Anchor Positioning.
 // https://drafts.csswg.org/css-anchor-position-1/#anchor-center
 struct AlignSelf {
     constexpr AlignSelf(CSS::Keyword::Auto);
@@ -71,7 +70,7 @@ struct AlignSelf {
 
     constexpr bool operator==(const AlignSelf&) const = default;
 
-    StyleSelfAlignmentData resolve(std::optional<StyleSelfAlignmentData> = std::nullopt) const;
+    StyleSelfAlignmentData resolve(const RenderStyle* containerStyle = nullptr) const; // Resolves 'auto' against containerStyle's justify-items.
 
 private:
     enum class PrimaryKind : uint8_t {

--- a/Source/WebCore/style/values/align/StyleJustifyItems.cpp
+++ b/Source/WebCore/style/values/align/StyleJustifyItems.cpp
@@ -32,7 +32,7 @@
 namespace WebCore {
 namespace Style {
 
-StyleSelfAlignmentData JustifyItems::resolve(std::optional<StyleSelfAlignmentData> valueForNormalOrLegacy) const
+StyleSelfAlignmentData JustifyItems::resolve() const
 {
     auto resolveOverflowPosition = [&](auto itemPosition) -> StyleSelfAlignmentData {
         switch (overflowPosition()) {
@@ -48,7 +48,7 @@ StyleSelfAlignmentData JustifyItems::resolve(std::optional<StyleSelfAlignmentDat
 
     switch (primary()) {
     case PrimaryKind::Normal:
-        return valueForNormalOrLegacy.value_or(ItemPosition::Normal);
+        return { ItemPosition::Normal };
     case PrimaryKind::Stretch:
         return { ItemPosition::Stretch };
     case PrimaryKind::Baseline:
@@ -78,7 +78,7 @@ StyleSelfAlignmentData JustifyItems::resolve(std::optional<StyleSelfAlignmentDat
     case PrimaryKind::Legacy:
         switch (legacyPosition()) {
         case LegacyPositionKind::None:
-            return valueForNormalOrLegacy.value_or(ItemPosition::Legacy);
+            return { ItemPosition::Normal, OverflowAlignment::Default, ItemPositionType::Legacy };
         case LegacyPositionKind::Left:
             return { ItemPosition::Left, OverflowAlignment::Default, ItemPositionType::Legacy };
         case LegacyPositionKind::Right:

--- a/Source/WebCore/style/values/align/StyleJustifyItems.h
+++ b/Source/WebCore/style/values/align/StyleJustifyItems.h
@@ -81,7 +81,7 @@ struct JustifyItems {
 
     constexpr bool operator==(const JustifyItems&) const = default;
 
-    StyleSelfAlignmentData resolve(std::optional<StyleSelfAlignmentData> = std::nullopt) const;
+    StyleSelfAlignmentData resolve() const;
 
 private:
     enum class PrimaryKind : uint8_t {

--- a/Source/WebCore/style/values/align/StyleJustifySelf.cpp
+++ b/Source/WebCore/style/values/align/StyleJustifySelf.cpp
@@ -28,14 +28,19 @@
 
 #include "AnchorPositionEvaluator.h"
 #include "RenderStyle.h"
+#include "RenderStyle+GettersInlines.h"
 #include "StyleBuilderChecking.h"
+#include "StyleJustifyItems.h"
 #include "StylePrimitiveNumericTypes+CSSValueConversion.h"
 
 namespace WebCore {
 namespace Style {
 
-StyleSelfAlignmentData JustifySelf::resolve(std::optional<StyleSelfAlignmentData> valueForNormalOrAuto) const
+StyleSelfAlignmentData JustifySelf::resolve(const RenderStyle* containerStyle) const
 {
+    if (PrimaryKind::Auto == primary())
+        return containerStyle ? containerStyle->justifyItems().resolve() : StyleSelfAlignmentData { ItemPosition::Normal };
+
     auto resolveOverflowPosition = [&](auto itemPosition) -> StyleSelfAlignmentData {
         switch (overflowPosition()) {
         case OverflowPositionKind::None:
@@ -43,16 +48,17 @@ StyleSelfAlignmentData JustifySelf::resolve(std::optional<StyleSelfAlignmentData
         case OverflowPositionKind::Unsafe:
             return { itemPosition, OverflowAlignment::Unsafe };
         case OverflowPositionKind::Safe:
-            return { itemPosition, OverflowAlignment::Safe, };
+            return { itemPosition, OverflowAlignment::Safe };
         }
         RELEASE_ASSERT_NOT_REACHED();
     };
 
     switch (primary()) {
     case PrimaryKind::Auto:
-        return valueForNormalOrAuto.value_or(ItemPosition::Auto);
+        ASSERT_NOT_REACHED();
+        return { ItemPosition::Auto };
     case PrimaryKind::Normal:
-        return valueForNormalOrAuto.value_or(ItemPosition::Normal);
+        return { ItemPosition::Normal };
     case PrimaryKind::Stretch:
         return { ItemPosition::Stretch };
     case PrimaryKind::Baseline:

--- a/Source/WebCore/style/values/align/StyleJustifySelf.h
+++ b/Source/WebCore/style/values/align/StyleJustifySelf.h
@@ -34,8 +34,7 @@ namespace Style {
 
 // <'justify-self'> = auto | normal | stretch | <baseline-position> | <overflow-position>? [ <self-position> | left | right ]
 // https://drafts.csswg.org/css-align/#propdef-justify-self
-// Additional values, `anchor-center` and `dialog` added to <self-position> by CSS Anchor Positioning.
-// FIXME: Add support for `dialog`.
+// Additional values, `anchor-center` added to <self-position> by CSS Anchor Positioning.
 // https://drafts.csswg.org/css-anchor-position-1/#anchor-center
 struct JustifySelf {
     constexpr JustifySelf(CSS::Keyword::Auto);
@@ -75,7 +74,7 @@ struct JustifySelf {
 
     constexpr bool operator==(const JustifySelf&) const = default;
 
-    StyleSelfAlignmentData resolve(std::optional<StyleSelfAlignmentData> = std::nullopt) const;
+    StyleSelfAlignmentData resolve(const RenderStyle* containerStyle = nullptr) const; // Resolves 'auto' against containerStyle's justify-items.
 
 private:
     enum class PrimaryKind : uint8_t {


### PR DESCRIPTION
#### fd2edbac21f5950d58d0720afc0471640061a6e7
<pre>
Refactor self-alignment property resolution to manage &apos;auto&apos; instead of &apos;normal&apos;
<a href="https://bugs.webkit.org/show_bug.cgi?id=304716">https://bugs.webkit.org/show_bug.cgi?id=304716</a>
<a href="https://rdar.apple.com/167221674">rdar://167221674</a>

Reviewed by Sammy Gill.

The way &apos;normal&apos; resolution is looped through the style system ties into our
layout code in an awkward way. Instead, loop &apos;auto&apos; resolution through the
style system, and make layout code handle &apos;normal&apos; (which is much more
tied to formatting context subtleties) directly. This creates more
straightforward logic in both systems, divides the work along a more
appropriate boundary, and also avoids doing &apos;normal&apos; resolution work when
we don&apos;t need it.

This is Part 1 of a refactoring stack for grid-lanes item sizing (bug 304715).

* Source/WebCore/layout/formattingContexts/flex/FlexLayout.cpp:
(WebCore::Layout::FlexLayout::crossSizeForFlexLines const):
(WebCore::Layout::FlexLayout::computeCrossSizeForFlexItems const):
(WebCore::Layout::FlexLayout::handleCrossAxisAlignmentForFlexItems const):
* Source/WebCore/rendering/PositionedLayoutConstraints.cpp:
(WebCore::PositionedLayoutConstraints::remainingSpaceForStaticAlignment const):
(WebCore::PositionedLayoutConstraints::resolveAlignmentValue const):
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::styleDidChange):
(WebCore::RenderFlexibleBox::overflowAlignmentForFlexItem const):
(WebCore::RenderFlexibleBox::alignmentForFlexItem const):
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::styleDidChange):
(WebCore::RenderGrid::columnAxisPositionForGridItem const):
(WebCore::RenderGrid::alignSelfForGridItem const): Deleted.
(WebCore::RenderGrid::justifySelfForGridItem const): Deleted.
* Source/WebCore/rendering/style/StyleSelfAlignmentData.h:
(WebCore::StyleSelfAlignmentData::isNormal const):
(WebCore::StyleSelfAlignmentData::isStretch const):
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjust const):
* Source/WebCore/style/values/align/StyleAlignItems.cpp:
(WebCore::Style::AlignItems::resolve const):
* Source/WebCore/style/values/align/StyleAlignItems.h:
* Source/WebCore/style/values/align/StyleAlignSelf.cpp:
(WebCore::Style::AlignSelf::resolve const):
* Source/WebCore/style/values/align/StyleAlignSelf.h:
* Source/WebCore/style/values/align/StyleJustifyItems.cpp:
(WebCore::Style::JustifyItems::resolve const):
* Source/WebCore/style/values/align/StyleJustifyItems.h:
* Source/WebCore/style/values/align/StyleJustifySelf.cpp:
(WebCore::Style::JustifySelf::resolve const):
* Source/WebCore/style/values/align/StyleJustifySelf.h:

Canonical link: <a href="https://commits.webkit.org/305146@main">https://commits.webkit.org/305146@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4874a64e84b74bc3d523a16099eaf21b32efaa74

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137625 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9986 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48913 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145383 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90598 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2c9d573d-c4b6-4d03-b826-68fe3b1c9ad9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139497 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10689 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10116 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105261 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f3d018a7-9cc0-4545-8b4c-a91c6276b120) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140570 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7943 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123341 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86116 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9cf789d1-c3b8-4105-b7a9-0ffb93836efe) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7571 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5294 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5966 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116959 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41500 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148150 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9669 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42051 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113642 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9686 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8149 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113985 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28936 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7501 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119580 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64333 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9717 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37629 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9448 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73282 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9657 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9509 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->