### PR TITLE
Reduce unsafe member variables in WebCore/platform/graphics

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -28,8 +28,6 @@ platform/PODInterval.h
 [ iOS ] platform/audio/ios/AudioSessionIOS.mm
 platform/graphics/GraphicsLayer.h
 platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
-platform/graphics/ca/TileController.h
-platform/graphics/controls/PlatformControl.h
 platform/graphics/filters/software/FEConvolveMatrixSoftwareApplier.h
 platform/graphics/filters/software/FELightingSoftwareApplier.h
 platform/graphics/filters/software/FEMorphologySoftwareApplier.h

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -591,8 +591,6 @@ platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm
 platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
 platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
 platform/graphics/ca/GraphicsLayerCA.cpp
-platform/graphics/ca/TileController.cpp
-platform/graphics/ca/TileCoverageMap.cpp
 platform/graphics/ca/TileGrid.cpp
 platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
 platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -328,9 +328,6 @@ platform/graphics/filters/software/FETileSoftwareApplier.cpp
 platform/graphics/filters/software/FETurbulenceSoftwareApplier.cpp
 platform/graphics/filters/software/SourceAlphaSoftwareApplier.cpp
 platform/graphics/filters/software/SourceGraphicSoftwareApplier.cpp
-[ Mac ] platform/graphics/mac/controls/MeterMac.mm
-[ Mac ] platform/graphics/mac/controls/ProgressBarMac.mm
-[ Mac ] platform/graphics/mac/controls/SliderTrackMac.mm
 platform/graphics/transforms/RotateTransformOperation.cpp
 [ iOS ] platform/ios/DragImageIOS.mm
 [ iOS ] platform/ios/LegacyTileGrid.mm

--- a/Source/WebCore/platform/graphics/adwaita/ProgressBarAdwaita.cpp
+++ b/Source/WebCore/platform/graphics/adwaita/ProgressBarAdwaita.cpp
@@ -88,16 +88,16 @@ void ProgressBarAdwaita::draw(GraphicsContext& graphicsContext, const FloatRound
             fieldRect.move(offset, 0);
     };
 
