### PR TITLE
Untangle grid self-alignment code

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1708,8 +1708,6 @@ webkit.org/b/279412 imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid
 imported/w3c/web-platform-tests/css/css-grid/subgrid/standalone-axis-size-005.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-button.html [ ImageOnlyFailure ]
 
-imported/w3c/web-platform-tests/css/css-grid/computed-grid-column.html [ Timeout ]
-
 # grid-lanes
 imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/abspos/row-grid-lanes-positioned-item-dynamic-change.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/alignment/column-justify-items-center-001.html [ ImageOnlyFailure ]
@@ -1892,7 +1890,6 @@ imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/a
 imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/row-auto-repeat-021.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/row-auto-repeat-024.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-item-with-margin-left-auto.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-grid/subgrid/sticky-subgrid-item.html [ Crash ]
 imported/w3c/web-platform-tests/css/css-grid/parsing/grid-template-columns-crash.html [ Skip ]
 
 # Flaky tests at import time

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/computed-grid-column-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/computed-grid-column-expected.txt
@@ -1,0 +1,5 @@
+X XX X
+X XX X
+
+PASS CSS Grid Layout Test: row/column is complex calc()
+

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1521,8 +1521,6 @@ webkit.org/b/212215 media/video-isplayingtoautomotiveheadunit.html [ Pass Failur
 
 webkit.org/b/212219 media/track/track-cue-missing.html [ Pass Failure ]
 
-webkit.org/b/212226 imported/w3c/web-platform-tests/css/css-grid/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-008.html [ ImageOnlyFailure ]
-
 fast/text/text-styles/-apple-system [ Pass ]
 
 webkit.org/b/214155 imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/blob.https.html [ Pass Failure ]

--- a/Source/WebCore/rendering/GridLayoutFunctions.h
+++ b/Source/WebCore/rendering/GridLayoutFunctions.h
@@ -84,11 +84,8 @@ unsigned alignmentContextForBaselineAlignment(const GridSpan&, const ItemPositio
 bool hasAutoMarginsInColumnAxis(const RenderBox&, WritingMode parentWritingMode);
 bool hasAutoMarginsInRowAxis(const RenderBox&, WritingMode parentWritingMode);
 
-bool hasAutoSizeInColumnAxis(const RenderBox&, WritingMode parentWritingMode);
-bool hasAutoSizeInRowAxis(const RenderBox&, WritingMode parentWritingMode);
-
-bool allowedToStretchGridItemAlongColumnAxis(const RenderBox&, ItemPosition, WritingMode);
-bool allowedToStretchGridItemAlongRowAxis(const RenderBox&, ItemPosition, WritingMode);
+bool hasStretchableSizeInColumnAxis(const RenderBox&, const RenderGrid& gridContainer);
+bool hasStretchableSizeInRowAxis(const RenderBox&, const RenderGrid& gridContainer);
 
 LayoutUnit availableAlignmentSpaceForGridItemBeforeStretching(const RenderGrid&, LayoutUnit gridAreaBreadthForGridItem, const RenderBox&, Style::GridTrackSizingDirection);
 

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -1244,7 +1244,7 @@ void GridTrackSizingAlgorithm::updateBaselineAlignmentContext(const RenderBox& g
     ASSERT(wasSetup());
     ASSERT(canParticipateInBaselineAlignment(gridItem, alignmentContextType));
 
-    auto align = m_renderGrid->selfAlignmentForGridItem(alignmentContextType, gridItem).position();
+    auto align = m_renderGrid->selfAlignmentForGridItem(gridItem, Style::logicalAxis(alignmentContextType)).position();
     const auto& span = m_renderGrid->gridSpanForGridItem(gridItem, alignmentContextType);
     auto alignmentContext = GridLayoutFunctions::alignmentContextForBaselineAlignment(span, align);
     m_baselineAlignment.updateBaselineAlignmentContext(align, alignmentContext, gridItem, alignmentContextType);
@@ -1261,7 +1261,7 @@ LayoutUnit GridTrackSizingAlgorithm::baselineOffsetForGridItem(const RenderBox& 
         return LayoutUnit();
 
     ASSERT_IMPLIES(alignmentContextType == Style::GridTrackSizingDirection::Rows, !m_renderGrid->isSubgridRows());
-    auto align = m_renderGrid->selfAlignmentForGridItem(alignmentContextType, gridItem).position();
+    auto align = m_renderGrid->selfAlignmentForGridItem(gridItem, Style::logicalAxis(alignmentContextType)).position();
     const auto& span = m_renderGrid->gridSpanForGridItem(gridItem, alignmentContextType);
     auto alignmentContext = GridLayoutFunctions::alignmentContextForBaselineAlignment(span, align);
     return m_baselineAlignment.baselineOffsetForGridItem(align, alignmentContext, gridItem, alignmentContextType);

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -2254,6 +2254,14 @@ void RenderBlock::offsetForContents(LayoutPoint& offset) const
     offset = flipForWritingMode(offset);
 }
 
+bool RenderBlock::willStretchItem(const RenderBox& item, LogicalBoxAxis containingAxis, StretchingMode mode) const
+{
+    UNUSED_PARAM(item);
+    UNUSED_PARAM(containingAxis);
+    UNUSED_PARAM(mode);
+    return false;
+}
+
 void RenderBlock::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const
 {
     ASSERT(!childrenInline());

--- a/Source/WebCore/rendering/RenderBlock.h
+++ b/Source/WebCore/rendering/RenderBlock.h
@@ -93,6 +93,7 @@ public:
     static bool hasPercentHeightContainerMap();
     static void clearPercentHeightDescendantsFrom(RenderBox&);
 
+    virtual bool willStretchItem(const RenderBox& item, LogicalBoxAxis containingAxis, StretchingMode = StretchingMode::Normal) const;
     bool isContainingBlockAncestorFor(RenderObject&) const;
 
     void setHasMarginBeforeQuirk(bool b) { setRenderBlockHasMarginBeforeQuirk(b); }

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -48,7 +48,7 @@ enum class AvailableLogicalHeightType : bool { ExcludeMarginBorderPadding, Inclu
 
 enum class ShouldComputePreferred : bool { ComputeActual, ComputePreferred };
 
-enum class StretchingMode { Any, Explicit };
+enum class StretchingMode { Normal, Explicit };
 
 class RenderBox : public RenderBoxModelObject {
     WTF_MAKE_TZONE_ALLOCATED(RenderBox);
@@ -392,10 +392,9 @@ public:
     // of a containing block).  HTML4 buttons, <select>s, <input>s, legends, and floating/compact elements do this.
     bool sizesPreferredLogicalWidthToFitContent() const;
 
-    bool hasStretchedLogicalHeight() const;
-    bool hasStretchedLogicalWidth(StretchingMode = StretchingMode::Any) const;
+    inline bool hasStretchedLogicalHeight(StretchingMode = StretchingMode::Normal) const;
+    inline bool hasStretchedLogicalWidth(StretchingMode = StretchingMode::Normal) const;
     bool isStretchingColumnFlexItem() const;
-    bool columnFlexItemHasStretchAlignment() const;
     
     LayoutUnit shrinkLogicalWidthToAvoidFloats(LayoutUnit childMarginStart, LayoutUnit childMarginEnd, const RenderBlock& containingBlock) const;
 
@@ -642,8 +641,6 @@ protected:
 
     virtual bool shouldResetLogicalHeightBeforeLayout() const;
     void resetLogicalHeightBeforeLayoutIfNeeded();
-
-    virtual ItemPosition selfAlignmentNormalBehavior(const RenderBox* = nullptr) const { return ItemPosition::Stretch; }
 
     // Returns false if it could not cheaply compute the extent (e.g. fixed background), in which case the returned rect may be incorrect.
     bool getBackgroundPaintedExtent(const LayoutPoint& paintOffset, LayoutRect&) const;

--- a/Source/WebCore/rendering/RenderBoxInlines.h
+++ b/Source/WebCore/rendering/RenderBoxInlines.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <WebCore/DocumentView.h>
+#include <WebCore/RenderBlock.h>
 #include <WebCore/RenderBox.h>
 #include <WebCore/RenderBoxModelObjectInlines.h>
 #include <WebCore/RenderElementInlines.h>
@@ -194,6 +195,31 @@ inline void RenderBox::setLogicalWidth(LayoutUnit size)
     else
         setHeight(size);
 }
+
+inline bool RenderBox::hasStretchedLogicalHeight(StretchingMode mode) const
+{
+    CheckedPtr containingBlock = this->containingBlock();
+    if (!containingBlock)
+        return false;
+
+    auto containingAxis = writingMode().isOrthogonal(containingBlock->writingMode())
+        ? LogicalBoxAxis::Inline : LogicalBoxAxis::Block;
+
+    return containingBlock->willStretchItem(*this, containingAxis, mode);
+}
+
+inline bool RenderBox::hasStretchedLogicalWidth(StretchingMode mode) const
+{
+    CheckedPtr containingBlock = this->containingBlock();
+    if (!containingBlock)
+        return false;
+
+    auto containingAxis = writingMode().isOrthogonal(containingBlock->writingMode())
+        ? LogicalBoxAxis::Block : LogicalBoxAxis::Inline;
+
+    return containingBlock->willStretchItem(*this, containingAxis, mode);
+}
+
 
 inline LayoutUnit resolveHeightForRatio(LayoutUnit borderAndPaddingLogicalWidth, LayoutUnit borderAndPaddingLogicalHeight, LayoutUnit logicalWidth, double aspectRatio, BoxSizing boxSizing)
 {

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -2254,6 +2254,23 @@ void RenderFlexibleBox::resetAutoMarginsAndLogicalTopInCrossAxis(RenderBox& flex
     }
 }
 
+bool RenderFlexibleBox::willStretchItem(const RenderBox& item, LogicalBoxAxis containingAxis, StretchingMode mode) const
+{
+    auto physicalAxis = mapAxisLogicalToPhysical(writingMode(), containingAxis);
+    if (isHorizontalFlow() == (BoxAxis::Horizontal == physicalAxis))
+        return false;
+
+    auto& itemStyle = item.style();
+
+    if (!itemStyle.alignSelf().resolve(&style()).isStretchy(mode == StretchingMode::Explicit ? ItemPosition::Normal : ItemPosition::Stretch))
+        return false;
+
+    bool isItemBlockAxis = (LogicalBoxAxis::Block == containingAxis) == !writingMode().isOrthogonal(itemStyle.writingMode());
+    return isItemBlockAxis
+        ? itemStyle.logicalHeight().isAuto() && !itemStyle.marginBefore().isAuto() && !itemStyle.marginAfter().isAuto()
+        : itemStyle.logicalWidth().isAuto() && !itemStyle.marginStart().isAuto() && !itemStyle.marginEnd().isAuto();
+}
+
 bool RenderFlexibleBox::needToStretchFlexItemLogicalHeight(const RenderBox& flexItem) const
 {
     // This function is a little bit magical. It relies on the fact that blocks

--- a/Source/WebCore/rendering/RenderFlexibleBox.h
+++ b/Source/WebCore/rendering/RenderFlexibleBox.h
@@ -62,6 +62,8 @@ public:
     bool hitTestChildren(const HitTestRequest&, HitTestResult&, const HitTestLocation&, const LayoutPoint& adjustedLocation, HitTestAction) override;
     void paintChildren(PaintInfo& forSelf, const LayoutPoint&, PaintInfo& forChild, bool usePrintRect) override;
 
+    bool willStretchItem(const RenderBox& item, LogicalBoxAxis containingAxis, StretchingMode = StretchingMode::Normal) const override;
+
     bool isHorizontalFlow() const;
     Direction crossAxisDirection() const;
 

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -106,9 +106,9 @@ public:
     bool isBaselineAlignmentForGridItem(const RenderBox&) const;
     bool isBaselineAlignmentForGridItem(const RenderBox& gridItem, Style::GridTrackSizingDirection alignmentContext) const;
 
-    StyleSelfAlignmentData selfAlignmentForGridItem(Style::GridTrackSizingDirection alignmentContext, const RenderBox&, const RenderStyle* = nullptr) const;
-
     StyleContentAlignmentData contentAlignment(Style::GridTrackSizingDirection) const;
+    StyleSelfAlignmentData selfAlignmentForGridItem(const RenderBox&, LogicalBoxAxis containingAxis, StretchingMode = StretchingMode::Normal, const RenderStyle* = nullptr) const;
+    bool willStretchItem(const RenderBox& item, LogicalBoxAxis containingAxis, StretchingMode = StretchingMode::Normal) const override;
 
     // These functions handle the actual implementation of layoutBlock based on if
     // the grid is a standard grid or a masonry one. While masonry is an extension of grid,
@@ -134,6 +134,7 @@ public:
 
     bool isMasonry() const;
     bool isMasonry(Style::GridTrackSizingDirection) const;
+    bool isMasonry(LogicalBoxAxis axis) const { return isMasonry(Style::gridTrackSizingDirection(axis)); }
     bool areMasonryRows() const { return isMasonry(Style::GridTrackSizingDirection::Rows); }
     bool areMasonryColumns() const { return isMasonry(Style::GridTrackSizingDirection::Columns); }
 
@@ -169,17 +170,11 @@ private:
     void computeLayoutRequirementsForItemsBeforeLayout(GridLayoutState&) const;
     bool canSetColumnAxisStretchRequirementForItem(const RenderBox&) const;
 
-    ItemPosition selfAlignmentNormalBehavior(const RenderBox* gridItem = nullptr) const override
-    {
-        ASSERT(gridItem);
-        return gridItem->isRenderReplaced() ? ItemPosition::Start : ItemPosition::Stretch;
-    }
-
     ASCIILiteral renderName() const override;
     void computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const override;
 
-    bool selfAlignmentChangedToStretch(Style::GridTrackSizingDirection alignmentContext, const RenderStyle& oldStyle, const RenderStyle& newStyle, const RenderBox&) const;
-    bool selfAlignmentChangedFromStretch(Style::GridTrackSizingDirection alignmentContext, const RenderStyle& oldStyle, const RenderStyle& newStyle, const RenderBox&) const;
+    bool selfAlignmentChangedToStretch(LogicalBoxAxis containingAxis, const RenderStyle& oldStyle, const RenderStyle& newStyle, const RenderBox& gridItem) const;
+    bool selfAlignmentChangedFromStretch(LogicalBoxAxis containingAxis, const RenderStyle& oldStyle, const RenderStyle& newStyle, const RenderBox& gridItem) const;
 
     SubgridDidChange subgridDidChange(const RenderStyle& oldStyle) const;
     bool explicitGridDidResize(const RenderStyle&) const;
@@ -249,8 +244,6 @@ private:
     LayoutOptionalOutsets allowedLayoutOverflow() const override;
     void computeOverflow(LayoutUnit oldClientAfterEdge, OptionSet<ComputeOverflowOptions> = { }) override;
 
-    StyleSelfAlignmentData justifySelfForGridItem(const RenderBox&, StretchingMode = StretchingMode::Any, const RenderStyle* = nullptr) const;
-    StyleSelfAlignmentData alignSelfForGridItem(const RenderBox&, StretchingMode = StretchingMode::Any, const RenderStyle* = nullptr) const;
     void applyStretchAlignmentToGridItemIfNeeded(RenderBox&, GridLayoutState&);
     void applySubgridStretchAlignmentToGridItemIfNeeded(RenderBox&);
     bool isChildEligibleForMarginTrim(Style::MarginTrimSide, const RenderBox&) const final;

--- a/Source/WebCore/style/values/grid/StyleGridTrackSizingDirection.h
+++ b/Source/WebCore/style/values/grid/StyleGridTrackSizingDirection.h
@@ -23,6 +23,7 @@
  */
 
 #pragma once
+#include <WebCore/BoxSides.h>
 
 namespace WebCore {
 namespace Style {
@@ -34,6 +35,20 @@ constexpr GridTrackSizingDirection orthogonalDirection(GridTrackSizingDirection 
     return direction == GridTrackSizingDirection::Columns
         ? GridTrackSizingDirection::Rows
         : GridTrackSizingDirection::Columns;
+}
+
+constexpr LogicalBoxAxis logicalAxis(GridTrackSizingDirection direction)
+{
+    return direction == GridTrackSizingDirection::Columns
+        ? LogicalBoxAxis::Inline
+        : LogicalBoxAxis::Block;
+}
+
+constexpr GridTrackSizingDirection gridTrackSizingDirection(LogicalBoxAxis axis)
+{
+    return axis == LogicalBoxAxis::Inline
+        ? GridTrackSizingDirection::Columns
+        : GridTrackSizingDirection::Rows;
 }
 
 } // namespace Style


### PR DESCRIPTION
#### 810cb2deb1447536eab4490c6cde79ebd227a04e
<pre>
Untangle grid self-alignment code
<a href="https://bugs.webkit.org/show_bug.cgi?id=304717">https://bugs.webkit.org/show_bug.cgi?id=304717</a>
<a href="https://rdar.apple.com/167221679">rdar://167221679</a>

Reviewed by Sammy Gill.

This patch untangles the self-alignment code for grid containers by:
- Consolidating self-alignment getters into a single method, so that each
    place where it&apos;s needed uses consistent logic and special cases are
    always handled instead of sometimes forgotten.
- Redesigning the API for checking stretch alignment so that we encapsulate
    logic that varies per formatting context within the formatting context
    instead of making RenderBox contain logical specific to its subclasses.

This is Part 2 of a refactoring stack for grid-lanes item sizing (bug 304715).

* LayoutTests/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/rendering/GridLayoutFunctions.cpp:
(WebCore::GridLayoutFunctions::hasStretchableSizeInColumnAxis):
(WebCore::GridLayoutFunctions::hasStretchableSizeInRowAxis):
(WebCore::GridLayoutFunctions::hasAutoSizeInColumnAxis): Deleted.
(WebCore::GridLayoutFunctions::hasAutoSizeInRowAxis): Deleted.
(WebCore::GridLayoutFunctions::allowedToStretchGridItemAlongColumnAxis): Deleted.
(WebCore::GridLayoutFunctions::allowedToStretchGridItemAlongRowAxis): Deleted.
* Source/WebCore/rendering/GridLayoutFunctions.h:
* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::GridTrackSizingAlgorithm::updateBaselineAlignmentContext):
(WebCore::GridTrackSizingAlgorithm::baselineOffsetForGridItem const):
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::willStretchItem const):
* Source/WebCore/rendering/RenderBlock.h:
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::isStretchingColumnFlexItem const):
(WebCore::RenderBox::sizesPreferredLogicalWidthToFitContent const):
(WebCore::RenderBox::shouldComputeLogicalHeightFromAspectRatio const):
(WebCore::RenderBox::columnFlexItemHasStretchAlignment const): Deleted.
(WebCore::RenderBox::hasStretchedLogicalHeight const): Deleted.
(WebCore::RenderBox::hasStretchedLogicalWidth const): Deleted.
* Source/WebCore/rendering/RenderBox.h:
(WebCore::RenderBox::selfAlignmentNormalBehavior const): Deleted.
* Source/WebCore/rendering/RenderBoxInlines.h:
(WebCore::RenderBox::hasStretchedLogicalHeight const):
(WebCore::RenderBox::hasStretchedLogicalWidth const):
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::willStretchItem const):
* Source/WebCore/rendering/RenderFlexibleBox.h:
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::selfAlignmentForGridItem const):
(WebCore::RenderGrid::selfAlignmentChangedToStretch const):
(WebCore::RenderGrid::selfAlignmentChangedFromStretch const):
(WebCore::RenderGrid::styleDidChange):
(WebCore::RenderGrid::canSetColumnAxisStretchRequirementForItem const):
(WebCore::RenderGrid::computeLayoutRequirementsForItemsBeforeLayout const):
(WebCore::RenderGrid::willStretchItem const):
(WebCore::RenderGrid::aspectRatioPrefersInline):
(WebCore::RenderGrid::applyStretchAlignmentToGridItemIfNeeded):
(WebCore::RenderGrid::isBaselineAlignmentForGridItem const):
(WebCore::RenderGrid::baselineGridItem const):
(WebCore::RenderGrid::columnAxisPositionForGridItem const):
(WebCore::RenderGrid::rowAxisPositionForGridItem const):
(WebCore::RenderGrid::columnAxisOffsetForGridItem const):
(WebCore::RenderGrid::rowAxisOffsetForGridItem const):
(WebCore::RenderGrid::alignSelfForGridItem const): Deleted.
(WebCore::RenderGrid::justifySelfForGridItem const): Deleted.
* Source/WebCore/rendering/RenderGrid.h:
* Source/WebCore/style/values/grid/StyleGridTrackSizingDirection.h:
(WebCore::Style::logicalAxis):
(WebCore::Style::gridTrackSizingDirection):

Canonical link: <a href="https://commits.webkit.org/305260@main">https://commits.webkit.org/305260@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64310dd5925c30e01f1b70559b0120aaff2f6e1e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137927 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10291 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49285 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145994 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90902 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1d4f7979-e5fa-48ac-9969-aff6140fedb7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139799 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10993 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10432 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105484 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ee875b77-86b2-489d-8984-5ea0af0a300a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140872 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8191 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123646 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86335 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2a7a50b9-3c59-47a1-828f-f43b3e300ae8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7808 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5559 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6276 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117202 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41813 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148704 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9974 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42372 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113885 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9991 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8416 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114215 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29014 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7749 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119899 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64698 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10020 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37901 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9750 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73588 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9961 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9812 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->