### PR TITLE
SVG <stop> offset attribute incorrectly accepts invalid values with trailing garbage

### DIFF
--- a/LayoutTests/svg/parser/whitespace-number-expected.txt
+++ b/LayoutTests/svg/parser/whitespace-number-expected.txt
@@ -1,0 +1,1460 @@
+
+PASS Test <number> valid value: -47
+PASS Test <number> valid value: .1
+PASS Test <number> valid value: 0.35
+PASS Test <number> valid value: 1e-10
+PASS Test <number> valid value: +32
+PASS Test <number> valid value: +17E-1
+PASS Test <number> valid value: 17e+2
+PASS Test <number> valid value: -47
+PASS Test <number> valid value: .1
+PASS Test <number> valid value: 0.35
+PASS Test <number> valid value: 1e-10
+PASS Test <number> valid value: +32
+PASS Test <number> valid value: +17E-1
+PASS Test <number> valid value: 17e+2
+PASS Test <number> valid value: -47
+PASS Test <number> valid value: .1
+PASS Test <number> valid value: 0.35
+PASS Test <number> valid value: 1e-10
+PASS Test <number> valid value: +32
+PASS Test <number> valid value: +17E-1
+PASS Test <number> valid value: 17e+2
+PASS Test <number> valid value: -47\r\n\t
+PASS Test <number> valid value: .1\r\n\t
+PASS Test <number> valid value: 0.35\r\n\t
+PASS Test <number> valid value: 1e-10\r\n\t
+PASS Test <number> valid value: +32\r\n\t
+PASS Test <number> valid value: +17E-1\r\n\t
+PASS Test <number> valid value: 17e+2\r\n\t
+PASS Test <number> valid value: -47\f
+PASS Test <number> valid value: .1\f
+PASS Test <number> valid value: 0.35\f
+PASS Test <number> valid value: 1e-10\f
+PASS Test <number> valid value: +32\f
+PASS Test <number> valid value: +17E-1\f
+PASS Test <number> valid value: 17e+2\f
+PASS Test <number> trailing garbage, value: -47a
+PASS Test <number> trailing garbage, value: .1a
+PASS Test <number> trailing garbage, value: 0.35a
+PASS Test <number> trailing garbage, value: 1e-10a
+PASS Test <number> trailing garbage, value: +32a
+PASS Test <number> trailing garbage, value: +17E-1a
+PASS Test <number> trailing garbage, value: 17e+2a
+PASS Test <number> trailing garbage, value: -47e
+PASS Test <number> trailing garbage, value: .1e
+PASS Test <number> trailing garbage, value: 0.35e
+PASS Test <number> trailing garbage, value: 1e-10e
+PASS Test <number> trailing garbage, value: +32e
+PASS Test <number> trailing garbage, value: +17E-1e
+PASS Test <number> trailing garbage, value: 17e+2e
+PASS Test <number> trailing garbage, value: -47foo
+PASS Test <number> trailing garbage, value: .1foo
+PASS Test <number> trailing garbage, value: 0.35foo
+PASS Test <number> trailing garbage, value: 1e-10foo
+PASS Test <number> trailing garbage, value: +32foo
+PASS Test <number> trailing garbage, value: +17E-1foo
+PASS Test <number> trailing garbage, value: 17e+2foo
+PASS Test <number> trailing garbage, value: -47)90
+PASS Test <number> trailing garbage, value: .1)90
+PASS Test <number> trailing garbage, value: 0.35)90
+PASS Test <number> trailing garbage, value: 1e-10)90
+PASS Test <number> trailing garbage, value: +32)90
+PASS Test <number> trailing garbage, value: +17E-1)90
+PASS Test <number> trailing garbage, value: 17e+2)90
+PASS Test <number> valid value:  -47
+PASS Test <number> valid value:  .1
+PASS Test <number> valid value:  0.35
+PASS Test <number> valid value:  1e-10
+PASS Test <number> valid value:  +32
+PASS Test <number> valid value:  +17E-1
+PASS Test <number> valid value:  17e+2
+PASS Test <number> valid value:  -47
+PASS Test <number> valid value:  .1
+PASS Test <number> valid value:  0.35
+PASS Test <number> valid value:  1e-10
+PASS Test <number> valid value:  +32
+PASS Test <number> valid value:  +17E-1
+PASS Test <number> valid value:  17e+2
+PASS Test <number> valid value:  -47
+PASS Test <number> valid value:  .1
+PASS Test <number> valid value:  0.35
+PASS Test <number> valid value:  1e-10
+PASS Test <number> valid value:  +32
+PASS Test <number> valid value:  +17E-1
+PASS Test <number> valid value:  17e+2
+PASS Test <number> valid value:  -47\r\n\t
+PASS Test <number> valid value:  .1\r\n\t
+PASS Test <number> valid value:  0.35\r\n\t
+PASS Test <number> valid value:  1e-10\r\n\t
+PASS Test <number> valid value:  +32\r\n\t
+PASS Test <number> valid value:  +17E-1\r\n\t
+PASS Test <number> valid value:  17e+2\r\n\t
+PASS Test <number> valid value:  -47\f
+PASS Test <number> valid value:  .1\f
+PASS Test <number> valid value:  0.35\f
+PASS Test <number> valid value:  1e-10\f
+PASS Test <number> valid value:  +32\f
+PASS Test <number> valid value:  +17E-1\f
+PASS Test <number> valid value:  17e+2\f
+PASS Test <number> trailing garbage, value:  -47a
+PASS Test <number> trailing garbage, value:  .1a
+PASS Test <number> trailing garbage, value:  0.35a
+PASS Test <number> trailing garbage, value:  1e-10a
+PASS Test <number> trailing garbage, value:  +32a
+PASS Test <number> trailing garbage, value:  +17E-1a
+PASS Test <number> trailing garbage, value:  17e+2a
+PASS Test <number> trailing garbage, value:  -47e
+PASS Test <number> trailing garbage, value:  .1e
+PASS Test <number> trailing garbage, value:  0.35e
+PASS Test <number> trailing garbage, value:  1e-10e
+PASS Test <number> trailing garbage, value:  +32e
+PASS Test <number> trailing garbage, value:  +17E-1e
+PASS Test <number> trailing garbage, value:  17e+2e
+PASS Test <number> trailing garbage, value:  -47foo
+PASS Test <number> trailing garbage, value:  .1foo
+PASS Test <number> trailing garbage, value:  0.35foo
+PASS Test <number> trailing garbage, value:  1e-10foo
+PASS Test <number> trailing garbage, value:  +32foo
+PASS Test <number> trailing garbage, value:  +17E-1foo
+PASS Test <number> trailing garbage, value:  17e+2foo
+PASS Test <number> trailing garbage, value:  -47)90
+PASS Test <number> trailing garbage, value:  .1)90
+PASS Test <number> trailing garbage, value:  0.35)90
+PASS Test <number> trailing garbage, value:  1e-10)90
+PASS Test <number> trailing garbage, value:  +32)90
+PASS Test <number> trailing garbage, value:  +17E-1)90
+PASS Test <number> trailing garbage, value:  17e+2)90
+PASS Test <number> valid value:    -47
+PASS Test <number> valid value:    .1
+PASS Test <number> valid value:    0.35
+PASS Test <number> valid value:    1e-10
+PASS Test <number> valid value:    +32
+PASS Test <number> valid value:    +17E-1
+PASS Test <number> valid value:    17e+2
+PASS Test <number> valid value:    -47
+PASS Test <number> valid value:    .1
+PASS Test <number> valid value:    0.35
+PASS Test <number> valid value:    1e-10
+PASS Test <number> valid value:    +32
+PASS Test <number> valid value:    +17E-1
+PASS Test <number> valid value:    17e+2
+PASS Test <number> valid value:    -47
+PASS Test <number> valid value:    .1
+PASS Test <number> valid value:    0.35
+PASS Test <number> valid value:    1e-10
+PASS Test <number> valid value:    +32
+PASS Test <number> valid value:    +17E-1
+PASS Test <number> valid value:    17e+2
+PASS Test <number> valid value:    -47\r\n\t
+PASS Test <number> valid value:    .1\r\n\t
+PASS Test <number> valid value:    0.35\r\n\t
+PASS Test <number> valid value:    1e-10\r\n\t
+PASS Test <number> valid value:    +32\r\n\t
+PASS Test <number> valid value:    +17E-1\r\n\t
+PASS Test <number> valid value:    17e+2\r\n\t
+PASS Test <number> valid value:    -47\f
+PASS Test <number> valid value:    .1\f
+PASS Test <number> valid value:    0.35\f
+PASS Test <number> valid value:    1e-10\f
+PASS Test <number> valid value:    +32\f
+PASS Test <number> valid value:    +17E-1\f
+PASS Test <number> valid value:    17e+2\f
+PASS Test <number> trailing garbage, value:    -47a
+PASS Test <number> trailing garbage, value:    .1a
+PASS Test <number> trailing garbage, value:    0.35a
+PASS Test <number> trailing garbage, value:    1e-10a
+PASS Test <number> trailing garbage, value:    +32a
+PASS Test <number> trailing garbage, value:    +17E-1a
+PASS Test <number> trailing garbage, value:    17e+2a
+PASS Test <number> trailing garbage, value:    -47e
+PASS Test <number> trailing garbage, value:    .1e
+PASS Test <number> trailing garbage, value:    0.35e
+PASS Test <number> trailing garbage, value:    1e-10e
+PASS Test <number> trailing garbage, value:    +32e
+PASS Test <number> trailing garbage, value:    +17E-1e
+PASS Test <number> trailing garbage, value:    17e+2e
+PASS Test <number> trailing garbage, value:    -47foo
+PASS Test <number> trailing garbage, value:    .1foo
+PASS Test <number> trailing garbage, value:    0.35foo
+PASS Test <number> trailing garbage, value:    1e-10foo
+PASS Test <number> trailing garbage, value:    +32foo
+PASS Test <number> trailing garbage, value:    +17E-1foo
+PASS Test <number> trailing garbage, value:    17e+2foo
+PASS Test <number> trailing garbage, value:    -47)90
+PASS Test <number> trailing garbage, value:    .1)90
+PASS Test <number> trailing garbage, value:    0.35)90
+PASS Test <number> trailing garbage, value:    1e-10)90
+PASS Test <number> trailing garbage, value:    +32)90
+PASS Test <number> trailing garbage, value:    +17E-1)90
+PASS Test <number> trailing garbage, value:    17e+2)90
+PASS Test <number> valid value: \r\n\t -47
+PASS Test <number> valid value: \r\n\t .1
+PASS Test <number> valid value: \r\n\t 0.35
+PASS Test <number> valid value: \r\n\t 1e-10
+PASS Test <number> valid value: \r\n\t +32
+PASS Test <number> valid value: \r\n\t +17E-1
+PASS Test <number> valid value: \r\n\t 17e+2
+PASS Test <number> valid value: \r\n\t -47
+PASS Test <number> valid value: \r\n\t .1
+PASS Test <number> valid value: \r\n\t 0.35
+PASS Test <number> valid value: \r\n\t 1e-10
+PASS Test <number> valid value: \r\n\t +32
+PASS Test <number> valid value: \r\n\t +17E-1
+PASS Test <number> valid value: \r\n\t 17e+2
+PASS Test <number> valid value: \r\n\t -47
+PASS Test <number> valid value: \r\n\t .1
+PASS Test <number> valid value: \r\n\t 0.35
+PASS Test <number> valid value: \r\n\t 1e-10
+PASS Test <number> valid value: \r\n\t +32
+PASS Test <number> valid value: \r\n\t +17E-1
+PASS Test <number> valid value: \r\n\t 17e+2
+PASS Test <number> valid value: \r\n\t -47\r\n\t
+PASS Test <number> valid value: \r\n\t .1\r\n\t
+PASS Test <number> valid value: \r\n\t 0.35\r\n\t
+PASS Test <number> valid value: \r\n\t 1e-10\r\n\t
+PASS Test <number> valid value: \r\n\t +32\r\n\t
+PASS Test <number> valid value: \r\n\t +17E-1\r\n\t
+PASS Test <number> valid value: \r\n\t 17e+2\r\n\t
+PASS Test <number> valid value: \r\n\t -47\f
+PASS Test <number> valid value: \r\n\t .1\f
+PASS Test <number> valid value: \r\n\t 0.35\f
+PASS Test <number> valid value: \r\n\t 1e-10\f
+PASS Test <number> valid value: \r\n\t +32\f
+PASS Test <number> valid value: \r\n\t +17E-1\f
+PASS Test <number> valid value: \r\n\t 17e+2\f
+PASS Test <number> trailing garbage, value: \r\n\t -47a
+PASS Test <number> trailing garbage, value: \r\n\t .1a
+PASS Test <number> trailing garbage, value: \r\n\t 0.35a
+PASS Test <number> trailing garbage, value: \r\n\t 1e-10a
+PASS Test <number> trailing garbage, value: \r\n\t +32a
+PASS Test <number> trailing garbage, value: \r\n\t +17E-1a
+PASS Test <number> trailing garbage, value: \r\n\t 17e+2a
+PASS Test <number> trailing garbage, value: \r\n\t -47e
+PASS Test <number> trailing garbage, value: \r\n\t .1e
+PASS Test <number> trailing garbage, value: \r\n\t 0.35e
+PASS Test <number> trailing garbage, value: \r\n\t 1e-10e
+PASS Test <number> trailing garbage, value: \r\n\t +32e
+PASS Test <number> trailing garbage, value: \r\n\t +17E-1e
+PASS Test <number> trailing garbage, value: \r\n\t 17e+2e
+PASS Test <number> trailing garbage, value: \r\n\t -47foo
+PASS Test <number> trailing garbage, value: \r\n\t .1foo
+PASS Test <number> trailing garbage, value: \r\n\t 0.35foo
+PASS Test <number> trailing garbage, value: \r\n\t 1e-10foo
+PASS Test <number> trailing garbage, value: \r\n\t +32foo
+PASS Test <number> trailing garbage, value: \r\n\t +17E-1foo
+PASS Test <number> trailing garbage, value: \r\n\t 17e+2foo
+PASS Test <number> trailing garbage, value: \r\n\t -47)90
+PASS Test <number> trailing garbage, value: \r\n\t .1)90
+PASS Test <number> trailing garbage, value: \r\n\t 0.35)90
+PASS Test <number> trailing garbage, value: \r\n\t 1e-10)90
+PASS Test <number> trailing garbage, value: \r\n\t +32)90
+PASS Test <number> trailing garbage, value: \r\n\t +17E-1)90
+PASS Test <number> trailing garbage, value: \r\n\t 17e+2)90
+PASS Test <number> valid value: \f-47
+PASS Test <number> valid value: \f.1
+PASS Test <number> valid value: \f0.35
+PASS Test <number> valid value: \f1e-10
+PASS Test <number> valid value: \f+32
+PASS Test <number> valid value: \f+17E-1
+PASS Test <number> valid value: \f17e+2
+PASS Test <number> valid value: \f-47
+PASS Test <number> valid value: \f.1
+PASS Test <number> valid value: \f0.35
+PASS Test <number> valid value: \f1e-10
+PASS Test <number> valid value: \f+32
+PASS Test <number> valid value: \f+17E-1
+PASS Test <number> valid value: \f17e+2
+PASS Test <number> valid value: \f-47
+PASS Test <number> valid value: \f.1
+PASS Test <number> valid value: \f0.35
+PASS Test <number> valid value: \f1e-10
+PASS Test <number> valid value: \f+32
+PASS Test <number> valid value: \f+17E-1
+PASS Test <number> valid value: \f17e+2
+PASS Test <number> valid value: \f-47\r\n\t
+PASS Test <number> valid value: \f.1\r\n\t
+PASS Test <number> valid value: \f0.35\r\n\t
+PASS Test <number> valid value: \f1e-10\r\n\t
+PASS Test <number> valid value: \f+32\r\n\t
+PASS Test <number> valid value: \f+17E-1\r\n\t
+PASS Test <number> valid value: \f17e+2\r\n\t
+PASS Test <number> valid value: \f-47\f
+PASS Test <number> valid value: \f.1\f
+PASS Test <number> valid value: \f0.35\f
+PASS Test <number> valid value: \f1e-10\f
+PASS Test <number> valid value: \f+32\f
+PASS Test <number> valid value: \f+17E-1\f
+PASS Test <number> valid value: \f17e+2\f
+PASS Test <number> trailing garbage, value: \f-47a
+PASS Test <number> trailing garbage, value: \f.1a
+PASS Test <number> trailing garbage, value: \f0.35a
+PASS Test <number> trailing garbage, value: \f1e-10a
+PASS Test <number> trailing garbage, value: \f+32a
+PASS Test <number> trailing garbage, value: \f+17E-1a
+PASS Test <number> trailing garbage, value: \f17e+2a
+PASS Test <number> trailing garbage, value: \f-47e
+PASS Test <number> trailing garbage, value: \f.1e
+PASS Test <number> trailing garbage, value: \f0.35e
+PASS Test <number> trailing garbage, value: \f1e-10e
+PASS Test <number> trailing garbage, value: \f+32e
+PASS Test <number> trailing garbage, value: \f+17E-1e
+PASS Test <number> trailing garbage, value: \f17e+2e
+PASS Test <number> trailing garbage, value: \f-47foo
+PASS Test <number> trailing garbage, value: \f.1foo
+PASS Test <number> trailing garbage, value: \f0.35foo
+PASS Test <number> trailing garbage, value: \f1e-10foo
+PASS Test <number> trailing garbage, value: \f+32foo
+PASS Test <number> trailing garbage, value: \f+17E-1foo
+PASS Test <number> trailing garbage, value: \f17e+2foo
+PASS Test <number> trailing garbage, value: \f-47)90
+PASS Test <number> trailing garbage, value: \f.1)90
+PASS Test <number> trailing garbage, value: \f0.35)90
+PASS Test <number> trailing garbage, value: \f1e-10)90
+PASS Test <number> trailing garbage, value: \f+32)90
+PASS Test <number> trailing garbage, value: \f+17E-1)90
+PASS Test <number> trailing garbage, value: \f17e+2)90
+PASS Test <percentage> valid value: -47%
+PASS Test <percentage> valid value: .1%
+PASS Test <percentage> valid value: 0.35%
+PASS Test <percentage> valid value: 1e-10%
+PASS Test <percentage> valid value: +32%
+PASS Test <percentage> valid value: +17E-1%
+PASS Test <percentage> valid value: 17e+2%
+PASS Test <percentage> valid value: -47%
+PASS Test <percentage> valid value: .1%
+PASS Test <percentage> valid value: 0.35%
+PASS Test <percentage> valid value: 1e-10%
+PASS Test <percentage> valid value: +32%
+PASS Test <percentage> valid value: +17E-1%
+PASS Test <percentage> valid value: 17e+2%
+PASS Test <percentage> valid value: -47%
+PASS Test <percentage> valid value: .1%
+PASS Test <percentage> valid value: 0.35%
+PASS Test <percentage> valid value: 1e-10%
+PASS Test <percentage> valid value: +32%
+PASS Test <percentage> valid value: +17E-1%
+PASS Test <percentage> valid value: 17e+2%
+PASS Test <percentage> valid value: -47%\r\n\t
+PASS Test <percentage> valid value: .1%\r\n\t
+PASS Test <percentage> valid value: 0.35%\r\n\t
+PASS Test <percentage> valid value: 1e-10%\r\n\t
+PASS Test <percentage> valid value: +32%\r\n\t
+PASS Test <percentage> valid value: +17E-1%\r\n\t
+PASS Test <percentage> valid value: 17e+2%\r\n\t
+PASS Test <percentage> valid value: -47%\f
+PASS Test <percentage> valid value: .1%\f
+PASS Test <percentage> valid value: 0.35%\f
+PASS Test <percentage> valid value: 1e-10%\f
+PASS Test <percentage> valid value: +32%\f
+PASS Test <percentage> valid value: +17E-1%\f
+PASS Test <percentage> valid value: 17e+2%\f
+PASS Test <percentage> trailing garbage, value: -47a
+PASS Test <percentage> trailing garbage, value: .1a
+PASS Test <percentage> trailing garbage, value: 0.35a
+PASS Test <percentage> trailing garbage, value: 1e-10a
+PASS Test <percentage> trailing garbage, value: +32a
+PASS Test <percentage> trailing garbage, value: +17E-1a
+PASS Test <percentage> trailing garbage, value: 17e+2a
+PASS Test <percentage> trailing garbage, value: -47e
+PASS Test <percentage> trailing garbage, value: .1e
+PASS Test <percentage> trailing garbage, value: 0.35e
+PASS Test <percentage> trailing garbage, value: 1e-10e
+PASS Test <percentage> trailing garbage, value: +32e
+PASS Test <percentage> trailing garbage, value: +17E-1e
+PASS Test <percentage> trailing garbage, value: 17e+2e
+PASS Test <percentage> trailing garbage, value: -47foo
+PASS Test <percentage> trailing garbage, value: .1foo
+PASS Test <percentage> trailing garbage, value: 0.35foo
+PASS Test <percentage> trailing garbage, value: 1e-10foo
+PASS Test <percentage> trailing garbage, value: +32foo
+PASS Test <percentage> trailing garbage, value: +17E-1foo
+PASS Test <percentage> trailing garbage, value: 17e+2foo
+PASS Test <percentage> trailing garbage, value: -47)90
+PASS Test <percentage> trailing garbage, value: .1)90
+PASS Test <percentage> trailing garbage, value: 0.35)90
+PASS Test <percentage> trailing garbage, value: 1e-10)90
+PASS Test <percentage> trailing garbage, value: +32)90
+PASS Test <percentage> trailing garbage, value: +17E-1)90
+PASS Test <percentage> trailing garbage, value: 17e+2)90
+PASS Test <percentage> valid value:  -47%
+PASS Test <percentage> valid value:  .1%
+PASS Test <percentage> valid value:  0.35%
+PASS Test <percentage> valid value:  1e-10%
+PASS Test <percentage> valid value:  +32%
+PASS Test <percentage> valid value:  +17E-1%
+PASS Test <percentage> valid value:  17e+2%
+PASS Test <percentage> valid value:  -47%
+PASS Test <percentage> valid value:  .1%
+PASS Test <percentage> valid value:  0.35%
+PASS Test <percentage> valid value:  1e-10%
+PASS Test <percentage> valid value:  +32%
+PASS Test <percentage> valid value:  +17E-1%
+PASS Test <percentage> valid value:  17e+2%
+PASS Test <percentage> valid value:  -47%
+PASS Test <percentage> valid value:  .1%
+PASS Test <percentage> valid value:  0.35%
+PASS Test <percentage> valid value:  1e-10%
+PASS Test <percentage> valid value:  +32%
+PASS Test <percentage> valid value:  +17E-1%
+PASS Test <percentage> valid value:  17e+2%
+PASS Test <percentage> valid value:  -47%\r\n\t
+PASS Test <percentage> valid value:  .1%\r\n\t
+PASS Test <percentage> valid value:  0.35%\r\n\t
+PASS Test <percentage> valid value:  1e-10%\r\n\t
+PASS Test <percentage> valid value:  +32%\r\n\t
+PASS Test <percentage> valid value:  +17E-1%\r\n\t
+PASS Test <percentage> valid value:  17e+2%\r\n\t
+PASS Test <percentage> valid value:  -47%\f
+PASS Test <percentage> valid value:  .1%\f
+PASS Test <percentage> valid value:  0.35%\f
+PASS Test <percentage> valid value:  1e-10%\f
+PASS Test <percentage> valid value:  +32%\f
+PASS Test <percentage> valid value:  +17E-1%\f
+PASS Test <percentage> valid value:  17e+2%\f
+PASS Test <percentage> WS invalid value: -47 %
+PASS Test <percentage> WS invalid value: .1 %
+PASS Test <percentage> WS invalid value: 0.35 %
+PASS Test <percentage> WS invalid value: 1e-10 %
+PASS Test <percentage> WS invalid value: +32 %
+PASS Test <percentage> WS invalid value: +17E-1 %
+PASS Test <percentage> WS invalid value: 17e+2 %
+PASS Test <percentage> trailing garbage, value:  -47a
+PASS Test <percentage> trailing garbage, value:  .1a
+PASS Test <percentage> trailing garbage, value:  0.35a
+PASS Test <percentage> trailing garbage, value:  1e-10a
+PASS Test <percentage> trailing garbage, value:  +32a
+PASS Test <percentage> trailing garbage, value:  +17E-1a
+PASS Test <percentage> trailing garbage, value:  17e+2a
+PASS Test <percentage> trailing garbage, value:  -47e
+PASS Test <percentage> trailing garbage, value:  .1e
+PASS Test <percentage> trailing garbage, value:  0.35e
+PASS Test <percentage> trailing garbage, value:  1e-10e
+PASS Test <percentage> trailing garbage, value:  +32e
+PASS Test <percentage> trailing garbage, value:  +17E-1e
+PASS Test <percentage> trailing garbage, value:  17e+2e
+PASS Test <percentage> trailing garbage, value:  -47foo
+PASS Test <percentage> trailing garbage, value:  .1foo
+PASS Test <percentage> trailing garbage, value:  0.35foo
+PASS Test <percentage> trailing garbage, value:  1e-10foo
+PASS Test <percentage> trailing garbage, value:  +32foo
+PASS Test <percentage> trailing garbage, value:  +17E-1foo
+PASS Test <percentage> trailing garbage, value:  17e+2foo
+PASS Test <percentage> trailing garbage, value:  -47)90
+PASS Test <percentage> trailing garbage, value:  .1)90
+PASS Test <percentage> trailing garbage, value:  0.35)90
+PASS Test <percentage> trailing garbage, value:  1e-10)90
+PASS Test <percentage> trailing garbage, value:  +32)90
+PASS Test <percentage> trailing garbage, value:  +17E-1)90
+PASS Test <percentage> trailing garbage, value:  17e+2)90
+PASS Test <percentage> valid value:    -47%
+PASS Test <percentage> valid value:    .1%
+PASS Test <percentage> valid value:    0.35%
+PASS Test <percentage> valid value:    1e-10%
+PASS Test <percentage> valid value:    +32%
+PASS Test <percentage> valid value:    +17E-1%
+PASS Test <percentage> valid value:    17e+2%
+PASS Test <percentage> valid value:    -47%
+PASS Test <percentage> valid value:    .1%
+PASS Test <percentage> valid value:    0.35%
+PASS Test <percentage> valid value:    1e-10%
+PASS Test <percentage> valid value:    +32%
+PASS Test <percentage> valid value:    +17E-1%
+PASS Test <percentage> valid value:    17e+2%
+PASS Test <percentage> valid value:    -47%
+PASS Test <percentage> valid value:    .1%
+PASS Test <percentage> valid value:    0.35%
+PASS Test <percentage> valid value:    1e-10%
+PASS Test <percentage> valid value:    +32%
+PASS Test <percentage> valid value:    +17E-1%
+PASS Test <percentage> valid value:    17e+2%
+PASS Test <percentage> valid value:    -47%\r\n\t
+PASS Test <percentage> valid value:    .1%\r\n\t
+PASS Test <percentage> valid value:    0.35%\r\n\t
+PASS Test <percentage> valid value:    1e-10%\r\n\t
+PASS Test <percentage> valid value:    +32%\r\n\t
+PASS Test <percentage> valid value:    +17E-1%\r\n\t
+PASS Test <percentage> valid value:    17e+2%\r\n\t
+PASS Test <percentage> valid value:    -47%\f
+PASS Test <percentage> valid value:    .1%\f
+PASS Test <percentage> valid value:    0.35%\f
+PASS Test <percentage> valid value:    1e-10%\f
+PASS Test <percentage> valid value:    +32%\f
+PASS Test <percentage> valid value:    +17E-1%\f
+PASS Test <percentage> valid value:    17e+2%\f
+PASS Test <percentage> WS invalid value: -47   %
+PASS Test <percentage> WS invalid value: .1   %
+PASS Test <percentage> WS invalid value: 0.35   %
+PASS Test <percentage> WS invalid value: 1e-10   %
+PASS Test <percentage> WS invalid value: +32   %
+PASS Test <percentage> WS invalid value: +17E-1   %
+PASS Test <percentage> WS invalid value: 17e+2   %
+PASS Test <percentage> trailing garbage, value:    -47a
+PASS Test <percentage> trailing garbage, value:    .1a
+PASS Test <percentage> trailing garbage, value:    0.35a
+PASS Test <percentage> trailing garbage, value:    1e-10a
+PASS Test <percentage> trailing garbage, value:    +32a
+PASS Test <percentage> trailing garbage, value:    +17E-1a
+PASS Test <percentage> trailing garbage, value:    17e+2a
+PASS Test <percentage> trailing garbage, value:    -47e
+PASS Test <percentage> trailing garbage, value:    .1e
+PASS Test <percentage> trailing garbage, value:    0.35e
+PASS Test <percentage> trailing garbage, value:    1e-10e
+PASS Test <percentage> trailing garbage, value:    +32e
+PASS Test <percentage> trailing garbage, value:    +17E-1e
+PASS Test <percentage> trailing garbage, value:    17e+2e
+PASS Test <percentage> trailing garbage, value:    -47foo
+PASS Test <percentage> trailing garbage, value:    .1foo
+PASS Test <percentage> trailing garbage, value:    0.35foo
+PASS Test <percentage> trailing garbage, value:    1e-10foo
+PASS Test <percentage> trailing garbage, value:    +32foo
+PASS Test <percentage> trailing garbage, value:    +17E-1foo
+PASS Test <percentage> trailing garbage, value:    17e+2foo
+PASS Test <percentage> trailing garbage, value:    -47)90
+PASS Test <percentage> trailing garbage, value:    .1)90
+PASS Test <percentage> trailing garbage, value:    0.35)90
+PASS Test <percentage> trailing garbage, value:    1e-10)90
+PASS Test <percentage> trailing garbage, value:    +32)90
+PASS Test <percentage> trailing garbage, value:    +17E-1)90
+PASS Test <percentage> trailing garbage, value:    17e+2)90
+PASS Test <percentage> valid value: \r\n\t -47%
+PASS Test <percentage> valid value: \r\n\t .1%
+PASS Test <percentage> valid value: \r\n\t 0.35%
+PASS Test <percentage> valid value: \r\n\t 1e-10%
+PASS Test <percentage> valid value: \r\n\t +32%
+PASS Test <percentage> valid value: \r\n\t +17E-1%
+PASS Test <percentage> valid value: \r\n\t 17e+2%
+PASS Test <percentage> valid value: \r\n\t -47%
+PASS Test <percentage> valid value: \r\n\t .1%
+PASS Test <percentage> valid value: \r\n\t 0.35%
+PASS Test <percentage> valid value: \r\n\t 1e-10%
+PASS Test <percentage> valid value: \r\n\t +32%
+PASS Test <percentage> valid value: \r\n\t +17E-1%
+PASS Test <percentage> valid value: \r\n\t 17e+2%
+PASS Test <percentage> valid value: \r\n\t -47%
+PASS Test <percentage> valid value: \r\n\t .1%
+PASS Test <percentage> valid value: \r\n\t 0.35%
+PASS Test <percentage> valid value: \r\n\t 1e-10%
+PASS Test <percentage> valid value: \r\n\t +32%
+PASS Test <percentage> valid value: \r\n\t +17E-1%
+PASS Test <percentage> valid value: \r\n\t 17e+2%
+PASS Test <percentage> valid value: \r\n\t -47%\r\n\t
+PASS Test <percentage> valid value: \r\n\t .1%\r\n\t
+PASS Test <percentage> valid value: \r\n\t 0.35%\r\n\t
+PASS Test <percentage> valid value: \r\n\t 1e-10%\r\n\t
+PASS Test <percentage> valid value: \r\n\t +32%\r\n\t
+PASS Test <percentage> valid value: \r\n\t +17E-1%\r\n\t
+PASS Test <percentage> valid value: \r\n\t 17e+2%\r\n\t
+PASS Test <percentage> valid value: \r\n\t -47%\f
+PASS Test <percentage> valid value: \r\n\t .1%\f
+PASS Test <percentage> valid value: \r\n\t 0.35%\f
+PASS Test <percentage> valid value: \r\n\t 1e-10%\f
+PASS Test <percentage> valid value: \r\n\t +32%\f
+PASS Test <percentage> valid value: \r\n\t +17E-1%\f
+PASS Test <percentage> valid value: \r\n\t 17e+2%\f
+PASS Test <percentage> WS invalid value: -47\r\n\t %
+PASS Test <percentage> WS invalid value: .1\r\n\t %
+PASS Test <percentage> WS invalid value: 0.35\r\n\t %
+PASS Test <percentage> WS invalid value: 1e-10\r\n\t %
+PASS Test <percentage> WS invalid value: +32\r\n\t %
+PASS Test <percentage> WS invalid value: +17E-1\r\n\t %
+PASS Test <percentage> WS invalid value: 17e+2\r\n\t %
+PASS Test <percentage> trailing garbage, value: \r\n\t -47a
+PASS Test <percentage> trailing garbage, value: \r\n\t .1a
+PASS Test <percentage> trailing garbage, value: \r\n\t 0.35a
+PASS Test <percentage> trailing garbage, value: \r\n\t 1e-10a
+PASS Test <percentage> trailing garbage, value: \r\n\t +32a
+PASS Test <percentage> trailing garbage, value: \r\n\t +17E-1a
+PASS Test <percentage> trailing garbage, value: \r\n\t 17e+2a
+PASS Test <percentage> trailing garbage, value: \r\n\t -47e
+PASS Test <percentage> trailing garbage, value: \r\n\t .1e
+PASS Test <percentage> trailing garbage, value: \r\n\t 0.35e
+PASS Test <percentage> trailing garbage, value: \r\n\t 1e-10e
+PASS Test <percentage> trailing garbage, value: \r\n\t +32e
+PASS Test <percentage> trailing garbage, value: \r\n\t +17E-1e
+PASS Test <percentage> trailing garbage, value: \r\n\t 17e+2e
+PASS Test <percentage> trailing garbage, value: \r\n\t -47foo
+PASS Test <percentage> trailing garbage, value: \r\n\t .1foo
+PASS Test <percentage> trailing garbage, value: \r\n\t 0.35foo
+PASS Test <percentage> trailing garbage, value: \r\n\t 1e-10foo
+PASS Test <percentage> trailing garbage, value: \r\n\t +32foo
+PASS Test <percentage> trailing garbage, value: \r\n\t +17E-1foo
+PASS Test <percentage> trailing garbage, value: \r\n\t 17e+2foo
+PASS Test <percentage> trailing garbage, value: \r\n\t -47)90
+PASS Test <percentage> trailing garbage, value: \r\n\t .1)90
+PASS Test <percentage> trailing garbage, value: \r\n\t 0.35)90
+PASS Test <percentage> trailing garbage, value: \r\n\t 1e-10)90
+PASS Test <percentage> trailing garbage, value: \r\n\t +32)90
+PASS Test <percentage> trailing garbage, value: \r\n\t +17E-1)90
+PASS Test <percentage> trailing garbage, value: \r\n\t 17e+2)90
+PASS Test <percentage> valid value: \f-47%
+PASS Test <percentage> valid value: \f.1%
+PASS Test <percentage> valid value: \f0.35%
+PASS Test <percentage> valid value: \f1e-10%
+PASS Test <percentage> valid value: \f+32%
+PASS Test <percentage> valid value: \f+17E-1%
+PASS Test <percentage> valid value: \f17e+2%
+PASS Test <percentage> valid value: \f-47%
+PASS Test <percentage> valid value: \f.1%
+PASS Test <percentage> valid value: \f0.35%
+PASS Test <percentage> valid value: \f1e-10%
+PASS Test <percentage> valid value: \f+32%
+PASS Test <percentage> valid value: \f+17E-1%
+PASS Test <percentage> valid value: \f17e+2%
+PASS Test <percentage> valid value: \f-47%
+PASS Test <percentage> valid value: \f.1%
+PASS Test <percentage> valid value: \f0.35%
+PASS Test <percentage> valid value: \f1e-10%
+PASS Test <percentage> valid value: \f+32%
+PASS Test <percentage> valid value: \f+17E-1%
+PASS Test <percentage> valid value: \f17e+2%
+PASS Test <percentage> valid value: \f-47%\r\n\t
+PASS Test <percentage> valid value: \f.1%\r\n\t
+PASS Test <percentage> valid value: \f0.35%\r\n\t
+PASS Test <percentage> valid value: \f1e-10%\r\n\t
+PASS Test <percentage> valid value: \f+32%\r\n\t
+PASS Test <percentage> valid value: \f+17E-1%\r\n\t
+PASS Test <percentage> valid value: \f17e+2%\r\n\t
+PASS Test <percentage> valid value: \f-47%\f
+PASS Test <percentage> valid value: \f.1%\f
+PASS Test <percentage> valid value: \f0.35%\f
+PASS Test <percentage> valid value: \f1e-10%\f
+PASS Test <percentage> valid value: \f+32%\f
+PASS Test <percentage> valid value: \f+17E-1%\f
+PASS Test <percentage> valid value: \f17e+2%\f
+PASS Test <percentage> WS invalid value: -47\f%
+PASS Test <percentage> WS invalid value: .1\f%
+PASS Test <percentage> WS invalid value: 0.35\f%
+PASS Test <percentage> WS invalid value: 1e-10\f%
+PASS Test <percentage> WS invalid value: +32\f%
+PASS Test <percentage> WS invalid value: +17E-1\f%
+PASS Test <percentage> WS invalid value: 17e+2\f%
+PASS Test <percentage> trailing garbage, value: \f-47a
+PASS Test <percentage> trailing garbage, value: \f.1a
+PASS Test <percentage> trailing garbage, value: \f0.35a
+PASS Test <percentage> trailing garbage, value: \f1e-10a
+PASS Test <percentage> trailing garbage, value: \f+32a
+PASS Test <percentage> trailing garbage, value: \f+17E-1a
+PASS Test <percentage> trailing garbage, value: \f17e+2a
+PASS Test <percentage> trailing garbage, value: \f-47e
+PASS Test <percentage> trailing garbage, value: \f.1e
+PASS Test <percentage> trailing garbage, value: \f0.35e
+PASS Test <percentage> trailing garbage, value: \f1e-10e
+PASS Test <percentage> trailing garbage, value: \f+32e
+PASS Test <percentage> trailing garbage, value: \f+17E-1e
+PASS Test <percentage> trailing garbage, value: \f17e+2e
+PASS Test <percentage> trailing garbage, value: \f-47foo
+PASS Test <percentage> trailing garbage, value: \f.1foo
+PASS Test <percentage> trailing garbage, value: \f0.35foo
+PASS Test <percentage> trailing garbage, value: \f1e-10foo
+PASS Test <percentage> trailing garbage, value: \f+32foo
+PASS Test <percentage> trailing garbage, value: \f+17E-1foo
+PASS Test <percentage> trailing garbage, value: \f17e+2foo
+PASS Test <percentage> trailing garbage, value: \f-47)90
+PASS Test <percentage> trailing garbage, value: \f.1)90
+PASS Test <percentage> trailing garbage, value: \f0.35)90
+PASS Test <percentage> trailing garbage, value: \f1e-10)90
+PASS Test <percentage> trailing garbage, value: \f+32)90
+PASS Test <percentage> trailing garbage, value: \f+17E-1)90
+PASS Test <percentage> trailing garbage, value: \f17e+2)90
+PASS Test <number> invalid value: NaN
+PASS Test <number> invalid value: Infinity
+PASS Test <number> invalid value: -Infinity
+PASS Test <number> invalid value: fnord
+PASS Test <number> invalid value: E
+PASS Test <number> invalid value: e
+PASS Test <number> invalid value: e+
+PASS Test <number> invalid value: E-
+PASS Test <number> invalid value: -
+PASS Test <number> invalid value: +
+PASS Test <number> invalid value: -.
+PASS Test <number> invalid value: .-
+PASS Test <number> invalid value: .
+PASS Test <number> invalid value: +.
+PASS Test <number> invalid value: .E0
+PASS Test <number> invalid value: e1
+PASS Test <number> invalid value: NaN
+PASS Test <number> invalid value: Infinity
+PASS Test <number> invalid value: -Infinity
+PASS Test <number> invalid value: fnord
+PASS Test <number> invalid value: E
+PASS Test <number> invalid value: e
+PASS Test <number> invalid value: e+
+PASS Test <number> invalid value: E-
+PASS Test <number> invalid value: -
+PASS Test <number> invalid value: +
+PASS Test <number> invalid value: -.
+PASS Test <number> invalid value: .-
+PASS Test <number> invalid value: .
+PASS Test <number> invalid value: +.
+PASS Test <number> invalid value: .E0
+PASS Test <number> invalid value: e1
+PASS Test <number> invalid value: NaN
+PASS Test <number> invalid value: Infinity
+PASS Test <number> invalid value: -Infinity
+PASS Test <number> invalid value: fnord
+PASS Test <number> invalid value: E
+PASS Test <number> invalid value: e
+PASS Test <number> invalid value: e+
+PASS Test <number> invalid value: E-
+PASS Test <number> invalid value: -
+PASS Test <number> invalid value: +
+PASS Test <number> invalid value: -.
+PASS Test <number> invalid value: .-
+PASS Test <number> invalid value: .
+PASS Test <number> invalid value: +.
+PASS Test <number> invalid value: .E0
+PASS Test <number> invalid value: e1
+PASS Test <number> invalid value: NaN\r\n\t
+PASS Test <number> invalid value: Infinity\r\n\t
+PASS Test <number> invalid value: -Infinity\r\n\t
+PASS Test <number> invalid value: fnord\r\n\t
+PASS Test <number> invalid value: E\r\n\t
+PASS Test <number> invalid value: e\r\n\t
+PASS Test <number> invalid value: e+\r\n\t
+PASS Test <number> invalid value: E-\r\n\t
+PASS Test <number> invalid value: -\r\n\t
+PASS Test <number> invalid value: +\r\n\t
+PASS Test <number> invalid value: -.\r\n\t
+PASS Test <number> invalid value: .-\r\n\t
+PASS Test <number> invalid value: .\r\n\t
+PASS Test <number> invalid value: +.\r\n\t
+PASS Test <number> invalid value: .E0\r\n\t
+PASS Test <number> invalid value: e1\r\n\t
+PASS Test <number> invalid value: NaN\f
+PASS Test <number> invalid value: Infinity\f
+PASS Test <number> invalid value: -Infinity\f
+PASS Test <number> invalid value: fnord\f
+PASS Test <number> invalid value: E\f
+PASS Test <number> invalid value: e\f
+PASS Test <number> invalid value: e+\f
+PASS Test <number> invalid value: E-\f
+PASS Test <number> invalid value: -\f
+PASS Test <number> invalid value: +\f
+PASS Test <number> invalid value: -.\f
+PASS Test <number> invalid value: .-\f
+PASS Test <number> invalid value: .\f
+PASS Test <number> invalid value: +.\f
+PASS Test <number> invalid value: .E0\f
+PASS Test <number> invalid value: e1\f
+PASS Test <number> invalid value:  NaN
+PASS Test <number> invalid value:  Infinity
+PASS Test <number> invalid value:  -Infinity
+PASS Test <number> invalid value:  fnord
+PASS Test <number> invalid value:  E
+PASS Test <number> invalid value:  e
+PASS Test <number> invalid value:  e+
+PASS Test <number> invalid value:  E-
+PASS Test <number> invalid value:  -
+PASS Test <number> invalid value:  +
+PASS Test <number> invalid value:  -.
+PASS Test <number> invalid value:  .-
+PASS Test <number> invalid value:  .
+PASS Test <number> invalid value:  +.
+PASS Test <number> invalid value:  .E0
+PASS Test <number> invalid value:  e1
+PASS Test <number> invalid value:  NaN
+PASS Test <number> invalid value:  Infinity
+PASS Test <number> invalid value:  -Infinity
+PASS Test <number> invalid value:  fnord
+PASS Test <number> invalid value:  E
+PASS Test <number> invalid value:  e
+PASS Test <number> invalid value:  e+
+PASS Test <number> invalid value:  E-
+PASS Test <number> invalid value:  -
+PASS Test <number> invalid value:  +
+PASS Test <number> invalid value:  -.
+PASS Test <number> invalid value:  .-
+PASS Test <number> invalid value:  .
+PASS Test <number> invalid value:  +.
+PASS Test <number> invalid value:  .E0
+PASS Test <number> invalid value:  e1
+PASS Test <number> invalid value:  NaN
+PASS Test <number> invalid value:  Infinity
+PASS Test <number> invalid value:  -Infinity
+PASS Test <number> invalid value:  fnord
+PASS Test <number> invalid value:  E
+PASS Test <number> invalid value:  e
+PASS Test <number> invalid value:  e+
+PASS Test <number> invalid value:  E-
+PASS Test <number> invalid value:  -
+PASS Test <number> invalid value:  +
+PASS Test <number> invalid value:  -.
+PASS Test <number> invalid value:  .-
+PASS Test <number> invalid value:  .
+PASS Test <number> invalid value:  +.
+PASS Test <number> invalid value:  .E0
+PASS Test <number> invalid value:  e1
+PASS Test <number> invalid value:  NaN\r\n\t
+PASS Test <number> invalid value:  Infinity\r\n\t
+PASS Test <number> invalid value:  -Infinity\r\n\t
+PASS Test <number> invalid value:  fnord\r\n\t
+PASS Test <number> invalid value:  E\r\n\t
+PASS Test <number> invalid value:  e\r\n\t
+PASS Test <number> invalid value:  e+\r\n\t
+PASS Test <number> invalid value:  E-\r\n\t
+PASS Test <number> invalid value:  -\r\n\t
+PASS Test <number> invalid value:  +\r\n\t
+PASS Test <number> invalid value:  -.\r\n\t
+PASS Test <number> invalid value:  .-\r\n\t
+PASS Test <number> invalid value:  .\r\n\t
+PASS Test <number> invalid value:  +.\r\n\t
+PASS Test <number> invalid value:  .E0\r\n\t
+PASS Test <number> invalid value:  e1\r\n\t
+PASS Test <number> invalid value:  NaN\f
+PASS Test <number> invalid value:  Infinity\f
+PASS Test <number> invalid value:  -Infinity\f
+PASS Test <number> invalid value:  fnord\f
+PASS Test <number> invalid value:  E\f
+PASS Test <number> invalid value:  e\f
+PASS Test <number> invalid value:  e+\f
+PASS Test <number> invalid value:  E-\f
+PASS Test <number> invalid value:  -\f
+PASS Test <number> invalid value:  +\f
+PASS Test <number> invalid value:  -.\f
+PASS Test <number> invalid value:  .-\f
+PASS Test <number> invalid value:  .\f
+PASS Test <number> invalid value:  +.\f
+PASS Test <number> invalid value:  .E0\f
+PASS Test <number> invalid value:  e1\f
+PASS Test <number> invalid value:    NaN
+PASS Test <number> invalid value:    Infinity
+PASS Test <number> invalid value:    -Infinity
+PASS Test <number> invalid value:    fnord
+PASS Test <number> invalid value:    E
+PASS Test <number> invalid value:    e
+PASS Test <number> invalid value:    e+
+PASS Test <number> invalid value:    E-
+PASS Test <number> invalid value:    -
+PASS Test <number> invalid value:    +
+PASS Test <number> invalid value:    -.
+PASS Test <number> invalid value:    .-
+PASS Test <number> invalid value:    .
+PASS Test <number> invalid value:    +.
+PASS Test <number> invalid value:    .E0
+PASS Test <number> invalid value:    e1
+PASS Test <number> invalid value:    NaN
+PASS Test <number> invalid value:    Infinity
+PASS Test <number> invalid value:    -Infinity
+PASS Test <number> invalid value:    fnord
+PASS Test <number> invalid value:    E
+PASS Test <number> invalid value:    e
+PASS Test <number> invalid value:    e+
+PASS Test <number> invalid value:    E-
+PASS Test <number> invalid value:    -
+PASS Test <number> invalid value:    +
+PASS Test <number> invalid value:    -.
+PASS Test <number> invalid value:    .-
+PASS Test <number> invalid value:    .
+PASS Test <number> invalid value:    +.
+PASS Test <number> invalid value:    .E0
+PASS Test <number> invalid value:    e1
+PASS Test <number> invalid value:    NaN
+PASS Test <number> invalid value:    Infinity
+PASS Test <number> invalid value:    -Infinity
+PASS Test <number> invalid value:    fnord
+PASS Test <number> invalid value:    E
+PASS Test <number> invalid value:    e
+PASS Test <number> invalid value:    e+
+PASS Test <number> invalid value:    E-
+PASS Test <number> invalid value:    -
+PASS Test <number> invalid value:    +
+PASS Test <number> invalid value:    -.
+PASS Test <number> invalid value:    .-
+PASS Test <number> invalid value:    .
+PASS Test <number> invalid value:    +.
+PASS Test <number> invalid value:    .E0
+PASS Test <number> invalid value:    e1
+PASS Test <number> invalid value:    NaN\r\n\t
+PASS Test <number> invalid value:    Infinity\r\n\t
+PASS Test <number> invalid value:    -Infinity\r\n\t
+PASS Test <number> invalid value:    fnord\r\n\t
+PASS Test <number> invalid value:    E\r\n\t
+PASS Test <number> invalid value:    e\r\n\t
+PASS Test <number> invalid value:    e+\r\n\t
+PASS Test <number> invalid value:    E-\r\n\t
+PASS Test <number> invalid value:    -\r\n\t
+PASS Test <number> invalid value:    +\r\n\t
+PASS Test <number> invalid value:    -.\r\n\t
+PASS Test <number> invalid value:    .-\r\n\t
+PASS Test <number> invalid value:    .\r\n\t
+PASS Test <number> invalid value:    +.\r\n\t
+PASS Test <number> invalid value:    .E0\r\n\t
+PASS Test <number> invalid value:    e1\r\n\t
+PASS Test <number> invalid value:    NaN\f
+PASS Test <number> invalid value:    Infinity\f
+PASS Test <number> invalid value:    -Infinity\f
+PASS Test <number> invalid value:    fnord\f
+PASS Test <number> invalid value:    E\f
+PASS Test <number> invalid value:    e\f
+PASS Test <number> invalid value:    e+\f
+PASS Test <number> invalid value:    E-\f
+PASS Test <number> invalid value:    -\f
+PASS Test <number> invalid value:    +\f
+PASS Test <number> invalid value:    -.\f
+PASS Test <number> invalid value:    .-\f
+PASS Test <number> invalid value:    .\f
+PASS Test <number> invalid value:    +.\f
+PASS Test <number> invalid value:    .E0\f
+PASS Test <number> invalid value:    e1\f
+PASS Test <number> invalid value: \r\n\t NaN
+PASS Test <number> invalid value: \r\n\t Infinity
+PASS Test <number> invalid value: \r\n\t -Infinity
+PASS Test <number> invalid value: \r\n\t fnord
+PASS Test <number> invalid value: \r\n\t E
+PASS Test <number> invalid value: \r\n\t e
+PASS Test <number> invalid value: \r\n\t e+
+PASS Test <number> invalid value: \r\n\t E-
+PASS Test <number> invalid value: \r\n\t -
+PASS Test <number> invalid value: \r\n\t +
+PASS Test <number> invalid value: \r\n\t -.
+PASS Test <number> invalid value: \r\n\t .-
+PASS Test <number> invalid value: \r\n\t .
+PASS Test <number> invalid value: \r\n\t +.
+PASS Test <number> invalid value: \r\n\t .E0
+PASS Test <number> invalid value: \r\n\t e1
+PASS Test <number> invalid value: \r\n\t NaN
+PASS Test <number> invalid value: \r\n\t Infinity
+PASS Test <number> invalid value: \r\n\t -Infinity
+PASS Test <number> invalid value: \r\n\t fnord
+PASS Test <number> invalid value: \r\n\t E
+PASS Test <number> invalid value: \r\n\t e
+PASS Test <number> invalid value: \r\n\t e+
+PASS Test <number> invalid value: \r\n\t E-
+PASS Test <number> invalid value: \r\n\t -
+PASS Test <number> invalid value: \r\n\t +
+PASS Test <number> invalid value: \r\n\t -.
+PASS Test <number> invalid value: \r\n\t .-
+PASS Test <number> invalid value: \r\n\t .
+PASS Test <number> invalid value: \r\n\t +.
+PASS Test <number> invalid value: \r\n\t .E0
+PASS Test <number> invalid value: \r\n\t e1
+PASS Test <number> invalid value: \r\n\t NaN
+PASS Test <number> invalid value: \r\n\t Infinity
+PASS Test <number> invalid value: \r\n\t -Infinity
+PASS Test <number> invalid value: \r\n\t fnord
+PASS Test <number> invalid value: \r\n\t E
+PASS Test <number> invalid value: \r\n\t e
+PASS Test <number> invalid value: \r\n\t e+
+PASS Test <number> invalid value: \r\n\t E-
+PASS Test <number> invalid value: \r\n\t -
+PASS Test <number> invalid value: \r\n\t +
+PASS Test <number> invalid value: \r\n\t -.
+PASS Test <number> invalid value: \r\n\t .-
+PASS Test <number> invalid value: \r\n\t .
+PASS Test <number> invalid value: \r\n\t +.
+PASS Test <number> invalid value: \r\n\t .E0
+PASS Test <number> invalid value: \r\n\t e1
+PASS Test <number> invalid value: \r\n\t NaN\r\n\t
+PASS Test <number> invalid value: \r\n\t Infinity\r\n\t
+PASS Test <number> invalid value: \r\n\t -Infinity\r\n\t
+PASS Test <number> invalid value: \r\n\t fnord\r\n\t
+PASS Test <number> invalid value: \r\n\t E\r\n\t
+PASS Test <number> invalid value: \r\n\t e\r\n\t
+PASS Test <number> invalid value: \r\n\t e+\r\n\t
+PASS Test <number> invalid value: \r\n\t E-\r\n\t
+PASS Test <number> invalid value: \r\n\t -\r\n\t
+PASS Test <number> invalid value: \r\n\t +\r\n\t
+PASS Test <number> invalid value: \r\n\t -.\r\n\t
+PASS Test <number> invalid value: \r\n\t .-\r\n\t
+PASS Test <number> invalid value: \r\n\t .\r\n\t
+PASS Test <number> invalid value: \r\n\t +.\r\n\t
+PASS Test <number> invalid value: \r\n\t .E0\r\n\t
+PASS Test <number> invalid value: \r\n\t e1\r\n\t
+PASS Test <number> invalid value: \r\n\t NaN\f
+PASS Test <number> invalid value: \r\n\t Infinity\f
+PASS Test <number> invalid value: \r\n\t -Infinity\f
+PASS Test <number> invalid value: \r\n\t fnord\f
+PASS Test <number> invalid value: \r\n\t E\f
+PASS Test <number> invalid value: \r\n\t e\f
+PASS Test <number> invalid value: \r\n\t e+\f
+PASS Test <number> invalid value: \r\n\t E-\f
+PASS Test <number> invalid value: \r\n\t -\f
+PASS Test <number> invalid value: \r\n\t +\f
+PASS Test <number> invalid value: \r\n\t -.\f
+PASS Test <number> invalid value: \r\n\t .-\f
+PASS Test <number> invalid value: \r\n\t .\f
+PASS Test <number> invalid value: \r\n\t +.\f
+PASS Test <number> invalid value: \r\n\t .E0\f
+PASS Test <number> invalid value: \r\n\t e1\f
+PASS Test <number> invalid value: \fNaN
+PASS Test <number> invalid value: \fInfinity
+PASS Test <number> invalid value: \f-Infinity
+PASS Test <number> invalid value: \ffnord
+PASS Test <number> invalid value: \fE
+PASS Test <number> invalid value: \fe
+PASS Test <number> invalid value: \fe+
+PASS Test <number> invalid value: \fE-
+PASS Test <number> invalid value: \f-
+PASS Test <number> invalid value: \f+
+PASS Test <number> invalid value: \f-.
+PASS Test <number> invalid value: \f.-
+PASS Test <number> invalid value: \f.
+PASS Test <number> invalid value: \f+.
+PASS Test <number> invalid value: \f.E0
+PASS Test <number> invalid value: \fe1
+PASS Test <number> invalid value: \fNaN
+PASS Test <number> invalid value: \fInfinity
+PASS Test <number> invalid value: \f-Infinity
+PASS Test <number> invalid value: \ffnord
+PASS Test <number> invalid value: \fE
+PASS Test <number> invalid value: \fe
+PASS Test <number> invalid value: \fe+
+PASS Test <number> invalid value: \fE-
+PASS Test <number> invalid value: \f-
+PASS Test <number> invalid value: \f+
+PASS Test <number> invalid value: \f-.
+PASS Test <number> invalid value: \f.-
+PASS Test <number> invalid value: \f.
+PASS Test <number> invalid value: \f+.
+PASS Test <number> invalid value: \f.E0
+PASS Test <number> invalid value: \fe1
+PASS Test <number> invalid value: \fNaN
+PASS Test <number> invalid value: \fInfinity
+PASS Test <number> invalid value: \f-Infinity
+PASS Test <number> invalid value: \ffnord
+PASS Test <number> invalid value: \fE
+PASS Test <number> invalid value: \fe
+PASS Test <number> invalid value: \fe+
+PASS Test <number> invalid value: \fE-
+PASS Test <number> invalid value: \f-
+PASS Test <number> invalid value: \f+
+PASS Test <number> invalid value: \f-.
+PASS Test <number> invalid value: \f.-
+PASS Test <number> invalid value: \f.
+PASS Test <number> invalid value: \f+.
+PASS Test <number> invalid value: \f.E0
+PASS Test <number> invalid value: \fe1
+PASS Test <number> invalid value: \fNaN\r\n\t
+PASS Test <number> invalid value: \fInfinity\r\n\t
+PASS Test <number> invalid value: \f-Infinity\r\n\t
+PASS Test <number> invalid value: \ffnord\r\n\t
+PASS Test <number> invalid value: \fE\r\n\t
+PASS Test <number> invalid value: \fe\r\n\t
+PASS Test <number> invalid value: \fe+\r\n\t
+PASS Test <number> invalid value: \fE-\r\n\t
+PASS Test <number> invalid value: \f-\r\n\t
+PASS Test <number> invalid value: \f+\r\n\t
+PASS Test <number> invalid value: \f-.\r\n\t
+PASS Test <number> invalid value: \f.-\r\n\t
+PASS Test <number> invalid value: \f.\r\n\t
+PASS Test <number> invalid value: \f+.\r\n\t
+PASS Test <number> invalid value: \f.E0\r\n\t
+PASS Test <number> invalid value: \fe1\r\n\t
+PASS Test <number> invalid value: \fNaN\f
+PASS Test <number> invalid value: \fInfinity\f
+PASS Test <number> invalid value: \f-Infinity\f
+PASS Test <number> invalid value: \ffnord\f
+PASS Test <number> invalid value: \fE\f
+PASS Test <number> invalid value: \fe\f
+PASS Test <number> invalid value: \fe+\f
+PASS Test <number> invalid value: \fE-\f
+PASS Test <number> invalid value: \f-\f
+PASS Test <number> invalid value: \f+\f
+PASS Test <number> invalid value: \f-.\f
+PASS Test <number> invalid value: \f.-\f
+PASS Test <number> invalid value: \f.\f
+PASS Test <number> invalid value: \f+.\f
+PASS Test <number> invalid value: \f.E0\f
+PASS Test <number> invalid value: \fe1\f
+PASS Test <percentage> invalid value: NaN%
+PASS Test <percentage> invalid value: Infinity%
+PASS Test <percentage> invalid value: -Infinity%
+PASS Test <percentage> invalid value: fnord%
+PASS Test <percentage> invalid value: E%
+PASS Test <percentage> invalid value: e%
+PASS Test <percentage> invalid value: e+%
+PASS Test <percentage> invalid value: E-%
+PASS Test <percentage> invalid value: -%
+PASS Test <percentage> invalid value: +%
+PASS Test <percentage> invalid value: -.%
+PASS Test <percentage> invalid value: .-%
+PASS Test <percentage> invalid value: .%
+PASS Test <percentage> invalid value: +.%
+PASS Test <percentage> invalid value: .E0%
+PASS Test <percentage> invalid value: e1%
+PASS Test <percentage> invalid value: NaN%
+PASS Test <percentage> invalid value: Infinity%
+PASS Test <percentage> invalid value: -Infinity%
+PASS Test <percentage> invalid value: fnord%
+PASS Test <percentage> invalid value: E%
+PASS Test <percentage> invalid value: e%
+PASS Test <percentage> invalid value: e+%
+PASS Test <percentage> invalid value: E-%
+PASS Test <percentage> invalid value: -%
+PASS Test <percentage> invalid value: +%
+PASS Test <percentage> invalid value: -.%
+PASS Test <percentage> invalid value: .-%
+PASS Test <percentage> invalid value: .%
+PASS Test <percentage> invalid value: +.%
+PASS Test <percentage> invalid value: .E0%
+PASS Test <percentage> invalid value: e1%
+PASS Test <percentage> invalid value: NaN%
+PASS Test <percentage> invalid value: Infinity%
+PASS Test <percentage> invalid value: -Infinity%
+PASS Test <percentage> invalid value: fnord%
+PASS Test <percentage> invalid value: E%
+PASS Test <percentage> invalid value: e%
+PASS Test <percentage> invalid value: e+%
+PASS Test <percentage> invalid value: E-%
+PASS Test <percentage> invalid value: -%
+PASS Test <percentage> invalid value: +%
+PASS Test <percentage> invalid value: -.%
+PASS Test <percentage> invalid value: .-%
+PASS Test <percentage> invalid value: .%
+PASS Test <percentage> invalid value: +.%
+PASS Test <percentage> invalid value: .E0%
+PASS Test <percentage> invalid value: e1%
+PASS Test <percentage> invalid value: NaN%\r\n\t
+PASS Test <percentage> invalid value: Infinity%\r\n\t
+PASS Test <percentage> invalid value: -Infinity%\r\n\t
+PASS Test <percentage> invalid value: fnord%\r\n\t
+PASS Test <percentage> invalid value: E%\r\n\t
+PASS Test <percentage> invalid value: e%\r\n\t
+PASS Test <percentage> invalid value: e+%\r\n\t
+PASS Test <percentage> invalid value: E-%\r\n\t
+PASS Test <percentage> invalid value: -%\r\n\t
+PASS Test <percentage> invalid value: +%\r\n\t
+PASS Test <percentage> invalid value: -.%\r\n\t
+PASS Test <percentage> invalid value: .-%\r\n\t
+PASS Test <percentage> invalid value: .%\r\n\t
+PASS Test <percentage> invalid value: +.%\r\n\t
+PASS Test <percentage> invalid value: .E0%\r\n\t
+PASS Test <percentage> invalid value: e1%\r\n\t
+PASS Test <percentage> invalid value: NaN%\f
+PASS Test <percentage> invalid value: Infinity%\f
+PASS Test <percentage> invalid value: -Infinity%\f
+PASS Test <percentage> invalid value: fnord%\f
+PASS Test <percentage> invalid value: E%\f
+PASS Test <percentage> invalid value: e%\f
+PASS Test <percentage> invalid value: e+%\f
+PASS Test <percentage> invalid value: E-%\f
+PASS Test <percentage> invalid value: -%\f
+PASS Test <percentage> invalid value: +%\f
+PASS Test <percentage> invalid value: -.%\f
+PASS Test <percentage> invalid value: .-%\f
+PASS Test <percentage> invalid value: .%\f
+PASS Test <percentage> invalid value: +.%\f
+PASS Test <percentage> invalid value: .E0%\f
+PASS Test <percentage> invalid value: e1%\f
+PASS Test <percentage> invalid value:  NaN%
+PASS Test <percentage> invalid value:  Infinity%
+PASS Test <percentage> invalid value:  -Infinity%
+PASS Test <percentage> invalid value:  fnord%
+PASS Test <percentage> invalid value:  E%
+PASS Test <percentage> invalid value:  e%
+PASS Test <percentage> invalid value:  e+%
+PASS Test <percentage> invalid value:  E-%
+PASS Test <percentage> invalid value:  -%
+PASS Test <percentage> invalid value:  +%
+PASS Test <percentage> invalid value:  -.%
+PASS Test <percentage> invalid value:  .-%
+PASS Test <percentage> invalid value:  .%
+PASS Test <percentage> invalid value:  +.%
+PASS Test <percentage> invalid value:  .E0%
+PASS Test <percentage> invalid value:  e1%
+PASS Test <percentage> invalid value:  NaN%
+PASS Test <percentage> invalid value:  Infinity%
+PASS Test <percentage> invalid value:  -Infinity%
+PASS Test <percentage> invalid value:  fnord%
+PASS Test <percentage> invalid value:  E%
+PASS Test <percentage> invalid value:  e%
+PASS Test <percentage> invalid value:  e+%
+PASS Test <percentage> invalid value:  E-%
+PASS Test <percentage> invalid value:  -%
+PASS Test <percentage> invalid value:  +%
+PASS Test <percentage> invalid value:  -.%
+PASS Test <percentage> invalid value:  .-%
+PASS Test <percentage> invalid value:  .%
+PASS Test <percentage> invalid value:  +.%
+PASS Test <percentage> invalid value:  .E0%
+PASS Test <percentage> invalid value:  e1%
+PASS Test <percentage> invalid value:  NaN%
+PASS Test <percentage> invalid value:  Infinity%
+PASS Test <percentage> invalid value:  -Infinity%
+PASS Test <percentage> invalid value:  fnord%
+PASS Test <percentage> invalid value:  E%
+PASS Test <percentage> invalid value:  e%
+PASS Test <percentage> invalid value:  e+%
+PASS Test <percentage> invalid value:  E-%
+PASS Test <percentage> invalid value:  -%
+PASS Test <percentage> invalid value:  +%
+PASS Test <percentage> invalid value:  -.%
+PASS Test <percentage> invalid value:  .-%
+PASS Test <percentage> invalid value:  .%
+PASS Test <percentage> invalid value:  +.%
+PASS Test <percentage> invalid value:  .E0%
+PASS Test <percentage> invalid value:  e1%
+PASS Test <percentage> invalid value:  NaN%\r\n\t
+PASS Test <percentage> invalid value:  Infinity%\r\n\t
+PASS Test <percentage> invalid value:  -Infinity%\r\n\t
+PASS Test <percentage> invalid value:  fnord%\r\n\t
+PASS Test <percentage> invalid value:  E%\r\n\t
+PASS Test <percentage> invalid value:  e%\r\n\t
+PASS Test <percentage> invalid value:  e+%\r\n\t
+PASS Test <percentage> invalid value:  E-%\r\n\t
+PASS Test <percentage> invalid value:  -%\r\n\t
+PASS Test <percentage> invalid value:  +%\r\n\t
+PASS Test <percentage> invalid value:  -.%\r\n\t
+PASS Test <percentage> invalid value:  .-%\r\n\t
+PASS Test <percentage> invalid value:  .%\r\n\t
+PASS Test <percentage> invalid value:  +.%\r\n\t
+PASS Test <percentage> invalid value:  .E0%\r\n\t
+PASS Test <percentage> invalid value:  e1%\r\n\t
+PASS Test <percentage> invalid value:  NaN%\f
+PASS Test <percentage> invalid value:  Infinity%\f
+PASS Test <percentage> invalid value:  -Infinity%\f
+PASS Test <percentage> invalid value:  fnord%\f
+PASS Test <percentage> invalid value:  E%\f
+PASS Test <percentage> invalid value:  e%\f
+PASS Test <percentage> invalid value:  e+%\f
+PASS Test <percentage> invalid value:  E-%\f
+PASS Test <percentage> invalid value:  -%\f
+PASS Test <percentage> invalid value:  +%\f
+PASS Test <percentage> invalid value:  -.%\f
+PASS Test <percentage> invalid value:  .-%\f
+PASS Test <percentage> invalid value:  .%\f
+PASS Test <percentage> invalid value:  +.%\f
+PASS Test <percentage> invalid value:  .E0%\f
+PASS Test <percentage> invalid value:  e1%\f
+PASS Test <percentage> invalid value:    NaN%
+PASS Test <percentage> invalid value:    Infinity%
+PASS Test <percentage> invalid value:    -Infinity%
+PASS Test <percentage> invalid value:    fnord%
+PASS Test <percentage> invalid value:    E%
+PASS Test <percentage> invalid value:    e%
+PASS Test <percentage> invalid value:    e+%
+PASS Test <percentage> invalid value:    E-%
+PASS Test <percentage> invalid value:    -%
+PASS Test <percentage> invalid value:    +%
+PASS Test <percentage> invalid value:    -.%
+PASS Test <percentage> invalid value:    .-%
+PASS Test <percentage> invalid value:    .%
+PASS Test <percentage> invalid value:    +.%
+PASS Test <percentage> invalid value:    .E0%
+PASS Test <percentage> invalid value:    e1%
+PASS Test <percentage> invalid value:    NaN%
+PASS Test <percentage> invalid value:    Infinity%
+PASS Test <percentage> invalid value:    -Infinity%
+PASS Test <percentage> invalid value:    fnord%
+PASS Test <percentage> invalid value:    E%
+PASS Test <percentage> invalid value:    e%
+PASS Test <percentage> invalid value:    e+%
+PASS Test <percentage> invalid value:    E-%
+PASS Test <percentage> invalid value:    -%
+PASS Test <percentage> invalid value:    +%
+PASS Test <percentage> invalid value:    -.%
+PASS Test <percentage> invalid value:    .-%
+PASS Test <percentage> invalid value:    .%
+PASS Test <percentage> invalid value:    +.%
+PASS Test <percentage> invalid value:    .E0%
+PASS Test <percentage> invalid value:    e1%
+PASS Test <percentage> invalid value:    NaN%
+PASS Test <percentage> invalid value:    Infinity%
+PASS Test <percentage> invalid value:    -Infinity%
+PASS Test <percentage> invalid value:    fnord%
+PASS Test <percentage> invalid value:    E%
+PASS Test <percentage> invalid value:    e%
+PASS Test <percentage> invalid value:    e+%
+PASS Test <percentage> invalid value:    E-%
+PASS Test <percentage> invalid value:    -%
+PASS Test <percentage> invalid value:    +%
+PASS Test <percentage> invalid value:    -.%
+PASS Test <percentage> invalid value:    .-%
+PASS Test <percentage> invalid value:    .%
+PASS Test <percentage> invalid value:    +.%
+PASS Test <percentage> invalid value:    .E0%
+PASS Test <percentage> invalid value:    e1%
+PASS Test <percentage> invalid value:    NaN%\r\n\t
+PASS Test <percentage> invalid value:    Infinity%\r\n\t
+PASS Test <percentage> invalid value:    -Infinity%\r\n\t
+PASS Test <percentage> invalid value:    fnord%\r\n\t
+PASS Test <percentage> invalid value:    E%\r\n\t
+PASS Test <percentage> invalid value:    e%\r\n\t
+PASS Test <percentage> invalid value:    e+%\r\n\t
+PASS Test <percentage> invalid value:    E-%\r\n\t
+PASS Test <percentage> invalid value:    -%\r\n\t
+PASS Test <percentage> invalid value:    +%\r\n\t
+PASS Test <percentage> invalid value:    -.%\r\n\t
+PASS Test <percentage> invalid value:    .-%\r\n\t
+PASS Test <percentage> invalid value:    .%\r\n\t
+PASS Test <percentage> invalid value:    +.%\r\n\t
+PASS Test <percentage> invalid value:    .E0%\r\n\t
+PASS Test <percentage> invalid value:    e1%\r\n\t
+PASS Test <percentage> invalid value:    NaN%\f
+PASS Test <percentage> invalid value:    Infinity%\f
+PASS Test <percentage> invalid value:    -Infinity%\f
+PASS Test <percentage> invalid value:    fnord%\f
+PASS Test <percentage> invalid value:    E%\f
+PASS Test <percentage> invalid value:    e%\f
+PASS Test <percentage> invalid value:    e+%\f
+PASS Test <percentage> invalid value:    E-%\f
+PASS Test <percentage> invalid value:    -%\f
+PASS Test <percentage> invalid value:    +%\f
+PASS Test <percentage> invalid value:    -.%\f
+PASS Test <percentage> invalid value:    .-%\f
+PASS Test <percentage> invalid value:    .%\f
+PASS Test <percentage> invalid value:    +.%\f
+PASS Test <percentage> invalid value:    .E0%\f
+PASS Test <percentage> invalid value:    e1%\f
+PASS Test <percentage> invalid value: \r\n\t NaN%
+PASS Test <percentage> invalid value: \r\n\t Infinity%
+PASS Test <percentage> invalid value: \r\n\t -Infinity%
+PASS Test <percentage> invalid value: \r\n\t fnord%
+PASS Test <percentage> invalid value: \r\n\t E%
+PASS Test <percentage> invalid value: \r\n\t e%
+PASS Test <percentage> invalid value: \r\n\t e+%
+PASS Test <percentage> invalid value: \r\n\t E-%
+PASS Test <percentage> invalid value: \r\n\t -%
+PASS Test <percentage> invalid value: \r\n\t +%
+PASS Test <percentage> invalid value: \r\n\t -.%
+PASS Test <percentage> invalid value: \r\n\t .-%
+PASS Test <percentage> invalid value: \r\n\t .%
+PASS Test <percentage> invalid value: \r\n\t +.%
+PASS Test <percentage> invalid value: \r\n\t .E0%
+PASS Test <percentage> invalid value: \r\n\t e1%
+PASS Test <percentage> invalid value: \r\n\t NaN%
+PASS Test <percentage> invalid value: \r\n\t Infinity%
+PASS Test <percentage> invalid value: \r\n\t -Infinity%
+PASS Test <percentage> invalid value: \r\n\t fnord%
+PASS Test <percentage> invalid value: \r\n\t E%
+PASS Test <percentage> invalid value: \r\n\t e%
+PASS Test <percentage> invalid value: \r\n\t e+%
+PASS Test <percentage> invalid value: \r\n\t E-%
+PASS Test <percentage> invalid value: \r\n\t -%
+PASS Test <percentage> invalid value: \r\n\t +%
+PASS Test <percentage> invalid value: \r\n\t -.%
+PASS Test <percentage> invalid value: \r\n\t .-%
+PASS Test <percentage> invalid value: \r\n\t .%
+PASS Test <percentage> invalid value: \r\n\t +.%
+PASS Test <percentage> invalid value: \r\n\t .E0%
+PASS Test <percentage> invalid value: \r\n\t e1%
+PASS Test <percentage> invalid value: \r\n\t NaN%
+PASS Test <percentage> invalid value: \r\n\t Infinity%
+PASS Test <percentage> invalid value: \r\n\t -Infinity%
+PASS Test <percentage> invalid value: \r\n\t fnord%
+PASS Test <percentage> invalid value: \r\n\t E%
+PASS Test <percentage> invalid value: \r\n\t e%
+PASS Test <percentage> invalid value: \r\n\t e+%
+PASS Test <percentage> invalid value: \r\n\t E-%
+PASS Test <percentage> invalid value: \r\n\t -%
+PASS Test <percentage> invalid value: \r\n\t +%
+PASS Test <percentage> invalid value: \r\n\t -.%
+PASS Test <percentage> invalid value: \r\n\t .-%
+PASS Test <percentage> invalid value: \r\n\t .%
+PASS Test <percentage> invalid value: \r\n\t +.%
+PASS Test <percentage> invalid value: \r\n\t .E0%
+PASS Test <percentage> invalid value: \r\n\t e1%
+PASS Test <percentage> invalid value: \r\n\t NaN%\r\n\t
+PASS Test <percentage> invalid value: \r\n\t Infinity%\r\n\t
+PASS Test <percentage> invalid value: \r\n\t -Infinity%\r\n\t
+PASS Test <percentage> invalid value: \r\n\t fnord%\r\n\t
+PASS Test <percentage> invalid value: \r\n\t E%\r\n\t
+PASS Test <percentage> invalid value: \r\n\t e%\r\n\t
+PASS Test <percentage> invalid value: \r\n\t e+%\r\n\t
+PASS Test <percentage> invalid value: \r\n\t E-%\r\n\t
+PASS Test <percentage> invalid value: \r\n\t -%\r\n\t
+PASS Test <percentage> invalid value: \r\n\t +%\r\n\t
+PASS Test <percentage> invalid value: \r\n\t -.%\r\n\t
+PASS Test <percentage> invalid value: \r\n\t .-%\r\n\t
+PASS Test <percentage> invalid value: \r\n\t .%\r\n\t
+PASS Test <percentage> invalid value: \r\n\t +.%\r\n\t
+PASS Test <percentage> invalid value: \r\n\t .E0%\r\n\t
+PASS Test <percentage> invalid value: \r\n\t e1%\r\n\t
+PASS Test <percentage> invalid value: \r\n\t NaN%\f
+PASS Test <percentage> invalid value: \r\n\t Infinity%\f
+PASS Test <percentage> invalid value: \r\n\t -Infinity%\f
+PASS Test <percentage> invalid value: \r\n\t fnord%\f
+PASS Test <percentage> invalid value: \r\n\t E%\f
+PASS Test <percentage> invalid value: \r\n\t e%\f
+PASS Test <percentage> invalid value: \r\n\t e+%\f
+PASS Test <percentage> invalid value: \r\n\t E-%\f
+PASS Test <percentage> invalid value: \r\n\t -%\f
+PASS Test <percentage> invalid value: \r\n\t +%\f
+PASS Test <percentage> invalid value: \r\n\t -.%\f
+PASS Test <percentage> invalid value: \r\n\t .-%\f
+PASS Test <percentage> invalid value: \r\n\t .%\f
+PASS Test <percentage> invalid value: \r\n\t +.%\f
+PASS Test <percentage> invalid value: \r\n\t .E0%\f
+PASS Test <percentage> invalid value: \r\n\t e1%\f
+PASS Test <percentage> invalid value: \fNaN%
+PASS Test <percentage> invalid value: \fInfinity%
+PASS Test <percentage> invalid value: \f-Infinity%
+PASS Test <percentage> invalid value: \ffnord%
+PASS Test <percentage> invalid value: \fE%
+PASS Test <percentage> invalid value: \fe%
+PASS Test <percentage> invalid value: \fe+%
+PASS Test <percentage> invalid value: \fE-%
+PASS Test <percentage> invalid value: \f-%
+PASS Test <percentage> invalid value: \f+%
+PASS Test <percentage> invalid value: \f-.%
+PASS Test <percentage> invalid value: \f.-%
+PASS Test <percentage> invalid value: \f.%
+PASS Test <percentage> invalid value: \f+.%
+PASS Test <percentage> invalid value: \f.E0%
+PASS Test <percentage> invalid value: \fe1%
+PASS Test <percentage> invalid value: \fNaN%
+PASS Test <percentage> invalid value: \fInfinity%
+PASS Test <percentage> invalid value: \f-Infinity%
+PASS Test <percentage> invalid value: \ffnord%
+PASS Test <percentage> invalid value: \fE%
+PASS Test <percentage> invalid value: \fe%
+PASS Test <percentage> invalid value: \fe+%
+PASS Test <percentage> invalid value: \fE-%
+PASS Test <percentage> invalid value: \f-%
+PASS Test <percentage> invalid value: \f+%
+PASS Test <percentage> invalid value: \f-.%
+PASS Test <percentage> invalid value: \f.-%
+PASS Test <percentage> invalid value: \f.%
+PASS Test <percentage> invalid value: \f+.%
+PASS Test <percentage> invalid value: \f.E0%
+PASS Test <percentage> invalid value: \fe1%
+PASS Test <percentage> invalid value: \fNaN%
+PASS Test <percentage> invalid value: \fInfinity%
+PASS Test <percentage> invalid value: \f-Infinity%
+PASS Test <percentage> invalid value: \ffnord%
+PASS Test <percentage> invalid value: \fE%
+PASS Test <percentage> invalid value: \fe%
+PASS Test <percentage> invalid value: \fe+%
+PASS Test <percentage> invalid value: \fE-%
+PASS Test <percentage> invalid value: \f-%
+PASS Test <percentage> invalid value: \f+%
+PASS Test <percentage> invalid value: \f-.%
+PASS Test <percentage> invalid value: \f.-%
+PASS Test <percentage> invalid value: \f.%
+PASS Test <percentage> invalid value: \f+.%
+PASS Test <percentage> invalid value: \f.E0%
+PASS Test <percentage> invalid value: \fe1%
+PASS Test <percentage> invalid value: \fNaN%\r\n\t
+PASS Test <percentage> invalid value: \fInfinity%\r\n\t
+PASS Test <percentage> invalid value: \f-Infinity%\r\n\t
+PASS Test <percentage> invalid value: \ffnord%\r\n\t
+PASS Test <percentage> invalid value: \fE%\r\n\t
+PASS Test <percentage> invalid value: \fe%\r\n\t
+PASS Test <percentage> invalid value: \fe+%\r\n\t
+PASS Test <percentage> invalid value: \fE-%\r\n\t
+PASS Test <percentage> invalid value: \f-%\r\n\t
+PASS Test <percentage> invalid value: \f+%\r\n\t
+PASS Test <percentage> invalid value: \f-.%\r\n\t
+PASS Test <percentage> invalid value: \f.-%\r\n\t
+PASS Test <percentage> invalid value: \f.%\r\n\t
+PASS Test <percentage> invalid value: \f+.%\r\n\t
+PASS Test <percentage> invalid value: \f.E0%\r\n\t
+PASS Test <percentage> invalid value: \fe1%\r\n\t
+PASS Test <percentage> invalid value: \fNaN%\f
+PASS Test <percentage> invalid value: \fInfinity%\f
+PASS Test <percentage> invalid value: \f-Infinity%\f
+PASS Test <percentage> invalid value: \ffnord%\f
+PASS Test <percentage> invalid value: \fE%\f
+PASS Test <percentage> invalid value: \fe%\f
+PASS Test <percentage> invalid value: \fe+%\f
+PASS Test <percentage> invalid value: \fE-%\f
+PASS Test <percentage> invalid value: \f-%\f
+PASS Test <percentage> invalid value: \f+%\f
+PASS Test <percentage> invalid value: \f-.%\f
+PASS Test <percentage> invalid value: \f.-%\f
+PASS Test <percentage> invalid value: \f.%\f
+PASS Test <percentage> invalid value: \f+.%\f
+PASS Test <percentage> invalid value: \f.E0%\f
+PASS Test <percentage> invalid value: \fe1%\f
+

