### PR TITLE
[CI Filters] FETurbulence in Core Image

### DIFF
--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -511,6 +511,7 @@ platform/graphics/coreimage/FEMergeCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/FEMorphologyCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/FEOffsetCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/FETileCoreImageApplier.mm @nonARC
+platform/graphics/coreimage/FETurbulenceCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/FilterImageCoreImage.mm @nonARC
 platform/graphics/coreimage/SourceAlphaCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/SourceGraphicCoreImageApplier.mm @nonARC

--- a/Source/WebCore/platform/graphics/coreimage/FETurbulenceCoreImageApplier.h
+++ b/Source/WebCore/platform/graphics/coreimage/FETurbulenceCoreImageApplier.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(CORE_IMAGE)
+
+#import "FETurbulenceSoftwareApplier.h"
+#import "FilterEffectApplier.h"
+#import <wtf/TZoneMalloc.h>
+
+namespace WebCore {
+
+class FETurbulenceCoreImageApplier final : public FilterEffectConcreteApplier<FETurbulence> {
+    WTF_MAKE_TZONE_ALLOCATED(FETurbulenceCoreImageApplier);
+    using Base = FilterEffectConcreteApplier<FETurbulence>;
+
+public:
+    FETurbulenceCoreImageApplier(const FETurbulence&);
+    ~FETurbulenceCoreImageApplier();
+
+    static bool supportsCoreImageRendering(const FETurbulence&);
+
+private:
+    bool apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const final;
+
+};
+
+} // namespace WebCore
+
+#endif // USE(CORE_IMAGE)

