### PR TITLE
Resync `web-animations` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -13464,6 +13464,7 @@
         "web-platform-tests/web-animations/animation-model/side-effects-of-animations-current-ref.html",
         "web-platform-tests/web-animations/animation-model/side-effects-of-animations-in-effect-ref.html",
         "web-platform-tests/web-animations/animation-model/side-effects-of-animations-none-ref.html",
+        "web-platform-tests/web-animations/responsive/background-color-animation-plus-opacity-ref.html",
         "web-platform-tests/web-animations/responsive/neutral-keyframe-ref.html",
         "web-platform-tests/web-animations/responsive/toggle-animated-iframe-visibility-ref.html",
         "web-platform-tests/web-animations/timing-model/animations/document-timeline-animation-ref.html",

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
@@ -48,6 +48,8 @@ PASS list-style-position: "inside" onto "outside"
 PASS list-style-type (type: discrete) has testAccumulation function
 PASS list-style-type: "square" onto "circle"
 PASS list-style-type: "circle" onto "square"
+PASS math-depth (type: integer) has testAccumulation function
+PASS math-depth: integer
 PASS marker-end (type: discrete) has testAccumulation function
 PASS marker-end: "url("http://localhost/test-2")" onto "url("http://localhost/test-1")"
 PASS marker-end: "url("http://localhost/test-1")" onto "url("http://localhost/test-2")"

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
@@ -48,6 +48,8 @@ PASS list-style-position: "inside" onto "outside"
 PASS list-style-type (type: discrete) has testAddition function
 PASS list-style-type: "square" onto "circle"
 PASS list-style-type: "circle" onto "square"
+PASS math-depth (type: integer) has testAddition function
+PASS math-depth: integer
 PASS marker-end (type: discrete) has testAddition function
 PASS marker-end: "url("http://localhost/test-2")" onto "url("http://localhost/test-1")"
 PASS marker-end: "url("http://localhost/test-1")" onto "url("http://localhost/test-2")"

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
@@ -55,6 +55,8 @@ PASS list-style-type (type: discrete) has testInterpolation function
 PASS list-style-type uses discrete animation when animating between "circle" and "square" with linear easing
 PASS list-style-type uses discrete animation when animating between "circle" and "square" with effect easing
 PASS list-style-type uses discrete animation when animating between "circle" and "square" with keyframe easing
+PASS math-depth (type: integer) has testInterpolation function
+PASS math-depth supports animating as an integer
 PASS marker-end (type: discrete) has testInterpolation function
 PASS marker-end uses discrete animation when animating between "url("http://localhost/test-1")" and "url("http://localhost/test-2")" with linear easing
 PASS marker-end uses discrete animation when animating between "url("http://localhost/test-1")" and "url("http://localhost/test-2")" with effect easing

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js
@@ -905,6 +905,22 @@ const gCSSProperties2 = {
       { type: 'discrete', options: [ [ 'circle', 'square' ] ] }
     ]
   },
