### PR TITLE
[JSC] Move MicrotaskQueue driving AsyncGenerator code to C++ and remove "WithoutPromise" variants

### DIFF
--- a/Source/JavaScriptCore/builtins/BuiltinNames.h
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.h
@@ -78,16 +78,11 @@ namespace JSC {
     macro(resolvePromise) \
     macro(rejectPromise) \
     macro(fulfillPromise) \
-    macro(resolveWithoutPromise) \
-    macro(rejectWithoutPromise) \
-    macro(fulfillWithoutPromise) \
     macro(resolvePromiseWithFirstResolvingFunctionCallCheck) \
     macro(rejectPromiseWithFirstResolvingFunctionCallCheck) \
     macro(fulfillPromiseWithFirstResolvingFunctionCallCheck) \
-    macro(resolveWithoutPromiseForAsyncAwait) \
     macro(resolveWithInternalMicrotaskForAsyncAwait) \
     macro(driveAsyncFunction) \
-    macro(awaitValue) \
     macro(newHandledRejectedPromise) \
     macro(promiseEmptyOnFulfilled) \
     macro(promiseEmptyOnRejected) \

--- a/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.cpp
+++ b/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.cpp
@@ -152,6 +152,10 @@ BytecodeIntrinsicRegistry::BytecodeIntrinsicRegistry(VM& vm)
     m_AsyncDisposableStackStateDisposed.set(m_vm, jsNumber(static_cast<int32_t>(JSAsyncDisposableStack::State::Disposed)));
     m_InternalMicrotaskAsyncFromSyncIteratorContinue.set(m_vm, jsNumber(static_cast<int32_t>(InternalMicrotask::AsyncFromSyncIteratorContinue)));
     m_InternalMicrotaskAsyncFromSyncIteratorDone.set(m_vm, jsNumber(static_cast<int32_t>(InternalMicrotask::AsyncFromSyncIteratorDone)));
+    m_InternalMicrotaskAsyncGeneratorYieldAwaited.set(m_vm, jsNumber(static_cast<int32_t>(InternalMicrotask::AsyncGeneratorYieldAwaited)));
+    m_InternalMicrotaskAsyncGeneratorBodyCallNormal.set(m_vm, jsNumber(static_cast<int32_t>(InternalMicrotask::AsyncGeneratorBodyCallNormal)));
+    m_InternalMicrotaskAsyncGeneratorBodyCallReturn.set(m_vm, jsNumber(static_cast<int32_t>(InternalMicrotask::AsyncGeneratorBodyCallReturn)));
+    m_InternalMicrotaskAsyncGeneratorResumeNext.set(m_vm, jsNumber(static_cast<int32_t>(InternalMicrotask::AsyncGeneratorResumeNext)));
 }
 
 std::optional<BytecodeIntrinsicRegistry::Entry> BytecodeIntrinsicRegistry::lookup(const Identifier& ident) const

--- a/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h
+++ b/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h
@@ -214,6 +214,10 @@ enum class LinkTimeConstant : int32_t;
     macro(AsyncDisposableStackStateDisposed) \
     macro(InternalMicrotaskAsyncFromSyncIteratorContinue) \
     macro(InternalMicrotaskAsyncFromSyncIteratorDone) \
+    macro(InternalMicrotaskAsyncGeneratorYieldAwaited) \
+    macro(InternalMicrotaskAsyncGeneratorBodyCallNormal) \
+    macro(InternalMicrotaskAsyncGeneratorBodyCallReturn) \
+    macro(InternalMicrotaskAsyncGeneratorResumeNext) \
 
 
 #define JSC_COMMON_BYTECODE_INTRINSIC_CONSTANTS_CUSTOM_EACH_NAME(macro) \

--- a/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
+++ b/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
@@ -59,16 +59,11 @@ class JSGlobalObject;
     v(resolvePromise, nullptr) \
     v(rejectPromise, nullptr) \
     v(fulfillPromise, nullptr) \
-    v(resolveWithoutPromise, nullptr) \
-    v(rejectWithoutPromise, nullptr) \
-    v(fulfillWithoutPromise, nullptr) \
     v(resolvePromiseWithFirstResolvingFunctionCallCheck, nullptr) \
     v(rejectPromiseWithFirstResolvingFunctionCallCheck, nullptr) \
     v(fulfillPromiseWithFirstResolvingFunctionCallCheck, nullptr) \
