### PR TITLE
Reduce unsafe member variables in WebCore scrolling code

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -60,7 +60,6 @@ page/PageOverlayController.cpp
 [ iOS ] page/ios/ContentChangeObserver.h
 [ Mac ] page/mac/ImageOverlayControllerMac.mm
 [ Mac ] page/mac/ServicesOverlayController.mm
-page/scrolling/ScrollingCoordinator.h
 page/scrolling/ScrollingStateNode.h
 [ Mac ] page/scrolling/ScrollingStateScrollingNode.cpp
 platform/PODRedBlackTree.h

--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -20,8 +20,6 @@ dom/Node.h
 dom/TreeScope.h
 layout/formattingContexts/inline/InlineItemsBuilder.h
 [ iOS ] page/ios/ContentChangeObserver.h
-page/scrolling/ScrollingCoordinator.h
-page/scrolling/ScrollingTreeGestureState.h
 platform/PODInterval.h
 [ iOS ] platform/audio/ios/AudioSessionIOS.mm
 platform/graphics/filters/software/FEConvolveMatrixSoftwareApplier.h
@@ -30,7 +28,6 @@ platform/graphics/filters/software/FEMorphologySoftwareApplier.h
 platform/graphics/filters/software/FETurbulenceSoftwareApplier.h
 [ iOS ] platform/graphics/ios/DisplayRefreshMonitorIOS.mm
 [ iOS ] platform/ios/wak/WAKWindow.h
-platform/mock/ScrollbarsControllerMock.h
 rendering/PaintInfo.h
 rendering/RenderLayer.h
 rendering/RenderLayerBacking.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -552,7 +552,6 @@ page/scrolling/AsyncScrollingCoordinator.cpp
 page/scrolling/ScrollAnchoringController.cpp
 page/scrolling/ScrollSnapOffsetsInfo.cpp
 page/scrolling/ScrollingCoordinator.cpp
-[ Mac ] page/scrolling/ScrollingTreeGestureState.cpp
 [ Mac ] page/scrolling/ThreadedScrollingCoordinator.cpp
 [ Mac ] page/scrolling/mac/ScrollingCoordinatorMac.mm
 page/text-extraction/TextExtraction.cpp

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -1017,27 +1017,27 @@ void AsyncScrollingCoordinator::setNodeLayers(ScrollingNodeID nodeID, const Node
     if (!node)
         return;
 
-    node->setLayer(nodeLayers.layer);
+    node->setLayer(nodeLayers.layer.get());
 
     if (auto* scrollingNode = dynamicDowncast<ScrollingStateScrollingNode>(*node)) {
-        scrollingNode->setScrollContainerLayer(nodeLayers.scrollContainerLayer);
-        scrollingNode->setScrolledContentsLayer(nodeLayers.scrolledContentsLayer);
-        scrollingNode->setHorizontalScrollbarLayer(nodeLayers.horizontalScrollbarLayer);
-        scrollingNode->setVerticalScrollbarLayer(nodeLayers.verticalScrollbarLayer);
+        scrollingNode->setScrollContainerLayer(nodeLayers.scrollContainerLayer.get());
+        scrollingNode->setScrolledContentsLayer(nodeLayers.scrolledContentsLayer.get());
+        scrollingNode->setHorizontalScrollbarLayer(nodeLayers.horizontalScrollbarLayer.get());
+        scrollingNode->setVerticalScrollbarLayer(nodeLayers.verticalScrollbarLayer.get());
         if (RefPtr frameView = frameViewForScrollingNode(nodeID)) {
             if (CheckedPtr scrollableArea = frameView->scrollableAreaForScrollingNodeID(nodeID))
                 scrollingNode->setScrollbarLayoutDirection(scrollableArea->shouldPlaceVerticalScrollbarOnLeft() ? UserInterfaceLayoutDirection::RTL : UserInterfaceLayoutDirection::LTR);
         }
 
         if (auto* frameScrollingNode = dynamicDowncast<ScrollingStateFrameScrollingNode>(*scrollingNode)) {
-            frameScrollingNode->setInsetClipLayer(nodeLayers.insetClipLayer);
-            frameScrollingNode->setCounterScrollingLayer(nodeLayers.counterScrollingLayer);
-            frameScrollingNode->setRootContentsLayer(nodeLayers.rootContentsLayer);
+            frameScrollingNode->setInsetClipLayer(nodeLayers.insetClipLayer.get());
+            frameScrollingNode->setCounterScrollingLayer(nodeLayers.counterScrollingLayer.get());
+            frameScrollingNode->setRootContentsLayer(nodeLayers.rootContentsLayer.get());
         }
     }
 
     if (RefPtr stickyNode = dynamicDowncast<ScrollingStateStickyNode>(*node))
-        stickyNode->setViewportAnchorLayer(nodeLayers.viewportAnchorLayer);
+        stickyNode->setViewportAnchorLayer(nodeLayers.viewportAnchorLayer.get());
 }
 
 void AsyncScrollingCoordinator::setFrameScrollingNodeState(ScrollingNodeID nodeID, const LocalFrameView& frameView)

