### PR TITLE
[CI Filters] FEDropShadow in Core Image

### DIFF
--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -504,6 +504,7 @@ platform/graphics/coreimage/FEBlendCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/FEColorMatrixCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/FEComponentTransferCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/FECompositeCoreImageApplier.mm @nonARC
+platform/graphics/coreimage/FEDropShadowCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/FEFloodCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/FEGaussianBlurCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/FEMergeCoreImageApplier.mm @nonARC

--- a/Source/WebCore/platform/graphics/coreimage/FEDropShadowCoreImageApplier.h
+++ b/Source/WebCore/platform/graphics/coreimage/FEDropShadowCoreImageApplier.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(CORE_IMAGE)
+
+#import "FilterEffectApplier.h"
+#import <wtf/TZoneMalloc.h>
+
+namespace WebCore {
+
+class FEDropShadow;
+
+class FEDropShadowCoreImageApplier final : public FilterEffectConcreteApplier<FEDropShadow> {
+    WTF_MAKE_TZONE_ALLOCATED(FEDropShadowCoreImageApplier);
+    using Base = FilterEffectConcreteApplier<FEDropShadow>;
+
+public:
+    FEDropShadowCoreImageApplier(const FEDropShadow&);
+
+private:
+    bool apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const final;
+};
+
+} // namespace WebCore
+
+#endif // USE(CORE_IMAGE)

--- a/Source/WebCore/platform/graphics/coreimage/FEDropShadowCoreImageApplier.mm
+++ b/Source/WebCore/platform/graphics/coreimage/FEDropShadowCoreImageApplier.mm
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "FEDropShadowCoreImageApplier.h"
+
+#if USE(CORE_IMAGE)
+
+#import "ColorSpaceCG.h"
+#import "FEDropShadow.h"
+#import "Filter.h"
+#import "Logging.h"
+#import <CoreImage/CIFilterBuiltins.h>
+#import <CoreImage/CoreImage.h>
+#import <wtf/BlockObjCExceptions.h>
+#import <wtf/NeverDestroyed.h>
+#import <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FEDropShadowCoreImageApplier);
+
+FEDropShadowCoreImageApplier::FEDropShadowCoreImageApplier(const FEDropShadow& effect)
+    : Base(effect)
+{
+}
+
+bool FEDropShadowCoreImageApplier::apply(const Filter& filter, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
+{
+    BEGIN_BLOCK_OBJC_EXCEPTIONS
+
+    ASSERT(inputs.size() == 1);
+    Ref input = inputs[0].get();
+
+    RetainPtr inputImage = input->ciImage();
+    if (!inputImage)
+        return false;
+
+    auto stdDeviation = filter.resolvedSize({ m_effect->stdDeviationX(), m_effect->stdDeviationY() });
+    auto blurRadius = filter.scaledByFilterScale(stdDeviation);
+
+    auto offset = filter.resolvedSize({ m_effect->dx(), m_effect->dy() });
+    auto absoluteOffset = filter.scaledByFilterScale(offset);
+
+    auto shadowColor = m_effect->shadowColor().colorWithAlphaMultipliedBy(m_effect->shadowOpacity());
+    auto [r, g, b, a] = shadowColor.toResolvedColorComponentsInColorSpace(m_effect->operatingColorSpace());
+
+    RetainPtr colorSpace = m_effect->operatingColorSpace() == DestinationColorSpace::SRGB() ? sRGBColorSpaceSingleton() : linearSRGBColorSpaceSingleton();
+    RetainPtr shadowCIColor = [CIColor colorWithRed:r green:g blue:b alpha:a colorSpace:colorSpace.get()];
+
+    // Extract alpha.
+    RetainPtr alphaFilter = [CIFilter filterWithName:@"CIColorMatrix"];
+    [alphaFilter setValue:inputImage.get() forKey:kCIInputImageKey];
+
+    [alphaFilter setValue:[CIVector vectorWithX:0 Y:0 Z:0 W:0] forKey:@"inputRVector"];
+    [alphaFilter setValue:[CIVector vectorWithX:0 Y:0 Z:0 W:0] forKey:@"inputGVector"];
+    [alphaFilter setValue:[CIVector vectorWithX:0 Y:0 Z:0 W:0] forKey:@"inputBVector"];
+    [alphaFilter setValue:[CIVector vectorWithX:0 Y:0 Z:0 W:1] forKey:@"inputAVector"];
+    [alphaFilter setValue:[CIVector vectorWithX:0 Y:0 Z:0 W:0] forKey:@"inputBiasVector"];
+
+    auto blurFilter = [CIFilter filterWithName:@"CIGaussianBlurXY"];
+    [blurFilter setValue:[alphaFilter outputImage] forKey:kCIInputImageKey];
+    [blurFilter setValue:@(blurRadius.width()) forKey:@"inputSigmaX"];
+    [blurFilter setValue:@(blurRadius.height()) forKey:@"inputSigmaY"];
+
+    RetainPtr shadowImage = [[blurFilter outputImage] imageByApplyingTransform:CGAffineTransformMakeTranslation(absoluteOffset.width(), -absoluteOffset.height())];
+
+    RetainPtr shadowColorImage = [CIImage imageWithColor:shadowCIColor.get()];
+    RetainPtr compositeFilter = [CIFilter filterWithName:@"CISourceInCompositing"];
+    [compositeFilter setValue:shadowColorImage.get() forKey:kCIInputImageKey];
+    [compositeFilter setValue:shadowImage.get() forKey:kCIInputBackgroundImageKey];
+
+    RetainPtr shadowedImage = [inputImage imageByCompositingOverImage:[compositeFilter outputImage]];
+    auto cropRect = filter.flippedRectRelativeToAbsoluteEnclosingFilterRegion(result.absoluteImageRect());
+    shadowedImage = [shadowedImage imageByCroppingToRect:cropRect];
+
+    result.setCIImage(shadowedImage.get());
+    return true;
+
+    END_BLOCK_OBJC_EXCEPTIONS
+    return false;
+}
+
+} // namespace WebCore
+
+#endif // USE(CORE_IMAGE)

