### PR TITLE
Col elements with span > 1 don't apply width to spanned columns

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/column-track-merging-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/column-track-merging-expected.txt
@@ -145,6 +145,6 @@ FAIL main table 12 assert_equals:
   <td></td>
 </tr>
 </tbody></table>
-width expected 640 but got 180
+width expected 640 but got 580
 PASS main table 13
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/tentative/colgroup-col-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/tentative/colgroup-col-expected.txt
@@ -20,23 +20,7 @@ cg1	col1	col1	cg2	cg2	50px
 PASS table 1
 PASS table 2
 PASS table 3
-FAIL table 4 assert_equals:
-<table>
-  <colgroup span="3" style="width:100px">
-    <col>
-    <col style="width:50px" span="2">
-  </colgroup>
-  <colgroup style="width:66px">
-    <col span="2">
-  </colgroup>
-  <tbody><tr><td data-expected-width="100">cg1</td>
-  <td data-expected-width="50">col1</td>
-  <td data-expected-width="50">col1</td>
-  <td data-expected-width="66">cg2</td>
-  <td data-expected-width="66">cg2</td>
-  <td data-expected-width="75"><div style="width:75px">50px</div></td>
-</tr></tbody></table>
-width expected 66 but got 23
+PASS table 4
 PASS table 5
 PASS table 6
 

