### PR TITLE
[JSC] Add dumpIonGraph option

### DIFF
--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -2136,6 +2136,8 @@
 		E3F23A821ECF13FE00978D99 /* Snippet.h in Headers */ = {isa = PBXBuildFile; fileRef = E3F23A7B1ECF13E500978D99 /* Snippet.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3F429BD2A41742F00C5FEFF /* AirOptimizePairedLoadStore.h in Headers */ = {isa = PBXBuildFile; fileRef = E3F429BB2A41742700C5FEFF /* AirOptimizePairedLoadStore.h */; };
 		E3F52B2B2A8D9BB70080E92D /* NativeCallee.h in Headers */ = {isa = PBXBuildFile; fileRef = E3F52B292A8D9BB60080E92D /* NativeCallee.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E3FB5BEC2F0886090016B5F5 /* AirDominators.h in Headers */ = {isa = PBXBuildFile; fileRef = E3FB5BEB2F0886090016B5F5 /* AirDominators.h */; };
+		E3FB5BEE2F0886E00016B5F5 /* AirNaturalLoops.h in Headers */ = {isa = PBXBuildFile; fileRef = E3FB5BED2F0886E00016B5F5 /* AirNaturalLoops.h */; };
 		E3FCCB642310A90D00238E72 /* ConstructorKind.h in Headers */ = {isa = PBXBuildFile; fileRef = E3FCCB632310A90D00238E72 /* ConstructorKind.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3FF75331D9CEA1800C7E16D /* DOMJITGetterSetter.h in Headers */ = {isa = PBXBuildFile; fileRef = E3FF752F1D9CEA1200C7E16D /* DOMJITGetterSetter.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E49DC16C12EF294E00184A1F /* SourceProviderCache.h in Headers */ = {isa = PBXBuildFile; fileRef = E49DC15112EF272200184A1F /* SourceProviderCache.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -6040,6 +6042,8 @@
 		E3F429BC2A41742700C5FEFF /* AirOptimizePairedLoadStore.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = AirOptimizePairedLoadStore.cpp; path = b3/air/AirOptimizePairedLoadStore.cpp; sourceTree = "<group>"; };
 		E3F52B292A8D9BB60080E92D /* NativeCallee.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NativeCallee.h; sourceTree = "<group>"; };
 		E3F52B2A2A8D9BB70080E92D /* NativeCallee.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NativeCallee.cpp; sourceTree = "<group>"; };
+		E3FB5BEB2F0886090016B5F5 /* AirDominators.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AirDominators.h; path = b3/air/AirDominators.h; sourceTree = "<group>"; };
+		E3FB5BED2F0886E00016B5F5 /* AirNaturalLoops.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AirNaturalLoops.h; path = b3/air/AirNaturalLoops.h; sourceTree = "<group>"; };
 		E3FC25102256ECF400583518 /* DoublePredictionFuzzerAgent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = DoublePredictionFuzzerAgent.cpp; sourceTree = "<group>"; };
 		E3FC25112256ECF400583518 /* DoublePredictionFuzzerAgent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DoublePredictionFuzzerAgent.h; sourceTree = "<group>"; };
 		E3FCCB632310A90D00238E72 /* ConstructorKind.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ConstructorKind.h; sourceTree = "<group>"; };
@@ -6948,6 +6952,7 @@
 				0F10F1A21C420BF0001C07D2 /* AirCustom.h */,
 				79ABB17B1E5CCB570045B9A6 /* AirDisassembler.cpp */,
 				79ABB17C1E5CCB570045B9A6 /* AirDisassembler.h */,
+				E3FB5BEB2F0886090016B5F5 /* AirDominators.h */,
 				0F4570361BE44C910062A629 /* AirEliminateDeadCode.cpp */,
 				0F4570371BE44C910062A629 /* AirEliminateDeadCode.h */,
 				0F6183231C45BF070072450B /* AirEmitShuffle.cpp */,
@@ -6986,6 +6991,7 @@
 				0F6183281C45BF070072450B /* AirLowerMacros.h */,
 				0F5CF9821E9D537500C18692 /* AirLowerStackArgs.cpp */,
 				0F5CF9831E9D537500C18692 /* AirLowerStackArgs.h */,
+				E3FB5BED2F0886E00016B5F5 /* AirNaturalLoops.h */,
 				264091FA1BE2FD4100684DB2 /* AirOpcode.opcodes */,
 				0FB3878C1BFBC44D00E3AB1E /* AirOptimizeBlockOrder.cpp */,
 				0FB3878D1BFBC44D00E3AB1E /* AirOptimizeBlockOrder.h */,
@@ -10627,6 +10633,7 @@
 				0FEC85761BDACDC70080FF74 /* AirCode.h in Headers */,
 				0F10F1A31C420BF0001C07D2 /* AirCustom.h in Headers */,
 				79ABB17E1E5CCB570045B9A6 /* AirDisassembler.h in Headers */,
+				E3FB5BEC2F0886090016B5F5 /* AirDominators.h in Headers */,
 				0F4570391BE44C910062A629 /* AirEliminateDeadCode.h in Headers */,
 				0F61832D1C45BF070072450B /* AirEmitShuffle.h in Headers */,
 				0F4DE1CF1C4C1B54004D6C11 /* AirFixObviousSpills.h in Headers */,
@@ -10649,6 +10656,7 @@
 				0FDF70861D3F2C2500927449 /* AirLowerEntrySwitch.h in Headers */,
 				0F6183311C45BF070072450B /* AirLowerMacros.h in Headers */,
 				0F5CF9841E9D537700C18692 /* AirLowerStackArgs.h in Headers */,
+				E3FB5BEE2F0886E00016B5F5 /* AirNaturalLoops.h in Headers */,
 				0F40E4A71C497F7400A577FA /* AirOpcode.h in Headers */,
 				0F40E4A81C497F7400A577FA /* AirOpcodeGenerated.h in Headers */,
 				0F40E4A91C497F7400A577FA /* AirOpcodeUtils.h in Headers */,

--- a/Source/JavaScriptCore/assembler/PerfLog.cpp
+++ b/Source/JavaScriptCore/assembler/PerfLog.cpp
@@ -178,7 +178,7 @@ static inline uint32_t getCurrentThreadID()
 PerfLog::PerfLog()
 {
     {
-        m_file = FileSystem::createDumpFile(makeString("jit-"_s, getCurrentThreadID(), "-"_s, WTF::getCurrentProcessID(), ".dump"_s), String::fromUTF8(Options::jitDumpDirectory()));
+        m_file = FileSystem::createDumpFile(makeString("jit-"_s, getCurrentThreadID(), "-"_s, WTF::getCurrentProcessID()), ".dump"_s, String::fromUTF8(Options::jitDumpDirectory()));
         RELEASE_ASSERT(m_file);
 
 #if OS(LINUX)

--- a/Source/JavaScriptCore/b3/B3Generate.cpp
+++ b/Source/JavaScriptCore/b3/B3Generate.cpp
@@ -74,10 +74,12 @@ void generateToAir(Procedure& procedure)
         dataLog(tierName, "Initial B3:\n");
         dataLog(procedure);
     }
-
     // We don't require the incoming IR to have predecessors computed.
     procedure.resetReachability();
-    
+
+    if (Options::dumpIonGraph()) [[unlikely]]
+        procedure.appendIonGraphPass("InitialCFG"_s);
+
     if (shouldValidateIR())
         validate(procedure);
     

--- a/Source/JavaScriptCore/b3/B3PhaseScope.cpp
+++ b/Source/JavaScriptCore/b3/B3PhaseScope.cpp
@@ -55,6 +55,9 @@ PhaseScope::~PhaseScope()
     m_procedure.setLastPhaseName(m_name);
     if (shouldValidateIRAtEachPhase())
         validate(m_procedure, m_dumpBefore.data());
+
+    if (Options::dumpIonGraph()) [[unlikely]]
+        m_procedure.appendIonGraphPass(m_name);
 }
 
 } } // namespace JSC::B3

--- a/Source/JavaScriptCore/b3/B3Procedure.h
+++ b/Source/JavaScriptCore/b3/B3Procedure.h
@@ -39,6 +39,7 @@
 #include <wtf/FastMalloc.h>
 #include <wtf/HashSet.h>
 #include <wtf/IndexedContainerIterator.h>
+#include <wtf/JSONValues.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/PrintStream.h>
 #include <wtf/SequesteredMalloc.h>
@@ -303,6 +304,9 @@ public:
         return m_usesSIMD;
     }
 
+    void setIonGraphPasses(Ref<JSON::Array>&&);
+    void appendIonGraphPass(ASCIILiteral);
+
 private:
     friend class BlockInsertionSet;
 
@@ -325,6 +329,7 @@ private:
     RefPtr<SharedTask<void(PrintStream&, Origin)>> m_originPrinter;
     const void* m_frontendData;
     PCToOriginMap m_pcToOriginMap;
+    RefPtr<JSON::Array> m_ionGraphPasses;
     unsigned m_numEntrypoints { 1 };
     unsigned m_optLevel { defaultOptLevel() };
     bool m_needsUsedRegisters { true };

--- a/Source/JavaScriptCore/b3/air/AirCode.h
+++ b/Source/JavaScriptCore/b3/air/AirCode.h
@@ -40,6 +40,7 @@
 #include "StackAlignment.h"
 #include <wtf/HashSet.h>
 #include <wtf/IndexMap.h>
+#include <wtf/JSONValues.h>
 #include <wtf/SequesteredMalloc.h>
 #include <wtf/SmallSet.h>
 #include <wtf/TZoneMalloc.h>
@@ -363,7 +364,10 @@ public:
 
     void setForceIRCRegisterAllocation() { m_forceIRC = true; }
     bool forceIRCRegisterAllocation() { return m_forceIRC; }
-    
+
+    void setIonGraphPasses(Ref<JSON::Array>&&);
+    void appendIonGraphPass(ASCIILiteral);
+
 private:
     friend class ::JSC::B3::Procedure;
     friend class BlockInsertionSet;
@@ -412,6 +416,7 @@ private:
     const char* m_lastPhaseName;
     std::unique_ptr<Disassembler> m_disassembler;
     const Ref<PrologueGenerator> m_defaultPrologueGenerator;
+    RefPtr<JSON::Array> m_ionGraphPasses;
 };
 
 } } } // namespace JSC::B3::Air

