### PR TITLE
[Swift in WebKit] Work towards modularizing PAL (part 3)

### DIFF
--- a/Source/WebCore/PAL/pal/FileSizeFormatter.h
+++ b/Source/WebCore/PAL/pal/FileSizeFormatter.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <pal/ExportMacros.h>
 #include <wtf/text/WTFString.h>
 
 namespace PAL {

--- a/Source/WebCore/PAL/pal/Logging.h
+++ b/Source/WebCore/PAL/pal/Logging.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <pal/ExportMacros.h>
+#include <wtf/Assertions.h>
 #include <wtf/Forward.h>
 
 namespace PAL {

--- a/Source/WebCore/PAL/pal/ThreadGlobalData.h
+++ b/Source/WebCore/PAL/pal/ThreadGlobalData.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <pal/ExportMacros.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/Threading.h>

--- a/Source/WebCore/PAL/pal/avfoundation/MediaTimeAVFoundation.h
+++ b/Source/WebCore/PAL/pal/avfoundation/MediaTimeAVFoundation.h
@@ -25,9 +25,12 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if USE(AVFOUNDATION)
 
 #include <CoreMedia/CMTime.h>
+#include <pal/ExportMacros.h>
 #include <wtf/MediaTime.h>
 
 namespace PAL {

--- a/Source/WebCore/PAL/pal/avfoundation/OutputContext.h
+++ b/Source/WebCore/PAL/pal/avfoundation/OutputContext.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if USE(AVFOUNDATION)
 
 #include <wtf/text/WTFString.h>

--- a/Source/WebCore/PAL/pal/avfoundation/OutputDevice.h
+++ b/Source/WebCore/PAL/pal/avfoundation/OutputDevice.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if USE(AVFOUNDATION)
 
 OBJC_CLASS AVOutputDevice;

--- a/Source/WebCore/PAL/pal/cf/AudioToolboxSoftLink.h
+++ b/Source/WebCore/PAL/pal/cf/AudioToolboxSoftLink.h
@@ -24,6 +24,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if USE(AVFOUNDATION)
 
 #include <AudioToolbox/AudioToolbox.h>

--- a/Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.h
+++ b/Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if USE(AVFOUNDATION)
 // FIXME: Should be USE(COREMEDIA), but this isn't currently defined on Windows.
 

--- a/Source/WebCore/PAL/pal/cf/VideoToolboxSoftLink.h
+++ b/Source/WebCore/PAL/pal/cf/VideoToolboxSoftLink.h
@@ -24,6 +24,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if USE(AVFOUNDATION)
 
 #include <VideoToolbox/VTCompressionSession.h>

--- a/Source/WebCore/PAL/pal/cg/CoreGraphicsSoftLink.h
+++ b/Source/WebCore/PAL/pal/cg/CoreGraphicsSoftLink.h
@@ -24,6 +24,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 #if USE(CG)
 
 #include <pal/spi/cg/CoreGraphicsSPI.h>

--- a/Source/WebCore/PAL/pal/cocoa/AVFAudioSoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/AVFAudioSoftLink.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 #if HAVE(AVAUDIOAPPLICATION)
 
 #import <AVFAudio/AVFAudio.h>

--- a/Source/WebCore/PAL/pal/cocoa/AVFoundationSoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/AVFoundationSoftLink.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 #if USE(AVFOUNDATION)
 
 #import <AVFoundation/AVFoundation.h>

--- a/Source/WebCore/PAL/pal/cocoa/AccessibilitySoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/AccessibilitySoftLink.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 #if HAVE(ACCESSIBILITY_FRAMEWORK)
 
 #import <Accessibility/Accessibility.h>

--- a/Source/WebCore/PAL/pal/cocoa/AppSSOSoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/AppSSOSoftLink.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 #if HAVE(APP_SSO)
 
 #import <pal/spi/cocoa/AppSSOSPI.h>

--- a/Source/WebCore/PAL/pal/cocoa/ContactsSoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/ContactsSoftLink.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 #if HAVE(CONTACTS)
 
 #import <Contacts/Contacts.h>

--- a/Source/WebCore/PAL/pal/cocoa/CoreMaterialSoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/CoreMaterialSoftLink.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 #if HAVE(CORE_MATERIAL)
 
 #import <pal/spi/cocoa/CoreMaterialSPI.h>

--- a/Source/WebCore/PAL/pal/cocoa/CryptoKitPrivateSoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/CryptoKitPrivateSoftLink.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 #if HAVE(RSA_BSSA)
 
 #import <pal/spi/cocoa/CryptoKitPrivateSPI.h>

--- a/Source/WebCore/PAL/pal/cocoa/LinkPresentationSoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/LinkPresentationSoftLink.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #import <pal/spi/cocoa/LinkPresentationSPI.h>
+#import <wtf/Platform.h>
 #import <wtf/SoftLinking.h>
 
 SOFT_LINK_FRAMEWORK_FOR_HEADER(PAL, LinkPresentation)

--- a/Source/WebCore/PAL/pal/cocoa/MediaToolboxSoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/MediaToolboxSoftLink.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if USE(MEDIATOOLBOX)
 
 #include <pal/spi/cocoa/MediaToolboxSPI.h>

--- a/Source/WebCore/PAL/pal/cocoa/RevealSoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/RevealSoftLink.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(REVEAL)
 
 #import <pal/spi/cocoa/RevealSPI.h>

--- a/Source/WebCore/PAL/pal/cocoa/SpeechSoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/SpeechSoftLink.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if HAVE(SPEECHRECOGNIZER)
 
 #import <Speech/Speech.h>

--- a/Source/WebCore/PAL/pal/cocoa/TranslationUIServicesSoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/TranslationUIServicesSoftLink.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if HAVE(TRANSLATION_UI_SERVICES)
 
 #import <pal/spi/cocoa/TranslationUIServicesSPI.h>

--- a/Source/WebCore/PAL/pal/cocoa/UsageTrackingSoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/UsageTrackingSoftLink.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if HAVE(MEDIA_USAGE_FRAMEWORK)
 
 #import <wtf/SoftLinking.h>

--- a/Source/WebCore/PAL/pal/cocoa/VisionKitCoreSoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/VisionKitCoreSoftLink.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#import <wtf/Platform.h>
+
 #if HAVE(VK_IMAGE_ANALYSIS)
 
 #import <pal/spi/cocoa/VisionKitCoreSPI.h>

--- a/Source/WebCore/PAL/pal/cocoa/VisionSoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/VisionSoftLink.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#import <wtf/Platform.h>
+
 #if HAVE(VISION)
 
 #import <Vision/Vision.h>

--- a/Source/WebCore/PAL/pal/cocoa/WebContentAnalysisSoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/WebContentAnalysisSoftLink.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#import <wtf/Platform.h>
+
 #if HAVE(PARENTAL_CONTROLS_WITH_UNBLOCK_HANDLER)
 
 #import <pal/spi/cocoa/WebFilterEvaluatorSPI.h>

--- a/Source/WebCore/PAL/pal/cocoa/WebContentRestrictionsSoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/WebContentRestrictionsSoftLink.h
@@ -23,6 +23,8 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#import <wtf/Platform.h>
+
 #if HAVE(WEBCONTENTRESTRICTIONS)
 
 #import <pal/spi/cocoa/WebContentRestrictionsSPI.h>

--- a/Source/WebCore/PAL/pal/cocoa/WebPrivacySoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/WebPrivacySoftLink.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#import <wtf/Platform.h>
+
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
 
 #import <pal/spi/cocoa/WebPrivacySPI.h>

--- a/Source/WebCore/PAL/pal/crypto/gcrypt/Handle.h
+++ b/Source/WebCore/PAL/pal/crypto/gcrypt/Handle.h
@@ -26,6 +26,10 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
+#if USE(GCRYPT)
+
 #include <gcrypt.h>
 
 namespace PAL {
@@ -132,3 +136,5 @@ struct HandleDeleter<gcry_sexp_t> {
 
 } // namespace GCrypt
 } // namespace PAL
+
+#endif

--- a/Source/WebCore/PAL/pal/crypto/gcrypt/Initialization.h
+++ b/Source/WebCore/PAL/pal/crypto/gcrypt/Initialization.h
@@ -26,6 +26,10 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
+#if USE(GCRYPT)
+
 #include <gcrypt.h>
 
 namespace PAL {
@@ -44,3 +48,5 @@ static inline void initialize()
 
 } // namespace PAL
 } // namespace GCrypt
+
+#endif

--- a/Source/WebCore/PAL/pal/crypto/gcrypt/Utilities.h
+++ b/Source/WebCore/PAL/pal/crypto/gcrypt/Utilities.h
@@ -26,6 +26,10 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
+#if USE(GCRYPT)
+
 #include <gcrypt.h>
 #include <optional>
 #include <wtf/Assertions.h>
@@ -69,3 +73,5 @@ static inline std::optional<int> aesAlgorithmForKeySize(size_t keySize)
 
 } // namespace GCrypt
 } // namespace PAL
