### PR TITLE
[LBSE] Disallow layers for gradients

### DIFF
--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/W3C-SVG-1.1/coords-units-01-b-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/W3C-SVG-1.1/coords-units-01-b-expected.txt
@@ -6,6 +6,24 @@ layer at (0,0) size 480x360
   RenderSVGViewportContainer at (0,0) size 480x360
 layer at (0,0) size 479x359
   RenderSVGTransformableContainer {g} at (0,0) size 479x359
+    RenderSVGResourceLinearGradient {linearGradient} at (0,0) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#FF0000]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#0000FF]
+    RenderSVGResourceLinearGradient {linearGradient} at (0,0) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#FF0000]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#0000FF]
+    RenderSVGResourceLinearGradient {linearGradient} at (0,0) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#FF0000]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#0000FF]
+    RenderSVGResourceRadialGradient {radialGradient} at (0,0) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#FF0000]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#0000FF]
+    RenderSVGResourceRadialGradient {radialGradient} at (0,0) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#FF0000]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#0000FF]
+    RenderSVGResourceRadialGradient {radialGradient} at (0,0) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#FF0000]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#0000FF]
 layer at (30,16) size 386x18
   RenderSVGText {text} at (30,16) size 386x18 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 386x18

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/W3C-SVG-1.1/pservers-grad-01-b-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/W3C-SVG-1.1/pservers-grad-01-b-expected.txt
@@ -6,6 +6,10 @@ layer at (0,0) size 480x360
   RenderSVGViewportContainer at (0,0) size 480x360
 layer at (20,20) size 440x247
   RenderSVGTransformableContainer {g} at (20,20) size 440x246.36