-    v(resolveWithoutPromiseForAsyncAwait, nullptr) \
     v(resolveWithInternalMicrotaskForAsyncAwait, nullptr) \
     v(driveAsyncFunction, nullptr) \
-    v(awaitValue, nullptr) \
     v(newHandledRejectedPromise, nullptr) \
     v(promiseEmptyOnFulfilled, nullptr) \
     v(promiseEmptyOnRejected, nullptr) \

--- a/Source/JavaScriptCore/runtime/CommonIdentifiers.h
+++ b/Source/JavaScriptCore/runtime/CommonIdentifiers.h
@@ -334,6 +334,7 @@
     macro(disposeAsync) \
     macro(keys) \
     macro(promise) \
+    macro(resumeMode) \
 
 #define JSC_COMMON_IDENTIFIERS_EACH_PRIVATE_FIELD(macro) \
     macro(constructor)

--- a/Source/JavaScriptCore/runtime/JSAsyncGenerator.h
+++ b/Source/JavaScriptCore/runtime/JSAsyncGenerator.h
@@ -82,6 +82,61 @@ public:
     static JSAsyncGenerator* create(VM&, Structure*);
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
+    int32_t state() const
+    {
+        return Base::internalField(static_cast<unsigned>(Field::State)).get().asInt32AsAnyInt();
+    }
+
+    void setState(VM& vm, int32_t state)
+    {
+        Base::internalField(static_cast<unsigned>(Field::State)).set(vm, this, jsNumber(state));
+    }
+
+    int32_t suspendReason() const
+    {
+        return Base::internalField(static_cast<unsigned>(Field::SuspendReason)).get().asInt32AsAnyInt();
+    }
+
+    void setSuspendReason(VM& vm, int32_t reason)
+    {
+        Base::internalField(static_cast<unsigned>(Field::SuspendReason)).set(vm, this, jsNumber(reason));
+    }
+
+    JSValue next() const
+    {
+        return Base::internalField(static_cast<unsigned>(Field::Next)).get();
+    }
+
+    JSValue thisValue() const
+    {
+        return Base::internalField(static_cast<unsigned>(Field::This)).get();
+    }
+
+    JSValue frame() const
+    {
+        return Base::internalField(static_cast<unsigned>(Field::Frame)).get();
+    }
+
+    JSValue queueFirst() const
+    {
+        return Base::internalField(static_cast<unsigned>(Field::QueueFirst)).get();
+    }
+
+    void setQueueFirst(VM& vm, JSValue value)
+    {
+        Base::internalField(static_cast<unsigned>(Field::QueueFirst)).set(vm, this, value);
+    }
+
+    JSValue queueLast() const
+    {
+        return Base::internalField(static_cast<unsigned>(Field::QueueLast)).get();
+    }
+
+    void setQueueLast(VM& vm, JSValue value)
+    {
+        Base::internalField(static_cast<unsigned>(Field::QueueLast)).set(vm, this, value);
+    }
+
     DECLARE_EXPORT_INFO;
 
     DECLARE_VISIT_CHILDREN;

--- a/Source/JavaScriptCore/runtime/JSFunctionWithFields.h
+++ b/Source/JavaScriptCore/runtime/JSFunctionWithFields.h
@@ -48,8 +48,8 @@ public:
 
         FirstResolvingPromise = 0,
 
-        ResolvingWithoutPromiseContext = 0,
-        ResolvingWithoutPromiseOther = 1,
+        ResolvingWithInternalMicrotaskContext = 0,
+        ResolvingWithInternalMicrotaskOther = 1,
 
         PromiseAllContext = 0,
         PromiseAllResolve = 1,

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -349,16 +349,11 @@ static JSC_DECLARE_HOST_FUNCTION(disableSuperSampler);
 static JSC_DECLARE_HOST_FUNCTION(resolvePromise);
 static JSC_DECLARE_HOST_FUNCTION(rejectPromise);
 static JSC_DECLARE_HOST_FUNCTION(fulfillPromise);
-static JSC_DECLARE_HOST_FUNCTION(resolveWithoutPromise);
-static JSC_DECLARE_HOST_FUNCTION(rejectWithoutPromise);
-static JSC_DECLARE_HOST_FUNCTION(fulfillWithoutPromise);
 static JSC_DECLARE_HOST_FUNCTION(resolvePromiseWithFirstResolvingFunctionCallCheck);
 static JSC_DECLARE_HOST_FUNCTION(rejectPromiseWithFirstResolvingFunctionCallCheck);
 static JSC_DECLARE_HOST_FUNCTION(fulfillPromiseWithFirstResolvingFunctionCallCheck);