--- a/Source/WebCore/page/scrolling/ScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinator.h
@@ -156,15 +156,15 @@ public:
     virtual void scrollBySimulatingWheelEventForTesting(ScrollingNodeID, FloatSize) { }
 
     struct NodeLayers {
-        GraphicsLayer* layer { nullptr };
-        GraphicsLayer* scrollContainerLayer { nullptr };
-        GraphicsLayer* scrolledContentsLayer { nullptr };
-        GraphicsLayer* counterScrollingLayer { nullptr };
-        GraphicsLayer* insetClipLayer { nullptr };
-        GraphicsLayer* rootContentsLayer { nullptr };
-        GraphicsLayer* horizontalScrollbarLayer { nullptr };
-        GraphicsLayer* verticalScrollbarLayer { nullptr };
-        GraphicsLayer* viewportAnchorLayer { nullptr };
+        RefPtr<GraphicsLayer> layer { nullptr };
+        RefPtr<GraphicsLayer> scrollContainerLayer { nullptr };
+        RefPtr<GraphicsLayer> scrolledContentsLayer { nullptr };
+        RefPtr<GraphicsLayer> counterScrollingLayer { nullptr };
+        RefPtr<GraphicsLayer> insetClipLayer { nullptr };
+        RefPtr<GraphicsLayer> rootContentsLayer { nullptr };
+        RefPtr<GraphicsLayer> horizontalScrollbarLayer { nullptr };
+        RefPtr<GraphicsLayer> verticalScrollbarLayer { nullptr };
+        RefPtr<GraphicsLayer> viewportAnchorLayer { nullptr };
     };
     virtual void setNodeLayers(ScrollingNodeID, const NodeLayers&) { }
 