--- a/Source/JavaScriptCore/b3/air/AirDominators.h
+++ b/Source/JavaScriptCore/b3/air/AirDominators.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -20,38 +20,32 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #pragma once
 
 #if ENABLE(B3_JIT)
 
-#include "B3Dominators.h"
-#include <wtf/NaturalLoops.h>
+#include "AirCFG.h"
+#include "AirCode.h"
+#include <wtf/Dominators.h>
+#include <wtf/Noncopyable.h>
 #include <wtf/SequesteredMalloc.h>
 #include <wtf/TZoneMalloc.h>
 
-namespace JSC { namespace B3 {
+namespace JSC::B3::Air {
 
-typedef WTF::NaturalLoop<CFG> NaturalLoop;
-
-class NaturalLoops : public WTF::NaturalLoops<CFG> {
-    WTF_MAKE_NONCOPYABLE(NaturalLoops);
-    WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED(NaturalLoops);
+class Dominators : public WTF::Dominators<CFG> {
+    WTF_MAKE_NONCOPYABLE(Dominators);
+    WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED(Dominators);
 public:
-    NaturalLoops(Procedure& proc)
-        : WTF::NaturalLoops<CFG>(proc.cfg(), proc.dominators())
-    {
-    }
-
-    NaturalLoops(Procedure& proc, Dominators& dominators)
-        : WTF::NaturalLoops<CFG>(proc.cfg(), dominators)
+    Dominators(Code& code)
+        : WTF::Dominators<CFG>(code.cfg())
     {
     }
 };
 
-} } // namespace JSC::B3
+} // namespace JSC::B3::Air
 
 #endif // ENABLE(B3_JIT)
-

--- a/Source/JavaScriptCore/b3/air/AirGenerate.cpp
+++ b/Source/JavaScriptCore/b3/air/AirGenerate.cpp
@@ -70,7 +70,10 @@ void prepareForGeneration(Code& code)
     
     // We don't expect the incoming code to have predecessors computed.
     code.resetReachability();
-    
+
+    if (Options::dumpIonGraph()) [[unlikely]]
+        code.appendIonGraphPass("InitialCFG"_s);
+
     if (shouldValidateIR())
         validate(code);
 

--- a/Source/JavaScriptCore/b3/air/AirNaturalLoops.h
+++ b/Source/JavaScriptCore/b3/air/AirNaturalLoops.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -20,19 +20,19 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #pragma once
 
 #if ENABLE(B3_JIT)
 
-#include "B3Dominators.h"
+#include "AirDominators.h"
 #include <wtf/NaturalLoops.h>
 #include <wtf/SequesteredMalloc.h>
 #include <wtf/TZoneMalloc.h>
 
-namespace JSC { namespace B3 {
+namespace JSC::B3::Air {
 
 typedef WTF::NaturalLoop<CFG> NaturalLoop;
 
@@ -40,18 +40,13 @@ class NaturalLoops : public WTF::NaturalLoops<CFG> {
     WTF_MAKE_NONCOPYABLE(NaturalLoops);
     WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED(NaturalLoops);
 public:
-    NaturalLoops(Procedure& proc)
-        : WTF::NaturalLoops<CFG>(proc.cfg(), proc.dominators())
-    {
-    }
-
-    NaturalLoops(Procedure& proc, Dominators& dominators)
-        : WTF::NaturalLoops<CFG>(proc.cfg(), dominators)
+    NaturalLoops(Code& code, Dominators& dominators)
+        : WTF::NaturalLoops<CFG>(code.cfg(), dominators)
     {
     }
 };
 
-} } // namespace JSC::B3
+} // namespace JSC::B3::Air
 
 #endif // ENABLE(B3_JIT)
 

--- a/Source/JavaScriptCore/b3/air/AirPhaseScope.cpp
+++ b/Source/JavaScriptCore/b3/air/AirPhaseScope.cpp
@@ -54,6 +54,9 @@ PhaseScope::~PhaseScope()
     m_code.setLastPhaseName(m_name);
     if (shouldValidateIRAtEachPhase())
         validate(m_code, m_dumpBefore.data());
+
+    if (Options::dumpIonGraph()) [[unlikely]]
+        m_code.appendIonGraphPass(m_name);
 }
 
 } } } // namespace JSC::B3::Air

