### PR TITLE
<mpadded> should treat percentage values as absent for width/height/depth attribute

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/mpadded/mpadded-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/mpadded/mpadded-002-expected.txt
@@ -2,7 +2,7 @@
 PASS mpadded with no attributes
 PASS Different widths
 PASS Different heights
-FAIL Percentage calculation for width, height and depth assert_equals: width expected 100 but got 50
+PASS Percentage calculation for width, height and depth
 PASS Different depths
 PASS Various combinations of height, depth and width.
 PASS Preferred width

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/mpadded/mpadded-percentage-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/mpadded/mpadded-percentage-002-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL width='200%' is interpreted as the default value assert_approx_equals: inline size expected 10 +/- 1 but got 20
-FAIL height='200%' is interpreted as the default value assert_approx_equals: block size expected 50 +/- 1 but got 70
-FAIL depth='200%' is interpreted as the default value assert_approx_equals: block size expected 50 +/- 1 but got 80
+PASS width='200%' is interpreted as the default value
+PASS height='200%' is interpreted as the default value
+PASS depth='200%' is interpreted as the default value
 PASS lspace='200%' is interpreted as the default value
 PASS voffset='200%' is interpreted as the default value
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLPadded.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLPadded.cpp
@@ -57,24 +57,35 @@ LayoutUnit RenderMathMLPadded::voffset() const
 
 LayoutUnit RenderMathMLPadded::lspace() const
 {
-    LayoutUnit lspace = toUserUnits(element().lspace(), style(), 0);
     // FIXME: Negative lspace values are not supported yet (https://bugs.webkit.org/show_bug.cgi?id=85730).
-    return std::max<LayoutUnit>(0, lspace);
+    return std::max(0_lu, toUserUnits(element().lspace(), style(), 0));
 }
 
 LayoutUnit RenderMathMLPadded::mpaddedWidth(LayoutUnit contentWidth) const
 {
-    return std::max<LayoutUnit>(0, toUserUnits(element().width(), style(), contentWidth));
+    auto& widthAttr = element().width();
+    // If parsing failed (attribute not set) or it's a percentage, use the content width as default.
+    if (widthAttr.type == MathMLElement::LengthType::ParsingFailed ||  widthAttr.type == MathMLElement::LengthType::Percentage)
+        return contentWidth;
+    return std::max(0_lu, toUserUnits(widthAttr, style(), 0));
 }
 
 LayoutUnit RenderMathMLPadded::mpaddedHeight(LayoutUnit contentHeight) const
 {
-    return std::max<LayoutUnit>(0, toUserUnits(element().height(), style(), contentHeight));
+    auto& heightAttr = element().height();
+    // If parsing failed (attribute not set) or it's a percentage, use the content height as default.
+    if (heightAttr.type == MathMLElement::LengthType::ParsingFailed ||  heightAttr.type == MathMLElement::LengthType::Percentage)
+        return contentHeight;
+    return std::max(0_lu, toUserUnits(heightAttr, style(), 0));
 }
 
 LayoutUnit RenderMathMLPadded::mpaddedDepth(LayoutUnit contentDepth) const
 {
-    return std::max<LayoutUnit>(0, toUserUnits(element().depth(), style(), contentDepth));
+    auto& depthAttr = element().depth();
+    // If parsing failed (attribute not set) or it's a percentage, use the content depth as default.
+    if (depthAttr.type == MathMLElement::LengthType::ParsingFailed ||  depthAttr.type == MathMLElement::LengthType::Percentage)
+        return contentDepth;
+    return std::max(0_lu, toUserUnits(depthAttr, style(), 0));
 }
 
 void RenderMathMLPadded::computePreferredLogicalWidths()


### PR DESCRIPTION
#### 91904fc633cb4554e1fdc653b170f4fe1087636d
<pre>
&lt;mpadded&gt; should treat percentage values as absent for width/height/depth attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=304790">https://bugs.webkit.org/show_bug.cgi?id=304790</a>
<a href="https://rdar.apple.com/167350169">rdar://167350169</a>

Reviewed by Alan Baradlay.

According to the MathML Core specification [1], if the width, height, or
depth attributes are percentages, they should be treated as if absent
(using default values based on the inner box dimensions). Previously, these
percentage values were incorrectly resolved relative to the content dimensions.

This patch checks for LengthType::Percentage in mpaddedWidth(), mpaddedHeight(),
and mpaddedDepth(), and returns the content dimension directly when a percentage
is encountered, matching the behavior for absent/invalid attributes.

[1] <a href="https://w3c.github.io/mathml-core/#inner-box-and-requested-parameters">https://w3c.github.io/mathml-core/#inner-box-and-requested-parameters</a>

As drive-by, we updated to use std::max(0_lu, ..) rather than explicity
std::max&lt;LayoutUnit&gt; similar to through out other code.

* Source/WebCore/rendering/mathml/RenderMathMLPadded.cpp:
(WebCore::RenderMathMLPadded::lspace const): Drive-by fix
(WebCore::RenderMathMLPadded::mpaddedWidth const):
(WebCore::RenderMathMLPadded::mpaddedHeight const):
(WebCore::RenderMathMLPadded::mpaddedDepth const):

&gt; Progressions:
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/mpadded/mpadded-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mathml/presentation-markup/mpadded/mpadded-percentage-002-expected.txt:

Canonical link: <a href="https://commits.webkit.org/305027@main">https://commits.webkit.org/305027@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/186b4ca90ee5f12567d3a48c84be5662b29f95ff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137221 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9581 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48508 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144972 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90194 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/85f78ad2-1793-4069-8d31-e8eb87a18e83) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139093 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10284 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9708 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104941 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c404d1ec-0e38-4744-86f1-051ee92b0897) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140166 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7588 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/122977 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85783 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3ede9f11-72b9-49ae-837e-56ca5bda33e2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7225 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/4935 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5558 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116583 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41137 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147728 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9264 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/41699 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/113301 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9282 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7797 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113632 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28859 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7143 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119229 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63746 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9313 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37283 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9038 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72878 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9253 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9105 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->