### PR TITLE
Reduce unsafeness in WebAuthn code

### DIFF
--- a/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientOutputs.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientOutputs.cpp
@@ -96,8 +96,8 @@ Vector<uint8_t> AuthenticationExtensionsClientOutputs::toCBOR() const
         if (largeBlob->supported)
             largeBlobMap[cbor::CBORValue("supported")] = cbor::CBORValue(largeBlob->supported.value());
 
-        if (largeBlob->blob)
-            largeBlobMap[cbor::CBORValue("blob")] = cbor::CBORValue(largeBlob->blob->toVector());
+        if (RefPtr blob = largeBlob->blob)
+            largeBlobMap[cbor::CBORValue("blob")] = cbor::CBORValue(blob->toVector());
 
         if (largeBlob->written)
             largeBlobMap[cbor::CBORValue("written")] = cbor::CBORValue(largeBlob->written.value());
@@ -116,10 +116,12 @@ AuthenticationExtensionsClientOutputsJSON AuthenticationExtensionsClientOutputs:
     AuthenticationExtensionsClientOutputsJSON result;
     result.appid = appid;
     result.credProps = credProps;
+    RefPtr<ArrayBuffer> blob;
     if (largeBlob) {
+        blob = largeBlob->blob;
         result.largeBlob = AuthenticationExtensionsClientOutputsJSON::LargeBlobOutputsJSON {
             largeBlob->supported,
-            base64URLEncodeToString(largeBlob->blob->span()),
+            base64URLEncodeToString(blob->span()),
             largeBlob->written,
         };
     }
@@ -127,8 +129,8 @@ AuthenticationExtensionsClientOutputsJSON AuthenticationExtensionsClientOutputs:
         result.prf = AuthenticationExtensionsClientOutputsJSON::PRFOutputsJSON {
             prf->enabled,
             AuthenticationExtensionsClientOutputsJSON::PRFValuesJSON {
-                base64URLEncodeToString(largeBlob->blob->span()),
-                base64URLEncodeToString(largeBlob->blob->span()),
+                base64URLEncodeToString(blob->span()),
+                base64URLEncodeToString(blob->span()),
             },
         };
     }

--- a/Source/WebCore/Modules/webauthn/AuthenticatorAssertionResponse.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorAssertionResponse.cpp
@@ -96,13 +96,13 @@ AuthenticatorResponseData AuthenticatorAssertionResponse::data() const
 AuthenticationResponseJSON::AuthenticatorAssertionResponseJSON AuthenticatorAssertionResponse::toJSON()
 {
     AuthenticationResponseJSON::AuthenticatorAssertionResponseJSON value;
-    if (auto authData = authenticatorData())
+    if (RefPtr authData = authenticatorData())
         value.authenticatorData = base64URLEncodeToString(authData->span());
-    if (auto sig = signature())
+    if (RefPtr sig = signature())
         value.signature = base64URLEncodeToString(sig->span());
     if (auto handle = userHandle())
         value.userHandle = base64URLEncodeToString(handle->span());
-    if (auto clientData = clientDataJSON())
+    if (RefPtr clientData = clientDataJSON())
         value.clientDataJSON = base64URLEncodeToString(clientData->span());
     return value;
 }

--- a/Source/WebCore/Modules/webauthn/AuthenticatorAttestationResponse.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorAttestationResponse.cpp
@@ -196,7 +196,7 @@ RegistrationResponseJSON::AuthenticatorAttestationResponseJSON AuthenticatorAtte
     for (auto transport : getTransports())
         transports.append(toString(transport));
     RegistrationResponseJSON::AuthenticatorAttestationResponseJSON value;