-static JSC_DECLARE_HOST_FUNCTION(resolveWithoutPromiseForAsyncAwait);
 static JSC_DECLARE_HOST_FUNCTION(resolveWithInternalMicrotaskForAsyncAwait);
 static JSC_DECLARE_HOST_FUNCTION(driveAsyncFunction);
-static JSC_DECLARE_HOST_FUNCTION(awaitValue);
 static JSC_DECLARE_HOST_FUNCTION(newHandledRejectedPromise);
 static JSC_DECLARE_HOST_FUNCTION(promiseEmptyOnFulfilled);
 static JSC_DECLARE_HOST_FUNCTION(promiseEmptyOnRejected);
@@ -759,24 +754,6 @@ JSC_DEFINE_HOST_FUNCTION(fulfillPromise, (JSGlobalObject* globalObject, CallFram
     return encodedJSUndefined();
 }
 
-JSC_DEFINE_HOST_FUNCTION(resolveWithoutPromise, (JSGlobalObject* globalObject, CallFrame* callFrame))
-{
-    JSPromise::resolveWithoutPromise(globalObject, callFrame->uncheckedArgument(0), callFrame->uncheckedArgument(1), callFrame->uncheckedArgument(2), callFrame->uncheckedArgument(3));
-    return encodedJSUndefined();
-}
-
-JSC_DEFINE_HOST_FUNCTION(rejectWithoutPromise, (JSGlobalObject* globalObject, CallFrame* callFrame))
-{
-    JSPromise::rejectWithoutPromise(globalObject, callFrame->uncheckedArgument(0), callFrame->uncheckedArgument(1), callFrame->uncheckedArgument(2), callFrame->uncheckedArgument(3));
-    return encodedJSUndefined();
-}
-
-JSC_DEFINE_HOST_FUNCTION(fulfillWithoutPromise, (JSGlobalObject* globalObject, CallFrame* callFrame))
-{
-    JSPromise::fulfillWithoutPromise(globalObject, callFrame->uncheckedArgument(0), callFrame->uncheckedArgument(1), callFrame->uncheckedArgument(2), callFrame->uncheckedArgument(3));
-    return encodedJSUndefined();
-}
-
 JSC_DEFINE_HOST_FUNCTION(resolvePromiseWithFirstResolvingFunctionCallCheck, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     auto* promise = jsCast<JSPromise*>(callFrame->uncheckedArgument(0));
@@ -801,16 +778,6 @@ JSC_DEFINE_HOST_FUNCTION(fulfillPromiseWithFirstResolvingFunctionCallCheck, (JSG
     return encodedJSUndefined();
 }
 
-JSC_DEFINE_HOST_FUNCTION(resolveWithoutPromiseForAsyncAwait, (JSGlobalObject* globalObject, CallFrame* callFrame))
-{
-    JSValue resolution = callFrame->uncheckedArgument(0);
-    JSValue onFulfilled = callFrame->uncheckedArgument(1);
-    JSValue onRejected = callFrame->uncheckedArgument(2);
-    JSValue context = callFrame->uncheckedArgument(3);
-    JSPromise::resolveWithoutPromiseForAsyncAwait(globalObject, resolution, onFulfilled, onRejected, context);
-    return encodedJSUndefined();
-}
-
 JSC_DEFINE_HOST_FUNCTION(resolveWithInternalMicrotaskForAsyncAwait, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     JSValue resolution = callFrame->uncheckedArgument(0);
@@ -825,15 +792,6 @@ JSC_DEFINE_HOST_FUNCTION(driveAsyncFunction, (JSGlobalObject* globalObject, Call
     JSValue resolution = callFrame->uncheckedArgument(0);
     JSValue context = callFrame->uncheckedArgument(1);
     JSPromise::resolveWithInternalMicrotaskForAsyncAwait(globalObject, resolution, InternalMicrotask::AsyncFunctionResume, context);
-    return encodedJSUndefined();
-}
-
-JSC_DEFINE_HOST_FUNCTION(awaitValue, (JSGlobalObject* globalObject, CallFrame* callFrame))
-{
-    JSValue generator = callFrame->uncheckedArgument(0);
-    JSValue value = callFrame->uncheckedArgument(1);
-    JSValue onFulfilled = callFrame->uncheckedArgument(2);
-    JSPromise::resolveWithoutPromiseForAsyncAwait(globalObject, value, onFulfilled, globalObject->asyncGeneratorYieldOnRejectedFunction(), generator);
     return encodedJSUndefined();
 }
 
@@ -1879,15 +1837,6 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::fulfillPromise)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "fulfillPromise"_s, fulfillPromise, ImplementationVisibility::Private));
         });
