### PR TITLE
[JSC] Use `hasSpecialProperties` for checking iterable

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -2004,13 +2004,14 @@ bool Graph::canDoFastSpread(Node* node, const AbstractValue& value)
 
     JSGlobalObject* globalObject = globalObjectFor(node->child1()->origin.semantic);
     ArrayPrototype* arrayPrototype = globalObject->arrayPrototype();
+
     bool allGood = true;
     value.m_structure.forEach([&] (RegisteredStructure structure) {
-        allGood &= structure->globalObject() == globalObject 
+        allGood &= structure->globalObject() == globalObject
             && structure->hasMonoProto()
             && structure->storedPrototype() == arrayPrototype
             && !structure->isDictionary()
-            && structure->getConcurrently(m_vm.propertyNames->iteratorSymbol.impl()) == invalidOffset
+            && !structure->hasSpecialProperties()
             && !structure->mayInterceptIndexedAccesses();
     });
 

--- a/Source/JavaScriptCore/runtime/JSArray.cpp
+++ b/Source/JavaScriptCore/runtime/JSArray.cpp
@@ -1977,7 +1977,6 @@ bool JSArray::isIteratorProtocolFastAndNonObservable()
     if (!globalObject->isArrayPrototypeIteratorProtocolFastAndNonObservable())
         return false;
 
-    VM& vm = globalObject->vm();
     Structure* structure = this->structure();
     // This is the fast case. Many arrays will be an original array.
     if (globalObject->isOriginalArrayStructure(structure))
@@ -1989,10 +1988,7 @@ bool JSArray::isIteratorProtocolFastAndNonObservable()
     if (getPrototypeDirect() != globalObject->arrayPrototype())
         return false;
 
-    if (getDirectOffset(vm, vm.propertyNames->iteratorSymbol) != invalidOffset)
-        return false;
-
-    return true;
+    return !structure->hasSpecialProperties();
 }
 
 bool JSArray::isToPrimitiveFastAndNonObservable()

--- a/Source/JavaScriptCore/runtime/JSArrayBufferView.cpp
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferView.cpp
@@ -366,7 +366,6 @@ bool JSArrayBufferView::isIteratorProtocolFastAndNonObservable()
     if (!globalObject->isTypedArrayPrototypeIteratorProtocolFastAndNonObservable(typedArrayType))
         return false;
 
-    VM& vm = globalObject->vm();
     Structure* structure = this->structure();
     // This is the fast case. Many TypedArrays will be an original typed array structure.
     if (globalObject->isOriginalTypedArrayStructure(structure, true) || globalObject->isOriginalTypedArrayStructure(structure, false))
@@ -375,10 +374,7 @@ bool JSArrayBufferView::isIteratorProtocolFastAndNonObservable()
     if (getPrototypeDirect() != globalObject->typedArrayPrototype(typedArrayType))
         return false;
 
-    if (getDirectOffset(vm, vm.propertyNames->iteratorSymbol) != invalidOffset)
-        return false;
-
-    return true;
+    return !structure->hasSpecialProperties();
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSMapInlines.h
+++ b/Source/JavaScriptCore/runtime/JSMapInlines.h
@@ -45,7 +45,6 @@ ALWAYS_INLINE bool JSMap::isIteratorProtocolFastAndNonObservable()
     if (!globalObject->isMapPrototypeIteratorProtocolFastAndNonObservable())
         return false;
 
-    VM& vm = globalObject->vm();
     Structure* structure = this->structure();
     // This is the fast case. Many maps will be an original map.
     if (structure == globalObject->mapStructure())
@@ -54,10 +53,7 @@ ALWAYS_INLINE bool JSMap::isIteratorProtocolFastAndNonObservable()
     if (getPrototypeDirect() != globalObject->mapPrototype())
         return false;
 
-    if (getDirectOffset(vm, vm.propertyNames->iteratorSymbol) != invalidOffset)
-        return false;
-
-    return true;
+    return !structure->hasSpecialProperties();
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSSetInlines.h
+++ b/Source/JavaScriptCore/runtime/JSSetInlines.h
@@ -40,7 +40,6 @@ ALWAYS_INLINE bool JSSet::isIteratorProtocolFastAndNonObservable()
     if (!globalObject->isSetPrototypeIteratorProtocolFastAndNonObservable())
         return false;
 
