### PR TITLE
[CI Filters] FETile in Core Image

### DIFF
--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -509,6 +509,7 @@ platform/graphics/coreimage/FEGaussianBlurCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/FEMergeCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/FEMorphologyCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/FEOffsetCoreImageApplier.mm @nonARC
+platform/graphics/coreimage/FETileCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/FilterImageCoreImage.mm @nonARC
 platform/graphics/coreimage/SourceAlphaCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/SourceGraphicCoreImageApplier.mm @nonARC

--- a/Source/WebCore/platform/graphics/coreimage/FETileCoreImageApplier.h
+++ b/Source/WebCore/platform/graphics/coreimage/FETileCoreImageApplier.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(CORE_IMAGE)
+
+#import "FilterEffectApplier.h"
+#import <wtf/TZoneMalloc.h>
+
+namespace WebCore {
+
+class FETile;
+
+class FETileCoreImageApplier final : public FilterEffectConcreteApplier<FETile> {
+    WTF_MAKE_TZONE_ALLOCATED(FETileCoreImageApplier);
+    using Base = FilterEffectConcreteApplier<FETile>;
+
+public:
+    FETileCoreImageApplier(const FETile&);
+
+private:
+    bool apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const final;
+};
+
+} // namespace WebCore
+
+#endif // USE(CORE_IMAGE)

--- a/Source/WebCore/platform/graphics/coreimage/FETileCoreImageApplier.mm
+++ b/Source/WebCore/platform/graphics/coreimage/FETileCoreImageApplier.mm
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "FETileCoreImageApplier.h"
+
+#if USE(CORE_IMAGE)
+
+#import "AffineTransform.h"
+#import "FETile.h"
+#import "Filter.h"
+#import "Logging.h"
+#import <CoreImage/CoreImage.h>
+#import <wtf/BlockObjCExceptions.h>
+#import <wtf/NeverDestroyed.h>
+#import <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FETileCoreImageApplier);
+
+FETileCoreImageApplier::FETileCoreImageApplier(const FETile& effect)
+    : Base(effect)
+{
+}
+
+bool FETileCoreImageApplier::apply(const Filter& filter, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
+{
+    BEGIN_BLOCK_OBJC_EXCEPTIONS
+
+    ASSERT(inputs.size() == 1);
+    Ref input = inputs[0].get();
+
+    RetainPtr inputImage = input->ciImage();
+    if (!inputImage)
+        return false;
+
+    auto tileRect = input->maxEffectRect(filter);
+    tileRect.scale(filter.filterScale());
+    tileRect = filter.flippedRectRelativeToAbsoluteEnclosingFilterRegion(tileRect);
+
+    auto imageExtent = FloatRect { [inputImage extent] };
+    RetainPtr<CIImage> tileImage;
+    if (imageExtent.contains(tileRect))
+        tileImage = [inputImage imageByCroppingToRect:tileRect];
+    else {
+        // Extend the image by compositing over the clear color.
+        RetainPtr clearImage = [[CIImage imageWithColor:[CIColor clearColor]] imageByCroppingToRect:tileRect];
+        tileImage = [[inputImage imageByCompositingOverImage:clearImage.get()] imageByCroppingToRect:tileRect];
+    }
+
+    RetainPtr tileFilter = [CIFilter filterWithName:@"CIAffineTile"];
+    [tileFilter setValue:tileImage.get() forKey:kCIInputImageKey];
+    // This identity transform is necessary, otherwise the tiling is half scale when filterScale is not one.
+    [tileFilter setValue:[NSValue valueWithBytes:&CGAffineTransformIdentity objCType:@encode(CGAffineTransform)] forKey:kCIInputTransformKey];
+
+    auto cropRect = filter.flippedRectRelativeToAbsoluteEnclosingFilterRegion(result.absoluteImageRect());
+    RetainPtr image = [[tileFilter outputImage] imageByCroppingToRect:cropRect];
+
+    result.setCIImage(WTF::move(image));
+    return true;
+
+    END_BLOCK_OBJC_EXCEPTIONS
+    return false;
+}
+
+} // namespace WebCore
+
+#endif // USE(CORE_IMAGE)

--- a/Source/WebCore/platform/graphics/coreimage/SourceGraphicCoreImageApplier.mm
+++ b/Source/WebCore/platform/graphics/coreimage/SourceGraphicCoreImageApplier.mm
@@ -28,6 +28,7 @@
 
 #if USE(CORE_IMAGE)
 
+#import "Filter.h"
 #import "FilterImage.h"
 #import "IOSurface.h"
 #import "ImageBuffer.h"

--- a/Source/WebCore/platform/graphics/filters/FETile.h
+++ b/Source/WebCore/platform/graphics/filters/FETile.h
@@ -39,6 +39,8 @@ private:
 
     bool resultIsAlphaImage(std::span<const Ref<FilterImage>> inputs) const override;
 
