### PR TITLE
Make math-style and math-shift animate discretely

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
@@ -50,6 +50,12 @@ PASS list-style-type: "square" onto "circle"
 PASS list-style-type: "circle" onto "square"
 PASS math-depth (type: integer) has testAccumulation function
 PASS math-depth: integer
+PASS math-shift (type: discrete) has testAccumulation function
+PASS math-shift: "compact" onto "normal"
+PASS math-shift: "normal" onto "compact"
+PASS math-style (type: discrete) has testAccumulation function
+PASS math-style: "compact" onto "normal"
+PASS math-style: "normal" onto "compact"
 PASS marker-end (type: discrete) has testAccumulation function
 PASS marker-end: "url("http://localhost/test-2")" onto "url("http://localhost/test-1")"
 PASS marker-end: "url("http://localhost/test-1")" onto "url("http://localhost/test-2")"

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
@@ -50,6 +50,12 @@ PASS list-style-type: "square" onto "circle"
 PASS list-style-type: "circle" onto "square"
 PASS math-depth (type: integer) has testAddition function
 PASS math-depth: integer
+PASS math-shift (type: discrete) has testAddition function
+PASS math-shift: "compact" onto "normal"
+PASS math-shift: "normal" onto "compact"
+PASS math-style (type: discrete) has testAddition function
+PASS math-style: "compact" onto "normal"
+PASS math-style: "normal" onto "compact"
 PASS marker-end (type: discrete) has testAddition function
 PASS marker-end: "url("http://localhost/test-2")" onto "url("http://localhost/test-1")"
 PASS marker-end: "url("http://localhost/test-1")" onto "url("http://localhost/test-2")"

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
@@ -57,6 +57,14 @@ PASS list-style-type uses discrete animation when animating between "circle" and
 PASS list-style-type uses discrete animation when animating between "circle" and "square" with keyframe easing
 PASS math-depth (type: integer) has testInterpolation function
 PASS math-depth supports animating as an integer
+PASS math-shift (type: discrete) has testInterpolation function
+PASS math-shift uses discrete animation when animating between "normal" and "compact" with linear easing
+PASS math-shift uses discrete animation when animating between "normal" and "compact" with effect easing
+PASS math-shift uses discrete animation when animating between "normal" and "compact" with keyframe easing
+PASS math-style (type: discrete) has testInterpolation function
+PASS math-style uses discrete animation when animating between "normal" and "compact" with linear easing
+PASS math-style uses discrete animation when animating between "normal" and "compact" with effect easing
+PASS math-style uses discrete animation when animating between "normal" and "compact" with keyframe easing
 PASS marker-end (type: discrete) has testInterpolation function
 PASS marker-end uses discrete animation when animating between "url("http://localhost/test-1")" and "url("http://localhost/test-2")" with linear easing
 PASS marker-end uses discrete animation when animating between "url("http://localhost/test-1")" and "url("http://localhost/test-2")" with effect easing

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -6376,7 +6376,7 @@
             }
         },
         "math-shift": {
-            "animation-type": "not animatable",
+            "animation-type": "discrete",
             "inherited": true,
             "initial": "normal",
             "values": [
@@ -6395,7 +6395,7 @@
             }
         },
         "math-style": {
-            "animation-type": "not animatable",
+            "animation-type": "discrete",
             "inherited": true,
             "initial": "normal",
             "values": [


### PR DESCRIPTION
#### 162561d5f00f3a20d2d8efe5f633dfbccc8ed140
<pre>
Make math-style and math-shift animate discretely
<a href="https://bugs.webkit.org/show_bug.cgi?id=304779">https://bugs.webkit.org/show_bug.cgi?id=304779</a>

Reviewed by Tim Nguyen.

The MathML Core spec says that math-style and math-shift animate &quot;by
computed value type&quot;. Their values being keywords means that they will
combine as discrete: <a href="https://www.w3.org/TR/web-animations/#by-computed-value.">https://www.w3.org/TR/web-animations/#by-computed-value.</a>
Change animation type of math-style and math-shift to discrete.
Update expectations for math-* properties in animations tests.

* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt:
* Source/WebCore/css/CSSProperties.json:

Canonical link: <a href="https://commits.webkit.org/305017@main">https://commits.webkit.org/305017@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f52eae957fa32d1cf154511027417143763d0bb6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137210 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9570 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48497 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144959 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90183 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139082 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10273 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9697 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104931 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140155 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7575 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122964 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85772 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7212 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/4923 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5546 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116568 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41126 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147717 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9253 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41688 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113291 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9271 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/7786 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113622 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28853 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7132 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119218 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/63706 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9302 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37272 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9027 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72867 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9242 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9094 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->