--- a/Source/JavaScriptCore/bytecode/BytecodeIndex.cpp
+++ b/Source/JavaScriptCore/bytecode/BytecodeIndex.cpp
@@ -30,11 +30,15 @@
 
 namespace JSC {
 
-void BytecodeIndex::dump(WTF::PrintStream& out) const
+void BytecodeIndex::dump(WTF::PrintStream& out, bool inIonGraph) const
 {
-    out.print("bc#", offset());
+    ASCIILiteral split = "#"_s;
+    if (inIonGraph)
+        split = "/"_s;
+
+    out.print("bc"_s, split, offset());
     if (checkpoint())
-        out.print("cp#", checkpoint());
+        out.print("cp"_s, split, checkpoint());
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/bytecode/BytecodeIndex.h
+++ b/Source/JavaScriptCore/bytecode/BytecodeIndex.h
@@ -72,7 +72,7 @@ public:
     explicit operator bool() const { return m_packedBits != invalidOffset && m_packedBits != deletedValue().offset(); }
     friend auto operator<=>(const BytecodeIndex&, const BytecodeIndex&) = default;
 
-    void dump(WTF::PrintStream&) const;
+    void dump(WTF::PrintStream&, bool inIonGraph = false) const;
 
 private:
     static constexpr uint32_t invalidOffset = std::numeric_limits<uint32_t>::max();

--- a/Source/JavaScriptCore/bytecode/CodeOrigin.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeOrigin.cpp
@@ -135,7 +135,7 @@ int CodeOrigin::stackOffset() const
     return inlineCallFrame->stackOffset;
 }
 
-void CodeOrigin::dump(PrintStream& out) const
+void CodeOrigin::dump(PrintStream& out, bool inIonGraph) const
 {
     if (!isSet()) {
         out.print("<none>");
@@ -152,8 +152,7 @@ void CodeOrigin::dump(PrintStream& out) const
             if (frame->isClosureCall)
                 out.print("(closure) ");
         }
-        
-        out.print(stack[i].bytecodeIndex());
+        stack[i].bytecodeIndex().dump(out, inIonGraph);
     }
 }
 