-    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::resolveWithoutPromise)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 4, "resolveWithoutPromise"_s, resolveWithoutPromise, ImplementationVisibility::Private));
-        });
-    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::rejectWithoutPromise)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 4, "rejectWithoutPromise"_s, rejectWithoutPromise, ImplementationVisibility::Private));
-        });
-    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::fulfillWithoutPromise)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 4, "fulfillWithoutPromise"_s, fulfillWithoutPromise, ImplementationVisibility::Private));
-        });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::resolvePromiseWithFirstResolvingFunctionCallCheck)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "resolvePromiseWithFirstResolvingFunctionCallCheck"_s, resolvePromiseWithFirstResolvingFunctionCallCheck, ImplementationVisibility::Private, ResolvePromiseWithFirstResolvingFunctionCallCheckIntrinsic));
         });
@@ -1897,17 +1846,11 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::fulfillPromiseWithFirstResolvingFunctionCallCheck)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "fulfillPromiseWithFirstResolvingFunctionCallCheck"_s, fulfillPromiseWithFirstResolvingFunctionCallCheck, ImplementationVisibility::Private, FulfillPromiseWithFirstResolvingFunctionCallCheckIntrinsic));
         });
-    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::resolveWithoutPromiseForAsyncAwait)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 4, "resolveWithoutPromiseForAsyncAwait"_s, resolveWithoutPromiseForAsyncAwait, ImplementationVisibility::Private));
-        });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::resolveWithInternalMicrotaskForAsyncAwait)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 3, "resolveWithInternalMicrotaskForAsyncAwait"_s, resolveWithInternalMicrotaskForAsyncAwait, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::driveAsyncFunction)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 2, "driveAsyncFunction"_s, driveAsyncFunction, ImplementationVisibility::Private));
-        });
-    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::awaitValue)].initLater([] (const Initializer<JSCell>& init) {
-            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, "awaitValue"_s, awaitValue, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::newHandledRejectedPromise)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, "newHandledRejectedPromise"_s, newHandledRejectedPromise, ImplementationVisibility::Private));

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -748,7 +748,6 @@ public:
     JSFunction* parseIntFunction() const { return m_parseIntFunction.get(this); }
     JSFunction* parseFloatFunction() const { return m_parseFloatFunction.get(this); }
 
-    JSFunction* asyncGeneratorYieldOnRejectedFunction() const;
     JSFunction* promiseEmptyOnFulfilledFunction() const;
     JSFunction* promiseEmptyOnRejectedFunction() const;
     JSFunction* evalFunction() const;

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
@@ -215,7 +215,6 @@ ALWAYS_INLINE Structure* JSGlobalObject::arrayStructureForIndexingTypeDuringAllo
 inline JSFunction* JSGlobalObject::evalFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::evalFunction)); }
 inline JSFunction* JSGlobalObject::throwTypeErrorFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::throwTypeErrorFunction)); }
 inline JSFunction* JSGlobalObject::iteratorProtocolFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::performIteration)); }
-inline JSFunction* JSGlobalObject::asyncGeneratorYieldOnRejectedFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::asyncGeneratorYieldOnRejected)); }
 inline JSFunction* JSGlobalObject::promiseProtoThenFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::defaultPromiseThen)); }
 inline JSFunction* JSGlobalObject::promiseEmptyOnFulfilledFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::promiseEmptyOnFulfilled)); }
 inline JSFunction* JSGlobalObject::promiseEmptyOnRejectedFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::promiseEmptyOnRejected)); }

--- a/Source/JavaScriptCore/runtime/JSPromise.h
+++ b/Source/JavaScriptCore/runtime/JSPromise.h
@@ -134,11 +134,6 @@ public:
     void fulfillPromise(VM&, JSGlobalObject*, JSValue);
     void resolvePromise(JSGlobalObject*, JSValue);
 
