### PR TITLE
[WTF] Optimize `String::fromUTF8` using simdutf

### DIFF
--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -826,6 +826,7 @@ else ()
     set_source_files_properties(
         SIMDUTF.cpp
         text/Base64.cpp
+        text/StringImpl.cpp
         PROPERTIES COMPILE_FLAGS "-Wno-error=undef -Wno-undef")
 endif ()
 


### PR DESCRIPTION
#### 3fbc2eefcf863f4c24d3ed9763e86c7e0f6543b2
<pre>
[WTF] Optimize `String::fromUTF8` using simdutf
<a href="https://bugs.webkit.org/show_bug.cgi?id=304800">https://bugs.webkit.org/show_bug.cgi?id=304800</a>

Reviewed by Yusuke Suzuki.

This patch changes to optimize `String::fromUTF8` using simdutf.

Here are the benchmark results measured on my local machine (M4 MAX MBP).
ASCII is neutral, and the others large data show significant improvement:

16 chars:
                    original      this patch     speedup

  ASCII only     :   1375.0 MB/s   1410.7 MB/s    1.03x
  Japanese       :   1028.9 MB/s   1210.0 MB/s    1.18x
  Mixed          :    861.2 MB/s    936.5 MB/s    1.09x
  Emoji          :    857.4 MB/s    988.8 MB/s    1.15x

32 chars:
                    original      this patch     speedup

  ASCII only     :   2434.5 MB/s   2538.4 MB/s    1.04x
  Japanese       :   1040.8 MB/s   2188.0 MB/s    2.10x
  Mixed          :    723.2 MB/s   1635.7 MB/s    2.26x
  Emoji          :   1007.1 MB/s   1539.4 MB/s    1.53x

64 chars:
                    original      this patch     speedup

  ASCII only     :   4874.6 MB/s   5203.6 MB/s    1.07x
  Japanese       :   1071.9 MB/s   2914.0 MB/s    2.72x
  Mixed          :    827.9 MB/s   2082.4 MB/s    2.52x
  Emoji          :   1222.0 MB/s   2118.1 MB/s    1.73x

128 chars:
                    original      this patch     speedup

  ASCII only     :   7691.5 MB/s   7701.6 MB/s    1.00x
  Japanese       :   1120.6 MB/s   4147.8 MB/s    3.70x
  Mixed          :    988.1 MB/s   2936.0 MB/s    2.97x
  Emoji          :   1283.0 MB/s   2727.3 MB/s    2.13x

256 chars:
                    original      this patch     speedup

  ASCII only     :  10547.6 MB/s  10894.6 MB/s    1.03x
  Japanese       :   1461.3 MB/s   4491.9 MB/s    3.07x
  Mixed          :   1142.8 MB/s   2978.2 MB/s    2.61x
  Emoji          :   1365.1 MB/s   3316.0 MB/s    2.43x

1K chars:
                    original      this patch     speedup

  ASCII only     :  15578.1 MB/s  15431.4 MB/s    0.99x
  Japanese       :   1049.6 MB/s   4686.6 MB/s    4.47x
  Mixed          :    627.7 MB/s   2986.9 MB/s    4.76x
  Emoji          :    830.1 MB/s   3094.2 MB/s    3.73x

4K chars:
                    original      this patch     speedup

  ASCII only     :  17720.4 MB/s  17419.0 MB/s    0.98x
  Japanese       :   1049.6 MB/s   4895.0 MB/s    4.66x
  Mixed          :    659.9 MB/s   3487.1 MB/s    5.28x
  Emoji          :    941.8 MB/s   2764.5 MB/s    2.94x

10K chars:
                    original      this patch     speedup

  ASCII only     :  18314.3 MB/s  19397.0 MB/s    1.06x
  Japanese       :    620.2 MB/s   4925.0 MB/s    7.94x
  Mixed          :    400.4 MB/s   3524.1 MB/s    8.80x
  Emoji          :    684.5 MB/s   3058.3 MB/s    4.47x

100K chars:
                    original      this patch     speedup

  ASCII only     :  14003.4 MB/s  22619.4 MB/s    1.62x
  Japanese       :    830.0 MB/s   4994.0 MB/s    6.02x
  Mixed          :    717.9 MB/s   3012.6 MB/s    4.20x
  Emoji          :    936.2 MB/s   3357.0 MB/s    3.59x

Test: Tools/TestWebKitAPI/Tests/WTF/UTF8Conversion.cpp

* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::create):

Canonical link: <a href="https://commits.webkit.org/305014@main">https://commits.webkit.org/305014@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef57c997b35cad2662522364d4dfa6d2016b8f6e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137199 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9559 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48486 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144946 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90172 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10262 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9686 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104920 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140144 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7562 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122951 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85760 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7199 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4911 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5535 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/129160 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116558 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41115 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147704 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/135691 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9242 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41677 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113280 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9260 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7774 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113610 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28852 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7119 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119207 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63673 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9291 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37261 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/168467 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9016 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72856 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43975 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9231 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9083 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->