--- a/Source/WebCore/platform/graphics/coreimage/FETurbulenceCoreImageApplier.mm
+++ b/Source/WebCore/platform/graphics/coreimage/FETurbulenceCoreImageApplier.mm
@@ -1,0 +1,359 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "FETurbulenceCoreImageApplier.h"
+
+#if USE(CORE_IMAGE)
+
+#import "FETurbulence.h"
+#import "Filter.h"
+#import "Logging.h"
+#import <CoreImage/CoreImage.h>
+#import <simd/simd.h>
+#import <wtf/FastMalloc.h>
+#import <wtf/NeverDestroyed.h>
+#import <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+// FIXME: Find a way to share these with the shader.
+#define TURBULENCE_BLOCK_SIZE 256
+#define TURBULENCE_LATTICE_SIZE (2 * TURBULENCE_BLOCK_SIZE + 2)
+#define TURBULENCE_GRADIENT_COLUMNS TURBULENCE_BLOCK_SIZE
+
+static CIKernel* turbulenceKernel()
+{
+    static NeverDestroyed<RetainPtr<CIKernel>> kernel;
+    static std::once_flag onceFlag;
+
+    std::call_once(onceFlag, [] {
+        NSError *error = nil;
+        NSArray<CIKernel *> *kernels = [CIKernel kernelsWithMetalString:@R"( /* NOLINT */
+#define TURBULENCE_BLOCK_SIZE 256
+#define TURBULENCE_LATTICE_SIZE (2 * TURBULENCE_BLOCK_SIZE + 2)
+#define TURBULENCE_GRADIENT_COLUMNS TURBULENCE_BLOCK_SIZE
+
+#define PERLIN_NOISE 4096
+#define BLOCK_MASK (TURBULENCE_BLOCK_SIZE - 1)
+
+extern "C" {
+namespace coreimage {
+
+enum NoiseType : uint8_t {
+    FractalNoise,
+    Turbulence
+};
+
+struct TurbulenceStitchData {
+    vector_int2 size; // How much to subtract to wrap for stitching.
+    vector_int2 wrap; // Minimum value to wrap.
+};
+
+struct TurbulenceConstants {
+    uint8_t type;
+    uint8_t stitchTiles;
+    int numOctaves;
+    float extentBottom;
+    float2 origin;
+    float2 scale;
+    float2 baseFrequency;
+    TurbulenceStitchData stitchData;
+};
+
+struct LatticeSelector {
+    int data[TURBULENCE_LATTICE_SIZE];
+};
+
+struct GradientChannel {
+    float2 data[TURBULENCE_LATTICE_SIZE];
+};
+
+static inline float2 sCurve(float2 t)
+{
+    return t * t * (3.0 - 2.0 * t);
+}
+
+static inline float lerp(float t, float a, float b)
+{
+    return a + t * (b - a);
+}
+
+float noiseForChannel(constant GradientChannel& gradient, int4 indices, float2 fraction, float2 s)
+{
+    // q = fGradient[nColorChannel][b00];
+    // u = rx0 * q[0] + ry0 * q[1];
+    float2 q1 = gradient.data[indices[0] % TURBULENCE_BLOCK_SIZE];
+    float u1 = fraction.x * q1[0] + fraction.y * q1[1];
+
+    // q = fGradient[nColorChannel][b10];
+    // v = rx1 * q[0] + ry0 * q[1];
+    float2 q2 = gradient.data[indices[1] % TURBULENCE_BLOCK_SIZE];
+    float v1 = (fraction.x - 1) * q2[0] + fraction.y * q2[1];
+
+    // a = lerp(sx, u, v);
+    float a = lerp(s.x, u1, v1);
+
+    // q = fGradient[nColorChannel][b01];
+    // u = rx0 * q[0] + ry1 * q[1];
+    float2 q3 = gradient.data[indices[2] % TURBULENCE_BLOCK_SIZE];
+    float u2 = fraction.x * q3[0] + (fraction.y - 1) * q3[1];
+
+    // q = fGradient[nColorChannel][b11];
+    // v = rx1 * q[0] + ry1 * q[1];
+    float2 q4 = gradient.data[indices[3] % TURBULENCE_BLOCK_SIZE];
+    float v2 = (fraction.x - 1) * q4[0] + (fraction.y - 1) * q4[1];
+
+    // b = lerp(sx, u, v);
+    float b = lerp(s.x, u2, v2);
+
+    return lerp(s.y, a, b);
+}
+
+float4 noise2D(constant TurbulenceConstants& constants,
+    constant LatticeSelector& latticeSelector,
+    constant GradientChannel& redGradient,
+    constant GradientChannel& greenGradient,
+    constant GradientChannel& blueGradient,
+    constant GradientChannel& alphaGradient,
+    float2 noiseVector, TurbulenceStitchData stitchData)
+{
+    // t = vec[0] + PerlinN;
+    float2 position = noiseVector + PERLIN_NOISE;
+    // bx0 = (int)t;
+    int2 index = (int2)floor(position);
+    // bx1 = bx0 + 1;
+    int2 nextIndex = index + 1;
+    // rx0 = t - (int)t;
+    float2 fraction = position - (float2)index;
+
+    if (constants.stitchTiles) {
+        if (index.x >= stitchData.wrap.x)
+            index.x -= stitchData.size.x;
+
+        if (nextIndex.x >= stitchData.wrap.x)
+            nextIndex.x -= stitchData.size.x;
+
+        if (index.y >= stitchData.wrap.y)
+            index.y -= stitchData.size.y;
+
+        if (nextIndex.y >= stitchData.wrap.y)
+            nextIndex.y -= stitchData.size.y;
+    }
+
+    // bx0 &= BM;
+    // bx1 &= BM;
+    // by0 &= BM;
+    // by1 &= BM;
+    index &= BLOCK_MASK;
+    nextIndex &= BLOCK_MASK;
+
+    // i = uLatticeSelector[bx0];
+    // j = uLatticeSelector[bx1];
+    int latticeIndex = latticeSelector.data[index.x];
+    int nextLatticeIndex = latticeSelector.data[nextIndex.x];
+
+    // sx = double(s_curve(rx0));
+    // sy = double(s_curve(ry0));
+    float2 s = sCurve(fraction);
+
+    int4 indices = {
+        latticeSelector.data[latticeIndex      + index.y],        // b00 = uLatticeSelector[i + by0]
+        latticeSelector.data[nextLatticeIndex  + index.y],        // b10 = uLatticeSelector[j + by0]
+        latticeSelector.data[latticeIndex      + nextIndex.y],    // b01 = uLatticeSelector[i + by1]
+        latticeSelector.data[nextLatticeIndex  + nextIndex.y],    // b11 = uLatticeSelector[j + by1]
+    };
+
+    return {
+        noiseForChannel(redGradient,   indices, fraction, s),
+        noiseForChannel(greenGradient, indices, fraction, s),
+        noiseForChannel(blueGradient,  indices, fraction, s),
+        noiseForChannel(alphaGradient, indices, fraction, s),
+    };
+}
+
+[[stitchable]] float4 kernel_turbulence(
+    constant TurbulenceConstants* constants,
+    constant LatticeSelector* latticeSelector,
+    constant GradientChannel* redGradient,
+    constant GradientChannel* greenGradient,
+    constant GradientChannel* blueGradient,
+    constant GradientChannel* alphaGradient,
+    destination dest)
+{
+    // Texture coordinates are y-flipped. 
+    float2 coordinate = dest.coord();
+    coordinate.y = constants->extentBottom - coordinate.y;
+    coordinate += constants->origin;
+    coordinate /= constants->scale;
+    coordinate.x += 0.5;
+    coordinate.y += 0.5;
+
+    auto stitchData = constants->stitchData;
+
+    float ratio = 1;
+    float2 noiseVector = coordinate * constants->baseFrequency;
+
+    float4 resultPixel = { };
+
+    for (int octave = 0; octave < constants->numOctaves; ++octave) {
+        if (constants->type == NoiseType::FractalNoise)
+            resultPixel += noise2D(*constants, *latticeSelector, *redGradient, *greenGradient, *blueGradient, *alphaGradient, noiseVector, stitchData) / ratio;
+        else
+            resultPixel += fabs(noise2D(*constants, *latticeSelector, *redGradient, *greenGradient, *blueGradient, *alphaGradient, noiseVector, stitchData)) / ratio;
+
+        if (octave == constants->numOctaves - 1)
+            break;
+
+        noiseVector *= 2;
+        ratio *= 2;
+
+        if (constants->stitchTiles) {
+            stitchData.size *= 2;
+            stitchData.wrap = 2 * stitchData.wrap - PERLIN_NOISE;
+        }
+    }
+
+    if (constants->type == NoiseType::FractalNoise)
+        resultPixel = resultPixel * 0.5 + 0.5;
+
+    resultPixel = clamp(resultPixel, 0, 1);
+    return premultiply(resultPixel);
+}
+
+} // extern "C"
+} // namespace coreimage
+        )" /* NOLINT */ error:&error];
+
+        if (error || !kernels || !kernels.count) {
+            LOG(Filters, "Turbulence kernel compilation failed: %@", error);
+            return;
+        }
+
+        kernel.get() = kernels[0];
+    });
+
+    return kernel.get().get();
+}
+
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FETurbulenceCoreImageApplier);
+
+FETurbulenceCoreImageApplier::FETurbulenceCoreImageApplier(const FETurbulence& effect)
+    : Base(effect)
+{
+}
+
+FETurbulenceCoreImageApplier::~FETurbulenceCoreImageApplier() = default;
+
+bool FETurbulenceCoreImageApplier::apply(const Filter& filter, std::span<const Ref<FilterImage>>, FilterImage& result) const
+{
+    BEGIN_BLOCK_OBJC_EXCEPTIONS
+
+    RetainPtr kernel = turbulenceKernel();
+    if (!kernel)
+        return false;
+
+    auto tileSize = roundedIntSize(result.primitiveSubregion().size());
+
+    float baseFrequencyX = m_effect->baseFrequencyX();
+    float baseFrequencyY = m_effect->baseFrequencyY();
+    auto stitchData = FETurbulenceSoftwareApplier::computeStitching(tileSize, baseFrequencyX, baseFrequencyY, m_effect->stitchTiles());
+    auto paintingData = FETurbulenceSoftwareApplier::PaintingData(m_effect->type(), baseFrequencyX, baseFrequencyY, m_effect->numOctaves(), m_effect->seed(), m_effect->stitchTiles());
+
+    enum NoiseType {
+        FractalNoise,
+        Turbulence
+    };
+
+    struct TurbulenceStitchData {
+        vector_int2 size; // How much to subtract to wrap for stitching.
+        vector_int2 wrap; // Minimum value to wrap.
+    };
+
+    struct GradientChannel {
+        vector_float2 data[TURBULENCE_GRADIENT_COLUMNS];
+    };
+
+    struct TurbulenceConstants {
+        uint8_t type;
+        uint8_t stitchTiles;
+        int numOctaves;
+        float extentBottom;
+        vector_float2 origin;
+        vector_float2 scale;
+        vector_float2 baseFrequency;
+        TurbulenceStitchData stitchData;
+    };
+
+    auto origin = FloatPoint { result.absoluteImageRect().location() };
+    auto scale = filter.filterScale();
+    auto extent = filter.flippedRectRelativeToAbsoluteEnclosingFilterRegion(result.absoluteImageRect());
+    // Work around a bug where the extent of the kernel is too large after compositing with other CIImages (TODO: file the radar).
+    extent.shiftMaxXEdgeBy(1);
+
+    auto constants = TurbulenceConstants {
+        .type = static_cast<uint8_t>(paintingData.type == TurbulenceType::FractalNoise ? NoiseType::FractalNoise : NoiseType::Turbulence),
+        .stitchTiles = paintingData.stitchTiles,
+        .numOctaves = paintingData.numOctaves,
+        .extentBottom = extent.maxY(),
+        .origin = { origin.x(), origin.y() },
+        .scale = { scale.width(), scale.height() },
+        .baseFrequency = { paintingData.baseFrequencyX, paintingData.baseFrequencyY },
+        .stitchData = TurbulenceStitchData { { stitchData.width, stitchData.height }, { stitchData.wrapX, stitchData.wrapY } },
+    };
+
+    RetainPtr<NSArray> arguments = @[
+        [NSData dataWithBytes:&constants length:sizeof(TurbulenceConstants)],
+        [NSData dataWithBytes:&paintingData.latticeSelector length:sizeof(FETurbulenceSoftwareApplier::PaintingData::LatticeSelector)],
+        [NSData dataWithBytes:&paintingData.gradient[0] length:sizeof(FETurbulenceSoftwareApplier::PaintingData::ChannelGradient)],
+        [NSData dataWithBytes:&paintingData.gradient[1] length:sizeof(FETurbulenceSoftwareApplier::PaintingData::ChannelGradient)],
+        [NSData dataWithBytes:&paintingData.gradient[2] length:sizeof(FETurbulenceSoftwareApplier::PaintingData::ChannelGradient)],
+        [NSData dataWithBytes:&paintingData.gradient[3] length:sizeof(FETurbulenceSoftwareApplier::PaintingData::ChannelGradient)],
+    ];
+
+    RetainPtr outputImage = [kernel applyWithExtent:extent
+        roiCallback:^CGRect(int, CGRect destRect) {
+            return destRect;
+        }
+        arguments:arguments.get()];
+
+    if (!outputImage)
+        return false;
+
+    // Part 2 of the workaround; this extent modification is necessary to avoid this -imageByCroppingToRect: being a no-op.
+    extent.shiftMaxXEdgeBy(-1);
+    outputImage = [outputImage imageByCroppingToRect:extent];
+
+    result.setCIImage(WTF::move(outputImage));
+    return true;
+
+    END_BLOCK_OBJC_EXCEPTIONS
+    return false;
+}
+
+} // namespace WebCore
+
+#endif // USE(CORE_IMAGE)

