### PR TITLE
Fix HTMLImageElement.currentSrc for empty src attribute

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/environment-changes/viewport-change-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/environment-changes/viewport-change-expected.txt
@@ -1,7 +1,7 @@
 
 PASS img (no src), onload, narrow
 PASS img (no src), resize to wide
-FAIL img (empty src), onload, narrow assert_equals: expected "" but got "http://localhost:8800/html/semantics/embedded-content/the-img-element/environment-changes/iframed.sub.html?id=a7ed0945-cbf4-4916-a4b1-edd6d1c0c3b1"
+PASS img (empty src), onload, narrow
 PASS img (empty src), resize to wide
 PASS img (src only) broken image, onload, narrow
 PASS img (src only) broken image, resize to wide
@@ -12,18 +12,18 @@ PASS img (srcset 1 cand) broken image, resize to wide
 PASS img (srcset 1 cand) valid image, onload, narrow
 PASS img (srcset 1 cand) valid image, resize to wide
 PASS picture: source (max-width:500px) broken image, img broken image, onload, narrow
-FAIL picture: source (max-width:500px) broken image, img broken image, resize to wide assert_unreached: Got unexpected load event Reached unreachable code
+FAIL picture: source (max-width:500px) broken image, img broken image, resize to wide assert_unreached: Got unexpected error event Reached unreachable code
 PASS picture: source (max-width:500px) broken image, img valid image, onload, narrow
 PASS picture: source (max-width:500px) broken image, img valid image, resize to wide
 PASS picture: source (max-width:500px) valid image, img broken image, onload, narrow
-FAIL picture: source (max-width:500px) valid image, img broken image, resize to wide assert_unreached: Got unexpected load event Reached unreachable code
+FAIL picture: source (max-width:500px) valid image, img broken image, resize to wide assert_unreached: Got unexpected error event Reached unreachable code
 PASS picture: source (max-width:500px) valid image, img valid image, onload, narrow
 PASS picture: source (max-width:500px) valid image, img valid image, resize to wide
 PASS picture: same URL in source (max-width:500px) and img, onload, narrow
 PASS picture: same URL in source (max-width:500px) and img, resize to wide
 PASS img (no src), onload, wide
 PASS img (no src), resize to narrow
-FAIL img (empty src), onload, wide assert_equals: expected "" but got "http://localhost:8800/html/semantics/embedded-content/the-img-element/environment-changes/iframed.sub.html?id=3c874e49-a578-4024-91cf-0e1ddb0b0396"
+PASS img (empty src), onload, wide
 PASS img (empty src), resize to narrow
 PASS img (src only) broken image, onload, wide
 PASS img (src only) broken image, resize to narrow
@@ -34,9 +34,9 @@ PASS img (srcset 1 cand) broken image, resize to narrow
 PASS img (srcset 1 cand) valid image, onload, wide
 PASS img (srcset 1 cand) valid image, resize to narrow
 PASS picture: source (max-width:500px) broken image, img broken image, onload, wide
-FAIL picture: source (max-width:500px) broken image, img broken image, resize to narrow assert_unreached: Got unexpected load event Reached unreachable code
+FAIL picture: source (max-width:500px) broken image, img broken image, resize to narrow assert_unreached: Got unexpected error event Reached unreachable code
 PASS picture: source (max-width:500px) broken image, img valid image, onload, wide
-FAIL picture: source (max-width:500px) broken image, img valid image, resize to narrow assert_unreached: Got unexpected load event Reached unreachable code
+FAIL picture: source (max-width:500px) broken image, img valid image, resize to narrow assert_unreached: Got unexpected error event Reached unreachable code
 PASS picture: source (max-width:500px) valid image, img broken image, onload, wide
 PASS picture: source (max-width:500px) valid image, img broken image, resize to narrow
 PASS picture: source (max-width:500px) valid image, img valid image, onload, wide

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/update-the-source-set-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/update-the-source-set-expected.txt
@@ -1,6 +1,6 @@
 
 PASS <img data-expect="">
-FAIL <img src="" data-expect=""> assert_equals: expected "" but got "http://localhost:8800/html/semantics/embedded-content/the-img-element/update-the-source-set.html"
+PASS <img src="" data-expect="">
 PASS <img src="data:,a" data-expect="data:,a">
 PASS <img srcset="" src="data:,a" data-expect="data:,a">
 PASS <img srcset="data:,b" src="data:,a" data-expect="data:,b">

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/update-the-source-set-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/update-the-source-set-expected.txt
@@ -1,6 +1,6 @@
 
 PASS <img data-expect="">
