### PR TITLE
Preserve the exact color values defined by keyframes when animating colors

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animate-color-preserve-exact-serialization-at-keyframes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animate-color-preserve-exact-serialization-at-keyframes-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Animate from legacy rgb keyframe to non-legacy rgb keyframe
+PASS Animate from implicit legacy rgb keyframe to non-legacy rgb keyframe
+PASS Animate from non-oklab keyframe to non-oklab keyframe
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animate-color-preserve-exact-serialization-at-keyframes.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animate-color-preserve-exact-serialization-at-keyframes.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS color animaitons preserve exact serialization at keyframe stops</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-values-4/#interpolation">
+<meta name="assert" content="interpolation of colors persevere exact serialization at keyframe stops">
+</head>
+<style>
+  @keyframes legacy-rgb-to-non-legacy-rgb {
+    from { background-color: rgb(255, 0, 0); }
+    50% { background-color: color(srgb 0 1 0); }
+    to { background-color: color(srgb-linear 0 0 1); }
+  }
+
+  @keyframes implicit-legacy-rgb-to-non-legacy-rgb {
+    50% { background-color: color(srgb 0 1 0); }
+    to { background-color: color(srgb-linear 0 0 1); }
+  }
+
+  @keyframes non-oklab-to-non-oklab {
+    from { background-color: color(srgb 1 0 0); }
+    to { background-color: color(srgb-linear 0 0 1); }
+  }
+
+  #target {
+    background-color: red;
+    animation-duration: 1s;
+    animation-timing-function: linear;
+    animation-play-state: paused;
+    animation-fill-mode: forwards;
+    height: 100px;
+    width: 100px;
+  }
+  .legacy-rgb-to-non-legacy-rgb {
+    animation-name: legacy-rgb-to-non-legacy-rgb;
+  }
+  .implicit-legacy-rgb-to-non-legacy-rgb {
+    animation-name: implicit-legacy-rgb-to-non-legacy-rgb;
+  }
+  .non-oklab-to-non-oklab {
+    animation-name: non-oklab-to-non-oklab;
+  }
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/web-animations/testcommon.js"></script>
+<script src="/css/support/color-testcommon.js"></script>
+
+<body>
+  <div id="target"></div>
+  <div id="test"></div>
+</body>
+<script>
+  'use strict';
+
+  async function runAnimationTest(t, name, expected_colors) {
+    const target = document.getElementById('target');
+    target.classList.add(name);
+    t.add_cleanup(() => {
+      target.classList.remove(name);
+    });
+    const anim = document.getAnimations()[0];
+    await anim.ready;
+    expected_colors.forEach(data => {
+      anim.currentTime = 1000 * data.at;
+      const actual = getComputedStyle(target).backgroundColor;
+      const expected = data.value;
+      if (data.exact) {
+        assert_equals(
+            actual, expected,
+            `Background color at ${100*data.at}% animation progress`);
+      } else {
+        assert_oklab_color(
+            actual, expected,
+            `Background color at ${100*data.at}% animation progress`);
+      }
+    });
+  }
+
+  const legacy_rgb_to_non_legacy_rgb = [
+    { at: 0, value: 'rgb(255, 0, 0)', exact: true },
+    { at: 0.25, value: 'oklab(0.747198 -0.004512 0.152672)', exact: false },
+    { at: 0.5, value: 'color(srgb 0 1 0)', exact: true },
+    { at: 0.75, value: 'oklab(0.659227 -0.133172 -0.066015)', exact: false },
+    { at: 1, value: 'color(srgb-linear 0 0 1)', exact: true },
+  ];
+
+  const implicit_legacy_rgb_to_non_legacy_rgb = [
+    { at: 0, value: 'rgb(255, 0, 0)', exact: true },
+    { at: 0.25, value: 'oklab(0.747198 -0.004512 0.152672)', exact: false },
+    { at: 0.5, value: 'color(srgb 0 1 0)', exact: true },
+    { at: 0.75, value: 'oklab(0.659227 -0.133172 -0.066015)', exact: false },
+    { at: 1, value: 'color(srgb-linear 0 0 1)', exact: true },
+  ];
+
+  const non_oklab_to_non_ok_lab = [
+    { at: 0, value: 'color(srgb 1 0 0)', exact: true },
+    { at: 0.25, value: 'oklab(0.58397 0.160533 0.016503)', exact: false },
+    { at: 0.5, value: 'oklab(0.539985 0.096203 -0.092841)', exact: false },
+    { at: 0.75, value: 'oklab(0.495999 0.031873 -0.202185)', exact: false },
+    { at: 1, value: 'color(srgb-linear 0 0 1)', exact: true },
+  ];
+
+  window.onload = async () => {
+    promise_test(t => {
+      return runAnimationTest(t, 'legacy-rgb-to-non-legacy-rgb', legacy_rgb_to_non_legacy_rgb);
+    }, 'Animate from legacy rgb keyframe to non-legacy rgb keyframe');
+    promise_test(t => {
+      return runAnimationTest(t, 'implicit-legacy-rgb-to-non-legacy-rgb', implicit_legacy_rgb_to_non_legacy_rgb);
+    }, 'Animate from implicit legacy rgb keyframe to non-legacy rgb keyframe');
+    promise_test(t => {
+      return runAnimationTest(t, 'non-oklab-to-non-oklab', non_oklab_to_non_ok_lab);
+    }, 'Animate from non-oklab keyframe to non-oklab keyframe');
+  };
+</script>
+</html>

