### PR TITLE
Reduce unsafe member variables in WebCore filters code

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -22,10 +22,6 @@ layout/formattingContexts/inline/InlineItemsBuilder.h
 [ iOS ] page/ios/ContentChangeObserver.h
 platform/PODInterval.h
 [ iOS ] platform/audio/ios/AudioSessionIOS.mm
-platform/graphics/filters/software/FEConvolveMatrixSoftwareApplier.h
-platform/graphics/filters/software/FELightingSoftwareApplier.h
-platform/graphics/filters/software/FEMorphologySoftwareApplier.h
-platform/graphics/filters/software/FETurbulenceSoftwareApplier.h
 [ iOS ] platform/graphics/ios/DisplayRefreshMonitorIOS.mm
 [ iOS ] platform/ios/wak/WAKWindow.h
 rendering/PaintInfo.h

--- a/Source/WebCore/platform/graphics/PixelBuffer.h
+++ b/Source/WebCore/platform/graphics/PixelBuffer.h
@@ -29,7 +29,7 @@
 #include <WebCore/PixelBufferFormat.h>
 #include <optional>
 #include <span>
-#include <wtf/RefCounted.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 
 namespace WTF {
 class TextStream;
@@ -39,7 +39,7 @@ namespace WebCore {
 
 // Type for holding pixel buffers data.
 // For functions that source pixel buffers, see PixelBufferSourceView.
-class PixelBuffer : public RefCounted<PixelBuffer> {
+class PixelBuffer : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<PixelBuffer> {
     WTF_MAKE_NONCOPYABLE(PixelBuffer);
 public:
     static constexpr uint32_t bytesPerPixelComponent(PixelFormat);

--- a/Source/WebCore/platform/graphics/filters/FilterImage.h
+++ b/Source/WebCore/platform/graphics/filters/FilterImage.h
@@ -31,7 +31,7 @@
 #include <WebCore/IntRect.h>
 #include <WebCore/PixelBuffer.h>
 #include <WebCore/RenderingMode.h>
-#include <wtf/RefCounted.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/Vector.h>
 
 #if USE(CORE_IMAGE)
@@ -50,7 +50,7 @@ namespace WebCore {
 class Filter;
 class FloatRect;
 
-class FilterImage : public RefCounted<FilterImage> {
+class FilterImage : public RefCountedAndCanMakeWeakPtr<FilterImage> {
 public:
     static RefPtr<FilterImage> create(const FloatRect& primitiveSubregion, const FloatRect& imageRect, const IntRect& absoluteImageRect, bool isAlphaImage, bool isValidPremultiplied, RenderingMode, const DestinationColorSpace&, ImageBufferAllocator&);
     static RefPtr<FilterImage> create(const FloatRect& primitiveSubregion, const FloatRect& imageRect, const IntRect& absoluteImageRect, Ref<ImageBuffer>&&, ImageBufferAllocator&);

--- a/Source/WebCore/platform/graphics/filters/LightSource.h
+++ b/Source/WebCore/platform/graphics/filters/LightSource.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #include <WebCore/FloatPoint3D.h>
-#include <wtf/RefCounted.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 
 namespace WTF {
 class TextStream;
@@ -43,7 +43,7 @@ enum class LightType : uint8_t {
 class Filter;
 class FilterImage;
 
-class LightSource : public RefCounted<LightSource> {
+class LightSource : public RefCountedAndCanMakeWeakPtr<LightSource> {
 public:
     struct ComputedLightingData {
         FloatPoint3D lightVector;

--- a/Source/WebCore/platform/graphics/filters/software/FEConvolveMatrixSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEConvolveMatrixSoftwareApplier.cpp
@@ -167,6 +167,8 @@ inline void FEConvolveMatrixSoftwareApplier::setInteriorPixels(PaintingData& pai
     pixel += (clipBottom - yEnd) * (xIncrease + (clipRight + 1) * 4);
     int startKernelPixel = (clipBottom - yEnd) * (xIncrease + (clipRight + 1) * 4);
 
+    Ref sourcePixelBuffer = paintingData.sourcePixelBuffer.get();
+    Ref destinationPixelBuffer = paintingData.destinationPixelBuffer.get();
     for (int y = yEnd + 1; y > yStart; --y) {
         for (int x = clipRight + 1; x > 0; --x) {
             int kernelValue = paintingData.kernelMatrix.size() - 1;
@@ -179,11 +181,11 @@ inline void FEConvolveMatrixSoftwareApplier::setInteriorPixels(PaintingData& pai
             totals[3] = 0;
 
             while (kernelValue >= 0) {
-                totals[0] += paintingData.kernelMatrix[kernelValue] * static_cast<float>(paintingData.sourcePixelBuffer.item(kernelPixel++));
-                totals[1] += paintingData.kernelMatrix[kernelValue] * static_cast<float>(paintingData.sourcePixelBuffer.item(kernelPixel++));
-                totals[2] += paintingData.kernelMatrix[kernelValue] * static_cast<float>(paintingData.sourcePixelBuffer.item(kernelPixel++));
+                totals[0] += paintingData.kernelMatrix[kernelValue] * static_cast<float>(sourcePixelBuffer->item(kernelPixel++));
+                totals[1] += paintingData.kernelMatrix[kernelValue] * static_cast<float>(sourcePixelBuffer->item(kernelPixel++));
+                totals[2] += paintingData.kernelMatrix[kernelValue] * static_cast<float>(sourcePixelBuffer->item(kernelPixel++));
                 if (!paintingData.preserveAlpha)
-                    totals[3] += paintingData.kernelMatrix[kernelValue] * static_cast<float>(paintingData.sourcePixelBuffer.item(kernelPixel));
+                    totals[3] += paintingData.kernelMatrix[kernelValue] * static_cast<float>(sourcePixelBuffer->item(kernelPixel));
                 ++kernelPixel;
                 --kernelValue;
                 if (!--width) {
@@ -192,7 +194,7 @@ inline void FEConvolveMatrixSoftwareApplier::setInteriorPixels(PaintingData& pai
                 }
             }
 
-            setDestinationPixels(paintingData.sourcePixelBuffer, paintingData.destinationPixelBuffer, pixel, std::span { totals }, paintingData.divisor, paintingData.bias, paintingData.preserveAlpha);
+            setDestinationPixels(sourcePixelBuffer, destinationPixelBuffer, pixel, std::span { totals }, paintingData.divisor, paintingData.bias, paintingData.preserveAlpha);
             startKernelPixel += 4;
         }
         pixel += xIncrease;
@@ -216,6 +218,8 @@ inline void FEConvolveMatrixSoftwareApplier::setOuterPixels(PaintingData& painti
     // paintingData.divisor cannot be 0, SVGFEConvolveMatrixElement ensures this
     ASSERT(paintingData.divisor);
 
+    Ref sourcePixelBuffer = paintingData.sourcePixelBuffer.get();
+    Ref destinationPixelBuffer = paintingData.destinationPixelBuffer.get();
     for (int y = height; y > 0; --y) {
         for (int x = width; x > 0; --x) {
             int kernelValue = paintingData.kernelMatrix.size() - 1;
@@ -231,12 +235,12 @@ inline void FEConvolveMatrixSoftwareApplier::setOuterPixels(PaintingData& painti
             while (kernelValue >= 0) {
                 int pixelIndex = getPixelValue(paintingData, kernelPixelX, kernelPixelY);
                 if (pixelIndex >= 0) {
-                    totals[0] += paintingData.kernelMatrix[kernelValue] * static_cast<float>(paintingData.sourcePixelBuffer.item(pixelIndex));
-                    totals[1] += paintingData.kernelMatrix[kernelValue] * static_cast<float>(paintingData.sourcePixelBuffer.item(pixelIndex + 1));
-                    totals[2] += paintingData.kernelMatrix[kernelValue] * static_cast<float>(paintingData.sourcePixelBuffer.item(pixelIndex + 2));
+                    totals[0] += paintingData.kernelMatrix[kernelValue] * static_cast<float>(sourcePixelBuffer->item(pixelIndex));
+                    totals[1] += paintingData.kernelMatrix[kernelValue] * static_cast<float>(sourcePixelBuffer->item(pixelIndex + 1));
+                    totals[2] += paintingData.kernelMatrix[kernelValue] * static_cast<float>(sourcePixelBuffer->item(pixelIndex + 2));
                 }
                 if (!paintingData.preserveAlpha && pixelIndex >= 0)
-                    totals[3] += paintingData.kernelMatrix[kernelValue] * static_cast<float>(paintingData.sourcePixelBuffer.item(pixelIndex + 3));
+                    totals[3] += paintingData.kernelMatrix[kernelValue] * static_cast<float>(sourcePixelBuffer->item(pixelIndex + 3));
                 ++kernelPixelX;
                 --kernelValue;
                 if (!--width) {
@@ -246,7 +250,7 @@ inline void FEConvolveMatrixSoftwareApplier::setOuterPixels(PaintingData& painti
                 }
             }
 
-            setDestinationPixels(paintingData.sourcePixelBuffer, paintingData.destinationPixelBuffer, pixel, std::span { totals }, paintingData.divisor, paintingData.bias, paintingData.preserveAlpha);
+            setDestinationPixels(sourcePixelBuffer, destinationPixelBuffer, pixel, std::span { totals }, paintingData.divisor, paintingData.bias, paintingData.preserveAlpha);
             ++startKernelPixelX;
         }
         pixel += xIncrease;

--- a/Source/WebCore/platform/graphics/filters/software/FEConvolveMatrixSoftwareApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/FEConvolveMatrixSoftwareApplier.h
@@ -41,14 +41,14 @@ class FEConvolveMatrixSoftwareApplier final : public FilterEffectConcreteApplier
     using Base = FilterEffectConcreteApplier<FEConvolveMatrix>;
 
 public:
-    FEConvolveMatrixSoftwareApplier(const FEConvolveMatrix& effect);
+    explicit FEConvolveMatrixSoftwareApplier(const FEConvolveMatrix& effect);
 
 private:
     bool apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const final;
 
     struct PaintingData {
-        const PixelBuffer& sourcePixelBuffer;
-        PixelBuffer& destinationPixelBuffer;
+        ThreadSafeWeakRef<const PixelBuffer> sourcePixelBuffer;
+        ThreadSafeWeakRef<PixelBuffer> destinationPixelBuffer;
         int width;
         int height;
 

--- a/Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplier.cpp
@@ -94,12 +94,12 @@ void FELightingSoftwareApplier::setPixelInternal(int offset, const LightingData&
         static_cast<uint8_t>(lightStrength * lightingData.colorVector.z() * 255.0f)
     };
     
-    data.pixels->setRange({ pixelValue }, offset);
+    data.pixels.get()->setRange({ pixelValue }, offset);
 }
 
 void FELightingSoftwareApplier::setPixel(int offset, const LightingData& data, const LightSource::PaintingData& paintingData, int x, int y, float factorX, float factorY, IntSize normal2DVector)
 {
-    setPixelInternal(offset, data, paintingData, x, y, factorX, factorY, normal2DVector, data.pixels->item(offset + cAlphaChannelOffset));
+    setPixelInternal(offset, data, paintingData, x, y, factorX, factorY, normal2DVector, data.pixels.get()->item(offset + cAlphaChannelOffset));
 }
 
 void FELightingSoftwareApplier::applyPlatform(const LightingData& data) const
@@ -109,7 +109,7 @@ void FELightingSoftwareApplier::applyPlatform(const LightingData& data) const
     auto [r, g, b, a] = data.lightingColor.toResolvedColorComponentsInColorSpace(*data.operatingColorSpace);
     paintingData.initialLightingData.colorVector = FloatPoint3D(r, g, b);
 
-    data.lightSource->initPaintingData(Ref { *data.filter }, Ref { *data.result }, paintingData);
+    data.lightSource->initPaintingData(data.filter.get().releaseNonNull(), Ref { *data.result }, paintingData);
 
     // Top left.
     int offset = 0;
@@ -157,16 +157,17 @@ void FELightingSoftwareApplier::applyPlatform(const LightingData& data) const
     }
 
     int lastPixel = data.widthMultipliedByPixelSize * data.height;
+    Ref pixels = data.pixels.get().releaseNonNull();
     if (data.filterType == FilterEffect::Type::FEDiffuseLighting) {
         for (int i = cAlphaChannelOffset; i < lastPixel; i += cPixelSize)
-            data.pixels->set(i, cOpaqueAlpha);
+            pixels->set(i, cOpaqueAlpha);
     } else {
         for (int i = 0; i < lastPixel; i += cPixelSize) {
-            uint8_t a1 = data.pixels->item(i);
-            uint8_t a2 = data.pixels->item(i + 1);
-            uint8_t a3 = data.pixels->item(i + 2);
+            uint8_t a1 = pixels->item(i);
+            uint8_t a2 = pixels->item(i + 1);
+            uint8_t a3 = pixels->item(i + 2);
             // alpha set to set to max(a1, a2, a3)
-            data.pixels->set(i + 3, a1 >= a2 ? (a1 >= a3 ? a1 : a3) : (a2 >= a3 ? a2 : a3));
+            pixels->set(i + 3, a1 >= a2 ? (a1 >= a3 ? a1 : a3) : (a2 >= a3 ? a2 : a3));
         }
     }
 }

--- a/Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplier.h
@@ -92,18 +92,18 @@ protected:
 
     struct LightingData {
         // This structure contains only read-only (SMP safe) data
-        const Filter* filter;
-        const FilterImage* result;
+        ThreadSafeWeakPtr<const Filter> filter;
+        WeakPtr<const FilterImage> result;
         FilterEffect::Type filterType;
         Color lightingColor;
         float surfaceScale;
         float diffuseConstant;
         float specularConstant;
         float specularExponent;
-        const LightSource* lightSource;
+        WeakPtr<const LightSource> lightSource;
         const DestinationColorSpace* operatingColorSpace;
 
-        PixelBuffer* pixels;
+        ThreadSafeWeakPtr<PixelBuffer> pixels;
         int widthMultipliedByPixelSize;
         int width;
         int height;

--- a/Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplierInlines.h
+++ b/Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplierInlines.h
@@ -33,6 +33,7 @@ namespace WebCore {
 
 inline IntSize FELightingSoftwareApplier::LightingData::topLeftNormal(int offset) const
 {
+    Ref pixels = this->pixels.get().releaseNonNull();
     int center = static_cast<int>(pixels->item(offset + cAlphaChannelOffset));
     int right = static_cast<int>(pixels->item(offset + cPixelSize + cAlphaChannelOffset));
     offset += widthMultipliedByPixelSize;
@@ -46,6 +47,7 @@ inline IntSize FELightingSoftwareApplier::LightingData::topLeftNormal(int offset
 
 inline IntSize FELightingSoftwareApplier::LightingData::topRowNormal(int offset) const
 {
+    Ref pixels = this->pixels.get().releaseNonNull();
     int left = static_cast<int>(pixels->item(offset - cPixelSize + cAlphaChannelOffset));
     int center = static_cast<int>(pixels->item(offset + cAlphaChannelOffset));
     int right = static_cast<int>(pixels->item(offset + cPixelSize + cAlphaChannelOffset));
@@ -61,6 +63,7 @@ inline IntSize FELightingSoftwareApplier::LightingData::topRowNormal(int offset)
 
 inline IntSize FELightingSoftwareApplier::LightingData::topRightNormal(int offset) const
 {
+    Ref pixels = this->pixels.get().releaseNonNull();
     int left = static_cast<int>(pixels->item(offset - cPixelSize + cAlphaChannelOffset));
     int center = static_cast<int>(pixels->item(offset + cAlphaChannelOffset));
     offset += widthMultipliedByPixelSize;
@@ -74,6 +77,7 @@ inline IntSize FELightingSoftwareApplier::LightingData::topRightNormal(int offse
 
 inline IntSize FELightingSoftwareApplier::LightingData::leftColumnNormal(int offset) const
 {
+    Ref pixels = this->pixels.get().releaseNonNull();
     int center = static_cast<int>(pixels->item(offset + cAlphaChannelOffset));
     int right = static_cast<int>(pixels->item(offset + cPixelSize + cAlphaChannelOffset));
     offset -= widthMultipliedByPixelSize;
@@ -92,6 +96,7 @@ inline IntSize FELightingSoftwareApplier::LightingData::interiorNormal(int offse
 {
     int rightAlphaOffset = offset + cPixelSize + cAlphaChannelOffset;
 
+    Ref pixels = this->pixels.get().releaseNonNull();
     int right = static_cast<int>(pixels->item(rightAlphaOffset));
     int topRight = static_cast<int>(pixels->item(rightAlphaOffset - widthMultipliedByPixelSize));
     int bottomRight = static_cast<int>(pixels->item(rightAlphaOffset + widthMultipliedByPixelSize));
@@ -120,6 +125,7 @@ inline IntSize FELightingSoftwareApplier::LightingData::interiorNormal(int offse
 
 inline IntSize FELightingSoftwareApplier::LightingData::rightColumnNormal(int offset) const
 {
+    Ref pixels = this->pixels.get().releaseNonNull();
     int left = static_cast<int>(pixels->item(offset - cPixelSize + cAlphaChannelOffset));
     int center = static_cast<int>(pixels->item(offset + cAlphaChannelOffset));
     offset -= widthMultipliedByPixelSize;
@@ -136,6 +142,7 @@ inline IntSize FELightingSoftwareApplier::LightingData::rightColumnNormal(int of
 
 inline IntSize FELightingSoftwareApplier::LightingData::bottomLeftNormal(int offset) const
 {
+    Ref pixels = this->pixels.get().releaseNonNull();
     int center = static_cast<int>(pixels->item(offset + cAlphaChannelOffset));
     int right = static_cast<int>(pixels->item(offset + cPixelSize + cAlphaChannelOffset));
     offset -= widthMultipliedByPixelSize;
@@ -149,6 +156,7 @@ inline IntSize FELightingSoftwareApplier::LightingData::bottomLeftNormal(int off
 
 inline IntSize FELightingSoftwareApplier::LightingData::bottomRowNormal(int offset) const
 {
+    Ref pixels = this->pixels.get().releaseNonNull();
     int left = static_cast<int>(pixels->item(offset - cPixelSize + cAlphaChannelOffset));
     int center = static_cast<int>(pixels->item(offset + cAlphaChannelOffset));
     int right = static_cast<int>(pixels->item(offset + cPixelSize + cAlphaChannelOffset));
@@ -164,6 +172,7 @@ inline IntSize FELightingSoftwareApplier::LightingData::bottomRowNormal(int offs
 
 inline IntSize FELightingSoftwareApplier::LightingData::bottomRightNormal(int offset) const
 {
+    Ref pixels = this->pixels.get().releaseNonNull();
     int left = static_cast<int>(pixels->item(offset - cPixelSize + cAlphaChannelOffset));
     int center = static_cast<int>(pixels->item(offset + cAlphaChannelOffset));
     offset -= widthMultipliedByPixelSize;

--- a/Source/WebCore/platform/graphics/filters/software/FELightingSoftwareParallelApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FELightingSoftwareParallelApplier.cpp
@@ -45,6 +45,7 @@ void FELightingSoftwareParallelApplier::applyPlatformPaint(const LightingData& d
     ASSERT(startY);
     ASSERT(endY > startY);
 
+    Ref pixels = data.pixels.get().releaseNonNull();
     for (int y = startY; y < endY; ++y) {
         int rowStartOffset = y * data.widthMultipliedByPixelSize;
         int previousRowStart = rowStartOffset - data.widthMultipliedByPixelSize;
@@ -54,14 +55,14 @@ void FELightingSoftwareParallelApplier::applyPlatformPaint(const LightingData& d
         // Fill the two right columns putting the left edge value in the center column.
         // For each pixel, we shift each row left then fill the right column.
         AlphaWindow alphaWindow;
-        alphaWindow.setTop(data.pixels->item(previousRowStart + cAlphaChannelOffset));
-        alphaWindow.setTopRight(data.pixels->item(previousRowStart + cPixelSize + cAlphaChannelOffset));
+        alphaWindow.setTop(pixels->item(previousRowStart + cAlphaChannelOffset));
+        alphaWindow.setTopRight(pixels->item(previousRowStart + cPixelSize + cAlphaChannelOffset));
 
-        alphaWindow.setCenter(data.pixels->item(rowStartOffset + cAlphaChannelOffset));
-        alphaWindow.setRight(data.pixels->item(rowStartOffset + cPixelSize + cAlphaChannelOffset));
+        alphaWindow.setCenter(pixels->item(rowStartOffset + cAlphaChannelOffset));
+        alphaWindow.setRight(pixels->item(rowStartOffset + cPixelSize + cAlphaChannelOffset));
 
-        alphaWindow.setBottom(data.pixels->item(nextRowStart + cAlphaChannelOffset));
-        alphaWindow.setBottomRight(data.pixels->item(nextRowStart + cPixelSize + cAlphaChannelOffset));
+        alphaWindow.setBottom(pixels->item(nextRowStart + cAlphaChannelOffset));
+        alphaWindow.setBottomRight(pixels->item(nextRowStart + cPixelSize + cAlphaChannelOffset));
 
         int offset = rowStartOffset + cPixelSize;
         for (int x = 1; x < data.width - 1; ++x, offset += cPixelSize) {

--- a/Source/WebCore/platform/graphics/filters/software/FEMorphologySoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEMorphologySoftwareApplier.cpp
@@ -68,8 +68,8 @@ void FEMorphologySoftwareApplier::applyPlatformGeneric(const PaintingData& paint
 {
     ASSERT(endY > startY);
 
-    const auto& srcPixelBuffer = *paintingData.srcPixelBuffer;
-    auto& dstPixelBuffer = *paintingData.dstPixelBuffer;
+    Ref srcPixelBuffer = paintingData.srcPixelBuffer.get().releaseNonNull();
+    Ref dstPixelBuffer = paintingData.dstPixelBuffer.get().releaseNonNull();
 
     const int radiusX = paintingData.radiusX;
     const int radiusY = paintingData.radiusY;
@@ -100,7 +100,7 @@ void FEMorphologySoftwareApplier::applyPlatformGeneric(const PaintingData& paint
             if (x > radiusX)
                 extrema.removeAt(0);
 
-            unsigned& destPixel = reinterpretCastSpanStartTo<unsigned>(dstPixelBuffer.bytes().subspan(pixelArrayIndex(x, y, width)));
+            unsigned& destPixel = reinterpretCastSpanStartTo<unsigned>(dstPixelBuffer->bytes().subspan(pixelArrayIndex(x, y, width)));
             destPixel = makePixelValueFromColorComponents(kernelExtremum(extrema, paintingData.type)).value;
         }
     }

--- a/Source/WebCore/platform/graphics/filters/software/FEMorphologySoftwareApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/FEMorphologySoftwareApplier.h
@@ -28,6 +28,7 @@
 #include "PixelBuffer.h"
 #include <JavaScriptCore/Forward.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
@@ -50,8 +51,8 @@ private:
         MorphologyOperatorType type;
         int radiusX;
         int radiusY;
-        const PixelBuffer* srcPixelBuffer;
-        PixelBuffer* dstPixelBuffer;
+        ThreadSafeWeakPtr<const PixelBuffer> srcPixelBuffer;
+        ThreadSafeWeakPtr<PixelBuffer> dstPixelBuffer;
         int width;
         int height;
     };

--- a/Source/WebCore/platform/graphics/filters/software/FETurbulenceSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FETurbulenceSoftwareApplier.cpp
@@ -327,7 +327,7 @@ void FETurbulenceSoftwareApplier::applyPlatformGeneric(const IntRect& filterRegi
 
 void FETurbulenceSoftwareApplier::applyPlatformWorker(ApplyParameters* parameters)
 {
-    applyPlatformGeneric(parameters->filterRegion, parameters->filterScale, *parameters->pixelBuffer, *parameters->paintingData, parameters->stitchData, parameters->startY, parameters->endY);
+    applyPlatformGeneric(parameters->filterRegion, parameters->filterScale, parameters->pixelBuffer.get().releaseNonNull(), *parameters->paintingData, parameters->stitchData, parameters->startY, parameters->endY);
 }
 
 void FETurbulenceSoftwareApplier::applyPlatform(const IntRect& filterRegion, const FloatSize& filterScale, PixelBuffer& pixelBuffer, PaintingData& paintingData, StitchData& stitchData)

--- a/Source/WebCore/platform/graphics/filters/software/FETurbulenceSoftwareApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/FETurbulenceSoftwareApplier.h
@@ -31,6 +31,7 @@
 #include "PixelBuffer.h"
 #include <JavaScriptCore/Forward.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
@@ -78,7 +79,7 @@ private:
     struct ApplyParameters {
         IntRect filterRegion;
         FloatSize filterScale;
-        PixelBuffer* pixelBuffer;
+        ThreadSafeWeakPtr<PixelBuffer> pixelBuffer;
         PaintingData* paintingData;
         StitchData stitchData;
         int startY;


### PR DESCRIPTION
#### 1cfe387661f65f7d78ccfc797359c34a060f818d
<pre>
Reduce unsafe member variables in WebCore filters code
<a href="https://bugs.webkit.org/show_bug.cgi?id=304777">https://bugs.webkit.org/show_bug.cgi?id=304777</a>

Reviewed by NOBODY (OOPS!).

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1cfe387661f65f7d78ccfc797359c34a060f818d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137523 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9884 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48810 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145280 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90496 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/13686692-8d73-4012-9176-840e608c8ce8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139395 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10587 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10010 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105174 "Found 25 new test failures: css3/color-filters/svg/color-filter-inline-svg.html imported/mozilla/svg/filters/filter-kernelUnitLength-01.svg imported/w3c/web-platform-tests/css/filter-effects/tainting-fediffuselighting-001.html imported/w3c/web-platform-tests/css/filter-effects/tainting-fespecularlighting-001.html svg/dynamic-updates/SVGFEDiffuseLightingElement-dom-in-attr.html svg/dynamic-updates/SVGFEDiffuseLightingElement-svgdom-diffuseConstant-prop.html svg/dynamic-updates/SVGFEPointLightElement-svgdom-x-prop.html svg/dynamic-updates/SVGFESpotLightElement-dom-x-attr.html svg/dynamic-updates/SVGFESpotLightElement-svgdom-y-prop.html svg/dynamic-updates/SVGFilterElement-svgdom-y-prop.html ... (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76805 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Exiting early after 60 failures. 21474 tests run. 60 failures; Uploaded test results; layout-tests (exception)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5137944a-0488-4b9d-96c4-3e33b38a1788) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140468 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7855 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123253 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86025 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5b22c802-aaa0-4ab4-a420-268178331c86) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7491 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5210 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5862 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116861 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41408 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148044 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9566 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41963 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113556 "Found 20 new test failures: css3/color-filters/svg/color-filter-inline-svg.html imported/mozilla/svg/filters/filter-kernelUnitLength-01.svg imported/w3c/web-platform-tests/css/filter-effects/tainting-fediffuselighting-001.html imported/w3c/web-platform-tests/css/filter-effects/tainting-fespecularlighting-001.html svg/dynamic-updates/SVGFEDiffuseLightingElement-inherit-lighting-color-css-prop.html svg/dynamic-updates/SVGFilterElement-dom-filterRes-attr.html svg/dynamic-updates/SVGFilterElement-svgdom-y-prop.html svg/filters/feDiffuseLighting-fePointLight-primitiveUnits-objectBoundingBox.svg svg/filters/feDiffuseLighting-feSpotLight-dynamic-update.svg svg/filters/feDiffuseLighting-feSpotLight-primitiveUnits-objectBoundingBox.svg ... (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9584 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8063 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113897 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7411 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119492 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64213 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9615 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37545 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9346 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73180 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9555 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9407 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->