### PR TITLE
Stop requiring a separate std::array static variable to use SortedArrayMap / SortedArraySet

### DIFF
--- a/Source/JavaScriptCore/inspector/scripts/codegen/generate_objc_protocol_type_conversions_header.py
+++ b/Source/JavaScriptCore/inspector/scripts/codegen/generate_objc_protocol_type_conversions_header.py
@@ -166,11 +166,10 @@ class ObjCProtocolTypeConversionsHeaderGenerator(ObjCGenerator):
         lines.append('template<>')
         lines.append('inline std::optional<%s> fromProtocolString(const String& value)' % objc_enum_name)
         lines.append('{')
-        lines.append('    static constexpr auto mappings = std::to_array<std::pair<ComparableASCIILiteral, %s>>({' % objc_enum_name)
+        lines.append('    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, %s>>({' % objc_enum_name)
         for enum_value in sorted(enum_values):
             lines.append('        { "%s"_s, %s%s },' % (enum_value, objc_enum_name, Generator.stylized_name_for_enum_value(enum_value)))
-        lines.append('    });')
-        lines.append('    static constexpr SortedArrayMap map { mappings };')
+        lines.append('   }) };')
         lines.append('    if (auto* result = map.tryGet(value))')
         lines.append('        return *result;')
         lines.append('    return std::nullopt;')

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/command-targetType-matching-domain-debuggableType.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/command-targetType-matching-domain-debuggableType.json-result
@@ -107,6 +107,8 @@ InspectorBackend.activateDomain("Domain", ["page"]);
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(INSPECTOR_ALTERNATE_DISPATCHERS)
 
 #include "TestProtocolObjects.h"
@@ -448,6 +450,7 @@ void DomainFrontendDispatcher::Event()
 #pragma once
 
 #include <JavaScriptCore/InspectorProtocolTypes.h>
+#include <JavaScriptCore/JSExportMacros.h>
 #include <wtf/JSONValues.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-async-attribute.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-async-attribute.json-result
@@ -113,6 +113,8 @@ InspectorBackend.activateDomain("Database", null);
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(INSPECTOR_ALTERNATE_DISPATCHERS)
 
 #include "TestProtocolObjects.h"
