### PR TITLE
Introduce ThreadSafeWeakRef and adopt it where appropriate

### DIFF
--- a/Source/WebCore/Modules/webdatabase/Database.cpp
+++ b/Source/WebCore/Modules/webdatabase/Database.cpp
@@ -311,11 +311,11 @@ public:
 
     ~DoneCreatingDatabaseOnExitCaller()
     {
-        DatabaseTracker::singleton().doneCreatingDatabase(*m_database.get());
+        DatabaseTracker::singleton().doneCreatingDatabase(m_database.get());
     }
 
 private:
-    ThreadSafeWeakPtr<Database> m_database;
+    ThreadSafeWeakRef<Database> m_database;
 };
 
 ExceptionOr<void> Database::performOpenAndVerify(bool shouldSetVersionInNewDatabase)

--- a/Source/WebCore/page/scrolling/ScrollingTreeGestureState.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeGestureState.h
@@ -51,7 +51,7 @@ public:
 private:
     void clearAllNodes();
 
-    ThreadSafeWeakPtr<ScrollingTree> m_scrollingTree; // Cannot be null.
+    ThreadSafeWeakRef<ScrollingTree> m_scrollingTree;
     Markable<ScrollingNodeID> m_mayBeginNodeID;
     Markable<ScrollingNodeID> m_activeNodeID;
 };

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h
@@ -39,8 +39,8 @@ public:
     WEBCORE_EXPORT explicit ScrollingTreeScrollingNodeDelegate(ScrollingTreeScrollingNode&);
     WEBCORE_EXPORT virtual ~ScrollingTreeScrollingNodeDelegate();
 
-    Ref<ScrollingTreeScrollingNode> scrollingNode() { return m_scrollingNode.get().releaseNonNull(); }
-    Ref<const ScrollingTreeScrollingNode> scrollingNode() const { return m_scrollingNode.get().releaseNonNull(); }
+    Ref<ScrollingTreeScrollingNode> scrollingNode() { return m_scrollingNode.get(); }
+    Ref<const ScrollingTreeScrollingNode> scrollingNode() const { return m_scrollingNode.get(); }
 
     virtual bool startAnimatedScrollToPosition(FloatPoint) = 0;
     virtual void stopAnimatedScroll() = 0;
@@ -85,7 +85,7 @@ protected:
     ScrollElasticity verticalScrollElasticity() const { return scrollingNode()->verticalScrollElasticity(); }
 
 private:
-    ThreadSafeWeakPtr<ScrollingTreeScrollingNode> m_scrollingNode; // m_scrollingNode is expected never be null
+    ThreadSafeWeakRef<ScrollingTreeScrollingNode> m_scrollingNode;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/ImageFrameAnimator.cpp
+++ b/Source/WebCore/platform/graphics/ImageFrameAnimator.cpp
@@ -66,7 +66,7 @@ void ImageFrameAnimator::destroyDecodedData(bool destroyAll)
     // only hang on to one frame at a time.
     static constexpr unsigned LargeAnimationCutoff = 30 * 1024 * 1024;
 
-    RefPtr source = m_source.get();
+    Ref source = m_source.get();
     if (source->decodedSize() < LargeAnimationCutoff)
         return;
 
