### PR TITLE
[JSC] Add fast path for Array.from(set)

### DIFF
--- a/JSTests/microbenchmarks/array-from-set-double-large.js
+++ b/JSTests/microbenchmarks/array-from-set-double-large.js
@@ -1,0 +1,14 @@
+const set = new Set();
+for (let i = 0; i < 1000; i++) {
+  set.add(i + 0.5);
+}
+
+function test(set) {
+  const arr = Array.from(set);
+  return arr;
+}
+noInline(test);
+
+for (let i = 0; i < 1e4; i++) {
+  test(set);
+}

--- a/JSTests/microbenchmarks/array-from-set-double-small.js
+++ b/JSTests/microbenchmarks/array-from-set-double-small.js
@@ -1,0 +1,11 @@
+const set = new Set([1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7]);
+
+function test(set) {
+  const arr = Array.from(set);
+  return arr;
+}
+noInline(test);
+
+for (let i = 0; i < 1e5; i++) {
+  test(set);
+}

--- a/JSTests/microbenchmarks/array-from-set-int-large.js
+++ b/JSTests/microbenchmarks/array-from-set-int-large.js
@@ -1,0 +1,14 @@
+const set = new Set();
+for (let i = 0; i < 1000; i++) {
+  set.add(i);
+}
+
+function test(set) {
+  const arr = Array.from(set);
+  return arr;
+}
+noInline(test);
+
+for (let i = 0; i < 1e4; i++) {
+  test(set);
+}

--- a/JSTests/microbenchmarks/array-from-set-int-small.js
+++ b/JSTests/microbenchmarks/array-from-set-int-small.js
@@ -1,0 +1,11 @@
+const set = new Set([1, 2, 3, 4, 5, 6, 7]);
+
+function test(set) {
+  const arr = Array.from(set);
+  return arr;
+}
+noInline(test);
+
+for (let i = 0; i < 1e5; i++) {
+  test(set);
+}

--- a/JSTests/microbenchmarks/array-from-set-object-large.js
+++ b/JSTests/microbenchmarks/array-from-set-object-large.js
@@ -1,0 +1,14 @@
+const set = new Set();
+for (let i = 0; i < 1000; i++) {
+  set.add({ a: i });
+}
+
+function test(set) {
+  const arr = Array.from(set);
+  return arr;
+}
+noInline(test);
+
+for (let i = 0; i < 1e4; i++) {
+  test(set);
+}

--- a/JSTests/microbenchmarks/array-from-set-object-small.js
+++ b/JSTests/microbenchmarks/array-from-set-object-small.js
@@ -1,0 +1,19 @@
+const set = new Set([
+  { a: 1 },
+  { a: 2 },
+  { a: 3 },
+  { a: 4 },
+  { a: 5 },
+  { a: 6 },
+  { a: 7 }
+]);
+
+function test(set) {
+  const arr = Array.from(set);
+  return arr;
+}
+noInline(test);
+
+for (let i = 0; i < 1e5; i++) {
+  test(set);
+}

