### PR TITLE
[WTF] Use simdutf for UTF-16 to UTF-8 conversion

### DIFF
--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -827,6 +827,7 @@ else ()
         SIMDUTF.cpp
         text/Base64.cpp
         text/StringImpl.cpp
+        unicode/UTF8Conversion.cpp
         PROPERTIES COMPILE_FLAGS "-Wno-error=undef -Wno-undef")
 endif ()
 


### PR DESCRIPTION
#### fda0e1e0c823a562297b0741b65a93d0f426c877
<pre>
[WTF] Use simdutf for UTF-16 to UTF-8 conversion
<a href="https://bugs.webkit.org/show_bug.cgi?id=304916">https://bugs.webkit.org/show_bug.cgi?id=304916</a>

Reviewed by Yusuke Suzuki.

Add SIMD optimization for UTF-16 to UTF-8 conversion using simdutf library.
This improves performance for non-ASCII strings while remaining neutral for
ASCII strings.

Benchmark results (µs per iteration, lower is better):

Type    Length    Orig(µs)    SIMD(µs)    Speedup
-----   ------    --------    --------    -------
ASCII        5      0.1794      0.1184      1.52x
ASCII       10      0.1350      0.1277      1.06x
ASCII       20      0.1484      0.1454      1.02x
ASCII       50      0.2668      0.1895      1.41x
ASCII      100      0.3188      0.2364      1.35x
ASCII      500      0.6034      0.5830      1.04x
ASCII     1000      1.0247      1.0153      1.01x
JP           5      0.2474      0.1542      1.60x
JP          10      0.3662      0.1847      1.98x
JP          20      0.5966      0.3289      1.81x
JP          50      1.2413      0.5773      2.15x
JP         100      2.5593      0.6513      3.93x
JP         500     11.0678      2.2777      4.86x
JP        1000     22.2872      4.0778      5.46x

Note: ASCII results show some variance in speedup ratios due to fast
execution times, but are effectively neutral. The optimization primarily
benefits non-ASCII text (Japanese, Chinese, emoji, etc.) with 2-5x speedup.

* Source/WTF/wtf/CMakeLists.txt:
Add unicode/UTF8Conversion.cpp to SIMD warning suppression list.
* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::utf8ForCharactersIntoBuffer): Add SIMD fast path.
(WTF::StringImpl::utf8LengthFromUTF16): Added. Calculate exact UTF-8 length
using simdutf.
(WTF::StringImpl::tryConvertUTF16ToUTF8): Added. Try SIMD conversion and
return notFound on failure.
* Source/WTF/wtf/text/StringImpl.h:
(WTF::StringImpl::tryGetUTF8ForCharacters): Use exact buffer sizing with
utf8LengthFromUTF16 and SIMD conversion with tryConvertUTF16ToUTF8.
* Source/WTF/wtf/unicode/UTF8Conversion.cpp:
(WTF::Unicode::convert): Add SIMD fast path for UTF-16 to UTF-8 conversion.
Check buffer size before SIMD conversion to avoid overflow when caller
provides insufficient buffer.

Canonical link: <a href="https://commits.webkit.org/305091@main">https://commits.webkit.org/305091@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cdfaf26a7796a5aca9be702411e44f97af57823e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137467 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9827 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48754 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145219 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90440 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139339 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10531 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9954 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/105123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140412 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7806 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123206 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/85980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7442 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5163 "Passed tests") | [  ~~🛠 wpe-cairo-libwebrtc~~](https://ews-build.webkit.org/#/builders/166/builds/5808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/129428 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116812 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41360 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147980 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/135983 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9510 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41915 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/113501 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9528 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8016 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113846 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28898 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7363 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119445 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64142 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9559 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37498 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/168737 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9289 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73124 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/44035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9499 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9351 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->