### PR TITLE
Reduce unsafe member variables in AXSearchManager

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -1,5 +1,4 @@
 Modules/mediastream/libwebrtc/LibWebRTCObservers.h
-accessibility/AXSearchManager.h
 bindings/js/JSEventTargetCustom.h
 bindings/js/JSLazyEventListener.cpp
 css/CSSPrimitiveValue.h

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -416,8 +416,8 @@ TextStream& operator<<(TextStream& stream, const AccessibilitySearchCriteria& cr
     };
 
     stream << "SearchCriteria " << &criteria;
-    streamCriteriaObject("anchorObject"_s, criteria.anchorObject);
-    streamCriteriaObject("startObject"_s, criteria.startObject);
+    streamCriteriaObject("anchorObject"_s, criteria.anchorObject.get());
+    streamCriteriaObject("startObject"_s, criteria.startObject.get());
     stream.dumpProperty("searchDirection"_s, criteria.searchDirection);
 
     stream.nextLine();

--- a/Source/WebCore/accessibility/AXSearchManager.cpp
+++ b/Source/WebCore/accessibility/AXSearchManager.cpp
@@ -142,7 +142,7 @@ bool AXSearchManager::matchForSearchKeyAtIndex(Ref<AXCoreObject> axObject, const
     case AccessibilitySearchKey::PlainText:
         return axObject->hasPlainText();
     case AccessibilitySearchKey::RadioGroup:
-        return axObject->isRadioGroup() || isRadioButtonInDifferentAdhocGroup(axObject, criteria.startObject);
+        return axObject->isRadioGroup() || isRadioButtonInDifferentAdhocGroup(axObject, criteria.startObject.get());
     case AccessibilitySearchKey::SameType:
         return criteria.startObject
             && axObject->role() == criteria.startObject->role();
@@ -382,9 +382,9 @@ AXCoreObject::AccessibilityChildrenVector AXSearchManager::findMatchingObjectsIn
     // It does this by stepping up the parent chain and at each level doing a DFS.
 
     // If there's no start object, it means we want to search everything.
-    RefPtr<AXCoreObject> startObject = criteria.startObject;
+    RefPtr startObject = criteria.startObject.get();
     if (!startObject)
-        startObject = criteria.anchorObject;
+        startObject = criteria.anchorObject.get();
 
     bool isForward = criteria.searchDirection == AccessibilitySearchDirection::Next;
 
@@ -392,7 +392,7 @@ AXCoreObject::AccessibilityChildrenVector AXSearchManager::findMatchingObjectsIn
     // iterating backwards, the start object children should not be considered, so the loop is skipped ahead. We make an
     // exception when no start object was specified because we want to search everything regardless of search direction.
     RefPtr<AXCoreObject> previousObject;
-    if (!isForward && startObject != criteria.anchorObject) {
+    if (!isForward && startObject != criteria.anchorObject.get()) {
         previousObject = startObject;
         startObject = startObject->crossFrameParentObjectUnignored();
     }
@@ -406,7 +406,7 @@ AXCoreObject::AccessibilityChildrenVector AXSearchManager::findMatchingObjectsIn
         // Only append the children after/before the previous element, so that the search does not check elements that are
         // already behind/ahead of start element.
         AXCoreObject::AccessibilityChildrenVector searchStack;
-        if (!criteria.immediateDescendantsOnly || startObject == criteria.anchorObject)
+        if (!criteria.immediateDescendantsOnly || startObject == criteria.anchorObject.get())
             appendChildrenToArray(*startObject, isForward, previousObject, searchStack);
 
         // This now does a DFS at the current level of the parent.
@@ -426,7 +426,7 @@ AXCoreObject::AccessibilityChildrenVector AXSearchManager::findMatchingObjectsIn
             break;
 
         // When moving backwards, the parent object needs to be checked, because technically it's "before" the starting element.
-        if (!isForward && startObject != criteria.anchorObject && matchWithResultsLimit(*startObject, criteria, results))
+        if (!isForward && startObject != criteria.anchorObject.get() && matchWithResultsLimit(*startObject, criteria, results))
             break;
 
         previousObject = startObject;
@@ -448,9 +448,9 @@ std::optional<AXTextMarkerRange> AXSearchManager::findMatchingRange(Accessibilit
     }
 
     // If there's no start object, it means we want to search everything.
-    RefPtr startObject = criteria.startObject;
+    RefPtr startObject = criteria.startObject.get();
     if (!startObject)
-        startObject = criteria.anchorObject;
+        startObject = criteria.anchorObject.get();
     AXLOG(startObject);
 
     bool forward = criteria.searchDirection == AccessibilitySearchDirection::Next;

--- a/Source/WebCore/accessibility/AXSearchManager.h
+++ b/Source/WebCore/accessibility/AXSearchManager.h
@@ -27,6 +27,7 @@
 #include "AXCoreObject.h"
 #include <wtf/HashMap.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
@@ -78,8 +79,8 @@ enum class AccessibilitySearchKey {
 
 struct AccessibilitySearchCriteria {
     // FIXME: change the object pointers to object IDs.
-    AXCoreObject* anchorObject { nullptr };
-    AXCoreObject* startObject { nullptr };
+    WeakPtr<AXCoreObject> anchorObject { nullptr };
+    WeakPtr<AXCoreObject> startObject { nullptr };
     CharacterRange startRange;
     AccessibilitySearchDirection searchDirection { AccessibilitySearchDirection::Next };
     Vector<AccessibilitySearchKey> searchKeys;


### PR DESCRIPTION
#### 22335091403cdc31e9fc5a23ea30b55902bfc777
<pre>
Reduce unsafe member variables in AXSearchManager
<a href="https://bugs.webkit.org/show_bug.cgi?id=304774">https://bugs.webkit.org/show_bug.cgi?id=304774</a>

Reviewed by Tyler Wilcock.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

Canonical link: <a href="https://commits.webkit.org/305004@main">https://commits.webkit.org/305004@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb6f3649bf102b52591a2ef4f28e8bd00590edbb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137146 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9506 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48433 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144892 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90119 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e2466be8-8b2a-47ec-aaf2-032eab5f80c1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139018 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10209 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9633 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104877 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ada9a0a1-ad39-4e71-9ced-5bebe45ad404) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140091 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7513 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122899 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85716 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/623dabfe-834d-449a-9be0-db0bccdeab89) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7150 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4857 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5482 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116501 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41066 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147648 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9189 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41629 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113235 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9207 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7725 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113565 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7071 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119159 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63566 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21134 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9237 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37213 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8961 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72803 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9178 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9030 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->