-    auto& progressBarPart = owningProgressBarPart();
-    bool isDeterminate = progressBarPart.position() >= 0;
+    Ref progressBarPart = owningProgressBarPart();
+    bool isDeterminate = progressBarPart->position() >= 0;
     if (isDeterminate) {
-        auto progressSize = getPrimarySize() * progressBarPart.position();
+        auto progressSize = getPrimarySize() * progressBarPart->position();
         if (style.states.contains(ControlStyle::State::InlineFlippedWritingMode))
             movePrimaryAxis(getPrimarySize() - progressSize);
 
         setPrimarySize(progressSize);
     } else {
-        double animationProgress = currentAnimationProgress(progressBarPart.animationStartTime());
+        double animationProgress = currentAnimationProgress(progressBarPart->animationStartTime());
 
         // Never let the progress rect shrink smaller than 2 pixels.
         setPrimarySize(std::max<float>(2, getPrimarySize() / progressActivityBlocks));

--- a/Source/WebCore/platform/graphics/adwaita/ProgressBarAdwaita.h
+++ b/Source/WebCore/platform/graphics/adwaita/ProgressBarAdwaita.h
@@ -39,7 +39,7 @@ public:
     void draw(GraphicsContext&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&) override;
 
 private:
-    const ProgressBarPart& owningProgressBarPart() const { return downcast<ProgressBarPart>(m_owningPart); }
+    Ref<const ProgressBarPart> owningProgressBarPart() const { return downcast<ProgressBarPart>(m_owningPart.get().releaseNonNull()); }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/adwaita/SliderTrackAdwaita.cpp
+++ b/Source/WebCore/platform/graphics/adwaita/SliderTrackAdwaita.cpp
@@ -42,12 +42,12 @@ SliderTrackAdwaita::SliderTrackAdwaita(ControlPart& part, ControlFactoryAdwaita&
 
 void SliderTrackAdwaita::draw(GraphicsContext& graphicsContext, const FloatRoundedRect& borderRect, float /*deviceScaleFactor*/, const ControlStyle& style)
 {
-    auto& sliderTrackPart = owningSliderTrackPart();
+    Ref sliderTrackPart = owningSliderTrackPart();
     GraphicsContextStateSaver stateSaver(graphicsContext);
 
     FloatRect rect = borderRect.rect();
     FloatRect fieldRect = rect;
-    bool isHorizontal = sliderTrackPart.type() == StyleAppearance::SliderHorizontal;
+    bool isHorizontal = sliderTrackPart->type() == StyleAppearance::SliderHorizontal;
     if (isHorizontal) {
         fieldRect.move(0, rect.height() / 2 - (sliderTrackSize / 2));
         fieldRect.setHeight(sliderTrackSize);
@@ -78,7 +78,7 @@ void SliderTrackAdwaita::draw(GraphicsContext& graphicsContext, const FloatRound
     FloatRect rangeRect = fieldRect;
     FloatRoundedRect::Radii corners;
     if (isHorizontal) {
-        float offset = rangeRect.width() * sliderTrackPart.thumbPosition();
+        float offset = rangeRect.width() * sliderTrackPart->thumbPosition();
         if (style.states.contains(ControlStyle::State::InlineFlippedWritingMode)) {
             rangeRect.move(rangeRect.width() - offset, 0);
             rangeRect.setWidth(offset);
@@ -90,7 +90,7 @@ void SliderTrackAdwaita::draw(GraphicsContext& graphicsContext, const FloatRound
             corners.setBottomLeft(corner);
         }
     } else {
-        float offset = rangeRect.height() * sliderTrackPart.thumbPosition();
+        float offset = rangeRect.height() * sliderTrackPart->thumbPosition();
         if (style.states.contains(ControlStyle::State::VerticalWritingMode)) {
             rangeRect.setHeight(offset);
             corners.setTopLeft(corner);
@@ -108,7 +108,7 @@ void SliderTrackAdwaita::draw(GraphicsContext& graphicsContext, const FloatRound
     graphicsContext.setFillColor(accentColor(style));
     graphicsContext.fillPath(path);
 
-    sliderTrackPart.drawTicks(graphicsContext, borderRect.rect(), style);
+    sliderTrackPart->drawTicks(graphicsContext, borderRect.rect(), style);
 
     if (style.states.contains(ControlStyle::State::Focused)) {
         // Sliders support accent-color, so we want to color their focus rings too

--- a/Source/WebCore/platform/graphics/adwaita/SliderTrackAdwaita.h
+++ b/Source/WebCore/platform/graphics/adwaita/SliderTrackAdwaita.h
@@ -39,7 +39,7 @@ public:
     void draw(GraphicsContext&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&) override;
 
 private:
-    const SliderTrackPart& owningSliderTrackPart() const { return downcast<SliderTrackPart>(m_owningPart); }
+    Ref<const SliderTrackPart> owningSliderTrackPart() const { return downcast<SliderTrackPart>(m_owningPart.get().releaseNonNull()); }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/adwaita/ToggleButtonAdwaita.cpp
+++ b/Source/WebCore/platform/graphics/adwaita/ToggleButtonAdwaita.cpp
@@ -43,7 +43,7 @@ ToggleButtonAdwaita::ToggleButtonAdwaita(ControlPart& part, ControlFactoryAdwait
 
 void ToggleButtonAdwaita::draw(GraphicsContext& graphicsContext, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle& style)
 {
-    if (m_owningPart.type() == StyleAppearance::Checkbox)
+    if (m_owningPart.get()->type() == StyleAppearance::Checkbox)
         drawCheckbox(graphicsContext, borderRect, deviceScaleFactor, style);
     else
         drawRadio(graphicsContext, borderRect, deviceScaleFactor, style);

--- a/Source/WebCore/platform/graphics/ca/TileController.h
+++ b/Source/WebCore/platform/graphics/ca/TileController.h
@@ -96,8 +96,8 @@ public:
     WEBCORE_EXPORT void setTilesOpaque(bool);
     bool tilesAreOpaque() const { return m_tilesAreOpaque; }
 
-    PlatformCALayer& rootLayer() { return *m_tileCacheLayer; }
-    const PlatformCALayer& rootLayer() const { return *m_tileCacheLayer; }
+    Ref<PlatformCALayer> rootLayer() { return m_tileCacheLayer.get().releaseNonNull(); }
+    Ref<const PlatformCALayer> rootLayer() const { return m_tileCacheLayer.get().releaseNonNull(); }
 
     WEBCORE_EXPORT void setTileDebugBorderWidth(float);
     WEBCORE_EXPORT void setTileDebugBorderColor(Color);
@@ -230,13 +230,13 @@ private:
 
     IntRect boundsForSize(const FloatSize&) const;
 
-    PlatformCALayerClient* owningGraphicsLayer() const { return m_tileCacheLayer->owner(); }
+    PlatformCALayerClient* owningGraphicsLayer() const { return m_tileCacheLayer.get()->owner(); }
 
     void clearObscuredInsetsAdjustments() final { m_obscuredInsetsDelta = std::nullopt; }
     void obscuredInsetsWillChange(FloatBoxExtent&& obscuredInsetsDelta) final { m_obscuredInsetsDelta = WTF::move(obscuredInsetsDelta); }
     FloatRect adjustedTileClipRectForObscuredInsets(const FloatRect&) const;
 
-    PlatformCALayer* m_tileCacheLayer;
+    ThreadSafeWeakPtr<PlatformCALayer> m_tileCacheLayer;
 
     ThreadSafeWeakPtr<TiledBackingClient> m_client;
 

--- a/Source/WebCore/platform/graphics/ca/TileCoverageMap.cpp
+++ b/Source/WebCore/platform/graphics/ca/TileCoverageMap.cpp
@@ -38,10 +38,10 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(TileCoverageMap);
 TileCoverageMap::TileCoverageMap(const TileController& controller)
     : m_controller(controller)
     , m_updateTimer(*this, &TileCoverageMap::updateTimerFired)
-    , m_layer(controller.rootLayer().createCompatibleLayer(PlatformCALayer::LayerType::LayerTypeSimpleLayer, this))
-    , m_visibleViewportIndicatorLayer(controller.rootLayer().createCompatibleLayer(PlatformCALayer::LayerType::LayerTypeLayer, nullptr))
-    , m_layoutViewportIndicatorLayer(controller.rootLayer().createCompatibleLayer(PlatformCALayer::LayerType::LayerTypeLayer, nullptr))
-    , m_coverageRectIndicatorLayer(controller.rootLayer().createCompatibleLayer(PlatformCALayer::LayerType::LayerTypeLayer, nullptr))
+    , m_layer(controller.rootLayer()->createCompatibleLayer(PlatformCALayer::LayerType::LayerTypeSimpleLayer, this))
+    , m_visibleViewportIndicatorLayer(controller.rootLayer()->createCompatibleLayer(PlatformCALayer::LayerType::LayerTypeLayer, nullptr))
+    , m_layoutViewportIndicatorLayer(controller.rootLayer()->createCompatibleLayer(PlatformCALayer::LayerType::LayerTypeLayer, nullptr))
+    , m_coverageRectIndicatorLayer(controller.rootLayer()->createCompatibleLayer(PlatformCALayer::LayerType::LayerTypeLayer, nullptr))
 {
     auto obscuredContentInsets = controller.obscuredContentInsets();
     m_position = { obscuredContentInsets.left(), obscuredContentInsets.top() };
@@ -170,7 +170,7 @@ void TileCoverageMap::platformCALayerPaintContents(PlatformCALayer* platformCALa
 
 float TileCoverageMap::platformCALayerDeviceScaleFactor() const
 {
-    return m_controller.rootLayer().owner()->platformCALayerDeviceScaleFactor();
+    return m_controller.rootLayer()->owner()->platformCALayerDeviceScaleFactor();
 }
 
 void TileCoverageMap::setDeviceScaleFactor(float deviceScaleFactor)
@@ -180,7 +180,7 @@ void TileCoverageMap::setDeviceScaleFactor(float deviceScaleFactor)
 
 OptionSet<ContentsFormat> TileCoverageMap::screenContentsFormats() const
 {
-    return m_controller.rootLayer().owner()->screenContentsFormats();
+    return m_controller.rootLayer()->owner()->screenContentsFormats();
 }
 
 }

--- a/Source/WebCore/platform/graphics/ca/TileGrid.cpp
+++ b/Source/WebCore/platform/graphics/ca/TileGrid.cpp
@@ -65,7 +65,7 @@ static TextStream& operator<<(TextStream& ts, TileGrid::ValidationPolicyFlag fla
 TileGrid::TileGrid(TileController& controller)
     : m_identifier(TileGridIdentifier::generate())
     , m_controller(controller)
-    , m_containerLayer(controller.rootLayer().createCompatibleLayer(PlatformCALayer::LayerType::LayerTypeLayer, nullptr))
+    , m_containerLayer(controller.rootLayer()->createCompatibleLayer(PlatformCALayer::LayerType::LayerTypeLayer, nullptr))
     , m_cohortRemovalTimer(*this, &TileGrid::cohortRemovalTimerFired)
     , m_tileSize(kDefaultTileSize, kDefaultTileSize)
 {
@@ -207,7 +207,7 @@ void TileGrid::setTileNeedsDisplayInRect(const TileIndex& tileIndex, TileInfo& t
         tileLayer->setNeedsDisplayInRect(tileLocalRepaintRect);
         m_controller->willRepaintTile(*this, tileIndex, tileRect, tileRepaintRect);
 
-        if (m_controller->rootLayer().owner()->platformCALayerShowRepaintCounter(0)) {
+        if (m_controller->rootLayer()->owner()->platformCALayerShowRepaintCounter(0)) {
             FloatRect indicatorRect(0, 0, 52, 27);
             tileLayer->setNeedsDisplayInRect(indicatorRect);
         }
@@ -781,11 +781,11 @@ void TileGrid::platformCALayerPaintContents(PlatformCALayer* platformCALayer, Gr
         context.scale(m_scale);
 
         PlatformCALayer::RepaintRectList dirtyRects = PlatformCALayer::collectRectsToPaint(context, platformCALayer);
-        PlatformCALayer::drawLayerContents(context, &m_controller->rootLayer(), dirtyRects, layerPaintBehavior);
+        PlatformCALayer::drawLayerContents(context, m_controller->rootLayer().ptr(), dirtyRects, layerPaintBehavior);
     }
 
     int repaintCount = platformCALayerIncrementRepaintCount(platformCALayer);
-    if (m_controller->rootLayer().owner()->platformCALayerShowRepaintCounter(0))
+    if (m_controller->rootLayer()->owner()->platformCALayerShowRepaintCounter(0))
         PlatformCALayer::drawRepaintIndicator(context, platformCALayer, repaintCount, m_controller->tileDebugBorderColor());
 
     if (m_controller->scrollingPerformanceTestingEnabled()) {
@@ -799,42 +799,42 @@ void TileGrid::platformCALayerPaintContents(PlatformCALayer* platformCALayer, Gr
 
 float TileGrid::platformCALayerDeviceScaleFactor() const
 {
-    if (auto* layerOwner = m_controller->rootLayer().owner())
+    if (auto* layerOwner = m_controller->rootLayer()->owner())
         return layerOwner->platformCALayerDeviceScaleFactor();
     return 1.0f;
 }
 
 bool TileGrid::platformCALayerShowDebugBorders() const
 {
-    if (auto* layerOwner = m_controller->rootLayer().owner())
+    if (auto* layerOwner = m_controller->rootLayer()->owner())
         return layerOwner->platformCALayerShowDebugBorders();
     return false;
 }
 
 bool TileGrid::platformCALayerShowRepaintCounter(PlatformCALayer*) const
 {
-    if (auto* layerOwner = m_controller->rootLayer().owner())
+    if (auto* layerOwner = m_controller->rootLayer()->owner())
         return layerOwner->platformCALayerShowRepaintCounter(nullptr);
     return false;
 }
 
 bool TileGrid::isUsingDisplayListDrawing(PlatformCALayer*) const
 {
-    if (auto* layerOwner = m_controller->rootLayer().owner())
+    if (auto* layerOwner = m_controller->rootLayer()->owner())
         return layerOwner->isUsingDisplayListDrawing(nullptr);
     return false;
 }
 
 bool TileGrid::platformCALayerNeedsPlatformContext(const PlatformCALayer* layer) const
 {
-    if (auto* layerOwner = m_controller->rootLayer().owner())
+    if (auto* layerOwner = m_controller->rootLayer()->owner())
         return layerOwner->platformCALayerNeedsPlatformContext(layer);
     return false;
 }
 
 OptionSet<ContentsFormat> TileGrid::screenContentsFormats() const
 {
-    if (auto* layerOwner = m_controller->rootLayer().owner())
+    if (auto* layerOwner = m_controller->rootLayer()->owner())
         return layerOwner->screenContentsFormats();
     return { };
 }

--- a/Source/WebCore/platform/graphics/cocoa/controls/ApplePayButtonCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/controls/ApplePayButtonCocoa.h
@@ -37,10 +37,10 @@ class ApplePayButtonPart;
 class ApplePayButtonCocoa final : public PlatformControl {
     WTF_MAKE_TZONE_ALLOCATED(ApplePayButtonCocoa);
 public:
-    ApplePayButtonCocoa(ApplePayButtonPart& owningMeterPart);
+    explicit ApplePayButtonCocoa(ApplePayButtonPart&);
 
 private:
-    const ApplePayButtonPart& owningApplePayButtonPart() const { return downcast<ApplePayButtonPart>(m_owningPart); }
+    Ref<const ApplePayButtonPart> owningApplePayButtonPart() const { return downcast<ApplePayButtonPart>(m_owningPart.get().releaseNonNull()); }
 
     void draw(GraphicsContext&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&) override;
 };

--- a/Source/WebCore/platform/graphics/controls/ControlPart.h
+++ b/Source/WebCore/platform/graphics/controls/ControlPart.h
@@ -29,7 +29,7 @@
 #include <WebCore/ControlFactory.h>
 #include <WebCore/PlatformControl.h>
 #include <WebCore/StyleAppearance.h>
-#include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 
 namespace WebCore {
 
@@ -37,7 +37,7 @@ class FloatRect;
 class GraphicsContext;
 class ControlFactory;
 
-class ControlPart : public ThreadSafeRefCounted<ControlPart> {
+class ControlPart : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ControlPart> {
 public:
     virtual ~ControlPart() = default;
 
@@ -60,7 +60,6 @@ protected:
     const StyleAppearance m_type;
 
     mutable std::unique_ptr<PlatformControl> m_platformControl;
-    RefPtr<ControlFactory> m_controlFactory;
     RefPtr<ControlFactory> m_overrideControlFactory;
 };
 

--- a/Source/WebCore/platform/graphics/controls/PlatformControl.h
+++ b/Source/WebCore/platform/graphics/controls/PlatformControl.h
@@ -58,7 +58,7 @@ public:
     virtual void draw(GraphicsContext&, const FloatRoundedRect&, float, const ControlStyle&) { }
 
 protected:
-    ControlPart& m_owningPart;
+    ThreadSafeWeakPtr<ControlPart> m_owningPart; // Cannot be null.
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/mac/controls/ButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ButtonMac.mm
@@ -41,10 +41,10 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(ButtonMac);
 ButtonMac::ButtonMac(ButtonPart& owningPart, ControlFactoryMac& controlFactory, NSButtonCell *buttonCell)
     : ButtonControlMac(owningPart, controlFactory, buttonCell)
 {
-    ASSERT(m_owningPart.type() == StyleAppearance::Button
-        || m_owningPart.type() == StyleAppearance::DefaultButton
-        || m_owningPart.type() == StyleAppearance::PushButton
-        || m_owningPart.type() == StyleAppearance::SquareButton);
+    ASSERT(m_owningPart.get()->type() == StyleAppearance::Button
+        || m_owningPart.get()->type() == StyleAppearance::DefaultButton
+        || m_owningPart.get()->type() == StyleAppearance::PushButton
+        || m_owningPart.get()->type() == StyleAppearance::SquareButton);
 }
 
 IntSize ButtonMac::cellSize(NSControlSize controlSize, const ControlStyle&) const
@@ -75,7 +75,7 @@ IntOutsets ButtonMac::cellOutsets(NSControlSize controlSize, const ControlStyle&
 
 NSBezelStyle ButtonMac::bezelStyle(const FloatRect& rect, const ControlStyle& style) const
 {
-    if (m_owningPart.type() == StyleAppearance::SquareButton)
+    if (m_owningPart.get()->type() == StyleAppearance::SquareButton)
         return NSBezelStyleShadowlessSquare;
 
     auto controlSize = style.states.contains(ControlStyle::State::LargeControls) ? NSControlSizeLarge : NSControlSizeRegular;

--- a/Source/WebCore/platform/graphics/mac/controls/MeterMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/MeterMac.h
@@ -40,7 +40,7 @@ public:
     ~MeterMac();
 
 private:
-    const MeterPart& owningMeterPart() const { return downcast<MeterPart>(m_owningPart); }
+    Ref<const MeterPart> owningMeterPart() const { return downcast<MeterPart>(m_owningPart.get().releaseNonNull()); }
 
     void updateCellStates(const FloatRect&, const ControlStyle&) override;
 

--- a/Source/WebCore/platform/graphics/mac/controls/MeterMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/MeterMac.mm
@@ -56,31 +56,31 @@ void MeterMac::updateCellStates(const FloatRect& rect, const ControlStyle& style
 
     [m_levelIndicatorCell setUserInterfaceLayoutDirection:style.states.contains(ControlStyle::State::InlineFlippedWritingMode) ? NSUserInterfaceLayoutDirectionRightToLeft : NSUserInterfaceLayoutDirectionLeftToRight];
 
-    auto& meterPart = owningMeterPart();
+    Ref meterPart = owningMeterPart();
     
     // Because NSLevelIndicatorCell does not support optimum-in-the-middle type coloring,
     // we explicitly control the color instead giving low and high value to NSLevelIndicatorCell as is.
-    switch (meterPart.gaugeRegion()) {
+    switch (meterPart->gaugeRegion()) {
     case MeterPart::GaugeRegion::Optimum:
         // Make meter the green
-        [m_levelIndicatorCell setWarningValue:meterPart.value() + 1];
-        [m_levelIndicatorCell setCriticalValue:meterPart.value() + 2];
+        [m_levelIndicatorCell setWarningValue:meterPart->value() + 1];
+        [m_levelIndicatorCell setCriticalValue:meterPart->value() + 2];
         break;
     case MeterPart::GaugeRegion::Suboptimal:
         // Make the meter yellow
-        [m_levelIndicatorCell setWarningValue:meterPart.value() - 1];
-        [m_levelIndicatorCell setCriticalValue:meterPart.value() + 1];
+        [m_levelIndicatorCell setWarningValue:meterPart->value() - 1];
+        [m_levelIndicatorCell setCriticalValue:meterPart->value() + 1];
         break;
     case MeterPart::GaugeRegion::EvenLessGood:
         // Make the meter red
-        [m_levelIndicatorCell setWarningValue:meterPart.value() - 2];
-        [m_levelIndicatorCell setCriticalValue:meterPart.value() - 1];
+        [m_levelIndicatorCell setWarningValue:meterPart->value() - 2];
+        [m_levelIndicatorCell setCriticalValue:meterPart->value() - 1];
         break;
     }
 
-    [m_levelIndicatorCell setObjectValue:@(meterPart.value())];
-    [m_levelIndicatorCell setMinValue:meterPart.minimum()];
-    [m_levelIndicatorCell setMaxValue:meterPart.maximum()];
+    [m_levelIndicatorCell setObjectValue:@(meterPart->value())];
+    [m_levelIndicatorCell setMinValue:meterPart->minimum()];
+    [m_levelIndicatorCell setMaxValue:meterPart->maximum()];
 
     END_BLOCK_OBJC_EXCEPTIONS
 }

--- a/Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.h
@@ -42,7 +42,7 @@ public:
     ~ProgressBarMac();
 
 private:
-    const ProgressBarPart& owningProgressBarPart() const { return downcast<ProgressBarPart>(m_owningPart); }
+    Ref<const ProgressBarPart> owningProgressBarPart() const { return downcast<ProgressBarPart>(m_owningPart.get().releaseNonNull()); }
 
     IntSize cellSize(NSControlSize, const ControlStyle&) const override;
     IntOutsets cellOutsets(NSControlSize, const ControlStyle&) const override;

--- a/Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.mm
@@ -115,9 +115,9 @@ void ProgressBarMac::draw(GraphicsContext& context, const FloatRoundedRect& bord
 
     CGContextRef cgContext = imageBuffer->context().platformContext();
 
-    auto& progressBarPart = owningProgressBarPart();
+    Ref progressBarPart = owningProgressBarPart();
     auto controlSize = controlSizeForFont(style);
-    bool isIndeterminate = progressBarPart.position() < 0;
+    bool isIndeterminate = progressBarPart->position() < 0;
     bool isActive = style.states.contains(ControlStyle::State::WindowActive);
 
     auto coreUISizeForProgressBarSize = [](NSControlSize size) -> CFStringRef {
@@ -137,13 +137,13 @@ void ProgressBarMac::draw(GraphicsContext& context, const FloatRoundedRect& bord
 
     [[NSAppearance currentDrawingAppearance] _drawInRect:NSMakeRect(0, 0, inflatedRect.width(), inflatedRect.height()) context:cgContext options:@{
         (__bridge NSString *)kCUIWidgetKey: (__bridge NSString *)(isIndeterminate ? kCUIWidgetProgressIndeterminateBar : kCUIWidgetProgressBar),
-        (__bridge NSString *)kCUIValueKey: @(isIndeterminate ? 1 : std::min(nextafter(1.0, -1), progressBarPart.position())),
+        (__bridge NSString *)kCUIValueKey: @(isIndeterminate ? 1 : std::min(nextafter(1.0, -1), progressBarPart->position())),
         (__bridge NSString *)kCUISizeKey: (__bridge NSString *)coreUISizeForProgressBarSize(controlSize),
         (__bridge NSString *)kCUIUserInterfaceLayoutDirectionKey: (__bridge NSString *)kCUIUserInterfaceLayoutDirectionLeftToRight,
         (__bridge NSString *)kCUIScaleKey: @(deviceScaleFactor),
         (__bridge NSString *)kCUIPresentationStateKey: (__bridge NSString *)(isActive ? kCUIPresentationStateActiveKey : kCUIPresentationStateInactive),
         (__bridge NSString *)kCUIOrientationKey: (__bridge NSString *)kCUIOrientHorizontal,
-        (__bridge NSString *)kCUIAnimationStartTimeKey: @(progressBarPart.animationStartTime().seconds()),
+        (__bridge NSString *)kCUIAnimationStartTimeKey: @(progressBarPart->animationStartTime().seconds()),
         (__bridge NSString *)kCUIAnimationTimeKey: @(MonotonicTime::now().secondsSinceEpoch().seconds())
     }];
 

--- a/Source/WebCore/platform/graphics/mac/controls/SliderThumbMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SliderThumbMac.mm
@@ -43,7 +43,7 @@ SliderThumbMac::SliderThumbMac(SliderThumbPart& owningPart, ControlFactoryMac& c
     : ControlMac(owningPart, controlFactory)
     , m_sliderCell(sliderCell)
 {
-    ASSERT(m_owningPart.type() == StyleAppearance::SliderThumbHorizontal || m_owningPart.type() == StyleAppearance::SliderThumbVertical);
+    ASSERT(m_owningPart.get()->type() == StyleAppearance::SliderThumbHorizontal || m_owningPart.get()->type() == StyleAppearance::SliderThumbVertical);
 }
 
 SliderThumbMac::~SliderThumbMac() = default;
@@ -58,7 +58,7 @@ void SliderThumbMac::updateCellStates(const FloatRect& rect, const ControlStyle&
 
 FloatRect SliderThumbMac::rectForBounds(const FloatRect& bounds, const ControlStyle& style) const
 {
-    if (m_owningPart.type() == StyleAppearance::SliderThumbHorizontal)
+    if (m_owningPart.get()->type() == StyleAppearance::SliderThumbHorizontal)
         return bounds;
 
     // Make the height of the vertical slider slightly larger so NSSliderCell will draw a vertical slider.

--- a/Source/WebCore/platform/graphics/mac/controls/SliderTrackMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/SliderTrackMac.h
@@ -39,7 +39,7 @@ public:
     SliderTrackMac(SliderTrackPart&, ControlFactoryMac&);
 
 private:
-    const SliderTrackPart& owningSliderTrackPart() const { return downcast<SliderTrackPart>(m_owningPart); }
+    Ref<const SliderTrackPart> owningSliderTrackPart() const { return downcast<SliderTrackPart>(m_owningPart.get().releaseNonNull()); }
 
     FloatRect rectForBounds(const FloatRect& bounds, const ControlStyle&) const override;
 

--- a/Source/WebCore/platform/graphics/mac/controls/SliderTrackMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SliderTrackMac.mm
@@ -47,11 +47,10 @@ FloatRect SliderTrackMac::rectForBounds(const FloatRect& bounds, const ControlSt
     static constexpr int sliderTrackWidth = 5;
     float trackWidth = sliderTrackWidth * style.zoomFactor;
 
-    auto& sliderTrackPart = owningSliderTrackPart();
     auto rect = bounds;
     
     // Set the height/width and align the location in the center of the difference.
-    if (sliderTrackPart.type() == StyleAppearance::SliderHorizontal) {
+    if (owningSliderTrackPart()->type() == StyleAppearance::SliderHorizontal) {
         rect.setHeight(trackWidth);
         rect.setY(rect.y() + (bounds.height() - rect.height()) / 2);
     } else {
@@ -82,9 +81,9 @@ void SliderTrackMac::draw(GraphicsContext& context, const FloatRoundedRect& bord
     CGContextRef cgContext = context.platformContext();
     CGColorSpaceRef cspace = sRGBColorSpaceSingleton();
 
-    auto& sliderTrackPart = owningSliderTrackPart();
+    Ref sliderTrackPart = owningSliderTrackPart();
 
-    sliderTrackPart.drawTicks(context, borderRect.rect(), style);
+    sliderTrackPart->drawTicks(context, borderRect.rect(), style);
 
     GraphicsContextStateSaver stateSaver(context);
 
@@ -94,7 +93,7 @@ void SliderTrackMac::draw(GraphicsContext& context, const FloatRoundedRect& bord
     struct CGFunctionCallbacks mainCallbacks = { 0, trackGradientInterpolate, NULL };
     RetainPtr<CGFunctionRef> mainFunction = adoptCF(CGFunctionCreate(NULL, 1, NULL, 4, NULL, &mainCallbacks));
     RetainPtr<CGShadingRef> mainShading;
-    if (sliderTrackPart.type() == StyleAppearance::SliderVertical)
+    if (sliderTrackPart->type() == StyleAppearance::SliderVertical)
         mainShading = adoptCF(CGShadingCreateAxial(cspace, CGPointMake(logicalRect.x(),  logicalRect.maxY()), CGPointMake(logicalRect.maxX(), logicalRect.maxY()), mainFunction.get(), false, false));
     else
         mainShading = adoptCF(CGShadingCreateAxial(cspace, CGPointMake(logicalRect.x(),  logicalRect.y()), CGPointMake(logicalRect.x(), logicalRect.maxY()), mainFunction.get(), false, false));

--- a/Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.h
@@ -38,7 +38,7 @@ public:
     SwitchThumbMac(SwitchThumbPart&, ControlFactoryMac&);
 
 private:
-    const SwitchThumbPart& owningPart() const { return downcast<SwitchThumbPart>(m_owningPart); }
+    Ref<const SwitchThumbPart> owningPart() const { return downcast<SwitchThumbPart>(m_owningPart.get().releaseNonNull()); }
 
     IntSize cellSize(NSControlSize, const ControlStyle&) const override;
     IntOutsets cellOutsets(NSControlSize, const ControlStyle&) const override;

--- a/Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.mm
@@ -69,12 +69,13 @@ void SwitchThumbMac::draw(GraphicsContext& context, const FloatRoundedRect& bord
 
     GraphicsContextStateSaver stateSaver(context);
 
-    auto isOn = owningPart().isOn();
+    Ref owningPart = this->owningPart();
+    auto isOn = owningPart->isOn();
     auto isInlineFlipped = style.states.contains(ControlStyle::State::InlineFlippedWritingMode);
     auto isVertical = style.states.contains(ControlStyle::State::VerticalWritingMode);
     auto isEnabled = style.states.contains(ControlStyle::State::Enabled);
     auto isPressed = style.states.contains(ControlStyle::State::Pressed);
-    auto progress = SwitchMacUtilities::easeInOut(owningPart().progress());
+    auto progress = SwitchMacUtilities::easeInOut(owningPart->progress());
 
     auto logicalBounds = SwitchMacUtilities::rectWithTransposedSize(borderRect.rect(), isVertical);
     auto controlSize = controlSizeForSize(logicalBounds.size(), style);

--- a/Source/WebCore/platform/graphics/mac/controls/SwitchTrackMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/SwitchTrackMac.h
@@ -38,7 +38,7 @@ public:
     SwitchTrackMac(SwitchTrackPart&, ControlFactoryMac&);
 
 private:
-    const SwitchTrackPart& owningPart() const { return downcast<SwitchTrackPart>(m_owningPart); }
+    Ref<const SwitchTrackPart> owningPart() const { return downcast<SwitchTrackPart>(m_owningPart.get().releaseNonNull()); }
 
     IntSize cellSize(NSControlSize, const ControlStyle&) const override;
     IntOutsets cellOutsets(NSControlSize, const ControlStyle&) const override;

--- a/Source/WebCore/platform/graphics/mac/controls/SwitchTrackMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SwitchTrackMac.mm
@@ -139,7 +139,8 @@ void SwitchTrackMac::draw(GraphicsContext& context, const FloatRoundedRect& bord
 {
     GraphicsContextStateSaver stateSaver(context);
 
-    auto isOn = owningPart().isOn();
+    Ref owningPart = this->owningPart();
+    auto isOn = owningPart->isOn();
     auto isInlineFlipped = style.states.contains(ControlStyle::State::InlineFlippedWritingMode);
     auto isVertical = style.states.contains(ControlStyle::State::VerticalWritingMode);
     auto isEnabled = style.states.contains(ControlStyle::State::Enabled);
@@ -147,7 +148,7 @@ void SwitchTrackMac::draw(GraphicsContext& context, const FloatRoundedRect& bord
     auto isInActiveWindow = style.states.contains(ControlStyle::State::WindowActive);
     auto isFocused = style.states.contains(ControlStyle::State::Focused);
     auto needsOnOffLabels = userPrefersWithoutColorDifferentiation();
-    auto progress = SwitchMacUtilities::easeInOut(owningPart().progress());
+    auto progress = SwitchMacUtilities::easeInOut(owningPart->progress());
 
     auto logicalBounds = SwitchMacUtilities::rectWithTransposedSize(borderRect.rect(), isVertical);
     auto controlSize = controlSizeForSize(logicalBounds.size(), style);

--- a/Source/WebCore/platform/graphics/mac/controls/ToggleButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ToggleButtonMac.mm
@@ -43,7 +43,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(ToggleButtonMac);
 ToggleButtonMac::ToggleButtonMac(ToggleButtonPart& owningPart, ControlFactoryMac& controlFactory, NSButtonCell *buttonCell)
     : ButtonControlMac(owningPart, controlFactory, buttonCell)
 {
-    ASSERT(m_owningPart.type() == StyleAppearance::Checkbox || m_owningPart.type() == StyleAppearance::Radio);
+    ASSERT(m_owningPart.get()->type() == StyleAppearance::Checkbox || m_owningPart.get()->type() == StyleAppearance::Radio);
 }
 
 IntSize ToggleButtonMac::cellSize(NSControlSize controlSize, const ControlStyle& style) const
@@ -70,7 +70,7 @@ IntSize ToggleButtonMac::cellSize(NSControlSize controlSize, const ControlStyle&
         IntSize { 16, 16 }
     };
 
-    if (m_owningPart.type() == StyleAppearance::Checkbox)
+    if (m_owningPart.get()->type() == StyleAppearance::Checkbox)
         return checkboxSizes[controlSize];
 
     if (style.states.contains(ControlStyle::State::LargeControls))
@@ -95,7 +95,7 @@ IntOutsets ToggleButtonMac::cellOutsets(NSControlSize controlSize, const Control
         IntOutsets { 0, 0, 1, 1 },
         IntOutsets { 1, 0, 1, 2 },
     };
-    return (m_owningPart.type() == StyleAppearance::Checkbox ? checkboxOutsets : radioOutsets)[controlSize];
+    return (m_owningPart.get()->type() == StyleAppearance::Checkbox ? checkboxOutsets : radioOutsets)[controlSize];
 }
 
 FloatRect ToggleButtonMac::rectForBounds(const FloatRect& bounds, const ControlStyle& style) const


### PR DESCRIPTION
#### 5fa2ed82142d0f727f9e7a511e79cbcc4bfdd77b
<pre>
Reduce unsafe member variables in WebCore/platform/graphics
<a href="https://bugs.webkit.org/show_bug.cgi?id=304737">https://bugs.webkit.org/show_bug.cgi?id=304737</a>

Reviewed by Chris Dumez.

Also remove an unused variable from ControlPart.

See also <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

Canonical link: <a href="https://commits.webkit.org/304980@main">https://commits.webkit.org/304980@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46f46996c58dda9aa872efc97ecf8788f9e7b181

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137085 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9445 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48372 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144828 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90058 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/721ca122-b1b3-4ad1-8747-c8e1bec05c78) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138957 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10148 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9572 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104829 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8288c1e7-e08c-4c2b-8d26-1d08f9cab2d9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140030 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7464 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122844 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85664 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/264d2a3b-ce5f-4d03-9aab-303a3fd5d9a3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7101 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4802 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5417 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116449 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41013 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147584 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9128 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41578 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113184 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9146 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7671 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113514 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7020 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119108 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63463 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21122 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9176 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37162 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8900 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72742 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9117 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8969 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->