### PR TITLE
[Grid] Slow performance in accumulateIntrinsicSizesForTrack causes sluggish behavior on some content.

### DIFF
--- a/PerformanceTests/Layout/subgrids-spanning-many-rows.html
+++ b/PerformanceTests/Layout/subgrids-spanning-many-rows.html
@@ -1,0 +1,42 @@
+<html>
+<head>
+<script src="../resources/runner.js"></script>
+<style>
+#grid {
+  display: grid;
+  grid-template-columns: auto;
+}
+
+.subgrid {
+  display: grid;
+  grid-template-columns: subgrid;
+  grid-template-rows: subgrid;
+  grid-row: span 20000;
+}
+</style>
+</head>
+
+<body>
+<div id="grid">
+  <div class="subgrid">Row</div>
+  <div class="subgrid">Row</div>
+  <div class="subgrid">Row</div>
+  <div class="subgrid">Row</div>
+  <div class="subgrid">Row</div>
+  <div class="subgrid">Row</div>
+  <div class="subgrid">Row</div>
+  <div class="subgrid">Row</div>
+  <div class="subgrid">Row</div>
+  <div class="subgrid">Row</div>
+  <div class="subgrid">Row</div>
+  <div class="subgrid">Row</div>
+</div>
+</body>
+<script>
+var index = 0;
+PerfTestRunner.measureRunsPerSecond({run: function() {
+  document.querySelector("body").style.width = ++index % 2 ? "50%" : "100%";
+  document.body.offsetHeight;
+}});
+</script>
+</html>

--- a/Source/WebCore/rendering/Grid.h
+++ b/Source/WebCore/rendering/Grid.h
@@ -85,6 +85,7 @@ public:
     OrderedTrackIndexSet* autoRepeatEmptyTracks(Style::GridTrackSizingDirection) const;
 
     OrderIterator& orderIterator() { return m_orderIterator; }
+    const OrderIterator& orderIterator() const { return m_orderIterator; }
 
     void setNeedsItemsPlacement(bool);
     bool needsItemsPlacement() const { return m_needsItemsPlacement; };

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
@@ -274,7 +274,7 @@ private:
     void stretchFlexibleTracks(std::optional<LayoutUnit> freeSpace, GridLayoutState&);
     void stretchAutoTracks();
 
-    void accumulateIntrinsicSizesForTrack(GridTrack&, unsigned trackIndex, GridIterator&, Vector<GridItemWithSpan>& itemsSortedByIncreasingSpan, Vector<GridItemWithSpan>& itemsCrossingFlexibleTracks, SingleThreadWeakHashSet<RenderBox>& itemsSet, LayoutUnit currentAccumulatedMbp, GridLayoutState&);
+    void aggregateGridItemsForIntrinsicSizing(Vector<GridItemWithSpan>& itemsSortedByIncreasingSpan, Vector<GridItemWithSpan>& itemsCrossingFlexibleTracks, GridLayoutState&);
 
     bool copyUsedTrackSizesForSubgrid();
 


### PR DESCRIPTION
#### 425f9293f8d4f3cd2423eabd9dd099fe0dce82b2
<pre>
[Grid] Slow performance in accumulateIntrinsicSizesForTrack causes sluggish behavior on some content.
<a href="https://bugs.webkit.org/show_bug.cgi?id=304869">https://bugs.webkit.org/show_bug.cgi?id=304869</a>
<a href="https://rdar.apple.com/problem/167456605">rdar://problem/167456605</a>

Reviewed by Elika Etemad and Alan Baradlay.

Almost all of the time is spent inside of GridTrackSizingAlgorithm::accumulateIntrinsicSizesForTrack,
so in this patch I reworked this method from being a recursive
implementation that iterates over all of the tracks to being an
iterative one that just iterates over all of the grid items. To properly
explain and understand why this is an improvement I will first explain
what the code currently does. To keep things simple we will assume that
we are sizing the columns but the same exact logic applies to the rows.

In the case where the content does not have any subgrids this is
actually fairly straightforward. GridTrackSizingAlgorithm::resolveIntrinsicTrackSizes
will iterate over each of the intrinsically sized tracks and provide a
GridIterator via GridIterator iterator(grid, GridTrackSizingDirection::Columns, 0)
to accumulateIntrinsicSizesForTrack. That method will then use the
iterator to get each of the items in column 0 by calling iterator.nextGridItem().

The interesting bit is actually how the iterator handles looping over all
of the items in a track. When looping over the columns, the iterator
stores m_direction as Columns to find the track that we will loop over.
This loop is done by keeping track of a separate index in the opposite
dimension called the varyingTrackIndex which gets incremented to loop
over all of the tracks. So to get all of the items in column 0,
varyingTrackIndex will correspond to the index of the current row we are
looking at and will get incremented until we go through all the rows.
This means that the iterator may return the same item multiple times if
it ends up spanning multiple rows. accumulateIntrinsicTrackSizes handles
this quirk by keeping track of a separate items set and skips the item
if it is already present in the set.

Each time we get a new item from the iterator, we will then either call
sizeTrackToFitNonSpanningItem on that item or put it into one of two
other vectors that will get sorted and used later in
resolveIntrinsicTrackSizes.

However, things get slightly more complex when we start throwing
subgrids into the mix. This is because subgrids may add in an extra
layer of implicit margin to items in the track through their gaps and
any other margin, border, and padding specified on them and can be
accumulated from any nested subgrids. The code currently accomplishes
this by implementing the logic in a recursive manner and stores the
values in a LayoutUnit that is taken in as a reference to the function.
This value gets modified and reset as we progress through the call
stack.

The performance problem stems from the fact that if we see a subgrid
that spans multiple rows, we will recurse into this function for each
row that it spans. This is because we still run the logic to correctly
compute the implicit margins *before* we realize that this is a grid
item we have already seen and continue.

While there may have been a couple of different ways to fix this bug, I
opted to slightly rework this function to instead loop over the grid
items once instead of recursing into each subgrid multiple times. This
is based off the observation that when we are sizing the columns, we
should not need to care about the rows that the items span since that
should not have any bearing on the sizes that are contributed for the
columns.

In the case where the item is not a subgrid, the logic is basically the
same as before, but the only difference is that we need to figure out
the track that gets passed into sizeTrackToFitNonSpanningItem rather than the subgrid.
than using the one that was passed in from resolveIntrinsicTrackSizes.

When we encounter a subgrid, the core logic is mostly the same, but we
need to keep track of the state on our own stack rather than relying on
the call stack to hold the state during recursion. To do this, I created
a new struct that is used locally within this function called
SizingData.

On my M4 Max MBP, the above test case goes from ~0.20 runs/s to ~50
runs/s. Other engines still show considerably higher runs/s, but this is
definitely a noticeable improvement and a good starting point to build
on.

Canonical link: <a href="https://commits.webkit.org/305121@main">https://commits.webkit.org/305121@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b45bbcab1794529fe1c2067c84e206a009b53147

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137553 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9914 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48840 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145310 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90526 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4df7c5b1-0b43-4a06-808d-168c72e8ed28) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139425 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10617 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10044 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105198 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140498 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7879 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123275 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86051 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7066f158-6164-42a7-adc9-ee6a5c999e17) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7515 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/5262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5893 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116885 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41431 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148074 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9596 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41985 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113586 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9614 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8090 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113922 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28917 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7435 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119514 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64252 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9645 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37567 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9376 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73210 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9585 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9437 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->