@@ -609,6 +611,7 @@ namespace Inspector {
 #pragma once
 
 #include <JavaScriptCore/InspectorProtocolTypes.h>
+#include <JavaScriptCore/JSExportMacros.h>
 #include <wtf/JSONValues.h>
 #include <wtf/text/WTFString.h>
 
@@ -1461,12 +1464,11 @@ inline String toProtocolString(TestProtocolDatabasePrimaryColors value)
 template<>
 inline std::optional<TestProtocolDatabasePrimaryColors> fromProtocolString(const String& value)
 {
-    static constexpr auto mappings = std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabasePrimaryColors>>({
+    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabasePrimaryColors>>({
         { "blue"_s, TestProtocolDatabasePrimaryColorsBlue },
         { "green"_s, TestProtocolDatabasePrimaryColorsGreen },
         { "red"_s, TestProtocolDatabasePrimaryColorsRed },
-    });
-    static constexpr SortedArrayMap map { mappings };
+   }) };
     if (auto* result = map.tryGet(value))
         return *result;
     return std::nullopt;
@@ -1489,13 +1491,12 @@ inline String toProtocolString(TestProtocolDatabaseExecuteSQLSyncOptionalReturnV
 template<>
 inline std::optional<TestProtocolDatabaseExecuteSQLSyncOptionalReturnValuesPrintColor> fromProtocolString(const String& value)
 {
-    static constexpr auto mappings = std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteSQLSyncOptionalReturnValuesPrintColor>>({
+    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteSQLSyncOptionalReturnValuesPrintColor>>({
         { "black"_s, TestProtocolDatabaseExecuteSQLSyncOptionalReturnValuesPrintColorBlack },
         { "cyan"_s, TestProtocolDatabaseExecuteSQLSyncOptionalReturnValuesPrintColorCyan },
         { "magenta"_s, TestProtocolDatabaseExecuteSQLSyncOptionalReturnValuesPrintColorMagenta },
         { "yellow"_s, TestProtocolDatabaseExecuteSQLSyncOptionalReturnValuesPrintColorYellow },
-    });
-    static constexpr SortedArrayMap map { mappings };
+   }) };
     if (auto* result = map.tryGet(value))
         return *result;
     return std::nullopt;
@@ -1518,13 +1519,12 @@ inline String toProtocolString(TestProtocolDatabaseExecuteSQLAsyncOptionalReturn
 template<>
 inline std::optional<TestProtocolDatabaseExecuteSQLAsyncOptionalReturnValuesPrintColor> fromProtocolString(const String& value)
 {
-    static constexpr auto mappings = std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteSQLAsyncOptionalReturnValuesPrintColor>>({
+    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteSQLAsyncOptionalReturnValuesPrintColor>>({
         { "black"_s, TestProtocolDatabaseExecuteSQLAsyncOptionalReturnValuesPrintColorBlack },
         { "cyan"_s, TestProtocolDatabaseExecuteSQLAsyncOptionalReturnValuesPrintColorCyan },
         { "magenta"_s, TestProtocolDatabaseExecuteSQLAsyncOptionalReturnValuesPrintColorMagenta },
         { "yellow"_s, TestProtocolDatabaseExecuteSQLAsyncOptionalReturnValuesPrintColorYellow },
-    });
-    static constexpr SortedArrayMap map { mappings };
+   }) };
     if (auto* result = map.tryGet(value))
         return *result;
     return std::nullopt;
@@ -1547,13 +1547,12 @@ inline String toProtocolString(TestProtocolDatabaseExecuteSQLSyncPrintColor valu
 template<>
 inline std::optional<TestProtocolDatabaseExecuteSQLSyncPrintColor> fromProtocolString(const String& value)
 {
-    static constexpr auto mappings = std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteSQLSyncPrintColor>>({
+    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteSQLSyncPrintColor>>({
         { "black"_s, TestProtocolDatabaseExecuteSQLSyncPrintColorBlack },
         { "cyan"_s, TestProtocolDatabaseExecuteSQLSyncPrintColorCyan },
         { "magenta"_s, TestProtocolDatabaseExecuteSQLSyncPrintColorMagenta },
         { "yellow"_s, TestProtocolDatabaseExecuteSQLSyncPrintColorYellow },
-    });
-    static constexpr SortedArrayMap map { mappings };
+   }) };
     if (auto* result = map.tryGet(value))
         return *result;
     return std::nullopt;
@@ -1576,13 +1575,12 @@ inline String toProtocolString(TestProtocolDatabaseExecuteSQLAsyncPrintColor val
 template<>
 inline std::optional<TestProtocolDatabaseExecuteSQLAsyncPrintColor> fromProtocolString(const String& value)
 {
-    static constexpr auto mappings = std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteSQLAsyncPrintColor>>({
+    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteSQLAsyncPrintColor>>({
         { "black"_s, TestProtocolDatabaseExecuteSQLAsyncPrintColorBlack },
         { "cyan"_s, TestProtocolDatabaseExecuteSQLAsyncPrintColorCyan },
         { "magenta"_s, TestProtocolDatabaseExecuteSQLAsyncPrintColorMagenta },
         { "yellow"_s, TestProtocolDatabaseExecuteSQLAsyncPrintColorYellow },
-    });
-    static constexpr SortedArrayMap map { mappings };
+   }) };
     if (auto* result = map.tryGet(value))
         return *result;
     return std::nullopt;

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-optional-call-return-parameters.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-optional-call-return-parameters.json-result
@@ -107,6 +107,8 @@ InspectorBackend.activateDomain("Database", null);
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(INSPECTOR_ALTERNATE_DISPATCHERS)
 
 #include "TestProtocolObjects.h"
@@ -523,6 +525,7 @@ namespace Inspector {
 #pragma once
 
 #include <JavaScriptCore/InspectorProtocolTypes.h>
+#include <JavaScriptCore/JSExportMacros.h>
 #include <wtf/JSONValues.h>
 #include <wtf/text/WTFString.h>
 
@@ -1331,12 +1334,11 @@ inline String toProtocolString(TestProtocolDatabasePrimaryColors value)
 template<>
 inline std::optional<TestProtocolDatabasePrimaryColors> fromProtocolString(const String& value)
 {
-    static constexpr auto mappings = std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabasePrimaryColors>>({
+    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabasePrimaryColors>>({
         { "blue"_s, TestProtocolDatabasePrimaryColorsBlue },
         { "green"_s, TestProtocolDatabasePrimaryColorsGreen },
         { "red"_s, TestProtocolDatabasePrimaryColorsRed },
-    });
-    static constexpr SortedArrayMap map { mappings };
+   }) };
     if (auto* result = map.tryGet(value))
         return *result;
     return std::nullopt;
@@ -1359,13 +1361,12 @@ inline String toProtocolString(TestProtocolDatabaseExecuteAllOptionalParametersP
 template<>
 inline std::optional<TestProtocolDatabaseExecuteAllOptionalParametersPrintColor> fromProtocolString(const String& value)
 {
-    static constexpr auto mappings = std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteAllOptionalParametersPrintColor>>({
+    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteAllOptionalParametersPrintColor>>({
         { "black"_s, TestProtocolDatabaseExecuteAllOptionalParametersPrintColorBlack },
         { "cyan"_s, TestProtocolDatabaseExecuteAllOptionalParametersPrintColorCyan },
         { "magenta"_s, TestProtocolDatabaseExecuteAllOptionalParametersPrintColorMagenta },
         { "yellow"_s, TestProtocolDatabaseExecuteAllOptionalParametersPrintColorYellow },
-    });
-    static constexpr SortedArrayMap map { mappings };
+   }) };
     if (auto* result = map.tryGet(value))
         return *result;
     return std::nullopt;
@@ -1390,13 +1391,12 @@ inline String toProtocolString(TestProtocolDatabaseExecuteAllOptionalParametersP
 template<>
 inline std::optional<TestProtocolDatabaseExecuteAllOptionalParametersPrintColor> fromProtocolString(const String& value)
 {
-    static constexpr auto mappings = std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteAllOptionalParametersPrintColor>>({
+    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteAllOptionalParametersPrintColor>>({
         { "black"_s, TestProtocolDatabaseExecuteAllOptionalParametersPrintColorBlack },
         { "cyan"_s, TestProtocolDatabaseExecuteAllOptionalParametersPrintColorCyan },
         { "magenta"_s, TestProtocolDatabaseExecuteAllOptionalParametersPrintColorMagenta },
         { "yellow"_s, TestProtocolDatabaseExecuteAllOptionalParametersPrintColorYellow },
-    });
-    static constexpr SortedArrayMap map { mappings };
+   }) };
     if (auto* result = map.tryGet(value))
         return *result;
     return std::nullopt;
@@ -1419,13 +1419,12 @@ inline String toProtocolString(TestProtocolDatabaseExecuteNoOptionalParametersPr
 template<>
 inline std::optional<TestProtocolDatabaseExecuteNoOptionalParametersPrintColor> fromProtocolString(const String& value)
 {
-    static constexpr auto mappings = std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteNoOptionalParametersPrintColor>>({
+    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteNoOptionalParametersPrintColor>>({
         { "black"_s, TestProtocolDatabaseExecuteNoOptionalParametersPrintColorBlack },
         { "cyan"_s, TestProtocolDatabaseExecuteNoOptionalParametersPrintColorCyan },
         { "magenta"_s, TestProtocolDatabaseExecuteNoOptionalParametersPrintColorMagenta },
         { "yellow"_s, TestProtocolDatabaseExecuteNoOptionalParametersPrintColorYellow },
-    });
-    static constexpr SortedArrayMap map { mappings };
+   }) };
     if (auto* result = map.tryGet(value))
         return *result;
     return std::nullopt;
@@ -1450,13 +1449,12 @@ inline String toProtocolString(TestProtocolDatabaseExecuteNoOptionalParametersPr
 template<>
 inline std::optional<TestProtocolDatabaseExecuteNoOptionalParametersPrintColor> fromProtocolString(const String& value)
 {
-    static constexpr auto mappings = std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteNoOptionalParametersPrintColor>>({
+    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteNoOptionalParametersPrintColor>>({
         { "black"_s, TestProtocolDatabaseExecuteNoOptionalParametersPrintColorBlack },
         { "cyan"_s, TestProtocolDatabaseExecuteNoOptionalParametersPrintColorCyan },
         { "magenta"_s, TestProtocolDatabaseExecuteNoOptionalParametersPrintColorMagenta },
         { "yellow"_s, TestProtocolDatabaseExecuteNoOptionalParametersPrintColorYellow },
-    });
-    static constexpr SortedArrayMap map { mappings };
+   }) };
     if (auto* result = map.tryGet(value))
         return *result;
     return std::nullopt;

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/definitions-with-mac-platform.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/definitions-with-mac-platform.json-result
@@ -106,6 +106,8 @@ InspectorBackend.activateDomain("Network", null);
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(INSPECTOR_ALTERNATE_DISPATCHERS)
 
 #include "TestProtocolObjects.h"
@@ -477,6 +479,7 @@ void NetworkFrontendDispatcher::resourceLoaded()
 #pragma once
 
 #include <JavaScriptCore/InspectorProtocolTypes.h>
+#include <JavaScriptCore/JSExportMacros.h>
 #include <wtf/JSONValues.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/domain-debuggableTypes.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/domain-debuggableTypes.json-result
@@ -107,6 +107,8 @@ InspectorBackend.activateDomain("Domain", ["web-page"]);
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(INSPECTOR_ALTERNATE_DISPATCHERS)
 
 #include "TestProtocolObjects.h"
@@ -448,6 +450,7 @@ void DomainFrontendDispatcher::Event()
 #pragma once
 
 #include <JavaScriptCore/InspectorProtocolTypes.h>
+#include <JavaScriptCore/JSExportMacros.h>
 #include <wtf/JSONValues.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/domain-exposed-as-other-name.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/domain-exposed-as-other-name.json-result
@@ -115,6 +115,8 @@ InspectorBackend.activateDomain("Database", null);
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(INSPECTOR_ALTERNATE_DISPATCHERS)
 
 #include "TestProtocolObjects.h"
@@ -639,6 +641,7 @@ void DatabaseFrontendDispatcher::didEncounterError(RefPtr<Protocol::Database::Er
 #pragma once
 
 #include <JavaScriptCore/InspectorProtocolTypes.h>
+#include <JavaScriptCore/JSExportMacros.h>
 #include <wtf/JSONValues.h>
 #include <wtf/text/WTFString.h>
 
@@ -1537,12 +1540,11 @@ inline String toProtocolString(TestProtocolDatabasePrimaryColors value)
 template<>
 inline std::optional<TestProtocolDatabasePrimaryColors> fromProtocolString(const String& value)
 {
-    static constexpr auto mappings = std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabasePrimaryColors>>({
+    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabasePrimaryColors>>({
         { "blue"_s, TestProtocolDatabasePrimaryColorsBlue },
         { "green"_s, TestProtocolDatabasePrimaryColorsGreen },
         { "red"_s, TestProtocolDatabasePrimaryColorsRed },
-    });
-    static constexpr SortedArrayMap map { mappings };
+   }) };
     if (auto* result = map.tryGet(value))
         return *result;
     return std::nullopt;
@@ -1565,13 +1567,12 @@ inline String toProtocolString(TestProtocolDatabaseExecuteSQLSyncOptionalReturnV
 template<>
 inline std::optional<TestProtocolDatabaseExecuteSQLSyncOptionalReturnValuesPrintColor> fromProtocolString(const String& value)
 {
-    static constexpr auto mappings = std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteSQLSyncOptionalReturnValuesPrintColor>>({
+    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteSQLSyncOptionalReturnValuesPrintColor>>({
         { "black"_s, TestProtocolDatabaseExecuteSQLSyncOptionalReturnValuesPrintColorBlack },
         { "cyan"_s, TestProtocolDatabaseExecuteSQLSyncOptionalReturnValuesPrintColorCyan },
         { "magenta"_s, TestProtocolDatabaseExecuteSQLSyncOptionalReturnValuesPrintColorMagenta },
         { "yellow"_s, TestProtocolDatabaseExecuteSQLSyncOptionalReturnValuesPrintColorYellow },
-    });
-    static constexpr SortedArrayMap map { mappings };
+   }) };
     if (auto* result = map.tryGet(value))
         return *result;
     return std::nullopt;
@@ -1594,13 +1595,12 @@ inline String toProtocolString(TestProtocolDatabaseExecuteSQLAsyncOptionalReturn
 template<>
 inline std::optional<TestProtocolDatabaseExecuteSQLAsyncOptionalReturnValuesPrintColor> fromProtocolString(const String& value)
 {
-    static constexpr auto mappings = std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteSQLAsyncOptionalReturnValuesPrintColor>>({
+    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteSQLAsyncOptionalReturnValuesPrintColor>>({
         { "black"_s, TestProtocolDatabaseExecuteSQLAsyncOptionalReturnValuesPrintColorBlack },
         { "cyan"_s, TestProtocolDatabaseExecuteSQLAsyncOptionalReturnValuesPrintColorCyan },
         { "magenta"_s, TestProtocolDatabaseExecuteSQLAsyncOptionalReturnValuesPrintColorMagenta },
         { "yellow"_s, TestProtocolDatabaseExecuteSQLAsyncOptionalReturnValuesPrintColorYellow },
-    });
-    static constexpr SortedArrayMap map { mappings };
+   }) };
     if (auto* result = map.tryGet(value))
         return *result;
     return std::nullopt;
@@ -1623,13 +1623,12 @@ inline String toProtocolString(TestProtocolDatabaseExecuteSQLSyncPrintColor valu
 template<>
 inline std::optional<TestProtocolDatabaseExecuteSQLSyncPrintColor> fromProtocolString(const String& value)
 {
-    static constexpr auto mappings = std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteSQLSyncPrintColor>>({
+    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteSQLSyncPrintColor>>({
         { "black"_s, TestProtocolDatabaseExecuteSQLSyncPrintColorBlack },
         { "cyan"_s, TestProtocolDatabaseExecuteSQLSyncPrintColorCyan },
         { "magenta"_s, TestProtocolDatabaseExecuteSQLSyncPrintColorMagenta },
         { "yellow"_s, TestProtocolDatabaseExecuteSQLSyncPrintColorYellow },
-    });
-    static constexpr SortedArrayMap map { mappings };
+   }) };
     if (auto* result = map.tryGet(value))
         return *result;
     return std::nullopt;
@@ -1652,13 +1651,12 @@ inline String toProtocolString(TestProtocolDatabaseExecuteSQLAsyncPrintColor val
 template<>
 inline std::optional<TestProtocolDatabaseExecuteSQLAsyncPrintColor> fromProtocolString(const String& value)
 {
-    static constexpr auto mappings = std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteSQLAsyncPrintColor>>({
+    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteSQLAsyncPrintColor>>({
         { "black"_s, TestProtocolDatabaseExecuteSQLAsyncPrintColorBlack },
         { "cyan"_s, TestProtocolDatabaseExecuteSQLAsyncPrintColorCyan },
         { "magenta"_s, TestProtocolDatabaseExecuteSQLAsyncPrintColorMagenta },
         { "yellow"_s, TestProtocolDatabaseExecuteSQLAsyncPrintColorYellow },
-    });
-    static constexpr SortedArrayMap map { mappings };
+   }) };
     if (auto* result = map.tryGet(value))
         return *result;
     return std::nullopt;

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/domain-targetType-matching-domain-debuggableType.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/domain-targetType-matching-domain-debuggableType.json-result
@@ -107,6 +107,8 @@ InspectorBackend.activateDomain("Domain", ["page"]);
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(INSPECTOR_ALTERNATE_DISPATCHERS)
 
 #include "TestProtocolObjects.h"
@@ -448,6 +450,7 @@ void DomainFrontendDispatcher::Event()
 #pragma once
 
 #include <JavaScriptCore/InspectorProtocolTypes.h>
+#include <JavaScriptCore/JSExportMacros.h>
 #include <wtf/JSONValues.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/domain-targetTypes.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/domain-targetTypes.json-result
@@ -107,6 +107,8 @@ InspectorBackend.activateDomain("Domain", null);
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(INSPECTOR_ALTERNATE_DISPATCHERS)
 
 #include "TestProtocolObjects.h"
@@ -448,6 +450,7 @@ void DomainFrontendDispatcher::Event()
 #pragma once
 
 #include <JavaScriptCore/InspectorProtocolTypes.h>
+#include <JavaScriptCore/JSExportMacros.h>
 #include <wtf/JSONValues.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/domains-with-varying-command-sizes.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/domains-with-varying-command-sizes.json-result
@@ -125,6 +125,8 @@ InspectorBackend.activateDomain("Network3", null);
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(INSPECTOR_ALTERNATE_DISPATCHERS)
 
 #include "TestProtocolObjects.h"
@@ -671,6 +673,7 @@ namespace Inspector {
 #pragma once
 
 #include <JavaScriptCore/InspectorProtocolTypes.h>
+#include <JavaScriptCore/JSExportMacros.h>
 #include <wtf/JSONValues.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/enum-values.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/enum-values.json-result
@@ -129,6 +129,8 @@ InspectorBackend.activateDomain("EventDomain", null);
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(INSPECTOR_ALTERNATE_DISPATCHERS)
 
 #include "TestProtocolObjects.h"
@@ -515,6 +517,7 @@ void EventDomainFrontendDispatcher::event(Protocol::TypeDomain::Enum enumRequire
 #pragma once
 
 #include <JavaScriptCore/InspectorProtocolTypes.h>
+#include <JavaScriptCore/JSExportMacros.h>
 #include <wtf/JSONValues.h>
 #include <wtf/text/WTFString.h>
 
@@ -1162,12 +1165,11 @@ inline String toProtocolString(TestProtocolTypeDomainEnum value)
 template<>
 inline std::optional<TestProtocolTypeDomainEnum> fromProtocolString(const String& value)
 {
-    static constexpr auto mappings = std::to_array<std::pair<ComparableASCIILiteral, TestProtocolTypeDomainEnum>>({
+    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolTypeDomainEnum>>({
         { "1"_s, TestProtocolTypeDomainEnum1 },
         { "2"_s, TestProtocolTypeDomainEnum2 },
         { "shared"_s, TestProtocolTypeDomainEnumShared },
-    });
-    static constexpr SortedArrayMap map { mappings };
+   }) };
     if (auto* result = map.tryGet(value))
         return *result;
     return std::nullopt;

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/event-targetType-matching-domain-debuggableType.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/event-targetType-matching-domain-debuggableType.json-result
@@ -107,6 +107,8 @@ InspectorBackend.activateDomain("Domain", ["page"]);
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(INSPECTOR_ALTERNATE_DISPATCHERS)
 
 #include "TestProtocolObjects.h"
@@ -448,6 +450,7 @@ void DomainFrontendDispatcher::Event()
 #pragma once
 
 #include <JavaScriptCore/InspectorProtocolTypes.h>
+#include <JavaScriptCore/JSExportMacros.h>
 #include <wtf/JSONValues.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/events-with-optional-parameters.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/events-with-optional-parameters.json-result
@@ -107,6 +107,8 @@ InspectorBackend.activateDomain("Database", null);
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(INSPECTOR_ALTERNATE_DISPATCHERS)
 
 #include "TestProtocolObjects.h"
@@ -412,6 +414,7 @@ void DatabaseFrontendDispatcher::didExecuteNoOptionalParameters(Ref<JSON::ArrayO
 #pragma once
 
 #include <JavaScriptCore/InspectorProtocolTypes.h>
+#include <JavaScriptCore/JSExportMacros.h>
 #include <wtf/JSONValues.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/generate-domains-with-feature-guards.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/generate-domains-with-feature-guards.json-result
@@ -115,6 +115,8 @@ InspectorBackend.activateDomain("Network3", null);
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(INSPECTOR_ALTERNATE_DISPATCHERS)
 
 #include "TestProtocolObjects.h"
@@ -456,6 +458,7 @@ void Network3FrontendDispatcher::resourceLoaded()
 #pragma once
 
 #include <JavaScriptCore/InspectorProtocolTypes.h>
+#include <JavaScriptCore/JSExportMacros.h>
 #include <wtf/JSONValues.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/same-type-id-different-domain.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/same-type-id-different-domain.json-result
@@ -93,6 +93,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(INSPECTOR_ALTERNATE_DISPATCHERS)
 
 #include "TestProtocolObjects.h"
@@ -334,6 +336,7 @@ namespace Inspector {
 #pragma once
 
 #include <JavaScriptCore/InspectorProtocolTypes.h>
+#include <JavaScriptCore/JSExportMacros.h>
 #include <wtf/JSONValues.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/shadowed-optional-type-setters.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/shadowed-optional-type-setters.json-result
@@ -93,6 +93,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(INSPECTOR_ALTERNATE_DISPATCHERS)
 
 #include "TestProtocolObjects.h"
@@ -334,6 +336,7 @@ namespace Inspector {
 #pragma once
 
 #include <JavaScriptCore/InspectorProtocolTypes.h>
+#include <JavaScriptCore/JSExportMacros.h>
 #include <wtf/JSONValues.h>
 #include <wtf/text/WTFString.h>
 
@@ -927,12 +930,11 @@ inline String toProtocolString(TestProtocolRuntimeKeyPathType value)
 template<>
 inline std::optional<TestProtocolRuntimeKeyPathType> fromProtocolString(const String& value)
 {
-    static constexpr auto mappings = std::to_array<std::pair<ComparableASCIILiteral, TestProtocolRuntimeKeyPathType>>({
+    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolRuntimeKeyPathType>>({
         { "array"_s, TestProtocolRuntimeKeyPathTypeArray },
         { "null"_s, TestProtocolRuntimeKeyPathTypeNull },
         { "string"_s, TestProtocolRuntimeKeyPathTypeString },
-    });
-    static constexpr SortedArrayMap map { mappings };
+   }) };
     if (auto* result = map.tryGet(value))
         return *result;
     return std::nullopt;

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/should-strip-comments.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/should-strip-comments.json-result
@@ -93,6 +93,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(INSPECTOR_ALTERNATE_DISPATCHERS)
 
 #include "TestProtocolObjects.h"
@@ -334,6 +336,7 @@ namespace Inspector {
 #pragma once
 
 #include <JavaScriptCore/InspectorProtocolTypes.h>
+#include <JavaScriptCore/JSExportMacros.h>
 #include <wtf/JSONValues.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-aliased-primitive-type.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-aliased-primitive-type.json-result
@@ -93,6 +93,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(INSPECTOR_ALTERNATE_DISPATCHERS)
 
 #include "TestProtocolObjects.h"
@@ -334,6 +336,7 @@ namespace Inspector {
 #pragma once
 
 #include <JavaScriptCore/InspectorProtocolTypes.h>
+#include <JavaScriptCore/JSExportMacros.h>
 #include <wtf/JSONValues.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-array-type.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-array-type.json-result
@@ -103,6 +103,8 @@ InspectorBackend.activateDomain("Debugger", null);
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(INSPECTOR_ALTERNATE_DISPATCHERS)
 
 #include "TestProtocolObjects.h"
@@ -344,6 +346,7 @@ namespace Inspector {
 #pragma once
 
 #include <JavaScriptCore/InspectorProtocolTypes.h>
+#include <JavaScriptCore/JSExportMacros.h>
 #include <wtf/JSONValues.h>
 #include <wtf/text/WTFString.h>
 
@@ -874,12 +877,11 @@ inline String toProtocolString(TestProtocolDebuggerReason value)
 template<>
 inline std::optional<TestProtocolDebuggerReason> fromProtocolString(const String& value)
 {
-    static constexpr auto mappings = std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDebuggerReason>>({
+    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDebuggerReason>>({
         { "Died"_s, TestProtocolDebuggerReasonDied },
         { "Fainted"_s, TestProtocolDebuggerReasonFainted },
         { "Hungry"_s, TestProtocolDebuggerReasonHungry },
-    });
-    static constexpr SortedArrayMap map { mappings };
+   }) };
     if (auto* result = map.tryGet(value))
         return *result;
     return std::nullopt;

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-enum-type.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-enum-type.json-result
@@ -105,6 +105,8 @@ InspectorBackend.activateDomain("Runtime", null);
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(INSPECTOR_ALTERNATE_DISPATCHERS)
 
 #include "TestProtocolObjects.h"
@@ -346,6 +348,7 @@ namespace Inspector {
 #pragma once
 
 #include <JavaScriptCore/InspectorProtocolTypes.h>
+#include <JavaScriptCore/JSExportMacros.h>
 #include <wtf/JSONValues.h>
 #include <wtf/text/WTFString.h>
 
@@ -906,13 +909,12 @@ inline String toProtocolString(TestProtocolRuntimeFarmAnimals value)
 template<>
 inline std::optional<TestProtocolRuntimeFarmAnimals> fromProtocolString(const String& value)
 {
-    static constexpr auto mappings = std::to_array<std::pair<ComparableASCIILiteral, TestProtocolRuntimeFarmAnimals>>({
+    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolRuntimeFarmAnimals>>({
         { "Cats"_s, TestProtocolRuntimeFarmAnimalsCats },
         { "Cows"_s, TestProtocolRuntimeFarmAnimalsCows },
         { "Hens"_s, TestProtocolRuntimeFarmAnimalsHens },
         { "Pigs"_s, TestProtocolRuntimeFarmAnimalsPigs },
-    });
-    static constexpr SortedArrayMap map { mappings };
+   }) };
     if (auto* result = map.tryGet(value))
         return *result;
     return std::nullopt;
@@ -935,13 +937,12 @@ inline String toProtocolString(TestProtocolRuntimeTwoLeggedAnimals value)
 template<>
 inline std::optional<TestProtocolRuntimeTwoLeggedAnimals> fromProtocolString(const String& value)
 {
-    static constexpr auto mappings = std::to_array<std::pair<ComparableASCIILiteral, TestProtocolRuntimeTwoLeggedAnimals>>({
+    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolRuntimeTwoLeggedAnimals>>({
         { "Crows"_s, TestProtocolRuntimeTwoLeggedAnimalsCrows },
         { "Ducks"_s, TestProtocolRuntimeTwoLeggedAnimalsDucks },
         { "Flamingos"_s, TestProtocolRuntimeTwoLeggedAnimalsFlamingos },
         { "Hens"_s, TestProtocolRuntimeTwoLeggedAnimalsHens },
-    });
-    static constexpr SortedArrayMap map { mappings };
+   }) };
     if (auto* result = map.tryGet(value))
         return *result;
     return std::nullopt;

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-object-type.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-object-type.json-result
@@ -107,6 +107,8 @@ InspectorBackend.activateDomain("Database", null);
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(INSPECTOR_ALTERNATE_DISPATCHERS)
 
 #include "TestProtocolObjects.h"
@@ -348,6 +350,7 @@ namespace Inspector {
 #pragma once
 
 #include <JavaScriptCore/InspectorProtocolTypes.h>
+#include <JavaScriptCore/JSExportMacros.h>
 #include <wtf/JSONValues.h>
 #include <wtf/text/WTFString.h>
 
@@ -1758,13 +1761,12 @@ inline String toProtocolString(TestProtocolDatabaseMouseButton value)
 template<>
 inline std::optional<TestProtocolDatabaseMouseButton> fromProtocolString(const String& value)
 {
-    static constexpr auto mappings = std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabaseMouseButton>>({
+    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabaseMouseButton>>({
         { "Left"_s, TestProtocolDatabaseMouseButtonLeft },
         { "Middle"_s, TestProtocolDatabaseMouseButtonMiddle },
         { "None"_s, TestProtocolDatabaseMouseButtonNone },
         { "Right"_s, TestProtocolDatabaseMouseButtonRight },
-    });
-    static constexpr SortedArrayMap map { mappings };
+   }) };
     if (auto* result = map.tryGet(value))
         return *result;
     return std::nullopt;
@@ -1783,11 +1785,10 @@ inline String toProtocolString(TestProtocolDatabaseOptionalParameterBundleDirect
 template<>
 inline std::optional<TestProtocolDatabaseOptionalParameterBundleDirectionality> fromProtocolString(const String& value)
 {
-    static constexpr auto mappings = std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabaseOptionalParameterBundleDirectionality>>({
+    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabaseOptionalParameterBundleDirectionality>>({
         { "LTR"_s, TestProtocolDatabaseOptionalParameterBundleDirectionalityLTR },
         { "RTL"_s, TestProtocolDatabaseOptionalParameterBundleDirectionalityRTL },
-    });
-    static constexpr SortedArrayMap map { mappings };
+   }) };
     if (auto* result = map.tryGet(value))
         return *result;
     return std::nullopt;
@@ -1806,11 +1807,10 @@ inline String toProtocolString(TestProtocolDatabaseParameterBundleDirectionality
 template<>
 inline std::optional<TestProtocolDatabaseParameterBundleDirectionality> fromProtocolString(const String& value)
 {
-    static constexpr auto mappings = std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabaseParameterBundleDirectionality>>({
+    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabaseParameterBundleDirectionality>>({
         { "LTR"_s, TestProtocolDatabaseParameterBundleDirectionalityLTR },
         { "RTL"_s, TestProtocolDatabaseParameterBundleDirectionalityRTL },
-    });
-    static constexpr SortedArrayMap map { mappings };
+   }) };
     if (auto* result = map.tryGet(value))
         return *result;
     return std::nullopt;
@@ -1829,11 +1829,10 @@ inline String toProtocolString(TestProtocolTestParameterBundleDirectionality val
 template<>
 inline std::optional<TestProtocolTestParameterBundleDirectionality> fromProtocolString(const String& value)
 {
-    static constexpr auto mappings = std::to_array<std::pair<ComparableASCIILiteral, TestProtocolTestParameterBundleDirectionality>>({
+    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolTestParameterBundleDirectionality>>({
         { "LTR"_s, TestProtocolTestParameterBundleDirectionalityLTR },
         { "RTL"_s, TestProtocolTestParameterBundleDirectionalityRTL },
-    });
-    static constexpr SortedArrayMap map { mappings };
+   }) };
     if (auto* result = map.tryGet(value))
         return *result;
     return std::nullopt;

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/type-requiring-runtime-casts.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/type-requiring-runtime-casts.json-result
@@ -105,6 +105,8 @@ InspectorBackend.activateDomain("Test", null);
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(INSPECTOR_ALTERNATE_DISPATCHERS)
 
 #include "TestProtocolObjects.h"
@@ -346,6 +348,7 @@ namespace Inspector {
 #pragma once
 
 #include <JavaScriptCore/InspectorProtocolTypes.h>
+#include <JavaScriptCore/JSExportMacros.h>
 #include <wtf/JSONValues.h>
 #include <wtf/text/WTFString.h>
 
@@ -1276,13 +1279,12 @@ inline String toProtocolString(TestProtocolTestUncastedAnimals value)
 template<>
 inline std::optional<TestProtocolTestUncastedAnimals> fromProtocolString(const String& value)
 {
-    static constexpr auto mappings = std::to_array<std::pair<ComparableASCIILiteral, TestProtocolTestUncastedAnimals>>({
+    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolTestUncastedAnimals>>({
         { "Cats"_s, TestProtocolTestUncastedAnimalsCats },
         { "Cows"_s, TestProtocolTestUncastedAnimalsCows },
         { "Hens"_s, TestProtocolTestUncastedAnimalsHens },
         { "Pigs"_s, TestProtocolTestUncastedAnimalsPigs },
-    });
-    static constexpr SortedArrayMap map { mappings };
+   }) };
     if (auto* result = map.tryGet(value))
         return *result;
     return std::nullopt;
@@ -1305,13 +1307,12 @@ inline String toProtocolString(TestProtocolTestCastedAnimals value)
 template<>
 inline std::optional<TestProtocolTestCastedAnimals> fromProtocolString(const String& value)
 {
-    static constexpr auto mappings = std::to_array<std::pair<ComparableASCIILiteral, TestProtocolTestCastedAnimals>>({
+    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolTestCastedAnimals>>({
         { "Crows"_s, TestProtocolTestCastedAnimalsCrows },
         { "Ducks"_s, TestProtocolTestCastedAnimalsDucks },
         { "Flamingos"_s, TestProtocolTestCastedAnimalsFlamingos },
         { "Hens"_s, TestProtocolTestCastedAnimalsHens },
-    });
-    static constexpr SortedArrayMap map { mappings };
+   }) };
     if (auto* result = map.tryGet(value))
         return *result;
     return std::nullopt;

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/type-with-open-parameters.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/type-with-open-parameters.json-result
@@ -93,6 +93,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(INSPECTOR_ALTERNATE_DISPATCHERS)
 
 #include "TestProtocolObjects.h"
@@ -334,6 +336,7 @@ namespace Inspector {
 #pragma once
 
 #include <JavaScriptCore/InspectorProtocolTypes.h>
+#include <JavaScriptCore/JSExportMacros.h>
 #include <wtf/JSONValues.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/version.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/version.json-result
@@ -103,6 +103,8 @@ InspectorBackend.activateDomain("VersionDomain", null);
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(INSPECTOR_ALTERNATE_DISPATCHERS)
 
 #include "TestProtocolObjects.h"
@@ -344,6 +346,7 @@ namespace Inspector {
 #pragma once
 
 #include <JavaScriptCore/InspectorProtocolTypes.h>
+#include <JavaScriptCore/JSExportMacros.h>
 #include <wtf/JSONValues.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/WTF/wtf/SortedArrayMap.h
+++ b/Source/WTF/wtf/SortedArrayMap.h
@@ -52,7 +52,7 @@ class SortedArrayMap : public SortedArrayBase {
 public:
     using ValueType = typename ElementType::second_type;
 
-    constexpr SortedArrayMap(const std::array<ElementType, N>&);
+    constexpr SortedArrayMap(std::array<ElementType, N>&&);
     template<typename KeyArgument> bool contains(const KeyArgument&) const;
 
     // FIXME: To match HashMap interface better, would be nice to get the default value from traits.
@@ -61,17 +61,21 @@ public:
     // FIXME: Should add a function like this to HashMap so the two kinds of maps are more interchangable.
     template<typename KeyArgument> const ValueType* tryGet(const KeyArgument&) const;
 
+    const std::array<ElementType, N>& array() const { return m_array; }
+
 private:
-    const std::array<ElementType, N>& m_array;
+    std::array<ElementType, N> m_array;
 };
 
 template<typename ElementType, std::size_t N> class SortedArraySet : public SortedArrayBase {
 public:
-    constexpr SortedArraySet(const std::array<ElementType, N>&);
+    constexpr SortedArraySet(std::array<ElementType, N>&&);
     template<typename KeyArgument> bool contains(const KeyArgument&) const;
 
+    const std::array<ElementType, N>& array() const { return m_array; }
+
 private:
-    const std::array<ElementType, N>& m_array;
+    std::array<ElementType, N> m_array;
 };
 
 struct ComparableStringView {
@@ -163,10 +167,10 @@ template<ASCIISubset subset> constexpr ComparableASCIISubsetLiteral<subset>::Com
 }
 
 template<typename ElementType, std::size_t N>
-constexpr SortedArrayMap<ElementType, N>::SortedArrayMap(const std::array<ElementType, N>& array)
-    : m_array { array }
+constexpr SortedArrayMap<ElementType, N>::SortedArrayMap(std::array<ElementType, N>&& array)
+    : m_array { WTF::move(array) }
 {
-    ASSERT_UNDER_CONSTEXPR_CONTEXT(std::is_sorted(array.begin(), array.end(), [](auto& a, auto b) {
+    ASSERT_UNDER_CONSTEXPR_CONTEXT(std::is_sorted(m_array.begin(), m_array.end(), [](auto& a, auto b) {
         return a.first < b.first;
     }));
 }
@@ -205,10 +209,10 @@ template<typename ElementType, std::size_t N> template<typename KeyArgument> inl
     return tryGet(key);
 }
 
-template<typename ElementType, std::size_t N> constexpr SortedArraySet<ElementType, N>::SortedArraySet(const std::array<ElementType, N>& array)
-    : m_array { array }
+template<typename ElementType, std::size_t N> constexpr SortedArraySet<ElementType, N>::SortedArraySet(std::array<ElementType, N>&& array)
+    : m_array { WTF::move(array) }
 {
-    ASSERT_UNDER_CONSTEXPR_CONTEXT(std::is_sorted(array.begin(), array.end()));
+    ASSERT_UNDER_CONSTEXPR_CONTEXT(std::is_sorted(m_array.begin(), m_array.end()));
 }
 
 template<typename ElementType, std::size_t N> template<typename KeyArgument> inline bool SortedArraySet<ElementType, N>::contains(const KeyArgument& key) const

--- a/Source/WebCore/Modules/WebGPU/GPUAdapter.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUAdapter.cpp
@@ -75,7 +75,7 @@ static WebGPU::DeviceDescriptor convertToBacking(const std::optional<GPUDeviceDe
 
 static GPUFeatureName convertFeatureNameToEnum(const String& stringValue)
 {
-    static constexpr auto mappings = std::to_array<std::pair<ComparableASCIILiteral, GPUFeatureName>>({
+    static constexpr SortedArrayMap enumerationMapping { std::to_array<std::pair<ComparableASCIILiteral, GPUFeatureName>>({
         { "bgra8unorm-storage"_s, GPUFeatureName::Bgra8unormStorage },
         { "clip-distances"_s, GPUFeatureName::ClipDistances },
         { "core-features-and-limits"_s, GPUFeatureName::CoreFeaturesAndLimits },
@@ -96,8 +96,7 @@ static GPUFeatureName convertFeatureNameToEnum(const String& stringValue)
         { "texture-compression-etc2"_s, GPUFeatureName::TextureCompressionEtc2 },
         { "texture-formats-tier1"_s, GPUFeatureName::TextureFormatsTier1 },
         { "timestamp-query"_s, GPUFeatureName::TimestampQuery },
-    });
-    static constexpr SortedArrayMap enumerationMapping { mappings };
+    }) };
     if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); enumerationValue) [[likely]]
         return *enumerationValue;
 

--- a/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp
+++ b/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp
@@ -188,12 +188,11 @@ ApplicationManifest::Direction ApplicationManifestParser::parseDir(const JSON::O
         return Auto;
     }
 
-    static constexpr auto directionMappings = std::to_array<std::pair<ComparableLettersLiteral, ApplicationManifest::Direction>>({
+    static constexpr SortedArrayMap directions { std::to_array<std::pair<ComparableLettersLiteral, ApplicationManifest::Direction>>({
         { "auto"_s, Auto },
         { "ltr"_s, LTR },
         { "rtl"_s, RTL },
-    });
-    static constexpr SortedArrayMap directions { directionMappings };
+    }) };
 
     if (auto* dirValue = directions.tryGet(StringView(stringValue).trim(isASCIIWhitespace<char16_t>)))
         return *dirValue;
@@ -214,13 +213,12 @@ ApplicationManifest::Display ApplicationManifestParser::parseDisplay(const JSON:
         return ApplicationManifest::Display::Browser;
     }
 
-    static constexpr auto displayValueMappings = std::to_array<std::pair<ComparableLettersLiteral, ApplicationManifest::Display>>({
+    static constexpr SortedArrayMap displayValues { std::to_array<std::pair<ComparableLettersLiteral, ApplicationManifest::Display>>({
         { "browser"_s, ApplicationManifest::Display::Browser },
         { "fullscreen"_s, ApplicationManifest::Display::Fullscreen },
         { "minimal-ui"_s, ApplicationManifest::Display::MinimalUI },
         { "standalone"_s, ApplicationManifest::Display::Standalone },
-    });
-    static constexpr SortedArrayMap displayValues { displayValueMappings };
+    }) };
 
     if (auto* displayValue = displayValues.tryGet(StringView(stringValue).trim(isASCIIWhitespace<char16_t>)))
         return *displayValue;
@@ -241,7 +239,7 @@ const std::optional<ScreenOrientationLockType> ApplicationManifestParser::parseO
         return std::nullopt;
     }
 
-    static constexpr auto orientationValueMappings = std::to_array<std::pair<ComparableLettersLiteral, WebCore::ScreenOrientationLockType>>({
+    static SortedArrayMap orientationValues { std::to_array<std::pair<ComparableLettersLiteral, WebCore::ScreenOrientationLockType>>({
         { "any"_s, WebCore::ScreenOrientationLockType::Any },
         { "landscape"_s, WebCore::ScreenOrientationLockType::Landscape },
         { "landscape-primary"_s, WebCore::ScreenOrientationLockType::LandscapePrimary },
@@ -250,9 +248,7 @@ const std::optional<ScreenOrientationLockType> ApplicationManifestParser::parseO
         { "portrait"_s, WebCore::ScreenOrientationLockType::Portrait },
         { "portrait-primary"_s, WebCore::ScreenOrientationLockType::PortraitPrimary },
         { "portrait-secondary"_s, WebCore::ScreenOrientationLockType::PortraitSecondary },
-    });
-
-    static SortedArrayMap orientationValues { orientationValueMappings };
+    }) };
 
     if (auto* orientationValue = orientationValues.tryGet(StringView(stringValue).trim(isASCIIWhitespace<char16_t>)))
         return *orientationValue;

--- a/Source/WebCore/Modules/mediacapabilities/MediaCapabilities.cpp
+++ b/Source/WebCore/Modules/mediacapabilities/MediaCapabilities.cpp
@@ -50,7 +50,7 @@ static bool isValidMediaMIMEType(const ContentType& contentType)
 {
     // A "bucket" MIME types is one whose container type does not uniquely specify a codec.
     // See: https://tools.ietf.org/html/rfc6381
-    static constexpr auto bucketMIMETypeArray = std::to_array<ComparableASCIILiteral>({
+    static constexpr SortedArraySet bucketMIMETypes { std::to_array<ComparableASCIILiteral>({
         "application/mp21"_s,
         "application/mp4"_s,
         "audio/3gpp"_s,
@@ -66,8 +66,7 @@ static bool isValidMediaMIMEType(const ContentType& contentType)
         "video/quicktime"_s,
         "video/vnd.apple.mpegurl"_s,
         "video/webm"_s,
-    });
-    static constexpr SortedArraySet bucketMIMETypes { bucketMIMETypeArray };
+    }) };
 
     // 2.1.4. MIME types
     // https://wicg.github.io/media-capabilities/#valid-media-mime-type

--- a/Source/WebCore/Modules/mediasession/MediaSession.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaSession.cpp
@@ -74,7 +74,7 @@ static ASCIILiteral logClassName()
 
 static PlatformMediaSession::RemoteControlCommandType platformCommandForMediaSessionAction(MediaSessionAction action)
 {
-    static constexpr auto mappings = std::to_array<std::pair<MediaSessionAction, PlatformMediaSession::RemoteControlCommandType>>({
+    static constexpr SortedArrayMap map { std::to_array<std::pair<MediaSessionAction, PlatformMediaSession::RemoteControlCommandType>>({
         { MediaSessionAction::Play, PlatformMediaSession::RemoteControlCommandType::PlayCommand },
         { MediaSessionAction::Pause, PlatformMediaSession::RemoteControlCommandType::PauseCommand },
         { MediaSessionAction::Seekbackward, PlatformMediaSession::RemoteControlCommandType::SkipBackwardCommand },
@@ -84,8 +84,7 @@ static PlatformMediaSession::RemoteControlCommandType platformCommandForMediaSes
         { MediaSessionAction::Skipad, PlatformMediaSession::RemoteControlCommandType::NextTrackCommand },
         { MediaSessionAction::Stop, PlatformMediaSession::RemoteControlCommandType::StopCommand },
         { MediaSessionAction::Seekto, PlatformMediaSession::RemoteControlCommandType::SeekToPlaybackPositionCommand },
-    });
-    static constexpr SortedArrayMap map { mappings };
+    }) };
     return map.get(action, PlatformMediaSession::RemoteControlCommandType::NoCommand);
 }
 

--- a/Source/WebCore/accessibility/atspi/AccessibilityAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityAtspi.cpp
@@ -612,7 +612,7 @@ struct RoleNameEntry {
     const char* localizedName;
 };
 
-static constexpr auto roleNames = std::to_array<std::pair<AccessibilityRole, RoleNameEntry>>({
+static constexpr SortedArrayMap roleNamesMap { std::to_array<std::pair<AccessibilityRole, RoleNameEntry>>({
     { AccessibilityRole::Application, { "application", N_("application") } },
     { AccessibilityRole::ApplicationAlert, { "notification", N_("notification") } },
     { AccessibilityRole::ApplicationAlertDialog, { "alert", N_("alert") } },
@@ -727,11 +727,10 @@ static constexpr auto roleNames = std::to_array<std::pair<AccessibilityRole, Rol
     { AccessibilityRole::UserInterfaceTooltip, { "tool tip", N_("tool tip") } },
     { AccessibilityRole::Video, { "video", N_("video") } },
     { AccessibilityRole::WebArea, { "document web", N_("document web") } },
-});
+}) };
 
 const char* AccessibilityAtspi::localizedRoleName(AccessibilityRole role)
 {
-    static constexpr SortedArrayMap roleNamesMap { roleNames };
     if (auto entry = roleNamesMap.tryGet(role))
         return entry->localizedName;
 
@@ -840,7 +839,7 @@ namespace Accessibility {
 PlatformRoleMap createPlatformRoleMap()
 {
     PlatformRoleMap roleMap;
-    for (const auto& entry : roleNames)
+    for (const auto& entry : roleNamesMap.array())
         roleMap.add(static_cast<unsigned>(entry.first), String::fromUTF8(entry.second.name));
     return roleMap;
 }

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -2626,13 +2626,12 @@ sub GenerateEnumerationImplementationContent
         my $enumerationValueName = GetEnumerationValueName(shift(@sortedEnumerationValues));
         $result .= "        return ${className}::$enumerationValueName;\n";
     }
-    $result .= "    static constexpr std::array<std::pair<ComparableASCIILiteral, $className>, " . scalar(@sortedEnumerationValues) . "> mappings {\n";
+    $result .= "    static constexpr SortedArrayMap enumerationMapping { std::to_array<std::pair<ComparableASCIILiteral, $className>>({\n";
     for my $value (@sortedEnumerationValues) {
         my $enumerationValueName = GetEnumerationValueName($value);
-        $result .= "        std::pair<ComparableASCIILiteral, $className> { \"$value\"_s, ${className}::$enumerationValueName },\n";
+        $result .= "        { \"$value\"_s, ${className}::$enumerationValueName },\n";
     }
-    $result .= "    };\n";
-    $result .= "    static constexpr SortedArrayMap enumerationMapping { mappings };\n";
+    $result .= "    }) };\n";
     $result .= "    if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); enumerationValue) [[likely]]\n";
     $result .= "        return *enumerationValue;\n";
     $result .= "    return std::nullopt;\n";

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp
@@ -73,11 +73,10 @@ template<> JSString* convertEnumerationToJS(VM& vm, TestCallbackInterface::Enum 
 
 template<> std::optional<TestCallbackInterface::Enum> parseEnumerationFromString<TestCallbackInterface::Enum>(const String& stringValue)
 {
-    static constexpr std::array<std::pair<ComparableASCIILiteral, TestCallbackInterface::Enum>, 2> mappings {
-        std::pair<ComparableASCIILiteral, TestCallbackInterface::Enum> { "value1"_s, TestCallbackInterface::Enum::Value1 },
-        std::pair<ComparableASCIILiteral, TestCallbackInterface::Enum> { "value2"_s, TestCallbackInterface::Enum::Value2 },
-    };
-    static constexpr SortedArrayMap enumerationMapping { mappings };
+    static constexpr SortedArrayMap enumerationMapping { std::to_array<std::pair<ComparableASCIILiteral, TestCallbackInterface::Enum>>({
+        { "value1"_s, TestCallbackInterface::Enum::Value1 },
+        { "value2"_s, TestCallbackInterface::Enum::Value2 },
+    }) };
     if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); enumerationValue) [[likely]]
         return *enumerationValue;
     return std::nullopt;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONEnum.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONEnum.cpp
@@ -50,11 +50,10 @@ template<> JSString* convertEnumerationToJS(VM& vm, TestDefaultToJSONEnum enumer
 
 template<> std::optional<TestDefaultToJSONEnum> parseEnumerationFromString<TestDefaultToJSONEnum>(const String& stringValue)
 {
-    static constexpr std::array<std::pair<ComparableASCIILiteral, TestDefaultToJSONEnum>, 2> mappings {
-        std::pair<ComparableASCIILiteral, TestDefaultToJSONEnum> { "EnumValue1"_s, TestDefaultToJSONEnum::EnumValue1 },
-        std::pair<ComparableASCIILiteral, TestDefaultToJSONEnum> { "EnumValue2"_s, TestDefaultToJSONEnum::EnumValue2 },
-    };
-    static constexpr SortedArrayMap enumerationMapping { mappings };
+    static constexpr SortedArrayMap enumerationMapping { std::to_array<std::pair<ComparableASCIILiteral, TestDefaultToJSONEnum>>({
+        { "EnumValue1"_s, TestDefaultToJSONEnum::EnumValue1 },
+        { "EnumValue2"_s, TestDefaultToJSONEnum::EnumValue2 },
+    }) };
     if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); enumerationValue) [[likely]]
         return *enumerationValue;
     return std::nullopt;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
@@ -156,12 +156,11 @@ template<> std::optional<TestObj::EnumType> parseEnumerationFromString<TestObj::
 {
     if (stringValue.isEmpty())
         return TestObj::EnumType::EmptyString;
-    static constexpr std::array<std::pair<ComparableASCIILiteral, TestObj::EnumType>, 3> mappings {
-        std::pair<ComparableASCIILiteral, TestObj::EnumType> { "EnumValue2"_s, TestObj::EnumType::EnumValue2 },
-        std::pair<ComparableASCIILiteral, TestObj::EnumType> { "EnumValue3"_s, TestObj::EnumType::EnumValue3 },
-        std::pair<ComparableASCIILiteral, TestObj::EnumType> { "enumValue1"_s, TestObj::EnumType::EnumValue1 },
-    };
-    static constexpr SortedArrayMap enumerationMapping { mappings };
+    static constexpr SortedArrayMap enumerationMapping { std::to_array<std::pair<ComparableASCIILiteral, TestObj::EnumType>>({
+        { "EnumValue2"_s, TestObj::EnumType::EnumValue2 },
+        { "EnumValue3"_s, TestObj::EnumType::EnumValue3 },
+        { "enumValue1"_s, TestObj::EnumType::EnumValue1 },
+    }) };
     if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); enumerationValue) [[likely]]
         return *enumerationValue;
     return std::nullopt;
@@ -196,11 +195,10 @@ template<> JSString* convertEnumerationToJS(VM& vm, TestObj::EnumTrailingComma e
 
 template<> std::optional<TestObj::EnumTrailingComma> parseEnumerationFromString<TestObj::EnumTrailingComma>(const String& stringValue)
 {
-    static constexpr std::array<std::pair<ComparableASCIILiteral, TestObj::EnumTrailingComma>, 2> mappings {
-        std::pair<ComparableASCIILiteral, TestObj::EnumTrailingComma> { "enumValue1"_s, TestObj::EnumTrailingComma::EnumValue1 },
-        std::pair<ComparableASCIILiteral, TestObj::EnumTrailingComma> { "enumValue2"_s, TestObj::EnumTrailingComma::EnumValue2 },
-    };
-    static constexpr SortedArrayMap enumerationMapping { mappings };
+    static constexpr SortedArrayMap enumerationMapping { std::to_array<std::pair<ComparableASCIILiteral, TestObj::EnumTrailingComma>>({
+        { "enumValue1"_s, TestObj::EnumTrailingComma::EnumValue1 },
+        { "enumValue2"_s, TestObj::EnumTrailingComma::EnumValue2 },
+    }) };
     if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); enumerationValue) [[likely]]
         return *enumerationValue;
     return std::nullopt;
@@ -241,12 +239,11 @@ template<> std::optional<TestObj::Optional> parseEnumerationFromString<TestObj::
 {
     if (stringValue.isEmpty())
         return TestObj::Optional::EmptyString;
-    static constexpr std::array<std::pair<ComparableASCIILiteral, TestObj::Optional>, 3> mappings {
-        std::pair<ComparableASCIILiteral, TestObj::Optional> { "OptionalValue1"_s, TestObj::Optional::OptionalValue1 },
-        std::pair<ComparableASCIILiteral, TestObj::Optional> { "OptionalValue2"_s, TestObj::Optional::OptionalValue2 },
-        std::pair<ComparableASCIILiteral, TestObj::Optional> { "OptionalValue3"_s, TestObj::Optional::OptionalValue3 },
-    };
-    static constexpr SortedArrayMap enumerationMapping { mappings };
+    static constexpr SortedArrayMap enumerationMapping { std::to_array<std::pair<ComparableASCIILiteral, TestObj::Optional>>({
+        { "OptionalValue1"_s, TestObj::Optional::OptionalValue1 },
+        { "OptionalValue2"_s, TestObj::Optional::OptionalValue2 },
+        { "OptionalValue3"_s, TestObj::Optional::OptionalValue3 },
+    }) };
     if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); enumerationValue) [[likely]]
         return *enumerationValue;
     return std::nullopt;
@@ -281,11 +278,10 @@ template<> JSString* convertEnumerationToJS(VM& vm, AlternateEnumName enumeratio
 
 template<> std::optional<AlternateEnumName> parseEnumerationFromString<AlternateEnumName>(const String& stringValue)
 {
-    static constexpr std::array<std::pair<ComparableASCIILiteral, AlternateEnumName>, 2> mappings {
-        std::pair<ComparableASCIILiteral, AlternateEnumName> { "EnumValue2"_s, AlternateEnumName::EnumValue2 },
-        std::pair<ComparableASCIILiteral, AlternateEnumName> { "enumValue1"_s, AlternateEnumName::EnumValue1 },
-    };
-    static constexpr SortedArrayMap enumerationMapping { mappings };
+    static constexpr SortedArrayMap enumerationMapping { std::to_array<std::pair<ComparableASCIILiteral, AlternateEnumName>>({
+        { "EnumValue2"_s, AlternateEnumName::EnumValue2 },
+        { "enumValue1"_s, AlternateEnumName::EnumValue1 },
+    }) };
     if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); enumerationValue) [[likely]]
         return *enumerationValue;
     return std::nullopt;
@@ -320,10 +316,9 @@ template<> JSString* convertEnumerationToJS(VM& vm, TestObj::EnumA enumerationVa
 
 template<> std::optional<TestObj::EnumA> parseEnumerationFromString<TestObj::EnumA>(const String& stringValue)
 {
-    static constexpr std::array<std::pair<ComparableASCIILiteral, TestObj::EnumA>, 1> mappings {
-        std::pair<ComparableASCIILiteral, TestObj::EnumA> { "A"_s, TestObj::EnumA::A },
-    };
-    static constexpr SortedArrayMap enumerationMapping { mappings };
+    static constexpr SortedArrayMap enumerationMapping { std::to_array<std::pair<ComparableASCIILiteral, TestObj::EnumA>>({
+        { "A"_s, TestObj::EnumA::A },
+    }) };
     if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); enumerationValue) [[likely]]
         return *enumerationValue;
     return std::nullopt;
@@ -360,10 +355,9 @@ template<> JSString* convertEnumerationToJS(VM& vm, TestObj::EnumB enumerationVa
 
 template<> std::optional<TestObj::EnumB> parseEnumerationFromString<TestObj::EnumB>(const String& stringValue)
 {
-    static constexpr std::array<std::pair<ComparableASCIILiteral, TestObj::EnumB>, 1> mappings {
-        std::pair<ComparableASCIILiteral, TestObj::EnumB> { "B"_s, TestObj::EnumB::B },
-    };
-    static constexpr SortedArrayMap enumerationMapping { mappings };
+    static constexpr SortedArrayMap enumerationMapping { std::to_array<std::pair<ComparableASCIILiteral, TestObj::EnumB>>({
+        { "B"_s, TestObj::EnumB::B },
+    }) };
     if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); enumerationValue) [[likely]]
         return *enumerationValue;
     return std::nullopt;
@@ -400,10 +394,9 @@ template<> JSString* convertEnumerationToJS(VM& vm, TestObj::EnumC enumerationVa
 
 template<> std::optional<TestObj::EnumC> parseEnumerationFromString<TestObj::EnumC>(const String& stringValue)
 {
-    static constexpr std::array<std::pair<ComparableASCIILiteral, TestObj::EnumC>, 1> mappings {
-        std::pair<ComparableASCIILiteral, TestObj::EnumC> { "C"_s, TestObj::EnumC::C },
-    };
-    static constexpr SortedArrayMap enumerationMapping { mappings };
+    static constexpr SortedArrayMap enumerationMapping { std::to_array<std::pair<ComparableASCIILiteral, TestObj::EnumC>>({
+        { "C"_s, TestObj::EnumC::C },
+    }) };
     if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); enumerationValue) [[likely]]
         return *enumerationValue;
     return std::nullopt;
@@ -440,11 +433,10 @@ template<> JSString* convertEnumerationToJS(VM& vm, TestObj::Kind enumerationVal
 
 template<> std::optional<TestObj::Kind> parseEnumerationFromString<TestObj::Kind>(const String& stringValue)
 {
-    static constexpr std::array<std::pair<ComparableASCIILiteral, TestObj::Kind>, 2> mappings {
-        std::pair<ComparableASCIILiteral, TestObj::Kind> { "dead"_s, TestObj::Kind::Dead },
-        std::pair<ComparableASCIILiteral, TestObj::Kind> { "quick"_s, TestObj::Kind::Quick },
-    };
-    static constexpr SortedArrayMap enumerationMapping { mappings };
+    static constexpr SortedArrayMap enumerationMapping { std::to_array<std::pair<ComparableASCIILiteral, TestObj::Kind>>({
+        { "dead"_s, TestObj::Kind::Dead },
+        { "quick"_s, TestObj::Kind::Quick },
+    }) };
     if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); enumerationValue) [[likely]]
         return *enumerationValue;
     return std::nullopt;
@@ -479,11 +471,10 @@ template<> JSString* convertEnumerationToJS(VM& vm, TestObj::Size enumerationVal
 
 template<> std::optional<TestObj::Size> parseEnumerationFromString<TestObj::Size>(const String& stringValue)
 {
-    static constexpr std::array<std::pair<ComparableASCIILiteral, TestObj::Size>, 2> mappings {
-        std::pair<ComparableASCIILiteral, TestObj::Size> { "much-much-larger"_s, TestObj::Size::MuchMuchLarger },
-        std::pair<ComparableASCIILiteral, TestObj::Size> { "small"_s, TestObj::Size::Small },
-    };
-    static constexpr SortedArrayMap enumerationMapping { mappings };
+    static constexpr SortedArrayMap enumerationMapping { std::to_array<std::pair<ComparableASCIILiteral, TestObj::Size>>({
+        { "much-much-larger"_s, TestObj::Size::MuchMuchLarger },
+        { "small"_s, TestObj::Size::Small },
+    }) };
     if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); enumerationValue) [[likely]]
         return *enumerationValue;
     return std::nullopt;
@@ -518,11 +509,10 @@ template<> JSString* convertEnumerationToJS(VM& vm, TestObj::Confidence enumerat
 
 template<> std::optional<TestObj::Confidence> parseEnumerationFromString<TestObj::Confidence>(const String& stringValue)
 {
-    static constexpr std::array<std::pair<ComparableASCIILiteral, TestObj::Confidence>, 2> mappings {
-        std::pair<ComparableASCIILiteral, TestObj::Confidence> { "high"_s, TestObj::Confidence::High },
-        std::pair<ComparableASCIILiteral, TestObj::Confidence> { "kinda-low"_s, TestObj::Confidence::KindaLow },
-    };
-    static constexpr SortedArrayMap enumerationMapping { mappings };
+    static constexpr SortedArrayMap enumerationMapping { std::to_array<std::pair<ComparableASCIILiteral, TestObj::Confidence>>({
+        { "high"_s, TestObj::Confidence::High },
+        { "kinda-low"_s, TestObj::Confidence::KindaLow },
+    }) };
     if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); enumerationValue) [[likely]]
         return *enumerationValue;
     return std::nullopt;
@@ -563,12 +553,11 @@ template<> std::optional<TestObj::EnumWithMissingValueDefault> parseEnumerationF
 {
     if (stringValue.isEmpty())
         return TestObj::EnumWithMissingValueDefault::EmptyString;
-    static constexpr std::array<std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingValueDefault>, 3> mappings {
-        std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingValueDefault> { "value1"_s, TestObj::EnumWithMissingValueDefault::Value1 },
-        std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingValueDefault> { "value2"_s, TestObj::EnumWithMissingValueDefault::Value2 },
-        std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingValueDefault> { "value3"_s, TestObj::EnumWithMissingValueDefault::Value3 },
-    };
-    static constexpr SortedArrayMap enumerationMapping { mappings };
+    static constexpr SortedArrayMap enumerationMapping { std::to_array<std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingValueDefault>>({
+        { "value1"_s, TestObj::EnumWithMissingValueDefault::Value1 },
+        { "value2"_s, TestObj::EnumWithMissingValueDefault::Value2 },
+        { "value3"_s, TestObj::EnumWithMissingValueDefault::Value3 },
+    }) };
     if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); enumerationValue) [[likely]]
         return *enumerationValue;
     return std::nullopt;
@@ -609,12 +598,11 @@ template<> std::optional<TestObj::EnumWithInvalidValueDefault> parseEnumerationF
 {
     if (stringValue.isEmpty())
         return TestObj::EnumWithInvalidValueDefault::EmptyString;
-    static constexpr std::array<std::pair<ComparableASCIILiteral, TestObj::EnumWithInvalidValueDefault>, 3> mappings {
-        std::pair<ComparableASCIILiteral, TestObj::EnumWithInvalidValueDefault> { "value1"_s, TestObj::EnumWithInvalidValueDefault::Value1 },
-        std::pair<ComparableASCIILiteral, TestObj::EnumWithInvalidValueDefault> { "value2"_s, TestObj::EnumWithInvalidValueDefault::Value2 },
-        std::pair<ComparableASCIILiteral, TestObj::EnumWithInvalidValueDefault> { "value3"_s, TestObj::EnumWithInvalidValueDefault::Value3 },
-    };
-    static constexpr SortedArrayMap enumerationMapping { mappings };
+    static constexpr SortedArrayMap enumerationMapping { std::to_array<std::pair<ComparableASCIILiteral, TestObj::EnumWithInvalidValueDefault>>({
+        { "value1"_s, TestObj::EnumWithInvalidValueDefault::Value1 },
+        { "value2"_s, TestObj::EnumWithInvalidValueDefault::Value2 },
+        { "value3"_s, TestObj::EnumWithInvalidValueDefault::Value3 },
+    }) };
     if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); enumerationValue) [[likely]]
         return *enumerationValue;
     return std::nullopt;
@@ -655,12 +643,11 @@ template<> std::optional<TestObj::EnumWithMissingAndInvalidValueDefault> parseEn
 {
     if (stringValue.isEmpty())
         return TestObj::EnumWithMissingAndInvalidValueDefault::EmptyString;
-    static constexpr std::array<std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingAndInvalidValueDefault>, 3> mappings {
-        std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingAndInvalidValueDefault> { "value1"_s, TestObj::EnumWithMissingAndInvalidValueDefault::Value1 },
-        std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingAndInvalidValueDefault> { "value2"_s, TestObj::EnumWithMissingAndInvalidValueDefault::Value2 },
-        std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingAndInvalidValueDefault> { "value3"_s, TestObj::EnumWithMissingAndInvalidValueDefault::Value3 },
-    };
-    static constexpr SortedArrayMap enumerationMapping { mappings };
+    static constexpr SortedArrayMap enumerationMapping { std::to_array<std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingAndInvalidValueDefault>>({
+        { "value1"_s, TestObj::EnumWithMissingAndInvalidValueDefault::Value1 },
+        { "value2"_s, TestObj::EnumWithMissingAndInvalidValueDefault::Value2 },
+        { "value3"_s, TestObj::EnumWithMissingAndInvalidValueDefault::Value3 },
+    }) };
     if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); enumerationValue) [[likely]]
         return *enumerationValue;
     return std::nullopt;
@@ -701,12 +688,11 @@ template<> std::optional<TestObj::EnumWithMissingValueDefaultNoQuotes> parseEnum
 {
     if (stringValue.isEmpty())
         return TestObj::EnumWithMissingValueDefaultNoQuotes::EmptyString;
-    static constexpr std::array<std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingValueDefaultNoQuotes>, 3> mappings {
-        std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingValueDefaultNoQuotes> { "value1"_s, TestObj::EnumWithMissingValueDefaultNoQuotes::Value1 },
-        std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingValueDefaultNoQuotes> { "value2"_s, TestObj::EnumWithMissingValueDefaultNoQuotes::Value2 },
-        std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingValueDefaultNoQuotes> { "value3"_s, TestObj::EnumWithMissingValueDefaultNoQuotes::Value3 },
-    };
-    static constexpr SortedArrayMap enumerationMapping { mappings };
+    static constexpr SortedArrayMap enumerationMapping { std::to_array<std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingValueDefaultNoQuotes>>({
+        { "value1"_s, TestObj::EnumWithMissingValueDefaultNoQuotes::Value1 },
+        { "value2"_s, TestObj::EnumWithMissingValueDefaultNoQuotes::Value2 },
+        { "value3"_s, TestObj::EnumWithMissingValueDefaultNoQuotes::Value3 },
+    }) };
     if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); enumerationValue) [[likely]]
         return *enumerationValue;
     return std::nullopt;
@@ -747,12 +733,11 @@ template<> std::optional<TestObj::EnumWithMissingValueDefaultAsEmptyValue> parse
 {
     if (stringValue.isEmpty())
         return TestObj::EnumWithMissingValueDefaultAsEmptyValue::EmptyString;
-    static constexpr std::array<std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingValueDefaultAsEmptyValue>, 3> mappings {
-        std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingValueDefaultAsEmptyValue> { "value1"_s, TestObj::EnumWithMissingValueDefaultAsEmptyValue::Value1 },
-        std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingValueDefaultAsEmptyValue> { "value2"_s, TestObj::EnumWithMissingValueDefaultAsEmptyValue::Value2 },
-        std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingValueDefaultAsEmptyValue> { "value3"_s, TestObj::EnumWithMissingValueDefaultAsEmptyValue::Value3 },
-    };
-    static constexpr SortedArrayMap enumerationMapping { mappings };
+    static constexpr SortedArrayMap enumerationMapping { std::to_array<std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingValueDefaultAsEmptyValue>>({
+        { "value1"_s, TestObj::EnumWithMissingValueDefaultAsEmptyValue::Value1 },
+        { "value2"_s, TestObj::EnumWithMissingValueDefaultAsEmptyValue::Value2 },
+        { "value3"_s, TestObj::EnumWithMissingValueDefaultAsEmptyValue::Value3 },
+    }) };
     if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); enumerationValue) [[likely]]
         return *enumerationValue;
     return std::nullopt;
@@ -793,12 +778,11 @@ template<> std::optional<TestObj::EnumWithMissingValueDefaultNotInEnumValues> pa
 {
     if (stringValue.isEmpty())
         return TestObj::EnumWithMissingValueDefaultNotInEnumValues::EmptyString;
-    static constexpr std::array<std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingValueDefaultNotInEnumValues>, 3> mappings {
-        std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingValueDefaultNotInEnumValues> { "value1"_s, TestObj::EnumWithMissingValueDefaultNotInEnumValues::Value1 },
-        std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingValueDefaultNotInEnumValues> { "value2"_s, TestObj::EnumWithMissingValueDefaultNotInEnumValues::Value2 },
-        std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingValueDefaultNotInEnumValues> { "value3"_s, TestObj::EnumWithMissingValueDefaultNotInEnumValues::Value3 },
-    };
-    static constexpr SortedArrayMap enumerationMapping { mappings };
+    static constexpr SortedArrayMap enumerationMapping { std::to_array<std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingValueDefaultNotInEnumValues>>({
+        { "value1"_s, TestObj::EnumWithMissingValueDefaultNotInEnumValues::Value1 },
+        { "value2"_s, TestObj::EnumWithMissingValueDefaultNotInEnumValues::Value2 },
+        { "value3"_s, TestObj::EnumWithMissingValueDefaultNotInEnumValues::Value3 },
+    }) };
     if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); enumerationValue) [[likely]]
         return *enumerationValue;
     return std::nullopt;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneDictionary.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneDictionary.cpp
@@ -392,11 +392,10 @@ template<> JSString* convertEnumerationToJS(VM& vm, TestStandaloneDictionary::En
 
 template<> std::optional<TestStandaloneDictionary::EnumInStandaloneDictionaryFile> parseEnumerationFromString<TestStandaloneDictionary::EnumInStandaloneDictionaryFile>(const String& stringValue)
 {
-    static constexpr std::array<std::pair<ComparableASCIILiteral, TestStandaloneDictionary::EnumInStandaloneDictionaryFile>, 2> mappings {
-        std::pair<ComparableASCIILiteral, TestStandaloneDictionary::EnumInStandaloneDictionaryFile> { "enumValue1"_s, TestStandaloneDictionary::EnumInStandaloneDictionaryFile::EnumValue1 },
-        std::pair<ComparableASCIILiteral, TestStandaloneDictionary::EnumInStandaloneDictionaryFile> { "enumValue2"_s, TestStandaloneDictionary::EnumInStandaloneDictionaryFile::EnumValue2 },
-    };
-    static constexpr SortedArrayMap enumerationMapping { mappings };
+    static constexpr SortedArrayMap enumerationMapping { std::to_array<std::pair<ComparableASCIILiteral, TestStandaloneDictionary::EnumInStandaloneDictionaryFile>>({
+        { "enumValue1"_s, TestStandaloneDictionary::EnumInStandaloneDictionaryFile::EnumValue1 },
+        { "enumValue2"_s, TestStandaloneDictionary::EnumInStandaloneDictionaryFile::EnumValue2 },
+    }) };
     if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); enumerationValue) [[likely]]
         return *enumerationValue;
     return std::nullopt;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneEnumeration.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneEnumeration.cpp
@@ -55,12 +55,11 @@ template<> JSString* convertEnumerationToJS(VM& vm, TestStandaloneEnumeration en
 
 template<> std::optional<TestStandaloneEnumeration> parseEnumerationFromString<TestStandaloneEnumeration>(const String& stringValue)
 {
-    static constexpr std::array<std::pair<ComparableASCIILiteral, TestStandaloneEnumeration>, 3> mappings {
-        std::pair<ComparableASCIILiteral, TestStandaloneEnumeration> { "enum-value3"_s, TestStandaloneEnumeration::EnumValue3 },
-        std::pair<ComparableASCIILiteral, TestStandaloneEnumeration> { "enumValue1"_s, TestStandaloneEnumeration::EnumValue1 },
-        std::pair<ComparableASCIILiteral, TestStandaloneEnumeration> { "enumValue2"_s, TestStandaloneEnumeration::EnumValue2 },
-    };
-    static constexpr SortedArrayMap enumerationMapping { mappings };
+    static constexpr SortedArrayMap enumerationMapping { std::to_array<std::pair<ComparableASCIILiteral, TestStandaloneEnumeration>>({
+        { "enum-value3"_s, TestStandaloneEnumeration::EnumValue3 },
+        { "enumValue1"_s, TestStandaloneEnumeration::EnumValue1 },
+        { "enumValue2"_s, TestStandaloneEnumeration::EnumValue2 },
+    }) };
     if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); enumerationValue) [[likely]]
         return *enumerationValue;
     return std::nullopt;

--- a/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
@@ -57,14 +57,13 @@ static constexpr int maxExpressionDepth = 100;
 
 static std::optional<std::pair<Number, Type>> lookupConstantNumber(CSSValueID symbol)
 {
-    static constexpr auto constantMappings = std::to_array<std::pair<CSSValueID, double>>({
+    static constexpr SortedArrayMap constantMap { std::to_array<std::pair<CSSValueID, double>>({
         { CSSValueE,                     std::numbers::e                          },
         { CSSValuePi,                    std::numbers::pi                         },
         { CSSValueInfinity,              std::numeric_limits<double>::infinity()  },
         { CSSValueNegativeInfinity, -1 * std::numeric_limits<double>::infinity()  },
         { CSSValueNaN,                   std::numeric_limits<double>::quiet_NaN() },
-    });
-    static constexpr SortedArrayMap constantMap { constantMappings };
+    }) };
     if (auto value = constantMap.tryGet(symbol))
         return std::make_pair(Number { .value = *value }, Type { });
     return std::nullopt;

--- a/Source/WebCore/css/parser/CSSAtRuleID.cpp
+++ b/Source/WebCore/css/parser/CSSAtRuleID.cpp
@@ -36,7 +36,7 @@ namespace WebCore {
 
 CSSAtRuleID cssAtRuleID(StringView name)
 {
-    static constexpr auto mappings = std::to_array<std::pair<ComparableLettersLiteral, CSSAtRuleID>>({
+    static constexpr SortedArrayMap cssAtRules { std::to_array<std::pair<ComparableLettersLiteral, CSSAtRuleID>>({
         { "-internal-base-appearance"_s, CSSAtRuleInternalBaseAppearance },
         { "-webkit-keyframes"_s,     CSSAtRuleWebkitKeyframes },
         { "annotation"_s,            CSSAtRuleAnnotation },
@@ -64,8 +64,7 @@ CSSAtRuleID cssAtRuleID(StringView name)
         { "supports"_s,              CSSAtRuleSupports },
         { "swash"_s,                 CSSAtRuleSwash },
         { "view-transition"_s,       CSSAtRuleViewTransition },
-    });
-    static constexpr SortedArrayMap cssAtRules { mappings };
+    }) };
     return cssAtRules.get(name, CSSAtRuleInvalid);
 }
 

--- a/Source/WebCore/css/parser/CSSCustomPropertySyntax.cpp
+++ b/Source/WebCore/css/parser/CSSCustomPropertySyntax.cpp
@@ -182,7 +182,7 @@ bool CSSCustomPropertySyntax::containsUnknownType() const
 
 auto CSSCustomPropertySyntax::typeForTypeName(StringView dataTypeName) -> Type
 {
-    static constexpr auto mappings = std::to_array<std::pair<ComparableASCIILiteral, Type>>({
+    static constexpr SortedArrayMap typeMap { std::to_array<std::pair<ComparableASCIILiteral, Type>>({
         { "angle"_s, Type::Angle },
         { "color"_s, Type::Color },
         { "custom-ident"_s, Type::CustomIdent },
@@ -198,9 +198,7 @@ auto CSSCustomPropertySyntax::typeForTypeName(StringView dataTypeName) -> Type
         { "transform-function"_s, Type::TransformFunction },
         { "transform-list"_s, Type::TransformList },
         { "url"_s, Type::URL },
-    });
-
-    static constexpr SortedArrayMap typeMap { mappings };
+    }) };
     return typeMap.get(dataTypeName, Type::Unknown);
 }
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+ColorInterpolationMethod.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+ColorInterpolationMethod.cpp
@@ -38,13 +38,12 @@ namespace CSSPropertyParserHelpers {
 
 static std::optional<HueInterpolationMethod> consumeHueInterpolationMethod(CSSParserTokenRange& range)
 {
-    static constexpr auto hueInterpolationMethodMappings = std::to_array<std::pair<CSSValueID, HueInterpolationMethod>>({
+    static constexpr SortedArrayMap hueInterpolationMethodMap { std::to_array<std::pair<CSSValueID, HueInterpolationMethod>>({
         { CSSValueShorter, HueInterpolationMethod::Shorter },
         { CSSValueLonger, HueInterpolationMethod::Longer },
         { CSSValueIncreasing, HueInterpolationMethod::Increasing },
         { CSSValueDecreasing, HueInterpolationMethod::Decreasing },
-    });
-    static constexpr SortedArrayMap hueInterpolationMethodMap { hueInterpolationMethodMappings };
+    }) };
 
     return consumeIdentUsingMapping(range, hueInterpolationMethodMap);
 }

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp
@@ -387,17 +387,15 @@ template<CSSValueID Name> static RefPtr<CSSValue> consumePrefixedLinearGradient(
     //
     // see https://www.w3.org/TR/2011/WD-css3-images-20110217/#linear-gradients.
 
-    static constexpr auto verticalMappings = std::to_array<std::pair<CSSValueID, CSS::Vertical>>({
+    static constexpr SortedArrayMap verticalMap { std::to_array<std::pair<CSSValueID, CSS::Vertical>>({
         { CSSValueTop, CSS::Vertical { CSS::Keyword::Top { } } },
         { CSSValueBottom, CSS::Vertical { CSS::Keyword::Bottom { } } },
-    });
-    static constexpr SortedArrayMap verticalMap { verticalMappings };
+    }) };
 
-    static constexpr auto horizontalMappings = std::to_array<std::pair<CSSValueID, CSS::Horizontal>>({
+    static constexpr SortedArrayMap horizontalMap { std::to_array<std::pair<CSSValueID, CSS::Horizontal>>({
         { CSSValueLeft, CSS::Horizontal { CSS::Keyword::Left { } } },
         { CSSValueRight, CSS::Horizontal { CSS::Keyword::Right { } } },
-    });
-    static constexpr SortedArrayMap horizontalMap { horizontalMappings };
+    }) };
 
     auto consumeKeywordGradientLineKnownHorizontal = [&](CSSParserTokenRange& range, CSS::Horizontal knownHorizontal) -> CSS::PrefixedLinearGradient::GradientLine {
         if (auto vertical = consumeIdentUsingMapping(range, verticalMap))
@@ -477,21 +475,19 @@ template<CSSValueID Name> static RefPtr<CSSValue> consumePrefixedRadialGradient(
     //
     // see https://www.w3.org/TR/2011/WD-css3-images-20110217/#radial-gradients.
 
-    static constexpr auto shapeMappings = std::to_array<std::pair<CSSValueID, ShapeKeyword>>({
+    static constexpr SortedArrayMap shapeMap { std::to_array<std::pair<CSSValueID, ShapeKeyword>>({
         { CSSValueCircle, ShapeKeyword::Circle },
         { CSSValueEllipse, ShapeKeyword::Ellipse },
-    });
-    static constexpr SortedArrayMap shapeMap { shapeMappings };
+    }) };
 
-    static constexpr auto extentMappings = std::to_array<std::pair<CSSValueID, CSS::PrefixedRadialGradient::Extent>>({
+    static constexpr SortedArrayMap extentMap { std::to_array<std::pair<CSSValueID, CSS::PrefixedRadialGradient::Extent>>({
         { CSSValueContain, CSS::PrefixedRadialGradient::Extent { CSS::Keyword::Contain { } } },
         { CSSValueCover, CSS::PrefixedRadialGradient::Extent { CSS::Keyword::Cover { } } },
         { CSSValueClosestSide, CSS::PrefixedRadialGradient::Extent { CSS::Keyword::ClosestSide { } } },
         { CSSValueClosestCorner, CSS::PrefixedRadialGradient::Extent { CSS::Keyword::ClosestCorner { } } },
         { CSSValueFarthestSide, CSS::PrefixedRadialGradient::Extent { CSS::Keyword::FarthestSide { } } },
         { CSSValueFarthestCorner, CSS::PrefixedRadialGradient::Extent { CSS::Keyword::FarthestCorner { } } },
-    });
-    static constexpr SortedArrayMap extentMap { extentMappings };
+    }) };
 
     auto position = consumeOneOrTwoComponentPositionUnresolved(range, state);
     if (position) {
@@ -603,17 +599,15 @@ template<CSSValueID Name> static RefPtr<CSSValue> consumeLinearGradient(CSSParse
     //   <color-stop-list>
     // )
 
-    static constexpr auto verticalMappings = std::to_array<std::pair<CSSValueID, CSS::Vertical>>({
+    static constexpr SortedArrayMap verticalMap { std::to_array<std::pair<CSSValueID, CSS::Vertical>>({
         { CSSValueTop, CSS::Vertical { CSS::Keyword::Top { } } },
         { CSSValueBottom, CSS::Vertical { CSS::Keyword::Bottom { } } },
-    });
-    static constexpr SortedArrayMap verticalMap { verticalMappings };
+    }) };
 
-    static constexpr auto horizontalMappings = std::to_array<std::pair<CSSValueID, CSS::Horizontal>>({
+    static constexpr SortedArrayMap horizontalMap { std::to_array<std::pair<CSSValueID, CSS::Horizontal>>({
         { CSSValueLeft, CSS::Horizontal { CSS::Keyword::Left { } } },
         { CSSValueRight, CSS::Horizontal { CSS::Keyword::Right { } } },
-    });
-    static constexpr SortedArrayMap horizontalMap { horizontalMappings };
+    }) };
 
     auto consumeKeywordGradientLineKnownHorizontal = [&](CSSParserTokenRange& range, CSS::Horizontal knownHorizontal) -> CSS::LinearGradient::GradientLine {
         if (auto vertical = consumeIdentUsingMapping(range, verticalMap))
@@ -709,19 +703,17 @@ template<CSSValueID Name> static RefPtr<CSSValue> consumeRadialGradient(CSSParse
     //   <color-stop-list>
     // )
 
-    static constexpr auto shapeMappings = std::to_array<std::pair<CSSValueID, ShapeKeyword>>({
+    static constexpr SortedArrayMap shapeMap { std::to_array<std::pair<CSSValueID, ShapeKeyword>>({
         { CSSValueCircle, ShapeKeyword::Circle },
         { CSSValueEllipse, ShapeKeyword::Ellipse },
-    });
-    static constexpr SortedArrayMap shapeMap { shapeMappings };
+    }) };
 
-    static constexpr auto extentMappings = std::to_array<std::pair<CSSValueID, CSS::RadialGradient::Extent>>({
+    static constexpr SortedArrayMap extentMap { std::to_array<std::pair<CSSValueID, CSS::RadialGradient::Extent>>({
         { CSSValueClosestSide, CSS::RadialGradient::Extent { CSS::Keyword::ClosestSide { } } },
         { CSSValueClosestCorner, CSS::RadialGradient::Extent { CSS::Keyword::ClosestCorner { } } },
         { CSSValueFarthestSide, CSS::RadialGradient::Extent { CSS::Keyword::FarthestSide { } } },
         { CSSValueFarthestCorner, CSS::RadialGradient::Extent { CSS::Keyword::FarthestCorner { } } },
-    });
-    static constexpr SortedArrayMap extentMap { extentMappings };
+    }) };
 
     static constexpr auto defaultExtent = CSS::RadialGradient::Extent { CSS::Keyword::FarthestCorner { } };
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Motion.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Motion.cpp
@@ -54,14 +54,13 @@ static RefPtr<CSSValue> consumeRayFunction(CSSParserTokenRange& range, CSS::Prop
     // <ray-size> = closest-side | closest-corner | farthest-side | farthest-corner | sides
     // https://drafts.fxtf.org/motion-1/#ray-function
 
-    static constexpr auto sizeMappings = std::to_array<std::pair<CSSValueID, CSS::RaySize>>({
+    static constexpr SortedArrayMap sizeMap { std::to_array<std::pair<CSSValueID, CSS::RaySize>>({
         { CSSValueClosestSide, CSS::RaySize { CSS::Keyword::ClosestSide { } } },
         { CSSValueClosestCorner, CSS::RaySize { CSS::Keyword::ClosestCorner { } } },
         { CSSValueFarthestSide, CSS::RaySize { CSS::Keyword::FarthestSide { } } },
         { CSSValueFarthestCorner, CSS::RaySize { CSS::Keyword::FarthestCorner { } } },
         { CSSValueSides, CSS::RaySize { CSS::Keyword::Sides { } } },
-    });
-    static constexpr SortedArrayMap sizeMap { sizeMappings };
+    }) };
 
     if (range.peek().type() != FunctionToken || range.peek().functionId() != CSSValueRay)
         return { };

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Shapes.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Shapes.cpp
@@ -67,11 +67,10 @@ static std::optional<CSS::FillRule> peekFillRule(CSSParserTokenRange& range)
     // <'fill-rule'> = nonzero | evenodd
     // https://svgwg.org/svg2-draft/painting.html#FillRuleProperty
 
-    static constexpr auto fillRuleMappings = std::to_array<std::pair<CSSValueID, CSS::FillRule>>({
+    static constexpr SortedArrayMap fillRuleMap { std::to_array<std::pair<CSSValueID, CSS::FillRule>>({
         { CSSValueNonzero, CSS::FillRule { CSS::Keyword::Nonzero { } } },
         { CSSValueEvenodd, CSS::FillRule { CSS::Keyword::Evenodd { } } },
-    });
-    static constexpr SortedArrayMap fillRuleMap { fillRuleMappings };
+    }) };
 
     return peekIdentUsingMapping(range, fillRuleMap);
 }
@@ -114,12 +113,11 @@ static std::optional<CSS::RelativeControlPoint> consumeRelativeControlPoint(CSSP
 
     using Anchor = CSS::RelativeControlPoint::Anchor;
 
-    static constexpr auto anchorMappings = std::to_array<std::pair<CSSValueID, Anchor>>({
+    static constexpr SortedArrayMap anchorMap { std::to_array<std::pair<CSSValueID, Anchor>>({
         { CSSValueStart, Anchor { CSS::Keyword::Start { } } },
         { CSSValueEnd, Anchor { CSS::Keyword::End { } } },
         { CSSValueOrigin, Anchor { CSS::Keyword::Origin { } } },
-    });
-    static constexpr SortedArrayMap anchorMap { anchorMappings };
+    }) };
 
     auto rangeCopy = range;
 
@@ -183,13 +181,12 @@ static CSS::Circle::RadialSize consumeCircleRadialSize(CSSParserTokenRange& rang
     // <radial-extent>  = closest-corner | closest-side | farthest-corner | farthest-side
     // Default to `closest-side` if no radial-size is provided.
 
-    static constexpr auto extentMappings = std::to_array<std::pair<CSSValueID, CSS::Circle::Extent>>({
+    static constexpr SortedArrayMap extentMap { std::to_array<std::pair<CSSValueID, CSS::Circle::Extent>>({
         { CSSValueClosestSide, CSS::Circle::Extent { CSS::Keyword::ClosestSide { } } },
         { CSSValueClosestCorner, CSS::Circle::Extent { CSS::Keyword::ClosestCorner { } } },
         { CSSValueFarthestSide, CSS::Circle::Extent { CSS::Keyword::FarthestSide { } } },
         { CSSValueFarthestCorner, CSS::Circle::Extent { CSS::Keyword::FarthestCorner { } } },
-    });
-    static constexpr SortedArrayMap extentMap { extentMappings };
+    }) };
 
     // Default to `closest-side` if no radial-size is provided.
     // FIXME: The spec says that `farthest-corner` should be the default, but this does not match the tests.
@@ -242,13 +239,12 @@ static std::optional<CSS::Ellipse::RadialSize> consumeEllipseRadialSize(CSSParse
     // <radial-extent>  = closest-corner | closest-side | farthest-corner | farthest-side
     // Default to `closest-side` if no radial-size is provided.
 
-    static constexpr auto extentMappings = std::to_array<std::pair<CSSValueID, CSS::Ellipse::Extent>>({
+    static constexpr SortedArrayMap extentMap { std::to_array<std::pair<CSSValueID, CSS::Ellipse::Extent>>({
         { CSSValueClosestSide, CSS::Ellipse::Extent { CSS::Keyword::ClosestSide { } } },
         { CSSValueClosestCorner, CSS::Ellipse::Extent { CSS::Keyword::ClosestCorner { } } },
         { CSSValueFarthestSide, CSS::Ellipse::Extent { CSS::Keyword::FarthestSide { } } },
         { CSSValueFarthestCorner, CSS::Ellipse::Extent { CSS::Keyword::FarthestCorner { } } },
-    });
-    static constexpr SortedArrayMap extentMap { extentMappings };
+    }) };
 
     if (range.peek().type() == IdentToken) {
         if (auto extent = consumeIdentUsingMapping(range, extentMap))
@@ -373,11 +369,10 @@ static std::optional<CSS::CommandAffinity> consumeShapeCommandAffinity(CSSParser
     // <by-to> = by | to
     // https://drafts.csswg.org/css-shapes-2/#typedef-shape-by-to
 
-    static constexpr auto affinityMappings = std::to_array<std::pair<CSSValueID, CSS::CommandAffinity>>({
+    static constexpr SortedArrayMap affinityMap { std::to_array<std::pair<CSSValueID, CSS::CommandAffinity>>({
         { CSSValueTo, CSS::CommandAffinity { CSS::Keyword::To { } } },
         { CSSValueBy, CSS::CommandAffinity { CSS::Keyword::By { } } },
-    });
-    static constexpr SortedArrayMap affinityMap { affinityMappings };
+    }) };
 
     return consumeIdentUsingMapping(range, affinityMap);
 }

--- a/Source/WebCore/html/Autofill.cpp
+++ b/Source/WebCore/html/Autofill.cpp
@@ -44,7 +44,7 @@ struct AutofillFieldNameMapping {
     AutofillCategory category;
 };
 
-static constexpr auto fieldNameMappings = std::to_array<std::pair<ComparableLettersLiteral, AutofillFieldNameMapping>>({
+static constexpr SortedArrayMap fieldNameMap { std::to_array<std::pair<ComparableLettersLiteral, AutofillFieldNameMapping>>({
     { "additional-name"_s, { AutofillFieldName::AdditionalName, AutofillCategory::Normal } },
     { "address-level1"_s, { AutofillFieldName::AddressLevel1, AutofillCategory::Normal } },
     { "address-level2"_s, { AutofillFieldName::AddressLevel2, AutofillCategory::Normal } },
@@ -104,8 +104,7 @@ static constexpr auto fieldNameMappings = std::to_array<std::pair<ComparableLett
     { "url"_s, { AutofillFieldName::URL, AutofillCategory::Normal } },
     { "username"_s, { AutofillFieldName::Username, AutofillCategory::Normal } },
     { "webauthn"_s, { AutofillFieldName::WebAuthn, AutofillCategory::Credential } },
-});
-static constexpr SortedArrayMap fieldNameMap { fieldNameMappings };
+}) };
 
 AutofillFieldName toAutofillFieldName(const AtomString& value)
 {

--- a/Source/WebCore/html/EnterKeyHint.cpp
+++ b/Source/WebCore/html/EnterKeyHint.cpp
@@ -33,7 +33,7 @@ namespace WebCore {
 
 EnterKeyHint enterKeyHintForAttributeValue(StringView value)
 {
-    static constexpr auto mappings = std::to_array<std::pair<PackedLettersLiteral<uint64_t>, EnterKeyHint>>({
+    static constexpr SortedArrayMap enterKeyHints { std::to_array<std::pair<PackedLettersLiteral<uint64_t>, EnterKeyHint>>({
         { "done"_s, EnterKeyHint::Done },
         { "enter"_s, EnterKeyHint::Enter },
         { "go"_s, EnterKeyHint::Go },
@@ -41,8 +41,7 @@ EnterKeyHint enterKeyHintForAttributeValue(StringView value)
         { "previous"_s, EnterKeyHint::Previous },
         { "search"_s, EnterKeyHint::Search },
         { "send"_s, EnterKeyHint::Send }
-    });
-    static constexpr SortedArrayMap enterKeyHints { mappings };
+    }) };
     return enterKeyHints.get(value, EnterKeyHint::Unspecified);
 }
 

--- a/Source/WebCore/html/LinkRelAttribute.cpp
+++ b/Source/WebCore/html/LinkRelAttribute.cpp
@@ -49,7 +49,7 @@ struct LinkTypeDetails {
     void (*updateRel)(LinkRelAttribute&);
 };
 
-static constexpr auto linkTypesArray = std::to_array<std::pair<ComparableLettersLiteral, LinkTypeDetails>>({
+static constexpr SortedArrayMap linkTypes { std::to_array<std::pair<ComparableLettersLiteral, LinkTypeDetails>>({
     { "alternate"_s, { [](auto) { return true; }, [](auto relAttribute) { relAttribute.isAlternate = true; } } },
     { "apple-touch-icon"_s, { [](auto) { return true; }, [](auto relAttribute) { relAttribute.iconType = LinkIconType::TouchIcon; } } },
     { "apple-touch-icon-precomposed"_s, { [](auto) { return true; }, [](auto relAttribute) { relAttribute.iconType = LinkIconType::TouchPrecomposedIcon; } } },
@@ -72,9 +72,7 @@ static constexpr auto linkTypesArray = std::to_array<std::pair<ComparableLetters
     } },
 #endif
     { "stylesheet"_s, { [](auto) { return true; }, [](auto relAttribute) { relAttribute.isStyleSheet = true; } } },
-});
-
-static constexpr SortedArrayMap linkTypes { linkTypesArray };
+}) };
 
 LinkRelAttribute::LinkRelAttribute(Document& document, StringView rel)
 {

--- a/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
+++ b/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
@@ -60,7 +60,7 @@ using namespace HTMLNames;
 
 TokenPreloadScanner::TagId TokenPreloadScanner::tagIdFor(const HTMLToken::DataVector& data)
 {
-    static constexpr auto mappings = std::to_array<std::pair<PackedASCIILiteral<uint64_t>, TokenPreloadScanner::TagId>>({
+    static constexpr SortedArrayMap map { std::to_array<std::pair<PackedASCIILiteral<uint64_t>, TokenPreloadScanner::TagId>>({
         { "base"_s, TagId::Base },
         { "img"_s, TagId::Img },
         { "input"_s, TagId::Input },
@@ -72,8 +72,7 @@ TokenPreloadScanner::TagId TokenPreloadScanner::tagIdFor(const HTMLToken::DataVe
         { "style"_s, TagId::Style },
         { "template"_s, TagId::Template },
         { "video"_s, TagId::Video },
-    });
-    static constexpr SortedArrayMap map { mappings };
+    }) };
     return map.get(data.span(), TagId::Unknown);
 }
 

--- a/Source/WebCore/loader/MediaResourceLoader.cpp
+++ b/Source/WebCore/loader/MediaResourceLoader.cpp
@@ -211,15 +211,14 @@ Vector<ResourceResponse> MediaResourceLoader::responsesForTesting() const
 
 static bool isManifestMIMEType(const URL& url, const String& mimeType)
 {
-    static constexpr auto staticManifestMIMETypesArray = std::to_array<ComparableLettersLiteral>({
+    static constexpr SortedArraySet staticManifestMIMETypesSet { std::to_array<ComparableLettersLiteral>({
         "application/json"_s,
         "application/vnd.apple.mpegurl"_s,
         "application/vnd.apple.steering-list"_s,
         "application/x-mpegurl"_s,
         "audio/mpegurl"_s,
         "audio/x-mpegurl"_s
-    });
-    static constexpr SortedArraySet staticManifestMIMETypesSet { staticManifestMIMETypesArray };
+    }) };
 
     if (mimeType.isEmpty() || equalLettersIgnoringASCIICase(mimeType, "application/octet-stream"_s))
         return staticManifestMIMETypesSet.contains(ContentType::fromURL(url).containerType());

--- a/Source/WebCore/loader/soup/ResourceLoaderSoup.cpp
+++ b/Source/WebCore/loader/soup/ResourceLoaderSoup.cpp
@@ -54,7 +54,7 @@ static std::optional<String> contentTypeLookUpForKnownResource(const char* filen
     if (dotIndex != notFound && dotIndex < (fileName.length() - 1))
         extension = fileName.substring(dotIndex);
 
-    static constexpr auto extensionTypeMapping = std::to_array<std::pair<ComparableLettersLiteral, ASCIILiteral>>({
+    static constexpr SortedArrayMap mappings { std::to_array<std::pair<ComparableLettersLiteral, ASCIILiteral>>({
         { ".css"_s, "text/css"_s },
         { ".gif"_s, "image/gif"_s },
         { ".html"_s, "text/html"_s },
@@ -64,9 +64,7 @@ static std::optional<String> contentTypeLookUpForKnownResource(const char* filen
         { ".pfb"_s, "application/x-font-type1"_s },
         { ".svg"_s, "image/svg+xml"_s },
         { ".ttf"_s, "font/ttf"_s },
-    });
-
-    static constexpr SortedArrayMap mappings { extensionTypeMapping };
+    }) };
     if (const auto contentType = mappings.tryGet(extension))
         return *contentType;
 

--- a/Source/WebCore/mathml/MathMLPresentationElement.cpp
+++ b/Source/WebCore/mathml/MathMLPresentationElement.cpp
@@ -213,7 +213,7 @@ const MathMLElement::Length& MathMLPresentationElement::cachedMathMLLength(const
 MathVariant MathMLPresentationElement::parseMathVariantAttribute(const AtomString& attributeValue)
 {
     // The mathvariant attribute values is case-sensitive.
-    static constexpr auto mappings = std::to_array<std::pair<ComparableASCIILiteral, MathVariant>>({
+    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, MathVariant>>({
         { "bold"_s, MathVariant::Bold },
         { "bold-fraktur"_s, MathVariant::BoldFraktur },
         { "bold-italic"_s, MathVariant::BoldItalic },
@@ -232,8 +232,7 @@ MathVariant MathMLPresentationElement::parseMathVariantAttribute(const AtomStrin
         { "script"_s, MathVariant::Script },
         { "stretched"_s, MathVariant::Stretched },
         { "tailed"_s, MathVariant::Tailed },
-    });
-    static constexpr SortedArrayMap map { mappings };
+    }) };
     return map.get(attributeValue, MathVariant::None);
 }
 

--- a/Source/WebCore/page/DebugPageOverlays.cpp
+++ b/Source/WebCore/page/DebugPageOverlays.cpp
@@ -204,7 +204,7 @@ static void drawRightAlignedText(const String& text, GraphicsContext& context, c
 
 void NonFastScrollableRegionOverlay::drawRect(PageOverlay& pageOverlay, GraphicsContext& context, const IntRect&)
 {
-    static constexpr auto colorMappings = std::to_array<std::pair<EventTrackingRegions::EventType, SRGBA<uint8_t>>>({
+    constexpr SortedArrayMap colors { std::to_array<std::pair<EventTrackingRegions::EventType, SRGBA<uint8_t>>>({
         { EventTrackingRegions::EventType::Mousedown, { 80, 245, 80, 50 } },
         { EventTrackingRegions::EventType::Mousemove, { 245, 245, 80, 50 } },
         { EventTrackingRegions::EventType::Mouseup, { 80, 245, 176, 50 } },
@@ -213,8 +213,7 @@ void NonFastScrollableRegionOverlay::drawRect(PageOverlay& pageOverlay, Graphics
         { EventTrackingRegions::EventType::Touchmove, { 80, 204, 245, 50 } },
         { EventTrackingRegions::EventType::Touchstart, { 191, 191, 63, 50 } },
         { EventTrackingRegions::EventType::Wheel, { 255, 128, 0, 50 } },
-    });
-    constexpr SortedArrayMap colors { colorMappings };
+    }) };
     constexpr auto defaultColor = Color::black.colorWithAlphaByte(64);
 
     IntRect bounds = pageOverlay.bounds();

--- a/Source/WebCore/page/PerformanceUserTiming.cpp
+++ b/Source/WebCore/page/PerformanceUserTiming.cpp
@@ -48,7 +48,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(PerformanceUserTiming);
 
 using NavigationTimingFunction = unsigned long long (PerformanceTiming::*)() const;
 
-static constexpr auto restrictedMarkMappings = std::to_array<std::pair<ComparableASCIILiteral, NavigationTimingFunction>>({
+static constexpr SortedArrayMap restrictedMarkFunctions { std::to_array<std::pair<ComparableASCIILiteral, NavigationTimingFunction>>({
     { "connectEnd"_s, &PerformanceTiming::connectEnd },
     { "connectStart"_s, &PerformanceTiming::connectStart },
     { "domComplete"_s, &PerformanceTiming::domComplete },
@@ -70,8 +70,7 @@ static constexpr auto restrictedMarkMappings = std::to_array<std::pair<Comparabl
     { "secureConnectionStart"_s, &PerformanceTiming::secureConnectionStart },
     { "unloadEventEnd"_s, &PerformanceTiming::unloadEventEnd },
     { "unloadEventStart"_s, &PerformanceTiming::unloadEventStart },
-});
-static constexpr SortedArrayMap restrictedMarkFunctions { restrictedMarkMappings };
+}) };
 
 bool PerformanceUserTiming::isRestrictedMarkName(const String& markName)
 {

--- a/Source/WebCore/platform/KeyboardScrollingAnimator.cpp
+++ b/Source/WebCore/platform/KeyboardScrollingAnimator.cpp
@@ -53,7 +53,7 @@ const std::optional<KeyboardScrollingKey> keyboardScrollingKeyForKeyboardEvent(c
     if (!(platformEvent->type() == PlatformEvent::Type::RawKeyDown || platformEvent->type() == PlatformEvent::Type::Char))
         return { };
 
-    static constexpr auto mappings = std::to_array<std::pair<PackedASCIILiteral<uint64_t>, KeyboardScrollingKey>>({
+    static constexpr SortedArrayMap map { std::to_array<std::pair<PackedASCIILiteral<uint64_t>, KeyboardScrollingKey>>({
         { "Down"_s, KeyboardScrollingKey::DownArrow },
         { "End"_s, KeyboardScrollingKey::End },
         { "Home"_s, KeyboardScrollingKey::Home },
@@ -62,8 +62,7 @@ const std::optional<KeyboardScrollingKey> keyboardScrollingKeyForKeyboardEvent(c
         { "PageUp"_s, KeyboardScrollingKey::PageUp },
         { "Right"_s, KeyboardScrollingKey::RightArrow },
         { "Up"_s, KeyboardScrollingKey::UpArrow },
-    });
-    static constexpr SortedArrayMap map { mappings };
+    }) };
 
     auto identifier = platformEvent->keyIdentifier();
     if (auto* result = map.tryGet(identifier))

--- a/Source/WebCore/platform/audio/glib/MediaSessionGLib.cpp
+++ b/Source/WebCore/platform/audio/glib/MediaSessionGLib.cpp
@@ -39,7 +39,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaSessionGLib);
 
 static std::optional<PlatformMediaSession::RemoteControlCommandType> getCommand(const char* name)
 {
-    static const auto commandList = std::to_array<std::pair<ComparableASCIILiteral, PlatformMediaSession::RemoteControlCommandType>>({
+    static const SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, PlatformMediaSession::RemoteControlCommandType>>({
         { "Next"_s, PlatformMediaSession::RemoteControlCommandType::NextTrackCommand },
         { "Pause"_s, PlatformMediaSession::RemoteControlCommandType::PauseCommand },
         { "Play"_s, PlatformMediaSession::RemoteControlCommandType::PlayCommand },
@@ -47,9 +47,7 @@ static std::optional<PlatformMediaSession::RemoteControlCommandType> getCommand(
         { "Previous"_s, PlatformMediaSession::RemoteControlCommandType::PreviousTrackCommand },
         { "Seek"_s, PlatformMediaSession::RemoteControlCommandType::SeekToPlaybackPositionCommand },
         { "Stop"_s, PlatformMediaSession::RemoteControlCommandType::StopCommand }
-    });
-
-    static const SortedArrayMap map { commandList };
+    }) };
     auto value = map.get(StringView::fromLatin1(name), PlatformMediaSession::RemoteControlCommandType::NoCommand);
     if (value == PlatformMediaSession::RemoteControlCommandType::NoCommand)
         return { };
@@ -98,7 +96,7 @@ enum class MprisProperty : uint8_t {
 
 static std::optional<MprisProperty> getMprisProperty(const char* propertyName)
 {
-    static constexpr auto propertiesList = std::to_array<std::pair<ComparableASCIILiteral, MprisProperty>>({
+    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, MprisProperty>>({
         { "CanControl"_s, MprisProperty::CanControl },
         { "CanGoNext"_s, MprisProperty::CanGoNext },
         { "CanGoPrevious"_s, MprisProperty::CanGoPrevious },
@@ -115,8 +113,7 @@ static std::optional<MprisProperty> getMprisProperty(const char* propertyName)
         { "Position"_s, MprisProperty::GetPosition },
         { "SupportedMimeTypes"_s, MprisProperty::SupportedMimeTypes },
         { "SupportedUriSchemes"_s, MprisProperty::SupportedUriSchemes }
-    });
-    static constexpr SortedArrayMap map { propertiesList };
+    }) };
     auto value = map.get(StringView::fromLatin1(propertyName), MprisProperty::NoProperty);
     if (value == MprisProperty::NoProperty)
         return { };

--- a/Source/WebCore/platform/cocoa/RemoteCommandListenerCocoa.mm
+++ b/Source/WebCore/platform/cocoa/RemoteCommandListenerCocoa.mm
@@ -39,7 +39,7 @@ namespace WebCore {
 
 static std::optional<MRMediaRemoteCommand> mediaRemoteCommandForPlatformCommand(PlatformMediaSession::RemoteControlCommandType command)
 {
-    static constexpr auto mappings = std::to_array<std::pair<PlatformMediaSession::RemoteControlCommandType, MRMediaRemoteCommand>>({
+    static constexpr SortedArrayMap map { std::to_array<std::pair<PlatformMediaSession::RemoteControlCommandType, MRMediaRemoteCommand>>({
         { PlatformMediaSession::RemoteControlCommandType::PlayCommand, MRMediaRemoteCommandPlay },
         { PlatformMediaSession::RemoteControlCommandType::PauseCommand, MRMediaRemoteCommandPause },
         { PlatformMediaSession::RemoteControlCommandType::StopCommand, MRMediaRemoteCommandStop },
@@ -53,8 +53,7 @@ static std::optional<MRMediaRemoteCommand> mediaRemoteCommandForPlatformCommand(
         { PlatformMediaSession::RemoteControlCommandType::SkipBackwardCommand, MRMediaRemoteCommandSkipBackward },
         { PlatformMediaSession::RemoteControlCommandType::NextTrackCommand, MRMediaRemoteCommandNextTrack },
         { PlatformMediaSession::RemoteControlCommandType::PreviousTrackCommand, MRMediaRemoteCommandPreviousTrack },
-    });
-    static constexpr SortedArrayMap map { mappings };
+    }) };
     return makeOptionalFromPointer(map.tryGet(command));
 }
 

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -486,7 +486,7 @@ bool FontCascade::hasValidAverageCharWidth() const
         return false;
 #endif
 
-    static constexpr auto names = std::to_array<ComparableASCIILiteral>({
+    static constexpr SortedArraySet set { std::to_array<ComparableASCIILiteral>({
         "#GungSeo"_s,
         "#HeadLineA"_s,
         "#PCMyungjo"_s,
@@ -521,8 +521,7 @@ bool FontCascade::hasValidAverageCharWidth() const
         "STHeiti"_s,
         "Symbol"_s,
         "Times"_s,
-    });
-    static constexpr SortedArraySet set { names };
+    }) };
     return !set.contains(family);
 }
 

--- a/Source/WebCore/platform/graphics/HEVCUtilities.cpp
+++ b/Source/WebCore/platform/graphics/HEVCUtilities.cpp
@@ -291,27 +291,25 @@ std::optional<HEVCParameters> parseHEVCDecoderConfigurationRecord(FourCC codecCo
 
 static std::optional<DoViParameters::Codec> parseDoViCodecType(StringView string)
 {
-    static constexpr auto typesArray = std::to_array<std::pair<PackedLettersLiteral<uint32_t>, DoViParameters::Codec>>({
+    static constexpr SortedArrayMap typesMap { std::to_array<std::pair<PackedLettersLiteral<uint32_t>, DoViParameters::Codec>>({
         { "dva1"_s, DoViParameters::Codec::AVC1 },
         { "dvav"_s, DoViParameters::Codec::AVC3 },
         { "dvh1"_s, DoViParameters::Codec::HVC1 },
         { "dvhe"_s, DoViParameters::Codec::HEV1 },
-    });
-    static constexpr SortedArrayMap typesMap { typesArray };
+    }) };
     return makeOptionalFromPointer(typesMap.tryGet(string));
 }
 
 static std::optional<uint16_t> profileIDForAlphabeticDoViProfile(StringView profile)
 {
     // See Table 7 of "Dolby Vision Profiles and Levels Version 1.3.2"
-    static constexpr auto profilesArray = std::to_array<std::pair<PackedLettersLiteral<uint64_t>, uint16_t>>({
+    static constexpr SortedArrayMap profilesMap { std::to_array<std::pair<PackedLettersLiteral<uint64_t>, uint16_t>>({
         { "dvav.se"_s, 9 },
         { "dvhe.dtb"_s, 7 },
         { "dvhe.dtr"_s, 4 },
         { "dvhe.st"_s, 8 },
         { "dvhe.stn"_s, 5 },
-    });
-    static constexpr SortedArrayMap profilesMap { profilesArray };
+    }) };
     return makeOptionalFromPointer(profilesMap.tryGet(profile));
 }
 

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -96,7 +96,7 @@ static std::span<uint8_t> glMapBufferRangeSpan(GLenum target, GLintptr offset, G
     return unsafeMakeSpan(static_cast<uint8_t*>(ptr), length);
 }
 
-static constexpr auto extensionsMapping = std::to_array<std::pair<ComparableASCIILiteral, GCGLExtension>>({
+static constexpr SortedArrayMap extensionsMapping { std::to_array<std::pair<ComparableASCIILiteral, GCGLExtension>>({
     { "GL_ANGLE_base_vertex_base_instance"_s, GCGLExtension::ANGLE_base_vertex_base_instance },
     { "GL_ANGLE_clip_cull_distance"_s, GCGLExtension::ANGLE_clip_cull_distance },
     { "GL_ANGLE_compressed_texture_etc"_s, GCGLExtension::ANGLE_compressed_texture_etc },
@@ -154,16 +154,12 @@ static constexpr auto extensionsMapping = std::to_array<std::pair<ComparableASCI
     { "GL_OES_texture_half_float_linear"_s, GCGLExtension::OES_texture_half_float_linear },
     { "GL_OES_vertex_array_object"_s, GCGLExtension::OES_vertex_array_object },
     { "GL_QCOM_render_shared_exponent"_s, GCGLExtension::QCOM_render_shared_exponent },
-});
-// Enums are expected to map the strings. Verify that the extensions are in ascending order, like the strings.
-static_assert(std::is_sorted(std::begin(extensionsMapping), std::end(extensionsMapping), [](auto& a, auto b) {
-    return a.second < b.second;
-}));
+}) };
 
 static ASCIILiteral extensionName(GCGLExtension extension)
 {
     size_t index = static_cast<size_t>(extension);
-    std::span mapping { extensionsMapping };
+    std::span mapping { extensionsMapping.array() };
     if (mapping.size() < index) {
         ASSERT_NOT_REACHED();
         return { };
@@ -179,8 +175,7 @@ static ASCIILiteral extensionName(GCGLExtension extension)
 
 static std::optional<GCGLExtension> extensionEnum(const CString& extension)
 {
-    static constexpr SortedArrayMap map { extensionsMapping };
-    if (auto* result = map.tryGet(extension.span()))
+    if (auto* result = extensionsMapping.tryGet(extension.span()))
         return *result;
     return std::nullopt;
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AVAssetMIMETypeCache.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AVAssetMIMETypeCache.mm
@@ -139,14 +139,13 @@ bool AVAssetMIMETypeCache::isUnsupportedContainerType(const String& type)
         return true;
 
     // Reject types we know AVFoundation does not support that sites commonly ask about.
-    static constexpr auto unsupportedTypesArray = std::to_array<ComparableASCIILiteral>({ "video/h264"_s, "video/x-flv"_s });
-    static constexpr SortedArraySet unsupportedTypesSet { unsupportedTypesArray };
+    static constexpr SortedArraySet unsupportedTypesSet { std::to_array<ComparableASCIILiteral>({ "video/h264"_s, "video/x-flv"_s }) };
     return unsupportedTypesSet.contains(lowerCaseType);
 }
 
 bool AVAssetMIMETypeCache::isStaticContainerType(StringView type)
 {
-    static constexpr auto staticContainerTypesArray = std::to_array<ComparableLettersLiteral>({
+    static constexpr SortedArraySet staticContainerTypesSet { std::to_array<ComparableLettersLiteral>({
         "application/vnd.apple.mpegurl"_s,
         "application/x-mpegurl"_s,
         "audio/3gpp"_s,
@@ -178,8 +177,7 @@ bool AVAssetMIMETypeCache::isStaticContainerType(StringView type)
         "video/x-m4v"_s,
         "video/x-mpeg"_s,
         "video/x-mpg"_s,
-    });
-    static constexpr SortedArraySet staticContainerTypesSet { staticContainerTypesArray };
+    }) };
     return staticContainerTypesSet.contains(type);
 }
 

--- a/Source/WebCore/platform/graphics/filters/FilterFunction.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterFunction.cpp
@@ -46,10 +46,10 @@ FilterFunction::~FilterFunction()
 
 AtomString FilterFunction::filterName(Type filterType)
 {
-    static constexpr auto namesArray = std::to_array<std::pair<FilterFunction::Type, ASCIILiteral>>({
+    static constexpr SortedArrayMap namesMap { std::to_array<std::pair<FilterFunction::Type, ASCIILiteral>>({
         { FilterFunction::Type::CSSFilterRenderer,   "CSSFilterRenderer"_s   },
         { FilterFunction::Type::SVGFilterRenderer,   "SVGFilterRenderer"_s   },
-        
+
         { FilterFunction::Type::FEBlend,             "FEBlend"_s             },
         { FilterFunction::Type::FEColorMatrix,       "FEColorMatrix"_s       },
         { FilterFunction::Type::FEComponentTransfer, "FEComponentTransfer"_s },
@@ -70,9 +70,7 @@ AtomString FilterFunction::filterName(Type filterType)
 
         { FilterFunction::Type::SourceAlpha,         "SourceAlpha"_s         },
         { FilterFunction::Type::SourceGraphic,       "SourceGraphic"_s       }
-    });
-
-    static constexpr SortedArrayMap namesMap { namesArray };
+    }) };
     
     ASSERT(namesMap.tryGet(filterType));
     return namesMap.get(filterType, ""_s);

--- a/Source/WebCore/platform/network/mac/UTIUtilities.mm
+++ b/Source/WebCore/platform/network/mac/UTIUtilities.mm
@@ -103,13 +103,12 @@ RetainPtr<CFStringRef> mimeTypeFromUTITree(CFStringRef uti)
 
 static NSString *UTIFromPotentiallyUnknownMIMEType(StringView mimeType)
 {
-    static constexpr auto typesArray = std::to_array<std::pair<ComparableLettersLiteral, NSString *>>({
+    static constexpr SortedArrayMap typesMap { std::to_array<std::pair<ComparableLettersLiteral, NSString *>>({
         { "model/usd"_s, @"com.pixar.universal-scene-description-mobile" },
         { "model/vnd.pixar.usd"_s, @"com.pixar.universal-scene-description-mobile" },
         { "model/vnd.reality"_s, @"com.apple.reality" },
         { "model/vnd.usdz+zip"_s, @"com.pixar.universal-scene-description-mobile" },
-    });
-    static constexpr SortedArrayMap typesMap { typesArray };
+    }) };
     return typesMap.get(mimeType, nil);
 }
 

--- a/Source/WebCore/platform/network/mac/WebCoreURLResponse.mm
+++ b/Source/WebCore/platform/network/mac/WebCoreURLResponse.mm
@@ -54,7 +54,7 @@ void adjustMIMETypeIfNecessary(CFURLResponseRef response, IsMainResourceLoad, Is
         // Once UTType matches one of these mappings on all versions of macOS we support, we can remove that pair.
         // Alternatively, we could remove any pairs that we determine we no longer need.
         // And then remove this code entirely once they are all gone.
-        static constexpr auto extensionPairs = std::to_array<std::pair<ComparableLettersLiteral, NSString *>>({
+        static constexpr SortedArrayMap extensionMap { std::to_array<std::pair<ComparableLettersLiteral, NSString *>>({
             { "ai"_s, @"application/postscript" },
             { "asc"_s, @"text/plain" },
             { "bcpio"_s, @"application/x-bcpio" },
@@ -173,8 +173,7 @@ void adjustMIMETypeIfNecessary(CFURLResponseRef response, IsMainResourceLoad, Is
             { "xwd"_s, @"image/x-xwindowdump" },
             { "xyz"_s, @"chemical/x-xyz" },
             { "z"_s, @"application/x-compress" },
-        });
-        static constexpr SortedArrayMap extensionMap { extensionPairs };
+        }) };
         type = extensionMap.get(String { extension.get() });
         if (!type)
             type = preferredMIMETypeForFileExtensionFromUTType(bridge_cast(extension.get()));

--- a/Source/WebCore/platform/text/LocaleToScriptMapping.cpp
+++ b/Source/WebCore/platform/text/LocaleToScriptMapping.cpp
@@ -44,7 +44,9 @@ UScriptCode scriptNameToCode(StringView scriptName)
     // USCRIPT_KATAKANA_OR_HIRAGANA instead of USCRIPT_HIRAGANA, since we want all Japanese scripts to be rendered
     // using the same font setting.
     using ScriptName = PackedLettersLiteral<uint32_t>;
-    static constexpr auto scriptNameCodeList = std::to_array<std::pair<ScriptName, UScriptCode>>({
+    static_assert(ScriptName("arab"_s).value() == 0x61726162U);
+    static_assert(ScriptName("zzzz"_s).value() == 0x7a7a7a7aU);
+    static constexpr SortedArrayMap map { std::to_array<std::pair<ScriptName, UScriptCode>>({
         { "arab"_s, USCRIPT_ARABIC },
         { "armn"_s, USCRIPT_ARMENIAN },
         { "bali"_s, USCRIPT_BALINESE },
@@ -151,17 +153,16 @@ UScriptCode scriptNameToCode(StringView scriptName)
         { "zxxx"_s, USCRIPT_UNWRITTEN_LANGUAGES },
         { "zyyy"_s, USCRIPT_COMMON },
         { "zzzz"_s, USCRIPT_UNKNOWN },
-    });
-    static_assert(ScriptName("arab"_s).value() == 0x61726162U);
-    static_assert(ScriptName("zzzz"_s).value() == 0x7a7a7a7aU);
-    static constexpr SortedArrayMap map { scriptNameCodeList };
+    }) };
     return map.get(scriptName, USCRIPT_INVALID_CODE);
 }
 
 UScriptCode localeToScriptCode(const String& locale)
 {
     using LocaleName = PackedASCIILowerCodes<uint64_t>;
-    static constexpr auto localeScriptList = std::to_array<std::pair<LocaleName, UScriptCode>>({
+    static_assert(LocaleName("aa"_s).value() == 0x6161000000000000ULL);
+    static_assert(LocaleName("zh_tw"_s).value() == 0x7a685f7477000000ULL);
+    static constexpr SortedArrayMap map { std::to_array<std::pair<LocaleName, UScriptCode>>({
         { "aa"_s, USCRIPT_LATIN },
         { "ab"_s, USCRIPT_CYRILLIC },
         { "ady"_s, USCRIPT_CYRILLIC },
@@ -360,10 +361,7 @@ UScriptCode localeToScriptCode(const String& locale)
         { "zh_hk"_s, USCRIPT_TRADITIONAL_HAN },
         { "zh_tw"_s, USCRIPT_TRADITIONAL_HAN },
         { "zu"_s, USCRIPT_LATIN },
-    });
-    static_assert(LocaleName("aa"_s).value() == 0x6161000000000000ULL);
-    static_assert(LocaleName("zh_tw"_s).value() == 0x7a685f7477000000ULL);
-    static constexpr SortedArrayMap map { localeScriptList };
+    }) };
     String canonicalLocaleString = makeStringByReplacingAll(locale, '-', '_');
     for (StringView canonicalLocale = canonicalLocaleString; !canonicalLocale.isEmpty(); ) {
         if (auto scriptCode = map.tryGet(canonicalLocale))

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -1584,7 +1584,7 @@ Vector<char16_t> RenderText::previousCharacter() const
 static String convertToFullSizeKana(const String& string)
 {
     // https://www.w3.org/TR/css-text-3/#small-kana
-    static constexpr auto kanasMap = std::to_array<std::pair<char32_t, char16_t>>({
+    static constexpr SortedArrayMap sortedMap { std::to_array<std::pair<char32_t, char16_t>>({
         { 0x3041, 0x3042 },
         { 0x3043, 0x3044 },
         { 0x3045, 0x3046 },
@@ -1643,9 +1643,7 @@ static String convertToFullSizeKana(const String& string)
         { 0x1B165, 0x30F1 },
         { 0x1B166, 0x30F2 },
         { 0x1B167, 0x30F3 }
-    });
-
-    static constexpr SortedArrayMap sortedMap { kanasMap };
+    }) };
 
     auto codePoints = StringView { string }.codePoints();
 

--- a/Source/WebCore/rendering/mathml/MathVariant.cpp
+++ b/Source/WebCore/rendering/mathml/MathVariant.cpp
@@ -49,7 +49,7 @@ char32_t mathVariantMapCodePoint(char32_t codePoint, MathVariant mathvariant)
     // 1. In the Latin table it represents a hole in the mathematical alphanumeric block, where the character that should occupy that position is located elsewhere.
     // 2. It represents an Arabic letter.
     //  As a replacement, 0 is reserved to indicate no mapping was found.
-    static constexpr auto arabicInitialMapTableEntries = std::to_array<std::pair<char32_t, char32_t>>({
+    static constexpr SortedArrayMap arabicInitialMapTable = { std::to_array<std::pair<char32_t, char32_t>>({
         { 0x628, 0x1EE21 },
         { 0x62A, 0x1EE35 },
         { 0x62B, 0x1EE36 },
@@ -70,10 +70,9 @@ char32_t mathVariantMapCodePoint(char32_t codePoint, MathVariant mathvariant)
         { 0x646, 0x1EE2D },
         { 0x647, 0x1EE24 },
         { 0x64A, 0x1EE29 }
-    });
-    static constexpr SortedArrayMap arabicInitialMapTable = { arabicInitialMapTableEntries };
+    }) };
 
-    static constexpr auto arabicTailedMapTableEntries = std::to_array<std::pair<char32_t, char32_t>>({
+    static constexpr SortedArrayMap arabicTailedMapTable = { std::to_array<std::pair<char32_t, char32_t>>({
         { 0x62C, 0x1EE42 },
         { 0x62D, 0x1EE47 },
         { 0x62E, 0x1EE57 },
@@ -89,10 +88,9 @@ char32_t mathVariantMapCodePoint(char32_t codePoint, MathVariant mathvariant)
         { 0x64A, 0x1EE49 },
         { 0x66F, 0x1EE5F },
         { 0x6BA, 0x1EE5D }
-    });
-    static constexpr SortedArrayMap arabicTailedMapTable = { arabicTailedMapTableEntries };
+    }) };
 
-    static constexpr auto arabicStretchedMapTableEntries = std::to_array<std::pair<char32_t, char32_t>>({
+    static constexpr SortedArrayMap arabicStretchedMapTable = { std::to_array<std::pair<char32_t, char32_t>>({
         { 0x628, 0x1EE61 },
         { 0x62A, 0x1EE75 },
         { 0x62B, 0x1EE76 },
@@ -116,10 +114,9 @@ char32_t mathVariantMapCodePoint(char32_t codePoint, MathVariant mathvariant)
         { 0x64A, 0x1EE69 },
         { 0x66E, 0x1EE7C },
         { 0x6A1, 0x1EE7E }
-    });
-    static constexpr SortedArrayMap arabicStretchedMapTable = { arabicStretchedMapTableEntries };
+    }) };
 
-    static constexpr auto arabicLoopedMapTableEntries = std::to_array<std::pair<char32_t, char32_t>>({
+    static constexpr SortedArrayMap arabicLoopedMapTable = { std::to_array<std::pair<char32_t, char32_t>>({
         { 0x627, 0x1EE80 },
         { 0x628, 0x1EE81 },
         { 0x62A, 0x1EE95 },
@@ -147,10 +144,9 @@ char32_t mathVariantMapCodePoint(char32_t codePoint, MathVariant mathvariant)
         { 0x647, 0x1EE84 },
         { 0x648, 0x1EE85 },
         { 0x64A, 0x1EE89 }
-    });
-    static constexpr SortedArrayMap arabicLoopedMapTable = { arabicLoopedMapTableEntries };
+    }) };
 
-    static constexpr auto arabicDoubleMapTableEntries = std::to_array<std::pair<char32_t, char32_t>>({
+    static constexpr SortedArrayMap arabicDoubleMapTable = { std::to_array<std::pair<char32_t, char32_t>>({
         { 0x628, 0x1EEA1 },
         { 0x62A, 0x1EEB5 },
         { 0x62B, 0x1EEB6 },
@@ -176,10 +172,9 @@ char32_t mathVariantMapCodePoint(char32_t codePoint, MathVariant mathvariant)
         { 0x646, 0x1EEAD },
         { 0x648, 0x1EEA5 },
         { 0x64A, 0x1EEA9 }
-    });
-    static constexpr SortedArrayMap arabicDoubleMapTable = { arabicDoubleMapTableEntries };
+    }) };
 
-    static constexpr auto latinExceptionMapTableEntries = std::to_array<std::pair<char32_t, char32_t>>({
+    static constexpr SortedArrayMap latinExceptionMapTable = { std::to_array<std::pair<char32_t, char32_t>>({
         { 0x1D455, 0x210E },
         { 0x1D49D, 0x212C },
         { 0x1D4A0, 0x2130 },
@@ -204,8 +199,7 @@ char32_t mathVariantMapCodePoint(char32_t codePoint, MathVariant mathvariant)
         { 0x1D548, 0x211A },
         { 0x1D549, 0x211D },
         { 0x1D551, 0x2124 }
-    });
-    static constexpr SortedArrayMap latinExceptionMapTable = { latinExceptionMapTableEntries };
+    }) };
 
     constexpr char16_t greekUpperTheta = 0x03F4;
     constexpr char16_t holeGreekUpperTheta = 0x03A2;

--- a/Source/WebCore/svg/SVGComponentTransferFunctionElement.h
+++ b/Source/WebCore/svg/SVGComponentTransferFunctionElement.h
@@ -58,14 +58,13 @@ struct SVGPropertyTraits<ComponentTransferType> {
 
     static ComponentTransferType fromString(SVGElement&, const String& value)
     {
-        static constexpr auto mappings = std::to_array<std::pair<PackedASCIILiteral<uint64_t>, ComponentTransferType>>({
+        static constexpr SortedArrayMap map { std::to_array<std::pair<PackedASCIILiteral<uint64_t>, ComponentTransferType>>({
             { "discrete"_s, ComponentTransferType::FECOMPONENTTRANSFER_TYPE_DISCRETE },
             { "gamma"_s, ComponentTransferType::FECOMPONENTTRANSFER_TYPE_GAMMA },
             { "identity"_s, ComponentTransferType::FECOMPONENTTRANSFER_TYPE_IDENTITY },
             { "linear"_s, ComponentTransferType::FECOMPONENTTRANSFER_TYPE_LINEAR },
             { "table"_s, ComponentTransferType::FECOMPONENTTRANSFER_TYPE_TABLE }
-        });
-        static constexpr SortedArrayMap map { mappings };
+        }) };
         return map.get(value, ComponentTransferType::FECOMPONENTTRANSFER_TYPE_UNKNOWN);
     }
 };

--- a/Source/WebCore/svg/SVGFECompositeElement.h
+++ b/Source/WebCore/svg/SVGFECompositeElement.h
@@ -60,7 +60,7 @@ struct SVGPropertyTraits<CompositeOperationType> {
 
     static CompositeOperationType fromString(SVGElement&, const String& value)
     {
-        static constexpr auto mappings = std::to_array<std::pair<ComparableASCIILiteral, CompositeOperationType>>({
+        static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, CompositeOperationType>>({
             { "arithmetic"_s, CompositeOperationType::FECOMPOSITE_OPERATOR_ARITHMETIC },
             { "atop"_s, CompositeOperationType::FECOMPOSITE_OPERATOR_ATOP },
             { "in"_s, CompositeOperationType::FECOMPOSITE_OPERATOR_IN },
@@ -68,8 +68,7 @@ struct SVGPropertyTraits<CompositeOperationType> {
             { "out"_s, CompositeOperationType::FECOMPOSITE_OPERATOR_OUT },
             { "over"_s, CompositeOperationType::FECOMPOSITE_OPERATOR_OVER },
             { "xor"_s, CompositeOperationType::FECOMPOSITE_OPERATOR_XOR },
-        });
-        static constexpr SortedArrayMap map { mappings };
+        }) };
         return map.get(value, CompositeOperationType::FECOMPOSITE_OPERATOR_UNKNOWN);
     }
 };

--- a/Source/WebDriver/WebDriverService.cpp
+++ b/Source/WebDriver/WebDriverService.cpp
@@ -304,13 +304,12 @@ const WebDriverService::BidiCommand WebDriverService::s_bidiCommands[] = {
 
 std::optional<WebDriverService::HTTPMethod> WebDriverService::toCommandHTTPMethod(const String& method)
 {
-    static constexpr auto httpMethodMappings = std::to_array<std::pair<ComparableLettersLiteral, WebDriverService::HTTPMethod>>({
+    static constexpr SortedArrayMap httpMethods { std::to_array<std::pair<ComparableLettersLiteral, WebDriverService::HTTPMethod>>({
         { "delete"_s, WebDriverService::HTTPMethod::Delete },
         { "get"_s, WebDriverService::HTTPMethod::Get },
         { "post"_s, WebDriverService::HTTPMethod::Post },
         { "put"_s, WebDriverService::HTTPMethod::Post },
-    });
-    static constexpr SortedArrayMap httpMethods { httpMethodMappings };
+    }) };
 
     if (auto* methodValue = httpMethods.tryGet(method))
         return *methodValue;

--- a/Source/WebGPU/WGSL/Lexer.cpp
+++ b/Source/WebGPU/WGSL/Lexer.cpp
@@ -325,7 +325,7 @@ Token Lexer<T>::nextToken()
 
             String view(StringImpl::createWithoutCopying(startOfToken.subspan(0, currentTokenLength())));
 
-            static constexpr auto keywordMappings = std::to_array<std::pair<ComparableASCIILiteral, TokenType>>({
+            static constexpr SortedArrayMap keywords { std::to_array<std::pair<ComparableASCIILiteral, TokenType>>({
                 { "_"_s, TokenType::Underbar },
 
 #define MAPPING_ENTRY(lexeme, name)\
@@ -333,11 +333,10 @@ Token Lexer<T>::nextToken()
 FOREACH_KEYWORD(MAPPING_ENTRY)
 #undef MAPPING_ENTRY
 
-            });
-            static constexpr SortedArrayMap keywords { keywordMappings };
+            }) };
 
             // https://www.w3.org/TR/WGSL/#reserved-words
-            static constexpr auto reservedWords = std::to_array<ComparableASCIILiteral>({
+            static constexpr SortedArraySet reservedWordSet { std::to_array<ComparableASCIILiteral>({
                 "NULL"_s,
                 "Self"_s,
                 "abstract"_s,
@@ -483,8 +482,7 @@ FOREACH_KEYWORD(MAPPING_ENTRY)
                 "with"_s,
                 "writeonly"_s,
                 "yield"_s,
-            });
-            static constexpr SortedArraySet reservedWordSet { reservedWords };
+            }) };
 
             auto tokenType = keywords.get(view);
             if (tokenType != TokenType::Invalid)

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -2174,7 +2174,7 @@ void FunctionDefinitionWriter::visit(const Type* type, AST::CallExpression& call
     }
 
     if (auto* target = dynamicDowncast<AST::IdentifierExpression>(call.target())) {
-        static constexpr auto builtinMappings = std::to_array<std::pair<ComparableASCIILiteral, void(*)(FunctionDefinitionWriter*, AST::CallExpression&)>>({
+        static constexpr SortedArrayMap builtins { std::to_array<std::pair<ComparableASCIILiteral, void(*)(FunctionDefinitionWriter*, AST::CallExpression&)>>({
             { "__dynamicOffset"_s, emitDynamicOffset },
             { "arrayLength"_s, emitArrayLength },
             { "atomicAdd"_s, emitAtomicAdd },
@@ -2219,8 +2219,7 @@ void FunctionDefinitionWriter::visit(const Type* type, AST::CallExpression& call
             { "unpack4xU8"_s, emitUnpack4xU8 },
             { "workgroupBarrier"_s, emitWorkgroupBarrier },
             { "workgroupUniformLoad"_s, emitWorkgroupUniformLoad },
-        });
-        static constexpr SortedArrayMap builtins { builtinMappings };
+        }) };
         const auto& targetName = target->identifier().id();
         if (auto mappedBuiltin = builtins.get(targetName)) {
             mappedBuiltin(this, call);
@@ -2237,7 +2236,7 @@ void FunctionDefinitionWriter::visit(const Type* type, AST::CallExpression& call
 #define NOOP_HELPER(name) \
     [](HelperGenerator&) { return #name##_s; }
 
-        static constexpr auto directMappings = std::to_array<std::pair<ComparableASCIILiteral, ASCIILiteral(*)(HelperGenerator&)>>({
+        static constexpr SortedArrayMap mappedNames { std::to_array<std::pair<ComparableASCIILiteral, ASCIILiteral(*)(HelperGenerator&)>>({
             { "acos"_s, EMIT_HELPER(Acos) },
             { "acosh"_s, EMIT_HELPER(Acosh) },
             { "asin"_s, EMIT_HELPER(Asin) },
@@ -2279,12 +2278,10 @@ void FunctionDefinitionWriter::visit(const Type* type, AST::CallExpression& call
             { "unpack2x16unorm"_s, NOOP_HELPER(unpack_unorm2x16_to_float) },
             { "unpack4x8snorm"_s, NOOP_HELPER(unpack_snorm4x8_to_float) },
             { "unpack4x8unorm"_s, NOOP_HELPER(unpack_unorm4x8_to_float) },
-        });
-
+        }) };
 #undef EMIT_HELPER
 #undef NOOP_HELPER
 
-        static constexpr SortedArrayMap mappedNames { directMappings };
         if (call.isConstructor()) {
             if (call.isFloatToIntConversion()) {
                 m_body.append("__wgslFtoi<"_s);

--- a/Source/WebGPU/WGSL/Types.h
+++ b/Source/WebGPU/WGSL/Types.h
@@ -172,12 +172,10 @@ public:
         static constexpr unsigned fract = 0;
         static constexpr unsigned exp = 1;
 
-        static constexpr auto mapEntries = std::to_array<std::pair<ComparableASCIILiteral, unsigned>>({
+        static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, unsigned>>({
             { "exp"_s, exp },
             { "fract"_s, fract },
-        });
-
-        static constexpr SortedArrayMap map { mapEntries };
+        }) };
     };
 
     struct ModfResult {
@@ -185,12 +183,10 @@ public:
         static constexpr unsigned fract = 0;
         static constexpr unsigned whole = 1;
 
-        static constexpr auto mapEntries = std::to_array<std::pair<ComparableASCIILiteral, unsigned>>({
+        static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, unsigned>>({
             { "fract"_s, fract },
             { "whole"_s, whole },
-        });
-
-        static constexpr SortedArrayMap map { mapEntries };
+        }) };
     };
 
     struct AtomicCompareExchangeResult {
@@ -198,12 +194,10 @@ public:
         static constexpr unsigned oldValue = 0;
         static constexpr unsigned exchanged = 1;
 
-        static constexpr auto mapEntries = std::to_array<std::pair<ComparableASCIILiteral, unsigned>>({
+        static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, unsigned>>({
             { "exchanged"_s, exchanged },
             { "old_value"_s, oldValue },
-        });
-
-        static constexpr SortedArrayMap map { mapEntries };
+        }) };
     };
 
     static constexpr auto keys = std::to_array<SortedArrayMap<std::pair<ComparableASCIILiteral, unsigned>, 2>>({

--- a/Source/WebGPU/WGSL/WGSLEnums.cpp
+++ b/Source/WebGPU/WGSL/WGSLEnums.cpp
@@ -68,10 +68,9 @@ namespace WGSL {
 #define ENUM_DEFINE_PARSE(__name) \
     const __name* parse##__name(const String& __string) \
     { \
-        static constexpr auto __entries = std::to_array<std::pair<ComparableASCIILiteral, __name>>({ \
+        static constexpr SortedArrayMap __map { std::to_array<std::pair<ComparableASCIILiteral, __name>>({ \
             EXPAND(ENUM_##__name(ENUM_DEFINE_PARSE_ENTRY LPAREN __name RPAREN)) \
-        }); \
-        static constexpr SortedArrayMap __map { __entries }; \
+        }) }; \
         return __map.tryGet(__string); \
     }
 

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
@@ -196,7 +196,7 @@ static void dumpSeparatedLayerProperties(TextStream&, CALayer *) { }
 
 static String allowListedClassToString(UIView *view)
 {
-    static constexpr auto allowedClassesArray = std::to_array<ComparableASCIILiteral>({
+    static constexpr SortedArraySet allowedClasses { std::to_array<ComparableASCIILiteral>({
         "UIView"_s,
         "WKBackdropView"_s,
         "WKCompositingView"_s,
@@ -211,8 +211,7 @@ static String allowListedClassToString(UIView *view)
         "WKUIRemoteView"_s,
         "WKWebView"_s,
         "_UILayerHostView"_s,
-    });
-    static constexpr SortedArraySet allowedClasses { allowedClassesArray };
+    }) };
 
     String classString { NSStringFromClass(view.class) };
     if (allowedClasses.contains(classString))
@@ -224,11 +223,10 @@ static String allowListedClassToString(UIView *view)
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
 static bool shouldDumpSeparatedDetails(UIView *view)
 {
-    static constexpr auto deniedClassesArray = std::to_array<ComparableASCIILiteral>({
+    static constexpr SortedArraySet deniedClasses { std::to_array<ComparableASCIILiteral>({
         "WKCompositingView"_s,
         "WKSeparatedImageView"_s,
-    });
-    static constexpr SortedArraySet deniedClasses { deniedClassesArray };
+    }) };
 
     String classString { NSStringFromClass(view.class) };
     if (deniedClasses.contains(classString))

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -230,7 +230,7 @@ static String commandNameForSelectorName(const String& selectorName)
 {
     // Map selectors into Editor command names.
     // This is not needed for any selectors that have the same name as the Editor command.
-    static constexpr auto selectorExceptions = std::to_array<std::pair<ComparableASCIILiteral, ASCIILiteral>>({
+    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, ASCIILiteral>>({
         { "insertNewlineIgnoringFieldEditor:"_s, "InsertNewline"_s },
         { "insertParagraphSeparator:"_s, "InsertNewline"_s },
         { "insertTabIgnoringFieldEditor:"_s, "InsertTab"_s },
@@ -238,8 +238,7 @@ static String commandNameForSelectorName(const String& selectorName)
         { "pageDownAndModifySelection:"_s, "MovePageDownAndModifySelection"_s },
         { "pageUp:"_s, "MovePageUp"_s },
         { "pageUpAndModifySelection:"_s, "MovePageUpAndModifySelection"_s },
-    });
-    static constexpr SortedArrayMap map { selectorExceptions };
+    }) };
     if (auto commandName = map.tryGet(selectorName))
         return *commandName;
 

--- a/Tools/TestWebKitAPI/Tests/WTF/SortedArrayMap.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/SortedArrayMap.cpp
@@ -28,7 +28,7 @@
 
 TEST(WTF, SortedArraySet)
 {
-    static constexpr auto caseFoldingArray = std::to_array<ComparableCaseFoldingASCIILiteral>({
+    static constexpr SortedArraySet caseFoldingSet { std::to_array<ComparableCaseFoldingASCIILiteral>({
         "_"_s,
         "a"_s,
         "c"_s,
@@ -37,20 +37,18 @@ TEST(WTF, SortedArraySet)
         "q_"_s,
         "r/y"_s,
         "s-z"_s,
-    });
-    static constexpr SortedArraySet caseFoldingSet { caseFoldingArray };
+    }) };
 
-    static constexpr auto lettersArray = std::to_array<ComparableLettersLiteral>({
+    static constexpr SortedArraySet lettersSet { std::to_array<ComparableLettersLiteral>({
         "a"_s,
         "c"_s,
         "delightful"_s,
         "q"_s,
         "r/y"_s,
         "s-z"_s,
-    });
-    static constexpr SortedArraySet lettersSet { lettersArray };
+    }) };
 
-    static constexpr auto scriptTypesArray = std::to_array<ComparableLettersLiteral>({
+    static constexpr SortedArraySet scriptTypesSet { std::to_array<ComparableLettersLiteral>({
         "application/ecmascript"_s,
         "application/javascript"_s,
         "application/x-ecmascript"_s,
@@ -67,8 +65,7 @@ TEST(WTF, SortedArraySet)
         "text/livescript"_s,
         "text/x-ecmascript"_s,
         "text/x-javascript"_s,
-    });
-    static constexpr SortedArraySet scriptTypesSet { scriptTypesArray };
+    }) };
 
     EXPECT_FALSE(caseFoldingSet.contains(""_s));
     EXPECT_TRUE(caseFoldingSet.contains("_"_s));


### PR DESCRIPTION
#### ee22b7c2c5321c4ec93cb0b5344d75e4ac3d1b0b
<pre>
Stop requiring a separate std::array static variable to use SortedArrayMap / SortedArraySet
<a href="https://bugs.webkit.org/show_bug.cgi?id=304770">https://bugs.webkit.org/show_bug.cgi?id=304770</a>

Reviewed by Darin Adler.

* Source/JavaScriptCore/inspector/scripts/codegen/generate_objc_protocol_type_conversions_header.py:
(ObjCProtocolTypeConversionsHeaderGenerator._generate_enum_from_protocol_string):
* Source/JavaScriptCore/inspector/scripts/tests/expected/command-targetType-matching-domain-debuggableType.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-async-attribute.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-optional-call-return-parameters.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/definitions-with-mac-platform.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/domain-debuggableTypes.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/domain-exposed-as-other-name.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/domain-targetType-matching-domain-debuggableType.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/domain-targetTypes.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/domains-with-varying-command-sizes.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/enum-values.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/event-targetType-matching-domain-debuggableType.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/events-with-optional-parameters.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/generate-domains-with-feature-guards.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/same-type-id-different-domain.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/shadowed-optional-type-setters.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/should-strip-comments.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-aliased-primitive-type.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-array-type.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-enum-type.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-object-type.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/type-requiring-runtime-casts.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/type-with-open-parameters.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/version.json-result:
* Source/WTF/wtf/SortedArrayMap.h:
(WTF::SortedArrayMap::array const):
(WTF::SortedArraySet::array const):
(WTF::N&gt;::SortedArrayMap):
(WTF::N&gt;::SortedArraySet):
* Source/WebCore/Modules/WebGPU/GPUAdapter.cpp:
(WebCore::convertFeatureNameToEnum):
* Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp:
(WebCore::ApplicationManifestParser::parseDir):
(WebCore::ApplicationManifestParser::parseDisplay):
(WebCore::ApplicationManifestParser::parseOrientation):
* Source/WebCore/Modules/mediacapabilities/MediaCapabilities.cpp:
(WebCore::isValidMediaMIMEType):
* Source/WebCore/Modules/mediasession/MediaSession.cpp:
(WebCore::platformCommandForMediaSessionAction):
* Source/WebCore/accessibility/atspi/AccessibilityAtspi.cpp:
(WebCore::AccessibilityAtspi::localizedRoleName):
(WebCore::Accessibility::createPlatformRoleMap):
(WebCore::RoleNameEntry&gt;&gt;): Deleted.
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(GenerateEnumerationImplementationContent):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp:
(WebCore::parseEnumerationFromString&lt;TestCallbackInterface::Enum&gt;):
* Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONEnum.cpp:
(WebCore::parseEnumerationFromString&lt;TestDefaultToJSONEnum&gt;):
* Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp:
(WebCore::parseEnumerationFromString&lt;TestObj::EnumType&gt;):
(WebCore::parseEnumerationFromString&lt;TestObj::EnumTrailingComma&gt;):
(WebCore::parseEnumerationFromString&lt;TestObj::Optional&gt;):
(WebCore::parseEnumerationFromString&lt;AlternateEnumName&gt;):
(WebCore::parseEnumerationFromString&lt;TestObj::EnumA&gt;):
(WebCore::parseEnumerationFromString&lt;TestObj::EnumB&gt;):
(WebCore::parseEnumerationFromString&lt;TestObj::EnumC&gt;):
(WebCore::parseEnumerationFromString&lt;TestObj::Kind&gt;):
(WebCore::parseEnumerationFromString&lt;TestObj::Size&gt;):
(WebCore::parseEnumerationFromString&lt;TestObj::Confidence&gt;):
(WebCore::parseEnumerationFromString&lt;TestObj::EnumWithMissingValueDefault&gt;):
(WebCore::parseEnumerationFromString&lt;TestObj::EnumWithInvalidValueDefault&gt;):
(WebCore::parseEnumerationFromString&lt;TestObj::EnumWithMissingAndInvalidValueDefault&gt;):
(WebCore::parseEnumerationFromString&lt;TestObj::EnumWithMissingValueDefaultNoQuotes&gt;):
(WebCore::parseEnumerationFromString&lt;TestObj::EnumWithMissingValueDefaultAsEmptyValue&gt;):
(WebCore::parseEnumerationFromString&lt;TestObj::EnumWithMissingValueDefaultNotInEnumValues&gt;):
* Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneDictionary.cpp:
(WebCore::parseEnumerationFromString&lt;TestStandaloneDictionary::EnumInStandaloneDictionaryFile&gt;):
* Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneEnumeration.cpp:
(WebCore::parseEnumerationFromString&lt;TestStandaloneEnumeration&gt;):
* Source/WebCore/css/calc/CSSCalcTree+Parser.cpp:
(WebCore::CSSCalc::lookupConstantNumber):
* Source/WebCore/css/parser/CSSAtRuleID.cpp:
(WebCore::cssAtRuleID):
* Source/WebCore/css/parser/CSSCustomPropertySyntax.cpp:
(WebCore::CSSCustomPropertySyntax::typeForTypeName):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+ColorInterpolationMethod.cpp:
(WebCore::CSSPropertyParserHelpers::consumeHueInterpolationMethod):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp:
(WebCore::CSSPropertyParserHelpers::consumePrefixedLinearGradient):
(WebCore::CSSPropertyParserHelpers::consumePrefixedRadialGradient):
(WebCore::CSSPropertyParserHelpers::consumeLinearGradient):
(WebCore::CSSPropertyParserHelpers::consumeRadialGradient):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Motion.cpp:
(WebCore::CSSPropertyParserHelpers::consumeRayFunction):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Shapes.cpp:
(WebCore::CSSPropertyParserHelpers::peekFillRule):
(WebCore::CSSPropertyParserHelpers::consumeRelativeControlPoint):
(WebCore::CSSPropertyParserHelpers::consumeCircleRadialSize):
(WebCore::CSSPropertyParserHelpers::consumeEllipseRadialSize):
(WebCore::CSSPropertyParserHelpers::consumeShapeCommandAffinity):
* Source/WebCore/html/Autofill.cpp:
(WebCore::AutofillFieldNameMapping&gt;&gt;): Deleted.
* Source/WebCore/html/EnterKeyHint.cpp:
(WebCore::enterKeyHintForAttributeValue):
* Source/WebCore/html/LinkRelAttribute.cpp:
(WebCore::LinkTypeDetails&gt;&gt;): Deleted.
* Source/WebCore/html/parser/HTMLPreloadScanner.cpp:
(WebCore::TokenPreloadScanner::tagIdFor):
* Source/WebCore/loader/MediaResourceLoader.cpp:
(WebCore::isManifestMIMEType):
* Source/WebCore/loader/soup/ResourceLoaderSoup.cpp:
(WebCore::contentTypeLookUpForKnownResource):
* Source/WebCore/mathml/MathMLPresentationElement.cpp:
(WebCore::MathMLPresentationElement::parseMathVariantAttribute):
* Source/WebCore/page/DebugPageOverlays.cpp:
(WebCore::NonFastScrollableRegionOverlay::drawRect):
* Source/WebCore/page/PerformanceUserTiming.cpp:
(WebCore::NavigationTimingFunction&gt;&gt;): Deleted.
* Source/WebCore/platform/KeyboardScrollingAnimator.cpp:
(WebCore::keyboardScrollingKeyForKeyboardEvent):
* Source/WebCore/platform/MIMETypeRegistry.cpp:
(WebCore::MIMETypeRegistry::supportedImageMIMETypes):
(WebCore::MIMETypeRegistry::supportedNonImageMIMETypes):
(WebCore::MIMETypeRegistry::pdfMIMETypes):
(WebCore::MIMETypeRegistry::unsupportedTextMIMETypes):
(WebCore::MIMETypeRegistry::isSupportedImageMIMEType):
(WebCore::MIMETypeRegistry::isSupportedJavaScriptMIMEType):
(WebCore::MIMETypeRegistry::isUnsupportedTextMIMEType):
(WebCore::MIMETypeRegistry::isPDFMIMEType):
(WebCore::MIMETypeRegistry::usdMIMETypes):
(WebCore::MIMETypeRegistry::gltfMIMETypes):
(WebCore::MIMETypeRegistry::isUSDMIMEType):
(WebCore::MIMETypeRegistry::isGLTFMIMEType):
(WebCore::normalizedImageMIMEType):
(WebCore::std::to_array&lt;ComparableCaseFoldingASCIILiteral&gt;): Deleted.
(WebCore::std::to_array&lt;ComparableLettersLiteral&gt;): Deleted.
* Source/WebCore/platform/audio/glib/MediaSessionGLib.cpp:
(WebCore::getCommand):
(WebCore::getMprisProperty):
* Source/WebCore/platform/cocoa/RemoteCommandListenerCocoa.mm:
(WebCore::mediaRemoteCommandForPlatformCommand):
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::hasValidAverageCharWidth const):
* Source/WebCore/platform/graphics/HEVCUtilities.cpp:
(WebCore::parseDoViCodecType):
(WebCore::profileIDForAlphabeticDoViProfile):
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::extensionName):
(WebCore::extensionEnum):
(WebCore::GCGLExtension&gt;&gt;): Deleted.
(WebCore::static_assert): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/AVAssetMIMETypeCache.mm:
(WebCore::AVAssetMIMETypeCache::isUnsupportedContainerType):
(WebCore::AVAssetMIMETypeCache::isStaticContainerType):
* Source/WebCore/platform/graphics/filters/FilterFunction.cpp:
(WebCore::FilterFunction::filterName):
* Source/WebCore/platform/network/mac/UTIUtilities.mm:
(WebCore::UTIFromPotentiallyUnknownMIMEType):
* Source/WebCore/platform/network/mac/WebCoreURLResponse.mm:
(WebCore::adjustMIMETypeIfNecessary):
* Source/WebCore/platform/text/LocaleToScriptMapping.cpp:
(WebCore::scriptNameToCode):
(WebCore::localeToScriptCode):
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::convertToFullSizeKana):
* Source/WebCore/rendering/mathml/MathVariant.cpp:
(WebCore::mathVariantMapCodePoint):
* Source/WebCore/svg/SVGComponentTransferFunctionElement.h:
(WebCore::SVGPropertyTraits&lt;ComponentTransferType&gt;::fromString):
* Source/WebCore/svg/SVGFECompositeElement.h:
(WebCore::SVGPropertyTraits&lt;CompositeOperationType&gt;::fromString):
* Source/WebDriver/WebDriverService.cpp:
(WebDriver::WebDriverService::toCommandHTTPMethod):
* Source/WebGPU/WGSL/Lexer.cpp:
(WGSL::Lexer&lt;T&gt;::nextToken):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/Types.h:
(WGSL::Types::PrimitiveStruct::FrexpResult::unsigned&gt;&gt;): Deleted.
(WGSL::Types::PrimitiveStruct::ModfResult::unsigned&gt;&gt;): Deleted.
(WGSL::Types::PrimitiveStruct::AtomicCompareExchangeResult::unsigned&gt;&gt;): Deleted.
* Source/WebGPU/WGSL/WGSLEnums.cpp:
* Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm:
(allowListedClassToString):
(shouldDumpSeparatedDetails):
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::commandNameForSelectorName):
* Tools/TestWebKitAPI/Tests/WTF/SortedArrayMap.cpp:
(TEST(WTF, SortedArraySet)):

Canonical link: <a href="https://commits.webkit.org/305000@main">https://commits.webkit.org/305000@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc2f788d5f9c879c0f846c19c2dc73d6acabdc37

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137129 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9489 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48416 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144875 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90102 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/80854567-84ce-4eaa-b158-a465bf91b60b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139001 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10192 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9616 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104867 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e2f0b1b1-dc1a-4bcc-b0cf-b90958f82bce) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140074 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7499 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122884 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85703 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7136 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4844 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5465 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/129090 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116486 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41050 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147631 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/135617 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9172 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41614 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113222 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9190 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7711 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113551 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28842 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7057 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119144 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63535 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9220 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37198 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/168396 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8944 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72786 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43953 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9161 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9013 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->