### PR TITLE
[JSC] Optimize `String#isWellFormed` and `String#toWellFormed` using simdutf

### DIFF
--- a/JSTests/microbenchmarks/string-is-well-formed.js
+++ b/JSTests/microbenchmarks/string-is-well-formed.js
@@ -1,0 +1,15 @@
+function testWellFormed(string) {
+    return string.isWellFormed();
+}
+noInline(testWellFormed);
+
+var wellFormedShort = "こんにちは世界";
+var wellFormedMedium = "こんにちは世界".repeat(50);
+var wellFormedLong = "こんにちは世界".repeat(500);
+
+var withSurrogatePairs = "Hello 𠮷 World 𠮷".repeat(100);
+
+for (var i = 0; i < 1e5; ++i) {
+    testWellFormed(wellFormedLong);
+    testWellFormed(withSurrogatePairs);
+}

--- a/JSTests/microbenchmarks/string-to-well-formed.js
+++ b/JSTests/microbenchmarks/string-to-well-formed.js
@@ -1,0 +1,18 @@
+function testToWellFormed(string) {
+    return string.toWellFormed();
+}
+noInline(testToWellFormed);
+
+var wellFormedLong = "こんにちは世界".repeat(500);
+
+var illFormedShort = "A\uD842B";
+var illFormedMedium = ("Hello\uD842World").repeat(50);
+var illFormedLong = ("Hello\uD842World").repeat(500);
+
+var trailingLoneSurrogate = "こんにちは世界".repeat(100) + "\uD842";
+
+for (var i = 0; i < 5e4; ++i) {
+    testToWellFormed(wellFormedLong);
+    testToWellFormed(illFormedLong);
+    testToWellFormed(trailingLoneSurrogate);
+}

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -828,6 +828,7 @@ else ()
         text/Base64.cpp
         text/StringImpl.cpp
         unicode/UTF8Conversion.cpp
+        text/StringCommon.cpp
         PROPERTIES COMPILE_FLAGS "-Wno-error=undef -Wno-undef")
 endif ()
 

--- a/Source/WTF/wtf/text/StringCommon.cpp
+++ b/Source/WTF/wtf/text/StringCommon.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include <wtf/text/StringCommon.h>
 
+#include <wtf/SIMDUTF.h>
+
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WTF {
@@ -151,6 +153,17 @@ const char16_t* find16NonASCIIAlignedImpl(std::span<const char16_t> data)
         length -= stride;
         cursor += stride;
     }
+}
+
+bool isWellFormedUTF16(std::span<const char16_t> data)
+{
+    return simdutf::validate_utf16(data.data(), data.size());
+}
+
+void toWellFormedUTF16(std::span<const char16_t> input, std::span<char16_t> output)
+{
+    ASSERT(input.size() == output.size());
+    simdutf::to_well_formed_utf16(input.data(), input.size(), output.data());
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -762,6 +762,9 @@ ALWAYS_INLINE const double* findDouble(const double* pointer, double target, siz
 WTF_EXPORT_PRIVATE const Latin1Character* find8NonASCIIAlignedImpl(std::span<const Latin1Character>);
 WTF_EXPORT_PRIVATE const char16_t* find16NonASCIIAlignedImpl(std::span<const char16_t>);
 
+WTF_EXPORT_PRIVATE bool isWellFormedUTF16(std::span<const char16_t>);
+WTF_EXPORT_PRIVATE void toWellFormedUTF16(std::span<const char16_t> input, std::span<char16_t> output);
+
 #if CPU(ARM64)
 ALWAYS_INLINE const Latin1Character* find8NonASCII(std::span<const Latin1Character> data)
 {


### PR DESCRIPTION
#### e5f7abfaed5da1f24a206bd04b3e672980710bba
<pre>
[JSC] Optimize `String#isWellFormed` and `String#toWellFormed` using simdutf
<a href="https://bugs.webkit.org/show_bug.cgi?id=304842">https://bugs.webkit.org/show_bug.cgi?id=304842</a>

Reviewed by Yusuke Suzuki.

This patch changes to use simdutf in String.prototype.isWellFormed() and
String.prototype.toWellFormed().

                               TipOfTree                  Patched

string-to-well-formed      345.1334+-1.7600     ^     66.4591+-0.1386        ^ definitely 5.1932x faster
string-is-well-formed      155.4431+-66.9387    ^     29.0142+-0.4967        ^ definitely 5.3575x faster

* JSTests/microbenchmarks/string-is-well-formed.js: Added.
(testWellFormed):
* JSTests/microbenchmarks/string-to-well-formed.js: Added.
(testToWellFormed):
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::illFormedIndex): Deleted.
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/text/StringCommon.cpp:
(WTF::isWellFormedUTF16):
(WTF::toWellFormedUTF16):
* Source/WTF/wtf/text/StringCommon.h:

Canonical link: <a href="https://commits.webkit.org/305321@main">https://commits.webkit.org/305321@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99f2b1c4d4c10b9e1064f6678aca5bd382081914

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137957 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10321 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49321 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146024 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90932 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11023 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10464 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105498 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/76992 "Exiting early after 60 failures. 21546 tests run. 60 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140902 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8219 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123674 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86351 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7833 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5584 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6307 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/129921 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117229 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41844 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148735 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/136506 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10004 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42403 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113902 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10021 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8441 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114232 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29058 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7772 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119930 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64728 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10050 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37924 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/169229 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9781 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73618 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44141 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9991 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9842 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->