+    RenderSVGResourceLinearGradient {linearGradient} at (-20,-20) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#0000FF]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#FF0000]
+    RenderSVGResourceLinearGradient {linearGradient} at (-20,-20) size 0x0
 layer at (20,20) size 440x80
   RenderSVGRect {rect} at (0,0) size 440x80 [fill={[type=SOLID] [color=#00000000]}] [x=20.00] [y=20.00] [width=440.00] [height=80.00]
 layer at (20,102.83) size 208x33

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/W3C-SVG-1.1/pservers-grad-02-b-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/W3C-SVG-1.1/pservers-grad-02-b-expected.txt
@@ -6,6 +6,10 @@ layer at (0,0) size 480x360
   RenderSVGViewportContainer at (0,0) size 480x360
 layer at (20,20) size 440x247
   RenderSVGTransformableContainer {g} at (20,20) size 440x246.36
+    RenderSVGResourceRadialGradient {radialGradient} at (-20,-20) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#000000]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#FFA500]
+    RenderSVGResourceRadialGradient {radialGradient} at (-20,-20) size 0x0
 layer at (20,20) size 440x80
   RenderSVGRect {rect} at (0,0) size 440x80 [fill={[type=SOLID] [color=#00000000]}] [x=20.00] [y=20.00] [width=440.00] [height=80.00]
 layer at (20,102.83) size 210x33

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/W3C-SVG-1.1/pservers-grad-04-b-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/W3C-SVG-1.1/pservers-grad-04-b-expected.txt
@@ -6,6 +6,20 @@ layer at (0,0) size 480x360
   RenderSVGViewportContainer at (0,0) size 480x360
 layer at (20,20) size 440x247
   RenderSVGTransformableContainer {g} at (20,20) size 440x246.36
+    RenderSVGResourceLinearGradient {linearGradient} at (-20,-20) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#EE82EE]
+      RenderSVGGradientStop {stop} [offset=0.20] [color=#0000FF]
+      RenderSVGGradientStop {stop} [offset=0.40] [color=#00FF00]
+      RenderSVGGradientStop {stop} [offset=0.60] [color=#FFFF00]
+      RenderSVGGradientStop {stop} [offset=0.80] [color=#FFA500]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#FF0000]
+    RenderSVGResourceRadialGradient {radialGradient} at (-20,-20) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#000000]
+      RenderSVGGradientStop {stop} [offset=0.20] [color=#FFFF00]
+      RenderSVGGradientStop {stop} [offset=0.40] [color=#FF0000]
+      RenderSVGGradientStop {stop} [offset=0.60] [color=#0000FF]
+      RenderSVGGradientStop {stop} [offset=0.80] [color=#FFFFFF]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#008000]
 layer at (20,20) size 440x80
   RenderSVGRect {rect} at (0,0) size 440x80 [fill={[type=SOLID] [color=#00000000]}] [x=20.00] [y=20.00] [width=440.00] [height=80.00]
 layer at (20,102.83) size 345x33

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/W3C-SVG-1.1/pservers-grad-05-b-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/W3C-SVG-1.1/pservers-grad-05-b-expected.txt
@@ -6,6 +6,20 @@ layer at (0,0) size 480x360
   RenderSVGViewportContainer at (0,0) size 480x360
 layer at (20,20) size 440x210
   RenderSVGTransformableContainer {g} at (20,20) size 440x210
+    RenderSVGResourceLinearGradient {linearGradient} at (-20,-20) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#EE82EE]
+      RenderSVGGradientStop {stop} [offset=0.20] [color=#0000FF00]
+      RenderSVGGradientStop {stop} [offset=0.40] [color=#00FF0080]
+      RenderSVGGradientStop {stop} [offset=0.60] [color=#FFFF0033]
+      RenderSVGGradientStop {stop} [offset=0.80] [color=#FFA500CC]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#FF0000]
+    RenderSVGResourceRadialGradient {radialGradient} at (-20,-20) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#000000]
+      RenderSVGGradientStop {stop} [offset=0.20] [color=#FFFF0000]
+      RenderSVGGradientStop {stop} [offset=0.40] [color=#FF000080]
+      RenderSVGGradientStop {stop} [offset=0.60] [color=#0000FF33]
+      RenderSVGGradientStop {stop} [offset=0.80] [color=#FFFFFFCC]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#008000]
 layer at (70,25.67) size 320x67
   RenderSVGText {text} at (50,5) size 321x68 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 321x68

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/W3C-SVG-1.1/pservers-grad-06-b-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/W3C-SVG-1.1/pservers-grad-06-b-expected.txt
@@ -6,6 +6,13 @@ layer at (0,0) size 480x360
   RenderSVGViewportContainer at (0,0) size 480x360
 layer at (20,20) size 440x277
   RenderSVGTransformableContainer {g} at (20,20) size 440x276.36
+    RenderSVGResourceLinearGradient {linearGradient} at (-20,-20) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#0000FF]
+      RenderSVGGradientStop {stop} [offset=0.50] [color=#FF0000]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#00FF00]
+    RenderSVGResourceRadialGradient {radialGradient} at (-20,-20) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#000000]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#FFA500]
 layer at (20,20) size 440x50
   RenderSVGRect {rect} at (0,0) size 440x50 [fill={[type=SOLID] [color=#00000000]}] [x=20.00] [y=20.00] [width=440.00] [height=50.00]
 layer at (20,72.83) size 290x33

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/W3C-SVG-1.1/pservers-grad-07-b-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/W3C-SVG-1.1/pservers-grad-07-b-expected.txt
@@ -6,6 +6,9 @@ layer at (0,0) size 480x360
   RenderSVGViewportContainer at (0,0) size 480x360
 layer at (10,10) size 430x166
   RenderSVGTransformableContainer {g} at (10,10) size 430x165.09
+    RenderSVGResourceLinearGradient {linearGradient} at (-10,-10) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#0000FF]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#FF0000]
 layer at (10,10) size 430x60
   RenderSVGRect {rect} at (0,0) size 430x60 [fill={[type=SOLID] [color=#00000000]}] [x=10.00] [y=10.00] [width=430.00] [height=60.00]
 layer at (10,68.27) size 322x27

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/W3C-SVG-1.1/pservers-grad-08-b-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/W3C-SVG-1.1/pservers-grad-08-b-expected.txt
@@ -6,6 +6,9 @@ layer at (0,0) size 480x360
   RenderSVGViewportContainer at (0,0) size 480x360
 layer at (20,22.39) size 447x145
   RenderSVGTransformableContainer {g} at (20,22.39) size 446.30x144.61
+    RenderSVGResourceLinearGradient {linearGradient} at (-20,-22.39) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#0000FF]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#FF0000]
 layer at (20,22.39) size 446x56
   RenderSVGText {text} at (0,0) size 447x57 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 447x57

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/W3C-SVG-1.1/pservers-grad-09-b-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/W3C-SVG-1.1/pservers-grad-09-b-expected.txt
@@ -6,6 +6,15 @@ layer at (0,0) size 480x360
   RenderSVGViewportContainer at (0,0) size 480x360
 layer at (0,0) size 440x430 backgroundClip at (0,0) size 480x360 clip at (0,0) size 480x360
   RenderSVGTransformableContainer {g} at (0,0) size 440x430
+    RenderSVGResourceLinearGradient {linearGradient} at (0,0) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#FF0000]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#0000FF]
+    RenderSVGResourceLinearGradient {linearGradient} at (0,0) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#0000FF]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#FF0000]
+    RenderSVGResourceLinearGradient {linearGradient} at (0,0) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#FF0000]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#0000FF]
 layer at (10,11.41) size 200x17
   RenderSVGText {text} at (10,11) size 201x18 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 201x17

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/W3C-SVG-1.1/pservers-grad-10-b-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/W3C-SVG-1.1/pservers-grad-10-b-expected.txt
@@ -6,6 +6,15 @@ layer at (0,0) size 480x360
   RenderSVGViewportContainer at (0,0) size 480x360
 layer at (10,11.41) size 460x267
   RenderSVGTransformableContainer {g} at (10,11.41) size 460x266.14
+    RenderSVGResourceLinearGradient {linearGradient} at (-10,-11.41) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#0000FF]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#FF0000]
+    RenderSVGResourceLinearGradient {linearGradient} at (-10,-11.41) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#0000FF]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#FF0000]
+    RenderSVGResourceLinearGradient {linearGradient} at (-10,-11.41) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#0000FF]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#FF0000]
 layer at (10,11.41) size 208x17
   RenderSVGText {text} at (0,0) size 208x17 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 208x17

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/W3C-SVG-1.1/pservers-grad-11-b-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/W3C-SVG-1.1/pservers-grad-11-b-expected.txt
@@ -6,6 +6,18 @@ layer at (0,0) size 480x360
   RenderSVGViewportContainer at (0,0) size 480x360
 layer at (10,10) size 456x278
   RenderSVGTransformableContainer {g} at (10,10) size 455.23x277.55
+    RenderSVGResourceRadialGradient {radialGradient} at (-10,-10) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#000000]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#FF0000]
+    RenderSVGResourceRadialGradient {radialGradient} at (-10,-10) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#FF0000]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#FFFF00]
+    RenderSVGResourceRadialGradient {radialGradient} at (-10,-10) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#000000]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#FFFF00]
+    RenderSVGResourceRadialGradient {radialGradient} at (-10,-10) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#000000]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#FF0000]
 layer at (10,10) size 210x140
   RenderSVGRect {rect} at (0,0) size 210x140 [fill={[type=SOLID] [color=#00000000]}] [x=10.00] [y=10.00] [width=210.00] [height=140.00]
 layer at (10,154.13) size 178x14

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/W3C-SVG-1.1/pservers-grad-12-b-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/W3C-SVG-1.1/pservers-grad-12-b-expected.txt
@@ -6,6 +6,15 @@ layer at (0,0) size 480x360
   RenderSVGViewportContainer at (0,0) size 480x360
 layer at (0,0) size 470x460 backgroundClip at (0,0) size 480x360 clip at (0,0) size 480x360
   RenderSVGTransformableContainer {g} at (0,0) size 470x460
+    RenderSVGResourceRadialGradient {radialGradient} at (0,0) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#0000FF]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#FF0000]
+    RenderSVGResourceRadialGradient {radialGradient} at (0,0) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#0000FF]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#FF0000]
+    RenderSVGResourceRadialGradient {radialGradient} at (0,0) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#FF0000]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#0000FF]
 layer at (10,11.41) size 200x17
   RenderSVGText {text} at (10,11) size 201x18 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 201x17

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/W3C-SVG-1.1/pservers-grad-15-b-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/W3C-SVG-1.1/pservers-grad-15-b-expected.txt
@@ -6,6 +6,12 @@ layer at (0,0) size 480x360
   RenderSVGViewportContainer at (0,0) size 480x360
 layer at (20,20) size 440x210
   RenderSVGTransformableContainer {g} at (20,20) size 440x210
+    RenderSVGResourceLinearGradient {linearGradient} at (-20,-20) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#0000FF]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#FF0000]
+    RenderSVGResourceRadialGradient {radialGradient} at (-20,-20) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#000000]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#FF0000]
 layer at (20,20) size 440x80
   RenderSVGRect {rect} at (0,0) size 440x80 [fill={[type=SOLID] [color=#00000000]}] [x=20.00] [y=20.00] [width=440.00] [height=80.00]
 layer at (20,150) size 440x80

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/W3C-SVG-1.1/pservers-grad-16-b-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/W3C-SVG-1.1/pservers-grad-16-b-expected.txt
@@ -6,6 +6,14 @@ layer at (0,0) size 480x360
   RenderSVGViewportContainer at (0,0) size 480x360
 layer at (20,10) size 440x280
   RenderSVGTransformableContainer {g} at (20,10) size 440x280
+    RenderSVGResourceLinearGradient {linearGradient} at (-20,-10) size 0x0
+    RenderSVGResourceLinearGradient {linearGradient} at (-20,-10) size 0x0
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#000000]
+    RenderSVGResourceLinearGradient {linearGradient} at (-20,-10) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#FFFF00]
+      RenderSVGGradientStop {stop} [offset=0.25] [color=#FF0000]
+      RenderSVGGradientStop {stop} [offset=0.50] [color=#008000]
+      RenderSVGGradientStop {stop} [offset=0.10] [color=#0000FF]
 layer at (20,10) size 440x80
   RenderSVGRect {rect} at (0,0) size 440x80 [stroke={[type=SOLID] [color=#FF0000]}] [fill={[type=SOLID] [color=#00000000]}] [x=20.00] [y=10.00] [width=440.00] [height=80.00]
 layer at (20,110) size 440x80

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/W3C-SVG-1.1/styling-inherit-01-b-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/W3C-SVG-1.1/styling-inherit-01-b-expected.txt
@@ -6,6 +6,14 @@ layer at (0,0) size 480x360
   RenderSVGViewportContainer at (0,0) size 480x360
 layer at (40,20) size 380x260
   RenderSVGTransformableContainer {g} at (40,20) size 380x260
+    RenderSVGResourceRadialGradient {radialGradient} at (-40,-20) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#FFFF00]
+      RenderSVGGradientStop {stop} [offset=0.50] [color=#008000]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#FFFFFF]
+    RenderSVGResourceRadialGradient {radialGradient} at (-40,-20) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#FFFF00]
+      RenderSVGGradientStop {stop} [offset=0.50] [color=#770000]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#FFFFFF]
 layer at (240,80) size 180x120
   RenderSVGTransformableContainer {g} at (200,60) size 180x120
 layer at (240,80) size 180x120

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/broken-internal-references-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/broken-internal-references-expected.txt
@@ -6,6 +6,10 @@ layer at (0,0) size 800x600
   RenderSVGViewportContainer at (0,0) size 800x600
 layer at (0,-14) size 418x119 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
   RenderSVGHiddenContainer {defs} at (0,-14) size 418x119
+    RenderSVGResourceLinearGradient {linearGradient} at (0,14) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#0000FF]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#FF0000]
+    RenderSVGResourceLinearGradient {linearGradient} at (0,14) size 0x0
 layer at (0,0) size 60x10
   RenderSVGRect {rect} at (0,14) size 60x10 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=60.00] [height=10.00]
 layer at (199,26.97) size 219x79

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/fill-fallback-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/fill-fallback-expected.txt
@@ -4,6 +4,8 @@ layer at (0,0) size 800x600
   RenderSVGRoot {svg} at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderSVGViewportContainer at (0,0) size 800x600
+    RenderSVGResourceLinearGradient {linearGradient} at (0,0) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#008000]
 layer at (0,0) size 100x100
   RenderSVGRect {rect} at (0,0) size 100x100 [fill={[type=SOLID] [color=#008000]}] [x=0.00] [y=0.00] [width=100.00] [height=100.00]
 layer at (150,0) size 100x100

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/gradient-rotated-bbox-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/gradient-rotated-bbox-expected.txt
@@ -4,6 +4,14 @@ layer at (0,0) size 800x600
   RenderSVGRoot {svg} at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderSVGViewportContainer at (0,0) size 800x600
+    RenderSVGResourceLinearGradient {linearGradient} at (0,0) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#FF0000]
+      RenderSVGGradientStop {stop} [offset=0.50] [color=#008000]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#0000FF]
+    RenderSVGResourceRadialGradient {radialGradient} at (0,0) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#FF0000]
+      RenderSVGGradientStop {stop} [offset=0.50] [color=#008000]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#0000FF]
 layer at (0,0) size 400x300
   RenderSVGRect {rect} at (0,0) size 400x300 [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=0.00] [width=400.00] [height=300.00]
 layer at (0,0) size 400x300

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/gradient-stop-corner-cases-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/gradient-stop-corner-cases-expected.txt
@@ -6,6 +6,26 @@ layer at (0,0) size 800x600
   RenderSVGViewportContainer at (0,0) size 800x600
 layer at (20,10) size 440x280
   RenderSVGTransformableContainer {g} at (20,10) size 440x280
+    RenderSVGResourceLinearGradient {linearGradient} at (-20,-10) size 0x0
+    RenderSVGResourceLinearGradient {linearGradient} at (-20,-10) size 0x0
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#000000]
+    RenderSVGResourceLinearGradient {linearGradient} at (-20,-10) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#FFFF00]
+      RenderSVGGradientStop {stop} [offset=0.25] [color=#FF0000]
+      RenderSVGGradientStop {stop} [offset=0.50] [color=#008000]
+      RenderSVGGradientStop {stop} [offset=0.10] [color=#0000FF]
+    RenderSVGResourceLinearGradient {linearGradient} at (-20,-10) size 0x0
+      RenderSVGGradientStop {stop} [offset=-10.00] [color=#008000]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#FF0000]
+    RenderSVGResourceLinearGradient {linearGradient} at (-20,-10) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#FF0000]
+      RenderSVGGradientStop {stop} [offset=10.00] [color=#008000]
+    RenderSVGResourceLinearGradient {linearGradient} at (-20,-10) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#0000FF]
+      RenderSVGGradientStop {stop} [offset=0.50] [color=#008000]
+      RenderSVGGradientStop {stop} [offset=0.50] [color=#FF0000]
+      RenderSVGGradientStop {stop} [offset=0.50] [color=#008000]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#0000FF]
 layer at (20,10) size 440x30
   RenderSVGRect {rect} at (0,0) size 440x30 [stroke={[type=SOLID] [color=#FF0000]}] [fill={[type=SOLID] [color=#00000000]}] [x=20.00] [y=10.00] [width=440.00] [height=30.00]
 layer at (20,60) size 440x30

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/inline-svg-in-xhtml-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/inline-svg-in-xhtml-expected.txt
@@ -7,29 +7,32 @@ layer at (49,39) size 720x540
   RenderSVGRoot zI: -1 {svg} at (1,1) size 720x540
 layer at (49,39) size 720x540
   RenderSVGViewportContainer at (0,0) size 720x540
+    RenderSVGResourceLinearGradient {linearGradient} at (0,0) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#FFFF00]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#008000]
 layer at (49,39) size 100x100
   RenderSVGRect {rect} at (0,0) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=0.00] [width=100.00] [height=100.00]
 layer at (69,59) size 60x60
   RenderSVGEllipse {circle} at (20,20) size 60x60 [fill={[type=SOLID] [color=#00000000]}] [cx=50.00] [cy=50.00] [r=30.00]
 layer at (48,38) size 722x542 layerType: foreground only
   RenderBody {body} at (48,38) size 722x542 [border: (1px solid #000000)]
-    RenderBlock {form} at (1,1) size 720x123.59
-      RenderFieldSet {fieldset} at (2,0) size 716x123.59 [border: (2px groove #C0C0C0)]
+    RenderBlock {form} at (1,1) size 720x121.59
+      RenderFieldSet {fieldset} at (2,0) size 716x121.59 [border: (2px groove #C0C0C0)]
         RenderBlock {legend} at (14,0) size 87.42x18
           RenderText {#text} at (2,0) size 84x18
             text run at (2,0) width 84: "HTML Form"
-        RenderBlock {p} at (14,39.59) size 688x21
-          RenderInline {label} at (0,1) size 110x18
-            RenderText {#text} at (0,1) size 110x18
-              text run at (0,1) width 110: "Enter something:"
-          RenderText {#text} at (109,1) size 5x18
-            text run at (109,1) width 5: " "
-          RenderTextControl {input} at (113.75,0) size 155.88x21 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
+        RenderBlock {p} at (14,39.59) size 688x19
+          RenderInline {label} at (0,0) size 110x18
+            RenderText {#text} at (0,0) size 110x18
+              text run at (0,0) width 110: "Enter something:"
+          RenderText {#text} at (109,0) size 5x18
+            text run at (109,0) width 5: " "
+          RenderTextControl {input} at (113.75,0) size 147.88x19 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderText {#text} at (0,0) size 0x0
-        RenderBlock {p} at (14,76.59) size 688x19
-          RenderButton {button} at (0,1) size 62.09x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+        RenderBlock {p} at (14,74.59) size 688x19
+          RenderButton {button} at (0,1) size 62.09x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: none (2px outset #C0C0C0) none (2px outset #C0C0C0)]
             RenderBlock (anonymous) at (8,2) size 46.09x13
               RenderText {#text} at (0,0) size 47x13
                 text run at (0,0) width 47: "Activate!"
-layer at (185.75,82.59) size 142x13 backgroundClip at (185.75,82.59) size 141.88x13 clip at (185.75,82.59) size 141.88x13
-  RenderBlock {div} at (7,4) size 141.88x13
+layer at (181.75,81.59) size 142x13 backgroundClip at (181.75,81.59) size 141.88x13 clip at (181.75,81.59) size 141.88x13
+  RenderBlock {div} at (3,3) size 141.88x13

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/js-late-gradient-and-object-creation-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/js-late-gradient-and-object-creation-expected.txt
@@ -6,6 +6,11 @@ layer at (0,0) size 800x600
   RenderSVGViewportContainer at (0,0) size 800x600
 layer at (-150,8.80) size 605x219 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
   RenderSVGTransformableContainer {g} at (-150,8.80) size 604.30x218.20
+    RenderSVGResourceLinearGradient {linearGradient} at (150,-8.80) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#0000FF]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#FF0000]
+    RenderSVGResourceLinearGradient {linearGradient} at (150,-8.80) size 0x0
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#008000]
 layer at (-150,8.80) size 419x78 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
   RenderSVGText {text} at (0,0) size 420x79 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 420x79

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/js-late-gradient-creation-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/js-late-gradient-creation-expected.txt
@@ -6,6 +6,9 @@ layer at (0,0) size 800x600
   RenderSVGViewportContainer at (0,0) size 800x600
 layer at (20,8.64) size 420x79
   RenderSVGTransformableContainer {g} at (20,8.64) size 419.23x78.36
+    RenderSVGResourceLinearGradient {linearGradient} at (-20,-8.64) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#0000FF]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#FF0000]
 layer at (20,8.64) size 419x78
   RenderSVGText {text} at (0,0) size 420x79 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 420x79

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/large-bounding-box-percents-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/large-bounding-box-percents-expected.txt
@@ -4,5 +4,8 @@ layer at (0,0) size 800x600
   RenderSVGRoot {svg} at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderSVGViewportContainer at (0,0) size 800x600
+    RenderSVGResourceRadialGradient {radialGradient} at (0,0) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#008000]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#FF0000]
 layer at (0,0) size 100x100
   RenderSVGRect {rect} at (0,0) size 100x100 [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=0.00] [width=100.00] [height=100.00]

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/non-scaling-stroke-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/non-scaling-stroke-expected.txt
@@ -6,6 +6,12 @@ layer at (0,0) size 800x600
   RenderSVGViewportContainer at (0,0) size 800x600
 layer at (0,0) size 400x50
   RenderSVGHiddenContainer {defs} at (0,0) size 400x50
+    RenderSVGResourceLinearGradient {linearGradient} at (0,0) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#0000FF]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#FFFF00]
+    RenderSVGResourceLinearGradient {linearGradient} at (0,0) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#0000FF]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#FFFF00]
 layer at (0,0) size 20x20
   RenderSVGHiddenContainer {pattern} at (0,0) size 20x20
 layer at (0,0) size 10x10

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/resource-client-removal-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/resource-client-removal-expected.txt
@@ -6,6 +6,9 @@ layer at (0,0) size 800x600
   RenderSVGViewportContainer at (0,0) size 800x600
 layer at (0,0) size 100x100
   RenderSVGHiddenContainer {defs} at (0,0) size 100x100
+    RenderSVGResourceLinearGradient {linearGradient} at (0,0) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#008000]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#008000]
 layer at (0,0) size 100x100
   RenderSVGPath {path} at (0,0) size 100x100 [fill={[type=SOLID] [color=#000000]}] [data="M 0 0 L 100 0 L 100 100 L 0 100"]
 layer at (0,0) size 100x100

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/stroke-fallback-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/stroke-fallback-expected.txt
@@ -4,6 +4,8 @@ layer at (0,0) size 800x600
   RenderSVGRoot {svg} at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderSVGViewportContainer at (0,0) size 800x600
+    RenderSVGResourceLinearGradient {linearGradient} at (0,0) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#008000]
 layer at (0,0) size 95x95
   RenderSVGRect {rect} at (0,0) size 95x95 [stroke={[type=SOLID] [color=#008000] [stroke width=10.00]}] [fill={[type=SOLID] [color=#008000]}] [x=0.00] [y=0.00] [width=95.00] [height=95.00]
 layer at (150,0) size 95x95

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/text-gradient-no-content-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/text-gradient-no-content-expected.txt
@@ -4,6 +4,9 @@ layer at (0,0) size 800x600
   RenderSVGRoot {svg} at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderSVGViewportContainer at (0,0) size 800x600
+    RenderSVGResourceLinearGradient {linearGradient} at (0,0) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#FF0000]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#FF0000]
 layer at (0,0) size 800x600
   RenderSVGRect {rect} at (0,0) size 800x600 [fill={[type=SOLID] [color=#008000]}] [x=0.00] [y=0.00] [width=800.00] [height=600.00]
 layer at (0,0) size 0x0

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/xlink-custom-namespace-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/xlink-custom-namespace-expected.txt
@@ -4,6 +4,10 @@ layer at (0,0) size 800x600
   RenderSVGRoot {svg} at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderSVGViewportContainer at (0,0) size 800x600
+    RenderSVGResourceLinearGradient {linearGradient} at (0,0) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#008000]
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#008000]
+    RenderSVGResourceLinearGradient {linearGradient} at (0,0) size 0x0
 layer at (0,0) size 200x200
   RenderSVGRect {rect} at (0,0) size 200x200 [fill={[type=SOLID] [color=#FF0000]}] [x=0.00] [y=0.00] [width=200.00] [height=200.00]
 layer at (0,0) size 200x200

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/filters/feImage-late-indirect-update-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/filters/feImage-late-indirect-update-expected.txt
@@ -6,6 +6,8 @@ layer at (0,0) size 800x600
   RenderSVGViewportContainer at (0,0) size 800x600
 layer at (200,150) size 400x300
   RenderSVGHiddenContainer {defs} at (200,150) size 400x300
+    RenderSVGResourceLinearGradient {linearGradient} at (-200,-150) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#008000]
 layer at (200,150) size 400x300
   RenderSVGEllipse {ellipse} at (0,0) size 400x300 [fill={[type=SOLID] [color=#00000000]}] [cx=400.00] [cy=300.00] [rx=200.00] [ry=150.00]
 layer at (0,0) size 800x600

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/hixie/perf/005-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/hixie/perf/005-expected.txt
@@ -4,6 +4,11 @@ layer at (0,0) size 400x400
   RenderSVGRoot {svg} at (0,0) size 400x400
 layer at (0,0) size 400x400
   RenderSVGViewportContainer at (0,0) size 400x400
+    RenderSVGResourceLinearGradient {linearGradient} at (0,0) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#0000FF]
+      RenderSVGGradientStop {stop} [offset=0.10] [color=#FF6600]
+      RenderSVGGradientStop {stop} [offset=0.90] [color=#FFFF66]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#0000FF]
 layer at (10,10.50) size 49x5
   RenderSVGText {text} at (10,10) size 50x7 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 50x6

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/hixie/perf/006-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/hixie/perf/006-expected.txt
@@ -4,6 +4,11 @@ layer at (0,0) size 400x400
   RenderSVGRoot {svg} at (0,0) size 400x400
 layer at (0,0) size 400x400
   RenderSVGViewportContainer at (0,0) size 400x400
+    RenderSVGResourceRadialGradient {radialGradient} at (0,0) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#0000FF]
+      RenderSVGGradientStop {stop} [offset=0.10] [color=#FF6600]
+      RenderSVGGradientStop {stop} [offset=0.90] [color=#FFFF66]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#0000FF]
 layer at (10,10.50) size 49x5
   RenderSVGText {text} at (10,10) size 50x7 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 50x6

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/zoom/page/zoom-mask-with-percentages-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/zoom/page/zoom-mask-with-percentages-expected.txt
@@ -12,6 +12,9 @@ layer at (179,35.98) size 92x18
       chunk 1 (middle anchor) text run 1 at (179.00,50.00) startOffset 0 endOffset 12 width 92.00: "Mask Regions"
 layer at (0,0) size 100x81
   RenderSVGHiddenContainer {defs} at (0,17.02) size 100x80
+    RenderSVGResourceLinearGradient {linearGradient} at (0,0) size 0x0
+      RenderSVGGradientStop {stop} [offset=0.00] [color=#0000FF]
+      RenderSVGGradientStop {stop} [offset=1.00] [color=#FF0000]
 layer at (0,0) size 100x80
   RenderSVGRect {rect} at (0,0) size 100x80 [fill={[type=SOLID] [color=#00000000]}] [x=0.00] [y=0.00] [width=100.00] [height=80.00]
 layer at (5,0) size 90x80

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/zoom/page/zoom-svg-through-object-with-override-size-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/zoom/page/zoom-svg-through-object-with-override-size-expected.txt
@@ -14,6 +14,18 @@ layer at (0,0) size 800x376
           RenderSVGTransformableContainer {g} at (0,0) size 107x127
         layer at (0,0) size 108x127 backgroundClip at (0,0) size 347x347 clip at (0,0) size 347x347
           RenderSVGTransformableContainer {g} at (0,0) size 107x127
+            RenderSVGResourceLinearGradient {linearGradient} at (0,0) size 0x0
+              RenderSVGGradientStop {stop} [offset=0.00] [color=#FFFFFF]
+              RenderSVGGradientStop {stop} [offset=1.00] [color=#000000]
+            RenderSVGResourceLinearGradient {linearGradient} at (0,0) size 0x0
+              RenderSVGGradientStop {stop} [offset=0.00] [color=#FFA700]
+              RenderSVGGradientStop {stop} [offset=0.69] [color=#FFFF00]
+            RenderSVGResourceLinearGradient {linearGradient} at (0,0) size 0x0
+              RenderSVGGradientStop {stop} [offset=0.00] [color=#FFA700]
+              RenderSVGGradientStop {stop} [offset=0.69] [color=#FFFF00]
+            RenderSVGResourceLinearGradient {linearGradient} at (0,0) size 0x0
+              RenderSVGGradientStop {stop} [offset=0.00] [color=#FFA700]
+              RenderSVGGradientStop {stop} [offset=0.69] [color=#FFFF00]
         layer at (15,0) size 84x123 backgroundClip at (0,0) size 347x347 clip at (0,0) size 347x347
           RenderSVGPath {path} at (15,0) size 82x122 [fill={[type=SOLID] [color=#00000000] [fill rule=EVEN-ODD]}] [clip rule=EVEN-ODD] [data="M 96.658 84.788 C 95.021 91.534 86.719 105.601 82.313 111.808 C 77.91 118.033 78.448 123.634 70.292 121.456 C 62.17 119.261 59.876 119.671 51.492 120.161 C 43.139 120.651 44.957 119.917 39.717 122.257 C 34.524 124.616 17.052 93.712 15.627 87.966 C 14.252 82.218 13.58 82.903 17.199 76.683 C 20.817 70.476 21.325 64.334 26.124 56.801 C 30.906 49.235 36.424 45.402 36.031 39.622 C 34.477 18.183 33.233 7.474 42.748 2.51 C 51.819 -2.188 59.384 0.612 62.383 2.217 C 63.678 2.922 66.298 4.248 68.264 6.604 C 70.21 8.915 71.98 12.403 72.963 16.825 C 75.01 25.668 72.127 22.736 74.438 32.872 C 76.714 42.994 81.349 47.956 86.999 55.947 C 92.647 63.958 98.543 77.157 96.658 84.788 Z"]
         layer at (38,18) size 27x17

--- a/Source/WebCore/rendering/svg/RenderSVGResourceGradient.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceGradient.h
@@ -53,6 +53,8 @@ protected:
     GradientColorStops stopsByApplyingColorFilter(const GradientColorStops&, const RenderStyle&) const;
     GradientSpreadMethod platformSpreadMethodFromSVGType(SVGSpreadMethodType) const;
 
+    bool requiresLayer() const final { return false; }
+
     RefPtr<Gradient> m_gradient;
 };
 


### PR DESCRIPTION
#### adaaa7837c7310fc0286bd929e1184b1d3f089cb
<pre>
[LBSE] Disallow layers for gradients
<a href="https://bugs.webkit.org/show_bug.cgi?id=304843">https://bugs.webkit.org/show_bug.cgi?id=304843</a>

Reviewed by NOBODY (OOPS!).

Disallow layers for gradients.

* LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/W3C-SVG-1.1/coords-units-01-b-expected.txt:
* LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/W3C-SVG-1.1/pservers-grad-01-b-expected.txt:
* LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/W3C-SVG-1.1/pservers-grad-02-b-expected.txt:
* LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/W3C-SVG-1.1/pservers-grad-04-b-expected.txt:
* LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/W3C-SVG-1.1/pservers-grad-05-b-expected.txt:
* LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/W3C-SVG-1.1/pservers-grad-06-b-expected.txt:
* LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/W3C-SVG-1.1/pservers-grad-07-b-expected.txt:
* LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/W3C-SVG-1.1/pservers-grad-08-b-expected.txt:
* LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/W3C-SVG-1.1/pservers-grad-09-b-expected.txt:
* LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/W3C-SVG-1.1/pservers-grad-10-b-expected.txt:
* LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/W3C-SVG-1.1/pservers-grad-11-b-expected.txt:
* LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/W3C-SVG-1.1/pservers-grad-12-b-expected.txt:
* LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/W3C-SVG-1.1/pservers-grad-15-b-expected.txt:
* LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/W3C-SVG-1.1/pservers-grad-16-b-expected.txt:
* LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/W3C-SVG-1.1/styling-inherit-01-b-expected.txt:
* LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/broken-internal-references-expected.txt:
* LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/fill-fallback-expected.txt:
* LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/gradient-rotated-bbox-expected.txt:
* LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/gradient-stop-corner-cases-expected.txt:
* LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/inline-svg-in-xhtml-expected.txt:
* LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/js-late-gradient-and-object-creation-expected.txt:
* LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/js-late-gradient-creation-expected.txt:
* LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/large-bounding-box-percents-expected.txt:
* LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/non-scaling-stroke-expected.txt:
* LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/resource-client-removal-expected.txt:
* LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/stroke-fallback-expected.txt:
* LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/text-gradient-no-content-expected.txt:
* LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/xlink-custom-namespace-expected.txt:
* LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/filters/feImage-late-indirect-update-expected.txt:
* LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/hixie/perf/005-expected.txt:
* LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/hixie/perf/006-expected.txt:
* LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/zoom/page/zoom-mask-with-percentages-expected.txt:
* LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/zoom/page/zoom-svg-through-object-with-override-size-expected.txt:
* Source/WebCore/rendering/svg/RenderSVGResourceGradient.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/adaaa7837c7310fc0286bd929e1184b1d3f089cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139047 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11415 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/534 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147172 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92074 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140920 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12124 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11570 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106444 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77561 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141994 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9161 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124560 "Found 1 new API test failure: TestWebKitAPI.UnifiedPDF.PrintSize (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87311 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8718 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6491 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7467 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118167 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/454 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149952 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11099 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/467 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114834 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11117 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9387 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115144 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9030 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120905 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66013 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11146 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/434 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10882 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74796 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11085 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10933 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->