### PR TITLE
[JSC] Inline async function body when there is no await

### DIFF
--- a/JSTests/stress/async-function-without-await.js
+++ b/JSTests/stress/async-function-without-await.js
@@ -1,0 +1,134 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("Bad value: " + actual + " expected: " + expected);
+}
+
+function shouldThrow(func, errorType) {
+    let errorThrown = false;
+    try {
+        func();
+    } catch (error) {
+        errorThrown = true;
+        if (!(error instanceof errorType))
+            throw new Error("Bad error: " + error);
+    }
+    if (!errorThrown)
+        throw new Error("Should have thrown");
+}
+
+async function asyncReturn42() {
+    return 42;
+}
+
+async function asyncReturnUndefined() {
+    let x = 1;
+    x++;
+}
+
+async function asyncThrow() {
+    throw new Error("test error");
+}
+
+const asyncArrowReturn = async () => {
+    return "arrow result";
+};
+
+const asyncArrowExpr = async () => "expression result";
+
+async function asyncWithLocals() {
+    let a = 1;
+    let b = 2;
+    let c = a + b;
+    return c;
+}
+
+function helper() {
+    return "helper result";
+}
+
+async function asyncCallsHelper() {
+    return helper();
+}
+
+async function asyncWithTryCatch() {
+    try {
+        throw new Error("caught");
+    } catch (e) {
+        return "caught: " + e.message;
+    }
+}
+
+async function asyncWithControlFlow(x) {
+    if (x > 0) {
+        return "positive";
+    } else if (x < 0) {
+        return "negative";
+    } else {
+        return "zero";
+    }
+}
+
+class AsyncClass {
+    async asyncMethod() {
+        return "method result";
+    }
+
+    static async staticAsyncMethod() {
+        return "static method result";
+    }
+}
+
+async function asyncWithAwait() {
+    return await Promise.resolve(100);
+}
+
+async function runTests() {
+    let result1 = await asyncReturn42();
+    shouldBe(result1, 42);
+
+    let result2 = await asyncReturnUndefined();
+    shouldBe(result2, undefined);
+
+    let caught3 = false;
+    try {
+        await asyncThrow();
+    } catch (e) {
+        caught3 = true;
+        shouldBe(e.message, "test error");
+    }
+    shouldBe(caught3, true);
+
+    let result4 = await asyncArrowReturn();
+    shouldBe(result4, "arrow result");
+
+    let result5 = await asyncArrowExpr();
+    shouldBe(result5, "expression result");
+
+    let result6 = await asyncWithLocals();
+    shouldBe(result6, 3);
+
+    let result7 = await asyncCallsHelper();
+    shouldBe(result7, "helper result");
+
+    let result8 = await asyncWithTryCatch();
+    shouldBe(result8, "caught: caught");
+
+    shouldBe(await asyncWithControlFlow(5), "positive");
+    shouldBe(await asyncWithControlFlow(-5), "negative");
+    shouldBe(await asyncWithControlFlow(0), "zero");
+
+    let instance = new AsyncClass();
+    shouldBe(await instance.asyncMethod(), "method result");
+    shouldBe(await AsyncClass.staticAsyncMethod(), "static method result");
+
+    let result11 = await asyncWithAwait();
+    shouldBe(result11, 100);
+
+    for (let i = 0; i < 10000; i++) {
+        await asyncReturn42();
+        await asyncArrowReturn();
+        await asyncWithLocals();
+    }
+}
+
+runTests().catch($vm.abort);

