### PR TITLE
stroke-dasharray applied to markers and cannot be overriden by ="0"

### DIFF
--- a/LayoutTests/svg/custom/marker-stroke-dasharray-none-zero-expected.svg
+++ b/LayoutTests/svg/custom/marker-stroke-dasharray-none-zero-expected.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" overflow="visible">
+  <defs>
+    <marker id="my-marker-workaround" orient="auto" stroke-dasharray="1,0" overflow="visible" markerUnits="userSpaceOnUse" >
+      <path stroke="black" fill="white" d="M 0 -5 -10 0 0 5 z"></path>
+    </marker>
+  </defs>
+
+  <g transform="scale(2,2)">
+    <path d="M 50 20 200 20" stroke="black" stroke-width="2" stroke-dasharray="5,5" marker-start="url(#my-marker-workaround)" />
+  </g>
+</svg>

--- a/LayoutTests/svg/custom/marker-stroke-dasharray-none-zero.svg
+++ b/LayoutTests/svg/custom/marker-stroke-dasharray-none-zero.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" overflow="visible">
+<meta name="fuzzy" content="maxDifference=44-255; totalPixels=2-121" />
+  <defs>
+    <marker id="my-marker" orient="auto" overflow="visible" markerUnits="userSpaceOnUse" >
+      <path stroke="black" fill="white" d="M 0 -5 -10 0 0 5 z"></path>
+    </marker>
+  </defs>
+
+  <g transform="scale(2,2)">
+    <path d="M 50 20 200 20" stroke="black" stroke-width="2" stroke-dasharray="5,5" marker-start="url(#my-marker)" />
+  </g>
+</svg>

--- a/Source/WebCore/rendering/svg/RenderSVGPath.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGPath.cpp
@@ -234,6 +234,7 @@ void RenderSVGPath::drawMarkers(PaintInfo& paintInfo)
             auto& context = paintInfo.context();
             GraphicsContextStateSaver stateSaver(context);
 
+            context.setLineDash(DashArray(), 0);
             auto contentTransform = marker->markerTransformation(markerPosition.origin, markerPosition.angle, strokeWidth);
             marker->checkedLayer()->paintSVGResourceLayer(context, contentTransform);
         }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp
@@ -253,8 +253,13 @@ void LegacyRenderSVGPath::drawMarkers(PaintInfo& paintInfo)
     float strokeWidth = this->strokeWidth();
     unsigned size = m_markerPositions.size();
     for (unsigned i = 0; i < size; ++i) {
-        if (auto* marker = markerForType(m_markerPositions[i].type, markerStart, markerMid, markerEnd))
+        if (auto* marker = markerForType(m_markerPositions[i].type, markerStart, markerMid, markerEnd)) {
+            auto& context = paintInfo.context();
+            GraphicsContextStateSaver stateSaver(context);
+
+            context.setLineDash(DashArray(), 0);
             marker->draw(paintInfo, marker->markerTransformation(m_markerPositions[i].origin, m_markerPositions[i].angle, strokeWidth));
+        }
     }
 }
 


### PR DESCRIPTION
#### c948de8983c3153c7f57a6b5f81042b62fa7d1dc
<pre>
stroke-dasharray applied to markers and cannot be overriden by =&quot;0&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=192539">https://bugs.webkit.org/show_bug.cgi?id=192539</a>
<a href="https://rdar.apple.com/46607685">rdar://46607685</a>

Reviewed by Nikolas Zimmermann.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium. Further,
this fixes issue for both LegacySVG and Layer Based SVG Engine (LBSE).

SVG markers were inheriting stroke-dasharray from their parent elements,
causing dashed strokes to appear on marker content even when explicitly
set to &quot;0&quot; or &quot;none&quot;. This occurred because the marker rendering context
was not properly resetting the dash array state before painting.

The original issue is stroke-dasharray should not propagate into marker
content unless explicitly set on elements within the marker definition.

This change ensures that when rendering markers, we reset the stroke
dash array to empty before painting marker content, allowing marker-
specific stroke-dasharray values (including &quot;0&quot;) to be applied correctly
without inheriting from the parent path or shape.

* Source/WebCore/rendering/svg/RenderSVGPath.cpp:
(WebCore::RenderSVGPath::drawMarkers):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp:
(WebCore::LegacyRenderSVGPath::drawMarkers):
* LayoutTests/svg/custom/marker-stroke-dasharray-none-zero.svg: Added.
* LayoutTests/svg/custom/marker-stroke-dasharray-none-zero-expected.svg: Added.
(Added fuzziness in test due to Skia vs CG + known issue in CG of corner
missing - which was leading to difference)

Canonical link: <a href="https://commits.webkit.org/305042@main">https://commits.webkit.org/305042@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38455c9e2ef2ea29b0dc6fd2bcd558ff5b7690b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137135 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9495 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48422 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144881 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90108 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b97cf898-8092-4fd7-a1fb-a59a5f05662e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139007 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10198 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9622 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104871 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2e5c481d-3609-494d-92b3-bbf9a74f6549) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140080 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7503 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122887 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85708 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c72b4b2b-887a-46da-be75-92c950681737) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7140 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4848 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5471 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116491 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41054 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147637 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9178 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41617 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113227 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9196 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7716 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113556 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28868 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7062 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119147 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63554 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9226 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37201 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8950 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72792 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9167 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9019 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->