### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in wtf/fast_float

### DIFF
--- a/Source/WTF/wtf/fast_float/decimal_to_binary.h
+++ b/Source/WTF/wtf/fast_float/decimal_to_binary.h
@@ -10,8 +10,6 @@
 #include <cstdlib>
 #include <cstring>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace fast_float {
 
 // This will compute or rather approximate w * 5**q and return a pair of 64-bit words approximating
@@ -187,7 +185,5 @@ adjusted_mantissa compute_float(int64_t q, uint64_t w)  noexcept  {
 }
 
 } // namespace fast_float
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif

--- a/Source/WTF/wtf/fast_float/float_common.h
+++ b/Source/WTF/wtf/fast_float/float_common.h
@@ -5,12 +5,11 @@
 #include <cstdint>
 #include <cassert>
 #include <cstring>
+#include <span>
 #include <type_traits>
 #include <system_error>
 
 #include "constexpr_feature_detect.h"
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace fast_float {
 
@@ -195,26 +194,6 @@ fastfloat_strncasecmp(UC const * input1, UC const * input2, size_t length) {
 #ifndef FLT_EVAL_METHOD
 #error "FLT_EVAL_METHOD should be defined, please include cfloat."
 #endif
-
-// a pointer and a length to a contiguous block of memory
-template <typename T>
-struct span {
-  const T* ptr;
-  size_t length;
-  constexpr span(const T* _ptr, size_t _length) : ptr(_ptr), length(_length) {}
-  template<std::size_t N>
-  constexpr span(const std::array<T, N>& array) : ptr(array.data()), length(array.size()) {}
-  constexpr span() : ptr(nullptr), length(0) { }
-
-  constexpr size_t len() const noexcept {
-    return length;
-  }
-
-  FASTFLOAT_CONSTEXPR14 const T& operator[](size_t index) const noexcept {
-    FASTFLOAT_DEBUG_ASSERT(index < length);
-    return ptr[index];
-  }
-};
 
 struct value128 {
   uint64_t low;
@@ -621,7 +600,7 @@ static constexpr uint64_t int_cmp_zeros()
     return (sizeof(UC) == 1) ? 0x3030303030303030 : (sizeof(UC) == 2) ? (uint64_t(UC('0')) << 48 | uint64_t(UC('0')) << 32 | uint64_t(UC('0')) << 16 | UC('0')) : (uint64_t(UC('0')) << 32 | UC('0'));
 }
 template<typename UC>
-static constexpr int int_cmp_len()
+static constexpr size_t int_cmp_len()
 {
     return sizeof(uint64_t) / sizeof(UC);
 }
@@ -676,7 +655,5 @@ constexpr char32_t const * str_const_inf<char32_t>()
     return U"infinity";
 }
 } // namespace fast_float
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif


### PR DESCRIPTION
#### b6095d61994d183dd760ea84f63afaf2af578cd5
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in wtf/fast_float
<a href="https://bugs.webkit.org/show_bug.cgi?id=304748">https://bugs.webkit.org/show_bug.cgi?id=304748</a>

Reviewed by Ryosuke Niwa.

* Source/WTF/wtf/fast_float/ascii_number.h:
* Source/WTF/wtf/fast_float/bigint.h:
(fast_float::stackvec::dataSpan):
* Source/WTF/wtf/fast_float/decimal_to_binary.h:
* Source/WTF/wtf/fast_float/digit_comparison.h:
* Source/WTF/wtf/fast_float/float_common.h:
(fast_float::int_cmp_len):
(fast_float::span::span): Deleted.

Canonical link: <a href="https://commits.webkit.org/305124@main">https://commits.webkit.org/305124@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1eb07c5c5a968d13fe10e5a6a849dd2638ed4e0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137073 "56 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9433 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48360 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144816 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90046 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3c2e201a-e8db-42dc-bd51-cf24e095c947) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10136 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9560 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104819 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76464 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/053f5544-1058-4fa2-8304-dd890acf6f36) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140018 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7450 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122830 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85654 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d9379b44-48f4-47f5-86a0-c4dfbf9a9687) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7087 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4789 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5405 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/129034 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116434 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40998 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147572 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/135560 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9116 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41564 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113173 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9134 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7659 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113502 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28921 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7006 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119094 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63447 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9164 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37148 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/168340 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8887 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72730 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43934 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9105 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8957 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->