+    OptionSet<FilterRenderingMode> supportedFilterRenderingModes(OptionSet<FilterRenderingMode>) const override;
+    std::unique_ptr<FilterEffectApplier> createAcceleratedApplier() const override;
     std::unique_ptr<FilterEffectApplier> createSoftwareApplier() const override;
 
     WTF::TextStream& externalRepresentation(WTF::TextStream&, FilterRepresentation) const override;

--- a/WebKitLibraries/SDKs/watchos26.0-additions.sdk/System/Library/Frameworks/CoreImage.framework/CoreImage.tbd
+++ b/WebKitLibraries/SDKs/watchos26.0-additions.sdk/System/Library/Frameworks/CoreImage.framework/CoreImage.tbd
@@ -5,6 +5,6 @@ install-name: /System/Library/Frameworks/CoreImage.framework/CoreImage
 current-version: 7
 exports:
 -       targets: [armv7k-watchos, arm64-watchos, arm64e-watchos, arm64_32-watchos]
-        symbols: [_kCIContextWorkingColorSpace, _kCIInputBackgroundImageKey, _kCIInputImageKey]
+        symbols: [_kCIContextWorkingColorSpace, _kCIInputBackgroundImageKey, _kCIInputImageKey, _kCIInputTransformKey]
         objc-classes: [CIBlendKernel, CIColor, CIContext, CIFilter, CIImage, CIRenderDestination, CIVector]
 ...

--- a/WebKitLibraries/SDKs/watchsimulator26.0-additions.sdk/System/Library/Frameworks/CoreImage.framework/CoreImage.tbd
+++ b/WebKitLibraries/SDKs/watchsimulator26.0-additions.sdk/System/Library/Frameworks/CoreImage.framework/CoreImage.tbd
@@ -5,6 +5,6 @@ install-name: /System/Library/Frameworks/CoreImage.framework/CoreImage
 current-version: 7
 exports:
 -       targets: [i386-watchos-simulator, x86_64-watchos-simulator, arm64-watchos-simulator]
-        symbols: [_kCIContextWorkingColorSpace, _kCIInputBackgroundImageKey, _kCIInputImageKey]
+        symbols: [_kCIContextWorkingColorSpace, _kCIInputBackgroundImageKey, _kCIInputImageKey, _kCIInputTransformKey]
         objc-classes: [CIBlendKernel, CIColor, CIContext, CIFilter, CIImage, CIRenderDestination, CIVector]
 ...


### PR DESCRIPTION
#### c7ef838fa0064969f54dd5f50100bfbc50e583e2
<pre>
[CI Filters] FETile in Core Image
<a href="https://bugs.webkit.org/show_bug.cgi?id=304872">https://bugs.webkit.org/show_bug.cgi?id=304872</a>
<a href="https://rdar.apple.com/167458135">rdar://167458135</a>

Reviewed by Mike Wyrzykowski.

Core Image implementation of FETile. This uses the `CIAffineTile` filter, with a couple
of quirks. First, we may have to enlarge the input image by compositing with the clear color.
Second, for some reason it&apos;s necessary to set the identity transform to prevent the image
being scaled down when compositing at 2x.

* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/coreimage/FETileCoreImageApplier.h: Copied from Source/WebCore/platform/graphics/coreimage/SourceGraphicCoreImageApplier.mm.
* Source/WebCore/platform/graphics/coreimage/FETileCoreImageApplier.mm: Added.
(WebCore::FETileCoreImageApplier::FETileCoreImageApplier):
(WebCore::FETileCoreImageApplier::apply const):
* Source/WebCore/platform/graphics/coreimage/SourceGraphicCoreImageApplier.mm:
* Source/WebCore/platform/graphics/filters/FETile.cpp:
(WebCore::FETile::supportedFilterRenderingModes const):
(WebCore::FETile::createAcceleratedApplier const):
* Source/WebCore/platform/graphics/filters/FETile.h:
* WebKitLibraries/SDKs/watchos26.0-additions.sdk/System/Library/Frameworks/CoreImage.framework/CoreImage.tbd:
Add _kCIInputTransformKey
* WebKitLibraries/SDKs/watchsimulator26.0-additions.sdk/System/Library/Frameworks/CoreImage.framework/CoreImage.tbd:
Add _kCIInputTransformKey

Canonical link: <a href="https://commits.webkit.org/305068@main">https://commits.webkit.org/305068@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea86d8177b2e2a8e43427ed17bf2dd2469e115aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137382 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9742 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48669 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145133 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90355 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b3e3e2e1-f551-4d29-8933-a33d3fdaa2ed) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139254 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10446 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9869 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105048 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/37fef6f8-758b-4424-935b-93e8d81319c0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140327 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7724 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123127 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85903 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/227cc88b-b74d-4b6f-95de-1dc306c61a64) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7360 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5081 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5720 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116726 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41282 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147890 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9425 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41839 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113425 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9443 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7935 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113766 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28885 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7281 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119369 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64023 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9474 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37422 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9204 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73039 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9414 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9266 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->