@@ -89,7 +89,7 @@ void ImageFrameAnimator::timerFired()
 {
     clearTimer();
 
-    RefPtr source = m_source.get();
+    Ref source = m_source.get();
 
     // Don't advance to nextFrame if the next frame is being decoded.
     if (source->isPendingDecodingAtIndex(nextFrameIndex(), m_nextFrameSubsamplingLevel, m_nextFrameOptions))
@@ -124,7 +124,7 @@ bool ImageFrameAnimator::startAnimation(SubsamplingLevel subsamplingLevel, const
     if (m_frameTimer)
         return true;
 
-    RefPtr source = m_source.get();
+    Ref source = m_source.get();
 
     // ImageObserver may disallow animation.
     if (!source->isAnimationAllowed())

--- a/Source/WebCore/platform/graphics/ImageFrameAnimator.h
+++ b/Source/WebCore/platform/graphics/ImageFrameAnimator.h
@@ -72,7 +72,7 @@ private:
 
     CString sourceUTF8() const;
 
-    ThreadSafeWeakPtr<BitmapImageSource> m_source; // Cannot be null.
+    ThreadSafeWeakRef<BitmapImageSource> m_source;
     unsigned m_frameCount { 0 };
     RepetitionCount m_repetitionCount { RepetitionCountNone };
 

--- a/Source/WebCore/platform/graphics/adwaita/ProgressBarAdwaita.h
+++ b/Source/WebCore/platform/graphics/adwaita/ProgressBarAdwaita.h
@@ -39,7 +39,7 @@ public:
     void draw(GraphicsContext&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&) override;
 
 private:
-    Ref<const ProgressBarPart> owningProgressBarPart() const { return downcast<ProgressBarPart>(m_owningPart.get().releaseNonNull()); }
+    Ref<const ProgressBarPart> owningProgressBarPart() const { return downcast<ProgressBarPart>(m_owningPart.get()); }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/adwaita/SliderTrackAdwaita.h
+++ b/Source/WebCore/platform/graphics/adwaita/SliderTrackAdwaita.h
@@ -39,7 +39,7 @@ public:
     void draw(GraphicsContext&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&) override;
 
 private:
-    Ref<const SliderTrackPart> owningSliderTrackPart() const { return downcast<SliderTrackPart>(m_owningPart.get().releaseNonNull()); }
+    Ref<const SliderTrackPart> owningSliderTrackPart() const { return downcast<SliderTrackPart>(m_owningPart.get()); }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cocoa/controls/ApplePayButtonCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/controls/ApplePayButtonCocoa.h
@@ -40,7 +40,7 @@ public:
     explicit ApplePayButtonCocoa(ApplePayButtonPart&);
 
 private:
-    Ref<const ApplePayButtonPart> owningApplePayButtonPart() const { return downcast<ApplePayButtonPart>(m_owningPart.get().releaseNonNull()); }
+    Ref<const ApplePayButtonPart> owningApplePayButtonPart() const { return downcast<ApplePayButtonPart>(m_owningPart.get()); }
 
     void draw(GraphicsContext&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&) override;
 };

--- a/Source/WebCore/platform/graphics/controls/PlatformControl.h
+++ b/Source/WebCore/platform/graphics/controls/PlatformControl.h
@@ -58,7 +58,7 @@ public:
     virtual void draw(GraphicsContext&, const FloatRoundedRect&, float, const ControlStyle&) { }
 
 protected:
-    ThreadSafeWeakPtr<ControlPart> m_owningPart; // Cannot be null.
+    ThreadSafeWeakRef<ControlPart> m_owningPart;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/mac/controls/MeterMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/MeterMac.h
@@ -40,7 +40,7 @@ public:
     ~MeterMac();
 
 private:
-    Ref<const MeterPart> owningMeterPart() const { return downcast<MeterPart>(m_owningPart.get().releaseNonNull()); }
+    Ref<const MeterPart> owningMeterPart() const { return downcast<MeterPart>(m_owningPart.get()); }
 
     void updateCellStates(const FloatRect&, const ControlStyle&) override;
 

--- a/Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.h
@@ -42,7 +42,7 @@ public:
     ~ProgressBarMac();
 
 private:
-    Ref<const ProgressBarPart> owningProgressBarPart() const { return downcast<ProgressBarPart>(m_owningPart.get().releaseNonNull()); }
+    Ref<const ProgressBarPart> owningProgressBarPart() const { return downcast<ProgressBarPart>(m_owningPart.get()); }
 
     IntSize cellSize(NSControlSize, const ControlStyle&) const override;
     IntOutsets cellOutsets(NSControlSize, const ControlStyle&) const override;

--- a/Source/WebCore/platform/graphics/mac/controls/SliderTrackMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/SliderTrackMac.h
@@ -39,7 +39,7 @@ public:
     SliderTrackMac(SliderTrackPart&, ControlFactoryMac&);
 
 private:
-    Ref<const SliderTrackPart> owningSliderTrackPart() const { return downcast<SliderTrackPart>(m_owningPart.get().releaseNonNull()); }
+    Ref<const SliderTrackPart> owningSliderTrackPart() const { return downcast<SliderTrackPart>(m_owningPart.get()); }
 
     FloatRect rectForBounds(const FloatRect& bounds, const ControlStyle&) const override;
 

--- a/Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.h
@@ -38,7 +38,7 @@ public:
     SwitchThumbMac(SwitchThumbPart&, ControlFactoryMac&);
 
 private:
-    Ref<const SwitchThumbPart> owningPart() const { return downcast<SwitchThumbPart>(m_owningPart.get().releaseNonNull()); }
+    Ref<const SwitchThumbPart> owningPart() const { return downcast<SwitchThumbPart>(m_owningPart.get()); }
 
     IntSize cellSize(NSControlSize, const ControlStyle&) const override;
     IntOutsets cellOutsets(NSControlSize, const ControlStyle&) const override;

--- a/Source/WebCore/platform/graphics/mac/controls/SwitchTrackMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/SwitchTrackMac.h
@@ -38,7 +38,7 @@ public:
     SwitchTrackMac(SwitchTrackPart&, ControlFactoryMac&);
 
 private:
-    Ref<const SwitchTrackPart> owningPart() const { return downcast<SwitchTrackPart>(m_owningPart.get().releaseNonNull()); }
+    Ref<const SwitchTrackPart> owningPart() const { return downcast<SwitchTrackPart>(m_owningPart.get()); }
 
     IntSize cellSize(NSControlSize, const ControlStyle&) const override;
     IntOutsets cellOutsets(NSControlSize, const ControlStyle&) const override;

--- a/Source/WebKit/GPUProcess/media/RemoteMediaEngineConfigurationFactoryProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaEngineConfigurationFactoryProxy.cpp
@@ -76,9 +76,7 @@ void RemoteMediaEngineConfigurationFactoryProxy::deref() const
 
 std::optional<SharedPreferencesForWebProcess> RemoteMediaEngineConfigurationFactoryProxy::sharedPreferencesForWebProcess() const
 {
-    if (RefPtr connection = m_connection.get())
-        return connection->sharedPreferencesForWebProcess();
-    return std::nullopt;
+    return m_connection.get()->sharedPreferencesForWebProcess();
 }
 
 }