-    static void resolveWithoutPromiseForAsyncAwait(JSGlobalObject*, JSValue resolution, JSValue onFulfilled, JSValue onRejected, JSValue context);
-    static void resolveWithoutPromise(JSGlobalObject*, JSValue resolution, JSValue onFulfilled, JSValue onRejected, JSValue context);
-    static void rejectWithoutPromise(JSGlobalObject*, JSValue argument, JSValue onFulfilled, JSValue onRejected, JSValue context);
-    static void fulfillWithoutPromise(JSGlobalObject*, JSValue argument, JSValue onFulfilled, JSValue onRejected, JSValue context);
-
     static void resolveWithInternalMicrotaskForAsyncAwait(JSGlobalObject*, JSValue resolution, InternalMicrotask, JSValue context);
     static void resolveWithInternalMicrotask(JSGlobalObject*, JSValue resolution, InternalMicrotask, JSValue context);
     static void rejectWithInternalMicrotask(JSGlobalObject*, JSValue argument, InternalMicrotask, JSValue context);
@@ -150,7 +145,6 @@ public:
 
     std::tuple<JSFunction*, JSFunction*> createResolvingFunctions(VM&, JSGlobalObject*);
     std::tuple<JSFunction*, JSFunction*> createFirstResolvingFunctions(VM&, JSGlobalObject*);
-    static std::tuple<JSFunction*, JSFunction*> createResolvingFunctionsWithoutPromise(VM&, JSGlobalObject*, JSValue onFulfilled, JSValue onRejected, JSValue context);
     static std::tuple<JSFunction*, JSFunction*> createResolvingFunctionsWithInternalMicrotask(VM&, JSGlobalObject*, InternalMicrotask, JSValue context);
     static std::tuple<JSObject*, JSObject*, JSObject*> newPromiseCapability(JSGlobalObject*, JSValue constructor);
     static JSValue createPromiseCapability(VM&, JSGlobalObject*, JSObject* promise, JSObject* resolve, JSObject* reject);
@@ -179,8 +173,8 @@ JSC_DECLARE_HOST_FUNCTION(promiseResolvingFunctionResolve);
 JSC_DECLARE_HOST_FUNCTION(promiseResolvingFunctionReject);
 JSC_DECLARE_HOST_FUNCTION(promiseFirstResolvingFunctionResolve);
 JSC_DECLARE_HOST_FUNCTION(promiseFirstResolvingFunctionReject);
-JSC_DECLARE_HOST_FUNCTION(promiseResolvingFunctionResolveWithoutPromise);
-JSC_DECLARE_HOST_FUNCTION(promiseResolvingFunctionRejectWithoutPromise);
+JSC_DECLARE_HOST_FUNCTION(promiseResolvingFunctionResolveWithInternalMicrotask);
+JSC_DECLARE_HOST_FUNCTION(promiseResolvingFunctionRejectWithInternalMicrotask);
 JSC_DECLARE_HOST_FUNCTION(promiseCapabilityExecutor);
 
 JSObject* promiseSpeciesConstructor(JSGlobalObject*, JSObject*);