--- a/Source/JavaScriptCore/bytecode/CodeOrigin.h
+++ b/Source/JavaScriptCore/bytecode/CodeOrigin.h
@@ -175,7 +175,7 @@ public:
     // Get the inline stack. This is slow, and is intended for debugging only.
     Vector<CodeOrigin> inlineStack() const;
     
-    JS_EXPORT_PRIVATE void dump(PrintStream&) const;
+    JS_EXPORT_PRIVATE void dump(PrintStream&, bool inIonGraph = false) const;
     void dumpInContext(PrintStream&, DumpContext*) const;
 
     BytecodeIndex bytecodeIndex() const

--- a/Source/JavaScriptCore/dfg/DFGGraph.h
+++ b/Source/JavaScriptCore/dfg/DFGGraph.h
@@ -43,6 +43,7 @@
 #include <wtf/BitVector.h>
 #include <wtf/GenericHashKey.h>
 #include <wtf/HashMap.h>
+#include <wtf/JSONValues.h>
 #include <wtf/StackCheck.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/Vector.h>
@@ -314,13 +315,15 @@ public:
     enum PhiNodeDumpMode { DumpLivePhisOnly, DumpAllPhis };
     void dumpBlockHeader(PrintStream&, const char* prefix, BasicBlock*, PhiNodeDumpMode, DumpContext*);
     void dump(PrintStream&, Edge);
