### PR TITLE
[Style] Convert the 'caret-color' property to strong style types

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -3600,6 +3600,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/transitions/StyleTransitions.h
 
     style/values/ui/StyleAccentColor.h
+    style/values/ui/StyleCaretColor.h
     style/values/ui/StyleCursor.h
     style/values/ui/StyleResize.h
 

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3398,6 +3398,7 @@ style/values/transforms/StyleTranslate.cpp
 style/values/transitions/StyleSingleTransitionProperty.cpp
 style/values/transitions/StyleTransition.cpp
 style/values/ui/StyleAccentColor.cpp
+style/values/ui/StyleCaretColor.cpp
 style/values/ui/StyleCursor.cpp
 style/values/ui/StyleResize.cpp
 style/values/view-transitions/StyleViewTransitionName.cpp

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -369,16 +369,15 @@
                 "auto"
             ],
             "codegen-properties": {
-                "animation-wrapper": "CaretColorWrapper",
-                "animation-wrapper-requires-override-parameters": [],
                 "visited-link-color-support": true,
                 "color-property": true,
-                "style-builder-custom": "All",
-                "skip-render-style-getter": true,
-                "skip-render-style-setter": true,
-                "skip-render-style-initial": true,
-                "render-style-changed-for-animation-custom": true,
+                "color-property-traits-color-custom": true,
+                "color-property-traits-visited-link-color-custom": true,
+                "style-extractor-custom": true,
                 "render-style-storage-path": ["m_rareInheritedData"],
+                "render-style-storage-kind": "reference",
+                "render-style-type": "Style::CaretColor",
+                "render-style-visited-link-storage-path": ["m_rareInheritedData"],
                 "parser-grammar": "auto | <color>"
             },
             "specification": {

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -1992,7 +1992,7 @@ Color CaretBase::computeCaretColor(const RenderStyle& elementStyle, const Node* 
     // On iOS, we want to fall back to the tintColor, and only override if CSS has explicitly specified a custom color.
 #if PLATFORM(IOS_FAMILY) && !PLATFORM(MACCATALYST)
     UNUSED_PARAM(node);
-    if (elementStyle.hasAutoCaretColor())
+    if (elementStyle.caretColor().isAuto())
         return { };
     return elementStyle.caretColorResolvingCurrentColor();
 #elif HAVE(REDESIGNED_TEXT_CURSOR)
@@ -2002,7 +2002,7 @@ Color CaretBase::computeCaretColor(const RenderStyle& elementStyle, const Node* 
     auto appUsesCustomAccentColor = false;
 #endif
 
-    if (elementStyle.hasAutoCaretColor() && (!elementStyle.hasExplicitlySetColor() || appUsesCustomAccentColor)) {
+    if (elementStyle.caretColor().isAuto() && (!elementStyle.hasExplicitlySetColor() || appUsesCustomAccentColor)) {
 #if PLATFORM(MAC)
         auto cssColorValue = CSSValueAppleSystemControlAccent;
 #else
@@ -2020,7 +2020,7 @@ Color CaretBase::computeCaretColor(const RenderStyle& elementStyle, const Node* 
     RefPtr parentElement = node ? node->parentElement() : nullptr;
     auto* parentStyle = parentElement && parentElement->renderer() ? &parentElement->renderer()->style() : nullptr;
     // CSS value "auto" is treated as an invalid color.
-    if (elementStyle.hasAutoCaretColor() && parentStyle) {
+    if (elementStyle.caretColor().isAuto() && parentStyle) {
         auto parentBackgroundColor = parentStyle->visitedDependentBackgroundColorApplyingColorFilter();
         auto elementBackgroundColor = elementStyle.visitedDependentBackgroundColorApplyingColorFilter();
         auto disappearsIntoBackground = blendSourceOver(parentBackgroundColor, elementBackgroundColor) == parentBackgroundColor;

--- a/Source/WebCore/rendering/style/RenderStyleBase+GettersInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleBase+GettersInlines.h
@@ -540,28 +540,6 @@ inline const Style::PageSize& RenderStyleBase::pageSize() const
     return m_computedStyle.pageSize();
 }
 
-// FIXME: Add a type that encapsulates both caretColor() and hasAutoCaretColor().
-
-inline const Style::Color& RenderStyleBase::caretColor() const
-{
-    return m_computedStyle.caretColor();
-}
-
-inline bool RenderStyleBase::hasAutoCaretColor() const
-{
-    return m_computedStyle.hasAutoCaretColor();
-}
-
-inline const Style::Color& RenderStyleBase::visitedLinkCaretColor() const
-{
-    return m_computedStyle.visitedLinkCaretColor();
-}
-
-inline bool RenderStyleBase::hasVisitedLinkAutoCaretColor() const
-{
-    return m_computedStyle.hasVisitedLinkAutoCaretColor();
-}
-
 // MARK: - Properties/descriptors that are not yet generated
 
 inline const CounterDirectiveMap& RenderStyleBase::counterDirectives() const

--- a/Source/WebCore/rendering/style/RenderStyleBase+SettersInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleBase+SettersInlines.h
@@ -371,26 +371,4 @@ inline void RenderStyleBase::setPageSize(Style::PageSize&& pageSize)
     m_computedStyle.setPageSize(WTF::move(pageSize));
 }
 
-// FIXME: Add a type that encapsulates both caretColor() and hasAutoCaretColor().
-
-inline void RenderStyleBase::setCaretColor(Style::Color&& color)
-{
-    m_computedStyle.setCaretColor(WTF::move(color));
-}
-
-inline void RenderStyleBase::setHasAutoCaretColor()
-{
-    m_computedStyle.setHasAutoCaretColor();
-}
-
-inline void RenderStyleBase::setVisitedLinkCaretColor(Style::Color&& value)
-{
-    m_computedStyle.setVisitedLinkCaretColor(WTF::move(value));
-}
-
-inline void RenderStyleBase::setHasVisitedLinkAutoCaretColor()
-{
-    m_computedStyle.setHasVisitedLinkAutoCaretColor();
-}
-
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/RenderStyleBase.h
+++ b/Source/WebCore/rendering/style/RenderStyleBase.h
@@ -288,16 +288,6 @@ public:
 
     // MARK: - Properties/descriptors that are not yet generated
 
-    // `caret-color`
-    inline const Style::Color& caretColor() const;
-    inline const Style::Color& visitedLinkCaretColor() const;
-    inline bool hasAutoCaretColor() const;
-    inline bool hasVisitedLinkAutoCaretColor() const;
-    inline void setCaretColor(Style::Color&&);
-    inline void setVisitedLinkCaretColor(Style::Color&&);
-    inline void setHasAutoCaretColor();
-    inline void setHasVisitedLinkAutoCaretColor();
-
     // `cursor`
     inline CursorType cursorType() const;
 

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
@@ -46,8 +46,8 @@ StyleRareInheritedData::StyleRareInheritedData()
     , visitedLinkTextStrokeColor(Style::ComputedStyle::initialTextStrokeColor())
     , visitedLinkTextFillColor(Style::ComputedStyle::initialTextFillColor())
     , visitedLinkTextEmphasisColor(Style::ComputedStyle::initialTextEmphasisColor())
-    , caretColor(Style::Color::currentColor())
-    , visitedLinkCaretColor(Style::Color::currentColor())
+    , caretColor(Style::ComputedStyle::initialCaretColor())
+    , visitedLinkCaretColor(Style::ComputedStyle::initialCaretColor())
     , accentColor(Style::ComputedStyle::initialAccentColor())
     , scrollbarColor(Style::ComputedStyle::initialScrollbarColor())
     , textEmphasisStyle(Style::ComputedStyle::initialTextEmphasisStyle())
@@ -126,8 +126,6 @@ StyleRareInheritedData::StyleRareInheritedData()
     , joinStyle(static_cast<unsigned>(Style::ComputedStyle::initialJoinStyle()))
     , hasExplicitlySetStrokeWidth(false)
     , hasExplicitlySetStrokeColor(false)
-    , hasAutoCaretColor(true)
-    , hasVisitedLinkAutoCaretColor(true)
     , effectiveInert(false)
     , effectivelyTransparent(false)
     , isInSubtreeWithBlendMode(false)
@@ -234,8 +232,6 @@ inline StyleRareInheritedData::StyleRareInheritedData(const StyleRareInheritedDa
     , joinStyle(o.joinStyle)
     , hasExplicitlySetStrokeWidth(o.hasExplicitlySetStrokeWidth)
     , hasExplicitlySetStrokeColor(o.hasExplicitlySetStrokeColor)
-    , hasAutoCaretColor(o.hasAutoCaretColor)
-    , hasVisitedLinkAutoCaretColor(o.hasVisitedLinkAutoCaretColor)
     , effectiveInert(o.effectiveInert)
     , effectivelyTransparent(o.effectivelyTransparent)
     , isInSubtreeWithBlendMode(o.isInSubtreeWithBlendMode)
@@ -339,8 +335,6 @@ bool StyleRareInheritedData::operator==(const StyleRareInheritedData& o) const
         && hasExplicitlySetStrokeColor == o.hasExplicitlySetStrokeColor
         && mathShift == o.mathShift
         && mathStyle == o.mathStyle
-        && hasAutoCaretColor == o.hasAutoCaretColor
-        && hasVisitedLinkAutoCaretColor == o.hasVisitedLinkAutoCaretColor
         && isInSubtreeWithBlendMode == o.isInSubtreeWithBlendMode
         && isForceHidden == o.isForceHidden
         && autoRevealsWhenFound == o.autoRevealsWhenFound
@@ -470,8 +464,6 @@ void StyleRareInheritedData::dumpDifferences(TextStream& ts, const StyleRareInhe
     LOG_IF_DIFFERENT_WITH_CAST(MathShift, mathShift);
     LOG_IF_DIFFERENT_WITH_CAST(MathStyle, mathStyle);
 
-    LOG_IF_DIFFERENT_WITH_CAST(bool, hasAutoCaretColor);
-    LOG_IF_DIFFERENT_WITH_CAST(bool, hasVisitedLinkAutoCaretColor);
     LOG_IF_DIFFERENT_WITH_CAST(bool, effectiveInert);
     LOG_IF_DIFFERENT_WITH_CAST(bool, effectivelyTransparent);
 

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.h
@@ -28,6 +28,7 @@
 #include <WebCore/RenderStyleConstants.h>
 #include <WebCore/StyleAccentColor.h>
 #include <WebCore/StyleBlockEllipsis.h>
+#include <WebCore/StyleCaretColor.h>
 #include <WebCore/StyleColor.h>
 #include <WebCore/StyleCursor.h>
 #include <WebCore/StyleCustomPropertyData.h>
@@ -120,8 +121,8 @@ public:
     Style::Color visitedLinkTextStrokeColor;
     Style::Color visitedLinkTextFillColor;
     Style::Color visitedLinkTextEmphasisColor;
-    Style::Color caretColor;
-    Style::Color visitedLinkCaretColor;
+    Style::CaretColor caretColor;
+    Style::CaretColor visitedLinkCaretColor;
 
     Style::AccentColor accentColor;
 
@@ -219,8 +220,6 @@ public:
     PREFERRED_TYPE(LineJoin) unsigned joinStyle : 2;
     PREFERRED_TYPE(bool) unsigned hasExplicitlySetStrokeWidth : 1;
     PREFERRED_TYPE(bool) unsigned hasExplicitlySetStrokeColor : 1;
-    PREFERRED_TYPE(bool) unsigned hasAutoCaretColor : 1;
-    PREFERRED_TYPE(bool) unsigned hasVisitedLinkAutoCaretColor : 1;
     PREFERRED_TYPE(bool) unsigned effectiveInert : 1;
     PREFERRED_TYPE(bool) unsigned effectivelyTransparent : 1;
     PREFERRED_TYPE(bool) unsigned isInSubtreeWithBlendMode : 1;

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -88,6 +88,7 @@ inline BorderImageOutset forwardInheritedValue(const BorderImageOutset& value) {
 inline BorderImageRepeat forwardInheritedValue(const BorderImageRepeat& value) { auto copy = value; return copy; }
 inline BorderRadiusValue forwardInheritedValue(const BorderRadiusValue& value) { auto copy = value; return copy; }
 inline BoxShadows forwardInheritedValue(const BoxShadows& value) { auto copy = value; return copy; }
+inline CaretColor forwardInheritedValue(const CaretColor& value) { auto copy = value; return copy; }
 inline ContainIntrinsicSize forwardInheritedValue(const ContainIntrinsicSize& value) { auto copy = value; return copy; }
 inline ContainerNames forwardInheritedValue(const ContainerNames& value) { auto copy = value; return copy; }
 inline Content forwardInheritedValue(const Content& value) { auto copy = value; return copy; }
@@ -201,7 +202,6 @@ public:
     DECLARE_PROPERTY_CUSTOM_HANDLERS(BorderBottomRightRadius);
     DECLARE_PROPERTY_CUSTOM_HANDLERS(BorderTopLeftRadius);
     DECLARE_PROPERTY_CUSTOM_HANDLERS(BorderTopRightRadius);
-    DECLARE_PROPERTY_CUSTOM_HANDLERS(CaretColor);
     DECLARE_PROPERTY_CUSTOM_HANDLERS(Color);
     DECLARE_PROPERTY_CUSTOM_HANDLERS(CounterIncrement);
     DECLARE_PROPERTY_CUSTOM_HANDLERS(CounterReset);
@@ -529,47 +529,6 @@ inline void BuilderCustom::applyValueLineHeight(BuilderState& builderState, CSSV
 }
 
 #endif
-
-inline void BuilderCustom::applyInitialCaretColor(BuilderState& builderState)
-{
-    if (builderState.applyPropertyToRegularStyle())
-        builderState.style().setHasAutoCaretColor();
-    if (builderState.applyPropertyToVisitedLinkStyle())
-        builderState.style().setHasVisitedLinkAutoCaretColor();
-}
-
-inline void BuilderCustom::applyInheritCaretColor(BuilderState& builderState)
-{
-    auto& color = builderState.parentStyle().caretColor();
-    if (builderState.applyPropertyToRegularStyle()) {
-        if (builderState.parentStyle().hasAutoCaretColor())
-            builderState.style().setHasAutoCaretColor();
-        else
-            builderState.style().setCaretColor(forwardInheritedValue(color));
-    }
-    if (builderState.applyPropertyToVisitedLinkStyle()) {
-        if (builderState.parentStyle().hasVisitedLinkAutoCaretColor())
-            builderState.style().setHasVisitedLinkAutoCaretColor();
-        else
-            builderState.style().setVisitedLinkCaretColor(forwardInheritedValue(color));
-    }
-}
-
-inline void BuilderCustom::applyValueCaretColor(BuilderState& builderState, CSSValue& value)
-{
-    if (builderState.applyPropertyToRegularStyle()) {
-        if (value.valueID() == CSSValueAuto)
-            builderState.style().setHasAutoCaretColor();
-        else
-            builderState.style().setCaretColor(toStyleFromCSSValue<Color>(builderState, value, ForVisitedLink::No));
-    }
-    if (builderState.applyPropertyToVisitedLinkStyle()) {
-        if (value.valueID() == CSSValueAuto)
-            builderState.style().setHasVisitedLinkAutoCaretColor();
-        else
-            builderState.style().setVisitedLinkCaretColor(toStyleFromCSSValue<Color>(builderState, value, ForVisitedLink::Yes));
-    }
-}
 
 inline void BuilderCustom::applyValueWebkitLocale(BuilderState& builderState, CSSValue& value)
 {

--- a/Source/WebCore/style/StyleChangedAnimatablePropertiesCustom.h
+++ b/Source/WebCore/style/StyleChangedAnimatablePropertiesCustom.h
@@ -50,11 +50,5 @@ inline void ChangedAnimatablePropertiesCustom::conservativelyCollectChangedAnima
         changingProperties.m_properties.set(CSSPropertyZIndex);
 }
 
-inline void ChangedAnimatablePropertiesCustom::conservativelyCollectChangedAnimatablePropertiesForCaretColor(const StyleRareInheritedData& a, const StyleRareInheritedData& b, CSSPropertiesBitSet& changingProperties)
-{
-    if (a.caretColor != b.caretColor || a.visitedLinkCaretColor != b.visitedLinkCaretColor || a.hasAutoCaretColor != b.hasAutoCaretColor || a.hasVisitedLinkAutoCaretColor != b.hasVisitedLinkAutoCaretColor)
-        changingProperties.m_properties.set(CSSPropertyCaretColor);
-}
-
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -128,7 +128,7 @@ public:
     static Ref<CSSValue> extractWebkitMaskComposite(ExtractorState&);
     static Ref<CSSValue> extractWebkitMaskSourceType(ExtractorState&);
     static Ref<CSSValue> extractColor(ExtractorState&);
-    static Ref<CSSValue> extractZoom(ExtractorState&);
+    static Ref<CSSValue> extractCaretColor(ExtractorState&);
 
     // MARK: Shorthands
 
@@ -225,7 +225,7 @@ public:
     static void extractWebkitMaskCompositeSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractWebkitMaskSourceTypeSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractColorSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
-    static void extractZoomSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
+    static void extractCaretColorSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
 
     static void extractAnimationShorthandSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractAnimationRangeShorthandSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
@@ -1240,6 +1240,14 @@ template<> struct PropertyExtractorAdaptor<CSSPropertyColor> {
         return functor(Style::Color { state.style.color() });
     }
 };
+
+template<> struct PropertyExtractorAdaptor<CSSPropertyCaretColor> {
+    template<typename F> decltype(auto) computedValue(ExtractorState& state, F&& functor) const
+    {
+        return functor(state.style.caretColor().colorOrCurrentColor());
+    }
+};
+
 
 // MARK: - Adaptor Invokers
 
@@ -2390,6 +2398,22 @@ inline void ExtractorCustom::extractColorSerialization(ExtractorState& state, St
         return;
     }
     extractSerialization<CSSPropertyColor>(state, builder, context);
+}
+
+inline Ref<CSSValue> ExtractorCustom::extractCaretColor(ExtractorState& state)
+{
+    if (state.allowVisitedStyle)
+        return state.pool.createColorValue(state.style.visitedDependentCaretColor());
+    return extractCSSValue<CSSPropertyCaretColor>(state);
+}
+
+inline void ExtractorCustom::extractCaretColorSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context)
+{
+    if (state.allowVisitedStyle) {
+        builder.append(WebCore::serializationForCSS(state.style.visitedDependentCaretColor()));
+        return;
+    }
+    extractSerialization<CSSPropertyCaretColor>(state, builder, context);
 }
 
 // MARK: - Shorthands

--- a/Source/WebCore/style/StyleInterpolationWrappers.h
+++ b/Source/WebCore/style/StyleInterpolationWrappers.h
@@ -185,6 +185,11 @@ public:
         return m_wrapper.equals(a, b) && m_visitedWrapper.equals(a, b);
     }
 
+    bool canInterpolate(const RenderStyle& a, const RenderStyle& b, CompositeOperation operation) const override
+    {
+        return m_wrapper.canInterpolate(a, b, operation) || m_visitedWrapper.canInterpolate(a, b, operation);
+    }
+
     bool requiresInterpolationForAccumulativeIteration(const RenderStyle& a, const RenderStyle& b) const override
     {
         return m_wrapper.requiresInterpolationForAccumulativeIteration(a, b) && m_visitedWrapper.requiresInterpolationForAccumulativeIteration(a, b);
@@ -333,58 +338,6 @@ public:
 
     ColorWrapper m_wrapper;
     ColorWrapper m_visitedWrapper;
-};
-
-class CaretColorWrapper final : public VisitedAffectedStyleTypeWrapper<Color> {
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(CaretColorWrapper, Animation);
-public:
-    CaretColorWrapper()
-        : VisitedAffectedStyleTypeWrapper<Color>(CSSPropertyCaretColor, &RenderStyleProperties::caretColor, &RenderStyleProperties::setCaretColor, &RenderStyleProperties::visitedLinkCaretColor, &RenderStyleProperties::setVisitedLinkCaretColor)
-    {
-    }
-
-    bool equals(const RenderStyle& a, const RenderStyle& b) const final
-    {
-        return a.hasAutoCaretColor() == b.hasAutoCaretColor()
-            && a.hasVisitedLinkAutoCaretColor() == b.hasVisitedLinkAutoCaretColor()
-            && VisitedAffectedStyleTypeWrapper<Color>::equals(a, b);
-    }
-
-    bool canInterpolate(const RenderStyle& from, const RenderStyle& to, CompositeOperation) const final
-    {
-        return canInterpolateCaretColor(from, to, false) || canInterpolateCaretColor(from, to, true);
-    }
-
-    void interpolate(RenderStyle& destination, const RenderStyle& from, const RenderStyle& to, const Context& context) const final
-    {
-        if (canInterpolateCaretColor(from, to, false))
-            m_wrapper.interpolate(destination, from, to, context);
-        else {
-            auto& blendingRenderStyle = context.progress < 0.5 ? from : to;
-            if (blendingRenderStyle.hasAutoCaretColor())
-                destination.setHasAutoCaretColor();
-            else
-                destination.setCaretColor(Color { blendingRenderStyle.caretColor() });
-        }
-
-        if (canInterpolateCaretColor(from, to, true))
-            m_visitedWrapper.interpolate(destination, from, to, context);
-        else {
-            auto& blendingRenderStyle = context.progress < 0.5 ? from : to;
-            if (blendingRenderStyle.hasVisitedLinkAutoCaretColor())
-                destination.setHasVisitedLinkAutoCaretColor();
-            else
-                destination.setVisitedLinkCaretColor(Color { blendingRenderStyle.visitedLinkCaretColor() });
-        }
-    }
-
-private:
-    static bool canInterpolateCaretColor(const RenderStyle& from, const RenderStyle& to, bool visited)
-    {
-        if (visited)
-            return !from.hasVisitedLinkAutoCaretColor() && !to.hasVisitedLinkAutoCaretColor();
-        return !from.hasAutoCaretColor() && !to.hasAutoCaretColor();
-    }
 };
 
 // MARK: - Other Custom Wrappers

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h
@@ -482,27 +482,5 @@ inline const PageSize& ComputedStyleBase::pageSize() const
     return m_nonInheritedData->rareData->pageSize;
 }
 
-// FIXME: Add a type that encapsulates both caretColor() and hasAutoCaretColor().
-
-inline const Color& ComputedStyleBase::caretColor() const
-{
-    return m_rareInheritedData->caretColor;
-}
-
-inline bool ComputedStyleBase::hasAutoCaretColor() const
-{
-    return m_rareInheritedData->hasAutoCaretColor;
-}
-
-inline const Color& ComputedStyleBase::visitedLinkCaretColor() const
-{
-    return m_rareInheritedData->visitedLinkCaretColor;
-}
-
-inline bool ComputedStyleBase::hasVisitedLinkAutoCaretColor() const
-{
-    return m_rareInheritedData->hasVisitedLinkAutoCaretColor;
-}
-
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h
@@ -364,28 +364,6 @@ inline void ComputedStyleBase::setPageSize(PageSize&& pageSize)
     SET_NESTED(m_nonInheritedData, rareData, pageSize, WTF::move(pageSize));
 }
 
-// FIXME: Add a type that encapsulates both caretColor() and hasAutoCaretColor().
-
-inline void ComputedStyleBase::setCaretColor(Color&& color)
-{
-    SET_PAIR(m_rareInheritedData, caretColor, WTF::move(color), hasAutoCaretColor, false);
-}
-
-inline void ComputedStyleBase::setHasAutoCaretColor()
-{
-    SET_PAIR(m_rareInheritedData, hasAutoCaretColor, true, caretColor, Color::currentColor());
-}
-
-inline void ComputedStyleBase::setVisitedLinkCaretColor(Color&& value)
-{
-    SET_PAIR(m_rareInheritedData, visitedLinkCaretColor, WTF::move(value), hasVisitedLinkAutoCaretColor, false);
-}
-
-inline void ComputedStyleBase::setHasVisitedLinkAutoCaretColor()
-{
-    SET_PAIR(m_rareInheritedData, hasVisitedLinkAutoCaretColor, true, visitedLinkCaretColor, Color::currentColor());
-}
-
 } // namespace Style
 } // namespace WebCore
 

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.h
@@ -236,6 +236,7 @@ struct BorderImageSource;
 struct BorderImageWidth;
 struct BorderRadius;
 struct BoxShadow;
+struct CaretColor;
 struct Clip;
 struct ClipPath;
 struct Color;
@@ -717,16 +718,6 @@ public:
     inline void setTransformOrigin(TransformOrigin&&);
 
     // MARK: - Properties/descriptors that are not yet generated
-
-    // `caret-color`
-    inline const Color& caretColor() const;
-    inline const Color& visitedLinkCaretColor() const;
-    inline bool hasAutoCaretColor() const;
-    inline bool hasVisitedLinkAutoCaretColor() const;
-    inline void setCaretColor(Color&&);
-    inline void setVisitedLinkCaretColor(Color&&);
-    inline void setHasAutoCaretColor();
-    inline void setHasVisitedLinkAutoCaretColor();
 
     // `cursor`
     inline CursorType cursorType() const;

--- a/Source/WebCore/style/computed/StyleComputedStyleProperties+GettersCustomInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleProperties+GettersCustomInlines.h
@@ -308,6 +308,16 @@ inline const Color& ColorPropertyTraits<PropertyNameConstant<CSSPropertyAccentCo
     return style.accentColor().colorOrCurrentColor();
 }
 
