### PR TITLE
Fix subtle bug in SortedArrayMap's lessThanASCIICaseFolding()

### DIFF
--- a/Source/WTF/wtf/SortedArrayMap.h
+++ b/Source/WTF/wtf/SortedArrayMap.h
@@ -250,7 +250,7 @@ template<typename CharacterType> inline bool lessThanASCIICaseFolding(std::span<
         if (lowercaseCharacter != literalCharacter)
             return lowercaseCharacter < literalCharacter;
     }
-    return literalWithNoUppercase.length() < characters.size();
+    return characters.size() < literalWithNoUppercase.length();
 }
 
 inline bool lessThanASCIICaseFolding(StringView string, ASCIILiteral literalWithNoUppercase)

--- a/Tools/TestWebKitAPI/Tests/WTF/SortedArrayMap.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/SortedArrayMap.cpp
@@ -93,3 +93,28 @@ TEST(WTF, SortedArraySet)
     ASSERT_FALSE(scriptTypesSet.contains("application/json"_s));
     ASSERT_FALSE(scriptTypesSet.contains("foo/javascript"_s));
 }
+
+TEST(WTF, LessThanASCIICaseFoldingDirectComparison)
+{
+    // Direct comparison test.
+    StringView shorter = "ab"_s;
+    ASCIILiteral longer = "abc"_s;
+
+    WTF::ComparableStringView compShorter { shorter };
+    WTF::ComparableLettersLiteral compLonger { longer };
+
+    // "ab" should be less than "abc".
+    bool shorterLessThanLonger = compShorter < compLonger;
+    EXPECT_TRUE(shorterLessThanLonger) << "\"ab\" should be < \"abc\"";
+
+    // "abc" should NOT be less than "ab".
+    bool longerLessThanShorter = compLonger < compShorter;
+    EXPECT_FALSE(longerLessThanShorter) << "\"abc\" should NOT be < \"ab\"";
+
+    // Test with case differences.
+    StringView upperShorter = "AB"_s;
+    WTF::ComparableStringView compUpperShorter { upperShorter };
+
+    bool upperShorterLessThanLonger = compUpperShorter < compLonger;
+    EXPECT_TRUE(upperShorterLessThanLonger) << "\"AB\" should be < \"abc\" (case insensitive)";
+}


### PR DESCRIPTION
#### c52e971ff6541f8aed2ce6e200f99c6b731448d3
<pre>
Fix subtle bug in SortedArrayMap&apos;s lessThanASCIICaseFolding()
<a href="https://bugs.webkit.org/show_bug.cgi?id=304797">https://bugs.webkit.org/show_bug.cgi?id=304797</a>

Reviewed by Anne van Kesteren and Darin Adler.

Fix subtle bug in SortedArrayMap&apos;s lessThanASCIICaseFolding() where it would
treat &quot;ab&quot; as greater than &quot;abc&quot;, even though it is shorter.

Test: Tools/TestWebKitAPI/Tests/WTF/SortedArrayMap.cpp

* Source/WTF/wtf/SortedArrayMap.h:
(WTF::lessThanASCIICaseFolding):
* Tools/TestWebKitAPI/Tests/WTF/SortedArrayMap.cpp:
(TEST(WTF, LessThanASCIICaseFoldingDirectComparison)):

Canonical link: <a href="https://commits.webkit.org/305019@main">https://commits.webkit.org/305019@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/17507c9785f8da7b5334c2ba1c5a8981dd7a0e21

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137193 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9553 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48480 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144940 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90166 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b5874b09-a1ab-405d-a968-63677bf2cd0e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139065 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10256 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9680 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104917 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/73018566-1f8f-4e5c-8e86-517f0cfa7eab) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140138 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7558 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122945 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85756 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/faf10ff7-0201-45c5-a0ee-e2e0e7e640bc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7195 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4905 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5529 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/129154 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116550 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41109 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147698 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/135685 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9236 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41671 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113276 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9254 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7769 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113606 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28857 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7115 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119201 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63665 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9284 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37255 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/168461 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9010 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72850 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43971 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9225 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9077 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->