### PR TITLE
[CI Filters] FEImage in Core Image

### DIFF
--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -508,6 +508,7 @@ platform/graphics/coreimage/FEConvolveMatrixCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/FEDropShadowCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/FEFloodCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/FEGaussianBlurCoreImageApplier.mm @nonARC
+platform/graphics/coreimage/FEImageCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/FEMergeCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/FEMorphologyCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/FEOffsetCoreImageApplier.mm @nonARC

--- a/Source/WebCore/platform/graphics/coreimage/FEImageCoreImageApplier.h
+++ b/Source/WebCore/platform/graphics/coreimage/FEImageCoreImageApplier.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(CORE_IMAGE)
+
+#import "FilterEffectApplier.h"
+#import <wtf/TZoneMalloc.h>
+
+namespace WebCore {
+
+class FEImage;
+
+class FEImageCoreImageApplier final : public FilterEffectConcreteApplier<FEImage> {
+    WTF_MAKE_TZONE_ALLOCATED(FEImageCoreImageApplier);
+    using Base = FilterEffectConcreteApplier<FEImage>;
+
+public:
+    FEImageCoreImageApplier(const FEImage&);
+
+private:
+    bool apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const final;
+};
+
+} // namespace WebCore
+
+#endif // USE(CORE_IMAGE)

--- a/Source/WebCore/platform/graphics/coreimage/FEImageCoreImageApplier.mm
+++ b/Source/WebCore/platform/graphics/coreimage/FEImageCoreImageApplier.mm
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "FEImageCoreImageApplier.h"
+
+#if USE(CORE_IMAGE)
+
+#import "FEImage.h"
+#import "Filter.h"
+#import "IOSurface.h"
+#import "Logging.h"
+#import <CoreImage/CoreImage.h>
+#import <wtf/BlockObjCExceptions.h>
+#import <wtf/NeverDestroyed.h>
+#import <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FEImageCoreImageApplier);
+
+FEImageCoreImageApplier::FEImageCoreImageApplier(const FEImage& effect)
+    : Base(effect)
+{
+}
+
+bool FEImageCoreImageApplier::apply(const Filter& filter, std::span<const Ref<FilterImage>>, FilterImage& result) const
+{
+    BEGIN_BLOCK_OBJC_EXCEPTIONS
+
+    auto& sourceImage = m_effect->sourceImage();
+    auto primitiveSubregion = result.primitiveSubregion();
+
+    RetainPtr<CIImage> image;
+    if (RefPtr nativeImage = sourceImage.nativeImageIfExists()) {
+        auto imageRect = primitiveSubregion;
+        auto srcRect = m_effect->sourceImageRect();
+        m_effect->preserveAspectRatio().transformRect(imageRect, srcRect);
+        imageRect.scale(filter.filterScale());
+
+        image = [CIImage imageWithCGImage:nativeImage->platformImage().get()];
+        image = [image imageByCroppingToRect:srcRect];
+
+        auto destRect = filter.flippedRectRelativeToAbsoluteEnclosingFilterRegion(imageRect);
+
+        auto transform = makeMapBetweenRects(srcRect, destRect);
+        image = [image imageByApplyingTransform:transform];
+
+    } else if (RefPtr imageBuffer = sourceImage.imageBufferIfExists()) {
+        if (auto* surface = imageBuffer->surface()) {
+            RetainPtr ioSurface = surface->surface();
+            image = [CIImage imageWithIOSurface:ioSurface.get()];
+        }
+
+        if (!image)
+            return false;
+
+        // FIXME: This geometry computation needs fixing per webkit.org/b/304911.
+        auto sourceRect = m_effect->sourceImageRect();
+        sourceRect.moveBy(primitiveSubregion.location());
+        auto scaledSourceRect = filter.scaledByFilterScale(sourceRect);
+
+        auto absoluteSourceRect = filter.flippedRectRelativeToAbsoluteEnclosingFilterRegion(scaledSourceRect);
+        image = [image imageByApplyingTransform:CGAffineTransformMakeTranslation(absoluteSourceRect.x(), absoluteSourceRect.y())];
+
+        auto resultRect = filter.flippedRectRelativeToAbsoluteEnclosingFilterRegion(result.absoluteImageRect());
+        image = [image imageByCroppingToRect:resultRect];
+    }
+
+    if (!image)
+        return false;
+
+    result.setCIImage(WTF::move(image));
+    return true;
+
+    END_BLOCK_OBJC_EXCEPTIONS
+    return false;
+}
+
+} // namespace WebCore
+
+#endif // USE(CORE_IMAGE)

