### PR TITLE
Prevent resizing of video poster image while waiting for initial frame

### DIFF
--- a/LayoutTests/media/video-poster-delayed-expected.txt
+++ b/LayoutTests/media/video-poster-delayed-expected.txt
@@ -1,17 +1,4 @@
 
 
-Video loaded
-
-EXPECTED (video.clientWidth == '320') OK
-EXPECTED (video.clientHeight == '240') OK
-EXPECTED (video.videoWidth == '320') OK
-EXPECTED (video.videoHeight == '240') OK
-
-Poster loaded
-
-EXPECTED (video.clientWidth == '320') OK
-EXPECTED (video.clientHeight == '240') OK
-EXPECTED (video.videoWidth == '320') OK
-EXPECTED (video.videoHeight == '240') OK
-END OF TEST
+PASS Delayed load of poster should overwrite intrinsic size of video.
 

--- a/LayoutTests/media/video-poster-delayed.html
+++ b/LayoutTests/media/video-poster-delayed.html
@@ -1,53 +1,65 @@
 <!DOCTYPE HTML5>
+<title>Delayed load of poster should overwrite intrinsic size of video.</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<video></video>
+<script>
+function findSupportedVideoFormat() {
+    var video = document.createElement('video');
+    var formats = [
+        { file: 'content/test.mp4', type: 'video/mp4' },
+        { file: 'content/test.ogv', type: 'video/ogg' }
+    ];
+    
+    for (var i = 0; i < formats.length; i++) {
+        if (video.canPlayType(formats[i].type)) {
+            return formats[i].file;
+        }
+    }
+    
+    // Default to ogv if no format is explicitly supported.
+    return 'content/test.ogv';
+}
 