+
+#endif

--- a/Source/WebCore/PAL/pal/crypto/tasn1/Utilities.h
+++ b/Source/WebCore/PAL/pal/crypto/tasn1/Utilities.h
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#if __has_include(<libtasn1.h>)
+
 #include <libtasn1.h>
 #include <optional>
 #include <wtf/Forward.h>
@@ -63,3 +65,5 @@ bool writeElement(asn1_node root, const char* elementName, const void* data, siz
 
 } // namespace TASN1
 } // namespace PAL
+
+#endif

--- a/Source/WebCore/PAL/pal/spi/cf/CFNetworkSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cf/CFNetworkSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #include <CFNetwork/CFNetwork.h>

--- a/Source/WebCore/PAL/pal/spi/cf/CFNotificationCenterSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cf/CFNotificationCenterSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if USE(APPLE_INTERNAL_SDK)

--- a/Source/WebCore/PAL/pal/spi/cf/CFUtilitiesSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cf/CFUtilitiesSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if USE(APPLE_INTERNAL_SDK)

--- a/Source/WebCore/PAL/pal/spi/cf/CoreAudioSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cf/CoreAudioSPI.h
@@ -25,13 +25,17 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if PLATFORM(COCOA)
 
 #include <CoreAudio/CoreAudioTypes.h>
 
