### PR TITLE
[GLIB] Rebaseline tests after 304958@main

### DIFF
--- a/LayoutTests/platform/glib/fast/block/basic/015-expected.txt
+++ b/LayoutTests/platform/glib/fast/block/basic/015-expected.txt
@@ -1,163 +1,163 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x453
-  RenderBlock {HTML} at (0,0) size 800x453
-    RenderBody {BODY} at (8,21) size 784x416
-      RenderBlock {H1} at (0,0) size 784x38
-        RenderText {#text} at (0,1) size 454x36
-          text run at (0,1) width 454: "Minimum and Maximum Widths"
-      RenderBlock {DIV} at (0,59) size 784x27 [border: (3px solid #800080)]
-        RenderText {#text} at (3,3) size 33x19
-          text run at (3,3) width 33: "This "
-        RenderInline {CODE} at (35,8) size 24x14
-          RenderText {#text} at (35,8) size 24x14
-            text run at (35,8) width 24: "div"
-        RenderText {#text} at (58,3) size 418x19
-          text run at (58,3) width 418: " should have a medium solid purple border, as should all the rest."
-      RenderBlock {DIV} at (0,85) size 320x67 [border: (3px solid #800080)]
-        RenderText {#text} at (3,3) size 33x19
-          text run at (3,3) width 33: "This "
-        RenderInline {CODE} at (35,8) size 24x14
-          RenderText {#text} at (35,8) size 24x14
-            text run at (35,8) width 24: "div"
-        RenderText {#text} at (3,3) size 302x39
-          text run at (58,3) width 192: " should have a width of 40%. "
-          text run at (249,3) width 56: "This is a"
-          text run at (3,23) width 64: "reference "
-        RenderInline {CODE} at (66,28) size 24x14
-          RenderText {#text} at (66,28) size 24x14
-            text run at (66,28) width 24: "div"
-        RenderText {#text} at (89,23) size 183x19
-          text run at (89,23) width 183: " and should work as long as "
-        RenderInline {CODE} at (271,28) size 40x14
-          RenderText {#text} at (271,28) size 40x14
-            text run at (271,28) width 40: "width"
-        RenderText {#text} at (3,43) size 44x19
-          text run at (3,43) width 44: "works."
-      RenderBlock {DIV} at (0,151) size 320x27 [border: (3px solid #800080)]
-        RenderText {#text} at (3,3) size 33x19
-          text run at (3,3) width 33: "This "
-        RenderInline {CODE} at (35,8) size 24x14
-          RenderText {#text} at (35,8) size 24x14
-            text run at (35,8) width 24: "div"
-        RenderText {#text} at (58,3) size 188x19
-          text run at (58,3) width 188: " should have a width of 40%."
-      RenderBlock {DIV} at (0,177) size 320x27 [border: (3px solid #800080)]
-        RenderText {#text} at (3,3) size 33x19
-          text run at (3,3) width 33: "This "
-        RenderInline {CODE} at (35,8) size 24x14
-          RenderText {#text} at (35,8) size 24x14
-            text run at (35,8) width 24: "div"
-        RenderText {#text} at (58,3) size 188x19
-          text run at (58,3) width 188: " should have a width of 40%."
-      RenderBlock {DIV} at (0,203) size 320x27 [border: (3px solid #800080)]
-        RenderText {#text} at (3,3) size 33x19
-          text run at (3,3) width 33: "This "
-        RenderInline {CODE} at (35,8) size 24x14
-          RenderText {#text} at (35,8) size 24x14
-            text run at (35,8) width 24: "div"
-        RenderText {#text} at (58,3) size 188x19
-          text run at (58,3) width 188: " should have a width of 40%."
-      RenderBlock {DIV} at (0,229) size 320x27 [border: (3px solid #800080)]
-        RenderText {#text} at (3,3) size 33x19
-          text run at (3,3) width 33: "This "
-        RenderInline {CODE} at (35,8) size 24x14
-          RenderText {#text} at (35,8) size 24x14
-            text run at (35,8) width 24: "div"
-        RenderText {#text} at (58,3) size 188x19
-          text run at (58,3) width 188: " should have a width of 40%."
-      RenderBlock {DIV} at (0,255) size 320x27 [border: (3px solid #800080)]
-        RenderText {#text} at (3,3) size 33x19
-          text run at (3,3) width 33: "This "
-        RenderInline {CODE} at (35,8) size 24x14
-          RenderText {#text} at (35,8) size 24x14
-            text run at (35,8) width 24: "div"
-        RenderText {#text} at (58,3) size 188x19
-          text run at (58,3) width 188: " should have a width of 40%."
-      RenderBlock {DIV} at (0,281) size 320x27 [border: (3px solid #800080)]
-        RenderText {#text} at (3,3) size 33x19
-          text run at (3,3) width 33: "This "
-        RenderInline {CODE} at (35,8) size 24x14
-          RenderText {#text} at (35,8) size 24x14
-            text run at (35,8) width 24: "div"
-        RenderText {#text} at (58,3) size 188x19
-          text run at (58,3) width 188: " should have a width of 40%."
-      RenderBlock {DIV} at (0,307) size 320x27 [border: (3px solid #800080)]
-        RenderText {#text} at (3,3) size 33x19
-          text run at (3,3) width 33: "This "
-        RenderInline {CODE} at (35,8) size 24x14
-          RenderText {#text} at (35,8) size 24x14
-            text run at (35,8) width 24: "div"
-        RenderText {#text} at (58,3) size 188x19
-          text run at (58,3) width 188: " should have a width of 40%."
-      RenderBlock {DIV} at (0,333) size 320x27 [border: (3px solid #800080)]
-        RenderText {#text} at (3,3) size 33x19
-          text run at (3,3) width 33: "This "
-        RenderInline {CODE} at (35,8) size 24x14
-          RenderText {#text} at (35,8) size 24x14
-            text run at (35,8) width 24: "div"
-        RenderText {#text} at (58,3) size 188x19
-          text run at (58,3) width 188: " should have a width of 40%."
-      RenderBlock {P} at (0,375) size 784x41
-        RenderText {#text} at (0,0) size 204x19
-          text run at (0,0) width 204: "If the browser does not support "
-        RenderInline {CODE} at (203,5) size 71x14
-          RenderText {#text} at (203,5) size 71x14
-            text run at (203,5) width 71: "min-width"
-        RenderText {#text} at (273,0) size 32x19
-          text run at (273,0) width 32: " and "
-        RenderInline {CODE} at (304,5) size 72x14
-          RenderText {#text} at (304,5) size 72x14
-            text run at (304,5) width 72: "max-width"
-        RenderText {#text} at (375,0) size 176x19
-          text run at (375,0) width 176: ", then the widths should be "
-        RenderInline {CODE} at (550,5) size 32x14
-          RenderText {#text} at (550,5) size 32x14
-            text run at (550,5) width 32: "auto"
-        RenderText {#text} at (581,0) size 9x19
-          text run at (581,0) width 9: ", "
-        RenderInline {CODE} at (589,5) size 25x14
-          RenderText {#text} at (589,5) size 25x14
-            text run at (589,5) width 25: "40%"
-        RenderText {#text} at (613,0) size 9x19
-          text run at (613,0) width 9: ", "
-        RenderInline {CODE} at (621,5) size 24x14
-          RenderText {#text} at (621,5) size 24x14
-            text run at (621,5) width 24: "30%"
-        RenderText {#text} at (644,0) size 9x19
-          text run at (644,0) width 9: ", "
-        RenderInline {CODE} at (652,5) size 24x14
-          RenderText {#text} at (652,5) size 24x14
-            text run at (652,5) width 24: "50%"
-        RenderText {#text} at (675,0) size 9x19
-          text run at (675,0) width 9: ", "
-        RenderInline {CODE} at (683,5) size 25x14
-          RenderText {#text} at (683,5) size 25x14
-            text run at (683,5) width 25: "50%"
-        RenderText {#text} at (707,0) size 9x19
-          text run at (707,0) width 9: ", "
-        RenderInline {CODE} at (715,5) size 24x14
-          RenderText {#text} at (715,5) size 24x14
-            text run at (715,5) width 24: "40%"
-        RenderText {#text} at (738,0) size 9x19
-          text run at (738,0) width 9: ", "
-        RenderInline {CODE} at (746,5) size 25x14
-          RenderText {#text} at (746,5) size 25x14
-            text run at (746,5) width 25: "30%"
-        RenderText {#text} at (770,0) size 5x19
-          text run at (770,0) width 5: ","
-        RenderInline {CODE} at (0,25) size 24x14
-          RenderText {#text} at (0,25) size 24x14
-            text run at (0,25) width 24: "40%"
-        RenderText {#text} at (23,20) size 9x19
-          text run at (23,20) width 9: ", "
-        RenderInline {CODE} at (31,25) size 32x14
-          RenderText {#text} at (31,25) size 32x14
-            text run at (31,25) width 32: "auto"
-        RenderText {#text} at (62,20) size 197x19
-          text run at (62,20) width 197: " (with 70% margin-right), and "
-        RenderInline {CODE} at (258,25) size 32x14
-          RenderText {#text} at (258,25) size 32x14
-            text run at (258,25) width 32: "auto"
-        RenderText {#text} at (289,20) size 5x19
-          text run at (289,20) width 5: "."
+layer at (0,0) size 800x424
+  RenderBlock {HTML} at (0,0) size 800x424
+    RenderBody {BODY} at (8,21) size 784x387
+      RenderBlock {H1} at (0,0) size 784x37
+        RenderText {#text} at (0,0) size 457x36
+          text run at (0,0) width 457: "Minimum and Maximum Widths"
+      RenderBlock {DIV} at (0,58) size 784x25 [border: (3px solid #800080)]
+        RenderText {#text} at (3,3) size 32x17
+          text run at (3,3) width 32: "This "
+        RenderInline {CODE} at (35,6) size 24x15
+          RenderText {#text} at (35,6) size 24x15
+            text run at (35,6) width 24: "div"
+        RenderText {#text} at (59,3) size 408x17
+          text run at (59,3) width 408: " should have a medium solid purple border, as should all the rest."
+      RenderBlock {DIV} at (0,82) size 320x61 [border: (3px solid #800080)]
+        RenderText {#text} at (3,3) size 32x17
+          text run at (3,3) width 32: "This "
+        RenderInline {CODE} at (35,6) size 24x15
+          RenderText {#text} at (35,6) size 24x15
+            text run at (35,6) width 24: "div"
+        RenderText {#text} at (3,3) size 298x35
+          text run at (59,3) width 189: " should have a width of 40%. "
+          text run at (248,3) width 53: "This is a"
+          text run at (3,21) width 62: "reference "
+        RenderInline {CODE} at (65,24) size 24x15
+          RenderText {#text} at (65,24) size 24x15
+            text run at (65,24) width 24: "div"
+        RenderText {#text} at (89,21) size 180x17
+          text run at (89,21) width 180: " and should work as long as "
+        RenderInline {CODE} at (269,24) size 40x15
+          RenderText {#text} at (269,24) size 40x15
+            text run at (269,24) width 40: "width"
+        RenderText {#text} at (3,39) size 43x17
+          text run at (3,39) width 43: "works."
+      RenderBlock {DIV} at (0,142) size 320x25 [border: (3px solid #800080)]
+        RenderText {#text} at (3,3) size 32x17
+          text run at (3,3) width 32: "This "
+        RenderInline {CODE} at (35,6) size 24x15
+          RenderText {#text} at (35,6) size 24x15
+            text run at (35,6) width 24: "div"
+        RenderText {#text} at (59,3) size 185x17
+          text run at (59,3) width 185: " should have a width of 40%."
+      RenderBlock {DIV} at (0,166) size 320x25 [border: (3px solid #800080)]
+        RenderText {#text} at (3,3) size 32x17
+          text run at (3,3) width 32: "This "
+        RenderInline {CODE} at (35,6) size 24x15
+          RenderText {#text} at (35,6) size 24x15
+            text run at (35,6) width 24: "div"
+        RenderText {#text} at (59,3) size 185x17
+          text run at (59,3) width 185: " should have a width of 40%."
+      RenderBlock {DIV} at (0,190) size 320x25 [border: (3px solid #800080)]
+        RenderText {#text} at (3,3) size 32x17
+          text run at (3,3) width 32: "This "
+        RenderInline {CODE} at (35,6) size 24x15
+          RenderText {#text} at (35,6) size 24x15
+            text run at (35,6) width 24: "div"
+        RenderText {#text} at (59,3) size 185x17
+          text run at (59,3) width 185: " should have a width of 40%."
+      RenderBlock {DIV} at (0,214) size 320x25 [border: (3px solid #800080)]
+        RenderText {#text} at (3,3) size 32x17
+          text run at (3,3) width 32: "This "
+        RenderInline {CODE} at (35,6) size 24x15
+          RenderText {#text} at (35,6) size 24x15
+            text run at (35,6) width 24: "div"
+        RenderText {#text} at (59,3) size 185x17
+          text run at (59,3) width 185: " should have a width of 40%."
+      RenderBlock {DIV} at (0,238) size 320x25 [border: (3px solid #800080)]
+        RenderText {#text} at (3,3) size 32x17
+          text run at (3,3) width 32: "This "
+        RenderInline {CODE} at (35,6) size 24x15
+          RenderText {#text} at (35,6) size 24x15
+            text run at (35,6) width 24: "div"
+        RenderText {#text} at (59,3) size 185x17
+          text run at (59,3) width 185: " should have a width of 40%."
+      RenderBlock {DIV} at (0,262) size 320x25 [border: (3px solid #800080)]
+        RenderText {#text} at (3,3) size 32x17
+          text run at (3,3) width 32: "This "
+        RenderInline {CODE} at (35,6) size 24x15
+          RenderText {#text} at (35,6) size 24x15
+            text run at (35,6) width 24: "div"
+        RenderText {#text} at (59,3) size 185x17
+          text run at (59,3) width 185: " should have a width of 40%."
+      RenderBlock {DIV} at (0,286) size 320x25 [border: (3px solid #800080)]
+        RenderText {#text} at (3,3) size 32x17
+          text run at (3,3) width 32: "This "
+        RenderInline {CODE} at (35,6) size 24x15
+          RenderText {#text} at (35,6) size 24x15
+            text run at (35,6) width 24: "div"
+        RenderText {#text} at (59,3) size 185x17
+          text run at (59,3) width 185: " should have a width of 40%."
+      RenderBlock {DIV} at (0,310) size 320x25 [border: (3px solid #800080)]
+        RenderText {#text} at (3,3) size 32x17
+          text run at (3,3) width 32: "This "
+        RenderInline {CODE} at (35,6) size 24x15
+          RenderText {#text} at (35,6) size 24x15
+            text run at (35,6) width 24: "div"
+        RenderText {#text} at (59,3) size 185x17
+          text run at (59,3) width 185: " should have a width of 40%."
+      RenderBlock {P} at (0,350) size 784x37
+        RenderText {#text} at (0,0) size 200x17
+          text run at (0,0) width 200: "If the browser does not support "
+        RenderInline {CODE} at (200,3) size 72x15
+          RenderText {#text} at (200,3) size 72x15
+            text run at (200,3) width 72: "min-width"
+        RenderText {#text} at (272,0) size 31x17
+          text run at (272,0) width 31: " and "
+        RenderInline {CODE} at (303,3) size 72x15
+          RenderText {#text} at (303,3) size 72x15
+            text run at (303,3) width 72: "max-width"
+        RenderText {#text} at (375,0) size 173x17
+          text run at (375,0) width 173: ", then the widths should be "
+        RenderInline {CODE} at (548,3) size 32x15
+          RenderText {#text} at (548,3) size 32x15
+            text run at (548,3) width 32: "auto"
+        RenderText {#text} at (580,0) size 8x17
+          text run at (580,0) width 8: ", "
+        RenderInline {CODE} at (588,3) size 24x15
+          RenderText {#text} at (588,3) size 24x15
+            text run at (588,3) width 24: "40%"
+        RenderText {#text} at (612,0) size 8x17
+          text run at (612,0) width 8: ", "
+        RenderInline {CODE} at (620,3) size 24x15
+          RenderText {#text} at (620,3) size 24x15
+            text run at (620,3) width 24: "30%"
+        RenderText {#text} at (644,0) size 8x17
+          text run at (644,0) width 8: ", "
+        RenderInline {CODE} at (652,3) size 24x15
+          RenderText {#text} at (652,3) size 24x15
+            text run at (652,3) width 24: "50%"
+        RenderText {#text} at (676,0) size 8x17
+          text run at (676,0) width 8: ", "
+        RenderInline {CODE} at (684,3) size 24x15
+          RenderText {#text} at (684,3) size 24x15
+            text run at (684,3) width 24: "50%"
+        RenderText {#text} at (708,0) size 8x17
+          text run at (708,0) width 8: ", "
+        RenderInline {CODE} at (716,3) size 24x15
+          RenderText {#text} at (716,3) size 24x15
+            text run at (716,3) width 24: "40%"
+        RenderText {#text} at (740,0) size 8x17
+          text run at (740,0) width 8: ", "
+        RenderInline {CODE} at (748,3) size 24x15
+          RenderText {#text} at (748,3) size 24x15
+            text run at (748,3) width 24: "30%"
+        RenderText {#text} at (772,0) size 4x17
+          text run at (772,0) width 4: ","
+        RenderInline {CODE} at (0,21) size 24x15
+          RenderText {#text} at (0,21) size 24x15
+            text run at (0,21) width 24: "40%"
+        RenderText {#text} at (24,18) size 8x17
+          text run at (24,18) width 8: ", "
+        RenderInline {CODE} at (32,21) size 32x15
+          RenderText {#text} at (32,21) size 32x15
+            text run at (32,21) width 32: "auto"
+        RenderText {#text} at (64,18) size 192x17
+          text run at (64,18) width 192: " (with 70% margin-right), and "
+        RenderInline {CODE} at (255,21) size 33x15
+          RenderText {#text} at (255,21) size 33x15
+            text run at (255,21) width 33: "auto"
+        RenderText {#text} at (287,18) size 5x17
+          text run at (287,18) width 5: "."

--- a/LayoutTests/platform/glib/fast/css-generated-content/005-expected.txt
+++ b/LayoutTests/platform/glib/fast/css-generated-content/005-expected.txt
@@ -3,7 +3,7 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderInline {Q} at (0,0) size 784x51
+      RenderInline {Q} at (0,0) size 158x51
         RenderInline (generated) at (0,0) size 7x17
           RenderQuote at (0,0) size 7x17
             RenderText at (0,0) size 7x17

--- a/LayoutTests/platform/glib/fast/css-generated-content/after-duplicated-after-split-expected.txt
+++ b/LayoutTests/platform/glib/fast/css-generated-content/after-duplicated-after-split-expected.txt
@@ -20,8 +20,8 @@ layer at (0,0) size 800x600
       RenderBlock {DIV} at (0,68) size 784x222
         RenderText {#text} at (0,2) size 455x107
           text run at (0,2) width 455: "The test did"
-        RenderInline {SPAN} at (0,2) size 784x218
-          RenderInline {B} at (0,2) size 784x218
+        RenderInline {SPAN} at (0,2) size 455x218
+          RenderInline {B} at (0,2) size 455x218
             RenderBlock {DIV} at (0,111) size 784x0
           RenderInline (generated) at (0,113) size 147x107
             RenderText at (0,113) size 147x107

--- a/LayoutTests/platform/glib/fast/css-generated-content/beforeAfter-interdocument-expected.txt
+++ b/LayoutTests/platform/glib/fast/css-generated-content/beforeAfter-interdocument-expected.txt
@@ -15,7 +15,7 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,0) size 538x17
           text run at (0,0) width 538: "This test that moving a quote element sets the before / after flag in the final document."
       RenderBlock {DIV} at (0,68) size 784x52
-        RenderInline {Q} at (0,0) size 784x51
+        RenderInline {Q} at (0,0) size 158x51
           RenderInline (generated) at (0,0) size 7x17
             RenderQuote at (0,0) size 7x17
               RenderText at (0,0) size 7x17

--- a/LayoutTests/platform/glib/fast/dynamic/insert-before-table-part-in-continuation-expected.txt
+++ b/LayoutTests/platform/glib/fast/dynamic/insert-before-table-part-in-continuation-expected.txt
@@ -67,7 +67,7 @@ layer at (0,0) size 800x600
                   RenderText {#text} at (0,0) size 103x17
                     text run at (0,0) width 103: "...continues here"
       RenderBlock {DIV} at (0,208) size 784x36
-        RenderInline {SPAN} at (0,0) size 784x35
+        RenderInline {SPAN} at (0,0) size 103x35
           RenderText {#text} at (0,0) size 40x17
             text run at (0,0) width 40: "Text..."
           RenderBlock {DIV} at (0,18) size 784x0
@@ -124,7 +124,7 @@ layer at (0,0) size 800x600
                   RenderText {#text} at (0,0) size 103x17
                     text run at (0,0) width 103: "...continues here"
       RenderBlock {DIV} at (0,334) size 784x36
-        RenderInline {SPAN} at (0,0) size 784x35
+        RenderInline {SPAN} at (0,0) size 103x35
           RenderText {#text} at (0,0) size 40x17
             text run at (0,0) width 40: "Text..."
           RenderBlock {DIV} at (0,18) size 784x0
@@ -183,7 +183,7 @@ layer at (0,0) size 800x600
                   RenderText {#text} at (0,0) size 103x17
                     text run at (0,0) width 103: "...continues here"
       RenderBlock {DIV} at (0,460) size 784x36
-        RenderInline {SPAN} at (0,0) size 784x35
+        RenderInline {SPAN} at (0,0) size 103x35
           RenderText {#text} at (0,0) size 40x17
             text run at (0,0) width 40: "Text..."
           RenderBlock {DIV} at (0,18) size 784x0

--- a/LayoutTests/platform/glib/fast/inline/continuation-outlines-with-layers-2-expected.txt
+++ b/LayoutTests/platform/glib/fast/inline/continuation-outlines-with-layers-2-expected.txt
@@ -12,10 +12,10 @@ layer at (0,0) size 800x316
         RenderText {#text} at (0,0) size 156x17
           text run at (0,0) width 156: "This is just for reference:"
       RenderBlock {DIV} at (0,184) size 784x100
-        RenderInline {SPAN} at (0,0) size 784x100 [bgcolor=#FFFFFF]
+        RenderInline {SPAN} at (0,0) size 160x100 [bgcolor=#FFFFFF]
           RenderText {#text} at (0,0) size 50x50
             text run at (0,0) width 50: " "
-          RenderInline {SPAN} at (0,0) size 784x100
+          RenderInline {SPAN} at (0,0) size 160x100
             RenderText {#text} at (60,0) size 100x50
               text run at (60,0) width 50: " "
               text run at (110,0) width 50: " "
@@ -24,11 +24,11 @@ layer at (0,0) size 800x316
               text run at (0,50) width 50: " "
           RenderText {#text} at (0,0) size 0x0
         RenderText {#text} at (0,0) size 0x0
-layer at (8,50) size 784x100
-  RenderInline (relative positioned) {SPAN} at (0,0) size 784x100 [bgcolor=#FFFFFF]
+layer at (8,50) size 160x100
+  RenderInline (relative positioned) {SPAN} at (0,0) size 160x100 [bgcolor=#FFFFFF]
     RenderText {#text} at (0,0) size 50x50
       text run at (0,0) width 50: " "
-    RenderInline {SPAN} at (0,0) size 784x100
+    RenderInline {SPAN} at (0,0) size 160x100
       RenderText {#text} at (60,0) size 100x50
         text run at (60,0) width 50: " "
         text run at (110,0) width 50: " "

--- a/LayoutTests/platform/glib/fast/inline/outline-continuations-expected.txt
+++ b/LayoutTests/platform/glib/fast/inline/outline-continuations-expected.txt
@@ -3,9 +3,9 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x573
-      RenderInline {BIG} at (0,0) size 784x42
+      RenderInline {BIG} at (0,0) size 50x42
         RenderText {#text} at (0,0) size 0x0
-        RenderInline {PARSERERROR} at (0,0) size 784x61
+        RenderInline {PARSERERROR} at (0,0) size 50x61
           RenderText {#text} at (0,0) size 50x21
             text run at (0,0) width 50: "TEXT"
           RenderBlock {P} at (0,41) size 784x0

--- a/LayoutTests/platform/glib/fast/invalid/018-expected.txt
+++ b/LayoutTests/platform/glib/fast/invalid/018-expected.txt
@@ -17,7 +17,7 @@ layer at (0,0) size 800x600
         RenderTableSection {TBODY} at (0,0) size 4x4
           RenderTableRow {TR} at (0,2) size 4x0
       RenderBlock (anonymous) at (0,28) size 784x18
-        RenderInline {FONT} at (0,0) size 784x17
+        RenderInline {FONT} at (0,0) size 0x17
           RenderText {#text} at (0,0) size 0x0
           RenderBlock {P} at (0,0) size 784x0
           RenderInline {A} at (0,0) size 0x17

--- a/LayoutTests/platform/glib/http/tests/misc/acid3-expected.txt
+++ b/LayoutTests/platform/glib/http/tests/misc/acid3-expected.txt
@@ -30,7 +30,7 @@ layer at (20,20) size 644x433
           RenderText {#text} at (400,4) size 168x112
             text run at (400,4) width 168: "100"
       RenderBlock (anonymous) at (41,334) size 562x0
-        RenderInline {MAP} at (0,0) size 562x0
+        RenderInline {MAP} at (0,0) size 0x0
           RenderIFrame {IFRAME} at (0,0) size 0x0
             layer at (0,0) size 1x1
               RenderView at (0,0) size 0x0

--- a/LayoutTests/platform/glib/tables/mozilla_expected_failures/bugs/bug56024-expected.txt
+++ b/LayoutTests/platform/glib/tables/mozilla_expected_failures/bugs/bug56024-expected.txt
@@ -18,7 +18,7 @@ layer at (0,0) size 800x96
                         text run at (1,55) width 176: "nationally televised debates."
                       RenderBR {BR} at (177,55) size 0x17
             RenderTableCell {TD} at (302,2) size 96x74 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]
-              RenderInline {FONT} at (1,3) size 94x72 [color=#CC3333]
+              RenderInline {FONT} at (1,3) size 83x72 [color=#CC3333]
                 RenderText {#text} at (1,3) size 83x71
                   text run at (1,1) width 70: "Avon.com:"
                   text run at (1,19) width 78: "Fall makeup"

--- a/LayoutTests/platform/glib/transforms/3d/general/perspective-non-layer-expected.txt
+++ b/LayoutTests/platform/glib/transforms/3d/general/perspective-non-layer-expected.txt
@@ -3,7 +3,7 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderInline {SPAN} at (0,3) size 784x21
+      RenderInline {SPAN} at (0,3) size 192x21
         RenderText {#text} at (0,0) size 0x0
         RenderTextControl {INPUT} at (0,0) size 192x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
         RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/wpe/transforms/3d/general/perspective-non-layer-expected.txt
+++ b/LayoutTests/platform/wpe/transforms/3d/general/perspective-non-layer-expected.txt
@@ -3,7 +3,7 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderInline {SPAN} at (0,3) size 784x21
+      RenderInline {SPAN} at (0,3) size 173x21
         RenderText {#text} at (0,0) size 0x0
         RenderTextControl {INPUT} at (0,0) size 173x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
         RenderText {#text} at (0,0) size 0x0


### PR DESCRIPTION
#### e3df8b613258470f83aff5225de70b6bd4c435ab
<pre>
[GLIB] Rebaseline tests after 304958@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=304730">https://bugs.webkit.org/show_bug.cgi?id=304730</a>

Unreviewed gardening.

* LayoutTests/platform/glib/fast/block/basic/015-expected.txt:
* LayoutTests/platform/glib/fast/css-generated-content/005-expected.txt:
* LayoutTests/platform/glib/fast/css-generated-content/after-duplicated-after-split-expected.txt:
* LayoutTests/platform/glib/fast/css-generated-content/beforeAfter-interdocument-expected.txt:
* LayoutTests/platform/glib/fast/dynamic/insert-before-table-part-in-continuation-expected.txt:
* LayoutTests/platform/glib/fast/inline/continuation-outlines-with-layers-2-expected.txt:
* LayoutTests/platform/glib/fast/inline/outline-continuations-expected.txt:
* LayoutTests/platform/glib/fast/invalid/018-expected.txt:
* LayoutTests/platform/glib/http/tests/misc/acid3-expected.txt:
* LayoutTests/platform/glib/tables/mozilla_expected_failures/bugs/bug56024-expected.txt:
* LayoutTests/platform/glib/transforms/3d/general/perspective-non-layer-expected.txt:
* LayoutTests/platform/wpe/transforms/3d/general/perspective-non-layer-expected.txt:

Canonical link: <a href="https://commits.webkit.org/304961@main">https://commits.webkit.org/304961@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca52bb7b16d13603a37945ca12ef383133878962

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137041 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9401 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48328 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144784 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90014 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10104 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9528 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104793 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139986 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7418 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122795 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85628 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7055 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4755 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5373 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116398 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40964 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147539 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9084 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41533 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113147 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9102 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7628 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113476 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6976 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119063 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63392 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21117 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9132 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/37117 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8855 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9073 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8925 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->