-    if (auto clientData = clientDataJSON())
+    if (RefPtr clientData = clientDataJSON())
         value.clientDataJSON = base64URLEncodeToString(clientData->span());
     value.transports = transports;
     if (auto authData = getAuthenticatorData())

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredential.cpp
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredential.cpp
@@ -81,41 +81,41 @@ PublicKeyCredential::PublicKeyCredential(Ref<AuthenticatorResponse>&& response)
 
 void PublicKeyCredential::isUserVerifyingPlatformAuthenticatorAvailable(Document& document, DOMPromiseDeferred<IDLBoolean>&& promise)
 {
-    if (auto* page = document.page())
+    if (RefPtr page = document.page())
         page->authenticatorCoordinator().isUserVerifyingPlatformAuthenticatorAvailable(document, WTF::move(promise));
 }
 
 void PublicKeyCredential::getClientCapabilities(Document& document, DOMPromiseDeferred<IDLRecord<IDLDOMString, IDLBoolean>>&& promise)
 {
-    if (auto* page = document.page())
+    if (RefPtr page = document.page())
         page->authenticatorCoordinator().getClientCapabilities(document, WTF::move(promise));
 }
 
 PublicKeyCredentialJSON PublicKeyCredential::toJSON()
 {
-    if (is<AuthenticatorAttestationResponse>(m_response)) {
+    if (RefPtr attestationResponse = dynamicDowncast<AuthenticatorAttestationResponse>(m_response)) {
         RegistrationResponseJSON response;
-        if (auto id = rawId()) {
+        if (RefPtr id = rawId()) {
             auto encodedString = base64URLEncodeToString(id->span());
             response.id = encodedString;
             response.rawId = encodedString;
         }
 
-        response.response = downcast<AuthenticatorAttestationResponse>(m_response)->toJSON();
+        response.response = attestationResponse->toJSON();
         response.authenticatorAttachment = convertEnumerationToString(authenticatorAttachment());
         response.clientExtensionResults = getClientExtensionResults().toJSON();
         response.type = type();
 
         return response;
     }
-    if (is<AuthenticatorAssertionResponse>(m_response)) {
+    if (RefPtr assertionResponse = dynamicDowncast<AuthenticatorAssertionResponse>(m_response)) {
         AuthenticationResponseJSON response;
-        if (auto id = rawId()) {
+        if (RefPtr id = rawId()) {
             auto encodedString = base64URLEncodeToString(id->span());
             response.id = encodedString;
             response.rawId = encodedString;
         }
-        response.response = downcast<AuthenticatorAssertionResponse>(m_response)->toJSON();
+        response.response = assertionResponse->toJSON();
         response.authenticatorAttachment = convertEnumerationToString(authenticatorAttachment());
         response.clientExtensionResults = getClientExtensionResults().toJSON();
         response.type = type();
@@ -300,19 +300,19 @@ ExceptionOr<PublicKeyCredentialRequestOptions> PublicKeyCredential::parseRequest
 
 void PublicKeyCredential::signalUnknownCredential(Document& document, UnknownCredentialOptions&& options, DOMPromiseDeferred<void>&& promise)
 {
-    if (auto* page = document.page())
+    if (RefPtr page = document.page())
         page->authenticatorCoordinator().signalUnknownCredential(document, WTF::move(options), WTF::move(promise));
 }
 
 void PublicKeyCredential::signalAllAcceptedCredentials(Document& document, AllAcceptedCredentialsOptions&& options, DOMPromiseDeferred<void>&& promise)
 {
-    if (auto* page = document.page())
+    if (RefPtr page = document.page())
         page->authenticatorCoordinator().signalAllAcceptedCredentials(document, WTF::move(options), WTF::move(promise));
 }
 
 void PublicKeyCredential::signalCurrentUserDetails(Document& document, CurrentUserDetailsOptions&& options, DOMPromiseDeferred<void>&& promise)
 {
-    if (auto* page = document.page())
+    if (RefPtr page = document.page())
         page->authenticatorCoordinator().signalCurrentUserDetails(document, WTF::move(options), WTF::move(promise));
 }
 

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -58,9 +58,6 @@ Modules/webaudio/OfflineAudioDestinationNode.cpp
 Modules/webaudio/OscillatorNode.cpp
 Modules/webaudio/PannerNode.cpp
 Modules/webaudio/ScriptProcessorNode.cpp
-Modules/webauthn/AuthenticationExtensionsClientOutputs.cpp
-Modules/webauthn/AuthenticatorCoordinator.cpp
-Modules/webauthn/fido/Pin.cpp
 Modules/webcodecs/WebCodecsAudioData.cpp
 Modules/webcodecs/WebCodecsAudioInternalData.h
 Modules/webcodecs/WebCodecsVideoFrame.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -21,10 +21,6 @@ Modules/webaudio/OscillatorNode.cpp
 Modules/webaudio/PannerNode.cpp
 Modules/webaudio/ScriptProcessorNode.cpp
 Modules/webaudio/StereoPannerNode.cpp
-Modules/webauthn/AuthenticatorAssertionResponse.cpp
-Modules/webauthn/AuthenticatorAttestationResponse.cpp
-Modules/webauthn/AuthenticatorCoordinator.cpp
-Modules/webauthn/PublicKeyCredential.cpp
 Modules/webdatabase/DatabaseManager.cpp
 accessibility/AXObjectCache.cpp
 [ iOS ] accessibility/AccessibilityNodeObject.cpp

--- a/Source/WebCore/crypto/CryptoKeyPair.h
+++ b/Source/WebCore/crypto/CryptoKeyPair.h
@@ -32,8 +32,8 @@ namespace WebCore {
 class CryptoKey;
 
 struct CryptoKeyPair {
-    RefPtr<CryptoKey> publicKey;
-    RefPtr<CryptoKey> privateKey;
+    const RefPtr<CryptoKey> publicKey;
+    const RefPtr<CryptoKey> privateKey;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### ba393f7288fa61329fe42ed41d8da671658987fe
<pre>
Reduce unsafeness in WebAuthn code
<a href="https://bugs.webkit.org/show_bug.cgi?id=304818">https://bugs.webkit.org/show_bug.cgi?id=304818</a>

Reviewed by Chris Dumez.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

Canonical link: <a href="https://commits.webkit.org/305040@main">https://commits.webkit.org/305040@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5304c26df5152caf236d77e2e960a9cf77e89bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137243 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9603 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48530 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144994 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90216 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/eac96f27-7753-48fe-ae75-f789c7301b36) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139115 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10306 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9730 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/104957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b7f8165e-14e5-40ad-8243-b35ac5ae35ee) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140188 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7607 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123001 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/85801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ab7df90f-79df-4e15-97af-9882e83d7098) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7244 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4959 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5581 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116603 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41158 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147750 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9286 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41720 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113318 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9304 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7819 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113653 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7164 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119250 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63803 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21148 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9335 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37304 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9062 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72900 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9275 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9127 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->