### PR TITLE
Stop using MockLocalServiceAdditions.h

### DIFF
--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalService.mm
@@ -32,11 +32,12 @@
 #import "MockLocalConnection.h"
 #import <wtf/RunLoop.h>
 
-#if USE(APPLE_INTERNAL_SDK)
-#import <WebKitAdditions/MockLocalServiceAdditions.h>
-#else
-#define MOCK_LOCAL_SERVICE_ADDITIONS
-#endif
+#import "AuthenticationServicesCoreSoftLink.h"
+
+static BOOL ACSWebKitSPIMockSupportMethod(id, SEL)
+{
+    return NO;
+}
 
 namespace WebKit {
 
@@ -49,7 +50,8 @@ MockLocalService::MockLocalService(AuthenticatorTransportServiceObserver& observ
     : LocalService(observer)
     , m_configuration(configuration)
 {
-MOCK_LOCAL_SERVICE_ADDITIONS
+    Method methodToSwizzle = class_getClassMethod(getASCWebKitSPISupportClassSingleton(), @selector(shouldUseAlternateCredentialStore)); \
+    method_setImplementation(methodToSwizzle, (IMP)ACSWebKitSPIMockSupportMethod);
 }
 
 bool MockLocalService::platformStartDiscovery() const


### PR DESCRIPTION
#### ce5348371c2e4c16ea2bbef440f23892f293ef68
<pre>
Stop using MockLocalServiceAdditions.h
<a href="https://rdar.apple.com/167448853">rdar://167448853</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=304859">https://bugs.webkit.org/show_bug.cgi?id=304859</a>

Reviewed by Richard Robinson.

This patch upstreams some functions that can now
be moved from additions inline.

* Source/WebKit/UIProcess/WebAuthentication/Mock/MockLocalService.mm:
(ACSWebKitSPIMockSupportMethod):
(WebKit::MockLocalService::MockLocalService):

Canonical link: <a href="https://commits.webkit.org/305060@main">https://commits.webkit.org/305060@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e92ad7ac5885bea1d6794b38c36f68ff7f02a4c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137328 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9688 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48615 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145079 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90301 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/24d0ad58-3cd5-4f2a-bb24-557be760e4a7) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10392 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9815 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105009 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8029c067-cdac-4712-9879-5c3388558a15) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140273 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7676 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123075 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85865 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7ef81790-83e1-4514-b032-da5329622d9e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7313 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5033 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5666 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116677 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147836 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9371 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41788 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113381 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9389 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7887 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113722 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28877 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7233 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119318 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/63953 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9420 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37372 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9150 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72985 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9360 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9212 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->