-    void dump(PrintStream&, const char* prefix, Node*, DumpContext* = nullptr);
+    void dump(PrintStream&, const char* prefix, Node*, DumpContext* = nullptr, bool inIonGraph = false);
     static int amountOfNodeWhiteSpace(Node*);
     static void printNodeWhiteSpace(PrintStream&, Node*);
 
     // Dump the code origin of the given node as a diff from the code origin of the
     // preceding node. Returns true if anything was printed.
     bool dumpCodeOrigin(PrintStream&, const char* prefix, Node*& previousNode, Node* currentNode, DumpContext*);
+
+    void appendIonGraphPass(const String& passName);
 
     AddSpeculationMode addSpeculationMode(Node* add, bool leftShouldSpeculateInt32, bool rightShouldSpeculateInt32, PredictionPass pass)
     {
@@ -1248,6 +1251,8 @@ public:
 
     bool afterFixup() { return m_planStage >= PlanStage::AfterFixup; }
 
+    RefPtr<JSON::Array> ionGraphPasses() const { return m_ionGraphPasses; }
+
     StackCheck m_stackChecker;
     VM& m_vm;
     Plan& m_plan;
@@ -1444,6 +1449,8 @@ private:
     B3::SparseCollection<Node> m_nodes;
     SegmentedVector<RegisteredStructureSet, 16> m_structureSets;
     Prefix m_prefix;
+    RefPtr<JSON::Object> m_ionGraphFunction;
+    RefPtr<JSON::Array> m_ionGraphPasses;
 };
 
 } } // namespace JSC::DFG