-<html>
-    <head>
-        <title>Delayed load of poster should not overwrite intrinsic size of video</title>
-        <script src=video-test.js></script>
-        <script src=media-file.js></script>
-        <style>
-            video {
-                border: 3px solid red;
-                background-color: magenta;
-            }
-        </style>
-        <script>
-            function start()
-            {
-                video = document.getElementById('video');
+async_test(function(t) {
+    var video = document.querySelector("video");
 
-                video.addEventListener("loadeddata", function(ev) {
-
-                    consoleWrite("<br><b>Video loaded</b><br>");
-
-                    testExpected("video.clientWidth", 320);
-                    testExpected("video.clientHeight", 240);
-                    testExpected("video.videoWidth", 320);
-                    testExpected("video.videoHeight", 240);
-
-                    video.poster = "content/abe.png";
-                    setTimeout(testAfterLoadingPoster, 100);
+    video.onloadeddata = t.step_func(function() {
+        testVideoSize({
+            clientWidth: 320,
+            clientHeight: 240,
+            videoWidth: 320,
+            videoHeight: 240,
+        });
+        
+        video.poster = "content/abe.png";
+        
+        // Wait for the video element itself to resize
+        const clientWidthAfterResize = 76;
+        const clientHeightAfterResize = 103;
+        var checkResize = function() {
+            if (video.clientWidth === clientWidthAfterResize && video.clientHeight === clientHeightAfterResize) {
+                testVideoSize({
+                    clientWidth: clientWidthAfterResize,
+                    clientHeight: clientHeightAfterResize,
+                    videoWidth: 320,
+                    videoHeight: 240,
                 });
-
-                video.src = findMediaFile("video", "content/test");
+                t.done();
+            } else {
+                requestAnimationFrame(checkResize);
             }
+        };
+        requestAnimationFrame(checkResize);
+    });
 
-            function testAfterLoadingPoster()
-            {
-                consoleWrite("<br><b>Poster loaded</b><br>");
+    function testVideoSize(size) {
+        assert_equals(video.clientWidth, size.clientWidth);
+        assert_equals(video.clientHeight, size.clientHeight);
+        assert_equals(video.videoWidth, size.videoWidth);
+        assert_equals(video.videoHeight, size.videoHeight);
+    }
 
-                testExpected("video.clientWidth", 320);
-                testExpected("video.clientHeight", 240);
-                testExpected("video.videoWidth", 320);
-                testExpected("video.videoHeight", 240);
-
-                endTest();
-            }
-        </script>
-    </head>
-
-
-    <body onload="start()">
-        <video id=video></video>
-    </body>
-</html>
+    video.src = findSupportedVideoFormat();
+});
+</script>

--- a/LayoutTests/media/video-size-expected.txt
+++ b/LayoutTests/media/video-size-expected.txt
@@ -1,39 +1,9 @@
 
-Test <video> element size with and without 'src' and 'poster' attributes.
 
-Testing movie with no 'src' and no 'poster', with 'width' and 'height' attributes.
-EXPECTED (video.clientWidth == '640') OK
-EXPECTED (video.clientHeight == '480') OK
-EXPECTED (video.videoWidth == '0') OK
-EXPECTED (video.videoHeight == '0') OK
-
-Removing 'width' and 'height' attributes.
-Testing movie with no 'src' and no 'poster', with NO 'width' and 'height' attributes, should be default size.
-EXPECTED (video.clientWidth == '300') OK
-EXPECTED (video.clientHeight == '150') OK
-EXPECTED (video.videoWidth == '0') OK
-EXPECTED (video.videoHeight == '0') OK
-
-Setting 'poster' to "content/abe.png"
-Testing movie with 'poster' but no 'src', should be image size.
-EXPECTED (video.clientWidth == '76') OK
-EXPECTED (video.clientHeight == '103') OK
-EXPECTED (video.videoWidth == '0') OK
-EXPECTED (video.videoHeight == '0') OK
-
-Setting 'src' to "content/test.[extension]"
-Testing movie with 'poster' and 'src', should be <video> size.
-EXPECTED (video.clientWidth == '320') OK
-EXPECTED (video.clientHeight == '240') OK
-EXPECTED (video.videoWidth == '320') OK
-EXPECTED (video.videoHeight == '240') OK
-
-Setting 'src' to "content/bogus.[extension]" 'poster' to "content/greenbox.png"
-Testing movie with 'poster' and invalid 'src', should be image size.
-EXPECTED (video.clientWidth == '25') OK
-EXPECTED (video.clientHeight == '25') OK
-EXPECTED (video.videoWidth == '0') OK
-EXPECTED (video.videoHeight == '0') OK
-
-END OF TEST
+PASS no 'src' and no 'poster', with 'width' and 'height' attributes
+PASS no 'src' and no 'poster', with no 'width' and 'height' attributes, should be default size
+PASS 'poster' but no 'src', should be 'poster' size
+PASS 'poster' and 'src', should be 'poster' size before play
+PASS 'poster' and 'src', should be 'video' size after play
+PASS 'poster' and invalid 'src', should be 'poster' size
 

--- a/LayoutTests/media/video-size.html
+++ b/LayoutTests/media/video-size.html
@@ -1,141 +1,136 @@
-<html>
-    <head>
-        <title>&lt;video&gt; element size and resize test</title>
-        <script src=video-test.js></script>
-        <script src=media-file.js></script>
+<!DOCTYPE html>
+<title>Test "video" element size with and without "src" and "poster" attributes.</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<body>
+<script>
+function findSupportedVideoFormat() {
+    var video = document.createElement('video');
+    var formats = [
+        { file: 'content/test.mp4', type: 'video/mp4' },
+        { file: 'content/test.ogv', type: 'video/ogg' }
+    ];
+    
+    for (var i = 0; i < formats.length; i++) {
+        if (video.canPlayType(formats[i].type)) {
+            return formats[i].file;
+        }
+    }
+    
+    // Default to ogv if no format is explicitly supported
+    return 'content/test.ogv';
+}
 
-        <script>
-            var movieInfo = 
-            {
-                current:0,
-                retryCount: 0,
-                movies: 
-                [ 
-                    {   
-                        src:null,
-                        poster:null,
-                        description:"no 'src' and no 'poster', with 'width' and 'height' attributes",
-                        width:640,
-                        height:480,
-                        videoWidth:0,
-                        videoHeight:0
-                    },
-                    {
-                        src:null,
-                        poster:null,
-                        description:"no 'src' and no 'poster', with NO 'width' and 'height' attributes, should be default size",
-                        width:300,
-                        height:150,
-                        videoWidth:0,
-                        videoHeight:0
-                    },
-                    {
-                        src:null,
-                        poster:"content/abe.png",
-                        description:"'poster' but no  'src', should be image size",
-                        width:76,
-                        height:103,
-                        videoWidth:0,
-                        videoHeight:0
-                    },
-                    {
-                        src:"content/test",
-                        poster:"content/abe.png",
-                        description:"'poster' and  'src', should be &lt;video&gt; size",
-                        width:320,
-                        height:240,
-                        videoWidth:320,
-                        videoHeight:240
-                    },
-                    {
-                        src:"content/bogus",
-                        poster:"content/greenbox.png",
-                        description:"'poster' and invalid 'src', should be image size",
-                        width:25,
-                        height:25,
-                        videoWidth:0,
-                        videoHeight:0
-                    },
-                ]
-            };
+var supportedVideoSrc = findSupportedVideoFormat();
 
-            function setupNextConfiguration()
-            {
-                consoleWrite("");
-                movieInfo.current++;
-                movieInfo.retryCount = 0;
-                if (movieInfo.current >= movieInfo.movies.length)
-                {
-                    endTest();
-                    return;
-                }
+var movieInfo = [
+    {
+        src: null,
+        poster: null,
+        description: "no 'src' and no 'poster', with 'width' and 'height' attributes",
+        width: 640,
+        height: 480,
+        videoWidth: 0,
+        videoHeight: 0,
+        setSize: true
+    },
+    {
+        src: null,
+        poster: null,
+        description: "no 'src' and no 'poster', with no 'width' and 'height' attributes, should be default size",
+        width: 300,
+        height: 150,
+        videoWidth: 0,
+        videoHeight: 0
+    },
+    {
+        src: null,
+        poster: "content/abe.png",
+        description: "'poster' but no 'src', should be 'poster' size",
+        width: 76,
+        height: 103,
+        videoWidth: 0,
+        videoHeight: 0
+    },
+    {
+        src: supportedVideoSrc,
+        poster: "content/abe.png",
+        play: false,
+        description: "'poster' and 'src', should be 'poster' size before play",
+        width: 76,
+        height: 103,
+        videoWidth: 320,
+        videoHeight: 240
+    },
+    {
+        src: supportedVideoSrc,
+        poster: "content/abe.png",
+        play: true,
+        description: "'poster' and 'src', should be 'video' size after play",
+        width: 320,
+        height: 240,
+        videoWidth: 320,
+        videoHeight: 240
+    },
+    {
+        src: "content/bogus.ogv",
+        poster: "content/greenbox.png",
+        description: "'poster' and invalid 'src', should be 'poster' size",
+        width: 25,
+        height: 25,
+        videoWidth: 0,
+        videoHeight: 0
+    }
+];
 
-                var movie = movieInfo.movies[movieInfo.current];
-                if (movie.src || movie.poster) {
-                    var desc = "<b>Setting ";
-                    if (movie.src && relativeURL(video.src) != movie.src) {
-                        video.src = findMediaFile("video", movie.src);
-                        desc += "'src' to <em>\""+ movie.src + ".[extension]\"</em> ";
-                    }
-                    if (movie.poster && relativeURL(video.poster) != movie.poster) {
-                        video.poster = movie.poster;
-                        desc += "'poster' to <em>\""+ movie.poster + "\"</em>";
-                    }
-                    consoleWrite(desc + "</b>");
-                }
+movieInfo.forEach(function(movie) {
+    async_test(function(t) {
+        if (movie.poster) {
+            var image = document.createElement("img");
+            image.src = movie.poster;
+            document.body.appendChild(image);
+            image.onload = t.step_func(runTest);
+        } else {
+            runTest();
+        }
 
-                // Remove width/height attributes if present
-                if (video.width || video.height) {
-                    consoleWrite("<b>Removing 'width' and 'height' attributes.</b>");
-                    video.removeAttribute('width');
-                    video.removeAttribute('height');
-                }
-
-                if (!movie.src || movie.src.indexOf('bogus') >= 0)
-                    setTimeout(testMovie, 100);
+        function runTest() {
+            var video = document.createElement("video");
+            document.body.appendChild(video);
+            if (movie.setSize) {
+                video.setAttribute("width", "640");
+                video.setAttribute("height", "480");
             }
 
-            function testMovie()
-            {
-                if (movieInfo.current >= movieInfo.movies.length)
-                    return;
+            if (movie.src)
+                video.src = movie.src;
 
-                var temp = document.body.offsetWidth;
-                var movie = movieInfo.movies[movieInfo.current];
+            if (movie.poster)
+                video.poster = movie.poster;
 
-                // We can't detect when the poster has loaded and the 100ms timeout may
-                // not be long enough on a slow/loaded machine.
-                if (video.clientWidth != movie.width || video.clientHeight != movie.height
-                    || video.videoWidth != movie.videoWidth || video.videoHeight != movie.videoHeight) {
-                    if (++movieInfo.retryCount <= 2) {
-                        setTimeout(testMovie, 100);
-                        return;
-                    }
-                }
-
-                var desc = "<b>Testing movie with " + movie.description + ".</b>";
-                consoleWrite(desc);
-
-                testExpected("video.clientWidth", movie.width);
-                testExpected("video.clientHeight", movie.height);
-                testExpected("video.videoWidth", movie.videoWidth);
-                testExpected("video.videoHeight", movie.videoHeight);
-
-                setupNextConfiguration();
+            if (movie.play) {
+                video.oncanplaythrough = t.step_func(function() {
+                    video.play();
+                    // Use requestAnimationFrame to ensure a paint has occurred
+                    requestAnimationFrame(t.step_func(function() {
+                        requestAnimationFrame(t.step_func_done(testMovieSize));
+                    }));
+                });
+            } else {
+                video.onloadedmetadata = t.step_func_done(testMovieSize);
             }
 
-            function test()
-            {
-                findMediaElement();
-                testMovie();
+            if (!movie.src || movie.src.indexOf("bogus") >= 0) {
+                setTimeout(t.step_func_done(testMovieSize), 0);
             }
-        </script>
-    </head>
 
-    <body onload="setTimeout(test, 100)">
-
-        <video controls width=640 height=480 onloadedmetadata="testMovie()"></video>
-        <p>Test &lt;video&gt; element size with and without 'src' and 'poster' attributes.</p>
-
-    </body>
-</html>
+            function testMovieSize() {
+                assert_equals(video.clientWidth, movie.width);
+                assert_equals(video.clientHeight, movie.height);
+                assert_equals(video.videoWidth, movie.videoWidth);
+                assert_equals(video.videoHeight, movie.videoHeight);
+            }
+        }
+    }, movie.description);
+});
+</script>


### PR DESCRIPTION
#### 91c550440fa878e3e31b2fecf2d4f757d0f0dc0a
<pre>
Prevent resizing of video poster image while waiting for initial frame
<a href="https://bugs.webkit.org/show_bug.cgi?id=292414">https://bugs.webkit.org/show_bug.cgi?id=292414</a>
<a href="https://rdar.apple.com/problem/150975269">rdar://problem/150975269</a>

Reviewed by Eric Carlson.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/048c5c63908271582e4a36376d8c0e783b07523b">https://chromium.googlesource.com/chromium/src.git/+/048c5c63908271582e4a36376d8c0e783b07523b</a>

The previous logic for what intrinsic size to give to a video element
was based on outdated spec text. This patch updates it to prevent the
poster image from resizing between starting playback and the first video
frame being rendered.

The fix ensures that when a video has both a poster and video source,
the poster dimensions are used until a video frame is actually available,
then switches to the video&apos;s natural size.

* Source/WebCore/rendering/RenderVideo.cpp:
(WebCore::RenderVideo::calculateIntrinsicSizeInternal):
* LayoutTests/media/video-poster-delayed-expected.txt:
* LayoutTests/media/video-poster-delayed.html:
* LayoutTests/media/video-size-expected.txt:
* LayoutTests/media/video-size.html:

Canonical link: <a href="https://commits.webkit.org/305281@main">https://commits.webkit.org/305281@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21888e9806a6d6afef6772f733d9f65bc096602d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137967 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10331 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49336 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146035 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90942 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2234eb40-ab93-4d3e-a739-cf45d4562960) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139840 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11033 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10476 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105506 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d3185490-3166-42bd-b966-a9652c317c7e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140912 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8226 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123687 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86358 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1631e040-5175-472e-8525-1b53e6823d0a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7840 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5595 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6325 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117236 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41857 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148746 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10014 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42416 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113910 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10031 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8452 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114241 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29032 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7781 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119943 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64738 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10060 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37936 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9791 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73628 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10001 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9852 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->