### PR TITLE
[UIIntelligenceSupport] youtube.com: unable to retrieve context entities from video pages

### DIFF
--- a/LayoutTests/fast/text-extraction/extract-text-with-empty-body-expected.html
+++ b/LayoutTests/fast/text-extraction/extract-text-with-empty-body-expected.html
@@ -1,0 +1,37 @@
+<!-- webkit-test-runner [ textExtractionEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta charset="utf-8">
+<style>
+body, html {
+    width: 100%;
+    margin: 0;
+    font-size: 18px;
+}
+</style>
+<script src="../../resources/ui-helper.js"></script>
+</head>
+<body>
+<p>Hello world — this is a test</p>
+<div>
+    <a href="https://www.apple.com">Test link</a>
+</div>
+<script>
+addEventListener("load", async () => {
+    if (!window.testRunner)
+        return;
+
+    testRunner.waitUntilDone();
+    document.body.textContent = await UIHelper.requestTextExtraction({
+        mergeParagraphs: true,
+        skipNearlyTransparentContent: true,
+        clipToBounds: true,
+        includeRects: true
+    });
+    testRunner.notifyDone();
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/text-extraction/extract-text-with-empty-body.html
+++ b/LayoutTests/fast/text-extraction/extract-text-with-empty-body.html
@@ -1,0 +1,38 @@
+<!-- webkit-test-runner [ textExtractionEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta charset="utf-8">
+<style>
+body, html {
+    width: 100%;
+    height: 0;
+    margin: 0;
+    font-size: 18px;
+}
+</style>
+<script src="../../resources/ui-helper.js"></script>
+</head>
+<body>
+<p>Hello world — this is a test</p>
+<div>
+    <a href="https://www.apple.com">Test link</a>
+</div>
+<script>
+addEventListener("load", async () => {
+    if (!window.testRunner)
+        return;
+
+    testRunner.waitUntilDone();
+    document.body.textContent = await UIHelper.requestTextExtraction({
+        mergeParagraphs: true,
+        skipNearlyTransparentContent: true,
+        clipToBounds: true,
+        includeRects: true
+    });
+    testRunner.notifyDone();
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -932,7 +932,6 @@ Item extractItem(Request&& request, Page& page)
         return root;
 
     mainDocument->updateLayoutIgnorePendingStylesheets();
-    root.rectInRootView = rootViewBounds(*bodyElement);
 
     RefPtr extractionRootNode = [&] -> Node* {
         if (!request.targetNodeHandleIdentifier)
@@ -942,6 +941,14 @@ Item extractItem(Request&& request, Page& page)
     }();
 
     if (!extractionRootNode)
+        return root;
+
+    RefPtr view = mainFrame->view();
+    if (!view)
+        return root;
+
+    root.rectInRootView = view->contentsToRootView(IntRect { IntPoint::zero(), view->contentsSize() });
+    if (root.rectInRootView.isEmpty())
         return root;
 
     {


### PR DESCRIPTION
#### 9c12a46edfdbced04906e74a337d6fe7bdb7e525
<pre>
[UIIntelligenceSupport] youtube.com: unable to retrieve context entities from video pages
<a href="https://bugs.webkit.org/show_bug.cgi?id=304853">https://bugs.webkit.org/show_bug.cgi?id=304853</a>
<a href="https://rdar.apple.com/160218812">rdar://160218812</a>

Reviewed by Abrar Rahman Protyasha.

UIIntelligenceSupport automatically prunes the extracted IntelligenceSupport element tree by
filtering out all items whose bounding rects lie outside the bounds of its parent item&apos;s bounds. On
YouTube, this currently causes the entire page content to get filtered out, due to the fact that the
`body` element (represented by the `root` item) has `height: 0;`, and so the bounding rect is empty.
To fix this, use the mainframe `contentsSize()` instead of the `body`&apos;s bounding rect for the root
item&apos;s `rectInRootView`.

Test: fast/text-extraction/extract-text-with-empty-body.html

* LayoutTests/fast/text-extraction/extract-text-with-empty-body-expected.html: Added.
* LayoutTests/fast/text-extraction/extract-text-with-empty-body.html: Added.

Add a ref test to verify that the presence of `height: 0;` on `html` and/or `body` does not change
the extracted item tree.

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractItem):

Canonical link: <a href="https://commits.webkit.org/305053@main">https://commits.webkit.org/305053@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da13fdcada29a22bc6fd295de50f03afc3bb89ca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137313 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9673 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48600 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145064 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90286 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1cc9ac1f-476f-41b7-b6f4-615138afeae5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139185 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10377 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9800 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104996 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b49e0406-0029-470a-84bd-a469e3bbeb1f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140258 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7662 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123066 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85852 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f324b54c-bbe2-4b80-82cd-e067b4329f22) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7299 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5022 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5651 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116663 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41219 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147821 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9356 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41780 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113368 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9374 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7876 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113710 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28873 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7223 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119310 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63927 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9405 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37364 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9135 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72970 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9345 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9197 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->