+  "math-depth": {
+    // https://w3c.github.io/mathml-core/#propdef-math-depth
+    types: [ "integer" ],
+  },
+  "math-shift": {
+    // https://w3c.github.io/mathml-core/#propdef-math-shift
+    types: [
+      { type: "discrete", options: [ [ "normal", "compact" ] ] },
+    ],
+  },
+  "math-style": {
+    // https://w3c.github.io/mathml-core/#propdef-math-style
+    types: [
+      { type: "discrete", options: [ [ "normal", "compact" ] ] },
+    ],
+  },
   'margin-block-end': {
     // https://drafts.csswg.org/css-logical-props/#propdef-margin-block-end
     types: [

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-trigger/event-trigger-alternate.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-trigger/event-trigger-alternate.tentative-expected.txt
@@ -1,0 +1,5 @@
+Click me!
+Watch me!
+
+FAIL Basic event-based animation-trigger with 'alternate' behavior promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: EventTrigger"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-trigger/event-trigger-alternate.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-trigger/event-trigger-alternate.tentative.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="help" href="https://drafts.csswg.org/web-animations-2#animation-trigger">
+    <script src="/resources/testdriver.js"></script>
+    <script src="/resources/testdriver-vendor.js"></script>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/web-animations/testcommon.js"></script>
+  </head>
+  <body>
+    <div id="event-target">Click me!</div>
+
+    <div id="animation-target">Watch me!</div>
+    <script>
+      promise_test(async (test) => {
+        const eventTarget = document.getElementById("event-target");
+        const animationTarget = document.getElementById("animation-target");
+        const ANIMATION_DURATION_MS = 100000;
+        const animation = new Animation(
+          new KeyframeEffect(
+            animationTarget,
+            [
+              { transform: "translateY(0)" },
+              { transform: "translateY(3rem)" },
+            ],
+            { duration: ANIMATION_DURATION_MS, fill: "both" }
+          ));
+        const trigger = new EventTrigger({
+          eventType: "click",
+          eventTarget: eventTarget
+        });
+        trigger.addAnimation(animation, "play-alternate");
+        await waitForAnimationFrames(1);
+        assert_equals(animation.playState, "idle", "animation is idle");
+        assert_equals(animation.playbackRate, 1, "playbackRate is initially 1");
+        await test_driver.click(eventTarget);
+        await waitForAnimationFrames(1);
+        assert_equals(animation.playState, "running", "animation is running after first click");
+        assert_equals(animation.playbackRate, 1, "playbackRate is 1 after first click");
+
+        // Advance to middle of duration so that animation doesn't finish too
+        // quickly after reversing.
+        animation.currentTime = animation.startTime + (ANIMATION_DURATION_MS/2);
+        await waitForAnimationFrames(1);
+
+        await test_driver.click(eventTarget);
+        await waitForAnimationFrames(1);
+        assert_equals(animation.playState, "running", "animation is running after second click");
+        assert_equals(animation.playbackRate, -1, "playbackRate is -1 after second click");
+        animation.pause();
+        await waitForAnimationFrames(1);
+        await test_driver.click(eventTarget);
+        await waitForAnimationFrames(1);
+        assert_equals(animation.playState, "running", "animation is running after third click");
+        assert_equals(animation.playbackRate, 1, "playbackRate is 1 after third click");
+      }, "Basic event-based animation-trigger with 'alternate' behavior");
+    </script>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-trigger/event-trigger-before-handlers.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-trigger/event-trigger-before-handlers.tentative-expected.txt
@@ -1,0 +1,5 @@
+Click me!
+Watch me!
+
+FAIL Animation triggers are handled before registered event listeners promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: EventTrigger"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-trigger/event-trigger-before-handlers.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-trigger/event-trigger-before-handlers.tentative.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="help" href="https://drafts.csswg.org/web-animations-2#animation-trigger">
+    <script src="/resources/testdriver.js"></script>
+    <script src="/resources/testdriver-vendor.js"></script>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/web-animations/testcommon.js"></script>
+  </head>
+  <body>
+    <div id="event-target">Click me!</div>
+
+    <div id="animation-target">Watch me!</div>
+    <script>
+      promise_test(async (test) => {
+        const eventTarget = document.getElementById("event-target");
+        const animationTarget = document.getElementById("animation-target");
+        const ANIMATION_DURATION_MS = 10000;
+        const animation = new Animation(
+          new KeyframeEffect(
+            animationTarget,
+            [
+              { transform: "translateY(0)" },
+              { transform: "translateY(3rem)" },
+            ],
+            { duration: ANIMATION_DURATION_MS, fill: "both" }
+          ));
+        let listenerRan = false;
+        eventTarget.addEventListener("click", evt => {
+          listenerRan = true;
+          assert_equals(
+            animation.playState, "running",
+            "Animation is already running when event listener runs");
+        });
+        const trigger = new EventTrigger({
+          eventType: "click",
+          eventTarget: eventTarget
+        });
+        trigger.addAnimation(animation, "play");
+        await waitForAnimationFrames(2);
+        assert_equals(animation.playState, "idle", "animation is idle");
+        await test_driver.click(eventTarget);
+        await waitForAnimationFrames(1);
+        assert_true(listenerRan, "Click event listener ran.");
+      }, "Animation triggers are handled before registered event listeners");
+    </script>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-trigger/event-trigger-once.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-trigger/event-trigger-once.tentative-expected.txt
@@ -1,0 +1,5 @@
+Click me!
+Watch me!
+
+FAIL Basic event-based animation-trigger with 'once' behavior promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: EventTrigger"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-trigger/event-trigger-once.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-trigger/event-trigger-once.tentative.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="help" href="https://drafts.csswg.org/web-animations-2#animation-trigger">
+    <script src="/resources/testdriver.js"></script>
+    <script src="/resources/testdriver-vendor.js"></script>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/web-animations/testcommon.js"></script>
+  </head>
+  <body>
+    <div id="event-target">Click me!</div>
+
+    <div id="animation-target">Watch me!</div>
+    <script>
+      promise_test(async (test) => {
+        const eventTarget = document.getElementById("event-target");
+        const animationTarget = document.getElementById("animation-target");
+        const ANIMATION_DURATION_MS = 10000;
+        const animation = new Animation(
+          new KeyframeEffect(
+            animationTarget,
+            [
+              { transform: "translateY(0)" },
+              { transform: "translateY(3rem)" },
+            ],
+            { duration: ANIMATION_DURATION_MS, fill: "both" }
+          ));
+        const trigger = new EventTrigger({
+          eventType: "click",
+          eventTarget: eventTarget
+        });
+        trigger.addAnimation(animation, "play-once");
+        await waitForAnimationFrames(1);
+        assert_equals(animation.playState, "idle", "animation is idle");
+        await test_driver.click(eventTarget);
+        await waitForAnimationFrames(1);
+        assert_equals(animation.playState, "running", "animation is running");
+        animation.finish();
+        await waitForAnimationFrames(1);
+        assert_equals(animation.playState, "finished", "animation is finished");
+        await test_driver.click(eventTarget);
+        await waitForAnimationFrames(1);
+        assert_equals(animation.playState, "finished", "animation is still finished");
+      }, "Basic event-based animation-trigger with 'once' behavior");
+    </script>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-trigger/event-trigger-repeat.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-trigger/event-trigger-repeat.tentative-expected.txt
@@ -1,0 +1,5 @@
+Click me!
+Watch me!
+
+FAIL Basic event-based animation-trigger with 'repeat' behavior promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: EventTrigger"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-trigger/event-trigger-repeat.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-trigger/event-trigger-repeat.tentative.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="help" href="https://drafts.csswg.org/web-animations-2#animation-trigger">
+    <script src="/resources/testdriver.js"></script>
+    <script src="/resources/testdriver-vendor.js"></script>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/web-animations/testcommon.js"></script>
+  </head>
+  <body>
+    <div id="event-target">Click me!</div>
+
+    <div id="animation-target">Watch me!</div>
+    <script>
+      promise_test(async (test) => {
+        const eventTarget = document.getElementById("event-target");
+        const animationTarget = document.getElementById("animation-target");
+        const ANIMATION_DURATION_MS = 10000;
+        const animation = new Animation(
+          new KeyframeEffect(
+            animationTarget,
+            [
+              { transform: "translateY(0)" },
+              { transform: "translateY(3rem)" },
+            ],
+            { duration: ANIMATION_DURATION_MS, fill: "both" }
+          ));
+        const trigger = new EventTrigger({
+          eventType: "click",
+          eventTarget: eventTarget
+        });
+        trigger.addAnimation(animation, "replay");
+        await waitForAnimationFrames(1);
+        assert_equals(animation.playState, "idle", "animation is idle");
+        await test_driver.click(eventTarget);
+        await waitForAnimationFrames(3);
+        assert_equals(animation.playState, "running", "animation is running");
+        assert_less_than(0, animation.overallProgress, "Animation has progressed");
+        let progress = animation.overallProgress;
+        await test_driver.click(eventTarget);
+        await waitForAnimationFrames(1);
+        assert_equals(animation.playState, "running", "animation is still running");
+        assert_less_than(animation.overallProgress, progress, "Progress has been reset");
+        animation.finish();
+        await waitForAnimationFrames(1);
+        assert_equals(animation.playState, "finished", "Animation has finished");
+        await test_driver.click(eventTarget);
+        await waitForAnimationFrames(1);
+        assert_equals(animation.playState, "running", "animation is running again");
+        animation.pause();
+        await waitForAnimationFrames(1);
+        assert_equals(animation.playState, "paused", "Animation is paused");
+        await test_driver.click(eventTarget);
+        await waitForAnimationFrames(1);
+        assert_equals(animation.playState, "running", "animation is running after pause");
+      }, "Basic event-based animation-trigger with 'repeat' behavior");
+    </script>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-trigger/event-trigger-state.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-trigger/event-trigger-state.tentative-expected.txt
@@ -1,0 +1,5 @@
+Click me!
+Watch me!
+
+FAIL Basic event-based animation-trigger with 'state' behavior promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: EventTrigger"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-trigger/event-trigger-state.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-trigger/event-trigger-state.tentative.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="help" href="https://drafts.csswg.org/web-animations-2#animation-trigger">
+    <script src="/resources/testdriver.js"></script>
+    <script src="/resources/testdriver-vendor.js"></script>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/web-animations/testcommon.js"></script>
+  </head>
+  <body>
+    <div id="event-target">Click me!</div>
+
+    <div id="animation-target">Watch me!</div>
+    <script>
+      promise_test(async (test) => {
+        const eventTarget = document.getElementById("event-target");
+        const animationTarget = document.getElementById("animation-target");
+        const ANIMATION_DURATION_MS = 100000;
+        const animation = new Animation(
+          new KeyframeEffect(
+            animationTarget,
+            [
+              { transform: "translateY(0)" },
+              { transform: "translateY(3rem)" },
+            ],
+            { duration: ANIMATION_DURATION_MS, fill: "both" }
+          ));
+        const trigger = new EventTrigger({
+          eventType: "click",
+          eventTarget: eventTarget
+        });
+        trigger.addAnimation(animation, "play-pause");
+        await waitForAnimationFrames(1);
+        assert_equals(animation.playState, "idle", "animation is idle");
+        await test_driver.click(eventTarget);
+        await waitForAnimationFrames(1);
+        assert_equals(animation.playState, "running", "animation is running");
+        await test_driver.click(eventTarget);
+        await waitForAnimationFrames(1);
+        assert_equals(animation.playState, "paused", "animation is paused");
+        await test_driver.click(eventTarget);
+        await waitForAnimationFrames(1);
+        assert_equals(animation.playState, "running", "animation is running");
+      }, "Basic event-based animation-trigger with 'state' behavior");
+    </script>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-trigger/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-trigger/w3c-import.log
@@ -1,0 +1,21 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-trigger/event-trigger-alternate.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-trigger/event-trigger-before-handlers.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-trigger/event-trigger-once.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-trigger/event-trigger-repeat.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-trigger/event-trigger-state.tentative.html

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/crashtests/get-timing-bad-pseudo-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/crashtests/get-timing-bad-pseudo-crash.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<title>getTiming on a KeyframeEffect with invalid pseudoElement option</title>
+<link rel="help" href="https://bugs.chromium.org/p/chromium/issues/detail?id=441567711">
+<meta name="assert" content="This should not crash.">
+<body>
+  <script>
+    let t = (new KeyframeEffect(null, [], { pseudoElement: "img2" })).getTiming();
+  </script>
+</body>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/crashtests/set-timeline-undefined-progress.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/crashtests/set-timeline-undefined-progress.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html class="test-wait">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Set timeline when effect end is infinite.
+  </title>
+  <!-- crbug.com/440368332 -->
+</head>
+<style>
+  #target {
+    background-color: green;
+    width: 200px;
+    height: 200px;
+  }
+</style>
+<script>
+</script>
+<body>
+  <div id="target"></div>
+</body>
+<script>
+  window.onload = async () => {
+    const anim =
+        target.animate(null, { duration: 2000, iterations: Infinity });
+    // Setting an infinite playback rate combined with a future start time, puts
+    // current time infinitely in the past.
+    anim.playbackRate = Number.MAX_VALUE;
+    anim.startTime = performance.now() + 1000;
+    // When setting a new timeline, we compute the current progress on the old
+    // timeline in case we need to match the progress on the new timeline to
+    // avoid a jump. In this case, current progress is:
+    // currentTime / EffectEnd = -infinity / infinity = undefined.
+    anim.timeline = null;
+    requestAnimationFrame(() => {
+      document.documentElement.classList.remove('test-wait');
+    });
+  }
+</script>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/crashtests/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/crashtests/w3c-import.log
@@ -18,9 +18,11 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/web-animations/crashtests/effectively-infinite-timing-parameters.html
 /LayoutTests/imported/w3c/web-platform-tests/web-animations/crashtests/get-computed-timing-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/web-animations/crashtests/get-keyframe-fontsize-crash.html
+/LayoutTests/imported/w3c/web-platform-tests/web-animations/crashtests/get-timing-bad-pseudo-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/web-animations/crashtests/infinite-active-duration.html
 /LayoutTests/imported/w3c/web-platform-tests/web-animations/crashtests/non-interpolable-transition.html
 /LayoutTests/imported/w3c/web-platform-tests/web-animations/crashtests/partially-overlapping-animations-one-not-current-001.html
 /LayoutTests/imported/w3c/web-platform-tests/web-animations/crashtests/reparent-animating-element-001.html
 /LayoutTests/imported/w3c/web-platform-tests/web-animations/crashtests/reparent-animating-element-002.html
+/LayoutTests/imported/w3c/web-platform-tests/web-animations/crashtests/set-timeline-undefined-progress.html
 /LayoutTests/imported/w3c/web-platform-tests/web-animations/crashtests/sibling-index-offset-crash.html

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/AnimationTrigger/constructor-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/AnimationTrigger/constructor-expected.txt
@@ -1,6 +1,0 @@
-
-FAIL Default values when no property bag is supplied Can't find variable: AnimationTrigger
-FAIL Default values when an empty property bag is supplied. Can't find variable: AnimationTrigger
-FAIL All values supplied (scroll timeline). Can't find variable: AnimationTrigger
-FAIL All values supplied (view timeline). Can't find variable: AnimationTrigger
-

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/TimelineTrigger/constructor-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/TimelineTrigger/constructor-expected.txt
@@ -1,0 +1,6 @@
+
+FAIL Default values when no property bag is supplied Can't find variable: TimelineTrigger
+FAIL Default values when an empty property bag is supplied. Can't find variable: TimelineTrigger
+FAIL All values supplied (scroll timeline). Can't find variable: TimelineTrigger
+FAIL All values supplied (view timeline). Can't find variable: TimelineTrigger
+

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/TimelineTrigger/constructor.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/TimelineTrigger/constructor.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>AnimationTrigger constructor</title>
+<title>TimelineTrigger constructor</title>
 <link rel="help"
       href="https://drafts.csswg.org/web-animations-2/#the-animationtrigger-interface">
 <script src="/resources/testharness.js"></script>
@@ -10,8 +10,7 @@
 <script>
 
   test(t => {
-    const trigger = new AnimationTrigger();
-    assert_equals(trigger.behavior, "once", "default behavior is once.");
+    const trigger = new TimelineTrigger();
     assert_equals(trigger.timeline, document.timeline,
       "default timeline is document.timeline.");
     assert_equals(trigger.rangeStart, "normal", "default rangeStart is normal");
@@ -23,8 +22,7 @@
   }, "Default values when no property bag is supplied");
 
   test(t => {
-    const trigger = new AnimationTrigger({});
-    assert_equals(trigger.behavior, "once", "default behavior is once.");
+    const trigger = new TimelineTrigger({});
     assert_equals(trigger.timeline, document.timeline,
       "default timeline is document.timeline.");
     assert_equals(trigger.rangeStart, "normal", "default rangeStart is normal");
@@ -37,15 +35,13 @@
 
   test(t => {
     const scroll_timeline = new ScrollTimeline();
-    const trigger = new AnimationTrigger({
-      behavior: "repeat",
+    const trigger = new TimelineTrigger({
       timeline: scroll_timeline,
       rangeStart: "contain 10%",
       rangeEnd: "contain 90%",
       exitRangeStart: "cover 10%",
       exitRangeEnd: "cover 90%"
     });
-    assert_equals(trigger.behavior, "repeat", "default behavior is repeat.");
     assert_equals(trigger.timeline, scroll_timeline,
       "timeline is supplied scroll timeline.");
     assert_equals(trigger.rangeStart, "contain 10%",
@@ -60,15 +56,13 @@
 
   test(t => {
     const view_timeline = new ViewTimeline();
-    const trigger = new AnimationTrigger({
-      behavior: "repeat",
+    const trigger = new TimelineTrigger({
       timeline: view_timeline,
       rangeStart: "contain 10%",
       rangeEnd: "contain 90%",
       exitRangeStart: "cover 10%",
       exitRangeEnd: "cover 90%"
     });
-    assert_equals(trigger.behavior, "repeat", "behavior is supplied behavior.");
     assert_equals(trigger.timeline, view_timeline,
       "timeline is supplied scroll timeline.");
     assert_equals(trigger.rangeStart, "contain 10%",

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/TimelineTrigger/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/TimelineTrigger/w3c-import.log
@@ -14,4 +14,4 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
-/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/AnimationTrigger/constructor.html
+/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/TimelineTrigger/constructor.html

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/background-color-animation-plus-opacity-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/background-color-animation-plus-opacity-expected.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<style>
+  #target {
+    height: 200px;
+    width: 200px;
+    position: relative;
+    background-color: rgba(128, 64, 0, 0.5);
+  }
+</style>
+<body>
+  <div id="target"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/background-color-animation-plus-opacity-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/background-color-animation-plus-opacity-ref.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<style>
+  #target {
+    height: 200px;
+    width: 200px;
+    position: relative;
+    background-color: rgba(128, 64, 0, 0.5);
+  }
+</style>
+<body>
+  <div id="target"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/background-color-animation-plus-opacity.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/background-color-animation-plus-opacity.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="help" href="https://crbug.com/449865091">
+  <link rel="match" href="background-color-animation-plus-opacity-ref.html">
+  <!-- Tolerance for rounding on the color match -->
+  <meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-40000">
+</head>
+<script src="/web-animations/testcommon.js"></script>
+<script src="/common/reftest-wait.js"></script>
+<style>
+  #target {
+    height: 200px;
+    width: 200px;
+    position: relative;
+    background-color: red;
+    opacity: 0.5;
+    /* catch midpoint of transition */
+    transition: background-color 10000s -5000s cubic-bezier(0, 1, 1, 0);
+  }
+
+  #target.update {
+    background-color: green;
+  }
+</style>
+<body>
+  <div id='target'></div>
+</body>
+<script>
+  window.onload = async () => {
+    await waitForCompositorReady();
+    target.classList.add('update');
+    requestAnimationFrame(takeScreenshot);
+  };
+</script>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/w3c-import.log
@@ -15,6 +15,9 @@ None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/assorted-lengths.html
+/LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/background-color-animation-plus-opacity-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/background-color-animation-plus-opacity-ref.html
+/LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/background-color-animation-plus-opacity.html
 /LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/background-position-responsive.html
 /LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/backgroundPosition.html
 /LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/backgroundSize.html


### PR DESCRIPTION
#### ec30dff51652889e6b18e90dafde69d7421d2f42
<pre>
Resync `web-animations` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=304781">https://bugs.webkit.org/show_bug.cgi?id=304781</a>

Reviewed by Brandon Stewart.

Run `import-w3c-tests` for `web-animations`.
Needed to cover the CSS `math-*` properties from MathML Core.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/afce258ce1915a1a34522670d664031042e70f62">https://github.com/web-platform-tests/wpt/commit/afce258ce1915a1a34522670d664031042e70f62</a>

* LayoutTests/imported/w3c/resources/resource-files.json:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-trigger/event-trigger-alternate.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-trigger/event-trigger-alternate.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-trigger/event-trigger-before-handlers.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-trigger/event-trigger-before-handlers.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-trigger/event-trigger-once.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-trigger/event-trigger-once.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-trigger/event-trigger-repeat.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-trigger/event-trigger-repeat.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-trigger/event-trigger-state.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-trigger/event-trigger-state.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-trigger/w3c-import.log: Added.
* LayoutTests/imported/w3c/web-platform-tests/web-animations/crashtests/get-timing-bad-pseudo-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/web-animations/crashtests/set-timeline-undefined-progress.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/web-animations/crashtests/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/TimelineTrigger/constructor-expected.txt: Renamed from LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/AnimationTrigger/constructor-expected.txt.
* LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/TimelineTrigger/constructor.html: Renamed from LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/AnimationTrigger/constructor.html.
* LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/TimelineTrigger/w3c-import.log: Renamed from LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/AnimationTrigger/w3c-import.log.
* LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/background-color-animation-plus-opacity-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/background-color-animation-plus-opacity-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/background-color-animation-plus-opacity.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/305012@main">https://commits.webkit.org/305012@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/245610a3ffc65c3f3c5a700a3f5abf2ae9a84eb3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137160 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9520 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48447 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144906 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90133 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10223 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9647 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104888 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140105 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7530 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122912 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85727 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7167 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4882 "Found 11 new API test failures: TestWebKitAPI.WKWebExtensionAPIExtension.GetViewsForMultipleTabs, TestWebKitAPI.MemoryFootprintThreshold.TestDelegateMethod, TestWebKitAPI.MessagePort.MessageToClosedPort, TestWebKitAPI.WKWebExtensionAPIStorage.SetAccessLevelTrustedContexts, TestWebKitAPI.WEBKIT.NavigationActionHasOpener12, TestWebKitAPI.NSResponderTests.ValidRequestorForSendAndReturnTypes, TestWebKitAPI.WKWebExtensionAPIAlarms.ClearAllAlarms, TestWebKitAPI.GetUserMedia.OriginAndWebArchivePermission, TestWebKitAPI.MediaLoading.LockdownModeHLS, TestWebKitAPI.PermissionsAPI.GeolocationPermissionDeniedPermanentlyAndGeolocationRequestedSinceLoad ... (failure)") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5496 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116519 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41078 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147662 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9203 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41641 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113247 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9221 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7738 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113578 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28850 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7086 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119171 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/63590 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9251 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37225 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8976 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9192 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9044 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->