### PR TITLE
[GStreamer][WebRTC] Add support for dtls-state and transport state in GstStructure JSON serializer

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -1276,6 +1276,24 @@ static ASCIILiteral webrtcStatsTypeName(int value)
     return nullptr;
 }
 
+static ASCIILiteral webrtcDtlsTransportStateName(int value)
+{
+    switch (value) {
+    case GST_WEBRTC_DTLS_TRANSPORT_STATE_NEW:
+        return "new"_s;
+    case GST_WEBRTC_DTLS_TRANSPORT_STATE_CLOSED:
+        return "closed"_s;
+    case GST_WEBRTC_DTLS_TRANSPORT_STATE_FAILED:
+        return "failed"_s;
+    case GST_WEBRTC_DTLS_TRANSPORT_STATE_CONNECTING:
+        return "connecting"_s;
+    case GST_WEBRTC_DTLS_TRANSPORT_STATE_CONNECTED:
+        return "connected"_s;
+    }
+    ASSERT_NOT_REACHED();
+    return nullptr;
+}
+
 #if GST_CHECK_VERSION(1, 27, 0)
 static ASCIILiteral webrtcIceTcpCandidateTypeName(int value)
 {
@@ -1288,6 +1306,20 @@ static ASCIILiteral webrtcIceTcpCandidateTypeName(int value)
         return "passive"_s;
     case GST_WEBRTC_ICE_TCP_CANDIDATE_TYPE_SO:
         return "so"_s;
+    }
+    ASSERT_NOT_REACHED();
+    return nullptr;
+}
+
+static ASCIILiteral webrtcDtlsRoleName(int value)
+{
+    switch (value) {
+    case GST_WEBRTC_DTLS_ROLE_CLIENT:
+        return "client"_s;
+    case GST_WEBRTC_DTLS_ROLE_SERVER:
+        return "server"_s;
+    case GST_WEBRTC_DTLS_ROLE_UNKNOWN:
+        return "unknown"_s;
     }
     ASSERT_NOT_REACHED();
     return nullptr;
@@ -1509,9 +1541,19 @@ static std::optional<RefPtr<JSON::Value>> gstStructureValueToJSON(const GValue* 
         if (!name.isEmpty()) [[likely]]
             return JSON::Value::create(makeString(name))->asValue();
     }
+    if (valueType == GST_TYPE_WEBRTC_DTLS_TRANSPORT_STATE) {
+        auto name = webrtcDtlsTransportStateName(g_value_get_enum(value));
+        if (!name.isEmpty()) [[likely]]
+            return JSON::Value::create(makeString(name))->asValue();
+    }
 #if GST_CHECK_VERSION(1, 27, 0)
     if (valueType == GST_TYPE_WEBRTC_ICE_TCP_CANDIDATE_TYPE) {
         auto name = webrtcIceTcpCandidateTypeName(g_value_get_enum(value));
+        if (!name.isEmpty()) [[likely]]
+            return JSON::Value::create(makeString(name))->asValue();
+    }
+    if (valueType == GST_TYPE_WEBRTC_DTLS_ROLE) {
+        auto name = webrtcDtlsRoleName(g_value_get_enum(value));
         if (!name.isEmpty()) [[likely]]
             return JSON::Value::create(makeString(name))->asValue();
     }


### PR DESCRIPTION
#### 110775b1485b39c509011ad4d964bd16a72b0108
<pre>
[GStreamer][WebRTC] Add support for dtls-state and transport state in GstStructure JSON serializer
<a href="https://bugs.webkit.org/show_bug.cgi?id=304824">https://bugs.webkit.org/show_bug.cgi?id=304824</a>

Reviewed by Xabier Rodriguez-Calvar.

* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::webrtcDtlsTransportStateName):
(WebCore::webrtcDtlsRoleName):
(WebCore::gstStructureValueToJSON):

Canonical link: <a href="https://commits.webkit.org/305285@main">https://commits.webkit.org/305285@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f9df3858ae2a1fd6ff91ce761ce4e4d263da8034

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137250 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9610 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48537 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145001 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90223 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139122 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10313 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9737 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104958 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/76706 "Exiting early after 60 failures. 21530 tests run. 60 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140195 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7610 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123005 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85803 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7247 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4963 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5588 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116607 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41162 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147758 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9293 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41724 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113321 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9311 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7822 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113657 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29036 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7169 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119254 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63811 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9342 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37308 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9069 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72907 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9282 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9134 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->