### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in CSSSelectorList

### DIFF
--- a/Source/WebCore/css/CSSSelectorList.h
+++ b/Source/WebCore/css/CSSSelectorList.h
@@ -28,8 +28,8 @@
 #include <WebCore/CSSSelector.h>
 #include <iterator>
 #include <memory>
+#include <wtf/FixedVector.h>
 #include <wtf/TZoneMalloc.h>
-#include <wtf/UniqueArray.h>
 
 namespace WebCore {
 
@@ -43,7 +43,7 @@ public:
     CSSSelectorList(const CSSSelectorList&);
     CSSSelectorList(CSSSelectorList&&) = default;
     explicit CSSSelectorList(MutableCSSSelectorList&&);
-    explicit CSSSelectorList(UniqueArray<CSSSelector>&& array)
+    explicit CSSSelectorList(FixedVector<CSSSelector>&& array)
         : m_selectorArray(WTF::move(array)) { }
 
     static CSSSelectorList makeCopyingSimpleSelector(const CSSSelector&);
@@ -51,13 +51,11 @@ public:
     static CSSSelectorList makeJoining(const CSSSelectorList&, const CSSSelectorList&);
     static CSSSelectorList makeJoining(const Vector<const CSSSelectorList*>&);
 
-    bool isEmpty() const { return !m_selectorArray; }
-    const CSSSelector* first() const LIFETIME_BOUND { return m_selectorArray.get(); }
+    bool isEmpty() const { return m_selectorArray.isEmpty(); }
+    const CSSSelector* first() const LIFETIME_BOUND { return m_selectorArray.begin(); } // Using begin() instead of &m_selectorArray[0] to avoid assertions when the array is empty.
     const CSSSelector* selectorAt(size_t index) const LIFETIME_BOUND
     {
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         return &m_selectorArray[index];
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
 
     size_t indexOfNextSelectorAfter(size_t index) const
@@ -66,7 +64,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         ++current;
         if (current == end())
             return notFound;
-        return &*current - m_selectorArray.get();
+        return &*current - m_selectorArray.begin();
     }
 
     struct const_iterator {
@@ -124,7 +122,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 private:
     // End of a multipart selector is indicated by m_isLastInComplexSelector bit in the last item.
     // End of the array is indicated by m_isLastInSelectorList bit in the last item.
-    UniqueArray<CSSSelector> m_selectorArray;
+    FixedVector<CSSSelector> m_selectorArray;
 };
 
 void add(Hasher&, const CSSSelectorList&);

--- a/Source/WebCore/css/StyleRule.cpp
+++ b/Source/WebCore/css/StyleRule.cpp
@@ -332,12 +332,10 @@ void StyleRuleWithNesting::wrapperAdoptOriginalSelectorList(CSSSelectorList&& se
 Ref<StyleRule> StyleRule::createForSplitting(const Vector<const CSSSelector*>& selectors, Ref<StyleProperties>&& properties, bool hasDocumentSecurityOrigin)
 {
     ASSERT_WITH_SECURITY_IMPLICATION(!selectors.isEmpty());
-    auto selectorListArray = makeUniqueArray<CSSSelector>(selectors.size());
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    for (unsigned i = 0; i < selectors.size(); ++i)
-        new (NotNull, &selectorListArray[i]) CSSSelector(*selectors.at(i));
+    auto selectorListArray = FixedVector<CSSSelector>::map(selectors, [](auto* selector) {
+        return *selector;
+    });
     selectorListArray[selectors.size() - 1].setLastInSelectorList();
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     auto styleRule = StyleRule::create(WTF::move(properties), hasDocumentSecurityOrigin, CSSSelectorList(WTF::move(selectorListArray)));
     styleRule->markAsSplitRule();
     return styleRule;


### PR DESCRIPTION
#### 028ef08f4dbde1d974f45a43d9c6816d492724d4
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in CSSSelectorList
<a href="https://bugs.webkit.org/show_bug.cgi?id=304791">https://bugs.webkit.org/show_bug.cgi?id=304791</a>

Reviewed by Sam Weinig.

Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in CSSSelectorList. This
tested as performance neutral on Speedometer.

* Source/WebCore/css/CSSSelectorList.cpp:
(WebCore::CSSSelectorList::CSSSelectorList):
(WebCore::CSSSelectorList::makeCopyingSimpleSelector):
(WebCore::CSSSelectorList::makeCopyingComplexSelector):
(WebCore::CSSSelectorList::makeJoining):
(WebCore::CSSSelectorList::componentCount const):
(WebCore::CSSSelectorList::listSize const):
* Source/WebCore/css/CSSSelectorList.h:
(WebCore::CSSSelectorList::CSSSelectorList):
(WebCore::CSSSelectorList::isEmpty const):
(WebCore::CSSSelectorList::indexOfNextSelectorAfter const):
* Source/WebCore/css/StyleRule.cpp:
(WebCore::StyleRule::createForSplitting):

Canonical link: <a href="https://commits.webkit.org/305131@main">https://commits.webkit.org/305131@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0b8193f3f02d6a7bfc4873a5c81ae7e3f2de925

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137604 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9965 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48892 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145362 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90577 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/df1d3fec-e547-4a8f-a533-e5adddd22252) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139476 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10668 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10095 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105240 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0cee9bec-d3de-4409-9998-81c351aa2cc0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140549 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7923 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123319 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86096 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b021dfce-43cf-4af8-9589-548cb57e1a2f) 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/5277 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5945 "Built successfully") | | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41485 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148129 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9647 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42030 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113634 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9665 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8132 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113966 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28925 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7483 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119559 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64311 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9696 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37609 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9427 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73261 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9636 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9488 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->