--- a/Source/WebCore/platform/graphics/coreimage/FETurbulenceCoreImageApplier.mm
+++ b/Source/WebCore/platform/graphics/coreimage/FETurbulenceCoreImageApplier.mm
@@ -33,6 +33,7 @@
 #import "Logging.h"
 #import <CoreImage/CoreImage.h>
 #import <simd/simd.h>
+#import <wtf/BlockObjCExceptions.h>
 #import <wtf/FastMalloc.h>
 #import <wtf/NeverDestroyed.h>
 #import <wtf/TZoneMallocInlines.h>

--- a/Source/WebCore/platform/graphics/filters/FEImage.h
+++ b/Source/WebCore/platform/graphics/filters/FEImage.h
@@ -60,6 +60,8 @@ private:
 
     FloatRect calculateImageRect(const Filter&, std::span<const FloatRect> inputImageRects, const FloatRect& primitiveSubregion) const override;
 
+    OptionSet<FilterRenderingMode> supportedFilterRenderingModes(OptionSet<FilterRenderingMode>) const override;
+    std::unique_ptr<FilterEffectApplier> createAcceleratedApplier() const override;
     std::unique_ptr<FilterEffectApplier> createSoftwareApplier() const final;
 
     WTF::TextStream& externalRepresentation(WTF::TextStream&, FilterRepresentation) const final;


### PR DESCRIPTION
#### 2087b94ea277f9ba23184be3f7190fa9ec474972
<pre>
[CI Filters] FEImage in Core Image
<a href="https://bugs.webkit.org/show_bug.cgi?id=304877">https://bugs.webkit.org/show_bug.cgi?id=304877</a>
<a href="https://rdar.apple.com/167458677">rdar://167458677</a>

Reviewed by Mike Wyrzykowski.

Core Image implementation of FEImage. This has to handle two kinds of inputs; image URLs
which come in as a native image, and references to other SVG elements, which come in as
image buffers. Both need some geometry computation.

* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/coreimage/FEImageCoreImageApplier.h: Added.
* Source/WebCore/platform/graphics/coreimage/FEImageCoreImageApplier.mm: Added.
(WebCore::FEImageCoreImageApplier::FEImageCoreImageApplier):
(WebCore::FEImageCoreImageApplier::apply const):
* Source/WebCore/platform/graphics/coreimage/FETurbulenceCoreImageApplier.mm:
* Source/WebCore/platform/graphics/filters/FEImage.cpp:
(WebCore::FEImage::supportedFilterRenderingModes const):
(WebCore::FEImage::createAcceleratedApplier const):
* Source/WebCore/platform/graphics/filters/FEImage.h:

Canonical link: <a href="https://commits.webkit.org/305147@main">https://commits.webkit.org/305147@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6b9c15f7c5347d3b4b018d5115568fc51c60fe1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137646 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10007 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48934 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145404 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90619 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/aff0e690-a33b-4ce3-a2b1-41641dcb5743) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139518 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10710 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10137 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105279 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/29cd0c72-44d7-4ebb-b2b6-450a22736a5f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140591 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7958 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123357 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86135 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/83200101-e4fb-43e0-b2cc-f9953c5511f7) 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7585 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5310 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5987 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/129607 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116974 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41516 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148172 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9690 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42067 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113668 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9707 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8167 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114005 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28937 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7516 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119596 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64354 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9738 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37645 "Passed tests") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9469 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73303 "Built successfully") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9678 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9530 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->