--- a/LayoutTests/svg/parser/whitespace-number.html
+++ b/LayoutTests/svg/parser/whitespace-number.html
@@ -1,0 +1,68 @@
+<!doctype html> 
+<title>Whitespace in attribute values tests</title>
+<script src=../../resources/testharness.js></script>
+<script src=../../resources/testharnessreport.js></script>
+<script src=resources/whitespace-helper.js></script>
+<svg id="testcontainer">
+	<defs>
+		<marker/>
+		<stop/>
+		<filter>
+			<feTurbulence></feTurbulence>
+		</filter>
+	</defs>
+</svg>
+<div id=log></div>
+<script>
+var svg = document.querySelector("svg");
+
+// test length values
+var EPSILON = Math.pow(2, -24); // float epsilon
+var whitespace = [ "", " ", "   ", "\r\n\t ", "\f" ];
+var garbage = [ "a", "e", "foo", ")90" ];
+var validunits = [ "", "em", "ex", "px", "in", "cm", "mm", "pt", "pc", "%" ];
+
+testType("<number>",
+		 document.querySelector("stop"),
+		 "offset",
+		 0, // expected default value
+		 whitespace,
+		 [ "-47", ".1", "0.35", "1e-10", "+32", "+17E-1", "17e+2" ], // valid
+		 [ "" ], // valid units
+		 garbage,
+		 function(elm, value) { assert_approx_equals(elm.offset.baseVal, parseFloat(value), EPSILON); },
+		 function(elm, expected) { assert_approx_equals(elm.offset.baseVal, expected, EPSILON); } );
+
+testType("<percentage>",
+		 document.querySelector("stop"),
+		 "offset",
+		 0, // expected default value
+		 whitespace,
+		 [ "-47", ".1", "0.35", "1e-10", "+32", "+17E-1", "17e+2" ], // valid
+		 [ "%" ], // valid units
+		 garbage,
+		 function(elm, value) { assert_approx_equals(elm.offset.baseVal, parseFloat(value)/ 100, EPSILON); },
+		 function(elm, expected) { assert_approx_equals(elm.offset.baseVal, expected, EPSILON); } );
+
+testInvalidType("<number>",
+         document.querySelector("stop"),
+         "offset",
+         0, // expected default value
+         whitespace,
+         [ Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY, "fnord", "E", "e", "e+", "E-", "-", "+", "-.", ".-", ".", "+.", ".E0", "e1" ], // invalid
+         [ "" ], // valid units
+         function(elm, value) { assert_approx_equals(elm.offset.baseVal, parseFloat(value), EPSILON); },
+         function(elm, expected) { assert_approx_equals(elm.offset.baseVal, expected, EPSILON); } );
+
+testInvalidType("<percentage>",
+         document.querySelector("stop"),
+         "offset",
+         0, // expected default value
+         whitespace,
+         [ Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY, "fnord", "E", "e", "e+", "E-", "-", "+", "-.", ".-", ".", "+.", ".E0", "e1" ], // invalid
+         [ "%" ], // valid units
+         function(elm, value) { assert_approx_equals(elm.offset.baseVal, parseFloat(value)/ 100, EPSILON); },
+         function(elm, expected) { assert_approx_equals(elm.offset.baseVal, expected, EPSILON); } );
+
+
+</script>


