### PR TITLE
Reverse traversal order in `hitTestInlineBoxes` for SVG Text

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/elementsFromPoint-svg-text-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/elementsFromPoint-svg-text-expected.txt
@@ -6,5 +6,5 @@ Text underText over
 PASS elementsFromPoint for a point inside a <text>
 FAIL elementsFromPoint for a point inside a <tspan> nested in a <text> without content assert_equals: document.elementsFromPoint(125,185) expected "tspan#tspan1, svg#svg, DIV#sandbox, BODY, HTML" but got "tspan#tspan1, text#text2, svg#svg, DIV#sandbox, BODY, HTML"
 FAIL elementsFromPoint for a point inside a <textPath> nested in a <text> without content assert_equals: document.elementsFromPoint(125,245) expected "textPath#textpath1, svg#svg, DIV#sandbox, BODY, HTML" but got "textPath#textpath1, text#text3, svg#svg, DIV#sandbox, BODY, HTML"
-FAIL elementsFromPoint for a point inside an overlapping <tspan> nested in a <text> assert_equals: document.elementsFromPoint(125,305) expected "tspan#tspan2, text#text4, svg#svg, DIV#sandbox, BODY, HTML" but got "text#text4, tspan#tspan2, text#text4, svg#svg, DIV#sandbox, BODY, HTML"
+PASS elementsFromPoint for a point inside an overlapping <tspan> nested in a <text>
 

--- a/LayoutTests/svg/hittest/text-overlapped-expected.txt
+++ b/LayoutTests/svg/hittest/text-overlapped-expected.txt
@@ -1,0 +1,4 @@
+UNDEROVER
+
+PASS Hit-test of <text> with overlapping <tspan> hits the top-most node
+

--- a/LayoutTests/svg/hittest/text-overlapped.html
+++ b/LayoutTests/svg/hittest/text-overlapped.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<title>Hit-test of &lt;text> with overlapping &lt;tspan> hits the top-most node</title>
+<script src="../../resources/ahem.js"></script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<style>
+body {
+  margin: 0;
+  padding: 0;
+}
+</style>
+<svg font-family="Ahem" font-size="100" fill="blue" width="600" height="300">
+  <text y="80">UNDER<tspan x="100">OVER</tspan></text>
+</svg>
+<script>
+test(function() {
+  assert_equals(document.elementFromPoint(250, 50),
+                document.querySelector('tspan'));
+});
+</script>

--- a/Source/WebCore/layout/integration/inline/InlineIteratorBox.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorBox.h
@@ -190,6 +190,17 @@ public:
     IteratorType begin() const { return m_begin; }
     EndIterator end() const { return { }; }
 
+    // Collects all boxes into a Vector for operations that require random access,
+    // such as reverse iteration. This is necessary because BoxIterator is
+    // forward-only and doesn't support bidirectional iteration.
+    Vector<IteratorType> collectBoxes() const
+    {
+        Vector<IteratorType> boxes;
+        for (auto box = m_begin; box; ++box)
+            boxes.append(box);
+        return boxes;
+    }
+
 private:
     IteratorType m_begin;
 };