--- a/Source/WebCore/page/scrolling/ScrollingTreeGestureState.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeGestureState.cpp
@@ -52,7 +52,7 @@ bool ScrollingTreeGestureState::handleGestureCancel(const PlatformWheelEvent& ev
 {
     if (event.isGestureCancel()) {
         if (m_mayBeginNodeID)
-            m_scrollingTree.handleWheelEventPhase(*m_mayBeginNodeID, PlatformWheelEventPhase::Cancelled);
+            m_scrollingTree.get()->handleWheelEventPhase(*m_mayBeginNodeID, PlatformWheelEventPhase::Cancelled);
         return true;
     }
     
@@ -65,7 +65,7 @@ void ScrollingTreeGestureState::nodeDidHandleEvent(ScrollingNodeID nodeID, const
     switch (event.phase()) {
     case PlatformWheelEventPhase::MayBegin:
         m_mayBeginNodeID = nodeID;
-        m_scrollingTree.handleWheelEventPhase(nodeID, event.phase());
+        m_scrollingTree.get()->handleWheelEventPhase(nodeID, event.phase());
         break;
     case PlatformWheelEventPhase::Cancelled:
         // We can get here for via handleWheelEventAfterMainThread(), in which case handleGestureCancel() was not called first.
@@ -73,11 +73,11 @@ void ScrollingTreeGestureState::nodeDidHandleEvent(ScrollingNodeID nodeID, const
         break;
     case PlatformWheelEventPhase::Began:
         m_activeNodeID = nodeID;
-        m_scrollingTree.handleWheelEventPhase(nodeID, event.phase());
+        m_scrollingTree.get()->handleWheelEventPhase(nodeID, event.phase());
         break;
     case PlatformWheelEventPhase::Ended:
         if (m_activeNodeID)
-            m_scrollingTree.handleWheelEventPhase(*m_activeNodeID, event.phase());
+            m_scrollingTree.get()->handleWheelEventPhase(*m_activeNodeID, event.phase());
         break;
     case PlatformWheelEventPhase::Changed:
     case PlatformWheelEventPhase::Stationary:
@@ -93,11 +93,11 @@ void ScrollingTreeGestureState::nodeDidHandleEvent(ScrollingNodeID nodeID, const
         break;
     case PlatformWheelEventPhase::Began:
         m_activeNodeID = nodeID;
-        m_scrollingTree.handleWheelEventPhase(nodeID, event.momentumPhase());
+        m_scrollingTree.get()->handleWheelEventPhase(nodeID, event.momentumPhase());
         break;
     case PlatformWheelEventPhase::Ended:
         if (m_activeNodeID)
-            m_scrollingTree.handleWheelEventPhase(*m_activeNodeID, event.momentumPhase());
+            m_scrollingTree.get()->handleWheelEventPhase(*m_activeNodeID, event.momentumPhase());
         break;
     case PlatformWheelEventPhase::Changed:
     case PlatformWheelEventPhase::Stationary:

--- a/Source/WebCore/page/scrolling/ScrollingTreeGestureState.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeGestureState.h
@@ -29,6 +29,7 @@
 
 #include <WebCore/ScrollTypes.h>
 #include <wtf/Markable.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 
 namespace WebCore {
 
@@ -50,7 +51,7 @@ public:
 private:
     void clearAllNodes();
 
-    ScrollingTree& m_scrollingTree;
+    ThreadSafeWeakPtr<ScrollingTree> m_scrollingTree; // Cannot be null.
     Markable<ScrollingNodeID> m_mayBeginNodeID;
     Markable<ScrollingNodeID> m_activeNodeID;
 };

--- a/Source/WebCore/platform/mock/ScrollbarsControllerMock.h
+++ b/Source/WebCore/platform/mock/ScrollbarsControllerMock.h
@@ -33,6 +33,7 @@
 
 #include <WebCore/ScrollbarsController.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
@@ -63,8 +64,8 @@ private:
     ASCIILiteral scrollbarPrefix(Scrollbar*) const;
 
     Function<void(const String&)> m_logger;
-    Scrollbar* m_verticalScrollbar { nullptr };
-    Scrollbar* m_horizontalScrollbar { nullptr };
+    SingleThreadWeakPtr<Scrollbar> m_verticalScrollbar;
+    SingleThreadWeakPtr<Scrollbar> m_horizontalScrollbar;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 8e82e43489dafd2f1868b62442306fcfc6d0c401
<pre>
Reduce unsafe member variables in WebCore scrolling code
<a href="https://bugs.webkit.org/show_bug.cgi?id=304762">https://bugs.webkit.org/show_bug.cgi?id=304762</a>

Reviewed by Charlie Wolfe.

We use RefPtr for the members of the NodeLayers struct as it&apos;s
stack-allocated.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

Canonical link: <a href="https://commits.webkit.org/305024@main">https://commits.webkit.org/305024@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86a0640a0035c52a7beb6247a0ef7305d49604c8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137203 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9563 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48490 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144952 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90176 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c17dc18f-8f3f-4344-8204-21cbfbef41f2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139075 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10266 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9690 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104924 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/433caca3-4e6a-4bf3-8499-361fb9a00ef1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140148 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7567 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122955 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85765 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/71f2f45d-4f61-4065-b318-52cd06500a09) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7204 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4915 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5539 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116560 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41118 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147710 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9246 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41680 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113284 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9264 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7778 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113614 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7123 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119210 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63683 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21141 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9295 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37264 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9020 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72860 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9235 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9087 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->