--- a/JSTests/stress/array-from-set.js
+++ b/JSTests/stress/array-from-set.js
@@ -1,0 +1,405 @@
+function shouldBe(a, b) {
+  if (a !== b)
+    throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function test(set) {
+  return Array.from(set);
+}
+noInline(test);
+
+
+// contiguous
+{
+  const value1 = { value: 1 };
+  const value2 = { value: 2 };
+  const value3 = { value: 3 };
+  const value4 = { value: 4 };
+  const value5 = { value: 5 };
+  const set = new Set([value1, value2, value3, value4, value5]);
+  const array = test(set);
+  shouldBe(array.length, 5);
+  shouldBe(array[0], value1);
+  shouldBe(array[1], value2);
+  shouldBe(array[2], value3);
+  shouldBe(array[3], value4);
+  shouldBe(array[4], value5);
+}
+
+// double
+{
+  const set = new Set([1.1, 2.1, 3.1, 4.1, 5.1]);
+  const array = test(set);
+  shouldBe(array.length, 5);
+  shouldBe(array[0], 1.1);
+  shouldBe(array[1], 2.1);
+  shouldBe(array[2], 3.1);
+  shouldBe(array[3], 4.1);
+  shouldBe(array[4], 5.1);
+}
+
+// int32
+{
+  const set = new Set([1, 2, 3, 4, 5]);
+  const array = test(set);
+  shouldBe(array.length, 5);
+  shouldBe(array[0], 1);
+  shouldBe(array[1], 2);
+  shouldBe(array[2], 3);
+  shouldBe(array[3], 4);
+  shouldBe(array[4], 5);
+}
+
+// empty set
+{
+  const set = new Set();
+  const array = test(set);
+  shouldBe(array.length, 0);
+}
+
+// mixed types (should use contiguous)
+{
+  const set = new Set([1, "two", 3.0, { four: 4 }]);
+  const array = test(set);
+  shouldBe(array.length, 4);
+  shouldBe(array[0], 1);
+  shouldBe(array[1], "two");
+  shouldBe(array[2], 3.0);
+  shouldBe(array[3].four, 4);
+}
+
+// large set
+{
+  const largeSet = new Set();
+  for (let i = 0; i < 1000; i++) {
+    largeSet.add(i);
+  }
+  const array = test(largeSet);
+  shouldBe(array.length, 1000);
+  for (let i = 0; i < 1000; i++) {
+    shouldBe(array[i], i);
+  }
+}
+
+// set with deleted elements
+{
+  const set = new Set([1, 2, 3, 4, 5]);
+  set.delete(2);
+  set.delete(4);
+  const array = test(set);
+  shouldBe(array.length, 3);
+  shouldBe(array[0], 1);
+  shouldBe(array[1], 3);
+  shouldBe(array[2], 5);
+}
+
+// ensure iteration order is preserved
+{
+  const set = new Set();
+  set.add(3);
+  set.add(1);
+  set.add(4);
+  set.add(1); // duplicate, should be ignored
+  set.add(5);
+  set.add(9);
+  const array = test(set);
+  shouldBe(array.length, 5);
+  shouldBe(array[0], 3);
+  shouldBe(array[1], 1);
+  shouldBe(array[2], 4);
+  shouldBe(array[3], 5);
+  shouldBe(array[4], 9);
+}
+
+// special values: NaN, Infinity, -Infinity, 0, null, undefined
+// Note: Set treats -0 and +0 as the same value per ECMAScript spec
+{
+  const set = new Set([NaN, Infinity, -Infinity, 0, null, undefined]);
+  const array = test(set);
+  shouldBe(array.length, 6);
+  shouldBe(Number.isNaN(array[0]), true);
+  shouldBe(array[1], Infinity);
+  shouldBe(array[2], -Infinity);
+  shouldBe(array[3], 0);
+  shouldBe(array[4], null);
+  shouldBe(array[5], undefined);
+}
+
+// strings
+{
+  const set = new Set(["hello", "world", "", "foo"]);
+  const array = test(set);
+  shouldBe(array.length, 4);
+  shouldBe(array[0], "hello");
+  shouldBe(array[1], "world");
+  shouldBe(array[2], "");
+  shouldBe(array[3], "foo");
+}
+
+// symbols
+{
+  const sym1 = Symbol("a");
+  const sym2 = Symbol("b");
+  const sym3 = Symbol.for("c");
+  const set = new Set([sym1, sym2, sym3]);
+  const array = test(set);
+  shouldBe(array.length, 3);
+  shouldBe(array[0], sym1);
+  shouldBe(array[1], sym2);
+  shouldBe(array[2], sym3);
+}
+
+// BigInt
+{
+  const set = new Set([1n, 2n, 9007199254740993n]);
+  const array = test(set);
+  shouldBe(array.length, 3);
+  shouldBe(array[0], 1n);
+  shouldBe(array[1], 2n);
+  shouldBe(array[2], 9007199254740993n);
+}
+
+// single element
+{
+  const set = new Set([42]);
+  const array = test(set);
+  shouldBe(array.length, 1);
+  shouldBe(array[0], 42);
+}
+
+// re-adding deleted element changes order
+{
+  const set = new Set([1, 2, 3]);
+  set.delete(2);
+  set.add(2);
+  const array = test(set);
+  shouldBe(array.length, 3);
+  shouldBe(array[0], 1);
+  shouldBe(array[1], 3);
+  shouldBe(array[2], 2);
+}
+
+// modified Set.prototype[Symbol.iterator] should use slow path
+{
+  const originalIterator = Set.prototype[Symbol.iterator];
+  Set.prototype[Symbol.iterator] = function* () {
+    yield 100;
+    yield 200;
+  };
+  const set = new Set([1, 2, 3]);
+  const array = Array.from(set);
+  shouldBe(array.length, 2);
+  shouldBe(array[0], 100);
+  shouldBe(array[1], 200);
+  Set.prototype[Symbol.iterator] = originalIterator;
+}
+
+// modified Set.prototype.values does NOT affect Array.from
+// (Array.from uses Symbol.iterator, not values())
+{
+  const originalValues = Set.prototype.values;
+  Set.prototype.values = function* () {
+    yield 999;
+  };
+  const set = new Set([1, 2, 3]);
+  const array = Array.from(set);
+  // values() modification doesn't affect Array.from
+  shouldBe(array.length, 3);
+  shouldBe(array[0], 1);
+  shouldBe(array[1], 2);
+  shouldBe(array[2], 3);
+  Set.prototype.values = originalValues;
+}
+
+// Set subclass
+{
+  class MySet extends Set {
+    constructor(iterable) {
+      super(iterable);
+    }
+  }
+  const set = new MySet([1, 2, 3]);
+  const array = Array.from(set);
+  shouldBe(array.length, 3);
+  shouldBe(array[0], 1);
+  shouldBe(array[1], 2);
+  shouldBe(array[2], 3);
+}
+
+// Set subclass with overridden iterator
+{
+  class MySet extends Set {
+    *[Symbol.iterator]() {
+      yield* [...super.values()].reverse();
+    }
+  }
+  const set = new MySet([1, 2, 3]);
+  const array = Array.from(set);
+  shouldBe(array.length, 3);
+  shouldBe(array[0], 3);
+  shouldBe(array[1], 2);
+  shouldBe(array[2], 1);
+}
+
+// Array.from with mapFn should work correctly
+{
+  const set = new Set([1, 2, 3]);
+  const array = Array.from(set, x => x * 2);
+  shouldBe(array.length, 3);
+  shouldBe(array[0], 2);
+  shouldBe(array[1], 4);
+  shouldBe(array[2], 6);
+}
+
+// Array.from with mapFn and thisArg
+{
+  const set = new Set([1, 2, 3]);
+  const obj = { multiplier: 10 };
+  const array = Array.from(set, function(x) { return x * this.multiplier; }, obj);
+  shouldBe(array.length, 3);
+  shouldBe(array[0], 10);
+  shouldBe(array[1], 20);
+  shouldBe(array[2], 30);
+}
+
+// very large set
+{
+  const largeSet = new Set();
+  for (let i = 0; i < 10000; i++) {
+    largeSet.add(i);
+  }
+  const array = test(largeSet);
+  shouldBe(array.length, 10000);
+  shouldBe(array[0], 0);
+  shouldBe(array[9999], 9999);
+}
+
+// set with many deletions (sparse internal storage)
+{
+  const set = new Set();
+  for (let i = 0; i < 100; i++) {
+    set.add(i);
+  }
+  for (let i = 0; i < 100; i += 2) {
+    set.delete(i);
+  }
+  const array = test(set);
+  shouldBe(array.length, 50);
+  for (let i = 0; i < 50; i++) {
+    shouldBe(array[i], i * 2 + 1);
+  }
+}
+
+// int32 to double promotion
+{
+  const set = new Set([1, 2, 3.5, 4, 5]);
+  const array = test(set);
+  shouldBe(array.length, 5);
+  shouldBe(array[0], 1);
+  shouldBe(array[1], 2);
+  shouldBe(array[2], 3.5);
+  shouldBe(array[3], 4);
+  shouldBe(array[4], 5);
+}
+
+// int32 to contiguous promotion
+{
+  const obj = {};
+  const set = new Set([1, 2, obj, 4, 5]);
+  const array = test(set);
+  shouldBe(array.length, 5);
+  shouldBe(array[0], 1);
+  shouldBe(array[1], 2);
+  shouldBe(array[2], obj);
+  shouldBe(array[3], 4);
+  shouldBe(array[4], 5);
+}
+
+// double to contiguous promotion
+{
+  const obj = {};
+  const set = new Set([1.1, 2.2, obj, 4.4, 5.5]);
+  const array = test(set);
+  shouldBe(array.length, 5);
+  shouldBe(array[0], 1.1);
+  shouldBe(array[1], 2.2);
+  shouldBe(array[2], obj);
+  shouldBe(array[3], 4.4);
+  shouldBe(array[4], 5.5);
+}
+
+// repeated calls with same set
+{
+  const set = new Set([1, 2, 3]);
+  for (let i = 0; i < 1000; i++) {
+    const array = test(set);
+    shouldBe(array.length, 3);
+    shouldBe(array[0], 1);
+    shouldBe(array[1], 2);
+    shouldBe(array[2], 3);
+  }
+}
+
+// verify returned array is a proper Array
+{
+  const set = new Set([1, 2, 3]);
+  const array = test(set);
+  shouldBe(Array.isArray(array), true);
+  shouldBe(array.constructor, Array);
+  shouldBe(Object.getPrototypeOf(array), Array.prototype);
+}
+
+// verify returned array is mutable
+{
+  const set = new Set([1, 2, 3]);
+  const array = test(set);
+  array.push(4);
+  shouldBe(array.length, 4);
+  shouldBe(array[3], 4);
+  array[0] = 100;
+  shouldBe(array[0], 100);
+}
+
+// set containing functions
+{
+  const fn1 = () => 1;
+  const fn2 = function() { return 2; };
+  const fn3 = async () => 3;
+  const set = new Set([fn1, fn2, fn3]);
+  const array = test(set);
+  shouldBe(array.length, 3);
+  shouldBe(array[0], fn1);
+  shouldBe(array[1], fn2);
+  shouldBe(array[2], fn3);
+}
+
+// set containing arrays
+{
+  const arr1 = [1, 2];
+  const arr2 = [3, 4];
+  const set = new Set([arr1, arr2]);
+  const array = test(set);
+  shouldBe(array.length, 2);
+  shouldBe(array[0], arr1);
+  shouldBe(array[1], arr2);
+}
+
+// modified %SetIteratorPrototype%.next should use slow path
+{
+  const setIteratorPrototype = Object.getPrototypeOf(new Set()[Symbol.iterator]());
+  const originalNext = setIteratorPrototype.next;
+  let callCount = 0;
+  setIteratorPrototype.next = function() {
+    callCount++;
+    return originalNext.call(this);
+  };
+  const set = new Set([1, 2, 3]);
+  const array = Array.from(set);
+  shouldBe(array.length, 3);
+  shouldBe(array[0], 1);
+  shouldBe(array[1], 2);
+  shouldBe(array[2], 3);
+  // If slow path was used, next() should have been called
+  shouldBe(callCount > 0, true);
+  setIteratorPrototype.next = originalNext;
+}


### PR DESCRIPTION
#### ff70a7d009687d6a8a88ce87a6ae6f9c698c6817
<pre>
[JSC] Add fast path for Array.from(set)
<a href="https://bugs.webkit.org/show_bug.cgi?id=304804">https://bugs.webkit.org/show_bug.cgi?id=304804</a>

Reviewed by Yusuke Suzuki.

This patch adds a fast path for `Array.from(set)` similar to the existing
fast path for `Array.from(arguments)` (PR #53657).

When a Set&apos;s iterator protocol is fast and non-observable, we can directly
iterate over the Set&apos;s internal storage using `nextAndUpdateIterationEntry`
instead of going through the JavaScript iterator protocol, significantly
improving performance.

The implementation:
1. Checks if the Set&apos;s iterator protocol is fast and non-observable
2. First pass: scans all elements to determine the optimal indexing type
3. Allocates the result array with the appropriate structure
4. Second pass: copies elements directly to the result array

                                     TipOfTree                  Patched

array-from-set-double-small        8.6247+-0.4642     ^      4.2066+-0.1275        ^ definitely 2.0503x faster
array-from-set-object-small        8.3607+-0.2015     ^      3.8586+-0.0723        ^ definitely 2.1668x faster
array-from-set-int-small           8.5151+-0.1598     ^      3.8688+-0.1046        ^ definitely 2.2010x faster
array-from-set-object-large       49.8159+-0.9932     ^     35.2311+-0.6211        ^ definitely 1.4140x faster
array-from-set-double-large       53.1368+-2.0365     ^     37.7437+-0.6627        ^ definitely 1.4078x faster
array-from-set-int-large          49.8843+-1.9441     ^     34.7549+-0.4150        ^ definitely 1.4353x faster

* JSTests/microbenchmarks/array-from-set.js: Added.
* JSTests/stress/array-from-set.js: Added.
* Source/JavaScriptCore/runtime/ArrayConstructor.cpp:
(JSC::tryCreateArrayFromSet):
(JSC::arrayConstructorPrivateFromFastWithoutMapFn):

Canonical link: <a href="https://commits.webkit.org/305033@main">https://commits.webkit.org/305033@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd90372345a0367507f86003bddb83350ad4d161

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137208 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9568 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48495 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144957 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90181 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10271 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9695 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104929 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140153 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7573 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122962 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85770 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7210 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4954 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5544 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/129169 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116566 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41123 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147715 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/135702 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9251 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41685 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113290 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9269 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/7814 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113620 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28863 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7130 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119215 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63704 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9300 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37269 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/168476 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9025 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72865 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43978 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9240 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9092 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->