--- a/Source/WebCore/platform/graphics/coreimage/SourceAlphaCoreImageApplier.mm
+++ b/Source/WebCore/platform/graphics/coreimage/SourceAlphaCoreImageApplier.mm
@@ -28,6 +28,7 @@
 
 #if USE(CORE_IMAGE)
 
+#import "Filter.h"
 #import "FilterImage.h"
 #import <CoreImage/CIFilter.h>
 #import <CoreImage/CoreImage.h>

--- a/Source/WebCore/platform/graphics/filters/FETurbulence.h
+++ b/Source/WebCore/platform/graphics/filters/FETurbulence.h
@@ -70,6 +70,8 @@ private:
 
     FloatRect calculateImageRect(const Filter&, std::span<const FloatRect> inputImageRects, const FloatRect& primitiveSubregion) const override;
 
+    OptionSet<FilterRenderingMode> supportedFilterRenderingModes(OptionSet<FilterRenderingMode>) const override;
+    std::unique_ptr<FilterEffectApplier> createAcceleratedApplier() const override;
     std::unique_ptr<FilterEffectApplier> createSoftwareApplier() const override;
 
     WTF::TextStream& externalRepresentation(WTF::TextStream&, FilterRepresentation) const override;

--- a/Source/WebCore/platform/graphics/filters/software/FETurbulenceSoftwareApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/FETurbulenceSoftwareApplier.h
@@ -44,53 +44,36 @@ class FETurbulenceSoftwareApplier final : public FilterEffectConcreteApplier<FET
 public:
     using Base::Base;
 
