### PR TITLE
[WebRTC] Improve spec compliance for RTCConfiguration.iceServers

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2696,6 +2696,9 @@ webkit.org/b/235885 webrtc/canvas-to-peer-connection-vp8.html [ Failure ]
 # expected. The whole suite takes an hour(!) to run but ("only") reports 14
 # tests unexpected timeouts.
 imported/w3c/web-platform-tests/webrtc/ [ Skip ]
+imported/w3c/web-platform-tests/webrtc/RTCConfiguration-validation.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCConfiguration-iceCandidatePoolSize.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCConfiguration-iceServers.html [ Pass ]
 imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-canTrickleIceCandidates.html [ Pass ]
 imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-addIceCandidate-timing.https.html [ Pass ]
 imported/w3c/web-platform-tests/webrtc/RTCRtpParameters-encodings.html [ Pass ]

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc/RTCConfiguration-iceServers-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc/RTCConfiguration-iceServers-expected.txt
@@ -22,10 +22,10 @@ PASS new RTCPeerConnection(config) - with 2 stun servers should succeed
 PASS setConfiguration(config) - with 2 stun servers should succeed
 PASS new RTCPeerConnection(config) - with turn server, username, credential should succeed
 PASS setConfiguration(config) - with turn server, username, credential should succeed
-FAIL new RTCPeerConnection(config) - with turns server and empty string username, credential should succeed Bad Configuration Parameters
-FAIL setConfiguration(config) - with turns server and empty string username, credential should succeed Bad Configuration Parameters
-FAIL new RTCPeerConnection(config) - with turn server and empty string username, credential should succeed Bad Configuration Parameters
-FAIL setConfiguration(config) - with turn server and empty string username, credential should succeed Bad Configuration Parameters
+PASS new RTCPeerConnection(config) - with turns server and empty string username, credential should succeed
+PASS setConfiguration(config) - with turns server and empty string username, credential should succeed
+PASS new RTCPeerConnection(config) - with turn server and empty string username, credential should succeed
+PASS setConfiguration(config) - with turn server and empty string username, credential should succeed
 PASS new RTCPeerConnection(config) - with one turns server, one turn server, username, credential should succeed
 PASS setConfiguration(config) - with one turns server, one turn server, username, credential should succeed
 PASS new RTCPeerConnection(config) - with a turn server and a username of 509 characters should succeed

--- a/LayoutTests/webrtc/stun-server-filtering.html
+++ b/LayoutTests/webrtc/stun-server-filtering.html
@@ -39,7 +39,7 @@ test(() => {
 
     let string510 = string509 + 'a';
 
-    assert_throws_js(TypeError, () => new RTCPeerConnection({iceServers:[{username: 'test', credential: string510, urls:['turn:foo.com']}]}));
-    assert_throws_js(TypeError, () => new RTCPeerConnection({iceServers:[{username: string510, credential: 'test', urls:['turn:foo.com']}]}));
-}, "RTCPeerConnection and big TURN username/credential");
+    assert_throws_dom("InvalidAccessError", () => new RTCPeerConnection({iceServers:[{username: 'test', credential: string510, urls:['turn:foo.com']}]}));
+    assert_throws_dom("InvalidAccessError", () => new RTCPeerConnection({iceServers:[{username: string510, credential: 'test', urls:['turn:foo.com']}]}));
+ }, "RTCPeerConnection and big TURN username/credential");
 </script>

--- a/Source/WebCore/Modules/mediastream/RTCConfiguration.h
+++ b/Source/WebCore/Modules/mediastream/RTCConfiguration.h
@@ -42,7 +42,7 @@
 namespace WebCore {
 
 struct RTCConfiguration {
-    std::optional<Vector<RTCIceServer>> iceServers;
+    Vector<RTCIceServer> iceServers;
     RTCIceTransportPolicy iceTransportPolicy;
     RTCBundlePolicy bundlePolicy;
     RTCPMuxPolicy rtcpMuxPolicy;

--- a/Source/WebCore/Modules/mediastream/RTCConfiguration.idl
+++ b/Source/WebCore/Modules/mediastream/RTCConfiguration.idl
@@ -57,7 +57,7 @@
     JSGenerateToJSObject,
     JSGenerateToNativeObject
 ] dictionary RTCConfiguration {
-    sequence<RTCIceServer> iceServers;
+    sequence<RTCIceServer> iceServers = [];
     RTCIceTransportPolicy iceTransportPolicy = "all";
     RTCBundlePolicy bundlePolicy = "balanced";
     RTCPMuxPolicy rtcpMuxPolicy = "require";


### PR DESCRIPTION
#### 94a8f0d2e0ee45d3229f383dd150871bd8ad7976
<pre>
[WebRTC] Improve spec compliance for RTCConfiguration.iceServers
<a href="https://bugs.webkit.org/show_bug.cgi?id=304821">https://bugs.webkit.org/show_bug.cgi?id=304821</a>

Reviewed by Youenn Fablet.

Make the iceServers property a non-optional sequence with empty set as default value, as mandated by
the spec.

* LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCConfiguration-iceServers-expected.txt:
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/Modules/mediastream/RTCConfiguration.h:
* Source/WebCore/Modules/mediastream/RTCConfiguration.idl:
* Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp:
(WebCore::RTCPeerConnection::iceServersFromConfiguration):

Canonical link: <a href="https://commits.webkit.org/305152@main">https://commits.webkit.org/305152@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4149f9f6c8f55496dc1ac2c8147efb98c76af02a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137265 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9625 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48552 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145016 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90238 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139137 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10329 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9752 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104964 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76593 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140210 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7623 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123019 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85814 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7260 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4975 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5603 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116620 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41175 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147773 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9308 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41737 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113330 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9326 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7834 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113669 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28941 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7181 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119267 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63836 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9357 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37321 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9085 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72922 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9297 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9149 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->