+inline const Color& ColorPropertyTraits<PropertyNameConstant<CSSPropertyCaretColor>>::color(const ComputedStyleProperties& style)
+{
+    return style.caretColor().colorOrCurrentColor();
+}
+
+inline const Color& ColorPropertyTraits<PropertyNameConstant<CSSPropertyCaretColor>>::visitedLinkColor(const ComputedStyleProperties& style)
+{
+    return style.visitedLinkCaretColor().colorOrCurrentColor();
+}
+
 inline const Color& ColorPropertyTraits<PropertyNameConstant<CSSPropertyFill>>::color(const ComputedStyleProperties& style)
 {
     return style.fill().colorDisregardingType();

--- a/Source/WebCore/style/values/StyleValueTypes+CSSValueConversion.h
+++ b/Source/WebCore/style/values/StyleValueTypes+CSSValueConversion.h
@@ -110,153 +110,153 @@ template<> struct CSSValueConversion<PropertyIdentifier> {
 
 // Specialization for `TupleLike` (wrapper).
 template<TupleLike StyleType> requires (std::tuple_size_v<StyleType> == 1) struct CSSValueConversion<StyleType> {
-    StyleType operator()(BuilderState& state, const CSSValue& value)
+    template<typename... Rest> StyleType operator()(BuilderState& state, const CSSValue& value, Rest&&... rest)
     {
-        return { toStyleFromCSSValue<std::remove_cvref_t<std::tuple_element_t<0, StyleType>>>(state, value) };
+        return { toStyleFromCSSValue<std::remove_cvref_t<std::tuple_element_t<0, StyleType>>>(state, value, std::forward<Rest>(rest)...) };
     }
 };
 
 // Specialization for `SpaceSeparatedEnumSet`.
 template<typename T> struct CSSValueConversion<SpaceSeparatedEnumSet<T>> {
-    SpaceSeparatedEnumSet<T> operator()(BuilderState& state, const CSSValue& value)
+    template<typename... Rest> SpaceSeparatedEnumSet<T> operator()(BuilderState& state, const CSSValue& value, Rest&&... rest)
     {
         if (auto list = dynamicDowncast<CSSValueList>(value); list && list->separator() == CSSValueList::SpaceSeparator) {
             return SpaceSeparatedEnumSet<T>::map(*list, [&](const CSSValue& element) {
-                return toStyleFromCSSValue<T>(state, element);
+                return toStyleFromCSSValue<T>(state, element, rest...);
             });
         }
-        return { toStyleFromCSSValue<T>(state, value) };
+        return { toStyleFromCSSValue<T>(state, value, std::forward<Rest>(rest)...) };
     }
 };
 
 // Specialization for `CommaSeparatedEnumSet`.
 template<typename T> struct CSSValueConversion<CommaSeparatedEnumSet<T>> {
-    CommaSeparatedEnumSet<T> operator()(BuilderState& state, const CSSValue& value)
+    template<typename... Rest> CommaSeparatedEnumSet<T> operator()(BuilderState& state, const CSSValue& value, Rest&&... rest)
     {
         if (auto list = dynamicDowncast<CSSValueList>(value); list && list->separator() == CSSValueList::CommaSeparator) {
             return CommaSeparatedEnumSet<T>::map(*list, [&](const CSSValue& element) {
-                return toStyleFromCSSValue<T>(state, element);
+                return toStyleFromCSSValue<T>(state, element, rest...);
             });
         }
-        return { toStyleFromCSSValue<T>(state, value) };
+        return { toStyleFromCSSValue<T>(state, value, std::forward<Rest>(rest)...) };
     }
 };
 
 // Specialization for `SpaceSeparatedListHashSet`.
 template<typename T> struct CSSValueConversion<SpaceSeparatedListHashSet<T>> {
-    SpaceSeparatedListHashSet<T> operator()(BuilderState& state, const CSSValue& value)
+    template<typename... Rest> SpaceSeparatedListHashSet<T> operator()(BuilderState& state, const CSSValue& value, Rest&&... rest)
     {
         if (auto list = dynamicDowncast<CSSValueList>(value)) {
             return SpaceSeparatedListHashSet<T>::map(*list, [&](const CSSValue& element) {
-                return toStyleFromCSSValue<T>(state, element);
+                return toStyleFromCSSValue<T>(state, element, rest...);
             });
         }
-        return { toStyleFromCSSValue<T>(state, value) };
+        return { toStyleFromCSSValue<T>(state, value, std::forward<Rest>(rest)...) };
     }
 };
 
 // Specialization for `CommaSeparatedListHashSet`.
 template<typename T> struct CSSValueConversion<CommaSeparatedListHashSet<T>> {
-    CommaSeparatedListHashSet<T> operator()(BuilderState& state, const CSSValue& value)
+    template<typename... Rest> CommaSeparatedListHashSet<T> operator()(BuilderState& state, const CSSValue& value, Rest&&... rest)
     {
         if (auto list = dynamicDowncast<CSSValueList>(value)) {
             return CommaSeparatedListHashSet<T>::map(*list, [&](const CSSValue& element) {
-                return toStyleFromCSSValue<T>(state, element);
+                return toStyleFromCSSValue<T>(state, element, rest...);
             });
         }
-        return { toStyleFromCSSValue<T>(state, value) };
+        return { toStyleFromCSSValue<T>(state, value, std::forward<Rest>(rest)...) };
     }
 };
 
 // Specialization for `SpaceSeparatedFixedVector`.
 template<typename StyleType> struct CSSValueConversion<SpaceSeparatedFixedVector<StyleType>> {
-    SpaceSeparatedFixedVector<StyleType> operator()(BuilderState& state, const CSSValue& value)
+    template<typename... Rest> SpaceSeparatedFixedVector<StyleType> operator()(BuilderState& state, const CSSValue& value, Rest&&... rest)
     {
         if (auto list = dynamicDowncast<CSSValueList>(value); list && list->separator() == CSSValueList::SpaceSeparator) {
             return SpaceSeparatedFixedVector<StyleType>::map(*list, [&](const CSSValue& element) {
-                return toStyleFromCSSValue<StyleType>(state, element);
+                return toStyleFromCSSValue<StyleType>(state, element, rest...);
             });
         }
-        return { toStyleFromCSSValue<StyleType>(state, value) };
+        return { toStyleFromCSSValue<StyleType>(state, value, std::forward<Rest>(rest)...) };
     }
 };
 
 // Specialization for `CommaSeparatedFixedVector`.
 template<typename StyleType> struct CSSValueConversion<CommaSeparatedFixedVector<StyleType>> {
-    CommaSeparatedFixedVector<StyleType> operator()(BuilderState& state, const CSSValue& value)
+    template<typename... Rest> CommaSeparatedFixedVector<StyleType> operator()(BuilderState& state, const CSSValue& value, Rest&&... rest)
     {
         if (auto list = dynamicDowncast<CSSValueList>(value); list && list->separator() == CSSValueList::CommaSeparator) {
             return CommaSeparatedFixedVector<StyleType>::map(*list, [&](const CSSValue& element) {
-                return toStyleFromCSSValue<StyleType>(state, element);
+                return toStyleFromCSSValue<StyleType>(state, element, rest...);
             });
         }
-        return { toStyleFromCSSValue<StyleType>(state, value) };
+        return { toStyleFromCSSValue<StyleType>(state, value, std::forward<Rest>(rest)...) };
     }
 };
 
 // Specialization for `ValueOrKeyword`.
 template<typename StyleType, typename Keyword, typename StyleTypeMarkableTraits> struct CSSValueConversion<ValueOrKeyword<StyleType, Keyword, StyleTypeMarkableTraits>> {
-    ValueOrKeyword<StyleType, Keyword, StyleTypeMarkableTraits> operator()(BuilderState& state, const CSSValue& value)
+    template<typename... Rest> ValueOrKeyword<StyleType, Keyword, StyleTypeMarkableTraits> operator()(BuilderState& state, const CSSValue& value, Rest&&... rest)
     {
         if (value.valueID() == Keyword { }.value)
             return Keyword { };
-        return toStyleFromCSSValue<StyleType>(state, value);
+        return toStyleFromCSSValue<StyleType>(state, value, std::forward<Rest>(rest)...);
     }
 };
 
 // Specialization for types derived from `ValueOrKeyword`.
 template<ValueOrKeywordDerived T> struct CSSValueConversion<T> {
-    T operator()(BuilderState& state, const CSSValue& value)
+    template<typename... Rest> T operator()(BuilderState& state, const CSSValue& value, Rest&&... rest)
     {
         if (value.valueID() == typename T::Keyword { }.value)
             return typename T::Keyword { };
-        return toStyleFromCSSValue<typename T::Value>(state, value);
+        return toStyleFromCSSValue<typename T::Value>(state, value, std::forward<Rest>(rest)...);
     }
 };
 
 // Specialization for `ListOrNone`.
 template<typename ListType> struct CSSValueConversion<ListOrNone<ListType>> {
-    ListOrNone<ListType> operator()(BuilderState& state, const CSSValue& value)
+    template<typename... Rest> ListOrNone<ListType> operator()(BuilderState& state, const CSSValue& value, Rest&&... rest)
     {
         if (value.valueID() == CSSValueNone)
             return CSS::Keyword::None { };
-        return toStyleFromCSSValue<ListType>(state, value);
+        return toStyleFromCSSValue<ListType>(state, value, std::forward<Rest>(rest)...);
     }
 };
 
 // Specialization for types derived from `ListOrNone`.
 template<ListOrNoneDerived T> struct CSSValueConversion<T> {
-    T operator()(BuilderState& state, const CSSValue& value)
+    template<typename... Rest> T operator()(BuilderState& state, const CSSValue& value, Rest&&... rest)
     {
         if (value.valueID() == CSSValueNone)
             return CSS::Keyword::None { };
-        return toStyleFromCSSValue<typename T::List>(state, value);
+        return toStyleFromCSSValue<typename T::List>(state, value, std::forward<Rest>(rest)...);
     }
 };
 
 // Specialization for `ListOrDefault`.
 template<typename ListType, typename Defaulter> struct CSSValueConversion<ListOrDefault<ListType, Defaulter>> {
-    ListOrDefault<ListType, Defaulter> operator()(BuilderState& state, const CSSValue& value)
+    template<typename... Rest> ListOrDefault<ListType, Defaulter> operator()(BuilderState& state, const CSSValue& value, Rest&&... rest)
     {
-        return toStyleFromCSSValue<ListType>(state, value);
+        return toStyleFromCSSValue<ListType>(state, value, std::forward<Rest>(rest)...);
     }
 };
 
 // Specialization for types derived from `ListOrDefault`.
 template<ListOrDefaultDerived T> struct CSSValueConversion<T> {
-    T operator()(BuilderState& state, const CSSValue& value)
+    template<typename... Rest> T operator()(BuilderState& state, const CSSValue& value, Rest&&... rest)
     {
-        return toStyleFromCSSValue<typename T::List>(state, value);
+        return toStyleFromCSSValue<typename T::List>(state, value, std::forward<Rest>(rest)...);
     }
 };
 
 // Specialization for types derived from `EnumSetOrKeywordBase`.
 template<EnumSetOrKeywordBaseDerived T> struct CSSValueConversion<T> {
-    T operator()(BuilderState& state, const CSSValue& value)
+    template<typename... Rest> T operator()(BuilderState& state, const CSSValue& value, Rest&&... rest)
     {
         if (value.valueID() == typename T::Keyword { }.value)
             return typename T::Keyword { };
-        return toStyleFromCSSValue<typename T::EnumSet>(state, value);
+        return toStyleFromCSSValue<typename T::EnumSet>(state, value, std::forward<Rest>(rest)...);
     }
 };
 

--- a/Source/WebCore/style/values/ui/StyleCaretColor.cpp
+++ b/Source/WebCore/style/values/ui/StyleCaretColor.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleCaretColor.h"
+
+#include "AnimationUtilities.h"
+
+namespace WebCore {
+namespace Style {
+
+const Color& CaretColor::colorOrCurrentColor() const
+{
+    if (m_value)
+        return *m_value;
+    return Color::currentColor();
+}
+
+// MARK: - Blending
+
+auto Blending<CaretColor>::equals(const CaretColor& a, const CaretColor& b, const RenderStyle& aStyle, const RenderStyle& bStyle) -> bool
+{
+    bool aAuto = a.isAuto();
+    bool bAuto = b.isAuto();
+
+    if (aAuto || bAuto)
+        return aAuto == bAuto;
+
+    return Style::equalsForBlending(*a.tryColor(), *b.tryColor(), aStyle, bStyle);
+}
+
+auto Blending<CaretColor>::canBlend(const CaretColor& a, const CaretColor& b) -> bool
+{
+    return !a.isAuto() && !b.isAuto() && Style::canBlend(*a.tryColor(), *b.tryColor());
+}
+
+auto Blending<CaretColor>::blend(const CaretColor& a, const CaretColor& b, const RenderStyle& aStyle, const RenderStyle& bStyle, const BlendingContext& context) -> CaretColor
+{
+    if (context.isDiscrete) {
+        ASSERT(!context.progress || context.progress == 1);
+        return context.progress ? b : a;
+    }
+    return Style::blend(*a.tryColor(), *b.tryColor(), aStyle, bStyle, context);
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/ui/StyleCaretColor.h
+++ b/Source/WebCore/style/values/ui/StyleCaretColor.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/StyleColor.h>
+#include <WebCore/StyleValueTypes.h>
+
+namespace WebCore {
+namespace Style {
+
+// <'caret-color'> = auto | <color>
+// https://drafts.csswg.org/css-ui-4/#caret-color
+struct CaretColor : ValueOrKeyword<Color, CSS::Keyword::Auto> {
+    using Base::Base;
+
+    bool isAuto() const { return isKeyword(); }
+    bool isColor() const { return isValue(); }
+    std::optional<Color> tryColor() const { return tryValue(); }
+
+    // Returns the color or a `currentColor` singleton if `auto`.
+    const Color& colorOrCurrentColor() const;
+};
+
+// MARK: - Blending
+
+template<> struct Blending<CaretColor> {
+    auto equals(const CaretColor&, const CaretColor&, const RenderStyle&, const RenderStyle&) -> bool;
+    auto canBlend(const CaretColor&, const CaretColor&) -> bool;
+    constexpr auto requiresInterpolationForAccumulativeIteration(const CaretColor&, const CaretColor&) -> bool { return true; }
+    auto blend(const CaretColor&, const CaretColor&, const RenderStyle&, const RenderStyle&, const BlendingContext&) -> CaretColor;
+};
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::CaretColor);

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -459,7 +459,7 @@ void WebPage::getPlatformEditorState(LocalFrame& frame, EditorState& result) con
             if (RefPtr editableRoot = selection.rootEditableElement(); editableRoot && editableRoot->renderer()) {
                 auto& style = editableRoot->renderer()->style();
                 postLayoutData.caretColor = CaretBase::computeCaretColor(style, editableRoot.get());
-                postLayoutData.hasCaretColorAuto = style.hasAutoCaretColor();
+                postLayoutData.hasCaretColorAuto = style.caretColor().isAuto();
                 postLayoutData.hasGrammarDocumentMarkers = editableRoot->document().markers().hasMarkers(makeRangeSelectingNodeContents(*editableRoot), DocumentMarkerType::Grammar);
             }
         }


### PR DESCRIPTION
#### a6a367812f0b92041a3f40500395b5ba7ef9ade3
<pre>
[Style] Convert the &apos;caret-color&apos; property to strong style types
<a href="https://bugs.webkit.org/show_bug.cgi?id=304763">https://bugs.webkit.org/show_bug.cgi?id=304763</a>

Reviewed by Darin Adler.

Converts the &apos;caret-color&apos; property to use strong style types.

To allow passing the `ForVisitedLink` state down to Style::Color
during style building, added support for automatically passing
in all additional parameters in CSSValueConversion for common
aggregate types in StyleValueTypes+CSSValueConversion.h.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/editing/FrameSelection.cpp:
* Source/WebCore/rendering/style/RenderStyleBase+GettersInlines.h:
* Source/WebCore/rendering/style/RenderStyleBase+SettersInlines.h:
* Source/WebCore/rendering/style/RenderStyleBase.h:
* Source/WebCore/rendering/style/StyleRareInheritedData.cpp:
* Source/WebCore/rendering/style/StyleRareInheritedData.h:
* Source/WebCore/style/StyleBuilderCustom.h:
* Source/WebCore/style/StyleChangedAnimatablePropertiesCustom.h:
* Source/WebCore/style/StyleInterpolationWrappers.h:
* Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h:
* Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h:
* Source/WebCore/style/computed/StyleComputedStyleBase.h:
* Source/WebCore/style/computed/StyleComputedStyleProperties+GettersCustomInlines.h:
* Source/WebCore/style/values/StyleValueTypes+CSSValueConversion.h:
* Source/WebCore/style/values/ui/StyleCaretColor.cpp: Added.
* Source/WebCore/style/values/ui/StyleCaretColor.h: Added.
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:

Canonical link: <a href="https://commits.webkit.org/305008@main">https://commits.webkit.org/305008@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c79d97f9c591bb1b397715b474f454352073c71e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137167 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9527 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48454 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144913 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90140 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139039 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10230 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9654 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104894 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140112 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7534 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122920 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85733 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7171 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4880 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5503 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116523 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41085 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147670 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9210 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41648 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113252 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9228 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7746 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113583 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28846 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7092 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119178 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63607 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9258 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37232 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8983 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72824 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9199 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9051 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->