-private:
-    bool apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const final;
-
-    // Produces results in the range [1, 2**31 - 2]. Algorithm is:
-    // r = (a * r) mod m where a = s_randAmplitude = 16807 and
-    // m = s_randMaximum = 2**31 - 1 = 2147483647, r = seed.
-    // See [Park & Miller], CACM vol. 31 no. 10 p. 1195, Oct. 1988
-    // To test: the algorithm should produce the result 1043618065
-    // as the 10,000th generated number if the original seed is 1.
-    static const int s_perlinNoise = 4096;
-    static const long s_randMaximum = 2147483647; // 2**31 - 1
-    static const int s_randAmplitude = 16807; // 7**5; primitive root of m
-    static const int s_randQ = 127773; // m / a
-    static const int s_randR = 2836; // m % a
-
     static const int s_blockSize = 256;
-    static const int s_blockMask = s_blockSize - 1;
+    static const int s_latticeSize = 2 * s_blockSize + 2;
 
     struct PaintingData {
-        // Compute pseudo random number.
-        long random()
-        {
-            long result = s_randAmplitude * (seed % s_randQ) - s_randR * (seed / s_randQ);
-            if (result <= 0)
-                result += s_randMaximum;
-            seed = result;
-            return result;
-        }
-
         TurbulenceType type;
         float baseFrequencyX;
         float baseFrequencyY;
         int numOctaves;
-        long seed;
         bool stitchTiles;
-        IntSize paintingSize;
 
-        std::array<int, 2 * s_blockSize + 2> latticeSelector;
-        std::array<std::array<std::array<float, 2>, 2 * s_blockSize + 2>, 4> gradient;
+        using LatticeSelector = std::array<int, s_latticeSize>;
+        LatticeSelector latticeSelector;
+
+        using ChannelGradient = std::array<std::array<float, 2>, 2 * s_blockSize + 2>;
+        std::array<ChannelGradient, 4> gradient;
+
+        PaintingData(TurbulenceType, float baseFrequencyX, float baseFrequencyY, int numOctaves, long seed, bool stitchTiles);
     };
 
     struct StitchData {
         int width { 0 }; // How much to subtract to wrap for stitching.
-        int wrapX { 0 }; // Minimum value to wrap.
         int height { 0 };
+        int wrapX { 0 }; // Minimum value to wrap.
         int wrapY { 0 };
     };
