### PR TITLE
Upstream form accessory adjustments

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8342,10 +8342,7 @@ imported/w3c/web-platform-tests/inert/inert-pseudo-element-hittest.html [ Failur
 
 webkit.org/b/301670 imported/w3c/web-platform-tests/css/css-anchor-position/popover-implicit-anchor.html [ Failure ]
 
-# webkit.org/b/301869 [iOS] 5 tests in fast/forms/ios are constant failuring with text diff
-fast/forms/ios/accessory-bar-navigation.html [ Failure ]
-fast/forms/ios/focus-input-via-button.html [ Failure ]
-fast/forms/ios/focus-long-textarea.html [ Failure ]
+# webkit.org/b/304751 [iOS] 2 tests in fast/forms/ios are constant failuring with text diff
 fast/forms/ios/zoom-after-input-tap-wide-input.html [ Failure ]
 fast/forms/ios/zoom-after-input-tap.html [ Failure ]
 

--- a/Source/WebKit/UIProcess/ios/forms/WKFormAccessoryView.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormAccessoryView.mm
@@ -28,6 +28,7 @@
 
 #if PLATFORM(IOS_FAMILY)
 
+#import "WebPreferencesDefaultValues.h"
 #import <pal/system/ios/UserInterfaceIdiom.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
@@ -96,23 +97,10 @@ inline static RetainPtr<UIToolbar> createToolbarWithItems(NSArray<UIBarButtonIte
     BOOL _usesUniversalControlBar;
 }
 
-#if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/WKFormAccessoryViewAdditions.mm>)
-#import <WebKitAdditions/WKFormAccessoryViewAdditions.mm>
-#else
 - (CGFloat)_toolbarMargin
 {
-    return 0;
+    return WebKit::isLiquidGlassEnabled() ? 10 : 0;
 }
-
-- (BOOL)_useCheckmarkForDone
-{
-    return NO;
-}
-
-- (void)_adjustFlexibleSpaceItem:(UIBarButtonItem *)item
-{
-}
-#endif
 
 - (instancetype)_initForUniversalControlBar:(UITextInputAssistantItem *)inputAssistant
 {
@@ -192,16 +180,14 @@ inline static RetainPtr<UIToolbar> createToolbarWithItems(NSArray<UIBarButtonIte
     _autoFillButtonItemSpacer = adoptNS([[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFixedSpace target:nil action:nil]);
     [_autoFillButtonItemSpacer setWidth:WebKit::fixedSpaceBetweenButtonItems];
 
-    if (self._useCheckmarkForDone) {
-        [self _adjustFlexibleSpaceItem:_flexibleSpaceItem.get()];
-        [self _adjustFlexibleSpaceItem:_autoFillButtonItemSpacer.get()];
-    }
-
     // iPad doesn't show the "Done" button since the keyboard has its own dismiss key.
-    if (self._useCheckmarkForDone)
+    if (WebKit::isLiquidGlassEnabled()) {
         _doneButton = adoptNS([[UIBarButtonItem alloc] initWithImage:WebKit::checkmark() style:UIBarButtonItemStylePlain target:self action:@selector(_done)]);
-    else
+        [_flexibleSpaceItem setHidesSharedBackground:NO];
+        [_autoFillButtonItemSpacer setHidesSharedBackground:NO];
+    } else
         _doneButton = adoptNS([[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(_done)]);
+
     [items addObject:_flexibleSpaceItem.get()];
     [items addObject:_doneButton.get()];
 


### PR DESCRIPTION
#### bea3819e86deb681424bd928ce86f9d1963296a7
<pre>
Upstream form accessory adjustments
<a href="https://bugs.webkit.org/show_bug.cgi?id=304735">https://bugs.webkit.org/show_bug.cgi?id=304735</a>
<a href="https://rdar.apple.com/163942735">rdar://163942735</a>

Reviewed by Richard Robinson and Wenson Hsieh.

Upstream form accessory adjustments and do some minor refactoring.
Update test expectations for affected layout tests.

* LayoutTests/platform/ios/TestExpectations:
* Source/WebKit/UIProcess/ios/forms/WKFormAccessoryView.mm:
(-[WKFormAccessoryView _toolbarMargin]):
(-[WKFormAccessoryView initWithInputAssistantItem:delegate:]):
(-[WKFormAccessoryView _useCheckmarkForDone]): Deleted.
(-[WKFormAccessoryView _adjustFlexibleSpaceItem:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/305052@main">https://commits.webkit.org/305052@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6688c13427a19d838727d1245cd2e5eca94ee0aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137225 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9585 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48512 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144976 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90198 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ab4f1222-0a6e-4af8-9175-d3c64bd1e7fd) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10288 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9712 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104945 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ff5a3ad6-3098-425c-baae-e5fee7cdbfd7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140170 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7589 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122983 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85787 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d9d1d6f2-0eac-417d-99f6-48f4ed764dc8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7226 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4940 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5563 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116584 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41142 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147732 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9268 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41704 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113305 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9286 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7801 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113636 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28872 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7147 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119234 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63757 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9317 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37288 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9042 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72882 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9257 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9109 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->