--- a/LayoutTests/platform/glib/tables/mozilla_expected_failures/core/cols1-expected.txt
+++ b/LayoutTests/platform/glib/tables/mozilla_expected_failures/core/cols1-expected.txt
@@ -20,15 +20,15 @@ layer at (0,0) size 800x600
         RenderBR {BR} at (0,0) size 0x17
         RenderText {#text} at (0,18) size 197x17
           text run at (0,18) width 197: "Both columns should be 200px"
-      RenderTable {TABLE} at (0,82) size 62x28 [bgcolor=#FFA500] [border: (1px outset #000000)]
+      RenderTable {TABLE} at (0,82) size 408x28 [bgcolor=#FFA500] [border: (1px outset #000000)]
         RenderTableCol {COLGROUP} at (0,0) size 0x0
           RenderTableCol {COL} at (0,0) size 0x0
-        RenderTableSection {TBODY} at (1,1) size 60x26
-          RenderTableRow {TR} at (0,2) size 60x22
-            RenderTableCell {TD} at (2,2) size 27x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
+        RenderTableSection {TBODY} at (1,1) size 406x26
+          RenderTableRow {TR} at (0,2) size 406x22
+            RenderTableCell {TD} at (2,2) size 200x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 23x17
                 text run at (2,2) width 23: "c11"
-            RenderTableCell {TD} at (30,2) size 28x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (204,2) size 200x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 23x17
                 text run at (2,2) width 23: "c12"
       RenderBlock (anonymous) at (0,110) size 784x36

--- a/LayoutTests/platform/ios/tables/mozilla_expected_failures/core/cols1-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla_expected_failures/core/cols1-expected.txt
@@ -20,15 +20,15 @@ layer at (0,0) size 800x600
         RenderBR {BR} at (0,0) size 0x19
         RenderText {#text} at (0,20) size 200x19
           text run at (0,20) width 200: "Both columns should be 200px"
-      RenderTable {TABLE} at (0,90) size 62x30 [bgcolor=#FFA500] [border: (1px outset #000000)]
+      RenderTable {TABLE} at (0,90) size 408x30 [bgcolor=#FFA500] [border: (1px outset #000000)]
         RenderTableCol {COLGROUP} at (0,0) size 0x0
           RenderTableCol {COL} at (0,0) size 0x0
-        RenderTableSection {TBODY} at (1,1) size 60x28
-          RenderTableRow {TR} at (0,2) size 60x24
-            RenderTableCell {TD} at (2,2) size 27x24 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
+        RenderTableSection {TBODY} at (1,1) size 406x28
+          RenderTableRow {TR} at (0,2) size 406x24
+            RenderTableCell {TD} at (2,2) size 200x24 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 23x19
                 text run at (2,2) width 23: "c11"
-            RenderTableCell {TD} at (30,2) size 28x24 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (204,2) size 200x24 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 24x19
                 text run at (2,2) width 24: "c12"
       RenderBlock (anonymous) at (0,120) size 784x40

--- a/LayoutTests/platform/mac/tables/mozilla_expected_failures/core/cols1-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla_expected_failures/core/cols1-expected.txt
@@ -20,15 +20,15 @@ layer at (0,0) size 800x600
         RenderBR {BR} at (0,0) size 0x18
         RenderText {#text} at (0,18) size 200x18
           text run at (0,18) width 200: "Both columns should be 200px"
-      RenderTable {TABLE} at (0,82) size 62x28 [bgcolor=#FFA500] [border: (1px outset #000000)]
+      RenderTable {TABLE} at (0,82) size 408x28 [bgcolor=#FFA500] [border: (1px outset #000000)]
         RenderTableCol {COLGROUP} at (0,0) size 0x0
           RenderTableCol {COL} at (0,0) size 0x0
-        RenderTableSection {TBODY} at (1,1) size 60x26
-          RenderTableRow {TR} at (0,2) size 60x22
-            RenderTableCell {TD} at (2,2) size 27x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
+        RenderTableSection {TBODY} at (1,1) size 406x26
+          RenderTableRow {TR} at (0,2) size 406x22
+            RenderTableCell {TD} at (2,2) size 200x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 23x18
                 text run at (2,2) width 23: "c11"
-            RenderTableCell {TD} at (30,2) size 28x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (204,2) size 200x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 24x18
                 text run at (2,2) width 24: "c12"
       RenderBlock (anonymous) at (0,110) size 784x36

--- a/Source/WebCore/rendering/AutoTableLayout.cpp
+++ b/Source/WebCore/rendering/AutoTableLayout.cpp
@@ -169,13 +169,19 @@ void AutoTableLayout::fullRecalc()
                 colLogicalWidth = groupLogicalWidth;
             if (colLogicalWidth.isSpecified() && colLogicalWidth.isKnownZero())
                 colLogicalWidth = CSS::Keyword::Auto { };
-            unsigned effCol = m_table->colToEffCol(currentColumn);
             unsigned span = column->span();
-            if (!colLogicalWidth.isAuto() && span == 1 && effCol < nEffCols && m_table->spanOfEffCol(effCol) == 1) {
-                m_layoutStruct[effCol].usedZoom = column->style().usedZoom();
-                m_layoutStruct[effCol].logicalWidth = colLogicalWidth;
-                if (auto fixedColLogicalWidth = colLogicalWidth.tryFixed(); fixedColLogicalWidth && m_layoutStruct[effCol].maxLogicalWidth < fixedColLogicalWidth->resolveZoom(column->style().usedZoomForLength()))
-                    m_layoutStruct[effCol].maxLogicalWidth = fixedColLogicalWidth->resolveZoom(column->style().usedZoomForLength());
+
+            // Apply width to all columns covered by this col element.
+            if (!colLogicalWidth.isAuto()) {
+                for (unsigned spanOffset = 0; spanOffset < span; ++spanOffset) {
+                    unsigned effCol = m_table->colToEffCol(currentColumn + spanOffset);
+                    if (effCol < nEffCols && m_table->spanOfEffCol(effCol) == 1) {
+                        m_layoutStruct[effCol].usedZoom = column->style().usedZoom();
+                        m_layoutStruct[effCol].logicalWidth = colLogicalWidth;
+                        if (auto fixedColLogicalWidth = colLogicalWidth.tryFixed(); fixedColLogicalWidth && m_layoutStruct[effCol].maxLogicalWidth < fixedColLogicalWidth->resolveZoom(column->style().usedZoomForLength()))
+                            m_layoutStruct[effCol].maxLogicalWidth = fixedColLogicalWidth->resolveZoom(column->style().usedZoomForLength());
+                    }
+                }
             }
             currentColumn += span;
         }


### PR DESCRIPTION
#### 3cad02c9f18f2189c456f70dacf3102bfa828fcf
<pre>
Col elements with span &gt; 1 don&apos;t apply width to spanned columns
<a href="https://bugs.webkit.org/show_bug.cgi?id=304719">https://bugs.webkit.org/show_bug.cgi?id=304719</a>
<a href="https://rdar.apple.com/167225435">rdar://167225435</a>

Reviewed by Alan Baradlay.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

When a &lt;col&gt; element has span &gt; 1, its width (or inherited colgroup
width) should apply to all columns it spans. Previously, only cols
with span=1 had their widths applied, causing cols with larger spans
to be ignored during table layout width calculation.

* Source/WebCore/rendering/AutoTableLayout.cpp:
(WebCore::AutoTableLayout::fullRecalc):

&gt; Progression:
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/tentative/colgroup-col-expected.txt: Progression
* LayoutTests/platform/mac/tables/mozilla_expected_failures/core/cols1-expected.txt: Now matches other browser engines
* LayoutTests/platform/ios/tables/mozilla_expected_failures/core/cols1-expected.txt: Ditto
* LayoutTests/platform/glib/tables/mozilla_expected_failures/core/cols1-expected.txt: Ditto

&gt; Rebaseline:
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/column-track-merging-expected.txt: Seems more closer to expected now.

Canonical link: <a href="https://commits.webkit.org/305113@main">https://commits.webkit.org/305113@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f55051b954aa870dcc4ad8868eed21cc1b9b084

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137550 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9911 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48837 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145307 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90523 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/45f8a398-7b7b-4908-b275-a0db474d10f7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139422 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10614 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10041 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105195 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/29f191c6-8bee-4a7c-a510-1f96774622cf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140495 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7877 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123274 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86048 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/07e4581f-1619-4a8a-9edb-16b2c2efe829) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/7513 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/5237 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5890 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116883 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41430 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148071 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9593 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41984 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113575 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9611 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8089 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113919 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28909 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7433 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119513 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64249 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9642 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37566 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9373 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73207 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9582 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9434 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->