### PR TITLE
[Test gardening] 2 tests in fast/forms/ios are constantly failing with text diff

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8343,10 +8343,6 @@ imported/w3c/web-platform-tests/inert/inert-pseudo-element-hittest.html [ Failur
 
 webkit.org/b/301670 imported/w3c/web-platform-tests/css/css-anchor-position/popover-implicit-anchor.html [ Failure ]
 
-# webkit.org/b/304751 [iOS] 2 tests in fast/forms/ios are constant failuring with text diff
-fast/forms/ios/zoom-after-input-tap-wide-input.html [ Failure ]
-fast/forms/ios/zoom-after-input-tap.html [ Failure ]
-
 webkit.org/b/302104 fast/scrolling/ios/bounding-client-rect-on-fixed.html [ Pass Failure ]
 
 # List buttons do not have tint color on iOS.

--- a/LayoutTests/platform/ios/fast/forms/ios/zoom-after-input-tap-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/ios/zoom-after-input-tap-expected.txt
@@ -3,4 +3,4 @@ Tests zooming into a text input on tap.
 
 tap location	{ x: 38.000, y: 862.000 }
 scale	1.455
-visibleRect	{ left: 0.000, top: 611.401, width: 268.018, height: 547.718 }
+visibleRect	{ left: 0.000, top: 611.630, width: 268.018, height: 547.718 }

--- a/LayoutTests/platform/ios/fast/forms/ios/zoom-after-input-tap-wide-input-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/ios/zoom-after-input-tap-wide-input-expected.txt
@@ -3,4 +3,4 @@ Tests zooming to an offset in a wide text input on tap.
 
 tap location	{ x: 328.000, y: 862.000 }
 scale	1.455
-visibleRect	{ left: 384.388, top: 611.401, width: 268.018, height: 547.718 }
+visibleRect	{ left: 384.502, top: 611.630, width: 268.018, height: 547.718 }


### PR DESCRIPTION
#### ba42c78d5aa08398179086a641b8c0a3ed9f28a8
<pre>
[Test gardening] 2 tests in fast/forms/ios are constantly failing with text diff
<a href="https://bugs.webkit.org/show_bug.cgi?id=304751">https://bugs.webkit.org/show_bug.cgi?id=304751</a>
<a href="https://rdar.apple.com/167279396">rdar://167279396</a>

Unreviewed test gardening.

The layout tests listed below failed due to the coordinates
of the visible rect changing after 302852@main, which alters
how screen scale overrides are applied during test runs (previously,
they did not appear to affect the visible rects, but they now do).
Rebaseline the tests to reflect the new results.

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/ios/fast/forms/ios/zoom-after-input-tap-expected.txt:
* LayoutTests/platform/ios/fast/forms/ios/zoom-after-input-tap-wide-input-expected.txt:

Canonical link: <a href="https://commits.webkit.org/305109@main">https://commits.webkit.org/305109@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f34acb0ca5969c4a21b1b9bfea69aea250d1674

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137532 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9893 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48819 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145289 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90505 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c8db92cc-9f0b-495e-9da6-9292c10e8f76) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10596 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10021 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105182 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/432bdb81-80f0-4264-bffa-a5322a9aa6e6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140477 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7865 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123261 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86033 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/52dfbff8-a996-42cd-8e0f-2926937c56d2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7501 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5219 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5872 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116871 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41416 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148053 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9575 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41971 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113561 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9593 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8071 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113905 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7419 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119500 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64226 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21182 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9624 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37553 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9355 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9564 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9416 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->