--- a/Source/WebCore/rendering/svg/RenderSVGText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGText.cpp
@@ -717,14 +717,15 @@ bool RenderSVGText::nodeAtPoint(const HitTestRequest& request, HitTestResult& re
 bool RenderSVGText::hitTestInlineChildren(const HitTestRequest& request, HitTestResult& result, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction)
 {
     auto hitTestInlineBoxes = [&] {
-        for (auto& box : InlineIterator::boxesFor(*this)) {
-            auto* textBox = dynamicDowncast<InlineIterator::SVGTextBox>(box);
-            if (!textBox)
+        // Reverse paint order: later text is on top (in overlap case).
+        for (auto& box : InlineIterator::boxesFor(*this).collectBoxes() | std::views::reverse) {
+            if (!box->isSVGText())
                 continue;
 
+            auto& textBox = downcast<InlineIterator::SVGTextBox>(*box);
             PointerEventsHitRules hitRules(PointerEventsHitRules::HitTestingTargetType::SVGText, request, usedPointerEvents());
 
-            auto& renderer = textBox->renderer();
+            auto& renderer = textBox.renderer();
             if (!isVisibleToHitTesting(renderer.style(), request) && hitRules.requireVisible)
                 continue;
 
@@ -733,7 +734,7 @@ bool RenderSVGText::hitTestInlineChildren(const HitTestRequest& request, HitTest
             if (!hitsStroke && !hitsFill)
                 continue;
 
-            FloatRect rect = textBox->logicalRectIgnoringInlineDirection();
+            FloatRect rect = textBox.logicalRectIgnoringInlineDirection();
             rect.moveBy(accumulatedOffset);
             if (!locationInContainer.intersects(rect))
                 continue;
@@ -744,7 +745,7 @@ bool RenderSVGText::hitTestInlineChildren(const HitTestRequest& request, HitTest
             float baseline = renderer.scaledFont().metricsOfPrimaryFont().ascent() / scalingFactor;
 
             AffineTransform fragmentTransform;
-            for (auto& fragment : textBox->textFragments()) {
+            for (auto& fragment : textBox.textFragments()) {
                 FloatQuad fragmentQuad(FloatRect(fragment.x, fragment.y - baseline, fragment.width, fragment.height));
                 fragment.buildFragmentTransform(fragmentTransform);
                 if (!fragmentTransform.isIdentity())
@@ -760,7 +761,6 @@ bool RenderSVGText::hitTestInlineChildren(const HitTestRequest& request, HitTest
         }
         return false;
     };
-
 
     if (hitTestInlineBoxes()) {
         updateHitTestResult(result, locationInContainer.point() - toLayoutSize(accumulatedOffset));


### PR DESCRIPTION
#### 1193a33a7e6fb136a44db04b66b9a4d3a324ad3f
<pre>
Reverse traversal order in `hitTestInlineBoxes` for SVG Text
<a href="https://bugs.webkit.org/show_bug.cgi?id=304805">https://bugs.webkit.org/show_bug.cgi?id=304805</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Inspired by (Test - Merge): <a href="https://chromium.googlesource.com/chromium/src.git/+/9bb752c62627ce6584b6834d4f9e3ad0ed303a78">https://chromium.googlesource.com/chromium/src.git/+/9bb752c62627ce6584b6834d4f9e3ad0ed303a78</a>

Text painted later should make the top-most node, so line boxes should
be visited front-to-back. This will generally only make a difference for
text nodes that overlap.

This will also make a difference when elementsFromPoint is fixed, since
then we&apos;ll add the hit elements in the required &quot;innermost to outermost&quot;
order.

* Source/WebCore/layout/integration/inline/InlineIteratorBox.h:
(WebCore::InlineIterator::BoxRange::collectBoxes const):
* Source/WebCore/rendering/svg/RenderSVGText.cpp:
(WebCore::RenderSVGText::hitTestInlineChildren):

* LayoutTests/svg/hittest/text-overlapped-expected.txt: Added.
* LayoutTests/svg/hittest/text-overlapped.html: Added.
This test is separately added since it passes on Firefox but CSSOM (WPT)
does not. So it is good to track both.

&gt; Progression:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/elementsFromPoint-svg-text-expected.txt:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1193a33a7e6fb136a44db04b66b9a4d3a324ad3f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137435 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9795 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48722 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145186 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90408 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d7a668ff-0623-4e95-b8a2-a38895e3c076) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139307 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10499 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9922 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105091 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/805396ac-7111-48b5-9ec2-8fa555aaea63) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140380 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7777 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123175 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85946 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/af58bd48-7be5-4106-89ff-de80834a533b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7413 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5134 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5773 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116782 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41327 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147943 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9478 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41884 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113468 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9496 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7987 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113810 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7333 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119414 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64094 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9527 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37467 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9257 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73092 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9467 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9319 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->