### PR DESCRIPTION
#### 808edf62942c254bd4fab37f78369061fa53d320
<pre>
SVG &lt;stop&gt; offset attribute incorrectly accepts invalid values with trailing garbage
<a href="https://bugs.webkit.org/show_bug.cgi?id=304794">https://bugs.webkit.org/show_bug.cgi?id=304794</a>
<a href="https://rdar.apple.com/167356988">rdar://167356988</a>

Reviewed by Nikolas Zimmermann.

The offset attribute parser was using String::toFloat() which silently ignores
trailing garbage. Per the SVG specification, attribute values with trailing
non-numeric characters should be treated as invalid and fall back to the
default value of 0.

Fixed by using parseNumber() from SVGParserUtilities which properly validates
the entire string. Also optimized to use StringView to avoid unnecessary string
copies.

* Source/WebCore/svg/SVGStopElement.cpp:
(WebCore::SVGStopElement::attributeChanged):
* LayoutTests/svg/parser/whitespace-number.html: Added.
* LayoutTests/svg/parser/whitespace-number-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/305036@main">https://commits.webkit.org/305036@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d81db35e9cec042360e1786a2fd5974f5f16bf4e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137236 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9596 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48523 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144987 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90209 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7cee0f49-b980-4b50-8c18-fa55b068e4fb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139108 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10299 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9723 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104953 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6b2c095f-4032-40cd-b471-885efc601ce1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140181 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7601 "Found 1 new test failure: fast/forms/ios/select-option-removed-update.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122994 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85797 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fa936b98-63e0-4eaf-8eaa-4146f5789fd3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7238 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4952 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5574 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116597 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41152 "Found 2 new test failures: http/tests/xmlhttprequest/cross-origin-cookie-storage.html imported/w3c/web-platform-tests/streams/piping/abort.any.worker.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147743 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9279 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41714 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113313 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9297 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7812 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113647 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28864 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7158 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119244 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63787 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9328 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37298 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9054 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72893 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9268 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9120 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->