### PR TITLE
Unreviewed, address unexpected safer cpp failures on the bot

### DIFF
--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -3748,9 +3748,9 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/ReadableStreamDefaultReaderBuiltins
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/ReadableStreamDefaultReaderBuiltins.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/ReadableStreamInternalsBuiltins.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/ReadableStreamInternalsBuiltins.h
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/RenderStyleProperties.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/RenderStyleProperties+GettersInlines.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/RenderStyleProperties+SettersInlines.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/RenderStyleProperties.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/SVGElementFactory.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/SVGElementFactory.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/SVGElementTypeHelpers.h
@@ -3766,10 +3766,11 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/StreamInternalsBuiltins.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/StreamInternalsBuiltins.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/StyleBuilderGenerated.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/StyleChangedAnimatablePropertiesGenerated.cpp
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/StyleComputedStyleProperties.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/StyleComputedStyleProperties+GettersInlines.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/StyleComputedStyleProperties+InitialInlines.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/StyleComputedStyleProperties+SettersInlines.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/StyleComputedStyleProperties.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/StyleComputedStyleProperties.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/StyleExtractorGenerated.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/StyleInterpolationWrapperMap.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/StyleInterpolationWrapperMap.h

--- a/Source/WebCore/platform/graphics/coreimage/FEBlendCoreImageApplier.mm
+++ b/Source/WebCore/platform/graphics/coreimage/FEBlendCoreImageApplier.mm
@@ -53,14 +53,14 @@ bool FEBlendCoreImageApplier::supportsCoreImageRendering(const FEBlend&)
 bool FEBlendCoreImageApplier::apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
 {
     ASSERT(inputs.size() == 2);
-    auto& input1 = inputs[0].get();
-    auto& input2 = inputs[1].get();
+    Ref input1 = inputs[0];
+    Ref input2 = inputs[1];
 
-    auto inputImage1 = input1.ciImage();
+    auto inputImage1 = input1->ciImage();
     if (!inputImage1)
         return false;
 
-    auto inputImage2 = input2.ciImage();
+    auto inputImage2 = input2->ciImage();
     if (!inputImage2)
         return false;
 

--- a/Source/WebCore/platform/graphics/coreimage/FECompositeCoreImageApplier.mm
+++ b/Source/WebCore/platform/graphics/coreimage/FECompositeCoreImageApplier.mm
@@ -50,14 +50,14 @@ bool FECompositeCoreImageApplier::supportsCoreImageRendering(const FEComposite& 
 bool FECompositeCoreImageApplier::apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
 {
     ASSERT(inputs.size() == 2);
-    auto& input1 = inputs[0].get();
-    auto& input2 = inputs[1].get();
+    Ref input1 = inputs[0];
+    Ref input2 = inputs[1];
 
-    auto inputImage1 = input1.ciImage();
+    auto inputImage1 = input1->ciImage();
     if (!inputImage1)
         return false;
 
-    auto inputImage2 = input2.ciImage();
+    auto inputImage2 = input2->ciImage();
     if (!inputImage2)
         return false;
 


### PR DESCRIPTION
#### 1428c60607b1d515a910f1ee828296b4da56dc33
<pre>
Unreviewed, address unexpected safer cpp failures on the bot
<a href="https://bugs.webkit.org/show_bug.cgi?id=304767">https://bugs.webkit.org/show_bug.cgi?id=304767</a>

* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/platform/graphics/coreimage/FEBlendCoreImageApplier.mm:
(WebCore::FEBlendCoreImageApplier::apply const):
* Source/WebCore/platform/graphics/coreimage/FECompositeCoreImageApplier.mm:
(WebCore::FECompositeCoreImageApplier::apply const):

Canonical link: <a href="https://commits.webkit.org/304993@main">https://commits.webkit.org/304993@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e2f1b852cb96d8a807be5d6e2a10eba979bd4a0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137118 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9478 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48405 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144864 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90091 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/45a17b17-a714-40d2-b8d0-5880cd581673) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138990 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10181 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9605 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104859 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/28786f46-a01e-4354-959c-ba0960707e9c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140063 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7488 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122873 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85695 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/db0552a3-e867-4f90-95f0-7f07f9744144) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7125 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/4833 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5454 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116475 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41039 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147620 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9161 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41603 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/113221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9179 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7700 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113544 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28839 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7048 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119133 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63521 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9209 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37187 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8933 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72775 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9150 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9002 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->