### PR TITLE
[GTK][WPE] REGRESSION(303110@main): ASSERTION FAILED: hasOneBitSet(static_cast<StorageType>(option)) in WTF_OptionSet tests

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WTF/OptionCountedSet.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/OptionCountedSet.cpp
@@ -30,7 +30,7 @@
 
 namespace TestWebKitAPI {
 
-enum class ExampleFlags : uint32_t {
+enum class OptionCountedSetTestFlags : uint32_t {
     A = 1 << 0,
     B = 1 << 1,
     C = 1 << 2,
@@ -38,69 +38,69 @@ enum class ExampleFlags : uint32_t {
 
 TEST(WTF_OptionCountedSet, EmptySet)
 {
-    OptionCountedSet<ExampleFlags> set;
+    OptionCountedSet<OptionCountedSetTestFlags> set;
     EXPECT_TRUE(set.isEmpty());
-    EXPECT_FALSE(set.contains(ExampleFlags::A));
-    EXPECT_FALSE(set.contains(ExampleFlags::B));
-    EXPECT_FALSE(set.contains(ExampleFlags::C));
-    set.add({ ExampleFlags::C, ExampleFlags::B });
+    EXPECT_FALSE(set.contains(OptionCountedSetTestFlags::A));
+    EXPECT_FALSE(set.contains(OptionCountedSetTestFlags::B));
+    EXPECT_FALSE(set.contains(OptionCountedSetTestFlags::C));
+    set.add({ OptionCountedSetTestFlags::C, OptionCountedSetTestFlags::B });
     EXPECT_FALSE(set.isEmpty());
-    EXPECT_FALSE(set.contains(ExampleFlags::A));
-    EXPECT_TRUE(set.contains(ExampleFlags::B));
-    EXPECT_TRUE(set.contains(ExampleFlags::C));
+    EXPECT_FALSE(set.contains(OptionCountedSetTestFlags::A));
+    EXPECT_TRUE(set.contains(OptionCountedSetTestFlags::B));
+    EXPECT_TRUE(set.contains(OptionCountedSetTestFlags::C));
 }
 
 TEST(WTF_OptionCountedSet, AddAndRemove)
 {
-    OptionCountedSet<ExampleFlags> set;
-    set.add(ExampleFlags::A);
-    EXPECT_TRUE(set.contains(ExampleFlags::A));
-    EXPECT_FALSE(set.contains(ExampleFlags::B));
-    EXPECT_FALSE(set.contains(ExampleFlags::C));
+    OptionCountedSet<OptionCountedSetTestFlags> set;
+    set.add(OptionCountedSetTestFlags::A);
+    EXPECT_TRUE(set.contains(OptionCountedSetTestFlags::A));
+    EXPECT_FALSE(set.contains(OptionCountedSetTestFlags::B));
+    EXPECT_FALSE(set.contains(OptionCountedSetTestFlags::C));
 
     // Adding the same flag increments the counter.
-    set.add(ExampleFlags::A);
-    EXPECT_TRUE(set.contains(ExampleFlags::A));
-    EXPECT_FALSE(set.contains(ExampleFlags::B));
-    EXPECT_FALSE(set.contains(ExampleFlags::C));
+    set.add(OptionCountedSetTestFlags::A);
+    EXPECT_TRUE(set.contains(OptionCountedSetTestFlags::A));
+    EXPECT_FALSE(set.contains(OptionCountedSetTestFlags::B));
+    EXPECT_FALSE(set.contains(OptionCountedSetTestFlags::C));
 
     // Removing the flag added twice decrements the counter.
-    set.remove(ExampleFlags::A);
-    EXPECT_TRUE(set.contains(ExampleFlags::A));
-    EXPECT_FALSE(set.contains(ExampleFlags::B));
-    EXPECT_FALSE(set.contains(ExampleFlags::C));
+    set.remove(OptionCountedSetTestFlags::A);
+    EXPECT_TRUE(set.contains(OptionCountedSetTestFlags::A));
+    EXPECT_FALSE(set.contains(OptionCountedSetTestFlags::B));
+    EXPECT_FALSE(set.contains(OptionCountedSetTestFlags::C));
 
     // Removing again makes the flag not present anymore.
-    set.remove(ExampleFlags::A);
-    EXPECT_FALSE(set.contains(ExampleFlags::A));
-    EXPECT_FALSE(set.contains(ExampleFlags::B));
-    EXPECT_FALSE(set.contains(ExampleFlags::C));
+    set.remove(OptionCountedSetTestFlags::A);
+    EXPECT_FALSE(set.contains(OptionCountedSetTestFlags::A));
+    EXPECT_FALSE(set.contains(OptionCountedSetTestFlags::B));
+    EXPECT_FALSE(set.contains(OptionCountedSetTestFlags::C));
 
     // Remove again does nothing.
-    set.remove(ExampleFlags::A);
-    EXPECT_FALSE(set.contains(ExampleFlags::A));
-    EXPECT_FALSE(set.contains(ExampleFlags::B));
-    EXPECT_FALSE(set.contains(ExampleFlags::C));
+    set.remove(OptionCountedSetTestFlags::A);
+    EXPECT_FALSE(set.contains(OptionCountedSetTestFlags::A));
+    EXPECT_FALSE(set.contains(OptionCountedSetTestFlags::B));
+    EXPECT_FALSE(set.contains(OptionCountedSetTestFlags::C));
 
     // Add multiple flags.
-    set.add({ ExampleFlags::B, ExampleFlags::C });
-    EXPECT_FALSE(set.contains(ExampleFlags::A));
-    EXPECT_TRUE(set.contains(ExampleFlags::B));
-    EXPECT_TRUE(set.contains(ExampleFlags::C));
-    set.add({ ExampleFlags::A, ExampleFlags::C });
-    EXPECT_TRUE(set.contains(ExampleFlags::A));
-    EXPECT_TRUE(set.contains(ExampleFlags::B));
-    EXPECT_TRUE(set.contains(ExampleFlags::C));
+    set.add({ OptionCountedSetTestFlags::B, OptionCountedSetTestFlags::C });
+    EXPECT_FALSE(set.contains(OptionCountedSetTestFlags::A));
+    EXPECT_TRUE(set.contains(OptionCountedSetTestFlags::B));
+    EXPECT_TRUE(set.contains(OptionCountedSetTestFlags::C));
+    set.add({ OptionCountedSetTestFlags::A, OptionCountedSetTestFlags::C });
+    EXPECT_TRUE(set.contains(OptionCountedSetTestFlags::A));
+    EXPECT_TRUE(set.contains(OptionCountedSetTestFlags::B));
+    EXPECT_TRUE(set.contains(OptionCountedSetTestFlags::C));
 
     // Remove multiple flags.
-    set.remove({ ExampleFlags::B, ExampleFlags::C });
-    EXPECT_TRUE(set.contains(ExampleFlags::A));
-    EXPECT_FALSE(set.contains(ExampleFlags::B));
-    EXPECT_TRUE(set.contains(ExampleFlags::C));
-    set.remove({ ExampleFlags::A, ExampleFlags::C });
-    EXPECT_FALSE(set.contains(ExampleFlags::A));
-    EXPECT_FALSE(set.contains(ExampleFlags::B));
-    EXPECT_FALSE(set.contains(ExampleFlags::C));
+    set.remove({ OptionCountedSetTestFlags::B, OptionCountedSetTestFlags::C });
+    EXPECT_TRUE(set.contains(OptionCountedSetTestFlags::A));
+    EXPECT_FALSE(set.contains(OptionCountedSetTestFlags::B));
+    EXPECT_TRUE(set.contains(OptionCountedSetTestFlags::C));
+    set.remove({ OptionCountedSetTestFlags::A, OptionCountedSetTestFlags::C });
+    EXPECT_FALSE(set.contains(OptionCountedSetTestFlags::A));
+    EXPECT_FALSE(set.contains(OptionCountedSetTestFlags::B));
+    EXPECT_FALSE(set.contains(OptionCountedSetTestFlags::C));
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 048eb8af1e67bc8e75d6c0bbd98986909fd3f086
<pre>
[GTK][WPE] REGRESSION(303110@main): ASSERTION FAILED: hasOneBitSet(static_cast&lt;StorageType&gt;(option)) in WTF_OptionSet tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=304769">https://bugs.webkit.org/show_bug.cgi?id=304769</a>

Reviewed by Nikolas Zimmermann.

Both tests OptionSet.cpp and OptionCountedSet.cpp defines a same name
TestWebKitAPI::ExampleFlags enum class. This made the tests fail in debug
builds. Rename the one in OptionCountedSet.cpp to OptionCountedSetTestFlags.

* Tools/TestWebKitAPI/Tests/WTF/OptionCountedSet.cpp:
(TestWebKitAPI::TEST(WTF_OptionCountedSet, EmptySet)):
(TestWebKitAPI::TEST(WTF_OptionCountedSet, AddAndRemove)):

Canonical link: <a href="https://commits.webkit.org/304997@main">https://commits.webkit.org/304997@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e428dc96f02fdb290b87a1c106adfcd71dbcbfb9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137123 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9483 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48410 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144869 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90096 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138995 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10186 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9610 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104860 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140068 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7496 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122878 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85696 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7133 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4839 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5459 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116483 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41044 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147625 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9166 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41608 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113215 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9184 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7706 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113545 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7049 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119138 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63529 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21130 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9214 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37192 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8938 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9155 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9007 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->