--- a/Source/JavaScriptCore/runtime/Microtask.h
+++ b/Source/JavaScriptCore/runtime/Microtask.h
@@ -34,7 +34,6 @@ using MicrotaskIdentifier = ObjectIdentifier<MicrotaskIdentifierType>;
 
 enum class InternalMicrotask : uint16_t {
     PromiseResolveThenableJobFast = 0,
-    PromiseResolveThenableJobWithoutPromiseFast,
     PromiseResolveThenableJobWithInternalMicrotaskFast,
 
     PromiseResolveThenableJob,
@@ -49,11 +48,14 @@ enum class InternalMicrotask : uint16_t {
     InternalPromiseAllResolveJob,
 
     PromiseReactionJob,
-    PromiseReactionJobWithoutPromise,
 
     AsyncFunctionResume,
     AsyncFromSyncIteratorContinue,
     AsyncFromSyncIteratorDone,
+    AsyncGeneratorYieldAwaited,
+    AsyncGeneratorBodyCallNormal,
+    AsyncGeneratorBodyCallReturn,
+    AsyncGeneratorResumeNext,
 
     InvokeFunctionJob,
     Opaque, // Dispatch must handle everything.

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -1531,19 +1531,19 @@ NativeExecutable* VM::promiseFirstResolvingFunctionRejectExecutableSlow()
     return executable;
 }
 
-NativeExecutable* VM::promiseResolvingFunctionResolveWithoutPromiseExecutableSlow()
+NativeExecutable* VM::promiseResolvingFunctionResolveWithInternalMicrotaskExecutableSlow()
 {
-    ASSERT(!m_promiseResolvingFunctionResolveWithoutPromiseExecutable);
-    auto* executable = getHostFunction(promiseResolvingFunctionResolveWithoutPromise, ImplementationVisibility::Public, callHostFunctionAsConstructor, emptyString());
-    m_promiseResolvingFunctionResolveWithoutPromiseExecutable.setWithoutWriteBarrier(executable);
+    ASSERT(!m_promiseResolvingFunctionResolveWithInternalMicrotaskExecutable);
+    auto* executable = getHostFunction(promiseResolvingFunctionResolveWithInternalMicrotask, ImplementationVisibility::Public, callHostFunctionAsConstructor, emptyString());
+    m_promiseResolvingFunctionResolveWithInternalMicrotaskExecutable.setWithoutWriteBarrier(executable);
     return executable;
 }
 
-NativeExecutable* VM::promiseResolvingFunctionRejectWithoutPromiseExecutableSlow()
+NativeExecutable* VM::promiseResolvingFunctionRejectWithInternalMicrotaskExecutableSlow()
 {
-    ASSERT(!m_promiseResolvingFunctionRejectWithoutPromiseExecutable);
-    auto* executable = getHostFunction(promiseResolvingFunctionRejectWithoutPromise, ImplementationVisibility::Public, callHostFunctionAsConstructor, emptyString());
-    m_promiseResolvingFunctionRejectWithoutPromiseExecutable.setWithoutWriteBarrier(executable);
+    ASSERT(!m_promiseResolvingFunctionRejectWithInternalMicrotaskExecutable);
+    auto* executable = getHostFunction(promiseResolvingFunctionRejectWithInternalMicrotask, ImplementationVisibility::Public, callHostFunctionAsConstructor, emptyString());
+    m_promiseResolvingFunctionRejectWithInternalMicrotaskExecutable.setWithoutWriteBarrier(executable);
     return executable;
 }
 
@@ -1805,8 +1805,8 @@ void VM::visitAggregateImpl(Visitor& visitor)
     visitor.append(m_promiseResolvingFunctionRejectExecutable);
     visitor.append(m_promiseFirstResolvingFunctionResolveExecutable);
     visitor.append(m_promiseFirstResolvingFunctionRejectExecutable);
-    visitor.append(m_promiseResolvingFunctionResolveWithoutPromiseExecutable);
-    visitor.append(m_promiseResolvingFunctionRejectWithoutPromiseExecutable);
+    visitor.append(m_promiseResolvingFunctionResolveWithInternalMicrotaskExecutable);
+    visitor.append(m_promiseResolvingFunctionRejectWithInternalMicrotaskExecutable);
     visitor.append(m_promiseCapabilityExecutorExecutable);
     visitor.append(m_promiseAllFulfillFunctionExecutable);
     visitor.append(m_promiseAllSlowFulfillFunctionExecutable);

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -554,8 +554,8 @@ public:
     WriteBarrier<NativeExecutable> m_promiseResolvingFunctionRejectExecutable;
     WriteBarrier<NativeExecutable> m_promiseFirstResolvingFunctionResolveExecutable;
     WriteBarrier<NativeExecutable> m_promiseFirstResolvingFunctionRejectExecutable;
-    WriteBarrier<NativeExecutable> m_promiseResolvingFunctionResolveWithoutPromiseExecutable;
-    WriteBarrier<NativeExecutable> m_promiseResolvingFunctionRejectWithoutPromiseExecutable;
+    WriteBarrier<NativeExecutable> m_promiseResolvingFunctionResolveWithInternalMicrotaskExecutable;
+    WriteBarrier<NativeExecutable> m_promiseResolvingFunctionRejectWithInternalMicrotaskExecutable;
     WriteBarrier<NativeExecutable> m_promiseCapabilityExecutorExecutable;
     WriteBarrier<NativeExecutable> m_promiseAllFulfillFunctionExecutable;
     WriteBarrier<NativeExecutable> m_promiseAllSlowFulfillFunctionExecutable;
@@ -654,18 +654,18 @@ public:
         return promiseFirstResolvingFunctionRejectExecutableSlow();
     }
 