-#if USE(APPLE_INTERNAL_SDK)
+// FIXME: (rdar://167375656) Remove the `__has_feature(modules)` condition when possible.
+#if USE(APPLE_INTERNAL_SDK) && !__has_feature(modules)
 #include <CoreAudio/AudioHardwarePriv.h>
 #else
 

--- a/Source/WebCore/PAL/pal/spi/cf/CoreMediaSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cf/CoreMediaSPI.h
@@ -25,12 +25,18 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #include <CoreMedia/CoreMedia.h>
 
 #if PLATFORM(MAC)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnon-modular-include-in-module"
 #include <webrtc/webkit_sdk/WebKit/CMBaseObjectSPI.h>
+#pragma clang diagnostic pop
 #endif
 
 #if PLATFORM(COCOA)

--- a/Source/WebCore/PAL/pal/spi/cf/CoreTextSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cf/CoreTextSPI.h
@@ -25,12 +25,16 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #include <CoreText/CoreText.h>
 #include <pal/spi/cg/CoreGraphicsSPI.h>
 
-#if USE(APPLE_INTERNAL_SDK)
+// FIXME: (rdar://167351286) Remove the `__has_feature(modules)` condition when possible.
+#if USE(APPLE_INTERNAL_SDK) && !__has_feature(modules)
 
 #include <CoreText/CoreTextPriv.h>
 #include <OTSVG/OTSVG.h>