-    VM& vm = globalObject->vm();
     Structure* structure = this->structure();
     // This is the fast case. Many sets will be an original set.
     if (structure == globalObject->setStructure())
@@ -49,10 +48,7 @@ ALWAYS_INLINE bool JSSet::isIteratorProtocolFastAndNonObservable()
     if (getPrototypeDirect() != globalObject->jsSetPrototype())
         return false;
 
-    if (getDirectOffset(vm, vm.propertyNames->iteratorSymbol) != invalidOffset)
-        return false;
-
-    return true;
+    return !structure->hasSpecialProperties();
 }
 
 }

--- a/Source/JavaScriptCore/runtime/StructureInlines.h
+++ b/Source/JavaScriptCore/runtime/StructureInlines.h
@@ -525,7 +525,7 @@ inline PropertyOffset Structure::add(VM& vm, PropertyName propertyName, unsigned
     }
     if (propertyName == vm.propertyNames->underscoreProto)
         setHasUnderscoreProtoPropertyExcludingOriginalProto(true);
-    else if (propertyName == vm.propertyNames->then)
+    else if (propertyName == vm.propertyNames->then || propertyName == vm.propertyNames->iteratorSymbol)
         setHasSpecialProperties(true);
 
     auto rep = propertyName.uid();
@@ -685,7 +685,7 @@ ALWAYS_INLINE auto Structure::addOrReplacePropertyWithoutTransition(VM& vm, Prop
     }
     if (propertyName == vm.propertyNames->underscoreProto)
         setHasUnderscoreProtoPropertyExcludingOriginalProto(true);
-    else if (propertyName == vm.propertyNames->then)
+    else if (propertyName == vm.propertyNames->then || propertyName == vm.propertyNames->iteratorSymbol)
         setHasSpecialProperties(true);
 
     PropertyOffset newOffset = table->nextOffset(m_inlineCapacity);


### PR DESCRIPTION
#### 7f525e50e2986e1871b7765a9a021c416260bc67
<pre>
[JSC] Use `hasSpecialProperties` for checking iterable
<a href="https://bugs.webkit.org/show_bug.cgi?id=304718">https://bugs.webkit.org/show_bug.cgi?id=304718</a>

Reviewed by Yusuke Suzuki.

This patch changes to use `hasSpecialProperties` for checking iterables.

* Source/JavaScriptCore/dfg/DFGGraph.cpp:
(JSC::DFG::Graph::canDoFastSpread):
* Source/JavaScriptCore/runtime/JSArray.cpp:
(JSC::JSArray::isIteratorProtocolFastAndNonObservable):
* Source/JavaScriptCore/runtime/JSArrayBufferView.cpp:
(JSC::JSArrayBufferView::isIteratorProtocolFastAndNonObservable):
* Source/JavaScriptCore/runtime/JSMapInlines.h:
(JSC::JSMap::isIteratorProtocolFastAndNonObservable):
* Source/JavaScriptCore/runtime/JSSetInlines.h:
(JSC::JSSet::isIteratorProtocolFastAndNonObservable):
* Source/JavaScriptCore/runtime/StructureInlines.h:
(JSC::Structure::add):
(JSC::Structure::addOrReplacePropertyWithoutTransition):

Canonical link: <a href="https://commits.webkit.org/304975@main">https://commits.webkit.org/304975@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f12b8f2f5d55a9439b0d8880ee8f36bc39826f97

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137045 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9405 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48332 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144788 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90018 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10108 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9532 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104795 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139990 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7421 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122797 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85630 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7058 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4759 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5377 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/129006 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116402 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40966 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147543 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/135531 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9088 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41535 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113149 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9106 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7631 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113478 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28828 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6979 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119065 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63401 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9136 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37119 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/168312 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8859 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72702 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43923 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9077 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8929 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->