-    NativeExecutable* promiseResolvingFunctionResolveWithoutPromiseExecutable()
+    NativeExecutable* promiseResolvingFunctionResolveWithInternalMicrotaskExecutable()
     {
-        if (m_promiseResolvingFunctionResolveWithoutPromiseExecutable) [[likely]]
-            return m_promiseResolvingFunctionResolveWithoutPromiseExecutable.get();
-        return promiseResolvingFunctionResolveWithoutPromiseExecutableSlow();
+        if (m_promiseResolvingFunctionResolveWithInternalMicrotaskExecutable) [[likely]]
+            return m_promiseResolvingFunctionResolveWithInternalMicrotaskExecutable.get();
+        return promiseResolvingFunctionResolveWithInternalMicrotaskExecutableSlow();
     }
 
-    NativeExecutable* promiseResolvingFunctionRejectWithoutPromiseExecutable()
+    NativeExecutable* promiseResolvingFunctionRejectWithInternalMicrotaskExecutable()
     {
-        if (m_promiseResolvingFunctionRejectWithoutPromiseExecutable) [[likely]]
-            return m_promiseResolvingFunctionRejectWithoutPromiseExecutable.get();
-        return promiseResolvingFunctionRejectWithoutPromiseExecutableSlow();
+        if (m_promiseResolvingFunctionRejectWithInternalMicrotaskExecutable) [[likely]]
+            return m_promiseResolvingFunctionRejectWithInternalMicrotaskExecutable.get();
+        return promiseResolvingFunctionRejectWithInternalMicrotaskExecutableSlow();
     }
 
     NativeExecutable* promiseCapabilityExecutorExecutable()
@@ -1184,8 +1184,8 @@ private:
     NativeExecutable* promiseResolvingFunctionRejectExecutableSlow();
     NativeExecutable* promiseFirstResolvingFunctionResolveExecutableSlow();
     NativeExecutable* promiseFirstResolvingFunctionRejectExecutableSlow();
-    NativeExecutable* promiseResolvingFunctionResolveWithoutPromiseExecutableSlow();
-    NativeExecutable* promiseResolvingFunctionRejectWithoutPromiseExecutableSlow();
+    NativeExecutable* promiseResolvingFunctionResolveWithInternalMicrotaskExecutableSlow();
+    NativeExecutable* promiseResolvingFunctionRejectWithInternalMicrotaskExecutableSlow();
     NativeExecutable* promiseCapabilityExecutorExecutableSlow();
     NativeExecutable* promiseAllFulfillFunctionExecutableSlow();
     NativeExecutable* promiseAllSlowFulfillFunctionExecutableSlow();


### PR DESCRIPTION
#### c88ec0937ab27555a59e986679429f52f1c90b30
<pre>
[JSC] Move MicrotaskQueue driving AsyncGenerator code to C++ and remove &quot;WithoutPromise&quot; variants
<a href="https://bugs.webkit.org/show_bug.cgi?id=304772">https://bugs.webkit.org/show_bug.cgi?id=304772</a>
<a href="https://rdar.apple.com/167318733">rdar://167318733</a>

Reviewed by Sosuke Suzuki.

This patch adds MicrotaskQueue driving AsyncGenerator code in C++. But
importantly, we still keep JS version of that. The reason is that these
code can be called synchronously from `next()` call of AsyncGenerator,
and in this case, keeping them in JS is better for performance when it
is calling AsyncGenerator&apos;s body function. This also simplifies JS side
of AsyncGenerator code: we can inline `doAsyncGeneratorBodyCall` into
`asyncGeneratorResumeNext`.

As a result, we no longer need any &quot;WithoutPromise&quot; variants of
JSPromise related functions. We remove them since they can be replaced
with InternalMicrotask version instead.

