### PR TITLE
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE usage in WTF::MemoryDump

### DIFF
--- a/Source/WTF/wtf/MemoryDump.h
+++ b/Source/WTF/wtf/MemoryDump.h
@@ -42,40 +42,22 @@ class MemoryDump {
 public:
     static constexpr size_t DefaultSizeLimit = 4 * 1024;
 
-    template<typename T>
-    explicit MemoryDump(std::span<T> span, size_t sizeLimit = DefaultSizeLimit)
+    template<typename T, std::size_t N = std::dynamic_extent>
+    explicit MemoryDump(std::span<T, N> span, size_t sizeLimit = DefaultSizeLimit)
         : m_data(std::as_bytes(span))
         , m_sizeLimit(sizeLimit)
     { }
 
-    explicit MemoryDump(const void* start, const void* end, size_t sizeLimit = DefaultSizeLimit);
     MemoryDump() = default;
 
     std::span<const std::byte> span() const { return m_data; }
     size_t sizeLimit() const { return m_sizeLimit; }
-    const std::byte* invertedEnd() const { return m_invertedEnd; }
 
 private:
     std::span<const std::byte> m_data { };
     size_t m_sizeLimit { DefaultSizeLimit };
-    const std::byte* m_invertedEnd { nullptr }; // end pointer value, if it was below the start pointer
     // TODO: enhance to support larger chunks than 1 bytes
 };
-
-inline MemoryDump::MemoryDump(const void* start, const void* end, size_t sizeLimit)
-    : m_sizeLimit(sizeLimit)
-{
-    auto* startByte = static_cast<const std::byte*>(start);
-    auto* endByte = static_cast<const std::byte*>(end);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    if (startByte <= endByte) [[likely]]
-        m_data = std::span<const std::byte>(startByte, endByte - startByte);
-    else {
-        m_data = std::span<const std::byte>(startByte, 0);
-        m_invertedEnd = endByte;
-    }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-}
 
 } // namespace WTF
 

--- a/Source/WTF/wtf/PrintStream.cpp
+++ b/Source/WTF/wtf/PrintStream.cpp
@@ -253,11 +253,7 @@ void printInternal(PrintStream& out, MemoryDump value)
         return;
     }
     if (span.empty()) [[unlikely]] {
-        auto* invertedEnd = value.invertedEnd();
-        if (!invertedEnd)
-            out.printf("%08" PRIxPTR ": (span is empty)", reinterpret_cast<uintptr_t>(span.data()));
-        else
-            out.printf("%08" PRIxPTR ": (span end is below the start: %p)", reinterpret_cast<uintptr_t>(span.data()), invertedEnd);
+        out.printf("%08" PRIxPTR ": (span is empty)", reinterpret_cast<uintptr_t>(span.data()));
         return;
     }
 

--- a/Tools/TestWebKitAPI/Tests/WTF/MemoryDump.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/MemoryDump.cpp
@@ -278,21 +278,14 @@ TEST(WTF, MemoryDumpRange)
     uint8_t data[] = { 0x41, 0x42, 0x43, 0x44, 0x45 }; // "ABCDE"
 
     // Test range with pointers in correct order
-    MemoryDump dump1 = MemoryDump(data, data + 5);
+    MemoryDump dump1 = MemoryDump(std::span { data });
     EXPECT_EQ(dump1.span().data(), reinterpret_cast<const std::byte*>(data));
     EXPECT_EQ(dump1.span().size(), 5u);
     EXPECT_EQ(dump1.sizeLimit(), MemoryDump::DefaultSizeLimit);
-    EXPECT_EQ(dump1.invertedEnd(), nullptr);
-
-    // Test range with pointers in reverse order
-    MemoryDump dump2(data + 5, data);
-    EXPECT_EQ(dump2.span().data(), reinterpret_cast<const std::byte*>(data + 5));
-    EXPECT_EQ(dump2.span().size(), 0u);
-    EXPECT_EQ(dump2.invertedEnd(), reinterpret_cast<const std::byte*>(data));
 
     // Test range with custom size limit
     constexpr size_t customLimit = 256;
-    MemoryDump dump3(data, data + 3, customLimit);
+    MemoryDump dump3(std::span { data }.first(3), customLimit);
     EXPECT_EQ(dump3.span().data(), reinterpret_cast<const std::byte*>(data));
     EXPECT_EQ(dump3.span().size(), 3u);
     EXPECT_EQ(dump3.sizeLimit(), customLimit);
@@ -303,12 +296,6 @@ TEST(WTF, MemoryDumpRange)
     auto result1 = stream1.tryToString();
     EXPECT_TRUE(result1.has_value());
     EXPECT_TRUE(result1.value().contains("ABCDE"_s));
-
-    StringPrintStream stream2;
-    stream2.print(dump2);
-    auto result2 = stream2.tryToString();
-    EXPECT_TRUE(result2.has_value());
-    EXPECT_TRUE(result2.value().contains("span end is below the start"_s));
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### fc2411bacb586a958ebbc1189858eca1874db072
<pre>
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE usage in WTF::MemoryDump
<a href="https://bugs.webkit.org/show_bug.cgi?id=304749">https://bugs.webkit.org/show_bug.cgi?id=304749</a>

Reviewed by Darin Adler.

Test: Tools/TestWebKitAPI/Tests/WTF/MemoryDump.cpp

* Source/WTF/wtf/MemoryDump.h:
(WTF::MemoryDump::MemoryDump):
(WTF::MemoryDump::sizeLimit const):
(WTF::MemoryDump::invertedEnd const): Deleted.
* Source/WTF/wtf/PrintStream.cpp:
(WTF::printInternal):
* Tools/TestWebKitAPI/Tests/WTF/MemoryDump.cpp:
(TestWebKitAPI::TEST(WTF, MemoryDumpRange)):

Canonical link: <a href="https://commits.webkit.org/304990@main">https://commits.webkit.org/304990@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4976c437451572051692985a85cd73602dc2e3cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137077 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9437 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48364 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144820 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90050 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8f5ac6c3-f036-46d8-92ef-7992e33a3ea2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138949 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10140 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9564 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104823 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/58d0d9d1-4aa2-4a4a-8d78-5b2a87a2c1e4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140022 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7453 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122833 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85658 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fd654282-10e5-40e2-9530-c2667e4d5f10) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7090 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4793 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5409 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/129038 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116438 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41001 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147576 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/135564 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9120 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41567 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113177 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9138 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7663 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113507 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28837 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7011 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119097 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63453 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9168 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37151 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/168344 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8891 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72734 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43936 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9109 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8961 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->