+
+    static StitchData computeStitching(IntSize tileSize, float& baseFrequencyX, float& baseFrequencyY, bool stitchTiles);
+
+private:
+    bool apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const final;
 
     struct ApplyParameters {
         IntRect filterRegion;
@@ -102,11 +85,10 @@ private:
         int endY;
     };
 
+    static long random(long& seed);
+
     static inline float smoothCurve(float t) { return t * t * (3 - 2 * t); }
     static inline float linearInterpolation(float t, float a, float b) { return a + t * (b - a); }
-
-    static PaintingData initPaintingData(TurbulenceType, float baseFrequencyX, float baseFrequencyY, int numOctaves, long seed, bool stitchTiles, const IntSize& paintingSize);
-    static StitchData computeStitching(IntSize tileSize, float& baseFrequencyX, float& baseFrequencyY, bool stitchTiles);
 
     static ColorComponents<float, 4> noise2D(const PaintingData&, const StitchData&, const FloatPoint& noiseVector);
     static ColorComponents<uint8_t, 4> toIntBasedColorComponents(const ColorComponents<float, 4>& floatComponents);

--- a/WebKitLibraries/SDKs/watchos26.0-additions.sdk/System/Library/Frameworks/CoreImage.framework/CoreImage.tbd
+++ b/WebKitLibraries/SDKs/watchos26.0-additions.sdk/System/Library/Frameworks/CoreImage.framework/CoreImage.tbd
@@ -6,5 +6,5 @@ current-version: 7
 exports:
 -       targets: [armv7k-watchos, arm64-watchos, arm64e-watchos, arm64_32-watchos]
         symbols: [_kCIContextWorkingColorSpace, _kCIInputBackgroundImageKey, _kCIInputImageKey, _kCIInputTransformKey]
-        objc-classes: [CIBlendKernel, CIColor, CIContext, CIFilter, CIImage, CIRenderDestination, CIVector]
+        objc-classes: [CIBlendKernel, CIColor, CIContext, CIFilter, CIImage, CIKernel, CIRenderDestination, CIVector]
 ...