* Source/JavaScriptCore/builtins/AsyncGeneratorPrototype.js:
(linkTimeConstant.asyncGeneratorResumeNext):
(linkTimeConstant.asyncGeneratorYieldAwaited): Deleted.
(linkTimeConstant.asyncGeneratorYieldOnRejected): Deleted.
(linkTimeConstant.asyncGeneratorYield):
(linkTimeConstant.doAsyncGeneratorBodyCallOnFulfilledNormal): Deleted.
(linkTimeConstant.doAsyncGeneratorBodyCallOnFulfilledReturn): Deleted.
(linkTimeConstant.doAsyncGeneratorBodyCall):
(linkTimeConstant.asyncGeneratorResumeNextOnFulfilled): Deleted.
(linkTimeConstant.asyncGeneratorResumeNextOnRejected): Deleted.
* Source/JavaScriptCore/builtins/BuiltinNames.h:
* Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.cpp:
(JSC::BytecodeIntrinsicRegistry::BytecodeIntrinsicRegistry):
* Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h:
* Source/JavaScriptCore/bytecode/LinkTimeConstant.h:
* Source/JavaScriptCore/runtime/CommonIdentifiers.h:
* Source/JavaScriptCore/runtime/JSAsyncGenerator.h:
* Source/JavaScriptCore/runtime/JSFunctionWithFields.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
* Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h:
(JSC::JSGlobalObject::iteratorProtocolFunction const):
(JSC::JSGlobalObject::asyncGeneratorYieldOnRejectedFunction const): Deleted.
* Source/JavaScriptCore/runtime/JSMicrotask.cpp:
(JSC::asyncGeneratorQueueIsEmpty):
(JSC::asyncGeneratorQueueDequeue):
(JSC::isSuspendYieldState):
(JSC::asyncGeneratorReject):
(JSC::asyncGeneratorResolve):
(JSC::asyncGeneratorYield):
(JSC::doAsyncGeneratorBodyCall):
(JSC::asyncGeneratorResumeNext):
(JSC::asyncGeneratorYieldAwaited):
(JSC::asyncGeneratorBodyCallNormal):
(JSC::asyncGeneratorBodyCallReturn):
(JSC::asyncGeneratorResumeNextReturn):
(JSC::runInternalMicrotask):
(JSC::promiseResolveThenableJobWithoutPromiseFastSlow): Deleted.
* Source/JavaScriptCore/runtime/JSPromise.cpp:
(JSC::JSPromise::performPromiseThen):
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::JSPromise::triggerPromiseReactions):
(JSC::JSPromise::resolveWithoutPromiseForAsyncAwait): Deleted.
(JSC::JSPromise::resolveWithoutPromise): Deleted.
(JSC::JSPromise::rejectWithoutPromise): Deleted.
(JSC::JSPromise::fulfillWithoutPromise): Deleted.
* Source/JavaScriptCore/runtime/JSPromise.h:
* Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp:
(JSC::promiseRaceSlow):
* Source/JavaScriptCore/runtime/Microtask.h:
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::promiseResolvingFunctionResolveWithInternalMicrotaskExecutableSlow):
(JSC::VM::promiseResolvingFunctionRejectWithInternalMicrotaskExecutableSlow):
(JSC::VM::visitAggregateImpl):
(JSC::VM::promiseResolvingFunctionResolveWithoutPromiseExecutableSlow): Deleted.
(JSC::VM::promiseResolvingFunctionRejectWithoutPromiseExecutableSlow): Deleted.
* Source/JavaScriptCore/runtime/VM.h:
(JSC::VM::promiseResolvingFunctionResolveWithInternalMicrotaskExecutable):
(JSC::VM::promiseResolvingFunctionRejectWithInternalMicrotaskExecutable):
(JSC::VM::promiseResolvingFunctionResolveWithoutPromiseExecutable): Deleted.
(JSC::VM::promiseResolvingFunctionRejectWithoutPromiseExecutable): Deleted.

Canonical link: <a href="https://commits.webkit.org/304998@main">https://commits.webkit.org/304998@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57f75b2d008f67e29474eb5c5eb04a8ca3078099

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137143 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9503 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48430 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144889 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90116 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7d0812e9-43f2-4e4c-afda-a892acdf5c21) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10206 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9630 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104875 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3ca6f94e-99b8-4db2-8487-a25f7bc398b6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140088 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7510 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/122898 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85713 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8d406da3-2be0-4859-a4dc-a75942c73982) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7147 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4858 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5479 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/129104 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116498 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41065 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147645 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/135632 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9186 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41628 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113233 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9204 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7726 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113563 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7068 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119158 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63563 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21131 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9234 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37212 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/168411 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8958 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72800 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43957 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9175 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9027 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->