--- a/Source/JavaScriptCore/dfg/DFGNaturalLoops.h
+++ b/Source/JavaScriptCore/dfg/DFGNaturalLoops.h
@@ -43,6 +43,11 @@ public:
         : WTF::NaturalLoops<CFGKind>(selectCFG<CFGKind>(graph), ensureDominatorsForCFG<CFGKind>(graph), validationEnabled())
     {
     }
+
+    NaturalLoops(Graph& graph, Dominators<CFGKind>& dominators)
+        : WTF::NaturalLoops<CFGKind>(selectCFG<CFGKind>(graph), dominators, validationEnabled())
+    {
+    }
 };
 
 WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED_TEMPLATE_IMPL(template<typename CFGKind>, NaturalLoops<CFGKind>);

--- a/Source/JavaScriptCore/dfg/DFGPhase.h
+++ b/Source/JavaScriptCore/dfg/DFGPhase.h
@@ -87,6 +87,8 @@ bool runAndLog(PhaseType& phase)
 
     if (result && logCompilationChanges(phase.graph().m_plan.mode()))
         dataLogLn(phase.graph().prefix(), "Phase ", phase.name(), " changed the IR.\n");
+    if (Options::dumpIonGraph()) [[unlikely]]
+        phase.graph().appendIonGraphPass(phase.name());
     return result;
 }
 

--- a/Source/JavaScriptCore/ftl/FTLState.cpp
+++ b/Source/JavaScriptCore/ftl/FTLState.cpp
@@ -78,6 +78,8 @@ State::State(Graph& graph)
         });
 
     proc->setFrontendData(&graph);
+    if (RefPtr passes = graph.ionGraphPasses())
+        proc->setIonGraphPasses(passes.releaseNonNull());
 }
 
 void State::dumpDisassembly(PrintStream& out, LinkBuffer& linkBuffer, const ScopedLambda<void(DFG::Node*)>& perDFGNodeCallback)

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -639,6 +639,8 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useArrayAllocationSinking, true, Normal, nullptr) \
     v(Bool, dumpFTLCodeSize, false, Normal, nullptr) \
     v(Bool, dumpOptimizationTracing, false, Normal, nullptr) \
+    v(Bool, dumpIonGraph, false, Normal, nullptr) \
+    v(OptionString, ionGraphDirectory, nullptr, Normal, "Directory to place IonGraph"_s) \
     v(Unsigned, markedBlockDumpInfoCount, 0, Normal, nullptr) /* FIXME: rdar://139998916 */ \
     \
     /* Feature Flags */\

--- a/Source/JavaScriptCore/runtime/ProfilerSupport.h
+++ b/Source/JavaScriptCore/runtime/ProfilerSupport.h
@@ -29,6 +29,7 @@
 #include <stdio.h>
 #include <wtf/FilePrintStream.h>
 #include <wtf/HashMap.h>
+#include <wtf/JSONValues.h>
 #include <wtf/Lock.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/TZoneMalloc.h>
@@ -66,6 +67,8 @@ public:
     static uint64_t generateTimestamp();
 
     static ProfilerSupport& singleton();
+
+    static void dumpIonGraphFunction(const String& functionName, Ref<JSON::Object>&&);
 
 private:
     ProfilerSupport();

--- a/Source/WTF/wtf/FileSystem.cpp
+++ b/Source/WTF/wtf/FileSystem.cpp
@@ -50,12 +50,6 @@
 #include <wtf/StdFilesystem.h>
 #endif
 
