### PR TITLE
Simplify SortedArrayMap / SortedArraySet a bit now that it is consistently used with std::array

### DIFF
--- a/Source/WTF/wtf/SortedArrayMap.h
+++ b/Source/WTF/wtf/SortedArrayMap.h
@@ -166,7 +166,7 @@ template<typename ElementType, std::size_t N>
 constexpr SortedArrayMap<ElementType, N>::SortedArrayMap(const std::array<ElementType, N>& array)
     : m_array { array }
 {
-    ASSERT_UNDER_CONSTEXPR_CONTEXT(std::is_sorted(std::begin(array), std::end(array), [](auto& a, auto b) {
+    ASSERT_UNDER_CONSTEXPR_CONTEXT(std::is_sorted(array.begin(), array.end(), [](auto& a, auto b) {
         return a.first < b.first;
     }));
 }
@@ -178,17 +178,17 @@ template<typename ElementType, std::size_t N> template<typename KeyArgument> inl
     if (!parsedKey)
         return nullptr;
     decltype(std::begin(m_array)) iterator;
-    if (std::size(m_array) < binarySearchThreshold) {
-        iterator = std::find_if(std::begin(m_array), std::end(m_array), [&parsedKey](auto& pair) {
+    if constexpr (N < binarySearchThreshold) {
+        iterator = std::find_if(m_array.begin(), m_array.end(), [&parsedKey](auto& pair) {
             return pair.first == *parsedKey;
         });
-        if (iterator == std::end(m_array))
+        if (iterator == m_array.end())
             return nullptr;
     } else {
-        iterator = std::lower_bound(std::begin(m_array), std::end(m_array), *parsedKey, [](auto& pair, auto& value) {
+        iterator = std::lower_bound(m_array.begin(), m_array.end(), *parsedKey, [](auto& pair, auto& value) {
             return pair.first < value;
         });
-        if (iterator == std::end(m_array) || !(iterator->first == *parsedKey))
+        if (iterator == m_array.end() || !(iterator->first == *parsedKey))
             return nullptr;
     }
     return &iterator->second;
@@ -208,7 +208,7 @@ template<typename ElementType, std::size_t N> template<typename KeyArgument> inl
 template<typename ElementType, std::size_t N> constexpr SortedArraySet<ElementType, N>::SortedArraySet(const std::array<ElementType, N>& array)
     : m_array { array }
 {
-    ASSERT_UNDER_CONSTEXPR_CONTEXT(std::is_sorted(std::begin(array), std::end(array)));
+    ASSERT_UNDER_CONSTEXPR_CONTEXT(std::is_sorted(array.begin(), array.end()));
 }
 
 template<typename ElementType, std::size_t N> template<typename KeyArgument> inline bool SortedArraySet<ElementType, N>::contains(const KeyArgument& key) const
@@ -216,10 +216,10 @@ template<typename ElementType, std::size_t N> template<typename KeyArgument> inl
     auto parsedKey = SortedArrayKeyTraits<ElementType>::parse(key);
     if (!parsedKey)
         return false;
-    if (std::size(m_array) < binarySearchThreshold)
-        return std::find(std::begin(m_array), std::end(m_array), *parsedKey) != std::end(m_array);
-    auto iterator = std::lower_bound(std::begin(m_array), std::end(m_array), *parsedKey);
-    return iterator != std::end(m_array) && *iterator == *parsedKey;
+    if constexpr (N < binarySearchThreshold)
+        return std::find(m_array.begin(), m_array.end(), *parsedKey) != m_array.end();
+    auto iterator = std::lower_bound(m_array.begin(), m_array.end(), *parsedKey);
+    return iterator != m_array.end() && *iterator == *parsedKey;
 }
 
 constexpr int compareSpansConstExpr(std::span<const char> a, std::span<const char> b)


### PR DESCRIPTION
#### ea65ee72fe7e86580661e1c6254963156a1fb95c
<pre>
Simplify SortedArrayMap / SortedArraySet a bit now that it is consistently used with std::array
<a href="https://bugs.webkit.org/show_bug.cgi?id=304746">https://bugs.webkit.org/show_bug.cgi?id=304746</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/SortedArrayMap.h:
(WTF::N&gt;::tryGet const const):
(WTF::N&gt;::contains const):

Canonical link: <a href="https://commits.webkit.org/304992@main">https://commits.webkit.org/304992@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/591bf7b73a17c5d796c13925a03ac87addf8e060

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137067 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9427 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48354 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144810 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90040 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4d3d3900-13c3-4c56-8b78-9efce7a61e98) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10130 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9554 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104814 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8fed5ff4-41e7-4306-a08b-46631e899f5c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140012 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7441 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122822 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85649 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8a4d30df-7beb-4abc-a4fd-ce203200a1fc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7078 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4783 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5399 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/129028 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116425 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40991 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147566 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/135554 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9110 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41557 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113168 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9128 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7653 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113497 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28838 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7002 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119087 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63440 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9158 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37141 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/168334 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8881 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72724 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43931 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9099 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8951 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->