### PR TITLE
[JSC] Introduce PromiseReactionChain job which merges multiple chains into one

### DIFF
--- a/Source/JavaScriptCore/runtime/JSMicrotask.cpp
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.cpp
@@ -597,7 +597,62 @@ static void asyncGeneratorResumeNextReturn(JSGlobalObject* globalObject, JSAsync
     }
 }
 
-void runInternalMicrotask(JSGlobalObject* globalObject, InternalMicrotask task, uint8_t payload, std::span<const JSValue, maxMicrotaskArguments> arguments)
+static void promiseReactionJob(JSGlobalObject* globalObject, VM& vm, JSValue promiseOrCapability, JSValue handler, JSValue argument)
+{
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue result;
+    JSValue error;
+    {
+        auto catchScope = DECLARE_CATCH_SCOPE(vm);
+        result = callMicrotask(globalObject, handler, jsUndefined(), dynamicCastToCell(handler), ArgList { std::bit_cast<EncodedJSValue*>(&argument), 1 }, "handler is not a function"_s);
+        if (catchScope.exception()) {
+            if (promiseOrCapability.isUndefinedOrNull()) {
+                scope.release();
+                return;
+            }
+            error = catchScope.exception()->value();
+            if (!catchScope.clearExceptionExceptTermination()) [[unlikely]] {
+                scope.release();
+                return;
+            }
+        }
+
+        if (promiseOrCapability.isUndefinedOrNull()) {
+            scope.release();
+            return;
+        }
+    }
+
+    if (error) {
+        if (auto* promise = jsDynamicCast<JSPromise*>(promiseOrCapability))
+            RELEASE_AND_RETURN(scope, promise->rejectPromise(vm, globalObject, error));
+
+        JSValue reject = promiseOrCapability.get(globalObject, vm.propertyNames->reject);
+        RETURN_IF_EXCEPTION(scope, void());
+
+        MarkedArgumentBuffer arguments;
+        arguments.append(error);
+        ASSERT(!arguments.hasOverflowed());
+        scope.release();
+        call(globalObject, reject, jsUndefined(), arguments, "reject is not a function"_s);
+        return;
+    }
+
+    if (auto* promise = jsDynamicCast<JSPromise*>(promiseOrCapability))
+        RELEASE_AND_RETURN(scope, promise->resolvePromise(globalObject, result));
+
+    JSValue resolve = promiseOrCapability.get(globalObject, vm.propertyNames->resolve);
+    RETURN_IF_EXCEPTION(scope, void());
+
+    MarkedArgumentBuffer arguments;
+    arguments.append(result);
+    ASSERT(!arguments.hasOverflowed());
+    scope.release();
+    call(globalObject, resolve, jsUndefined(), arguments, "resolve is not a function"_s);
+}
+
+void runInternalMicrotaskImpl(JSGlobalObject* globalObject, InternalMicrotask task, uint8_t payload, std::span<const JSValue, maxMicrotaskArguments> arguments)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -701,58 +756,43 @@ void runInternalMicrotask(JSGlobalObject* globalObject, InternalMicrotask task, 
         RELEASE_AND_RETURN(scope, internalPromiseAllResolveJob(globalObject, vm, jsCast<JSPromise*>(arguments[0]), arguments[1], jsCast<JSPromiseCombinatorsContext*>(arguments[2]), static_cast<JSPromise::Status>(payload)));
 
     case InternalMicrotask::PromiseReactionJob: {
-        JSValue promiseOrCapability = arguments[0];
-        JSValue handler = arguments[1];
+        RELEASE_AND_RETURN(scope, promiseReactionJob(globalObject, vm, arguments[0], arguments[1], arguments[2]));
+    }
 
-        JSValue result;
-        JSValue error;
-        {
-            auto catchScope = DECLARE_CATCH_SCOPE(vm);
-            result = callMicrotask(globalObject, handler, jsUndefined(), dynamicCastToCell(handler), ArgList { std::bit_cast<EncodedJSValue*>(arguments.data() + 2), 1 }, "handler is not a function"_s);
-            if (catchScope.exception()) {
-                if (promiseOrCapability.isUndefinedOrNull()) {
-                    scope.release();
-                    return;
+    case InternalMicrotask::PromiseReactionChain: {
+        auto* head = jsCast<JSPromiseReaction*>(arguments[0].asCell());
+        auto status = static_cast<JSPromise::Status>(payload);
+
+        // Execute each reaction (chain is already in FIFO order).
+        auto* current = head;
+        while (current) {
+            JSValue promise = current->promise();
+            JSValue handler = current->onFulfilled();
+            JSValue argument = current->onRejected();
+            JSValue context = current->context();
+            JSPromiseReaction* next = current->next();
+            {
+                auto catchScope = DECLARE_CATCH_SCOPE(vm);
+                if (handler.isInt32()) {
+                    // Internal handler (encoded as int32).
+                    auto internalTask = static_cast<InternalMicrotask>(handler.asInt32());
+                    std::array<JSValue, maxMicrotaskArguments> internalArgs { { promise, argument, context } };
+                    runInternalMicrotaskImpl(globalObject, internalTask, static_cast<uint8_t>(status), std::span<const JSValue, maxMicrotaskArguments>(internalArgs.data(), maxMicrotaskArguments));
+                } else {
+                    // User JS callback - inline PromiseReactionJob logic.
+                    ASSERT(context.isUndefinedOrNull());
+                    promiseReactionJob(globalObject, vm, promise, handler, argument);
                 }
-                error = catchScope.exception()->value();
-                if (!catchScope.clearExceptionExceptTermination()) [[unlikely]] {
-                    scope.release();
-                    return;
+                if (catchScope.exception()) [[unlikely]] {
+                    if (catchScope.clearExceptionExceptTermination()) [[unlikely]] {
+                        scope.release();
+                        return;
+                    }
                 }
             }
-
-            if (promiseOrCapability.isUndefinedOrNull()) {
-                scope.release();
-                return;
-            }
+            current = next;
         }
-
-        if (error) {
-            if (auto* promise = jsDynamicCast<JSPromise*>(promiseOrCapability))
-                RELEASE_AND_RETURN(scope, promise->rejectPromise(vm, globalObject, error));
-
-            JSValue reject = promiseOrCapability.get(globalObject, vm.propertyNames->reject);
-            RETURN_IF_EXCEPTION(scope, void());
-
-            MarkedArgumentBuffer arguments;
-            arguments.append(error);
-            ASSERT(!arguments.hasOverflowed());
-            scope.release();
-            call(globalObject, reject, jsUndefined(), arguments, "reject is not a function"_s);
-            return;
-        }
-
-        if (auto* promise = jsDynamicCast<JSPromise*>(promiseOrCapability))
-            RELEASE_AND_RETURN(scope, promise->resolvePromise(globalObject, result));
-
-        JSValue resolve = promiseOrCapability.get(globalObject, vm.propertyNames->resolve);
-        RETURN_IF_EXCEPTION(scope, void());
-
-        MarkedArgumentBuffer arguments;
-        arguments.append(result);
-        ASSERT(!arguments.hasOverflowed());
         scope.release();
-        call(globalObject, resolve, jsUndefined(), arguments, "resolve is not a function"_s);
         return;
     }
 
@@ -853,6 +893,11 @@ void runInternalMicrotask(JSGlobalObject* globalObject, InternalMicrotask task, 
         return;
     }
     }
+}
+
+void runInternalMicrotask(JSGlobalObject* globalObject, InternalMicrotask task, uint8_t payload, std::span<const JSValue, maxMicrotaskArguments> arguments)
+{
+    return runInternalMicrotaskImpl(globalObject, task, payload, arguments);
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSMicrotask.h
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.h
@@ -31,6 +31,7 @@
 
 namespace JSC {
 
+void runInternalMicrotaskImpl(JSGlobalObject*, InternalMicrotask, uint8_t, std::span<const JSValue, maxMicrotaskArguments>);
 JS_EXPORT_PRIVATE void runInternalMicrotask(JSGlobalObject*, InternalMicrotask, uint8_t, std::span<const JSValue, maxMicrotaskArguments>);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSPromise.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromise.cpp
@@ -558,35 +558,24 @@ void JSPromise::triggerPromiseReactions(VM& vm, JSGlobalObject* globalObject, St
     if (!head)
         return;
 
-    // Reverse the order of singly-linked-list.
+
+    bool isResolved = status == JSPromise::Status::Fulfilled;
+    JSPromiseReaction* tail = head;
     JSPromiseReaction* previous = nullptr;
     {
         auto* current = head;
         while (current) {
             auto* next = current->next();
             current->setNext(vm, previous);
+            if (!isResolved && !current->onFulfilled().isInt32())
+                current->setOnFulfilled(vm, current->onRejected());
+            current->setOnRejected(vm, argument);
             previous = current;
             current = next;
         }
     }
     head = previous;
-
-    bool isResolved = status == JSPromise::Status::Fulfilled;
-    auto* current = head;
-    while (current) {
-        JSValue promise = current->promise();
-        JSValue handler = isResolved ? current->onFulfilled() : current->onRejected();
-        JSValue context = current->context();
-        current = current->next();
-
-        if (handler.isInt32()) {
-            auto task = static_cast<InternalMicrotask>(handler.asInt32());
-            globalObject->queueMicrotask(task, static_cast<uint8_t>(status), promise, argument, context);
-            continue;
-        }
-        ASSERT(context.isUndefinedOrNull());
-        globalObject->queueMicrotask(InternalMicrotask::PromiseReactionJob, static_cast<uint8_t>(status), promise, handler, argument);
-    }
+    globalObject->queueMicrotask(InternalMicrotask::PromiseReactionChain, static_cast<uint8_t>(status), JSValue(head), JSValue(tail), jsUndefined());
 }
 
 void JSPromise::resolveWithInternalMicrotaskForAsyncAwait(JSGlobalObject* globalObject, JSValue resolution, InternalMicrotask task, JSValue context)
@@ -615,7 +604,7 @@ void JSPromise::resolveWithInternalMicrotaskForAsyncAwait(JSGlobalObject* global
                 error,
                 context,
             } };
-            runInternalMicrotask(globalObject, task, static_cast<uint8_t>(JSPromise::Status::Rejected), arguments);
+            runInternalMicrotaskImpl(globalObject, task, static_cast<uint8_t>(JSPromise::Status::Rejected), arguments);
             return;
         }
 

--- a/Source/JavaScriptCore/runtime/Microtask.h
+++ b/Source/JavaScriptCore/runtime/Microtask.h
@@ -49,6 +49,7 @@ enum class InternalMicrotask : uint8_t {
     InternalPromiseAllResolveJob,
 
     PromiseReactionJob,
+    PromiseReactionChain,
 
     AsyncFunctionResume,
     AsyncFromSyncIteratorContinue,

--- a/Source/JavaScriptCore/runtime/MicrotaskQueue.cpp
+++ b/Source/JavaScriptCore/runtime/MicrotaskQueue.cpp
@@ -32,6 +32,7 @@
 #include "JSGlobalObject.h"
 #include "JSMicrotask.h"
 #include "JSObject.h"
+#include "JSPromiseReaction.h"
 #include "SlotVisitorInlines.h"
 #include <wtf/SetForScope.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -65,7 +66,7 @@ QueuedTaskResult DebuggableMicrotaskDispatcher::run(QueuedTask& task)
             return QueuedTask::Result::Executed;
     }
 
-    runInternalMicrotask(globalObject, task.job(), task.payload(), task.arguments());
+    runInternalMicrotaskImpl(globalObject, task.job(), task.payload(), task.arguments());
     if (!catchScope.clearExceptionExceptTermination()) [[unlikely]]
         return QueuedTask::Result::Executed;
 
@@ -103,15 +104,61 @@ void MicrotaskQueue::visitAggregateImpl(Visitor& visitor)
 }
 DEFINE_VISIT_AGGREGATE(MicrotaskQueue);
 
+bool MarkedMicrotaskDeque::tryMergePromiseReactionChain(VM& vm, QueuedTask& newTask)
+{
+    if (m_queue.isEmpty())
+        return false;
+
+    QueuedTask& lastTask = m_queue.last();
+
+    // Must match: task type, globalObject, dispatcher, status (payload).
+    if (lastTask.job() != InternalMicrotask::PromiseReactionChain)
+        return false;
+    if (lastTask.globalObject() != newTask.globalObject())
+        return false;
+    if (lastTask.dispatcher() != newTask.dispatcher())
+        return false;
+    if (lastTask.payload() != newTask.payload())
+        return false;
+
+    // Get tail of existing chain and head/tail of new chain.
+    auto* existingTail = jsCast<JSPromiseReaction*>(lastTask.m_arguments[1].asCell());
+    auto* newHead = jsCast<JSPromiseReaction*>(newTask.m_arguments[0].asCell());
+    auto* newTail = jsCast<JSPromiseReaction*>(newTask.m_arguments[1].asCell());
+
+    // Link chains: existing tail -> new head (write barrier handled by setNext).
+    existingTail->setNext(vm, newHead);
+
+    // Update tail pointer in existing task.
+    lastTask.m_arguments[1] = JSValue(newTail);
+
+    // Handle GC marking: if merged into already-marked entry, reset cursor.
+    size_t lastIndex = m_queue.size() - 1;
+    if (lastIndex < m_markedBefore)
+        m_markedBefore = lastIndex;
+
+    return true;
+}
+
 void MicrotaskQueue::enqueue(QueuedTask&& task)
 {
     auto* globalObject = task.globalObject();
     auto identifier = task.identifier();
-    m_queue.enqueue(WTF::move(task));
     if (globalObject) {
-        if (auto* debugger = globalObject->debugger(); debugger && identifier) [[unlikely]]
+        if (auto* debugger = globalObject->debugger(); debugger && identifier) [[unlikely]] {
+            m_queue.enqueue(WTF::move(task));
             debugger->didQueueMicrotask(globalObject, identifier.value());
+            return;
+        }
+
+        if (task.job() == InternalMicrotask::PromiseReactionChain) {
+            VM& vm = globalObject->vm();
+            if (m_queue.tryMergePromiseReactionChain(vm, task))
+                return;
+        }
     }
+
+    m_queue.enqueue(WTF::move(task));
 }
 
 bool MarkedMicrotaskDeque::hasMicrotasksForFullyActiveDocument() const

--- a/Source/JavaScriptCore/runtime/MicrotaskQueue.h
+++ b/Source/JavaScriptCore/runtime/MicrotaskQueue.h
@@ -189,6 +189,7 @@ public:
     }
 
     JS_EXPORT_PRIVATE bool hasMicrotasksForFullyActiveDocument() const;
+    bool tryMergePromiseReactionChain(VM&, QueuedTask& newTask);
 
     DECLARE_VISIT_AGGREGATE;
 

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -1361,7 +1361,7 @@ void VM::drainMicrotasks()
                         return dispatcher->run(task);
 
                     auto catchScope = DECLARE_CATCH_SCOPE(*this);
-                    runInternalMicrotask(globalObject, task.job(), task.payload(), task.arguments());
+                    runInternalMicrotaskImpl(globalObject, task.job(), task.payload(), task.arguments());
                     catchScope.clearExceptionExceptTermination();
                     return QueuedTask::Result::Executed;
                 });