--- a/Source/WebKit/GPUProcess/media/RemoteMediaEngineConfigurationFactoryProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaEngineConfigurationFactoryProxy.h
@@ -60,7 +60,7 @@ private:
     void createDecodingConfiguration(WebCore::MediaDecodingConfiguration&&, CompletionHandler<void(WebCore::MediaCapabilitiesDecodingInfo&&)>&&);
     void createEncodingConfiguration(WebCore::MediaEncodingConfiguration&&, CompletionHandler<void(WebCore::MediaCapabilitiesEncodingInfo&&)>&&);
 
-    ThreadSafeWeakPtr<GPUConnectionToWebProcess> m_connection; // Cannot be null.
+    ThreadSafeWeakRef<GPUConnectionToWebProcess> m_connection;
 };
 
 }

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp
@@ -244,7 +244,7 @@ private:
             LOG(NetworkCacheSpeculativePreloading, "(NetworkProcess) * Subresource: '%s'.", subresourceLoad->key.identifier().utf8().data());
 #endif
 
-        RefPtr storage = m_storage.get();
+        Ref storage = m_storage.get();
         if (m_existingEntry) {
             m_existingEntry->updateSubresourceLoads(m_subresourceLoads);
             storage->store(m_existingEntry->encodeAsStorageRecord(), [](const Data&) { });
@@ -254,7 +254,7 @@ private:
         }
     }
 
-    ThreadSafeWeakPtr<Storage> m_storage; // Not expected be to be null.
+    ThreadSafeWeakRef<Storage> m_storage;
     Key m_mainResourceKey;
     Vector<std::unique_ptr<SubresourceLoad>> m_subresourceLoads;
     WTF::Function<void()> m_loadCompletionHandler;
@@ -283,7 +283,7 @@ Ref<Cache> SpeculativeLoadManager::protectedCache() const
 
 Ref<Storage> SpeculativeLoadManager::protectedStorage() const
 {
-    return m_storage.get().releaseNonNull();
+    return m_storage.get();
 }
 
 bool SpeculativeLoadManager::canUsePreloadedEntry(const PreloadedEntry& entry, const ResourceRequest& actualRequest)
