### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in wtf/dragonbox

### DIFF
--- a/Source/JavaScriptCore/runtime/JSONObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSONObject.cpp
@@ -1233,13 +1233,13 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
             return;
         }
         if constexpr (sizeof(CharType) == 1) {
-            const char* cursor = WTF::dragonbox::detail::to_chars_n<WTF::dragonbox::Mode::ToShortest>(number, reinterpret_cast<char*>(buffer() + m_length));
-            m_length = cursor - reinterpret_cast<char*>(buffer());
+            auto cursor = WTF::dragonbox::detail::to_chars_n<WTF::dragonbox::Mode::ToShortest>(number, byteCast<char>(bufferSpan().subspan(m_length)));
+            m_length = cursor.data() - reinterpret_cast<char*>(buffer());
         } else {
             std::array<char, WTF::dragonbox::max_string_length<WTF::dragonbox::ieee754_binary64>()> temporary;
-            const char* cursor = WTF::dragonbox::detail::to_chars_n<WTF::dragonbox::Mode::ToShortest>(number, temporary.data());
-            size_t length = cursor - temporary.data();
-            WTF::copyElements(spanReinterpretCast<uint16_t>(bufferSpan().subspan(m_length)), spanReinterpretCast<const uint8_t>(std::span { temporary }).first(length));
+            auto cursor = WTF::dragonbox::detail::to_chars_n<WTF::dragonbox::Mode::ToShortest>(number, std::span { temporary });
+            size_t length = cursor.data() - temporary.data();
+            WTF::copyElements(spanReinterpretCast<uint16_t>(bufferSpan().subspan(m_length)), byteCast<uint8_t>(std::span { temporary }).first(length));
             m_length += length;
         }
         return;

--- a/Source/WTF/wtf/dtoa.cpp
+++ b/Source/WTF/wtf/dtoa.cpp
@@ -27,15 +27,15 @@ namespace WTF {
 NumberToStringSpan numberToStringAndSize(float number, NumberToStringBuffer& buffer)
 {
     static_assert(sizeof(buffer) >= (dragonbox::max_string_length<dragonbox::ieee754_binary32>() + 1));
-    auto* result = dragonbox::detail::to_chars_n<WTF::dragonbox::Mode::ToShortest>(number, buffer.data());
-    return std::span { buffer }.first(result - buffer.data());
+    auto result = dragonbox::detail::to_chars_n<WTF::dragonbox::Mode::ToShortest>(number, std::span { buffer });
+    return std::span { buffer }.first(result.data() - buffer.data());
 }
 
 NumberToStringSpan numberToStringAndSize(double number, NumberToStringBuffer& buffer)
 {
     static_assert(sizeof(buffer) >= (dragonbox::max_string_length<dragonbox::ieee754_binary64>() + 1));
-    auto* result = dragonbox::detail::to_chars_n<WTF::dragonbox::Mode::ToShortest>(number, buffer.data());
-    return std::span { buffer }.first(result - buffer.data());
+    auto result = dragonbox::detail::to_chars_n<WTF::dragonbox::Mode::ToShortest>(number, std::span { buffer });
+    return std::span { buffer }.first(result.data() - buffer.data());
 }
 
 NumberToStringSpan numberToStringWithTrailingPoint(double d, NumberToStringBuffer& buffer)

--- a/Source/WTF/wtf/dtoa/utils.h
+++ b/Source/WTF/wtf/dtoa/utils.h
@@ -286,6 +286,12 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     position_ += n;
   }
 
+  void AddSubstring(std::span<const char> s) {
+    ASSERT_WITH_SECURITY_IMPLICATION(!is_finalized() && position_ + s.size() < buffer_.length());
+    ASSERT_WITH_SECURITY_IMPLICATION(std::ranges::find(s, '\0') == s.end());
+    memmoveSpan(buffer_.start().subspan(position_), s);
+    position_ += s.size();
+  }
 
   // Add character padding to the builder. If count is non-positive,
   // nothing is added to the builder.


### PR DESCRIPTION
#### a13a9efcaa07111a5dada611a5e719dd2ba10d4f
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in wtf/dragonbox
<a href="https://bugs.webkit.org/show_bug.cgi?id=304750">https://bugs.webkit.org/show_bug.cgi?id=304750</a>

Reviewed by Darin Adler.

* Source/JavaScriptCore/runtime/JSONObject.cpp:
(JSC::bufferMode&gt;::append):
* Source/WTF/wtf/dragonbox/dragonbox_to_chars.cpp:
* Source/WTF/wtf/dragonbox/dragonbox_to_chars.h:
(WTF::dragonbox::ToExponential):
(WTF::dragonbox::ToShortest):
* Source/WTF/wtf/dtoa.cpp:
(WTF::numberToStringAndSize):
* Source/WTF/wtf/dtoa/utils.h:
(WTF::double_conversion::StringBuilder::AddSubstring):

Canonical link: <a href="https://commits.webkit.org/304991@main">https://commits.webkit.org/304991@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a543041f2a8c4edbbf3d8308c351fedf38920de2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137081 "14 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9441 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48368 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144824 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90054 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/49c39302-f694-4143-8446-53280cd646dd) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10144 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9568 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104828 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/dd0c5936-a09a-4033-b711-f49b55902b48) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140026 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7459 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122838 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85663 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7cbd40d8-1c5d-4e79-989e-755cffe6c545) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7096 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4800 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5413 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/129042 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116444 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41006 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147580 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/135568 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9124 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41572 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113182 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9142 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7669 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113512 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28836 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7018 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119102 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63459 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9172 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37156 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/168348 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8895 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72738 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43939 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9113 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8965 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->