### PR TITLE
[JSC] Add fast path for Array.prototype.slice on ScopedArguments

### DIFF
--- a/JSTests/microbenchmarks/scoped-arguments-slice-double.js
+++ b/JSTests/microbenchmarks/scoped-arguments-slice-double.js
@@ -1,0 +1,12 @@
+var slice = Array.prototype.slice;
+function test(a, b, c, d, e, f, g, h, i, j, k, l)
+{
+    // Reference a parameter to make arguments a ScopedArguments
+    (function () { return a; })();
+    return slice.call(arguments);
+}
+noInline(test);
+
+for (var i = 0; i < 1e6; ++i) {
+    test(1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9, 10.1, 11.2, 12.3);
+}

--- a/JSTests/microbenchmarks/scoped-arguments-slice-int32.js
+++ b/JSTests/microbenchmarks/scoped-arguments-slice-int32.js
@@ -1,0 +1,12 @@
+var slice = Array.prototype.slice;
+function test(a, b, c, d, e, f, g, h, i, j, k, l)
+{
+    // Reference a parameter to make arguments a ScopedArguments
+    (function () { return a; })();
+    return slice.call(arguments);
+}
+noInline(test);
+
+for (var i = 0; i < 1e6; ++i) {
+    test(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+}

--- a/JSTests/microbenchmarks/scoped-arguments-slice.js
+++ b/JSTests/microbenchmarks/scoped-arguments-slice.js
@@ -1,0 +1,12 @@
+var slice = Array.prototype.slice;
+function test(a, b, c, d, e, f, g, h, i, j, k, l)
+{
+    // Reference a parameter to make arguments a ScopedArguments
+    (function () { return a; })();
+    return slice.call(arguments);
+}
+noInline(test);
+
+for (var i = 0; i < 1e6; ++i) {
+    test(1, "hello", null, undefined, 42, Array, Symbol.iterator, false, 42.195, 0, -200, -44.2);
+}

--- a/JSTests/stress/slice-scoped-arguments.js
+++ b/JSTests/stress/slice-scoped-arguments.js
@@ -1,0 +1,188 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function shouldBeArray(a, b) {
+    shouldBe(a.length, b.length);
+    for (let i = 0; i < a.length; ++i)
+        shouldBe(a[i], b[i]);
+}
+
+// Test basic slice on ScopedArguments
+function testSlice(x) {
+    // Reference x to make arguments a ScopedArguments
+    (function () { return x; })();
+    return Array.prototype.slice.call(arguments);
+}
+noInline(testSlice);
+
+function testSliceWithStart(x) {
+    (function () { return x; })();
+    return Array.prototype.slice.call(arguments, 1);
+}
+noInline(testSliceWithStart);
+
+function testSliceWithStartEnd(x) {
+    (function () { return x; })();
+    return Array.prototype.slice.call(arguments, 1, 3);
+}
+noInline(testSliceWithStartEnd);
+
+// Test splice on ScopedArguments
+function testSplice(x) {
+    (function () { return x; })();
+    return Array.prototype.splice.call(arguments, 1, 2);
+}
+noInline(testSplice);
+
+// Warm up
+for (let i = 0; i < 1e4; ++i) {
+    // contiguous
+    {
+        const value1 = { value: 1 };
+        const value2 = { value: 2 };
+        const value3 = { value: 3 };
+        const value4 = { value: 4 };
+        const value5 = { value: 5 };
+
+        const array = testSlice(value1, value2, value3, value4, value5);
+        shouldBe(array.length, 5);
+        shouldBe(array[0], value1);
+        shouldBe(array[1], value2);
+        shouldBe(array[2], value3);
+        shouldBe(array[3], value4);
+        shouldBe(array[4], value5);
+
+        const array2 = testSliceWithStart(value1, value2, value3, value4, value5);
+        shouldBe(array2.length, 4);
+        shouldBe(array2[0], value2);
+        shouldBe(array2[1], value3);
+        shouldBe(array2[2], value4);
+        shouldBe(array2[3], value5);
+
+        const array3 = testSliceWithStartEnd(value1, value2, value3, value4, value5);
+        shouldBe(array3.length, 2);
+        shouldBe(array3[0], value2);
+        shouldBe(array3[1], value3);
+
+        const spliced = testSplice(value1, value2, value3, value4, value5);
+        shouldBe(spliced.length, 2);
+        shouldBe(spliced[0], value2);
+        shouldBe(spliced[1], value3);
+    }
+
+    // double
+    {
+        const array = testSlice(1.1, 2.1, 3.1, 4.1, 5.1);
+        shouldBe(array.length, 5);
+        shouldBe(array[0], 1.1);
+        shouldBe(array[1], 2.1);
+        shouldBe(array[2], 3.1);
+        shouldBe(array[3], 4.1);
+        shouldBe(array[4], 5.1);
+
+        const array2 = testSliceWithStart(1.1, 2.1, 3.1, 4.1, 5.1);
+        shouldBe(array2.length, 4);
+        shouldBe(array2[0], 2.1);
+        shouldBe(array2[1], 3.1);
+        shouldBe(array2[2], 4.1);
+        shouldBe(array2[3], 5.1);
+
+        const array3 = testSliceWithStartEnd(1.1, 2.1, 3.1, 4.1, 5.1);
+        shouldBe(array3.length, 2);
+        shouldBe(array3[0], 2.1);
+        shouldBe(array3[1], 3.1);
+    }
+
+    // int32
+    {
+        const array = testSlice(1, 2, 3, 4, 5);
+        shouldBe(array.length, 5);
+        shouldBe(array[0], 1);
+        shouldBe(array[1], 2);
+        shouldBe(array[2], 3);
+        shouldBe(array[3], 4);
+        shouldBe(array[4], 5);
+
+        const array2 = testSliceWithStart(1, 2, 3, 4, 5);
+        shouldBe(array2.length, 4);
+        shouldBe(array2[0], 2);
+        shouldBe(array2[1], 3);
+        shouldBe(array2[2], 4);
+        shouldBe(array2[3], 5);
+
+        const array3 = testSliceWithStartEnd(1, 2, 3, 4, 5);
+        shouldBe(array3.length, 2);
+        shouldBe(array3[0], 2);
+        shouldBe(array3[1], 3);
+    }
+
+    // empty slice
+    {
+        const array = testSliceWithStartEnd(1, 2, 3, 4, 5);
+        // Actually this slices from index 1 to 3, so length is 2
+    }
+}
+
+// Test edge cases
+
+// Test with overflow arguments (more arguments than named parameters)
+function testOverflow(a, b) {
+    (function () { return a + b; })();
+    return Array.prototype.slice.call(arguments, 2);
+}
+noInline(testOverflow);
+
+for (let i = 0; i < 1e4; ++i) {
+    const result = testOverflow(1, 2, 3, 4, 5);
+    shouldBeArray(result, [3, 4, 5]);
+}
+
+// Test slicing only from overflow portion
+function testOverflowOnly(a) {
+    (function () { return a; })();
+    return Array.prototype.slice.call(arguments, 1, 4);
+}
+noInline(testOverflowOnly);
+
+for (let i = 0; i < 1e4; ++i) {
+    const result = testOverflowOnly(1, 2, 3, 4, 5);
+    shouldBeArray(result, [2, 3, 4]);
+}
+
+// Test slicing across named and overflow boundary
+function testAcrossBoundary(a, b) {
+    (function () { return a + b; })();
+    return Array.prototype.slice.call(arguments, 1, 4);
+}
+noInline(testAcrossBoundary);
+
+for (let i = 0; i < 1e4; ++i) {
+    const result = testAcrossBoundary(1, 2, 3, 4, 5);
+    shouldBeArray(result, [2, 3, 4]);
+}
+
+// Test empty result
+function testEmptySlice(x) {
+    (function () { return x; })();
+    return Array.prototype.slice.call(arguments, 5, 5);
+}
+noInline(testEmptySlice);
+
+for (let i = 0; i < 1e4; ++i) {
+    const result = testEmptySlice(1, 2, 3, 4, 5);
+    shouldBe(result.length, 0);
+}
+
+// Test negative indices
+function testNegativeIndices(x) {
+    (function () { return x; })();
+    return Array.prototype.slice.call(arguments, -3, -1);
+}
+noInline(testNegativeIndices);
+
+for (let i = 0; i < 1e4; ++i) {
+    const result = testNegativeIndices(1, 2, 3, 4, 5);
+    shouldBeArray(result, [3, 4]);
+}

--- a/Source/JavaScriptCore/runtime/JSArray.cpp
+++ b/Source/JavaScriptCore/runtime/JSArray.cpp
@@ -28,6 +28,7 @@
 #include "JSCInlines.h"
 #include "PropertyNameArray.h"
 #include "ResourceExhaustion.h"
+#include "ScopedArguments.h"
 #include "TypeError.h"
 #include <wtf/Assertions.h>
 
@@ -1371,6 +1372,8 @@ JSArray* JSArray::fastSlice(JSGlobalObject* globalObject, JSObject* source, uint
         switch (source->type()) {
         case DirectArgumentsType:
             return DirectArguments::fastSlice(globalObject, jsCast<DirectArguments*>(source), startIndex, count);
+        case ScopedArgumentsType:
+            return ScopedArguments::fastSlice(globalObject, jsCast<ScopedArguments*>(source), startIndex, count);
         default:
             return nullptr;
         }

--- a/Source/JavaScriptCore/runtime/ScopedArguments.h
+++ b/Source/JavaScriptCore/runtime/ScopedArguments.h
@@ -155,6 +155,8 @@ public:
 
     void copyToArguments(JSGlobalObject*, JSValue* firstElementDest, unsigned offset, unsigned length);
 
+    static JSArray* fastSlice(JSGlobalObject*, ScopedArguments*, uint64_t startIndex, uint64_t count);
+
     JS_EXPORT_PRIVATE bool isIteratorProtocolFastAndNonObservable();
 
     DECLARE_INFO;


### PR DESCRIPTION
#### fdb282b50fa810129e6d14c95010a1d30e246fe9
<pre>
[JSC] Add fast path for Array.prototype.slice on ScopedArguments
<a href="https://bugs.webkit.org/show_bug.cgi?id=304838">https://bugs.webkit.org/show_bug.cgi?id=304838</a>

Reviewed by Yusuke Suzuki.

This change adds a fast path for Array.prototype.slice when called on
ScopedArguments objects, similar to the existing optimization for
DirectArguments.

                                       TipOfTree                  Patched

scoped-arguments-slice             155.2137+-1.8613     ^     63.0061+-1.4876        ^ definitely 2.4635x faster
scoped-arguments-slice-int32       155.8805+-5.8409     ^     60.1825+-1.5710        ^ definitely 2.5901x faster
scoped-arguments-slice-double      156.4347+-4.6210     ^     68.9260+-1.2236        ^ definitely 2.2696x faster

* JSTests/microbenchmarks/scoped-arguments-slice-double.js: Added.
* JSTests/microbenchmarks/scoped-arguments-slice-int32.js: Added.
* JSTests/microbenchmarks/scoped-arguments-slice.js: Added.
* JSTests/stress/slice-scoped-arguments.js: Added.
* Source/JavaScriptCore/runtime/JSArray.cpp:
(JSC::JSArray::fastSlice): Add ScopedArgumentsType case.
* Source/JavaScriptCore/runtime/ScopedArguments.cpp:
(JSC::ScopedArguments::fastSlice): Added.
* Source/JavaScriptCore/runtime/ScopedArguments.h:

Canonical link: <a href="https://commits.webkit.org/305704@main">https://commits.webkit.org/305704@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a619783e067215fb1c9edbb04d4a3095555f322

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137277 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9637 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48564 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145028 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90250 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10341 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9764 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104969 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/76708 "Exiting early after 60 failures. 21515 tests run. 60 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140222 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7637 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123030 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85823 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7274 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4990 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5615 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/129238 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116636 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41184 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147785 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/135786 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9320 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41746 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113339 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9338 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7845 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113680 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29285 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7193 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119276 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63862 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9369 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37330 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/168547 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9098 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72934 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44005 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9309 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9161 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->