--- a/JSTests/stress/async-stack-trace-basic.js
+++ b/JSTests/stress/async-stack-trace-basic.js
@@ -207,7 +207,6 @@ function shouldThrowAsync(run, errorType, message, stackFunctions) {
             }, Error, "error",
             [
                 ["throwError", "200:24"],
-                ["throwError", "199:35"],
                 ["two", "196:25"],
                 ["async one", "187:18"],
                 ["async test", "206:26"],

--- a/JSTests/stress/async-stack-trace-nested-deep.js
+++ b/JSTests/stress/async-stack-trace-nested-deep.js
@@ -653,7 +653,6 @@ for (let i = 0; i < count; i++) {
         }, Error, "error",
         [
             ["problematicFunction", "645:20"],
-            ["problematicFunction", "641:36"],
             ["level101", "632:30"],
             ["async level100", "620:19"],
             ["async level99", "615:19"],

--- a/JSTests/stress/async-stack-trace-nested.js
+++ b/JSTests/stress/async-stack-trace-nested.js
@@ -152,6 +152,7 @@ async function problematicFunction() {
 
     nop();
     throw new Error("error");
+    await 30;
 }
 
 for (let i = 0; i < testLoopCount; i++) {
@@ -161,7 +162,6 @@ for (let i = 0; i < testLoopCount; i++) {
         }, Error, "error",
         [
             ["problematicFunction", "154:20"],
-            ["problematicFunction", "150:36"],
             ["level10", "141:30"],
             ["async level9", "130:18"],
             ["async level8", "124:17"],
@@ -172,10 +172,10 @@ for (let i = 0; i < testLoopCount; i++) {
             ["async level3", "85:17"],
             ["async level2", "77:17"],
             ["async level1", "69:17"],
-            ["async test", "160:25"],
+            ["async test", "161:25"],
             ["drainMicrotasks", "[native code]"],
             ["shouldThrowAsync", "19:20"],
-            ["global code", "158:21"]
+            ["global code", "159:21"]
         ],
     );
     drainMicrotasks();

--- a/LayoutTests/http/tests/webgpu/webgpu/api/operation/uncapturederror-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/operation/uncapturederror-expected.txt
@@ -5,14 +5,12 @@ FAIL :iff_uncaptured:useOnuncapturederror=true;errorType="out-of-memory" assert_
   - EXCEPTION: Error: there were outstanding immediateAsyncExpectations (e.g. expectUncapturedError) at the end of the test
     assert@http://127.0.0.1:8000/webgpu/common/util/util.js:37:20
     finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:119:11
-    finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:118:20
     runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
  Reached unreachable code
 FAIL :iff_uncaptured:useOnuncapturederror=true;errorType="validation" assert_unreached:
   - EXCEPTION: Error: there were outstanding immediateAsyncExpectations (e.g. expectUncapturedError) at the end of the test
     assert@http://127.0.0.1:8000/webgpu/common/util/util.js:37:20
     finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:119:11
-    finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:118:20
     runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
  Reached unreachable code
 PASS :only_original_device_is_event_target:

--- a/LayoutTests/http/tests/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables-expected.txt
@@ -158,154 +158,112 @@ FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimi
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:301:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:301:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:301:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:301:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:301:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:301:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:301:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:301:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:301:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:301:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:301:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:301:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:301:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:301:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 PASS :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=true;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false
 PASS :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=true;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true
@@ -482,154 +440,112 @@ FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overL
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:301:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:301:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:301:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:301:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:301:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:301:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:301:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:301:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:301:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:301:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:301:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:301:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:301:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:301:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 PASS :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=true;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false
 PASS :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=true;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true
@@ -813,11 +729,8 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -825,11 +738,8 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -837,11 +747,8 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -849,11 +756,8 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -861,11 +765,8 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -873,11 +774,8 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -885,11 +783,8 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -897,11 +792,8 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -909,11 +801,8 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -921,11 +810,8 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -933,11 +819,8 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -945,11 +828,8 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -957,11 +837,8 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -969,11 +846,8 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -981,11 +855,8 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -993,11 +864,8 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1005,11 +873,8 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1017,11 +882,8 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1029,11 +891,8 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1041,11 +900,8 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=false;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1053,11 +909,8 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=false;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1065,11 +918,8 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=false;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1077,11 +927,8 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=false;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1089,11 +936,8 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=true;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1101,11 +945,8 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=true;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1113,11 +954,8 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=true;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1125,11 +963,8 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=true;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1137,11 +972,8 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=true;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1149,11 +981,8 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=true;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1161,11 +990,8 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=true;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1173,11 +999,8 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=true;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1185,11 +1008,8 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 PASS :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="overLimit";async=false;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false
 PASS :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="overLimit";async=false;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true
@@ -1421,11 +1241,8 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1433,11 +1250,8 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1445,11 +1259,8 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1457,11 +1268,8 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1469,11 +1277,8 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1481,11 +1286,8 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1493,11 +1295,8 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1505,11 +1304,8 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1517,11 +1313,8 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1529,11 +1322,8 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1541,11 +1331,8 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1553,11 +1340,8 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1565,11 +1349,8 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1577,11 +1358,8 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1589,11 +1367,8 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1601,11 +1376,8 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1613,11 +1385,8 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1625,11 +1394,8 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1637,11 +1403,8 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1649,11 +1412,8 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=false;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1661,11 +1421,8 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=false;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1673,11 +1430,8 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=false;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1685,11 +1439,8 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=false;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1697,11 +1448,8 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=true;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1709,11 +1457,8 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=true;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1721,11 +1466,8 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=true;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1733,11 +1475,8 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=true;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1745,11 +1484,8 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=true;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1757,11 +1493,8 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=true;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1769,11 +1502,8 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=true;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1781,11 +1511,8 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=true;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1793,11 +1520,8 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:280:34
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
-    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:690:40
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
-    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:930:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
  Reached unreachable code
 PASS :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="overLimit";async=false;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false
 PASS :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="overLimit";async=false;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
@@ -370,6 +370,7 @@ namespace JSC {
         bool usesThis() const { return m_scopeNode->usesThis(); }
         bool isFunctionNode() const { return m_scopeNode->isFunctionNode(); }
         bool hasShadowsArgumentsCodeFeature() const { return m_scopeNode->hasShadowsArgumentsFeature(); }
+        bool isAsyncFunctionWithoutAwait() const { return m_scopeNode->isAsyncFunctionWithoutAwait(); }
         LexicallyScopedFeatures lexicallyScopedFeatures() const { return m_scopeNode->lexicallyScopedFeatures(); }
         PrivateBrandRequirement privateBrandRequirement() const { return m_codeBlock->privateBrandRequirement(); }
         ConstructorKind constructorKind() const { return m_codeBlock->constructorKind(); }
@@ -1045,6 +1046,8 @@ namespace JSC {
     public:
         void pushFinallyControlFlowScope(FinallyContext&);
         void popFinallyControlFlowScope();
+
+        bool hasFinallyScopes() const { return m_currentFinallyContext; }
 
         void pushOptionalChainTarget();
         void popOptionalChainTarget();

--- a/Source/JavaScriptCore/parser/Nodes.h
+++ b/Source/JavaScriptCore/parser/Nodes.h
@@ -1969,6 +1969,7 @@ namespace JSC {
         bool usesSuperCall() const { return m_features & SuperCallFeature; }
         bool usesSuperProperty() const { return m_features & SuperPropertyFeature; }
         bool usesNewTarget() const { return m_features & NewTargetFeature; }
+        bool isAsyncFunctionWithoutAwait() const { return m_features & AsyncFunctionWithoutAwaitFeature; }
         bool needsActivation() const { return (hasCapturedVariables()) || (m_features & (EvalFeature | WithFeature)); }
         bool hasCapturedVariables() const { return m_varDeclarations.hasCapturedVariables(); }
         bool captures(UniquedStringImpl* uid) { return m_varDeclarations.captures(uid); }

--- a/Source/JavaScriptCore/parser/Parser.h
+++ b/Source/JavaScriptCore/parser/Parser.h
@@ -170,7 +170,11 @@ public:
     ImplementationVisibility implementationVisibility() const { return m_implementationVisibility; }
     void resetImplementationVisibility()
     {
-        m_implementationVisibility = ImplementationVisibility::Public;
+        setImplementationVisibility(ImplementationVisibility::Public);
+    }
+    void setImplementationVisibility(ImplementationVisibility implementationVisibility)
+    {
+        m_implementationVisibility = implementationVisibility;
     }
 
     void startSwitch() { m_switchDepth++; }
@@ -653,6 +657,12 @@ public:
     bool isArrowFunctionBoundary() { return m_isArrowFunctionBoundary; }
     bool isArrowFunction() { return m_isArrowFunction; }
 
+    void setAsyncFunctionBodyDoesNotUseAwait() { m_asyncFunctionBodyDoesNotUseAwait = true; }
+    bool asyncFunctionBodyDoesNotUseAwait() const { return m_asyncFunctionBodyDoesNotUseAwait; }
+
+    void setUsesAwait() { m_usesAwait = true; }
+    bool usesAwait() const { return m_usesAwait; }
+
     bool hasDirectSuper() const { return m_hasDirectSuper; }
     void setHasDirectSuper() { m_hasDirectSuper = true; }
 
@@ -850,6 +860,7 @@ public:
         m_usesImportMeta = info->usesImportMeta;
         m_lexicallyScopedFeatures = info->lexicallyScopedFeatures();
         m_innerArrowFunctionFeatures = info->innerArrowFunctionFeatures;
+        m_implementationVisibility = static_cast<ImplementationVisibility>(info->implementationVisibility);
         m_needsFullActivation = info->needsFullActivation;
         m_needsSuperBinding = info->needsSuperBinding;
         UniquedStringImplPtrSet& destSet = m_usedVariables.last();
@@ -984,6 +995,8 @@ private:
     bool m_isEvalContext : 1 { false };
     bool m_hasNonSimpleParameterList : 1 { false };
     bool m_isClassScope : 1 { false };
+    bool m_asyncFunctionBodyDoesNotUseAwait : 1 { false };
+    bool m_usesAwait : 1 { false };
     EvalContextType m_evalContextType { EvalContextType::None };
     ConstructorKind m_constructorKind { ConstructorKind::None };
     DerivedContextType m_derivedContextType { DerivedContextType::None };

--- a/Source/JavaScriptCore/parser/ParserModes.h
+++ b/Source/JavaScriptCore/parser/ParserModes.h
@@ -351,8 +351,9 @@ const CodeFeatures SuperPropertyFeature =          1 << 9;
 const CodeFeatures NewTargetFeature =              1 << 10;
 const CodeFeatures NoEvalCacheFeature =            1 << 11;
 const CodeFeatures ImportMetaFeature =             1 << 12;
+const CodeFeatures AsyncFunctionWithoutAwaitFeature = 1 << 13;
 
-const CodeFeatures AllFeatures = EvalFeature | ArgumentsFeature | WithFeature | ThisFeature | NonSimpleParameterListFeature | ShadowsArgumentsFeature | ArrowFunctionFeature | AwaitFeature | SuperCallFeature | SuperPropertyFeature | NewTargetFeature | NoEvalCacheFeature | ImportMetaFeature;
+const CodeFeatures AllFeatures = EvalFeature | ArgumentsFeature | WithFeature | ThisFeature | NonSimpleParameterListFeature | ShadowsArgumentsFeature | ArrowFunctionFeature | AwaitFeature | SuperCallFeature | SuperPropertyFeature | NewTargetFeature | NoEvalCacheFeature | ImportMetaFeature | AsyncFunctionWithoutAwaitFeature;
 static constexpr unsigned bitWidthOfCodeFeatures = 14;
 static_assert(AllFeatures <= (1 << bitWidthOfCodeFeatures) - 1, "CodeFeatures must fit within 14 bits");
 

--- a/Source/JavaScriptCore/parser/SourceProviderCacheItem.h
+++ b/Source/JavaScriptCore/parser/SourceProviderCacheItem.h
@@ -44,6 +44,7 @@ struct SourceProviderCacheItemCreationParameters {
     unsigned parameterCount { 0 };
     LexicallyScopedFeatures lexicallyScopedFeatures { 0 };
     InnerArrowFunctionCodeFeatures innerArrowFunctionFeatures { 0 };
+    ImplementationVisibility implementationVisibility { ImplementationVisibility::Public };
     Vector<UniquedStringImpl*, 8> usedVariables;
     JSTokenType tokenType { CLOSEBRACE };
     ConstructorKind constructorKind;
@@ -103,6 +104,7 @@ public:
     unsigned tokenType : 24; // JSTokenType
     unsigned innerArrowFunctionFeatures : 6; // InnerArrowFunctionCodeFeatures
     unsigned constructorKind : 2; // ConstructorKind
+    unsigned implementationVisibility : 2; // ImplementationVisibility
     bool usesImportMeta : 1 { false };
 
     PackedPtr<UniquedStringImpl>* usedVariables() const { return const_cast<PackedPtr<UniquedStringImpl>*>(m_variables); }
@@ -145,11 +147,13 @@ inline SourceProviderCacheItem::SourceProviderCacheItem(const SourceProviderCach
     , tokenType(static_cast<unsigned>(parameters.tokenType))
     , innerArrowFunctionFeatures(static_cast<unsigned>(parameters.innerArrowFunctionFeatures))
     , constructorKind(static_cast<unsigned>(parameters.constructorKind))
+    , implementationVisibility(static_cast<unsigned>(parameters.implementationVisibility))
     , usesImportMeta(parameters.usesImportMeta)
 {
     ASSERT(tokenType == static_cast<unsigned>(parameters.tokenType));
     ASSERT(innerArrowFunctionFeatures == static_cast<unsigned>(parameters.innerArrowFunctionFeatures));
     ASSERT(constructorKind == static_cast<unsigned>(parameters.constructorKind));
+    ASSERT(implementationVisibility == static_cast<unsigned>(parameters.implementationVisibility));
     ASSERT(expectedSuperBinding == static_cast<unsigned>(parameters.expectedSuperBinding));
     for (unsigned i = 0; i < usedVariablesCount; ++i) {
         auto* pointer = parameters.usedVariables[i];


### PR DESCRIPTION
#### f42c363069b53b4c3787cdd815d86f3840711b3d
<pre>
[JSC] Inline async function body when there is no await
<a href="https://bugs.webkit.org/show_bug.cgi?id=304740">https://bugs.webkit.org/show_bug.cgi?id=304740</a>
<a href="https://rdar.apple.com/167254635">rdar://167254635</a>

Reviewed by Justin Michaud and Sosuke Suzuki.

When there is no await in async function, it does not need to have a
separate body function and we do not need to use generator since it does
not have any suspend and resume. We can detect it lexically and we can
fully inline the implementation in the async wrapper function side.
The inlined code is something like,

    let promise = newPromise();
    try {
        async-function-body
    } catch (error) {
        rejectPromise(proimse, error);
    } finally {
        resolvePromise(promise, returnedValue);
        return promise;
    }

We also fix async stack trace by setting
implementationVisibility::Private for async wrapper function (when body
is not inlined).

Test: JSTests/stress/async-function-without-await.js

* JSTests/stress/async-function-without-await.js: Added.
(shouldBe):
(shouldThrow):
(async asyncReturn42):
(async asyncReturnUndefined):
(async asyncThrow):
(async asyncWithLocals):
(helper):
(async asyncCallsHelper):
(async asyncWithTryCatch):
(async asyncWithControlFlow):
(AsyncClass.prototype.async asyncMethod):
(AsyncClass.async staticAsyncMethod):
(AsyncClass):
(async asyncWithAwait):
(async runTests):
* JSTests/stress/async-stack-trace-basic.js:
* JSTests/stress/async-stack-trace-nested-deep.js:
* JSTests/stress/async-stack-trace-nested.js:
(async problematicFunction):
* LayoutTests/http/tests/webgpu/webgpu/api/operation/uncapturederror-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables-expected.txt:
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::BytecodeGenerator):
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h:
(JSC::BytecodeGenerator::isAsyncFunctionWithoutAwait const):
(JSC::BytecodeGenerator::hasFinallyScopes const):
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::ReturnNode::emitBytecode):
(JSC::FunctionNode::emitBytecode):
* Source/JavaScriptCore/parser/Nodes.h:
(JSC::ScopeNode::isAsyncFunctionWithoutAwait const):
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::parseInner):
(JSC::Parser&lt;LexerType&gt;::parseAsyncFunctionSourceElements):
(JSC::Parser&lt;LexerType&gt;::parseForStatement):
(JSC::Parser&lt;LexerType&gt;::parseFunctionBody):
(JSC::Parser&lt;LexerType&gt;::parseFunctionInfo):
(JSC::Parser&lt;LexerType&gt;::parseAwaitExpression):
* Source/JavaScriptCore/parser/Parser.h:
(JSC::Scope::resetImplementationVisibility):
(JSC::Scope::setImplementationVisibility):
(JSC::Scope::setAsyncFunctionBodyDoesNotUseAwait):
(JSC::Scope::asyncFunctionBodyDoesNotUseAwait const):
(JSC::Scope::setUsesAwait):
(JSC::Scope::usesAwait const):
(JSC::Scope::restoreFromSourceProviderCache):
* Source/JavaScriptCore/parser/ParserModes.h:
* Source/JavaScriptCore/parser/SourceProviderCacheItem.h:
(JSC::SourceProviderCacheItem::SourceProviderCacheItem):

Canonical link: <a href="https://commits.webkit.org/304987@main">https://commits.webkit.org/304987@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5f20501f84a7ec3018d3af15e642e51e3716a15

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137063 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9423 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48350 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144806 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90036 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6d0b485c-2dd8-47fb-863e-54efd6299fe1) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10126 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9550 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104810 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d433d208-7575-4e56-b8a9-1360505b86a3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140008 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7439 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122818 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85645 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/bd274f6e-fe57-4754-8f6b-000c13688de2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7076 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4779 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5395 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/129024 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116423 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40987 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147562 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/135550 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9106 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41553 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113164 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9124 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7649 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113493 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6997 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119083 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63431 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21124 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9154 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37137 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/168330 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8877 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72720 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43930 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9095 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8947 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->