### PR DESCRIPTION
#### 6b5e00ba4b34f3ea823b8514fc198fb7e938ba48
<pre>
[JSC] Introduce PromiseReactionChain job which merges multiple chains into one
<a href="https://bugs.webkit.org/show_bug.cgi?id=304832">https://bugs.webkit.org/show_bug.cgi?id=304832</a>
<a href="https://rdar.apple.com/167408029">rdar://167408029</a>

Reviewed by NOBODY (OOPS!).

Waiting for A/B test results...

* Source/JavaScriptCore/runtime/JSMicrotask.cpp:
(JSC::promiseReactionJob):
(JSC::runInternalMicrotaskImpl):
(JSC::runInternalMicrotask):
* Source/JavaScriptCore/runtime/JSMicrotask.h:
* Source/JavaScriptCore/runtime/JSPromise.cpp:
(JSC::JSPromise::triggerPromiseReactions):
(JSC::JSPromise::resolveWithInternalMicrotaskForAsyncAwait):
* Source/JavaScriptCore/runtime/Microtask.h:
* Source/JavaScriptCore/runtime/MicrotaskQueue.cpp:
(JSC::DebuggableMicrotaskDispatcher::run):
(JSC::MarkedMicrotaskDeque::tryMergePromiseReactionChain):
(JSC::MicrotaskQueue::enqueue):
* Source/JavaScriptCore/runtime/MicrotaskQueue.h:
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::drainMicrotasks):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b5e00ba4b34f3ea823b8514fc198fb7e938ba48

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137269 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9629 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48556 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145020 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90242 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b37c21fd-7ee5-4329-b039-5a994ba4b47c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10333 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9756 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104965 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f1fb61cf-7cae-4b7b-a7a9-0112eac6dbab) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140214 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7627 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123023 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85817 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/87efc525-2665-4127-880c-e63ed9e8e982) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7264 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4980 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5607 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/129230 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116625 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41178 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147777 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/135778 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9312 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41740 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113332 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9330 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7837 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113672 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7184 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119270 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63847 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9361 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37324 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/168538 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9089 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72926 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44000 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9301 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9153 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->