-#if OS(WINDOWS)
-    constexpr char pathSeparator = '\\';
-#else
-    constexpr char pathSeparator = '/';
-#endif
-
 namespace WTF::FileSystemImpl {
 
 #if HAVE(STD_FILESYSTEM) || HAVE(STD_EXPERIMENTAL_FILESYSTEM)
@@ -714,13 +708,13 @@ String createTemporaryFile(StringView prefix, StringView suffix)
     return path;
 }
 
-FileHandle createDumpFile(StringView filename, StringView path)
+FileHandle createDumpFile(StringView filename, StringView extension, StringView path)
 {
     if (path.isEmpty()) {
-        auto [p, handle] = openTemporaryFile(nullString(), filename);
+        auto [p, handle] = openTemporaryFile(filename, extension);
         return WTF::move(handle);
     }
-    return openFile(makeString(path, pathSeparator, filename), FileOpenMode::Truncate);
+    return openFile(makeString(path, pathSeparator, filename, extension), FileOpenMode::Truncate);
 }
 
 #if !PLATFORM(PLAYSTATION)

--- a/Source/WTF/wtf/FileSystem.h
+++ b/Source/WTF/wtf/FileSystem.h
@@ -82,6 +82,12 @@ enum class FileAccessPermission : bool {
     All
 };
 
+#if OS(WINDOWS)
+constexpr char pathSeparator = '\\';
+#else
+constexpr char pathSeparator = '/';
+#endif
+
 WTF_EXPORT_PRIVATE bool fileExists(const String&);
 WTF_EXPORT_PRIVATE bool deleteFile(const String&);
 WTF_EXPORT_PRIVATE void deleteAllFilesModifiedSince(const String&, WallTime);
@@ -109,7 +115,7 @@ WTF_EXPORT_PRIVATE std::optional<int32_t> getFileDeviceId(const String&);
 WTF_EXPORT_PRIVATE bool createSymbolicLink(const String& targetPath, const String& symbolicLinkPath);
 WTF_EXPORT_PRIVATE String createTemporaryZipArchive(const String& directory);
 WTF_EXPORT_PRIVATE String extractTemporaryZipArchive(const String& filePath);
-WTF_EXPORT_PRIVATE FileHandle createDumpFile(StringView filename, StringView path = StringView());
+WTF_EXPORT_PRIVATE FileHandle createDumpFile(StringView filename, StringView extension, StringView path = StringView());
 
 enum class FileType { Regular, Directory, SymbolicLink };
 WTF_EXPORT_PRIVATE std::optional<FileType> fileType(const String&);


### PR DESCRIPTION
#### c6bec679e3f15b7f15b27077951216048216d2ad
<pre>
[JSC] Add dumpIonGraph option
<a href="https://bugs.webkit.org/show_bug.cgi?id=304863">https://bugs.webkit.org/show_bug.cgi?id=304863</a>
<a href="https://rdar.apple.com/167451770">rdar://167451770</a>

Reviewed by Keith Miller.

This patch adds dumpIonGraph option, which generates IonGraph[1] that is
IR debugging format used in SpiderMonkey.
<a href="https://mozilla-spidermonkey.github.io/iongraph/">https://mozilla-spidermonkey.github.io/iongraph/</a> can visualize this
format so that we can easily see the entire CFG phase by phase.

Right now, JSC DFG / FTL / B3 / Air has more flexibility in CFG, for
example JSC CFG can have multiple entrypoints. These difference makes
IonGraph web page sometimes does not work, so right now we are using a
bit customized one, which will be pushed after approval.

[1]: <a href="https://spidermonkey.dev/blog/2025/10/28/iongraph-web.html">https://spidermonkey.dev/blog/2025/10/28/iongraph-web.html</a>

* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/assembler/PerfLog.cpp:
(JSC::PerfLog::PerfLog):
* Source/JavaScriptCore/b3/B3Generate.cpp:
(JSC::B3::generateToAir):
* Source/JavaScriptCore/b3/B3NaturalLoops.h:
(JSC::B3::NaturalLoops::NaturalLoops):
* Source/JavaScriptCore/b3/B3PhaseScope.cpp:
(JSC::B3::PhaseScope::~PhaseScope):
* Source/JavaScriptCore/b3/B3Procedure.cpp:
(JSC::B3::Procedure::setIonGraphPasses):
(JSC::B3::Procedure::appendIonGraphPass):
* Source/JavaScriptCore/b3/B3Procedure.h:
* Source/JavaScriptCore/b3/air/AirCode.cpp:
(JSC::B3::Air::Code::setIonGraphPasses):
(JSC::B3::Air::Code::appendIonGraphPass):
* Source/JavaScriptCore/b3/air/AirCode.h:
* Source/JavaScriptCore/b3/air/AirDominators.h: Copied from Source/JavaScriptCore/b3/B3NaturalLoops.h.
(JSC::B3::Air::Dominators::Dominators):
* Source/JavaScriptCore/b3/air/AirGenerate.cpp:
(JSC::B3::Air::prepareForGeneration):
* Source/JavaScriptCore/b3/air/AirNaturalLoops.h: Copied from Source/JavaScriptCore/b3/B3NaturalLoops.h.
(JSC::B3::Air::NaturalLoops::NaturalLoops):
* Source/JavaScriptCore/b3/air/AirPhaseScope.cpp:
(JSC::B3::Air::PhaseScope::~PhaseScope):
* Source/JavaScriptCore/bytecode/BytecodeIndex.cpp:
(JSC::BytecodeIndex::dump const):
* Source/JavaScriptCore/bytecode/BytecodeIndex.h:
* Source/JavaScriptCore/bytecode/CodeOrigin.cpp:
(JSC::CodeOrigin::dump const):
* Source/JavaScriptCore/bytecode/CodeOrigin.h:
* Source/JavaScriptCore/dfg/DFGGraph.cpp:
(JSC::DFG::Graph::Graph):
(JSC::DFG::Graph::~Graph):
(JSC::DFG::Graph::dump):
(JSC::DFG::Graph::appendIonGraphPass):
* Source/JavaScriptCore/dfg/DFGGraph.h:
* Source/JavaScriptCore/dfg/DFGNaturalLoops.h:
(JSC::DFG::NaturalLoops::NaturalLoops):
* Source/JavaScriptCore/dfg/DFGPhase.h:
(JSC::DFG::runAndLog):
* Source/JavaScriptCore/ftl/FTLState.cpp:
(JSC::FTL::State::State):
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/runtime/ProfilerSupport.cpp:
(JSC::ProfilerSupport::dumpIonGraphFunction):
* Source/JavaScriptCore/runtime/ProfilerSupport.h:
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::parseAndCompileOMG):
* Source/WTF/wtf/FileSystem.cpp:
(WTF::FileSystemImpl::createDumpFile):
* Source/WTF/wtf/FileSystem.h:

Canonical link: <a href="https://commits.webkit.org/305066@main">https://commits.webkit.org/305066@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec3ef9357921a9ed8c28f1b13a40082d112d9162

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137389 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9749 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48676 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145140 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90362 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fabf8727-664e-418a-a812-6cd840985054) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10453 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9876 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105055 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8dbc19fe-ba04-44cf-97a4-fb368de877ea) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140334 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7734 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123134 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85910 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/bebd0f08-8606-4b10-a0fe-30b3e3a606a3) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/7370 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/5089 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5727 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/129350 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116737 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41289 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147897 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/135901 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9432 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41846 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/113433 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9450 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7944 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113774 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7290 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119376 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64032 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21160 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9481 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37429 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/168659 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9211 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73046 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44017 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9421 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9273 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->