### PR TITLE
[LegacySVG] Don't check 'visibility' in LegacyRenderSVGResourceMasker

### DIFF
--- a/LayoutTests/svg/masking/mask-with-visibility-hidden-group-expected.html
+++ b/LayoutTests/svg/masking/mask-with-visibility-hidden-group-expected.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<div style="width: 100px; height: 100px; background-color: green"></div>

--- a/LayoutTests/svg/masking/mask-with-visibility-hidden-group.html
+++ b/LayoutTests/svg/masking/mask-with-visibility-hidden-group.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<svg>
+  <mask id="m">
+    <g visibility="hidden">
+      <rect width="100" height="100" fill="white" visibility="visible"/>
+      <rect width="200" height="100" fill="white"/>
+    </g>
+  </mask>
+  <rect width="200" height="100" fill="green" mask="url(#m)"/>
+</svg>

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.cpp
@@ -145,7 +145,7 @@ bool LegacyRenderSVGResourceMasker::drawContentIntoContext(GraphicsContext& cont
         if (renderer->needsLayout())
             return false;
         const CheckedRef style = renderer->style();
-        if (style->display() == DisplayType::None || style->usedVisibility() != Visibility::Visible)
+        if (style->display() == DisplayType::None)
             continue;
         SVGRenderingContext::renderSubtreeToContext(context, *renderer, maskContentTransformation);
     }
@@ -176,7 +176,7 @@ void LegacyRenderSVGResourceMasker::calculateMaskContentRepaintRect(RepaintRectC
         if (!renderer || !childNode->isSVGElement())
             continue;
         const CheckedRef style = renderer->style();
-        if (style->display() == DisplayType::None || style->usedVisibility() != Visibility::Visible)
+        if (style->display() == DisplayType::None)
              continue;
         m_maskContentBoundaries[repaintRectCalculation].unite(renderer->localToParentTransform().mapRect(renderer->repaintRectInLocalCoordinates(repaintRectCalculation)));
     }


### PR DESCRIPTION
#### bda153efaee1cfabc72f28b67690ebfeeb8a3e90
<pre>
[LegacySVG] Don&apos;t check &apos;visibility&apos; in LegacyRenderSVGResourceMasker
<a href="https://bugs.webkit.org/show_bug.cgi?id=297045">https://bugs.webkit.org/show_bug.cgi?id=297045</a>
<a href="https://rdar.apple.com/157729389">rdar://157729389</a>

Reviewed by Nikolas Zimmermann.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium. Note,
this bug does not exist in Layer Based SVG engine (LBSE).

Merge: <a href="https://chromium.googlesource.com/chromium/src/+/51a75fa55ba71462963ddcf085995cf3eca66104">https://chromium.googlesource.com/chromium/src/+/51a75fa55ba71462963ddcf085995cf3eca66104</a>

Since &apos;visibility&apos; does not work in the same way as &apos;display&apos;, it&apos;s not
possible to &quot;prune&quot; subtrees based on non-&apos;visible&apos; values of the
property. Remove the check from the two methods that use it, and leave
to lower levels to handle it.

* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.cpp:
(WebCore::LegacyRenderSVGResourceMasker::drawContentIntoContext):
(WebCore::LegacyRenderSVGResourceMasker::calculateMaskContentRepaintRect):
* LayoutTests/svg/masking/mask-with-visibility-hidden-group-expected.html: Added.
* LayoutTests/svg/masking/mask-with-visibility-hidden-group.html: Added.

Canonical link: <a href="https://commits.webkit.org/305047@main">https://commits.webkit.org/305047@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa9719728467340e9c8eff9cdc6c7ff013fac5e3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137270 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9630 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48557 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145021 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90243 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e5c95861-2e24-4ff9-98c1-1ee3eeb3af6e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139142 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10334 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9757 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104966 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f6c7f8f3-2ea0-4952-80fc-c0e3f387550f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140215 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7628 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123024 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85818 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e18212ed-003e-4497-b280-ba61d6abf2bf) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7265 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4981 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5608 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116626 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41179 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147778 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9313 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41741 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113333 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9331 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7838 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113674 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28870 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7185 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119271 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63848 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9362 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37325 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9090 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72927 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9302 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9154 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->