### PR TITLE
RefCountedWithInlineWeakPtr doesn't work in GCC Release builds

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4838,13 +4838,6 @@ webkit.org/b/304272 [ Debug ] http/tests/webrtc/filtering-ice-candidate-same-ori
 
 webkit.org/b/150840 [ Debug ] imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-popover-exit-animation.html [ Crash Pass Timeout ]
 
-webkit.org/b/304549 [ Release ] fast/events/tabindex-focus-blur-all.html [ Pass Crash ]
-webkit.org/b/304549 [ Release ] media/media-source/media-source-istypesupported-case-sensitive.html [ Pass Crash ]
-webkit.org/b/304549 [ Release ] imported/w3c/web-platform-tests/css/cssom-view/smooth-scrollIntoView-with-smooth-fragment-scroll.html [ Pass Crash ]
-webkit.org/b/304549 [ Release ] jquery/offset.html [ Pass Slow Crash ]
-webkit.org/b/304549 [ Release ] media/modern-media-controls/media-documents/media-document-video-with-initial-audio-layout.html [ Pass Crash ]
-webkit.org/b/304549 [ Release ] media/modern-media-controls/media-documents/media-document-video-iphone-sizing.html [ Pass Crash ]
-
 webkit.org/b/304615 [ Release ] fast/repaint/missing-out-of-flow-repaint-on-destroy.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/304619 http/wpt/service-workers/service-worker-preload-when-not-activated.https.html [ Failure Pass Timeout ]

--- a/Source/WTF/wtf/RefCountedWithInlineWeakPtr.h
+++ b/Source/WTF/wtf/RefCountedWithInlineWeakPtr.h
@@ -49,7 +49,8 @@ protected:
     {
         m_refCountDebugger.willDestroy(m_strongCount);
         RELEASE_ASSERT(m_strongCount == 1);
-        m_strongCount = 0;
+        // Use volatile to prevent compilers from eliminating this code. <https://webkit.org/b/304549>
+        *static_cast<volatile unsigned*>(&m_strongCount) = 0;
     }
 
     // Returns true if the pointer should be destroyed.

--- a/Tools/TestWebKitAPI/glib/TestExpectations.json
+++ b/Tools/TestWebKitAPI/glib/TestExpectations.json
@@ -363,15 +363,6 @@
             "WTF_Condition.OneProducerTenConsumersHundredSlotsNotifyOne": {
                 "expected": {"gtk": {"slow": true, "status": ["TIMEOUT", "PASS"], "bug": "webkit.org/b/246472" }}
             },
-            "WTF_HashMap.InlineWeakPtr": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/304549" }}
-            },
-            "WTF_HashSet.InlineWeakPtr": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/304549" }}
-            },
-            "WTF_ListHashSet.InlineWeakPtr": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/304549" }}
-            },
             "WTF_Lock.ContendedShortSection": {
                 "expected": {"all": {"slow": true, "status": ["TIMEOUT", "PASS"], "bug": "webkit.org/b/260029" }}
             },


### PR DESCRIPTION
#### c37c47affa469ed0fce9711a3ed6927e65936661
<pre>
RefCountedWithInlineWeakPtr doesn&apos;t work in GCC Release builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=304549">https://bugs.webkit.org/show_bug.cgi?id=304549</a>

Reviewed by Nikolas Zimmermann.

GCC eliminates `m_strongCount = 0` in ~RefCountedWithInlineWeakPtrBase. Use
`volatile` to prevent GCC from eliminating the code.

This is not a GCC bug. The future versions of other compilers can employ the
same optimization.

* LayoutTests/platform/glib/TestExpectations:
* Source/WTF/wtf/RefCountedWithInlineWeakPtr.h:
* Tools/TestWebKitAPI/glib/TestExpectations.json:

Canonical link: <a href="https://commits.webkit.org/305035@main">https://commits.webkit.org/305035@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1c89b7024394622f77fcb7a7e5281b8f582a570

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137211 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9571 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48498 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144960 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90184 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139083 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10274 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9698 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104932 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140156 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7576 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122965 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85773 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7213 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4924 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5547 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/129172 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116570 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41127 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147718 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/135706 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9254 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41689 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113292 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9272 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7787 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113623 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7133 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119219 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63712 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21146 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9303 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37273 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/168479 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9028 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72868 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43979 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9243 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9095 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->