### PR TITLE
Reduce unsafeness in mediasource/ code

### DIFF
--- a/Source/WebCore/Modules/mediasource/MediaSourceHandle.h
+++ b/Source/WebCore/Modules/mediasource/MediaSourceHandle.h
@@ -76,7 +76,7 @@ private:
 
     const bool m_detachable;
     bool m_detached { false };
-    Ref<SharedPrivate> m_private;
+    const Ref<SharedPrivate> m_private;
 };
 
 using DetachedMediaSourceHandle = MediaSourceHandle;

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -169,7 +169,7 @@ private:
 
 Ref<SourceBuffer> SourceBuffer::create(Ref<SourceBufferPrivate>&& sourceBufferPrivate, MediaSource& source)
 {
-    auto sourceBuffer = adoptRef(*new SourceBuffer(WTF::move(sourceBufferPrivate), source));
+    Ref sourceBuffer = adoptRef(*new SourceBuffer(WTF::move(sourceBufferPrivate), source));
     sourceBuffer->suspendIfNeeded();
     return sourceBuffer;
 }
@@ -929,7 +929,7 @@ Ref<MediaPromise> SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegme
             // FIXME: Implement steps 5.2.1-5.2.8.1 as per Editor's Draft 09 January 2015, and reorder this
             // 5.2.1 Let new audio track be a new AudioTrack object.
             // 5.2.2 Generate a unique ID and assign it to the id property on new video track.
-            auto newAudioTrack = AudioTrack::create(protectedScriptExecutionContext().get(), Ref { *audioTrackInfo.track });
+            Ref newAudioTrack = AudioTrack::create(protectedScriptExecutionContext().get(), Ref { *audioTrackInfo.track });
             newAudioTrack->addClient(*this);
             newAudioTrack->setSourceBuffer(this);
 
@@ -976,7 +976,7 @@ Ref<MediaPromise> SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegme
             // FIXME: Implement steps 5.3.1-5.3.8.1 as per Editor's Draft 09 January 2015, and reorder this
             // 5.3.1 Let new video track be a new VideoTrack object.
             // 5.3.2 Generate a unique ID and assign it to the id property on new video track.
-            auto newVideoTrack = VideoTrack::create(protectedScriptExecutionContext().get(), Ref { *videoTrackInfo.track });
+            Ref newVideoTrack = VideoTrack::create(protectedScriptExecutionContext().get(), Ref { *videoTrackInfo.track });
             newVideoTrack->addClient(*this);
             newVideoTrack->setSourceBuffer(this);
 
@@ -1020,24 +1020,24 @@ Ref<MediaPromise> SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegme
 
         // 5.4 For each text track in the initialization segment, run following steps:
         for (auto& textTrackInfo : segment.textTracks) {
-            auto& textTrackPrivate = *textTrackInfo.track;
+            Ref textTrackPrivate = *textTrackInfo.track;
 
             // FIXME: Implement steps 5.4.1-5.4.8.1 as per Editor's Draft 09 January 2015, and reorder this
             // 5.4.1 Let new text track be a new TextTrack object with its properties populated with the
             // appropriate information from the initialization segment.
-            auto newTextTrack = InbandTextTrack::create(*protectedScriptExecutionContext(), textTrackPrivate);
+            Ref newTextTrack = InbandTextTrack::create(*protectedScriptExecutionContext(), textTrackPrivate);
             newTextTrack->addClient(*this);
 
             // 5.4.2 If the mode property on new text track equals "showing" or "hidden", then set active
             // track flag to true.
-            if (textTrackPrivate.mode() != InbandTextTrackPrivate::Mode::Disabled)
+            if (textTrackPrivate->mode() != InbandTextTrackPrivate::Mode::Disabled)
                 activeTrackFlag = true;
 
             // 5.4.3 Add new text track to the textTracks attribute on this SourceBuffer object.
             // 5.4.4 Queue a task to fire a trusted event named addtrack, that does not bubble and is
             // not cancelable, and that uses the TrackEvent interface, at textTracks attribute on this
             // SourceBuffer object.
-            textTracks->append(newTextTrack.get());
+            textTracks->append(newTextTrack);
 
             // 5.4.5 Add new text track to the textTracks attribute on the HTMLMediaElement.
             // 5.4.6 Queue a task to fire a trusted event named addtrack, that does not bubble and is
@@ -1051,13 +1051,13 @@ Ref<MediaPromise> SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegme
                 // Let mirrored text track be a new TextTrack object.
                 // Assign the same property values to mirrored text track as were determined for new text track.
                 // Add mirrored text track to the textTracks attribute on the HTMLMediaElement.
-                source->addTextTrackMirrorToElement(textTrackPrivate);
+                source->addTextTrackMirrorToElement(textTrackPrivate.get());
             }
 
             m_textCodecs.append(RefPtr { textTrackInfo.description }->codec().toAtomString());
 
             // 5.4.7 Create a new track buffer to store coded frames for this track.
-            m_private->addTrackBuffer(textTrackPrivate.id(), WTF::move(textTrackInfo.description));
+            m_private->addTrackBuffer(textTrackPrivate->id(), WTF::move(textTrackInfo.description));
         }
 
         // 5.5 If active track flag equals true, then run the following steps:
@@ -1405,11 +1405,11 @@ void SourceBuffer::updateBuffered()
         if (isManaged()) {
             auto addedRanges = m_buffered->ranges();
             addedRanges -= oldRanges;
-            auto addedTimeRanges = TimeRanges::create(WTF::move(addedRanges));
+            Ref addedTimeRanges = TimeRanges::create(WTF::move(addedRanges));
 
             auto removedRanges = oldRanges;
             removedRanges -= m_buffered->ranges();
-            auto removedTimeRanges = TimeRanges::create(WTF::move(removedRanges));
+            Ref removedTimeRanges = TimeRanges::create(WTF::move(removedRanges));
 
             queueTaskToDispatchEvent(*this, TaskSource::MediaElement, BufferedChangeEvent::create(WTF::move(addedTimeRanges), WTF::move(removedTimeRanges)));
         }

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -10,7 +10,6 @@ Modules/mediasession/MediaMetadata.cpp
 Modules/mediasession/MediaSession.cpp
 [ Mac ] Modules/mediasession/MediaSessionCoordinator.cpp
 [ Mac ] Modules/mediasession/MediaSessionCoordinator.h
-Modules/mediasource/MediaSourceHandle.cpp
 Modules/mediastream/MediaStreamTrack.cpp
 Modules/mediastream/MediaStreamTrackProcessor.cpp
 Modules/mediastream/RTCDTMFSender.cpp
@@ -636,7 +635,6 @@ platform/mediastream/mac/RealtimeOutgoingAudioSourceCocoa.cpp
 platform/mediastream/mac/WebAudioSourceProviderCocoa.mm
 platform/mock/MockRealtimeVideoSource.cpp
 platform/mock/RTCNotifiersMock.cpp
-platform/mock/mediasource/MockMediaSourcePrivate.cpp
 platform/network/mac/ResourceHandleMac.mm
 platform/network/mac/WebCoreResourceHandleAsOperationQueueDelegate.mm
 platform/text/BidiContext.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -1,7 +1,6 @@
 Modules/mediacapabilities/MediaCapabilities.cpp
 Modules/mediacontrols/MediaControlsHost.cpp
 [ Mac ] Modules/mediasession/MediaSession.cpp
-Modules/mediasource/SourceBuffer.cpp
 Modules/model-element/HTMLModelElement.cpp
 Modules/webaudio/AudioBasicProcessorNode.cpp
 Modules/webaudio/AudioBuffer.cpp

--- a/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.cpp
@@ -38,7 +38,7 @@ namespace WebCore {
 
 Ref<MockMediaSourcePrivate> MockMediaSourcePrivate::create(MockMediaPlayerMediaSource& parent, MediaSourcePrivateClient& client)
 {
-    auto source = adoptRef(*new MockMediaSourcePrivate(parent, client));
+    Ref source = adoptRef(*new MockMediaSourcePrivate(parent, client));
     client.setPrivateAndOpen(source.copyRef());
     return source;
 }
@@ -47,12 +47,12 @@ MockMediaSourcePrivate::MockMediaSourcePrivate(MockMediaPlayerMediaSource& paren
     : MediaSourcePrivate(client)
     , m_player(parent)
 #if !RELEASE_LOG_DISABLED
-    , m_logger(m_player->mediaPlayerLogger())
-    , m_logIdentifier(m_player->mediaPlayerLogIdentifier())
+    , m_logger(parent.mediaPlayerLogger())
+    , m_logIdentifier(parent.mediaPlayerLogIdentifier())
 #endif
 {
 #if !RELEASE_LOG_DISABLED
-    client.setLogIdentifier(m_player->mediaPlayerLogIdentifier());
+    client.setLogIdentifier(parent.mediaPlayerLogIdentifier());
 #endif
 }
 
@@ -89,14 +89,14 @@ void MockMediaSourcePrivate::setPlayer(MediaPlayerPrivateInterface* player)
 void MockMediaSourcePrivate::durationChanged(const MediaTime& duration)
 {
     MediaSourcePrivate::durationChanged(duration);
-    if (m_player)
-        m_player->updateDuration(duration);
+    if (RefPtr player = m_player.get())
+        player->updateDuration(duration);
 }
 
 void MockMediaSourcePrivate::notifyActiveSourceBuffersChanged()
 {
-    if (m_player)
-        m_player->notifyActiveSourceBuffersChanged();
+    if (RefPtr player = m_player.get())
+        player->notifyActiveSourceBuffersChanged();
 }
 
 std::optional<VideoPlaybackQualityMetrics> MockMediaSourcePrivate::videoPlaybackQualityMetrics()


### PR DESCRIPTION
#### 4c9de0fedc467446f345d420bca0b7360805f205
<pre>
Reduce unsafeness in mediasource/ code
<a href="https://bugs.webkit.org/show_bug.cgi?id=304830">https://bugs.webkit.org/show_bug.cgi?id=304830</a>

Reviewed by Chris Dumez.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

Canonical link: <a href="https://commits.webkit.org/305046@main">https://commits.webkit.org/305046@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fbb26ee875108e3dbdfe1f9f3dafaf252352be05

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137282 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9642 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48569 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145033 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/90255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/50d3b330-7576-4f14-9c48-a0bd04c84bdb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139154 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10346 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9769 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/104973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/90255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/286cdb06-2a33-45dc-a885-7eeb32441db4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140227 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7639 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/123033 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/85827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/43d0b6fd-471e-414d-a2dc-8d5098983b61) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7276 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4992 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5620 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116638 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41187 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147790 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9325 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41749 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/113342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9343 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7847 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113683 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7195 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119279 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63867 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21151 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9374 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37333 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9103 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72939 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9314 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9166 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->