-FAIL <img src="" data-expect=""> assert_equals: expected "" but got "http://web-platform.test:8800/html/semantics/embedded-content/the-img-element/update-the-source-set.html"
+PASS <img src="" data-expect="">
 PASS <img src="data:,a" data-expect="data:,a">
 PASS <img srcset="" src="data:,a" data-expect="data:,a">
 PASS <img srcset="data:,b" src="data:,a" data-expect="data:,b">

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/update-the-source-set-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/update-the-source-set-expected.txt
@@ -1,6 +1,6 @@
 
 PASS <img data-expect="">
-FAIL <img src="" data-expect=""> assert_equals: expected "" but got "http://web-platform.test:8800/html/semantics/embedded-content/the-img-element/update-the-source-set.html"
+PASS <img src="" data-expect="">
 PASS <img src="data:,a" data-expect="data:,a">
 PASS <img srcset="" src="data:,a" data-expect="data:,a">
 PASS <img srcset="data:,b" src="data:,a" data-expect="data:,b">

--- a/LayoutTests/platform/mac/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/update-the-source-set-expected.txt
+++ b/LayoutTests/platform/mac/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/update-the-source-set-expected.txt
@@ -1,6 +1,6 @@
 
 PASS <img data-expect="">
-FAIL <img src="" data-expect=""> assert_equals: expected "" but got "http://web-platform.test:8800/html/semantics/embedded-content/the-img-element/update-the-source-set.html"
+PASS <img src="" data-expect="">
 PASS <img src="data:,a" data-expect="data:,a">
 PASS <img srcset="" src="data:,a" data-expect="data:,a">
 PASS <img srcset="data:,b" src="data:,a" data-expect="data:,b">

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -247,7 +247,11 @@ const AtomString& HTMLImageElement::currentSrc()
 void HTMLImageElement::setBestFitURLAndDPRFromImageCandidate(const ImageCandidate& candidate)
 {
     m_bestFitImageURL = candidate.string.toAtomString();
-    m_currentURL = protectedDocument()->completeURL(imageSourceURL());
+
+    auto& sourceURL = imageSourceURL();
+    // Only complete the URL if it's non-empty to avoid resolving "" to the document base URL.
+    m_currentURL = sourceURL.isEmpty() ? URL() : protectedDocument()->completeURL(sourceURL);
+
     m_currentSrc = { };
     if (candidate.density >= 0)
         m_imageDevicePixelRatio = 1 / candidate.density;


### PR DESCRIPTION
#### a75ff815de73fbcd5ba8992f6daccf3bf9a7e0f6
<pre>
Fix HTMLImageElement.currentSrc for empty src attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=304723">https://bugs.webkit.org/show_bug.cgi?id=304723</a>
<a href="https://rdar.apple.com/167229274">rdar://167229274</a>

Reviewed by Chris Dumez.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Don&apos;t resolve empty src attributes to the document base URL when
setting the image&apos;s current URL. The completeURL() call should only
be made for non-empty source URLs to comply with the HTML specification [1].

When the source URL is empty, the current URL should be set to an empty
URL rather than resolving to the document&apos;s base URL, ensuring currentSrc
returns the empty string as specified.

[1] <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-currentsrc">https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-currentsrc</a>

* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::setBestFitURLAndDPRFromImageCandidate):
&gt; Progression:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/environment-changes/viewport-change-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/update-the-source-set-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/update-the-source-set-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/update-the-source-set-expected.txt:
* LayoutTests/platform/mac/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/update-the-source-set-expected.txt:

Canonical link: <a href="https://commits.webkit.org/304982@main">https://commits.webkit.org/304982@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef1c54ce176d03a0be96b650f57658108a7adf7d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137078 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9438 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48365 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144821 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90051 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/038d2e98-9644-404b-b4f7-f15d09af1055) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138950 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10141 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9565 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104822 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/878ac0d8-718a-4536-b93f-9ba4df3faf36) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140023 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7452 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122834 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85657 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9eeda9e7-30f3-49e4-b478-bd136f940b6d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7089 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4794 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5410 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116437 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41002 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147577 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9121 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41568 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113176 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9139 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7664 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113506 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28832 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7012 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119098 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63454 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9169 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37152 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8892 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72735 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9110 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8962 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->