### PR TITLE
Add GPU acceleration for morphology filters

### DIFF
--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -505,6 +505,7 @@ platform/graphics/coreimage/FEColorMatrixCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/FEComponentTransferCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/FECompositeCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/FEFloodCoreImageApplier.mm @nonARC
+platform/graphics/coreimage/FEMorphologyCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/FilterImageCoreImage.mm @nonARC
 platform/graphics/coreimage/SourceAlphaCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/SourceGraphicCoreImageApplier.mm @nonARC

--- a/Source/WebCore/platform/graphics/coreimage/FEMorphologyCoreImageApplier.h
+++ b/Source/WebCore/platform/graphics/coreimage/FEMorphologyCoreImageApplier.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(CORE_IMAGE)
+
+#import "FilterEffectApplier.h"
+#import <wtf/TZoneMalloc.h>
+
+namespace WebCore {
+
+class FEMorphology;
+
+class FEMorphologyCoreImageApplier final : public FilterEffectConcreteApplier<FEMorphology> {
+    WTF_MAKE_TZONE_ALLOCATED(FEMorphologyCoreImageApplier);
+    using Base = FilterEffectConcreteApplier<FEMorphology>;
+
+public:
+    FEMorphologyCoreImageApplier(const FEMorphology&);
+
+    static bool supportsCoreImageRendering(const FEMorphology&);
+
+private:
+    bool apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const final;
+};
+
+} // namespace WebCore
+
+#endif // USE(CORE_IMAGE)

--- a/Source/WebCore/platform/graphics/coreimage/FEMorphologyCoreImageApplier.mm
+++ b/Source/WebCore/platform/graphics/coreimage/FEMorphologyCoreImageApplier.mm
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "FEMorphologyCoreImageApplier.h"
+
+#if USE(CORE_IMAGE)
+
+#import "FEMorphology.h"
+#import "Filter.h"
+#import "FilterImage.h"
+#import "Logging.h"
+#import <CoreImage/CoreImage.h>
+#import <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FEMorphologyCoreImageApplier);
+
+FEMorphologyCoreImageApplier::FEMorphologyCoreImageApplier(const FEMorphology& effect)
+    : Base(effect)
+{
+    ASSERT(supportsCoreImageRendering(effect));
+}
+
+bool FEMorphologyCoreImageApplier::supportsCoreImageRendering(const FEMorphology&)
+{
+    return true;
+}
+
+bool FEMorphologyCoreImageApplier::apply(const Filter& filter, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
+{
+    ASSERT(inputs.size() == 1);
+    Ref input = inputs[0].get();
+
+    RetainPtr inputImage = input->ciImage();
+    if (!inputImage)
+        return false;
+
+    auto radius = filter.resolvedSize({ m_effect->radiusX(), m_effect->radiusY() });
+    auto scaledRadius = filter.scaledByFilterScale(radius);
+
+    float radiusX = scaledRadius.width();
+    float radiusY = scaledRadius.height();
+
+    if (radiusX <= 0 && radiusY <= 0) {
+        result.setCIImage(inputImage.get());
+        return true;
+    }
+
+    // Core Image expects kernel size (width/height), not radius
+    // kernel size = 2 * radius + 1
+    int kernelWidth = static_cast<int>(2 * radiusX + 1);
+    int kernelHeight = static_cast<int>(2 * radiusY + 1);
+
+    NSString *filterName = (m_effect->morphologyOperator() == MorphologyOperatorType::Erode)
+        ? @"CIMorphologyRectangleMinimum"
+        : @"CIMorphologyRectangleMaximum";
+
+    RetainPtr morphologyFilter = [CIFilter filterWithName:filterName];
+    if (!morphologyFilter) {
+        LOG(Filters, "FEMorphologyCoreImageApplier: Failed to create filter %@", filterName);
+        return false;
+    }
+
+    [morphologyFilter setValue:inputImage.get() forKey:kCIInputImageKey];
+    [morphologyFilter setValue:@(kernelWidth) forKey:@"inputWidth"];
+    [morphologyFilter setValue:@(kernelHeight) forKey:@"inputHeight"];
+
+    result.setCIImage([morphologyFilter outputImage]);
+    return true;
+}
+
+} // namespace WebCore
+
+#endif // USE(CORE_IMAGE)

--- a/Source/WebCore/platform/graphics/filters/FEMorphology.h
+++ b/Source/WebCore/platform/graphics/filters/FEMorphology.h
@@ -58,6 +58,8 @@ private:
 
     bool resultIsAlphaImage(std::span<const Ref<FilterImage>> inputs) const override;
 
+    OptionSet<FilterRenderingMode> supportedFilterRenderingModes(OptionSet<FilterRenderingMode> preferredFilterRenderingModes) const override;
+    std::unique_ptr<FilterEffectApplier> createAcceleratedApplier() const override;
     std::unique_ptr<FilterEffectApplier> createSoftwareApplier() const override;
 
     WTF::TextStream& externalRepresentation(WTF::TextStream&, FilterRepresentation) const override;


### PR DESCRIPTION
#### b802bf60e5006c59c715973c2d1041abd33b847c
<pre>
Add GPU acceleration for morphology filters
<a href="https://bugs.webkit.org/show_bug.cgi?id=304758">https://bugs.webkit.org/show_bug.cgi?id=304758</a>
<a href="https://rdar.apple.com/167295476">rdar://167295476</a>

Reviewed by Simon Fraser.

This PR implements Core Image-based GPU acceleration for feMorphology
filters. It uses CIMorphologyRectangleMinimum for erosion and
CIMorphologyRectangleMaximum for dilation.

* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/coreimage/FEMorphologyCoreImageApplier.h: Added.
* Source/WebCore/platform/graphics/coreimage/FEMorphologyCoreImageApplier.mm: Added.
(WebCore::FEMorphologyCoreImageApplier::FEMorphologyCoreImageApplier):
(WebCore::FEMorphologyCoreImageApplier::supportsCoreImageRendering):
(WebCore::FEMorphologyCoreImageApplier::apply const):
* Source/WebCore/platform/graphics/filters/FEMorphology.cpp:
(WebCore::FEMorphology::supportedFilterRenderingModes const):
(WebCore::FEMorphology::createAcceleratedApplier const):
* Source/WebCore/platform/graphics/filters/FEMorphology.h:

Canonical link: <a href="https://commits.webkit.org/304986@main">https://commits.webkit.org/304986@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2ed550697a613bafd629fb279a39d12ee00bd70

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137105 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9465 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48392 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144848 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90078 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/faa6dd3e-55ab-4e50-a37f-96d0e185c4ab) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138977 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10168 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9592 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104847 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/90d98f9c-00a1-4a0a-9144-161b93d0c70d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140050 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7475 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122862 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85683 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/905e4049-1ba1-4e2f-b28e-2adc337838e3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7112 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4821 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5438 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116461 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41028 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147604 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9148 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41593 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113201 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9166 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7689 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113531 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28835 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7035 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119123 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63500 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9196 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37177 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8920 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72762 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9137 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8989 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->