@@ -104,9 +108,14 @@ typedef CF_OPTIONS(uint32_t, CTFontDescriptorOptions) {
 
 typedef CF_ENUM(uint32_t, CTFontTextStylePlatform)
 {
-    kCTFontTextStylePlatformDefault = (CTFontTextStylePlatform)-1,
-    kCTFontTextStylePlatformPhone = (CTFontTextStylePlatform)0,
-    kCTFontTextStylePlatformVision = (CTFontTextStylePlatform)5,
+    kCTFontTextStylePlatformDefault      = (CTFontTextStylePlatform)-1,
+    kCTFontTextStylePlatformPhone        = 0,
+    kCTFontTextStylePlatformWatch        = 1,
+    kCTFontTextStylePlatformTV           = 2,
+    kCTFontTextStylePlatformMac          = 3,
+    kCTFontTextStylePlatformMacTouchBar  = 4,
+    kCTFontTextStylePlatformVision       = 5,
+    kCTFontTextStylePlatformVisionLegacy = 6,
 };
 
 typedef CF_OPTIONS(CFOptionFlags, CTFontDescriptorMatchingOptions) {

--- a/Source/WebCore/PAL/pal/spi/cf/CoreVideoSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cf/CoreVideoSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #include <CoreVideo/CoreVideo.h>

--- a/Source/WebCore/PAL/pal/spi/cf/MediaAccessibilitySPI.h
+++ b/Source/WebCore/PAL/pal/spi/cf/MediaAccessibilitySPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if USE(APPLE_INTERNAL_SDK)

--- a/Source/WebCore/PAL/pal/spi/cf/VideoToolboxSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cf/VideoToolboxSPI.h
@@ -25,6 +25,10 @@
 
 #pragma once
 
+#include <cstdint>
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 WTF_EXTERN_C_BEGIN

--- a/Source/WebCore/PAL/pal/spi/cocoa/ARKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/ARKitSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if USE(APPLE_INTERNAL_SDK)

--- a/Source/WebCore/PAL/pal/spi/cocoa/AXSpeechManagerSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/AXSpeechManagerSPI.h
@@ -29,7 +29,8 @@ DECLARE_SYSTEM_HEADER
 
 #if PLATFORM(COCOA)
 
-#if USE(APPLE_INTERNAL_SDK)
+// FIXME: (rdar://167375794) Remove the `__has_feature(modules)` condition when possible.
+#if USE(APPLE_INTERNAL_SDK) && !__has_feature(modules)
 
 #include <AXSpeechManager.h>
 

--- a/Source/WebCore/PAL/pal/spi/cocoa/AppSSOSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/AppSSOSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if HAVE(APP_SSO)

--- a/Source/WebCore/PAL/pal/spi/cocoa/CommonCryptoSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/CommonCryptoSPI.h
@@ -29,7 +29,8 @@ DECLARE_SYSTEM_HEADER
 
 #include <CommonCrypto/CommonCrypto.h>
 
-#if USE(APPLE_INTERNAL_SDK)
+// FIXME: (rdar://167376052) Remove the `__has_feature(modules)` condition when possible.
+#if USE(APPLE_INTERNAL_SDK) && !__has_feature(modules)
 
 #include <CommonCrypto/CommonCryptorSPI.h>
 #include <CommonCrypto/CommonDigestSPI.h>

--- a/Source/WebCore/PAL/pal/spi/cocoa/CryptoKitPrivateSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/CryptoKitPrivateSPI.h
@@ -25,11 +25,15 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if HAVE(RSA_BSSA)
 
-#if USE(APPLE_INTERNAL_SDK)
+// FIXME: (rdar://167351607) Remove the `__has_feature(modules)` condition when possible.
+#if USE(APPLE_INTERNAL_SDK) && !__has_feature(modules)
 
 // FIXME(227598): Remove conditional once CryptoKitPrivate/RSABSSA.h is available.
 #if __has_include(<CryptoKitPrivate/RSABSSA.h>)
@@ -40,17 +44,17 @@ DECLARE_SYSTEM_HEADER
 
 #else
 
+@interface RSABSSATokenReady : NSObject
+@property (nonatomic, retain, readonly) NSData* tokenContent;
+@property (nonatomic, retain, readonly) NSData* keyId;
+@property (nonatomic, retain, readonly) NSData* signature;
+@end
+
 @interface RSABSSATokenWaitingActivation : NSObject
 #if HAVE(RSA_BSSA)
 - (RSABSSATokenReady*)activateTokenWithServerResponse:(NSData*)serverResponse error:(NSError* __autoreleasing *)error;
 #endif
 @property (nonatomic, retain, readonly) NSData* blindedMessage;
-@end
-
-@interface RSABSSATokenReady : NSObject
-@property (nonatomic, retain, readonly) NSData* tokenContent;
-@property (nonatomic, retain, readonly) NSData* keyId;
-@property (nonatomic, retain, readonly) NSData* signature;
 @end
 
 #if HAVE(RSA_BSSA)

--- a/Source/WebCore/PAL/pal/spi/cocoa/IOKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/IOKitSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if PLATFORM(MAC)

--- a/Source/WebCore/PAL/pal/spi/cocoa/IOPMLibSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/IOPMLibSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #include <CoreFoundation/CoreFoundation.h>

--- a/Source/WebCore/PAL/pal/spi/cocoa/IOPSLibSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/IOPSLibSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #include <CoreFoundation/CoreFoundation.h>

--- a/Source/WebCore/PAL/pal/spi/cocoa/LaunchServicesSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/LaunchServicesSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #import <Foundation/Foundation.h>

--- a/Source/WebCore/PAL/pal/spi/cocoa/LinkPresentationSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/LinkPresentationSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if !PLATFORM(WATCHOS) || USE(APPLE_INTERNAL_SDK)

--- a/Source/WebCore/PAL/pal/spi/cocoa/MediaToolboxSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/MediaToolboxSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if USE(MEDIATOOLBOX)

--- a/Source/WebCore/PAL/pal/spi/cocoa/MetalSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/MetalSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #import <Metal/Metal.h>

--- a/Source/WebCore/PAL/pal/spi/cocoa/NEFilterSourceSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/NEFilterSourceSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if USE(APPLE_INTERNAL_SDK)

--- a/Source/WebCore/PAL/pal/spi/cocoa/NSAccessibilitySPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/NSAccessibilitySPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if USE(APPKIT)

--- a/Source/WebCore/PAL/pal/spi/cocoa/NSAttributedStringSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/NSAttributedStringSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #import <wtf/SoftLinking.h>

--- a/Source/WebCore/PAL/pal/spi/cocoa/NSButtonCellSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/NSButtonCellSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #import <AppKit/NSButtonCell.h>

--- a/Source/WebCore/PAL/pal/spi/cocoa/NSCalendarDateSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/NSCalendarDateSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #import <Foundation/NSDate.h>

--- a/Source/WebCore/PAL/pal/spi/cocoa/NSExtensionSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/NSExtensionSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if USE(APPLE_INTERNAL_SDK)

--- a/Source/WebCore/PAL/pal/spi/cocoa/NSFileManagerSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/NSFileManagerSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #import <Foundation/NSFileManager.h>

--- a/Source/WebCore/PAL/pal/spi/cocoa/NSFileSizeFormatterSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/NSFileSizeFormatterSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if USE(APPLE_INTERNAL_SDK)

--- a/Source/WebCore/PAL/pal/spi/cocoa/NSKeyedUnarchiverSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/NSKeyedUnarchiverSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if USE(APPLE_INTERNAL_SDK)

--- a/Source/WebCore/PAL/pal/spi/cocoa/NSProgressSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/NSProgressSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if USE(APPLE_INTERNAL_SDK)

--- a/Source/WebCore/PAL/pal/spi/cocoa/NSStringSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/NSStringSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #import <Foundation/NSString.h>

--- a/Source/WebCore/PAL/pal/spi/cocoa/NSTouchBarSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/NSTouchBarSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if PLATFORM(MAC) && HAVE(TOUCH_BAR)

--- a/Source/WebCore/PAL/pal/spi/cocoa/NSURLConnectionSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/NSURLConnectionSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if USE(APPLE_INTERNAL_SDK)

--- a/Source/WebCore/PAL/pal/spi/cocoa/NSURLDownloadSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/NSURLDownloadSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if PLATFORM(MAC) || USE(APPLE_INTERNAL_SDK)

--- a/Source/WebCore/PAL/pal/spi/cocoa/NSURLFileTypeMappingsSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/NSURLFileTypeMappingsSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if USE(APPLE_INTERNAL_SDK)

--- a/Source/WebCore/PAL/pal/spi/cocoa/NSUserDefaultsSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/NSUserDefaultsSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 @interface NSObject (PrivateKVOMethods)

--- a/Source/WebCore/PAL/pal/spi/cocoa/NSXPCConnectionSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/NSXPCConnectionSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #import <wtf/spi/darwin/XPCSPI.h>

--- a/Source/WebCore/PAL/pal/spi/cocoa/NetworkSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/NetworkSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #import <Network/Network.h>

--- a/Source/WebCore/PAL/pal/spi/cocoa/NotifySPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/NotifySPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #define NOTIFY_OPT_DISPATCH 0x00000001

--- a/Source/WebCore/PAL/pal/spi/cocoa/PassKitInstallmentsSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/PassKitInstallmentsSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #ifndef PAL_PASSKIT_SPI_GUARD_AGAINST_INDIRECT_INCLUSION

--- a/Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if HAVE(PASSKIT_RECURRING_SUMMARY_ITEM)
@@ -105,11 +108,6 @@ DECLARE_SYSTEM_HEADER
 
 #if !PLATFORM(MAC) || USE(APPLE_INTERNAL_SDK)
 
-// FIXME: (rdar://165525506) This file is invalid in a module because PassKit has symbols with incorrect linkage.
-// FIXME: PassKit does not declare its NSString constant symbols with C linkage, so we end up with
-// linkage mismatches in the SOFT_LINK_CONSTANT macros used in PassKitSoftLink.mm unless we wrap
-// these includes in an extern "C" block.
-WTF_EXTERN_C_BEGIN
 #if HAVE(PASSKIT_MODULARIZATION) && USE(APPLE_INTERNAL_SDK)
 #import <PassKitCore/PKConstants.h>
 #import <PassKitCore/PKError.h>
@@ -117,7 +115,6 @@ WTF_EXTERN_C_BEGIN
 #import <PassKit/PKConstants.h>
 #import <PassKit/PKError.h>
 #endif
-WTF_EXTERN_C_END
 
 #endif // !PLATFORM(MAC) || USE(APPLE_INTERNAL_SDK)
 

--- a/Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #import <CoreVideo/CoreVideo.h>

--- a/Source/WebCore/PAL/pal/spi/cocoa/RevealSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/RevealSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #import <Foundation/Foundation.h>

--- a/Source/WebCore/PAL/pal/spi/cocoa/SQLite3SPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/SQLite3SPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if USE(APPLE_INTERNAL_SDK)

--- a/Source/WebCore/PAL/pal/spi/cocoa/SceneKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/SceneKitSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if HAVE(SCENEKIT)

--- a/Source/WebCore/PAL/pal/spi/cocoa/SecKeyProxySPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/SecKeyProxySPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if HAVE(SEC_KEY_PROXY)

--- a/Source/WebCore/PAL/pal/spi/cocoa/ServersSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/ServersSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #include <mach/message.h>

--- a/Source/WebCore/PAL/pal/spi/cocoa/SpeechSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/SpeechSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if HAVE(SPEECHRECOGNIZER)

--- a/Source/WebCore/PAL/pal/spi/cocoa/TCCSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/TCCSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if USE(APPLE_INTERNAL_SDK)

--- a/Source/WebCore/PAL/pal/spi/cocoa/TranslationUIServicesSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/TranslationUIServicesSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if PLATFORM(MAC)
@@ -35,7 +38,8 @@ DECLARE_SYSTEM_HEADER
 
 #if HAVE(TRANSLATION_UI_SERVICES)
 
-#if USE(APPLE_INTERNAL_SDK)
+// FIXME: (rdar://165508009) Remove the `__has_feature(modules)` condition when possible.
+#if USE(APPLE_INTERNAL_SDK) && !__has_feature(modules)
 #import <TranslationUIServices/LTUISourceMeta.h>
 #import <TranslationUIServices/LTUITranslationViewController.h>
 #else

--- a/Source/WebCore/PAL/pal/spi/cocoa/UIFoundationSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/UIFoundationSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if USE(APPLE_INTERNAL_SDK)

--- a/Source/WebCore/PAL/pal/spi/cocoa/URLFormattingSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/URLFormattingSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if USE(APPLE_INTERNAL_SDK)

--- a/Source/WebCore/PAL/pal/spi/cocoa/UniformTypeIdentifiersSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/UniformTypeIdentifiersSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if USE(APPLE_INTERNAL_SDK)

--- a/Source/WebCore/PAL/pal/spi/cocoa/VisionKitCoreSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/VisionKitCoreSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if HAVE(VK_IMAGE_ANALYSIS)

--- a/Source/WebCore/PAL/pal/spi/cocoa/WebContentRestrictionsSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/WebContentRestrictionsSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 #if HAVE(WEBCONTENTRESTRICTIONS)
 
 #if USE(APPLE_INTERNAL_SDK)

--- a/Source/WebCore/PAL/pal/spi/cocoa/WebFilterEvaluatorSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/WebFilterEvaluatorSPI.h
@@ -25,9 +25,13 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
-#if USE(APPLE_INTERNAL_SDK)
+// FIXME: (rdar://167375964) Remove the `__has_feature(modules)` condition when possible.
+#if USE(APPLE_INTERNAL_SDK) && !__has_feature(modules)
 
 #if HAVE(WEBCONTENTANALYSIS_FRAMEWORK)
 #import <WebContentAnalysis/WebFilterEvaluator.h>

--- a/Source/WebCore/PAL/pal/spi/cocoa/WebPrivacySPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/WebPrivacySPI.h
@@ -25,11 +25,15 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
 
-#if HAVE(WEB_PRIVACY_FRAMEWORK)
+// FIXME: (rdar://167350643) Remove the `__has_feature(modules)` condition when possible.
+#if HAVE(WEB_PRIVACY_FRAMEWORK) && !__has_feature(modules)
 #import <WebPrivacy/WebPrivacy.h>
 #else
 
@@ -180,7 +184,7 @@ typedef void (^WKWPResourcesGetSourceCompletionHandler)(NSString *, NSError *);
 - (void)requestResourceMonitorRulesSource:(WPResourceRequestOptions *)options completionHandler:(WKWPResourcesGetSourceCompletionHandler)completion;
 @end
 
-#if !__has_include(<WebPrivacy/WPFingerprintingScript.h>)
+#if !__has_include(<WebPrivacy/WPFingerprintingScript.h>) || __has_feature(modules)
 
 #define WPResourceTypeFingerprintingScripts ((WPResourceType)9)
 
@@ -197,7 +201,7 @@ using WPFingerprintingScriptCompletionHandler = void (^)(NSArray<WPFingerprintin
 - (void)requestFingerprintingScripts:(WPResourceRequestOptions *)options completionHandler:(WPFingerprintingScriptCompletionHandler)completion;
 @end
 
-#endif // !__has_include(<WebPrivacy/WPFingerprintingScript.h>)
+#endif // !__has_include(<WebPrivacy/WPFingerprintingScript.h>) || __has_feature(modules)
 
 #if !defined(WP_SUPPORTS_SCRIPT_ACCESS_CATEGORY)
 

--- a/Source/WebCore/PAL/pal/spi/cocoa/pthreadSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/pthreadSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #include <pthread.h>

--- a/Source/WebCore/PAL/pal/spi/ios/IOKitSPIIOS.h
+++ b/Source/WebCore/PAL/pal/spi/ios/IOKitSPIIOS.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if PLATFORM(IOS_FAMILY)
 
 #if USE(APPLE_INTERNAL_SDK)

--- a/Source/WebCore/PAL/pal/spi/mac/CoreUISPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/CoreUISPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if USE(APPLE_INTERNAL_SDK)

--- a/Source/WebCore/PAL/pal/spi/mac/DataDetectorsSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/DataDetectorsSPI.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
 DECLARE_SYSTEM_HEADER
 
 #import <wtf/Platform.h>

--- a/Source/WebCore/PAL/pal/spi/mac/HIServicesSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/HIServicesSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #include <pal/spi/cg/CoreGraphicsSPI.h>

--- a/Source/WebCore/PAL/pal/spi/mac/HIToolboxSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/HIToolboxSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if USE(APPLE_INTERNAL_SDK)

--- a/Source/WebCore/PAL/pal/spi/mac/IOKitSPIMac.h
+++ b/Source/WebCore/PAL/pal/spi/mac/IOKitSPIMac.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if PLATFORM(MAC)

--- a/Source/WebCore/PAL/pal/spi/mac/LookupSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/LookupSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if PLATFORM(MAC)

--- a/Source/WebCore/PAL/pal/spi/mac/MediaRemoteSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/MediaRemoteSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if USE(APPLE_INTERNAL_SDK)

--- a/Source/WebCore/PAL/pal/spi/mac/NSAppearanceSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSAppearanceSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if USE(APPKIT)

--- a/Source/WebCore/PAL/pal/spi/mac/NSApplicationSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSApplicationSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if USE(APPKIT)

--- a/Source/WebCore/PAL/pal/spi/mac/NSCellSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSCellSPI.h
@@ -25,9 +25,10 @@
 
 #pragma once
 
-DECLARE_SYSTEM_HEADER
-
+#include <wtf/Compiler.h>
 #include <wtf/Platform.h>
+
+DECLARE_SYSTEM_HEADER
 
 #if USE(APPKIT)
 

--- a/Source/WebCore/PAL/pal/spi/mac/NSColorSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSColorSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #import <AppKit/NSColor.h>

--- a/Source/WebCore/PAL/pal/spi/mac/NSColorWellSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSColorWellSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if USE(APPKIT)

--- a/Source/WebCore/PAL/pal/spi/mac/NSEventSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSEventSPI.h
@@ -25,9 +25,10 @@
 
 #pragma once
 
-DECLARE_SYSTEM_HEADER
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
 
-#import <wtf/Platform.h>
+DECLARE_SYSTEM_HEADER
 
 #if PLATFORM(MAC)
 

--- a/Source/WebCore/PAL/pal/spi/mac/NSGraphicsSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSGraphicsSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if PLATFORM(MAC)

--- a/Source/WebCore/PAL/pal/spi/mac/NSImageSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSImageSPI.h
@@ -25,9 +25,10 @@
 
 #pragma once
 
-DECLARE_SYSTEM_HEADER
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
 
-#import <wtf/Platform.h>
+DECLARE_SYSTEM_HEADER
 
 #if PLATFORM(MAC)
 

--- a/Source/WebCore/PAL/pal/spi/mac/NSImmediateActionGestureRecognizerSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSImmediateActionGestureRecognizerSPI.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
 DECLARE_SYSTEM_HEADER
 
 #include <wtf/Platform.h>

--- a/Source/WebCore/PAL/pal/spi/mac/NSMenuSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSMenuSPI.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
 DECLARE_SYSTEM_HEADER
 
 #import <wtf/Platform.h>

--- a/Source/WebCore/PAL/pal/spi/mac/NSPasteboardSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSPasteboardSPI.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
 DECLARE_SYSTEM_HEADER
 
 #include <wtf/Platform.h>

--- a/Source/WebCore/PAL/pal/spi/mac/NSPopoverColorWellSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSPopoverColorWellSPI.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
 DECLARE_SYSTEM_HEADER
 
 #import <wtf/Platform.h>

--- a/Source/WebCore/PAL/pal/spi/mac/NSPopoverSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSPopoverSPI.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
 DECLARE_SYSTEM_HEADER
 
 #import <wtf/Platform.h>

--- a/Source/WebCore/PAL/pal/spi/mac/NSResponderSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSResponderSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if PLATFORM(MAC)

--- a/Source/WebCore/PAL/pal/spi/mac/NSScrollViewSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSScrollViewSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if USE(APPKIT)

--- a/Source/WebCore/PAL/pal/spi/mac/NSScrollerImpSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSScrollerImpSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if USE(APPKIT)

--- a/Source/WebCore/PAL/pal/spi/mac/NSScrollingInputFilterSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSScrollingInputFilterSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if PLATFORM(MAC)

--- a/Source/WebCore/PAL/pal/spi/mac/NSScrollingMomentumCalculatorSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSScrollingMomentumCalculatorSPI.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
 DECLARE_SYSTEM_HEADER
 
 #include <wtf/Platform.h>

--- a/Source/WebCore/PAL/pal/spi/mac/NSSearchFieldCellSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSSearchFieldCellSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if USE(APPKIT)

--- a/Source/WebCore/PAL/pal/spi/mac/NSServicesRolloverButtonCellSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSServicesRolloverButtonCellSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if ENABLE(SERVICE_CONTROLS)

--- a/Source/WebCore/PAL/pal/spi/mac/NSSharingServicePickerSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSSharingServicePickerSPI.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
 DECLARE_SYSTEM_HEADER
 
 #include <wtf/Platform.h>

--- a/Source/WebCore/PAL/pal/spi/mac/NSSharingServiceSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSSharingServiceSPI.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
 DECLARE_SYSTEM_HEADER
 
 #include <wtf/Platform.h>

--- a/Source/WebCore/PAL/pal/spi/mac/NSSpellCheckerSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSSpellCheckerSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if PLATFORM(MAC)

--- a/Source/WebCore/PAL/pal/spi/mac/NSTextFieldCellSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSTextFieldCellSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if USE(APPKIT)

--- a/Source/WebCore/PAL/pal/spi/mac/NSTextFinderSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSTextFinderSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if USE(APPKIT)

--- a/Source/WebCore/PAL/pal/spi/mac/NSTextInputContextSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSTextInputContextSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if PLATFORM(MAC)

--- a/Source/WebCore/PAL/pal/spi/mac/NSTextTableSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSTextTableSPI.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
 DECLARE_SYSTEM_HEADER
 
 #include <wtf/Platform.h>

--- a/Source/WebCore/PAL/pal/spi/mac/NSUndoManagerSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSUndoManagerSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if PLATFORM(MAC)

--- a/Source/WebCore/PAL/pal/spi/mac/NSViewSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSViewSPI.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
 DECLARE_SYSTEM_HEADER
 
 #import <wtf/Platform.h>

--- a/Source/WebCore/PAL/pal/spi/mac/NSWindowSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSWindowSPI.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+
 DECLARE_SYSTEM_HEADER
 
 #import <wtf/Platform.h>

--- a/Source/WebCore/PAL/pal/spi/mac/PIPSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/PIPSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if PLATFORM(MAC)

--- a/Source/WebCore/PAL/pal/spi/mac/PowerLogSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/PowerLogSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if USE(APPLE_INTERNAL_SDK)

--- a/Source/WebCore/PAL/pal/spi/mac/QuarantineSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/QuarantineSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if PLATFORM(MAC)

--- a/Source/WebCore/PAL/pal/spi/mac/QuickLookMacSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/QuickLookMacSPI.h
@@ -25,11 +25,15 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #import <Quartz/Quartz.h>
 
-#if USE(APPLE_INTERNAL_SDK)
+// FIXME: (rdar://167376152) Remove the `__has_feature(modules)` condition when possible.
+#if USE(APPLE_INTERNAL_SDK) && !__has_feature(modules)
 
 #import <Quartz/QuartzPrivate.h>
 

--- a/Source/WebCore/PAL/pal/spi/mac/ScreenCaptureKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/ScreenCaptureKitSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if HAVE(SCREEN_CAPTURE_KIT)

--- a/Source/WebCore/PAL/pal/spi/mac/SystemPreviewSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/SystemPreviewSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if USE(APPLE_INTERNAL_SDK)

--- a/Source/WebCore/PAL/pal/spi/mac/TelephonyUtilitiesSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/TelephonyUtilitiesSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if PLATFORM(MAC)

--- a/Source/WebCore/PAL/pal/system/glib/SleepDisablerGLib.h
+++ b/Source/WebCore/PAL/pal/system/glib/SleepDisablerGLib.h
@@ -25,6 +25,10 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
+#if USE(GLIB)
+
 #include "SleepDisabler.h"
 
 #include <wtf/glib/GRefPtr.h>
@@ -57,3 +61,5 @@ private:
 };
 
 } // namespace PAL
+
+#endif


### PR DESCRIPTION
#### 283c780414b7c24e4a911c823af665f53a15e8f7
<pre>
[Swift in WebKit] Work towards modularizing PAL (part 3)
<a href="https://bugs.webkit.org/show_bug.cgi?id=304796">https://bugs.webkit.org/show_bug.cgi?id=304796</a>
<a href="https://rdar.apple.com/167357694">rdar://167357694</a>

Reviewed by Mike Wyrzykowski.

Continue working towards fixing all module-related issues in PAL.

* Source/WebCore/PAL/pal/spi/cf/CoreAudioSPI.h:
* Source/WebCore/PAL/pal/spi/cf/CoreMediaSPI.h:
* Source/WebCore/PAL/pal/spi/cf/CoreTextSPI.h:
* Source/WebCore/PAL/pal/spi/cocoa/AXSpeechManagerSPI.h:
* Source/WebCore/PAL/pal/spi/cocoa/CommonCryptoSPI.h:
* Source/WebCore/PAL/pal/spi/cocoa/CryptoKitPrivateSPI.h:
* Source/WebCore/PAL/pal/spi/cocoa/WebFilterEvaluatorSPI.h:
* Source/WebCore/PAL/pal/spi/cocoa/WebPrivacySPI.h:
* Source/WebCore/PAL/pal/spi/cocoa/TranslationUIServicesSPI.h:
* Source/WebCore/PAL/pal/spi/mac/QuickLookMacSPI.h:

These headers depend on non-modularized headers, which is not allowed. Therefore, until they have proper
modules, use the already-existing forward declarations for these symbols when building with modules.

* Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h:

Remove a now unnecessary and incorrect extern &quot;C&quot; block.

* &lt;the rest&gt;

Add missing includes and compilation guards.

Canonical link: <a href="https://commits.webkit.org/305044@main">https://commits.webkit.org/305044@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66ffc68475353c1195c8112f46693b4a84dbb424

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137218 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9578 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48505 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144967 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90191 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b890bf7c-6efc-461c-82af-5ff3015943b5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139090 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10281 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9705 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104937 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e1b170e6-6329-4fc1-9d15-bd40c310e7cc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140163 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7581 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122973 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85778 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4d18a161-4641-425d-8e34-bd23e4c3ad7a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7218 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4932 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5554 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116575 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41134 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147725 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9261 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41696 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9279 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7794 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/worker-performance.worker.html (failure)") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28869 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7140 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119226 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63735 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9310 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37280 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9035 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72875 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9250 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9102 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->