### PR TITLE
[WebRTC] Allow PeerConnectionBackend usage from non-main threads

### DIFF
--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
@@ -274,7 +274,7 @@ void PeerConnectionBackend::createOfferSucceeded(String&& sdp)
 
     ASSERT(m_offerAnswerCallback);
     validateSDP(sdp);
-    ActiveDOMObject::queueTaskKeepingObjectAlive(protectedPeerConnection().get(), TaskSource::Networking, [callback = WTF::move(m_offerAnswerCallback), sdp = WTF::move(sdp)](auto&) mutable {
+    ActiveDOMObject::queueTaskKeepingObjectAlive(peerConnection().get(), TaskSource::Networking, [callback = WTF::move(m_offerAnswerCallback), sdp = WTF::move(sdp)](auto&) mutable {
         callback(RTCSessionDescriptionInit { RTCSdpType::Offer, sdp });
     });
 }
@@ -285,7 +285,7 @@ void PeerConnectionBackend::createOfferFailed(Exception&& exception)
     ALWAYS_LOG(LOGIDENTIFIER, exception.message());
 
     ASSERT(m_offerAnswerCallback);
-    ActiveDOMObject::queueTaskKeepingObjectAlive(protectedPeerConnection().get(), TaskSource::Networking, [callback = WTF::move(m_offerAnswerCallback), exception = WTF::move(exception)](auto&) mutable {
+    ActiveDOMObject::queueTaskKeepingObjectAlive(peerConnection().get(), TaskSource::Networking, [callback = WTF::move(m_offerAnswerCallback), exception = WTF::move(exception)](auto&) mutable {
         callback(WTF::move(exception));
     });
 }
@@ -309,7 +309,7 @@ void PeerConnectionBackend::createAnswerSucceeded(String&& sdp)
 #endif
 
     ASSERT(m_offerAnswerCallback);
-    ActiveDOMObject::queueTaskKeepingObjectAlive(protectedPeerConnection().get(), TaskSource::Networking, [callback = WTF::move(m_offerAnswerCallback), sdp = WTF::move(sdp)](auto&) mutable {
+    ActiveDOMObject::queueTaskKeepingObjectAlive(peerConnection().get(), TaskSource::Networking, [callback = WTF::move(m_offerAnswerCallback), sdp = WTF::move(sdp)](auto&) mutable {
         callback(RTCSessionDescriptionInit { RTCSdpType::Answer, sdp });
     });
 }
@@ -320,7 +320,7 @@ void PeerConnectionBackend::createAnswerFailed(Exception&& exception)
     ALWAYS_LOG(LOGIDENTIFIER, exception.message());
 
     ASSERT(m_offerAnswerCallback);
-    ActiveDOMObject::queueTaskKeepingObjectAlive(protectedPeerConnection().get(), TaskSource::Networking, [callback = WTF::move(m_offerAnswerCallback), exception = WTF::move(exception)](auto&) mutable {
+    ActiveDOMObject::queueTaskKeepingObjectAlive(peerConnection().get(), TaskSource::Networking, [callback = WTF::move(m_offerAnswerCallback), exception = WTF::move(exception)](auto&) mutable {
         callback(WTF::move(exception));
     });
 }
@@ -384,7 +384,7 @@ void PeerConnectionBackend::setLocalDescriptionSucceeded(std::optional<Descripti
     if (transceiverStates)
         DEBUG_LOG(LOGIDENTIFIER, "Transceiver states: ", *transceiverStates);
     ASSERT(m_setDescriptionCallback);
-    ActiveDOMObject::queueTaskKeepingObjectAlive(protectedPeerConnection().get(), TaskSource::Networking, [this, protectedThis = Ref { *this }, callback = WTF::move(m_setDescriptionCallback), descriptionStates = WTF::move(descriptionStates), transceiverStates = WTF::move(transceiverStates), sctpBackend = WTF::move(sctpBackend), maxMessageSize](auto& peerConnection) mutable {
+    ActiveDOMObject::queueTaskKeepingObjectAlive(peerConnection().get(), TaskSource::Networking, [this, protectedThis = Ref { *this }, callback = WTF::move(m_setDescriptionCallback), descriptionStates = WTF::move(descriptionStates), transceiverStates = WTF::move(transceiverStates), sctpBackend = WTF::move(sctpBackend), maxMessageSize](auto& peerConnection) mutable {
         if (peerConnection.isClosed())
             return;
 
@@ -448,7 +448,7 @@ void PeerConnectionBackend::setLocalDescriptionFailed(Exception&& exception)
     ALWAYS_LOG(LOGIDENTIFIER, "Set local description failed:", exception.message());
 
     ASSERT(m_setDescriptionCallback);
-    ActiveDOMObject::queueTaskKeepingObjectAlive(protectedPeerConnection().get(), TaskSource::Networking, [callback = WTF::move(m_setDescriptionCallback), exception = WTF::move(exception)](auto& peerConnection) mutable {
+    ActiveDOMObject::queueTaskKeepingObjectAlive(peerConnection().get(), TaskSource::Networking, [callback = WTF::move(m_setDescriptionCallback), exception = WTF::move(exception)](auto& peerConnection) mutable {
         if (peerConnection.isClosed())
             return;
 
@@ -472,7 +472,7 @@ void PeerConnectionBackend::setRemoteDescriptionSucceeded(std::optional<Descript
         DEBUG_LOG(LOGIDENTIFIER, "Transceiver states: ", *transceiverStates);
     ASSERT(m_setDescriptionCallback);
 
-    ActiveDOMObject::queueTaskKeepingObjectAlive(protectedPeerConnection().get(), TaskSource::Networking, [this, callback = WTF::move(m_setDescriptionCallback), descriptionStates = WTF::move(descriptionStates), transceiverStates = WTF::move(transceiverStates), sctpBackend = WTF::move(sctpBackend), maxMessageSize](auto& peerConnection) mutable {
+    ActiveDOMObject::queueTaskKeepingObjectAlive(peerConnection().get(), TaskSource::Networking, [this, callback = WTF::move(m_setDescriptionCallback), descriptionStates = WTF::move(descriptionStates), transceiverStates = WTF::move(transceiverStates), sctpBackend = WTF::move(sctpBackend), maxMessageSize](auto& peerConnection) mutable {
         UNUSED_PARAM(this);
 
         if (peerConnection.isClosed())
@@ -577,7 +577,7 @@ void PeerConnectionBackend::setRemoteDescriptionFailed(Exception&& exception)
     ALWAYS_LOG(LOGIDENTIFIER, "Set remote description failed:", exception.message());
 
     ASSERT(m_setDescriptionCallback);
-    ActiveDOMObject::queueTaskKeepingObjectAlive(protectedPeerConnection().get(), TaskSource::Networking, [callback = WTF::move(m_setDescriptionCallback), exception = WTF::move(exception)](auto& peerConnection) mutable {
+    ActiveDOMObject::queueTaskKeepingObjectAlive(peerConnection().get(), TaskSource::Networking, [callback = WTF::move(m_setDescriptionCallback), exception = WTF::move(exception)](auto& peerConnection) mutable {
         if (peerConnection.isClosed())
             return;
 
@@ -587,7 +587,7 @@ void PeerConnectionBackend::setRemoteDescriptionFailed(Exception&& exception)
 
 void PeerConnectionBackend::iceGatheringStateChanged(RTCIceGatheringState state)
 {
-    ActiveDOMObject::queueTaskKeepingObjectAlive(protectedPeerConnection().get(), TaskSource::Networking, [this, protectedThis = Ref { *this }, state](auto& peerConnection) {
+    ActiveDOMObject::queueTaskKeepingObjectAlive(peerConnection().get(), TaskSource::Networking, [this, protectedThis = Ref { *this }, state](auto& peerConnection) {
         if (state == RTCIceGatheringState::Complete) {
             doneGatheringCandidates();
             return;
@@ -596,7 +596,7 @@ void PeerConnectionBackend::iceGatheringStateChanged(RTCIceGatheringState state)
     });
 }
 
-Ref<RTCPeerConnection> PeerConnectionBackend::protectedPeerConnection() const
+Ref<RTCPeerConnection> PeerConnectionBackend::peerConnection() const
 {
     return m_peerConnection.get();
 }
@@ -638,12 +638,12 @@ void PeerConnectionBackend::addIceCandidate(RTCIceCandidate* iceCandidate, Funct
         return;
     }
 
-    doAddIceCandidate(*iceCandidate, [weakThis = WeakPtr { *this }, callback = WTF::move(callback)]<typename Result> (Result&& result) mutable {
+    doAddIceCandidate(*iceCandidate, [weakThis = ThreadSafeWeakPtr { *this }, callback = WTF::move(callback)]<typename Result>(Result&& result) mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
 
-        ActiveDOMObject::queueTaskKeepingObjectAlive(protectedThis->protectedPeerConnection().get(), TaskSource::Networking, [callback = WTF::move(callback), result = std::forward<Result>(result)](auto& peerConnection) mutable {
+        ActiveDOMObject::queueTaskKeepingObjectAlive(protectedThis->peerConnection().get(), TaskSource::Networking, [callback = WTF::move(callback), result = std::forward<Result>(result)](auto& peerConnection) mutable {
             if (peerConnection.isClosed())
                 return;
 
@@ -685,7 +685,7 @@ void PeerConnectionBackend::validateSDP(const String& sdp) const
 
 void PeerConnectionBackend::newICECandidate(String&& sdp, String&& mid, unsigned short sdpMLineIndex, String&& serverURL, std::optional<DescriptionStates>&& descriptions)
 {
-    ActiveDOMObject::queueTaskKeepingObjectAlive(protectedPeerConnection().get(), TaskSource::Networking, [logSiteIdentifier = LOGIDENTIFIER, this, protectedThis = Ref { *this }, sdp = WTF::move(sdp), mid = WTF::move(mid), sdpMLineIndex, serverURL = WTF::move(serverURL), descriptions = WTF::move(descriptions)](auto& peerConnection) mutable {
+    ActiveDOMObject::queueTaskKeepingObjectAlive(peerConnection().get(), TaskSource::Networking, [logSiteIdentifier = LOGIDENTIFIER, this, protectedThis = Ref { *this }, sdp = WTF::move(sdp), mid = WTF::move(mid), sdpMLineIndex, serverURL = WTF::move(serverURL), descriptions = WTF::move(descriptions)](auto& peerConnection) mutable {
         if (peerConnection.isClosed())
             return;
 
@@ -708,7 +708,7 @@ void PeerConnectionBackend::newICECandidate(String&& sdp, String&& mid, unsigned
 
 void PeerConnectionBackend::newDataChannel(UniqueRef<RTCDataChannelHandler>&& channelHandler, String&& label, RTCDataChannelInit&& channelInit)
 {
-    protectedPeerConnection()->dispatchDataChannelEvent(WTF::move(channelHandler), WTF::move(label), WTF::move(channelInit));
+    peerConnection()->dispatchDataChannelEvent(WTF::move(channelHandler), WTF::move(label), WTF::move(channelInit));
 }
 
 void PeerConnectionBackend::doneGatheringCandidates()
@@ -732,7 +732,7 @@ void PeerConnectionBackend::stop()
 
 void PeerConnectionBackend::markAsNeedingNegotiation(uint32_t eventId)
 {
-    protectedPeerConnection()->updateNegotiationNeededFlag(eventId);
+    peerConnection()->updateNegotiationNeededFlag(eventId);
 }
 
 ExceptionOr<Ref<RTCRtpSender>> PeerConnectionBackend::addTrack(MediaStreamTrack&, FixedVector<String>&&)
@@ -778,7 +778,7 @@ void PeerConnectionBackend::generateCertificate(Document& document, const Certif
 
 ScriptExecutionContext* PeerConnectionBackend::context() const
 {
-    return protectedPeerConnection()->scriptExecutionContext();
+    return peerConnection()->scriptExecutionContext();
 }
 
 #if !RELEASE_LOG_DISABLED
@@ -821,16 +821,6 @@ static String toJSONString(const PeerConnectionBackend::TransceiverState& transc
 static String toJSONString(const PeerConnectionBackend::TransceiverStates& transceiverStates)
 {
     return toJSONArray(transceiverStates)->toJSONString();
-}
-
-void PeerConnectionBackend::ref() const
-{
-    m_peerConnection->ref();
-}
-
-void PeerConnectionBackend::deref() const
-{
-    m_peerConnection->deref();
 }
 
 String PeerConnectionBackend::generateJSONLogEvent(LogEvent&& logEvent, bool isForGatherLogs)

--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.h
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.h
@@ -42,7 +42,7 @@
 #include "RTCSignalingState.h"
 #include <wtf/FixedVector.h>
 #include <wtf/LoggerHelper.h>
-#include <wtf/WeakPtr.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 
 namespace WebCore {
 class PeerConnectionBackend;
@@ -88,7 +88,7 @@ using StatsPromise = DOMPromiseDeferred<IDLInterface<RTCStatsReport>>;
 using CreatePeerConnectionBackend = const std::unique_ptr<PeerConnectionBackend> (*)(RTCPeerConnection&, MediaEndpointConfiguration&&);
 
 class PeerConnectionBackend
-    : public CanMakeWeakPtr<PeerConnectionBackend>
+    : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<PeerConnectionBackend, WTF::DestructionThread::Main>
 #if !RELEASE_LOG_DISABLED
     , private LoggerHelper
 #if PLATFORM(WPE) || PLATFORM(GTK)
@@ -104,6 +104,9 @@ public:
 
     explicit PeerConnectionBackend(RTCPeerConnection&);
     virtual ~PeerConnectionBackend();
+
+    void ref() const { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
+    void deref() const { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
 
     using CreateCallback = Function<void(ExceptionOr<RTCSessionDescriptionInit>&&)>;
     void createOffer(RTCOfferOptions&&, CreateCallback&&);
@@ -181,8 +184,6 @@ public:
 
     virtual bool isLocalDescriptionSet() const = 0;
 
-    void finishedRegisteringMDNSName(const String& ipAddress, const String& name);
-
     struct CertificateInformation {
         enum class Type { RSASSAPKCS1v15, ECDSAP256 };
         struct RSA {
@@ -229,9 +230,6 @@ public:
     virtual void startGatheringStatLogs(Function<void(String&&)>&&) { }
     virtual void stopGatheringStatLogs() { }
 
-    WEBCORE_EXPORT void ref() const;
-    WEBCORE_EXPORT void deref() const;
-
 protected:
     void doneGatheringCandidates();
 
@@ -272,7 +270,7 @@ private:
     virtual void doStop() = 0;
 
 protected:
-    Ref<RTCPeerConnection> protectedPeerConnection() const;
+    Ref<RTCPeerConnection> peerConnection() const;
     WeakRef<RTCPeerConnection, WeakPtrImplWithEventTargetData> m_peerConnection;
 
 private:

--- a/Source/WebCore/Modules/mediastream/RTCRtpReceiver.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpReceiver.cpp
@@ -44,7 +44,7 @@
 namespace WebCore {
 
 #if !RELEASE_LOG_DISABLED
-#define LOGIDENTIFIER_RECEIVER Logger::LogSiteIdentifier(logClassName(), __func__, m_connection->logIdentifier())
+#define LOGIDENTIFIER_RECEIVER Logger::LogSiteIdentifier(logClassName(), __func__, connection->logIdentifier())
 #else
 #define LOGIDENTIFIER_RECEIVER
 #endif
@@ -82,11 +82,12 @@ void RTCRtpReceiver::stop()
 
 void RTCRtpReceiver::getStats(Ref<DeferredPromise>&& promise)
 {
-    if (!m_connection) {
+    RefPtr connection = m_connection.get();
+    if (!connection) {
         promise->reject(ExceptionCode::InvalidStateError);
         return;
     }
-    m_connection->getStats(*this, WTF::move(promise));
+    connection->getStats(*this, WTF::move(promise));
 }
 
 std::optional<RTCRtpCapabilities> RTCRtpReceiver::getCapabilities(ScriptExecutionContext& context, const String& kind)
@@ -96,7 +97,8 @@ std::optional<RTCRtpCapabilities> RTCRtpReceiver::getCapabilities(ScriptExecutio
 
 ExceptionOr<void> RTCRtpReceiver::setTransform(std::unique_ptr<RTCRtpTransform>&& transform)
 {
-    ALWAYS_LOG_IF(m_connection, LOGIDENTIFIER_RECEIVER);
+    RefPtr connection = m_connection.get();
+    ALWAYS_LOG_IF(connection, LOGIDENTIFIER_RECEIVER);
 
     if (transform && m_transform && *transform == *m_transform)
         return { };

--- a/Source/WebCore/Modules/mediastream/RTCRtpReceiver.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpReceiver.h
@@ -99,7 +99,7 @@ private:
     const Ref<MediaStreamTrack> m_track;
     RefPtr<RTCDtlsTransport> m_transport;
     std::unique_ptr<RTCRtpReceiverBackend> m_backend;
-    WeakPtr<PeerConnectionBackend> m_connection;
+    ThreadSafeWeakPtr<PeerConnectionBackend> m_connection;
     std::unique_ptr<RTCRtpTransform> m_transform;
     const RefPtr<RTCEncodedStreamProducer> m_encodedStreamProducer;
     Vector<WeakPtr<MediaStream>> m_associatedStreams;

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -71,8 +71,8 @@ GST_DEBUG_CATEGORY(webkit_webrtc_endpoint_debug);
 
 namespace WebCore {
 
-GStreamerMediaEndpoint::GStreamerMediaEndpoint(GStreamerPeerConnectionBackend& peerConnection)
-    : m_peerConnectionBackend(WeakPtr { &peerConnection })
+GStreamerMediaEndpoint::GStreamerMediaEndpoint(const GStreamerPeerConnectionBackend& peerConnection)
+    : m_peerConnectionBackend(ThreadSafeWeakPtr { &peerConnection })
     , m_statsCollector(GStreamerStatsCollector::create())
 #if !RELEASE_LOG_DISABLED
     , m_statsLogTimer(*this, &GStreamerMediaEndpoint::gatherStatsForLogging)
@@ -401,7 +401,7 @@ void GStreamerMediaEndpoint::disposeElementChain(GstElement* element)
     gst_element_release_request_pad(m_webrtcBin.get(), peer.get());
 }
 
-bool GStreamerMediaEndpoint::setConfiguration(MediaEndpointConfiguration& configuration)
+bool GStreamerMediaEndpoint::setConfiguration(const MediaEndpointConfiguration& configuration)
 {
     auto peerConnectionBackend = this->peerConnectionBackend();
     if (!peerConnectionBackend)
@@ -410,7 +410,11 @@ bool GStreamerMediaEndpoint::setConfiguration(MediaEndpointConfiguration& config
     if (!m_webrtcBin)
         return false;
 
-    auto& document = downcast<Document>(*peerConnectionBackend->connection().scriptExecutionContext());
+    RefPtr connection = peerConnectionBackend->peerConnection();
+    if (!connection)
+        return false;
+
+    auto& document = downcast<Document>(*connection->scriptExecutionContext());
     GST_DEBUG_OBJECT(m_pipeline.get(), "Configuring webrtcbin for PeerConnection created by %s", document.url().string().utf8().data());
     GstWebRTCBundlePolicy bundlePolicy;
     if (document.url().isMatchingDomain("www.xbox.com"_s)) {
@@ -806,7 +810,7 @@ void GStreamerMediaEndpoint::doSetLocalDescription(const RTCSessionDescription* 
     if (!peerConnectionBackend)
         return;
     auto initialSDP = description ? description->sdp().isolatedCopy() : emptyString();
-    auto remoteDescription = peerConnectionBackend->connection().remoteDescription();
+    auto remoteDescription = peerConnectionBackend->peerConnection()->remoteDescription();
     String remoteDescriptionSdp = remoteDescription ? remoteDescription->sdp() : emptyString();
     std::optional<RTCSdpType> remoteDescriptionSdpType = remoteDescription ? std::make_optional(remoteDescription->type()) : std::nullopt;
 
@@ -912,7 +916,7 @@ void GStreamerMediaEndpoint::doSetRemoteDescription(const RTCSessionDescription&
     auto peerConnectionBackend = this->peerConnectionBackend();
     if (!peerConnectionBackend)
         return;
-    auto localDescription = peerConnectionBackend->connection().localDescription();
+    auto localDescription = peerConnectionBackend->peerConnection()->localDescription();
     String localDescriptionSdp = localDescription ? localDescription->sdp() : emptyString();
     std::optional<RTCSdpType> localDescriptionSdpType = localDescription ? std::make_optional(localDescription->type()) : std::nullopt;
 
@@ -1446,7 +1450,7 @@ MediaStream& GStreamerMediaEndpoint::mediaStreamFromRTCStream(String mediaStream
         auto peerConnectionBackend = this->peerConnectionBackend();
         if (!peerConnectionBackend)
             return nullptr;
-        auto& document = downcast<Document>(*peerConnectionBackend->connection().scriptExecutionContext());
+        auto& document = downcast<Document>(*peerConnectionBackend->peerConnection()->scriptExecutionContext());
         return MediaStream::create(document, MediaStreamPrivate::create(document.logger(), { }, WTF::move(mediaStreamId)), MediaStream::AllowEventTracks::Yes);
     });
     return *mediaStream.iterator->value;
@@ -1878,7 +1882,7 @@ ExceptionOr<GStreamerMediaEndpoint::Backends> GStreamerMediaEndpoint::createTran
 
     auto transceiver = makeUnique<GStreamerRtpTransceiverBackend>(WTF::move(rtcTransceiver));
 
-    return GStreamerMediaEndpoint::Backends { transceiver->createSenderBackend(WeakPtr { m_peerConnectionBackend }, WTF::move(source), WTF::move(initData)), transceiver->createReceiverBackend(), WTF::move(transceiver) };
+    return GStreamerMediaEndpoint::Backends { transceiver->createSenderBackend(ThreadSafeWeakPtr { m_peerConnectionBackend }, WTF::move(source), WTF::move(initData)), transceiver->createReceiverBackend(), WTF::move(transceiver) };
 }
 
 ExceptionOr<GStreamerMediaEndpoint::Backends> GStreamerMediaEndpoint::addTransceiver(const String& trackKind, const RTCRtpTransceiverInit& init, PeerConnectionBackend::IgnoreNegotiationNeededFlag ignoreNegotiationNeededFlag)
@@ -2243,9 +2247,9 @@ void GStreamerMediaEndpoint::onIceConnectionChange()
         auto peerConnectionBackend = this->peerConnectionBackend();
         if (!peerConnectionBackend)
             return;
-        auto& connection = peerConnectionBackend->connection();
-        if (connection.iceConnectionState() != connectionState)
-            connection.updateIceConnectionState(connectionState);
+        auto connection = peerConnectionBackend->peerConnection();
+        if (connection->iceConnectionState() != connectionState)
+            connection->updateIceConnectionState(connectionState);
     });
 }
 
@@ -2400,7 +2404,7 @@ GUniquePtr<GstStructure> GStreamerMediaEndpoint::preprocessStats(const GRefPtr<G
         if (!peerConnectionBackend)
             return nullptr;
 
-        for (auto& sender : peerConnectionBackend->connection().getSenders()) {
+        for (auto& sender : peerConnectionBackend->peerConnection()->getSenders()) {
             auto& backend = peerConnectionBackend->backendFromRTPSender(sender);
             GUniquePtr<GstStructure> stats, captureStats;
             ASCIILiteral captureStatsName;
@@ -2422,7 +2426,7 @@ GUniquePtr<GstStructure> GStreamerMediaEndpoint::preprocessStats(const GRefPtr<G
 
             gst_structure_set(result.get(), captureStatsName.characters(), GST_TYPE_STRUCTURE, captureStats.get(), nullptr);
         }
-        for (auto& receiver : peerConnectionBackend->connection().getReceivers()) {
+        for (auto& receiver : peerConnectionBackend->peerConnection()->getReceivers()) {
             auto& track = receiver.get().track();
             if (!is<RealtimeIncomingVideoSourceGStreamer>(track.source()))
                 continue;

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h
@@ -55,10 +55,10 @@ class GStreamerMediaEndpoint : public ThreadSafeRefCountedAndCanMakeThreadSafeWe
 #endif
 {
 public:
-    static Ref<GStreamerMediaEndpoint> create(GStreamerPeerConnectionBackend& peerConnection) { return adoptRef(*new GStreamerMediaEndpoint(peerConnection)); }
+    static Ref<GStreamerMediaEndpoint> create(const GStreamerPeerConnectionBackend& peerConnection) { return adoptRef(*new GStreamerMediaEndpoint(peerConnection)); }
     ~GStreamerMediaEndpoint();
 
-    bool setConfiguration(MediaEndpointConfiguration&);
+    bool setConfiguration(const MediaEndpointConfiguration&);
     void restartIce();
 
     void doSetLocalDescription(const RTCSessionDescription*);
@@ -131,7 +131,7 @@ protected:
 #endif
 
 private:
-    GStreamerMediaEndpoint(GStreamerPeerConnectionBackend&);
+    explicit GStreamerMediaEndpoint(const GStreamerPeerConnectionBackend&);
 
     RefPtr<GStreamerPeerConnectionBackend> peerConnectionBackend() const;
 
@@ -192,7 +192,7 @@ private:
 
     HashMap<String, RealtimeMediaSource::Type> m_mediaForMid;
 
-    WeakPtr<GStreamerPeerConnectionBackend> m_peerConnectionBackend;
+    ThreadSafeWeakPtr<GStreamerPeerConnectionBackend> m_peerConnectionBackend;
     GRefPtr<GstElement> m_webrtcBin;
     GRefPtr<GstElement> m_pipeline;
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
@@ -40,8 +40,7 @@
 #include "RTCRtpCapabilities.h"
 #include "RTCRtpReceiver.h"
 #include "RTCSessionDescription.h"
-#include "RealtimeIncomingAudioSourceGStreamer.h"
-#include "RealtimeIncomingVideoSourceGStreamer.h"
+#include "RealtimeIncomingSourceGStreamer.h"
 #include "RealtimeOutgoingAudioSourceGStreamer.h"
 #include "RealtimeOutgoingVideoSourceGStreamer.h"
 #include <wtf/StdLibExtras.h>
@@ -86,8 +85,8 @@ static const std::unique_ptr<PeerConnectionBackend> createGStreamerPeerConnectio
         return nullptr;
     }
     auto backend = WTF::makeUniqueWithoutRefCountedCheck<GStreamerPeerConnectionBackend, PeerConnectionBackend>(peerConnection);
-    bool status = backend->setConfiguration(WTF::move(configuration));
-    ASSERT_UNUSED(status, status);
+    if (!backend->setConfiguration(WTF::move(configuration)))
+        return nullptr;
     return backend;
 }
 
@@ -146,7 +145,7 @@ GStreamerRtpSenderBackend& GStreamerPeerConnectionBackend::backendFromRTPSender(
 
 void GStreamerPeerConnectionBackend::dispatchSenderBitrateRequest(const GRefPtr<GstWebRTCDTLSTransport>& transport, uint32_t bitrate)
 {
-    for (auto& transceiver : protectedPeerConnection()->currentTransceivers()) {
+    for (auto& transceiver : peerConnection()->currentTransceivers()) {
         auto& senderBackend = backendFromRTPSender(transceiver->sender());
         GRefPtr<GstWebRTCDTLSTransport> candidate;
         g_object_get(senderBackend.rtcSender(), "transport", &candidate.outPtr(), nullptr);
@@ -237,7 +236,7 @@ void GStreamerPeerConnectionBackend::doAddIceCandidate(RTCIceCandidate& candidat
 
 Ref<RTCRtpReceiver> GStreamerPeerConnectionBackend::createReceiver(std::unique_ptr<GStreamerRtpReceiverBackend>&& backend, const String& trackKind, const String& trackId)
 {
-    auto& document = downcast<Document>(*protectedPeerConnection()->scriptExecutionContext());
+    auto& document = downcast<Document>(*peerConnection()->scriptExecutionContext());
 
     auto source = backend->createSource(trackKind, trackId);
     // Remote source is initially muted and will be unmuted when receiving the first packet.
@@ -263,7 +262,7 @@ ExceptionOr<Ref<RTCRtpSender>> GStreamerPeerConnectionBackend::addTrack(MediaStr
     // This is already done in RTCPeerConnection so no need to repeat:
     // If an RTCRtpSender for track already exists in senders, throw an InvalidAccessError.
     Vector<RefPtr<RTCRtpSender>> senders;
-    for (const auto& transceiver : protectedPeerConnection()->currentTransceivers()) {
+    for (const auto& transceiver : peerConnection()->currentTransceivers()) {
         if (transceiver->stopped())
             continue;
         senders.append(&transceiver->sender());
@@ -326,7 +325,7 @@ ExceptionOr<Ref<RTCRtpSender>> GStreamerPeerConnectionBackend::addTrack(MediaStr
 
         // 4. Let transceiver be the RTCRtpTransceiver associated with sender.
         RefPtr<RTCRtpTransceiver> transceiver;
-        for (const auto& currentTransceiver : protectedPeerConnection()->currentTransceivers()) {
+        for (const auto& currentTransceiver : peerConnection()->currentTransceivers()) {
             if (&currentTransceiver->sender() == sender.get()) {
                 transceiver = currentTransceiver;
                 break;
@@ -410,7 +409,7 @@ static inline GStreamerRtpTransceiverBackend& backendFromRTPTransceiver(RTCRtpTr
 
 RefPtr<RTCRtpTransceiver> GStreamerPeerConnectionBackend::existingTransceiver(WTF::Function<bool(GStreamerRtpTransceiverBackend&)>&& matchingFunction)
 {
-    for (auto& transceiver : protectedPeerConnection()->currentTransceivers()) {
+    for (auto& transceiver : peerConnection()->currentTransceivers()) {
         if (matchingFunction(backendFromRTPTransceiver(*transceiver)))
             return transceiver;
     }
@@ -443,7 +442,7 @@ void GStreamerPeerConnectionBackend::removeTrack(RTCRtpSender& sender)
 
 void GStreamerPeerConnectionBackend::applyRotationForOutgoingVideoSources()
 {
-    for (auto& transceiver : protectedPeerConnection()->currentTransceivers()) {
+    for (auto& transceiver : peerConnection()->currentTransceivers()) {
         if (!transceiver->sender().isStopped()) {
             if (auto* videoSource = backendFromRTPSender(transceiver->sender()).videoSource())
                 videoSource->setApplyRotation(true);
@@ -466,14 +465,10 @@ std::optional<bool> GStreamerPeerConnectionBackend::canTrickleIceCandidates() co
     return m_endpoint->canTrickleIceCandidates();
 }
 
-RTCPeerConnection& GStreamerPeerConnectionBackend::connection()
-{
-    return m_peerConnection.get();
-}
-
 void GStreamerPeerConnectionBackend::tearDown()
 {
-    for (auto& transceiver : connection().currentTransceivers()) {
+    auto connection = peerConnection();
+    for (auto& transceiver : connection->currentTransceivers()) {
         auto& sender = transceiver->sender();
         sender.setTransport(nullptr);
 
@@ -492,7 +487,7 @@ void GStreamerPeerConnectionBackend::tearDown()
         auto& backend = backendFromRTPTransceiver(*transceiver);
         backend.tearDown();
     }
-    connection().clearTransports();
+    connection->clearTransports();
 }
 
 void GStreamerPeerConnectionBackend::startGatheringStatLogs(Function<void(String&&)>&& callback)

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.h
@@ -91,7 +91,6 @@ private:
 
     friend class GStreamerMediaEndpoint;
     friend class GStreamerRtpSenderBackend;
-    RTCPeerConnection& connection();
 
     void getStatsSucceeded(const DeferredPromise&, Ref<RTCStatsReport>&&);
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.cpp
@@ -50,17 +50,17 @@ static void ensureDebugCategoryIsRegistered()
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(GStreamerRtpSenderBackend);
 
-Ref<GStreamerRtpSenderBackend> GStreamerRtpSenderBackend::create(WeakPtr<GStreamerPeerConnectionBackend>&& backend, GRefPtr<GstWebRTCRTPSender>&& rtcSender)
+Ref<GStreamerRtpSenderBackend> GStreamerRtpSenderBackend::create(ThreadSafeWeakPtr<GStreamerPeerConnectionBackend>&& backend, GRefPtr<GstWebRTCRTPSender>&& rtcSender)
 {
     return adoptRef(*new GStreamerRtpSenderBackend(WTF::move(backend), WTF::move(rtcSender)));
 }
 
-Ref<GStreamerRtpSenderBackend> GStreamerRtpSenderBackend::create(WeakPtr<GStreamerPeerConnectionBackend>&& backend, GRefPtr<GstWebRTCRTPSender>&& rtcSender, Source&& source, GUniquePtr<GstStructure>&& initData)
+Ref<GStreamerRtpSenderBackend> GStreamerRtpSenderBackend::create(ThreadSafeWeakPtr<GStreamerPeerConnectionBackend>&& backend, GRefPtr<GstWebRTCRTPSender>&& rtcSender, Source&& source, GUniquePtr<GstStructure>&& initData)
 {
     return adoptRef(*new GStreamerRtpSenderBackend(WTF::move(backend), WTF::move(rtcSender), WTF::move(source), WTF::move(initData)));
 }
 
-GStreamerRtpSenderBackend::GStreamerRtpSenderBackend(WeakPtr<GStreamerPeerConnectionBackend>&& backend, GRefPtr<GstWebRTCRTPSender>&& rtcSender)
+GStreamerRtpSenderBackend::GStreamerRtpSenderBackend(ThreadSafeWeakPtr<GStreamerPeerConnectionBackend>&& backend, GRefPtr<GstWebRTCRTPSender>&& rtcSender)
     : m_peerConnectionBackend(WTF::move(backend))
     , m_rtcSender(WTF::move(rtcSender))
 {
@@ -68,7 +68,7 @@ GStreamerRtpSenderBackend::GStreamerRtpSenderBackend(WeakPtr<GStreamerPeerConnec
     GST_DEBUG_OBJECT(m_rtcSender.get(), "constructed without associated source");
 }
 
-GStreamerRtpSenderBackend::GStreamerRtpSenderBackend(WeakPtr<GStreamerPeerConnectionBackend>&& backend, GRefPtr<GstWebRTCRTPSender>&& rtcSender, Source&& source, GUniquePtr<GstStructure>&& initData)
+GStreamerRtpSenderBackend::GStreamerRtpSenderBackend(ThreadSafeWeakPtr<GStreamerPeerConnectionBackend>&& backend, GRefPtr<GstWebRTCRTPSender>&& rtcSender, Source&& source, GUniquePtr<GstStructure>&& initData)
     : m_peerConnectionBackend(WTF::move(backend))
     , m_rtcSender(WTF::move(rtcSender))
     , m_source(WTF::move(source))

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.h
@@ -35,9 +35,9 @@ class GStreamerPeerConnectionBackend;
 class GStreamerRtpSenderBackend final : public RTCRtpSenderBackend, public RefCounted<GStreamerRtpSenderBackend> {
     WTF_MAKE_TZONE_ALLOCATED(GStreamerRtpSenderBackend);
 public:
-    static Ref<GStreamerRtpSenderBackend> create(WeakPtr<GStreamerPeerConnectionBackend>&&, GRefPtr<GstWebRTCRTPSender>&&);
+    static Ref<GStreamerRtpSenderBackend> create(ThreadSafeWeakPtr<GStreamerPeerConnectionBackend>&&, GRefPtr<GstWebRTCRTPSender>&&);
     using Source = Variant<std::nullptr_t, Ref<RealtimeOutgoingAudioSourceGStreamer>, Ref<RealtimeOutgoingVideoSourceGStreamer>>;
-    static Ref<GStreamerRtpSenderBackend> create(WeakPtr<GStreamerPeerConnectionBackend>&&, GRefPtr<GstWebRTCRTPSender>&&, Source&&, GUniquePtr<GstStructure>&& initData);
+    static Ref<GStreamerRtpSenderBackend> create(ThreadSafeWeakPtr<GStreamerPeerConnectionBackend>&&, GRefPtr<GstWebRTCRTPSender>&&, Source&&, GUniquePtr<GstStructure>&& initData);
 
     // RTCRtpSenderBackend.
     void ref() const final { RefCounted::ref(); }
@@ -83,8 +83,8 @@ public:
     void dispatchBitrateRequest(uint32_t bitrate);
 
 private:
-    GStreamerRtpSenderBackend(WeakPtr<GStreamerPeerConnectionBackend>&&, GRefPtr<GstWebRTCRTPSender>&&);
-    GStreamerRtpSenderBackend(WeakPtr<GStreamerPeerConnectionBackend>&&, GRefPtr<GstWebRTCRTPSender>&&, Source&&, GUniquePtr<GstStructure>&& initData);
+    GStreamerRtpSenderBackend(ThreadSafeWeakPtr<GStreamerPeerConnectionBackend>&&, GRefPtr<GstWebRTCRTPSender>&&);
+    GStreamerRtpSenderBackend(ThreadSafeWeakPtr<GStreamerPeerConnectionBackend>&&, GRefPtr<GstWebRTCRTPSender>&&, Source&&, GUniquePtr<GstStructure>&& initData);
 
     void clearSource();
     bool replaceTrack(RTCRtpSender&, MediaStreamTrack*) final;
@@ -97,7 +97,7 @@ private:
 
     void startSource();
 
-    WeakPtr<GStreamerPeerConnectionBackend> m_peerConnectionBackend;
+    ThreadSafeWeakPtr<GStreamerPeerConnectionBackend> m_peerConnectionBackend;
     GRefPtr<GstWebRTCRTPSender> m_rtcSender;
     Source m_source;
     GUniquePtr<GstStructure> m_initData;

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp
@@ -67,7 +67,7 @@ std::unique_ptr<GStreamerRtpReceiverBackend> GStreamerRtpTransceiverBackend::cre
     return WTF::makeUnique<GStreamerRtpReceiverBackend>(GRefPtr(m_rtcTransceiver));
 }
 
-Ref<GStreamerRtpSenderBackend> GStreamerRtpTransceiverBackend::createSenderBackend(WeakPtr<GStreamerPeerConnectionBackend>&& backend, GStreamerRtpSenderBackend::Source&& source, GUniquePtr<GstStructure>&& initData)
+Ref<GStreamerRtpSenderBackend> GStreamerRtpTransceiverBackend::createSenderBackend(ThreadSafeWeakPtr<GStreamerPeerConnectionBackend>&& backend, GStreamerRtpSenderBackend::Source&& source, GUniquePtr<GstStructure>&& initData)
 {
     GRefPtr<GstWebRTCRTPSender> sender;
     g_object_get(m_rtcTransceiver.get(), "sender", &sender.outPtr(), nullptr);

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.h
@@ -37,7 +37,7 @@ public:
     GStreamerRtpTransceiverBackend(GRefPtr<GstWebRTCRTPTransceiver>&&);
 
     std::unique_ptr<GStreamerRtpReceiverBackend> createReceiverBackend();
-    Ref<GStreamerRtpSenderBackend> createSenderBackend(WeakPtr<GStreamerPeerConnectionBackend>&&, GStreamerRtpSenderBackend::Source&&, GUniquePtr<GstStructure>&&);
+    Ref<GStreamerRtpSenderBackend> createSenderBackend(ThreadSafeWeakPtr<GStreamerPeerConnectionBackend>&&, GStreamerRtpSenderBackend::Source&&, GUniquePtr<GstStructure>&&);
 
     GstWebRTCRTPTransceiver* rtcTransceiver() { return m_rtcTransceiver.get(); }
 

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp
@@ -134,7 +134,6 @@ LibWebRTCMediaEndpoint::~LibWebRTCMediaEndpoint()
 
 void LibWebRTCMediaEndpoint::setPeerConnectionBackend(LibWebRTCPeerConnectionBackend& peerConnectionBackend)
 {
-    ASSERT(!m_peerConnectionBackend);
     m_peerConnectionBackend = peerConnectionBackend;
 }
 
@@ -156,10 +155,13 @@ static std::unique_ptr<LibWebRTCProvider::SuspendableSocketFactory> createLibWeb
 
 RefPtr<webrtc::PeerConnectionInterface> LibWebRTCMediaEndpoint::createBackend(LibWebRTCProvider& client, webrtc::PeerConnectionInterface::RTCConfiguration&& configuration)
 {
-    Ref peerConnectionBackend = *m_peerConnectionBackend;
+    RefPtr peerConnectionBackend = m_peerConnectionBackend.get();
+    if (!peerConnectionBackend)
+        return nullptr;
+
     Ref document = *downcast<Document>(peerConnectionBackend->protectedConnection()->scriptExecutionContext());
     if (!m_rtcSocketFactory)
-        lazyInitialize(m_rtcSocketFactory, createLibWebRTCMediaEndpointSocketFactory(client, peerConnectionBackend, document));
+        lazyInitialize(m_rtcSocketFactory, createLibWebRTCMediaEndpointSocketFactory(client, *peerConnectionBackend, document));
 
     return toRefPtr(client.createPeerConnection(document->identifier(), *this, m_rtcSocketFactory.get(), WTF::move(configuration)));
 }

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h
@@ -186,7 +186,7 @@ private:
     RefPtr<LibWebRTCPeerConnectionBackend> protectedPeerConnectionBackend() const;
     RefPtr<webrtc::PeerConnectionInterface> createBackend(LibWebRTCProvider&, webrtc::PeerConnectionInterface::RTCConfiguration&&);
 
-    WeakPtr<LibWebRTCPeerConnectionBackend> m_peerConnectionBackend;
+    ThreadSafeWeakPtr<LibWebRTCPeerConnectionBackend> m_peerConnectionBackend;
     const Ref<webrtc::PeerConnectionFactoryInterface> m_peerConnectionFactory;
     const RefPtr<webrtc::PeerConnectionInterface> m_backend;
 

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
@@ -290,7 +290,7 @@ void LibWebRTCPeerConnectionBackend::doAddIceCandidate(RTCIceCandidate& candidat
 
 Ref<RTCRtpReceiver> LibWebRTCPeerConnectionBackend::createReceiver(std::unique_ptr<LibWebRTCRtpReceiverBackend>&& backend)
 {
-    Ref document = downcast<Document>(*protectedPeerConnection()->scriptExecutionContext());
+    Ref document = downcast<Document>(*peerConnection()->scriptExecutionContext());
 
     auto source = backend->createSource(document.get());
 
@@ -381,7 +381,7 @@ static inline LibWebRTCRtpTransceiverBackend& backendFromRTPTransceiver(RTCRtpTr
 
 RefPtr<RTCRtpTransceiver> LibWebRTCPeerConnectionBackend::existingTransceiver(Function<bool(LibWebRTCRtpTransceiverBackend&)>&& matchingFunction)
 {
-    for (auto& transceiver : protectedPeerConnection()->currentTransceivers()) {
+    for (auto& transceiver : peerConnection()->currentTransceivers()) {
         if (matchingFunction(backendFromRTPTransceiver(*transceiver)))
             return transceiver;
     }
@@ -411,7 +411,7 @@ void LibWebRTCPeerConnectionBackend::removeTrack(RTCRtpSender& sender)
 
 void LibWebRTCPeerConnectionBackend::applyRotationForOutgoingVideoSources()
 {
-    for (auto& transceiver : protectedPeerConnection()->currentTransceivers()) {
+    for (auto& transceiver : peerConnection()->currentTransceivers()) {
         if (!transceiver->sender().isStopped()) {
             if (RefPtr videoSource = protectedBackendFromRTPSender(transceiver->sender())->videoSource())
                 videoSource->applyRotation();

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderBackend.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderBackend.h
@@ -85,7 +85,7 @@ private:
 
     RefPtr<LibWebRTCPeerConnectionBackend> protectedPeerConnectionBackend() const;
 
-    WeakPtr<LibWebRTCPeerConnectionBackend> m_peerConnectionBackend;
+    ThreadSafeWeakPtr<LibWebRTCPeerConnectionBackend> m_peerConnectionBackend;
     RefPtr<webrtc::RtpSenderInterface> m_rtcSender;
     Source m_source;
     const RefPtr<RTCRtpTransformBackend> m_transformBackend;

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -16,7 +16,6 @@ Modules/mediastream/RTCDTMFSender.cpp
 Modules/mediastream/RTCDataChannelRemoteHandler.cpp
 Modules/mediastream/RTCEncodedFrame.cpp
 Modules/mediastream/RTCPeerConnection.cpp
-Modules/mediastream/RTCRtpReceiver.cpp
 Modules/mediastream/RTCRtpSFrameTransform.cpp
 Modules/mediastream/RTCRtpSender.cpp
 Modules/mediastream/RTCRtpTransform.cpp


### PR DESCRIPTION
#### 9e1aa72c2608618f74af5216f3756286960893ac
<pre>
[WebRTC] Allow PeerConnectionBackend usage from non-main threads
<a href="https://bugs.webkit.org/show_bug.cgi?id=304819">https://bugs.webkit.org/show_bug.cgi?id=304819</a>

Reviewed by NOBODY (OOPS!).

Refactoring turning the PeerConnectionBackend to a ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr.
This is needed specially for an upcoming change in the GStreamer backend where ICE candidates are
notified from the webrtcbin PC thread and where I will need access to the backend to know whether or
not to apply ICE candidates filtering.

Covered by existing tests.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e1aa72c2608618f74af5216f3756286960893ac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137303 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9663 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48590 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145054 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90276 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139175 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10367 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9790 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104990 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140248 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7657 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123057 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85846 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7294 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5013 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5641 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116657 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41209 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147811 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9346 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41771 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113362 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9364 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7867 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113704 "Found 1 new API test failure: WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/itp (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7214 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119301 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63911 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9395 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37355 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9125 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72960 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9335 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9187 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->