--- a/Source/WebCore/platform/graphics/filters/FEDropShadow.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEDropShadow.cpp
@@ -28,6 +28,10 @@
 #include "GraphicsContext.h"
 #include <wtf/text/TextStream.h>
 
+#if USE(CORE_IMAGE)
+#include "FEDropShadowCoreImageApplier.h"
+#endif
+
 #if USE(SKIA)
 #include "FEDropShadowSkiaApplier.h"
 #endif
@@ -140,7 +144,7 @@ IntOutsets FEDropShadow::calculateOutsets(const FloatSize& offset, const FloatSi
 OptionSet<FilterRenderingMode> FEDropShadow::supportedFilterRenderingModes(OptionSet<FilterRenderingMode> preferredFilterRenderingModes) const
 {
     OptionSet<FilterRenderingMode> modes = FilterRenderingMode::Software;
-#if USE(SKIA)
+#if (USE(CORE_IMAGE)) || (USE(SKIA))
     modes.add(FilterRenderingMode::Accelerated);
 #endif
 #if USE(CG)
@@ -162,7 +166,9 @@ std::optional<GraphicsStyle> FEDropShadow::createGraphicsStyle(GraphicsContext& 
 
 std::unique_ptr<FilterEffectApplier> FEDropShadow::createAcceleratedApplier() const
 {
-#if USE(SKIA)
+#if USE(CORE_IMAGE)
+    return FilterEffectApplier::create<FEDropShadowCoreImageApplier>(*this);
+#elif USE(SKIA)
     return FilterEffectApplier::create<FEDropShadowSkiaApplier>(*this);
 #else
     return nullptr;


### PR DESCRIPTION
#### e60a2581b728cbe46908731190ad9ddb814f843a
<pre>
[CI Filters] FEDropShadow in Core Image
<a href="https://bugs.webkit.org/show_bug.cgi?id=304871">https://bugs.webkit.org/show_bug.cgi?id=304871</a>
<a href="https://rdar.apple.com/167458159">rdar://167458159</a>

Reviewed by Mike Wyrzykowski.

Core Image implementation of FEDropShadow. This works by extracting alpha via a CIColorMatrix,
applying an offset (`imageByApplyingTransform:`), compositing with a color to colorize the shadow,
and then compositing the original image with the shadow.

* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/coreimage/FEDropShadowCoreImageApplier.h: Added.
* Source/WebCore/platform/graphics/coreimage/FEDropShadowCoreImageApplier.mm: Added.
(WebCore::FEDropShadowCoreImageApplier::FEDropShadowCoreImageApplier):
(WebCore::FEDropShadowCoreImageApplier::apply const):
* Source/WebCore/platform/graphics/filters/FEDropShadow.cpp:
(WebCore::FEDropShadow::supportedFilterRenderingModes const):
(WebCore::FEDropShadow::createAcceleratedApplier const):

Canonical link: <a href="https://commits.webkit.org/305069@main">https://commits.webkit.org/305069@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c3e4389883aca1e7c17f372cc1a363b7ccdcffd6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137383 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9743 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48670 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145134 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90356 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/caa3b20a-ef6a-47a9-9978-3e6b7dca45d6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139255 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10447 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9870 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105050 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/618f8233-f8e7-4286-a39e-c15e09f98854) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140328 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7725 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123128 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85905 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1a85104a-cc58-4fd7-8636-2ce7aebeb6eb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7361 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5082 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5721 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116727 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41283 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147891 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9426 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41840 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113426 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9444 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7936 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113767 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28886 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7282 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119370 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64024 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9475 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37423 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9205 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73040 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9415 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9267 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->