--- a/WebKitLibraries/SDKs/watchsimulator26.0-additions.sdk/System/Library/Frameworks/CoreImage.framework/CoreImage.tbd
+++ b/WebKitLibraries/SDKs/watchsimulator26.0-additions.sdk/System/Library/Frameworks/CoreImage.framework/CoreImage.tbd
@@ -6,5 +6,5 @@ current-version: 7
 exports:
 -       targets: [i386-watchos-simulator, x86_64-watchos-simulator, arm64-watchos-simulator]
         symbols: [_kCIContextWorkingColorSpace, _kCIInputBackgroundImageKey, _kCIInputImageKey, _kCIInputTransformKey]
-        objc-classes: [CIBlendKernel, CIColor, CIContext, CIFilter, CIImage, CIRenderDestination, CIVector]
+        objc-classes: [CIBlendKernel, CIColor, CIContext, CIFilter, CIImage, CIKernel, CIRenderDestination, CIVector]
 ...


### PR DESCRIPTION
#### dd197abdfa4b84d284694cb5d4cd540bbe3c9ba0
<pre>
[CI Filters] FETurbulence in Core Image
<a href="https://bugs.webkit.org/show_bug.cgi?id=304873">https://bugs.webkit.org/show_bug.cgi?id=304873</a>
<a href="https://rdar.apple.com/167458150">rdar://167458150</a>

Reviewed by Mike Wyrzykowski.

Core Image implementation of FETurbulence. This requires some refactoring of
`FETurbulenceSoftwareApplier` so we can share `PaintingData` and access the local
`random()` function that FETurbulence uses. What runs in the kernel is the same
code that generates the output from `PaintingData` in the software applier. The
output is pixel-identical to the software code path.

There&apos;s a workaround for a Core Image bug that I did not yet reduce and file,
where it seems to generate an image larger than the `extent` provided to `applyWithExtent:`.

* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/coreimage/FETurbulenceCoreImageApplier.h: Copied from Source/WebCore/platform/graphics/coreimage/SourceAlphaCoreImageApplier.mm.
* Source/WebCore/platform/graphics/coreimage/FETurbulenceCoreImageApplier.mm: Added.
(WebCore::turbulenceKernel):
* Source/WebCore/platform/graphics/coreimage/SourceAlphaCoreImageApplier.mm: Unified build fix.
* Source/WebCore/platform/graphics/filters/FETurbulence.cpp:
(WebCore::FETurbulence::supportedFilterRenderingModes const):
(WebCore::FETurbulence::createAcceleratedApplier const):
* Source/WebCore/platform/graphics/filters/FETurbulence.h:
* Source/WebCore/platform/graphics/filters/software/FETurbulenceSoftwareApplier.cpp:
(WebCore::FETurbulenceSoftwareApplier::PaintingData::PaintingData):
(WebCore::FETurbulenceSoftwareApplier::random):
(WebCore::FETurbulenceSoftwareApplier::computeStitching):
(WebCore::FETurbulenceSoftwareApplier::apply const):
(WebCore::FETurbulenceSoftwareApplier::initPaintingData): Deleted.
* Source/WebCore/platform/graphics/filters/software/FETurbulenceSoftwareApplier.h:
* WebKitLibraries/SDKs/watchos26.0-additions.sdk/System/Library/Frameworks/CoreImage.framework/CoreImage.tbd:
* WebKitLibraries/SDKs/watchsimulator26.0-additions.sdk/System/Library/Frameworks/CoreImage.framework/CoreImage.tbd:

Canonical link: <a href="https://commits.webkit.org/305074@main">https://commits.webkit.org/305074@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2541448b34d0ef022b8b8aee2c1fc407faee80a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137404 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9764 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48691 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145155 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90377 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0a466ee8-e84e-48fc-9f8e-39cdc6e43648) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139276 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10468 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9891 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105070 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4854fc43-66af-41ba-8401-d43baa74cfb4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140349 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7747 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123150 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85925 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/16c8c621-fbd5-4c35-be3d-c89a68e41180) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7383 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5104 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5742 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116751 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41302 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147912 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9447 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41859 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113446 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9465 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/7957 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113787 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28888 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7304 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119389 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64055 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9496 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37442 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9226 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73061 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9436 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9288 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->