### PR TITLE
[AutoFill Debugging] Text extraction may hang indefinitely when invoked from system daemons

### DIFF
--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -1927,7 +1927,7 @@ void applyRules(const String& input, std::optional<NodeIdentifier>&& containerNo
         return completion(input);
 
     Ref world = filteringWorld();
-    auto arguments = [&] {
+    auto makeArguments = [&] {
         ArgumentMap argumentMap;
         argumentMap.reserveInitialCapacity(2);
         argumentMap.add("input"_s, [input](auto& lexicalGlobalObject) {
@@ -1942,7 +1942,7 @@ void applyRules(const String& input, std::optional<NodeIdentifier>&& containerNo
             return toJS(&lexicalGlobalObject, mainFrame->checkedScript()->globalObject(world), *containerNode);
         });
         return std::make_optional(WTF::move(argumentMap));
-    }();
+    };
 
     auto filteredStrings = Box<Vector<String>>::create();
     auto aggregator = MainRunLoopCallbackAggregator::create([completion = WTF::move(completion), input, filteredStrings] mutable {
@@ -1971,7 +1971,7 @@ void applyRules(const String& input, std::optional<NodeIdentifier>&& containerNo
             SourceTaintedOrigin::Untainted,
             { },
             true, // runAsAsyncFunction
-            WTF::move(arguments),
+            makeArguments(),
             false, // forceUserGesture
             RemoveTransientActivation::No
         };

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -443,6 +443,7 @@ UIProcess/SystemPreviewController.cpp
 UIProcess/SpeechRecognitionPermissionManager.cpp
 UIProcess/TextChecker.cpp
 UIProcess/TextCheckerCompletion.cpp
+UIProcess/TextExtractionAssertionScope.cpp
 UIProcess/UIProcessLogInitialization.cpp
 UIProcess/UserMediaPermissionCheckProxy.cpp
 UIProcess/UserMediaPermissionRequestManagerProxy.cpp

--- a/Source/WebKit/UIProcess/TextExtractionAssertionScope.cpp
+++ b/Source/WebKit/UIProcess/TextExtractionAssertionScope.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TextExtractionAssertionScope.h"
+
+namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(TextExtractionAssertionScope);
+
+TextExtractionAssertionScope::TextExtractionAssertionScope(WebPageProxy& page)
+    : m_page { page }
+{
+    if (!page.m_textExtractionCount++)
+        page.takeTextExtractionAssertion();
+}
+
+TextExtractionAssertionScope::~TextExtractionAssertionScope()
+{
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
+    if (!page->m_textExtractionCount) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    if (!--page->m_textExtractionCount)
+        page->dropTextExtractionAssertion();
+}
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/TextExtractionAssertionScope.h
+++ b/Source/WebKit/UIProcess/TextExtractionAssertionScope.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/FastMalloc.h>
+#include <wtf/WeakPtr.h>
+
+namespace WebKit {
+
+class WebPageProxy;
+
+class TextExtractionAssertionScope {
+    WTF_MAKE_TZONE_ALLOCATED(TextExtractionAssertionScope);
+    WTF_MAKE_NONCOPYABLE(TextExtractionAssertionScope);
+public:
+    TextExtractionAssertionScope(WebPageProxy&);
+    ~TextExtractionAssertionScope();
+
+private:
+    WeakPtr<WebPageProxy> m_page;
+};
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -135,6 +135,7 @@
 #include "SyntheticEditingCommandType.h"
 #include "TextChecker.h"
 #include "TextCheckerState.h"
+#include "TextExtractionAssertionScope.h"
 #include "TextRecognitionUpdateResult.h"
 #include "URLSchemeTaskParameters.h"
 #include "UndoOrRedo.h"
@@ -17508,6 +17509,27 @@ void WebPageProxy::takeActivitiesOnRemotePage(RemotePageProxy& remotePage)
 
     if (hasValidNetworkActivity())
         remotePage.processActivityState().takeNetworkActivity();
+}
+
+UniqueRef<TextExtractionAssertionScope> WebPageProxy::createTextExtractionAssertionScope()
+{
+    return makeUniqueRef<TextExtractionAssertionScope>(*this);
+}
+
+void WebPageProxy::takeTextExtractionAssertion()
+{
+    m_mainFrameProcessActivityState->takeTextExtractionAssertion();
+    protectedBrowsingContextGroup()->forEachRemotePage(*this, [](auto& remotePage) {
+        remotePage.processActivityState().takeTextExtractionAssertion();
+    });
+}
+
+void WebPageProxy::dropTextExtractionAssertion()
+{
+    m_mainFrameProcessActivityState->dropTextExtractionAssertion();
+    protectedBrowsingContextGroup()->forEachRemotePage(*this, [](auto& remotePage) {
+        remotePage.processActivityState().dropTextExtractionAssertion();
+    });
 }
 
 // See SwiftDemoLogo.swift for the rationale here

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -502,6 +502,7 @@ class SecKeyProxyStore;
 class SpeechRecognitionPermissionManager;
 class SuspendedPageProxy;
 class SystemPreviewController;
+class TextExtractionAssertionScope;
 class UserData;
 class UserMediaPermissionRequestManagerProxy;
 class UserMediaPermissionRequestProxy;
@@ -2889,6 +2890,9 @@ public:
     void exitImmersive();
 #endif
 
+    friend class TextExtractionAssertionScope;
+    UniqueRef<TextExtractionAssertionScope> createTextExtractionAssertionScope();
+
 private:
     WebPageProxy(PageClient&, WebProcessProxy&, Ref<API::PageConfiguration>&&);
     void platformInitialize();
@@ -3542,6 +3546,9 @@ private:
     bool hasValidOpeningAppLinkActivity() const;
 #endif
 
+    void takeTextExtractionAssertion();
+    void dropTextExtractionAssertion();
+
     RefPtr<SpeechRecognitionPermissionManager> protectedSpeechRecognitionPermissionManager();
 
 #if PLATFORM(COCOA)
@@ -4037,6 +4044,8 @@ private:
     bool m_isLockdownModeExplicitlySet { false };
 
     bool m_needsScrollGeometryUpdates { false };
+
+    unsigned m_textExtractionCount { 0 };
 
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
     RefPtr<ListDataObserver> m_linkDecorationFilteringDataUpdateObserver;

--- a/Source/WebKit/UIProcess/WebProcessActivityState.h
+++ b/Source/WebKit/UIProcess/WebProcessActivityState.h
@@ -47,6 +47,7 @@ public:
     void takeCapturingActivity();
     void takeMutedCaptureAssertion();
     void takeNetworkActivity();
+    void takeTextExtractionAssertion();
 
     void reset();
     void dropVisibleActivity();
@@ -54,6 +55,7 @@ public:
     void dropCapturingActivity();
     void dropMutedCaptureAssertion();
     void dropNetworkActivity();
+    void dropTextExtractionAssertion();
 
     bool hasValidVisibleActivity() const;
     bool hasValidAudibleActivity() const;
@@ -95,7 +97,7 @@ private:
     RefPtr<ProcessThrottlerActivity> m_openingAppLinkActivity;
 #endif
     RefPtr<ProcessThrottlerActivity> m_networkActivity;
-
+    RefPtr<ProcessAssertion> m_textExtractionAssertion;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2464,6 +2464,7 @@
 		F411457D2CD94161004CDBD1 /* _WKTouchEventGeneratorInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = F411457C2CD94161004CDBD1 /* _WKTouchEventGeneratorInternal.h */; };
 		F416F1C02C5C3E360085D8DD /* WKScrollViewTrackingTapGestureRecognizer.h in Headers */ = {isa = PBXBuildFile; fileRef = F416F1BE2C5C3E360085D8DD /* WKScrollViewTrackingTapGestureRecognizer.h */; };
 		F41795A62AC61B78007F5F12 /* CompactContextMenuPresenter.h in Headers */ = {isa = PBXBuildFile; fileRef = F41795A42AC619A2007F5F12 /* CompactContextMenuPresenter.h */; };
+		F41D73EC2EFF607700FD1ECB /* TextExtractionAssertionScope.h in Headers */ = {isa = PBXBuildFile; fileRef = F41D73E92EFF607700FD1ECB /* TextExtractionAssertionScope.h */; };
 		F422427A2E8C389800C1143F /* opaque_ipc_types.py in Copy Message Generation Scripts */ = {isa = PBXBuildFile; fileRef = F42242782E8C37AB00C1143F /* opaque_ipc_types.py */; };
 		F4299507270E234D0032298B /* StreamMessageReceiver.h in Headers */ = {isa = PBXBuildFile; fileRef = F4299506270E234C0032298B /* StreamMessageReceiver.h */; };
 		F42A04712CA1B328000D3118 /* _WKTextRunInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = F42A04702CA1B328000D3118 /* _WKTextRunInternal.h */; };
@@ -8633,6 +8634,8 @@
 		F416F1BF2C5C3E360085D8DD /* WKScrollViewTrackingTapGestureRecognizer.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKScrollViewTrackingTapGestureRecognizer.mm; sourceTree = "<group>"; };
 		F41795A42AC619A2007F5F12 /* CompactContextMenuPresenter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CompactContextMenuPresenter.h; sourceTree = "<group>"; };
 		F41795A52AC619A2007F5F12 /* CompactContextMenuPresenter.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CompactContextMenuPresenter.mm; sourceTree = "<group>"; };
+		F41D73E92EFF607700FD1ECB /* TextExtractionAssertionScope.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TextExtractionAssertionScope.h; sourceTree = "<group>"; };
+		F41D73EA2EFF607700FD1ECB /* TextExtractionAssertionScope.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TextExtractionAssertionScope.cpp; sourceTree = "<group>"; };
 		F4217F1C2E8EFF8A0036AAC1 /* TextExtractionToStringConversion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TextExtractionToStringConversion.h; sourceTree = "<group>"; };
 		F4217F1D2E8EFF8A0036AAC1 /* TextExtractionToStringConversion.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TextExtractionToStringConversion.cpp; sourceTree = "<group>"; };
 		F42242782E8C37AB00C1143F /* opaque_ipc_types.py */ = {isa = PBXFileReference; lastKnownFileType = text.script.python; name = opaque_ipc_types.py; path = webkit/opaque_ipc_types.py; sourceTree = "<group>"; };
@@ -15407,6 +15410,8 @@
 				1AA417C912C00CCA002BE67B /* TextChecker.h */,
 				53CFBBC62224D1B000266546 /* TextCheckerCompletion.cpp */,
 				53CFBBC72224D1B000266546 /* TextCheckerCompletion.h */,
+				F41D73EA2EFF607700FD1ECB /* TextExtractionAssertionScope.cpp */,
+				F41D73E92EFF607700FD1ECB /* TextExtractionAssertionScope.h */,
 				CD9A64A027C8972C003827C0 /* UIProcessLogInitialization.cpp */,
 				CD9A649F27C8972C003827C0 /* UIProcessLogInitialization.h */,
 				07297F9C1C17BBEA003F0735 /* UserMediaPermissionCheckProxy.cpp */,
@@ -18321,6 +18326,7 @@
 				1AA417CB12C00CCA002BE67B /* TextChecker.h in Headers */,
 				53CFBBC82224D1B500266546 /* TextCheckerCompletion.h in Headers */,
 				1A5E4DA412D3BD3D0099A2BB /* TextCheckerState.h in Headers */,
+				F41D73EC2EFF607700FD1ECB /* TextExtractionAssertionScope.h in Headers */,
 				F42CDFFF2E6E28A9005837F8 /* TextExtractionFilter.h in Headers */,
 				F4E89F5C2EFC702000E4D96E /* TextExtractionURLCache.h in Headers */,
 				CE1A0BD71A48E6C60054EF74 /* TextInputSPI.h in Headers */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm
@@ -445,8 +445,10 @@ static void overrideGetListsForNamespace(SSBLookupContext *instance, SEL, NSStri
     static NeverDestroyed workQueue = WorkQueue::create("Queue for simulating SSB API"_s);
     workQueue.get()->dispatch([completion = makeBlockPtr(completion)] {
         RetainPtr hardCodedResult = @{
-            @"test/domains": @[ @".*" ],
-            @"test/filter": @[ @"return input.replaceAll('o', '•').replaceAll('u', 'v')" ]
+            @"test1/domains": @[ @".*" ],
+            @"test1/filter": @[ @"return input.length >= 1000 ? '<too long>' : null" ],
+            @"test2/domains": @[ @".*" ],
+            @"test2/filter": @[ @"return input.replaceAll('o', '•').replaceAll('u', 'v')" ],
         };
         completion(hardCodedResult.get(), nil);
     });


### PR DESCRIPTION
#### 3001d64b831c10251b04ea560505aeab4fa0a9ec
<pre>
[AutoFill Debugging] Text extraction may hang indefinitely when invoked from system daemons
<a href="https://bugs.webkit.org/show_bug.cgi?id=304765">https://bugs.webkit.org/show_bug.cgi?id=304765</a>
<a href="https://rdar.apple.com/167099858">rdar://167099858</a>

Reviewed by Megan Gardner and Abrar Rahman Protyasha.

Take a background process assertion when performing text extraction; without this, the web process
might become idle in the middle of text extraction, for certain clients that run in the context of
system daemons.

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::applyRules):

Drive-by fix: avoid `WTF::move`-ing the same arguments map multiple times when calling into each
filtering script.

* Source/WebKit/Sources.txt:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _extractDebugTextWithConfiguration:completionHandler:]):
(-[WKWebView _extractDebugTextWithConfigurationWithoutUpdatingFilterRules:assertionScope:completionHandler:]):
(-[WKWebView _extractDebugTextWithConfigurationWithoutUpdatingFilterRules:completionHandler:]): Deleted.