--- a/Source/WebCore/platform/graphics/ColorBlending.cpp
+++ b/Source/WebCore/platform/graphics/ColorBlending.cpp
@@ -117,10 +117,6 @@ static bool requiresLegacyInterpolationRules(const Color& color)
 
 Color blend(const Color& from, const Color& to, const BlendingContext& context)
 {
-    // We need to preserve the state of the valid flag at the end of the animation
-    if (context.progress == 1 && !to.isValid())
-        return { };
-
     if (requiresLegacyInterpolationRules(from) && requiresLegacyInterpolationRules(to)) {
         using InterpolationColorSpace = ColorInterpolationMethod::SRGB;
 
@@ -138,6 +134,23 @@ Color blend(const Color& from, const Color& to, const BlendingContext& context)
             return addColorComponents<AlphaPremultiplication::Premultiplied>(InterpolationColorSpace { }, fromComponents, toComponents);
         }
     } else {
+        // Interpolation requires returning the exact `from` and `to` colors at
+        // `0` and `1` respectively so that they serialize exactly as they would
+        // if interpolation had occurred. If we let them go through, they would
+        // be converted to the interpolation color space, which, if different
+        // than the color space of the color itself, would cause the value to
+        // serialize differently.
+        //
+        // This also ensures that invalid colors will be preserved at the end
+        // points, which some consumers expect.
+
+        if (context.compositeOperation == CompositeOperation::Replace) {
+            if (context.progress == 0)
+                return from;
+            else if (context.progress == 1)
+                return to;
+        }
+
         using InterpolationColorSpace = ColorInterpolationMethod::OKLab;
 
         auto fromComponents = from.toColorTypeLossyCarryingForwardMissing<typename InterpolationColorSpace::ColorType>();


### PR DESCRIPTION
#### 3b3d23f54f5c5e3e55a4bdfa6e21852fc5f15709
<pre>
Preserve the exact color values defined by keyframes when animating colors
<a href="https://bugs.webkit.org/show_bug.cgi?id=304764">https://bugs.webkit.org/show_bug.cgi?id=304764</a>

Reviewed by NOBODY (OOPS!).

When animating colors, we now special case progress=0% and progress=100%
to return the unmodified `from` and `to` colors respectively, rather than
the old behavior, where the `from` and `to` colors would be returned as
values converted to the interpolation color space (Oklab).

See <a href="https://github.com/w3c/csswg-drafts/issues/13269">https://github.com/w3c/csswg-drafts/issues/13269</a> for more.

We could consider implementing this in `Style::Interpolation` and applying
it for all properties, but so far, only colors need to be special cased,
as other properties don&apos;t have a similar &quot;conversion to interpolation color
space&quot; concept and thus the extra branches would be wasted.

Test: imported/w3c/web-platform-tests/css/css-animations/animate-color-preserve-exact-serialization-at-keyframes.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animate-color-preserve-exact-serialization-at-keyframes-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animate-color-preserve-exact-serialization-at-keyframes.html: Added.
* Source/WebCore/platform/graphics/ColorBlending.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b3d23f54f5c5e3e55a4bdfa6e21852fc5f15709

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137174 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9534 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48461 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144920 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90147 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139046 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10237 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9661 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104902 "Found 8 new test failures: imported/w3c/web-platform-tests/css/css-animations/animate-with-background-color-oklch-002.html imported/w3c/web-platform-tests/css/css-animations/animate-with-color-mix.html imported/w3c/web-platform-tests/css/css-animations/animate-with-relative-color.html imported/w3c/web-platform-tests/css/css-backgrounds/animations/box-shadow-interpolation.html imported/w3c/web-platform-tests/css/css-color/animation/color-interpolation.html imported/w3c/web-platform-tests/css/css-fill-stroke/animation/fill-interpolation.html imported/w3c/web-platform-tests/css/css-transitions/animations/animate-with-color-mix.html imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-registered-properties-dynamic.html (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76509 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (exception)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140119 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7540 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122926 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85741 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7177 "Found 8 new test failures: imported/w3c/web-platform-tests/css/css-animations/animate-with-background-color-oklch-002.html imported/w3c/web-platform-tests/css/css-animations/animate-with-color-mix.html imported/w3c/web-platform-tests/css/css-animations/animate-with-relative-color.html imported/w3c/web-platform-tests/css/css-backgrounds/animations/box-shadow-interpolation.html imported/w3c/web-platform-tests/css/css-color/animation/color-interpolation.html imported/w3c/web-platform-tests/css/css-fill-stroke/animation/fill-interpolation.html imported/w3c/web-platform-tests/css/css-transitions/animations/animate-with-color-mix.html imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-registered-properties-dynamic.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4887 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5510 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116530 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41092 "Found 8 new test failures: imported/w3c/web-platform-tests/css/css-animations/animate-with-background-color-oklch-002.html imported/w3c/web-platform-tests/css/css-animations/animate-with-color-mix.html imported/w3c/web-platform-tests/css/css-animations/animate-with-relative-color.html imported/w3c/web-platform-tests/css/css-backgrounds/animations/box-shadow-interpolation.html imported/w3c/web-platform-tests/css/css-color/animation/color-interpolation.html imported/w3c/web-platform-tests/css/css-fill-stroke/animation/fill-interpolation.html imported/w3c/web-platform-tests/css/css-transitions/animations/animate-with-color-mix.html imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-registered-properties-dynamic.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147679 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9217 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41654 "Found 8 new test failures: imported/w3c/web-platform-tests/css/css-animations/animate-with-background-color-oklch-002.html imported/w3c/web-platform-tests/css/css-animations/animate-with-color-mix.html imported/w3c/web-platform-tests/css/css-animations/animate-with-relative-color.html imported/w3c/web-platform-tests/css/css-backgrounds/animations/box-shadow-interpolation.html imported/w3c/web-platform-tests/css/css-color/animation/color-interpolation.html imported/w3c/web-platform-tests/css/css-fill-stroke/animation/fill-interpolation.html imported/w3c/web-platform-tests/css/css-transitions/animations/animate-with-color-mix.html imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-registered-properties-dynamic.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113260 "Found 8 new test failures: imported/w3c/web-platform-tests/css/css-animations/animate-with-background-color-oklch-002.html imported/w3c/web-platform-tests/css/css-animations/animate-with-color-mix.html imported/w3c/web-platform-tests/css/css-animations/animate-with-relative-color.html imported/w3c/web-platform-tests/css/css-backgrounds/animations/box-shadow-interpolation.html imported/w3c/web-platform-tests/css/css-color/animation/color-interpolation.html imported/w3c/web-platform-tests/css/css-fill-stroke/animation/fill-interpolation.html imported/w3c/web-platform-tests/css/css-transitions/animations/animate-with-color-mix.html imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-registered-properties-dynamic.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9235 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7752 "Found 8 new test failures: imported/w3c/web-platform-tests/css/css-animations/animate-with-background-color-oklch-002.html imported/w3c/web-platform-tests/css/css-animations/animate-with-color-mix.html imported/w3c/web-platform-tests/css/css-animations/animate-with-relative-color.html imported/w3c/web-platform-tests/css/css-backgrounds/animations/box-shadow-interpolation.html imported/w3c/web-platform-tests/css/css-color/animation/color-interpolation.html imported/w3c/web-platform-tests/css/css-fill-stroke/animation/fill-interpolation.html imported/w3c/web-platform-tests/css/css-transitions/animations/animate-with-color-mix.html imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-registered-properties-dynamic.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113591 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7098 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119184 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63624 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9265 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37238 "Found 8 new test failures: imported/w3c/web-platform-tests/css/css-animations/animate-with-background-color-oklch-002.html imported/w3c/web-platform-tests/css/css-animations/animate-with-color-mix.html imported/w3c/web-platform-tests/css/css-animations/animate-with-relative-color.html imported/w3c/web-platform-tests/css/css-backgrounds/animations/box-shadow-interpolation.html imported/w3c/web-platform-tests/css/css-color/animation/color-interpolation.html imported/w3c/web-platform-tests/css/css-fill-stroke/animation/fill-interpolation.html imported/w3c/web-platform-tests/css/css-transitions/animations/animate-with-color-mix.html imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-index-keyframe-registered-properties-dynamic.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8991 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72831 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9206 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9058 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->