### PR TITLE
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE usage in ParallelJobsLibdispatch.h

### DIFF
--- a/Source/WTF/wtf/ParallelJobs.h
+++ b/Source/WTF/wtf/ParallelJobs.h
@@ -87,7 +87,7 @@ public:
 
     void execute()
     {
-        m_parallelEnvironment.execute(reinterpret_cast<unsigned char*>(m_parameters.mutableSpan().data()));
+        m_parallelEnvironment.execute(asMutableByteSpan(m_parameters.mutableSpan()));
     }
 
 private:

--- a/Source/WTF/wtf/ParallelJobsGeneric.h
+++ b/Source/WTF/wtf/ParallelJobsGeneric.h
@@ -51,7 +51,7 @@ public:
         return m_numberOfJobs;
     }
 
-    WTF_EXPORT_PRIVATE void execute(void* parameters);
+    WTF_EXPORT_PRIVATE void execute(std::span<uint8_t> parameters);
 
     class ThreadPrivate : public RefCounted<ThreadPrivate> {
     public:

--- a/Source/WTF/wtf/ParallelJobsLibdispatch.h
+++ b/Source/WTF/wtf/ParallelJobsLibdispatch.h
@@ -55,13 +55,10 @@ public:
         return m_numberOfJobs;
     }
 
-    void execute(unsigned char* parameters)
+    void execute(std::span<uint8_t> parameters)
     {
         static dispatch_queue_t globalQueue = globalDispatchQueueSingleton(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        dispatch_apply(m_numberOfJobs, globalQueue, ^(size_t i) { (*m_threadFunction)(parameters + (m_sizeOfParameter * i)); });
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+        dispatch_apply(m_numberOfJobs, globalQueue, ^(size_t i) { (*m_threadFunction)(parameters.subspan(m_sizeOfParameter * i, m_sizeOfParameter).data()); });
     }
 
 private:

--- a/Source/WTF/wtf/ParallelJobsOpenMP.h
+++ b/Source/WTF/wtf/ParallelJobsOpenMP.h
@@ -62,13 +62,13 @@ public:
         return m_numberOfJobs;
     }
 
-    void execute(unsigned char* parameters)
+    void execute(std::span<uint8_t> parameters)
     {
         omp_set_num_threads(m_numberOfJobs);
 
 #pragma omp parallel for
         for (int i = 0; i < m_numberOfJobs; ++i)
-            (*m_threadFunction)(parameters + i * m_sizeOfParameter);
+            (*m_threadFunction)(parameters.subspan(i * m_sizeOfParameter, m_sizeOfParameter).data());
     }
 
 private:


### PR DESCRIPTION
#### 1c07135c61c1b3da5c9433998524593ec235291a
<pre>
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE usage in ParallelJobsLibdispatch.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=304753">https://bugs.webkit.org/show_bug.cgi?id=304753</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/ParallelJobs.h:
(WTF::ParallelJobs::execute):
* Source/WTF/wtf/ParallelJobsGeneric.cpp:
(WTF::ParallelEnvironment::execute):
* Source/WTF/wtf/ParallelJobsGeneric.h:
* Source/WTF/wtf/ParallelJobsLibdispatch.h:
(WTF::ParallelEnvironment::execute):
* Source/WTF/wtf/ParallelJobsOpenMP.h:
(WTF::ParallelEnvironment::execute):

Canonical link: <a href="https://commits.webkit.org/305089@main">https://commits.webkit.org/305089@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/feed6c0ab629187293bc3b348090059c3ac0904f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137089 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9449 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48376 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144832 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90062 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d06b9371-cf4c-4e8f-98a1-1b96c95d3441) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10152 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9576 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104833 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/201e60ce-3480-46b8-ab4a-0c0b8c38ad20) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140034 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7463 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122842 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85668 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d07b3269-17ab-472e-8eb7-d822948aa90b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7100 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4806 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5421 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/129050 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116448 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41010 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147588 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/135576 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9132 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41576 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113187 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9150 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7675 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113517 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28896 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7023 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119106 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63470 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9180 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37160 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/168356 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8904 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72746 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43941 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9121 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8973 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->