Add `assertionScope` (see below) as an argument to this internal method, so that we can hold on to
it over the scope of this text extraction call.

* Source/WebKit/UIProcess/TextExtractionAssertionScope.cpp: Added.
(WebKit::TextExtractionAssertionScope::TextExtractionAssertionScope):
(WebKit::TextExtractionAssertionScope::~TextExtractionAssertionScope):
* Source/WebKit/UIProcess/TextExtractionAssertionScope.h: Added.

Add a RAII helper class that handles accounting for text extraction assertions. Because a client may
invoke text extraction multiple times for a given web view (e.g. with different filtering or output
configuration options specified), we maintain a pending text extraction count, and call into
`takeTextExtractionAssertion` only when the count increments for the first time, and later
`dropTextExtractionAssertion` when the count decrements back to 0.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::createTextExtractionAssertionScope):
(WebKit::WebPageProxy::takeTextExtractionAssertion):
(WebKit::WebPageProxy::dropTextExtractionAssertion):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebProcessActivityState.cpp:
(WebKit::WebProcessActivityState::takeTextExtractionAssertion):
(WebKit::WebProcessActivityState::dropTextExtractionAssertion):
* Source/WebKit/UIProcess/WebProcessActivityState.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm:
(TestWebKitAPI::overrideGetListsForNamespace):

Adjust an API test to exercise the fix in `TextExtraction::applyRules` by adding a second rule.

Canonical link: <a href="https://commits.webkit.org/305048@main">https://commits.webkit.org/305048@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/495c2a938f7e87606e246a5df83d9cddc28bcd38

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137120 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9480 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48407 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144866 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90093 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cdfefd92-8e40-42df-86af-cbfa8e7667ff) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138992 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10183 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9607 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104857 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e857d5fd-8876-48c4-b138-5898715eeb05) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140065 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7492 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122875 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85693 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/00e3b9db-8367-469a-b400-2e07ef1d9ac3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7129 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4837 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5456 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116479 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41041 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147622 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9163 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41605 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113212 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9181 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7704 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113542 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28871 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7052 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119135 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63524 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9211 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37189 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8935 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72777 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9152 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9004 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->