@@ -644,7 +644,7 @@ void SpeculativeLoadManager::startSpeculativeRevalidation(const GlobalFrameID& f
 void SpeculativeLoadManager::retrieveSubresourcesEntry(const Key& storageKey, WTF::Function<void (std::unique_ptr<SubresourcesEntry>)>&& completionHandler)
 {
     ASSERT(storageKey.type() == "Resource"_s);
-    RefPtr storage = m_storage.get();
+    Ref storage = m_storage.get();
     auto subresourcesStorageKey = makeSubresourcesKey(storageKey, storage->salt());
     storage->retrieve(subresourcesStorageKey, static_cast<unsigned>(ResourceLoadPriority::Medium), [completionHandler = WTF::move(completionHandler)](auto record, auto timings) {
         if (record.isNull()) {

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.h
@@ -88,7 +88,7 @@ private:
     Ref<Cache> protectedCache() const;
 
     const WeakRef<Cache> m_cache;
-    ThreadSafeWeakPtr<Storage> m_storage; // Not expected to be null.
+    ThreadSafeWeakRef<Storage> m_storage;
 
     class PendingFrameLoad;
     HashMap<GlobalFrameID, RefPtr<PendingFrameLoad>> m_pendingFrameLoads;

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -207,7 +207,7 @@ MediaPlayerPrivateRemote::~MediaPlayerPrivateRemote()
 #if PLATFORM(COCOA)
     m_videoLayerManager->didDestroyVideoLayer();
 #endif
-    protectedManager()->deleteRemoteMediaPlayer(m_id);
+    manager()->deleteRemoteMediaPlayer(m_id);
 
 #if ENABLE(WEB_AUDIO) && PLATFORM(COCOA)
     if (RefPtr audioSourceProvider = m_audioSourceProvider)
@@ -250,7 +250,7 @@ void MediaPlayerPrivateRemote::load(const URL& url, const LoadOptions& options)
 
         auto createExtension = [&] {
 #if HAVE(AUDIT_TOKEN)
-            if (auto auditToken = protectedManager()->protectedGPUProcessConnection()->auditToken()) {
+            if (auto auditToken = manager()->protectedGPUProcessConnection()->auditToken()) {
                 if (auto createdHandle = SandboxExtension::createHandleForReadByAuditToken(fileSystemPath, auditToken.value())) {
                     handle = WTF::move(*createdHandle);
                     return true;
@@ -757,7 +757,7 @@ void MediaPlayerPrivateRemote::addRemoteAudioTrack(AudioTrackPrivateRemoteConfig
 
     m_audioTracks.erase(configuration.trackId);
 
-    auto addResult = m_audioTracks.emplace(configuration.trackId, AudioTrackPrivateRemote::create(protectedManager()->protectedGPUProcessConnection(), m_id, WTF::move(configuration)));
+    auto addResult = m_audioTracks.emplace(configuration.trackId, AudioTrackPrivateRemote::create(manager()->protectedGPUProcessConnection(), m_id, WTF::move(configuration)));
     ASSERT(addResult.second);
 
 #if ENABLE(MEDIA_SOURCE)
@@ -807,7 +807,7 @@ void MediaPlayerPrivateRemote::addRemoteTextTrack(TextTrackPrivateRemoteConfigur
 
     m_textTracks.erase(configuration.trackId);
 
-    auto addResult = m_textTracks.emplace(configuration.trackId, TextTrackPrivateRemote::create(protectedManager()->protectedGPUProcessConnection(), m_id, WTF::move(configuration)));
+    auto addResult = m_textTracks.emplace(configuration.trackId, TextTrackPrivateRemote::create(manager()->protectedGPUProcessConnection(), m_id, WTF::move(configuration)));
     ASSERT(addResult.second);
 
 #if ENABLE(MEDIA_SOURCE)
@@ -971,7 +971,7 @@ void MediaPlayerPrivateRemote::addRemoteVideoTrack(VideoTrackPrivateRemoteConfig
 
     m_videoTracks.erase(configuration.trackId);
 
-    auto addResult = m_videoTracks.emplace(configuration.trackId, VideoTrackPrivateRemote::create(protectedManager()->protectedGPUProcessConnection(), m_id, WTF::move(configuration)));
+    auto addResult = m_videoTracks.emplace(configuration.trackId, VideoTrackPrivateRemote::create(manager()->protectedGPUProcessConnection(), m_id, WTF::move(configuration)));
     ASSERT(addResult.second);
 
 #if ENABLE(MEDIA_SOURCE)
@@ -1047,7 +1047,7 @@ void MediaPlayerPrivateRemote::load(const URL& url, const LoadOptions& options, 
             // MediaSource can only be re-opened after RemoteMediaPlayerProxy::LoadMediaSource has been called.
             client.reOpen();
         } else
-            m_mediaSourcePrivate = MediaSourcePrivateRemote::create(protectedManager()->protectedGPUProcessConnection(), identifier, protectedManager()->checkedTypeCache(m_remoteEngineIdentifier), *this, client);
+            m_mediaSourcePrivate = MediaSourcePrivateRemote::create(manager()->protectedGPUProcessConnection(), identifier, manager()->checkedTypeCache(m_remoteEngineIdentifier), *this, client);
         return;
     }
 
@@ -1870,9 +1870,9 @@ void MediaPlayerPrivateRemote::commitAllTransactions(CompletionHandler<void()>&&
     completionHandler();
 }
 
-Ref<RemoteMediaPlayerManager> MediaPlayerPrivateRemote::protectedManager() const
+Ref<RemoteMediaPlayerManager> MediaPlayerPrivateRemote::manager() const
 {
-    return m_manager.get().releaseNonNull();
+    return m_manager.get();
 }
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -112,8 +112,8 @@ public:
 
     WebCore::MediaPlayerEnums::MediaEngineIdentifier remoteEngineIdentifier() const { return m_remoteEngineIdentifier; }
     std::optional<WebCore::MediaPlayerIdentifier> identifier() const final { return m_id; }
-    IPC::Connection& connection() const { return protectedManager()->gpuProcessConnection().connection(); }
-    Ref<IPC::Connection> protectedConnection() const { return protectedManager()->gpuProcessConnection().connection(); }
+    IPC::Connection& connection() const { return manager()->gpuProcessConnection().connection(); }
+    Ref<IPC::Connection> protectedConnection() const { return manager()->gpuProcessConnection().connection(); }
     RefPtr<WebCore::MediaPlayer> player() const { return m_player.get(); }
 
     WebCore::MediaPlayer::ReadyState readyState() const final { return m_readyState; }
@@ -237,7 +237,7 @@ private:
         void forceUseOfCachedTimeUntilNextSetTime();
 
     private:
-        Ref<const MediaPlayerPrivateRemote> protectedParent() const { return m_parent.get().releaseNonNull(); }
+        Ref<const MediaPlayerPrivateRemote> protectedParent() const { return m_parent.get(); }
 
         mutable Lock m_lock;
         std::atomic<bool> m_timeIsProgressing { false };
@@ -246,7 +246,7 @@ private:
         double m_rate WTF_GUARDED_BY_LOCK(m_lock) { 1.0 };
         mutable std::optional<MediaTime> m_lastReturnedTime WTF_GUARDED_BY_LOCK(m_lock);
         bool m_forceUseCachedTime WTF_GUARDED_BY_LOCK(m_lock) { false };
-        ThreadSafeWeakPtr<const MediaPlayerPrivateRemote> m_parent; // Cannot be null.
+        ThreadSafeWeakRef<const MediaPlayerPrivateRemote> m_parent;
     };
     TimeProgressEstimator m_currentTimeEstimator;
 
@@ -497,10 +497,10 @@ private:
 #if PLATFORM(COCOA)
     void pushVideoFrameMetadata(WebCore::VideoFrameMetadata&&, RemoteVideoFrameProxy::Properties&&);
 #endif
-    RemoteVideoFrameObjectHeapProxy& videoFrameObjectHeapProxy() const { return protectedManager()->protectedGPUProcessConnection()->videoFrameObjectHeapProxy(); }
+    RemoteVideoFrameObjectHeapProxy& videoFrameObjectHeapProxy() const { return manager()->protectedGPUProcessConnection()->videoFrameObjectHeapProxy(); }
     Ref<RemoteVideoFrameObjectHeapProxy> protectedVideoFrameObjectHeapProxy() const { return videoFrameObjectHeapProxy(); }
 
-    Ref<RemoteMediaPlayerManager> protectedManager() const;
+    Ref<RemoteMediaPlayerManager> manager() const;
 
 #if PLATFORM(IOS_FAMILY)
     void sceneIdentifierDidChange() final;
@@ -515,7 +515,7 @@ private:
     mutable PlatformLayerContainer m_videoLayer;
 #endif
 
-    ThreadSafeWeakPtr<RemoteMediaPlayerManager> m_manager; // Cannot be null.
+    ThreadSafeWeakRef<RemoteMediaPlayerManager> m_manager;
     WebCore::MediaPlayerEnums::MediaEngineIdentifier m_remoteEngineIdentifier;
     WebCore::MediaPlayerIdentifier m_id;
     RemoteMediaPlayerConfiguration m_configuration;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVF.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVF.cpp
@@ -57,12 +57,12 @@ RemoteImageDecoderAVF::RemoteImageDecoderAVF(RemoteImageDecoderAVFManager& manag
 
 RemoteImageDecoderAVF::~RemoteImageDecoderAVF()
 {
-    protectedManager()->deleteRemoteImageDecoder(m_identifier);
+    manager()->deleteRemoteImageDecoder(m_identifier);
 }
 
-Ref<RemoteImageDecoderAVFManager> RemoteImageDecoderAVF::protectedManager() const
+Ref<RemoteImageDecoderAVFManager> RemoteImageDecoderAVF::manager() const
 {
-    return m_manager.get().releaseNonNull();
+    return m_manager.get();
 }
 
 bool RemoteImageDecoderAVF::canDecodeType(const String& mimeType)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVF.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVF.h
@@ -83,10 +83,10 @@ public:
     void encodedDataStatusChanged(size_t frameCount, const WebCore::IntSize&, bool hasTrack);
 
 private:
-    Ref<RemoteImageDecoderAVFManager> protectedManager() const;
+    Ref<RemoteImageDecoderAVFManager> manager() const;
 
     ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
-    ThreadSafeWeakPtr<RemoteImageDecoderAVFManager> m_manager; // Cannot be null.
+    ThreadSafeWeakRef<RemoteImageDecoderAVFManager> m_manager;
     WebCore::ImageDecoderIdentifier m_identifier;
 
     String m_mimeType;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.cpp
@@ -59,7 +59,7 @@ HashSet<String>& RemoteMediaPlayerMIMETypeCache::supportedTypes()
 {
     ASSERT(isMainRunLoop());
     if (!m_hasPopulatedSupportedTypesCacheFromGPUProcess) {
-        auto sendResult = protectedManager()->gpuProcessConnection().connection().sendSync(Messages::RemoteMediaPlayerManagerProxy::GetSupportedTypes(m_engineIdentifier), 0);
+        auto sendResult = manager()->gpuProcessConnection().connection().sendSync(Messages::RemoteMediaPlayerManagerProxy::GetSupportedTypes(m_engineIdentifier), 0);
         if (sendResult.succeeded()) {
             auto& [types] = sendResult.reply();
             addSupportedTypes(types);
@@ -86,7 +86,7 @@ MediaPlayerEnums::SupportsType RemoteMediaPlayerMIMETypeCache::supportsTypeAndCo
     if (!m_supportsTypeAndCodecsCache)
         m_supportsTypeAndCodecsCache = HashMap<SupportedTypesAndCodecsKey, MediaPlayerEnums::SupportsType> { };
 
-    auto sendResult = protectedManager()->gpuProcessConnection().connection().sendSync(Messages::RemoteMediaPlayerManagerProxy::SupportsTypeAndCodecs(m_engineIdentifier, parameters), 0);
+    auto sendResult = manager()->gpuProcessConnection().connection().sendSync(Messages::RemoteMediaPlayerManagerProxy::SupportsTypeAndCodecs(m_engineIdentifier, parameters), 0);
     auto [result] = sendResult.takeReplyOr(MediaPlayerEnums::SupportsType::IsNotSupported);
     if (sendResult.succeeded())
         m_supportsTypeAndCodecsCache->add(searchKey, result);
@@ -94,9 +94,9 @@ MediaPlayerEnums::SupportsType RemoteMediaPlayerMIMETypeCache::supportsTypeAndCo
     return result;
 }
 
-Ref<RemoteMediaPlayerManager> RemoteMediaPlayerMIMETypeCache::protectedManager() const
+Ref<RemoteMediaPlayerManager> RemoteMediaPlayerMIMETypeCache::manager() const
 {
-    return m_manager.get().releaseNonNull();
+    return m_manager.get();
 }
 
 }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.h
@@ -55,9 +55,9 @@ public:
     bool isEmpty() const;
 
 private:
-    Ref<RemoteMediaPlayerManager> protectedManager() const;
+    Ref<RemoteMediaPlayerManager> manager() const;
 
-    ThreadSafeWeakPtr<RemoteMediaPlayerManager> m_manager; // Cannot be null.
+    ThreadSafeWeakRef<RemoteMediaPlayerManager> m_manager;
     WebCore::MediaPlayerEnums::MediaEngineIdentifier m_engineIdentifier;
 
     using SupportedTypesAndCodecsKey = std::tuple<String, bool, bool, bool>;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
@@ -66,17 +66,17 @@ public:
 
     Ref<MediaPlayerPrivateInterface> createMediaEnginePlayer(MediaPlayer& player) const final
     {
-        return protectedManager()->createRemoteMediaPlayer(player, m_remoteEngineIdentifier);
+        return manager()->createRemoteMediaPlayer(player, m_remoteEngineIdentifier);
     }
 
     void getSupportedTypes(HashSet<String>& types) const final
     {
-        return protectedManager()->getSupportedTypes(m_remoteEngineIdentifier, types);
+        return manager()->getSupportedTypes(m_remoteEngineIdentifier, types);
     }
 
     MediaPlayer::SupportsType supportsTypeAndCodecs(const MediaEngineSupportParameters& parameters) const final
     {
-        return protectedManager()->supportsTypeAndCodecs(m_remoteEngineIdentifier, parameters);
+        return manager()->supportsTypeAndCodecs(m_remoteEngineIdentifier, parameters);
     }
 
     HashSet<SecurityOriginData> originsInMediaCache(const String& path) const final
@@ -97,14 +97,14 @@ public:
 
     bool supportsKeySystem(const String& keySystem, const String& mimeType) const final
     {
-        return protectedManager()->supportsKeySystem(m_remoteEngineIdentifier, keySystem, mimeType);
+        return manager()->supportsKeySystem(m_remoteEngineIdentifier, keySystem, mimeType);
     }
 
 private:
-    Ref<RemoteMediaPlayerManager> protectedManager() const { return m_manager.get().releaseNonNull(); }
+    Ref<RemoteMediaPlayerManager> manager() const { return m_manager.get(); }
 
     MediaPlayerEnums::MediaEngineIdentifier m_remoteEngineIdentifier;
-    ThreadSafeWeakPtr<RemoteMediaPlayerManager> m_manager; // Cannot be null.
+    ThreadSafeWeakRef<RemoteMediaPlayerManager> m_manager;
 };
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteMediaPlayerManager);

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaResourceProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaResourceProxy.cpp
@@ -46,14 +46,14 @@ RemoteMediaResourceProxy::RemoteMediaResourceProxy(Ref<IPC::Connection>&& connec
 
 RemoteMediaResourceProxy::~RemoteMediaResourceProxy() = default;
 
-Ref<WebCore::PlatformMediaResource> RemoteMediaResourceProxy::protectedMediaResource() const
+Ref<WebCore::PlatformMediaResource> RemoteMediaResourceProxy::mediaResource() const
 {
-    return m_platformMediaResource.get().releaseNonNull();
+    return m_platformMediaResource.get();
 }
 
 void RemoteMediaResourceProxy::responseReceived(WebCore::PlatformMediaResource&, const WebCore::ResourceResponse& response, CompletionHandler<void(WebCore::ShouldContinuePolicyCheck)>&& completionHandler)
 {
-    m_connection->sendWithAsyncReply(Messages::RemoteMediaResourceManager::ResponseReceived(m_id, response, protectedMediaResource()->didPassAccessControlCheck()), [completionHandler = WTF::move(completionHandler)](auto shouldContinue) mutable {
+    m_connection->sendWithAsyncReply(Messages::RemoteMediaResourceManager::ResponseReceived(m_id, response, mediaResource()->didPassAccessControlCheck()), [completionHandler = WTF::move(completionHandler)](auto shouldContinue) mutable {
         completionHandler(shouldContinue);
     });
 }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaResourceProxy.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaResourceProxy.h
@@ -53,10 +53,10 @@ private:
     void loadFailed(WebCore::PlatformMediaResource&, const WebCore::ResourceError&) final;
     void loadFinished(WebCore::PlatformMediaResource&, const WebCore::NetworkLoadMetrics&) final;
 
-    Ref<WebCore::PlatformMediaResource> protectedMediaResource() const;
+    Ref<WebCore::PlatformMediaResource> mediaResource() const;
 
     const Ref<IPC::Connection> m_connection;
-    ThreadSafeWeakPtr<WebCore::PlatformMediaResource> m_platformMediaResource; // Cannot be null.
+    ThreadSafeWeakRef<WebCore::PlatformMediaResource> m_platformMediaResource;
     RemoteMediaResourceIdentifier m_id;
 };
 


### PR DESCRIPTION
#### 987b4c4a4b457a83f3b93510e76c070d59baf155
<pre>
Introduce ThreadSafeWeakRef and adopt it where appropriate
<a href="https://bugs.webkit.org/show_bug.cgi?id=304801">https://bugs.webkit.org/show_bug.cgi?id=304801</a>

Reviewed by Charlie Wolfe.

Introduce ThreadSafeWeakRef and adopt it where appropriate. This is
consistent with WeakPtr / WeakPtr and CheckedPtr / CheckedRef.

* Source/WTF/wtf/ThreadSafeWeakPtr.h:
* Source/WebCore/Modules/webdatabase/Database.cpp:
(WebCore::DoneCreatingDatabaseOnExitCaller::~DoneCreatingDatabaseOnExitCaller):
* Source/WebCore/page/scrolling/ScrollingTreeGestureState.h:
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h:
(WebCore::ScrollingTreeScrollingNodeDelegate::scrollingNode):
(WebCore::ScrollingTreeScrollingNodeDelegate::scrollingNode const):
* Source/WebCore/platform/graphics/ImageFrameAnimator.cpp:
(WebCore::ImageFrameAnimator::destroyDecodedData):
(WebCore::ImageFrameAnimator::timerFired):
(WebCore::ImageFrameAnimator::startAnimation):
* Source/WebCore/platform/graphics/ImageFrameAnimator.h:
* Source/WebCore/platform/graphics/adwaita/ProgressBarAdwaita.h:
* Source/WebCore/platform/graphics/adwaita/SliderTrackAdwaita.h:
* Source/WebCore/platform/graphics/cocoa/controls/ApplePayButtonCocoa.h:
* Source/WebCore/platform/graphics/controls/PlatformControl.h:
* Source/WebCore/platform/graphics/mac/controls/MeterMac.h:
* Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.h:
* Source/WebCore/platform/graphics/mac/controls/SliderTrackMac.h:
* Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.h:
* Source/WebCore/platform/graphics/mac/controls/SwitchTrackMac.h:
* Source/WebKit/GPUProcess/media/RemoteMediaEngineConfigurationFactoryProxy.cpp:
(WebKit::RemoteMediaEngineConfigurationFactoryProxy::sharedPreferencesForWebProcess const):
* Source/WebKit/GPUProcess/media/RemoteMediaEngineConfigurationFactoryProxy.h:
* Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp:
(WebKit::NetworkCache::SpeculativeLoadManager::PendingFrameLoad::saveToDiskIfReady):
(WebKit::NetworkCache::SpeculativeLoadManager::protectedStorage const):
(WebKit::NetworkCache::SpeculativeLoadManager::retrieveSubresourcesEntry):
* Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.h:
* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::SyncMessageState::enqueueMatchingMessages):
(IPC::Connection::SyncMessageState::processIncomingMessage):
(IPC::Connection::SyncMessageState::dispatchMessages):
(IPC::Connection::SyncMessageState::dispatchMessagesUntil):
(IPC::Connection::SyncMessageState::dispatchMessagesAndResetDidScheduleDispatchMessagesForConnection):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::~MediaPlayerPrivateRemote):
(WebKit::MediaPlayerPrivateRemote::load):
(WebKit::MediaPlayerPrivateRemote::addRemoteAudioTrack):
(WebKit::MediaPlayerPrivateRemote::addRemoteTextTrack):
(WebKit::MediaPlayerPrivateRemote::addRemoteVideoTrack):
(WebKit::MediaPlayerPrivateRemote::manager const):
(WebKit::MediaPlayerPrivateRemote::protectedManager const): Deleted.
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVF.cpp:
(WebKit::RemoteImageDecoderAVF::~RemoteImageDecoderAVF):
(WebKit::RemoteImageDecoderAVF::manager const):
(WebKit::RemoteImageDecoderAVF::protectedManager const): Deleted.
* Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVF.h:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.cpp:
(WebKit::RemoteMediaPlayerMIMETypeCache::supportedTypes):
(WebKit::RemoteMediaPlayerMIMETypeCache::supportsTypeAndCodecs):
(WebKit::RemoteMediaPlayerMIMETypeCache::manager const):
(WebKit::RemoteMediaPlayerMIMETypeCache::protectedManager const): Deleted.
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.h:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaResourceProxy.cpp:
(WebKit::RemoteMediaResourceProxy::mediaResource const):
(WebKit::RemoteMediaResourceProxy::responseReceived):
(WebKit::RemoteMediaResourceProxy::protectedMediaResource const): Deleted.
* Source/WebKit/WebProcess/GPU/media/RemoteMediaResourceProxy.h:

Canonical link: <a href="https://commits.webkit.org/305039@main">https://commits.webkit.org/305039@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea40abc01db590954fe2fc1f811983a522294cdf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137239 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9599 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48526 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144990 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90212 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ee0607df-1fdb-4314-af8f-5c41487bcd96) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139111 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10302 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9726 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/104955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/11a76ec4-5ed3-4737-be6c-efc2bfa9cb44) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140184 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7602 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122997 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85799 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fda360fa-099a-42aa-b9aa-b22b71b965ba) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7239 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4955 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5577 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/129200 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116598 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41154 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147746 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/135738 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9282 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41716 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113314 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9300 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7815 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113649 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28866 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7160 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119246 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63793 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9331 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37300 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/168508 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9057 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72896 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43988 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9271 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9123 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->