### PR TITLE
Move text extraction retrieval and interaction methods from WebPage(Proxy) to WebFrame(Proxy)

### DIFF
--- a/Source/WebCore/page/text-extraction/TextExtraction.h
+++ b/Source/WebCore/page/text-extraction/TextExtraction.h
@@ -39,13 +39,12 @@ enum class ExceptionCode : uint8_t;
 
 namespace TextExtraction {
 
-WEBCORE_EXPORT Item extractItem(Request&&, Page&);
-Item extractItem(Request&&, LocalFrame&);
+WEBCORE_EXPORT Item extractItem(Request&&, LocalFrame&);
 
 WEBCORE_EXPORT Vector<std::pair<String, FloatRect>> extractAllTextAndRects(Page&);
 
-WEBCORE_EXPORT void handleInteraction(Interaction&&, Page&, CompletionHandler<void(bool, String&&)>&&);
-WEBCORE_EXPORT InteractionDescription interactionDescription(const Interaction&, Page&);
+WEBCORE_EXPORT void handleInteraction(Interaction&&, LocalFrame&, CompletionHandler<void(bool, String&&)>&&);
+WEBCORE_EXPORT InteractionDescription interactionDescription(const Interaction&, LocalFrame&);
 
 WEBCORE_EXPORT std::optional<SimpleRange> rangeForExtractedText(const LocalFrame&, ExtractedText&&);
 

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -878,6 +878,42 @@ void WebFrameProxy::sendMessageToInspectorFrontend(const String& targetId, const
         page->inspectorController().sendMessageToInspectorFrontend(targetId, message);
 }
 
+void WebFrameProxy::requestTextExtraction(WebCore::TextExtraction::Request&& request, CompletionHandler<void(WebCore::TextExtraction::Item&&)>&& completion)
+{
+    if (RefPtr page = m_page.get(); !page || !page->hasRunningProcess())
+        return completion({ });
+
+    sendWithAsyncReply(Messages::WebFrame::RequestTextExtraction(WTF::move(request)), WTF::move(completion));
+}
+
+void WebFrameProxy::handleTextExtractionInteraction(TextExtraction::Interaction&& interaction, CompletionHandler<void(bool, String&&)>&& completion)
+{
+    if (RefPtr page = m_page.get(); !page || !page->hasRunningProcess()) {
+        ASSERT_NOT_REACHED();
+        return completion(false, "Internal inconsistency / unexpected state. Please file a bug"_s);
+    }
+
+    sendWithAsyncReply(Messages::WebFrame::HandleTextExtractionInteraction(WTF::move(interaction)), WTF::move(completion));
+}
+
+void WebFrameProxy::takeSnapshotOfExtractedText(TextExtraction::ExtractedText&& extractedText, CompletionHandler<void(RefPtr<TextIndicator>&&)>&& completion)
+{
+    if (RefPtr page = m_page.get(); !page || !page->hasRunningProcess())
+        return completion({ });
+
+    sendWithAsyncReply(Messages::WebFrame::TakeSnapshotOfExtractedText(WTF::move(extractedText)), WTF::move(completion));
+}
+
+void WebFrameProxy::describeTextExtractionInteraction(TextExtraction::Interaction&& interaction, CompletionHandler<void(TextExtraction::InteractionDescription&&)>&& completion)
+{
+    if (RefPtr page = m_page.get(); !page || !page->hasRunningProcess()) {
+        ASSERT_NOT_REACHED();
+        return completion({ "Internal inconsistency / unexpected state. Please file a bug"_s, { } });
+    }
+
+    sendWithAsyncReply(Messages::WebFrame::DescribeTextExtractionInteraction(WTF::move(interaction)), WTF::move(completion));
+}
+
 } // namespace WebKit
 
 #undef MESSAGE_CHECK

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -64,6 +64,7 @@ class FrameTreeSyncData;
 class ResourceRequest;
 class SecurityOriginData;
 class ShareableBitmapHandle;
+class TextIndicator;
 
 struct FocusEventData;
 struct FrameIdentifierType;
@@ -76,6 +77,14 @@ enum class MouseEventPolicy : uint8_t;
 enum class ResourceResponseSource : uint8_t;
 enum class SandboxFlag : uint16_t;
 enum class ScrollbarMode : uint8_t;
+
+namespace TextExtraction {
+struct ExtractedText;
+struct InteractionDescription;
+struct Interaction;
+struct Item;
+struct Request;
+}
 
 using FrameIdentifier = ObjectIdentifier<FrameIdentifierType>;
 using NavigationIdentifier = ObjectIdentifier<NavigationIdentifierType, uint64_t>;
@@ -279,6 +288,11 @@ public:
     template<typename M> void send(M&&);
 
     void sendMessageToInspectorFrontend(const String& targetId, const String& message);
+
+    void requestTextExtraction(WebCore::TextExtraction::Request&&, CompletionHandler<void(WebCore::TextExtraction::Item&&)>&&);
+    void handleTextExtractionInteraction(WebCore::TextExtraction::Interaction&&, CompletionHandler<void(bool, String&&)>&&);
+    void describeTextExtractionInteraction(WebCore::TextExtraction::Interaction&&, CompletionHandler<void(WebCore::TextExtraction::InteractionDescription&&)>&&);
+    void takeSnapshotOfExtractedText(WebCore::TextExtraction::ExtractedText&&, CompletionHandler<void(RefPtr<WebCore::TextIndicator>&&)>&&);
 
 private:
     WebFrameProxy(WebPageProxy&, FrameProcess&, WebCore::FrameIdentifier, WebCore::SandboxFlags, WebCore::ReferrerPolicy, WebCore::ScrollbarMode, WebFrameProxy*, IsMainFrame);

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -17155,41 +17155,6 @@ void WebPageProxy::takeSnapshotForTargetedElement(const API::TargetedElementInfo
     sendWithAsyncReply(Messages::WebPage::TakeSnapshotForTargetedElement(info.nodeIdentifier(), info.documentIdentifier()), WTF::move(completion));
 }
 
-void WebPageProxy::requestTextExtraction(WebCore::TextExtraction::Request&& request, CompletionHandler<void(WebCore::TextExtraction::Item&&)>&& completion)
-{
-    if (!hasRunningProcess())
-        return completion({ });
-    sendWithAsyncReply(Messages::WebPage::RequestTextExtraction(WTF::move(request)), WTF::move(completion));
-}
-
-void WebPageProxy::handleTextExtractionInteraction(TextExtraction::Interaction&& interaction, CompletionHandler<void(bool, String&&)>&& completion)
-{
-    if (!hasRunningProcess()) {
-        ASSERT_NOT_REACHED();
-        return completion(false, "Internal inconsistency / unexpected state. Please file a bug"_s);
-    }
-
-    sendWithAsyncReply(Messages::WebPage::HandleTextExtractionInteraction(WTF::move(interaction)), WTF::move(completion));
-}
-
-void WebPageProxy::takeSnapshotOfExtractedText(TextExtraction::ExtractedText&& extractedText, CompletionHandler<void(RefPtr<TextIndicator>&&)>&& completion)
-{
-    if (!hasRunningProcess())
-        return completion({ });
-
-    sendWithAsyncReply(Messages::WebPage::TakeSnapshotOfExtractedText(WTF::move(extractedText)), WTF::move(completion));
-}
-
-void WebPageProxy::describeTextExtractionInteraction(TextExtraction::Interaction&& interaction, CompletionHandler<void(TextExtraction::InteractionDescription&&)>&& completion)
-{
-    if (!hasRunningProcess()) {
-        ASSERT_NOT_REACHED();
-        return completion({ "Internal inconsistency / unexpected state. Please file a bug"_s, { } });
-    }
-
-    sendWithAsyncReply(Messages::WebPage::DescribeTextExtractionInteraction(WTF::move(interaction)), WTF::move(completion));
-}
-
 void WebPageProxy::hasTextExtractionFilterRules(CompletionHandler<void(bool)>&& completion)
 {
     sendWithAsyncReply(Messages::WebPage::HasTextExtractionFilterRules(), WTF::move(completion));

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -348,12 +348,7 @@ struct OpenID4VPRequest;
 #endif
 
 namespace TextExtraction {
-struct ExtractedText;
 struct FilterRuleData;
-struct InteractionDescription;
-struct Interaction;
-struct Item;
-struct Request;
 }
 
 #if ENABLE(WRITING_TOOLS)
@@ -2670,10 +2665,6 @@ public:
     void requestAllTargetableElements(float, CompletionHandler<void(Vector<Vector<Ref<API::TargetedElementInfo>>>&&)>&&);
     void takeSnapshotForTargetedElement(const API::TargetedElementInfo&, CompletionHandler<void(std::optional<WebCore::ShareableBitmapHandle>&&)>&&);
 
-    void requestTextExtraction(WebCore::TextExtraction::Request&&, CompletionHandler<void(WebCore::TextExtraction::Item&&)>&&);
-    void handleTextExtractionInteraction(WebCore::TextExtraction::Interaction&&, CompletionHandler<void(bool, String&&)>&&);
-    void describeTextExtractionInteraction(WebCore::TextExtraction::Interaction&&, CompletionHandler<void(WebCore::TextExtraction::InteractionDescription&&)>&&);
-    void takeSnapshotOfExtractedText(WebCore::TextExtraction::ExtractedText&&, CompletionHandler<void(RefPtr<WebCore::TextIndicator>&&)>&&);
     void hasTextExtractionFilterRules(CompletionHandler<void(bool)>&&);
     void updateTextExtractionFilterRules(Vector<WebCore::TextExtraction::FilterRuleData>&&);
     void applyTextExtractionFilter(const String& input, std::optional<WebCore::NodeIdentifier>&&, CompletionHandler<void(String&&)>&&);

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -66,6 +66,15 @@ class IntRect;
 class LocalFrame;
 class PlatformMouseEvent;
 class RemoteFrame;
+class TextIndicator;
+
+namespace TextExtraction {
+struct ExtractedText;
+struct InteractionDescription;
+struct Interaction;
+struct Item;
+struct Request;
+}
 
 enum class FocusDirection : uint8_t;
 enum class FoundElementInRemoteFrame : bool;
@@ -276,6 +285,11 @@ public:
     void connectInspector(Inspector::FrontendChannel::ConnectionType);
     void disconnectInspector();
     void sendMessageToInspectorTarget(const String& message);
+
+    void requestTextExtraction(WebCore::TextExtraction::Request&&, CompletionHandler<void(WebCore::TextExtraction::Item&&)>&&);
+    void handleTextExtractionInteraction(WebCore::TextExtraction::Interaction&&, CompletionHandler<void(bool, String&&)>&&);
+    void describeTextExtractionInteraction(WebCore::TextExtraction::Interaction&&, CompletionHandler<void(WebCore::TextExtraction::InteractionDescription&&)>&&);
+    void takeSnapshotOfExtractedText(WebCore::TextExtraction::ExtractedText&&, CompletionHandler<void(RefPtr<WebCore::TextIndicator>&&)>&&);
 
 private:
     WebFrame(WebPage&, WebCore::FrameIdentifier);

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.messages.in
@@ -35,4 +35,10 @@ messages -> WebFrame {
     ConnectInspector(Inspector::FrontendChannel::ConnectionType connectionType)
     DisconnectInspector()
     SendMessageToInspectorTarget(String message)
+
+    # Text extraction support
+    RequestTextExtraction(struct WebCore::TextExtraction::Request request) -> (struct WebCore::TextExtraction::Item item)
+    HandleTextExtractionInteraction(struct WebCore::TextExtraction::Interaction interaction) -> (bool succeeded, String description)
+    DescribeTextExtractionInteraction(struct WebCore::TextExtraction::Interaction interaction) -> (struct WebCore::TextExtraction::InteractionDescription description)
+    TakeSnapshotOfExtractedText(struct WebCore::TextExtraction::ExtractedText text) -> (RefPtr<WebCore::TextIndicator> textIndicator)
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -9747,48 +9747,6 @@ void WebPage::requestAllTargetableElements(float hitTestInterval, CompletionHand
     completion(page->checkedElementTargetingController()->findAllTargets(hitTestInterval));
 }
 
-void WebPage::requestTextExtraction(TextExtraction::Request&& request, CompletionHandler<void(TextExtraction::Item&&)>&& completion)
-{
-    completion(TextExtraction::extractItem(WTF::move(request), Ref { *corePage() }));
-}
-
-void WebPage::takeSnapshotOfExtractedText(TextExtraction::ExtractedText&& extractedText, CompletionHandler<void(RefPtr<TextIndicator>&&)>&& completion)
-{
-    RefPtr frame = m_mainFrame->coreLocalFrame();
-    if (!frame) {
-        // FIXME: This logic will be moved into WebFrame once support for extracting content from subframes is
-        // implemented, at which point we should use the WebFrame's local frame. Until then, we only support
-        // content in the main frame anyways.
-        return completion({ });
-    }
-
-    auto range = TextExtraction::rangeForExtractedText(*frame, WTF::move(extractedText));
-    if (!range)
-        return completion({ });
-
-    using enum WebCore::TextIndicatorOption;
-    constexpr OptionSet options {
-        RespectTextColor,
-        PaintBackgrounds,
-        PaintAllContent,
-        TightlyFitContent,
-        UseBoundingRectAndPaintAllContentForComplexRanges,
-        DoNotClipToVisibleRect
-    };
-
-    completion(TextIndicator::createWithRange(*range, options, TextIndicatorPresentationTransition::None));
-}
-
-void WebPage::describeTextExtractionInteraction(TextExtraction::Interaction&& interaction, CompletionHandler<void(TextExtraction::InteractionDescription&&)>&& completion)
-{
-    completion(TextExtraction::interactionDescription(interaction, Ref { *corePage() }));
-}
-
-void WebPage::handleTextExtractionInteraction(TextExtraction::Interaction&& interaction, CompletionHandler<void(bool, String&&)>&& completion)
-{
-    TextExtraction::handleInteraction(WTF::move(interaction), Ref { *corePage() }, WTF::move(completion));
-}
-
 void WebPage::hasTextExtractionFilterRules(CompletionHandler<void(bool)>&& completion)
 {
     completion(!m_textExtractionFilterRules.isEmpty());

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -359,13 +359,8 @@ using ScrollOffset = IntPoint;
 using UserMediaRequestIdentifier = ObjectIdentifier<UserMediaRequestIdentifierType>;
 
 namespace TextExtraction {
-struct ExtractedText;
 struct FilterRuleData;
 struct FilterRule;
-struct InteractionDescription;
-struct Interaction;
-struct Item;
-struct Request;
 }
 
 namespace WritingTools {
@@ -2652,10 +2647,6 @@ private:
     void requestTargetedElement(WebCore::TargetedElementRequest&&, CompletionHandler<void(Vector<WebCore::TargetedElementInfo>&&)>&&);
     void requestAllTargetableElements(float, CompletionHandler<void(Vector<Vector<WebCore::TargetedElementInfo>>&&)>&&);
 
-    void requestTextExtraction(WebCore::TextExtraction::Request&&, CompletionHandler<void(WebCore::TextExtraction::Item&&)>&&);
-    void handleTextExtractionInteraction(WebCore::TextExtraction::Interaction&&, CompletionHandler<void(bool, String&&)>&&);
-    void describeTextExtractionInteraction(WebCore::TextExtraction::Interaction&&, CompletionHandler<void(WebCore::TextExtraction::InteractionDescription&&)>&&);
-    void takeSnapshotOfExtractedText(WebCore::TextExtraction::ExtractedText&&, CompletionHandler<void(RefPtr<WebCore::TextIndicator>&&)>&&);
     void hasTextExtractionFilterRules(CompletionHandler<void(bool)>&&);
     void updateTextExtractionFilterRules(Vector<WebCore::TextExtraction::FilterRuleData>&&);
     void applyTextExtractionFilter(const String& input, std::optional<WebCore::NodeIdentifier>&& containerNode, CompletionHandler<void(const String&)>&&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -828,10 +828,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
 
     RequestAllTargetableElements(float hitTestInterval) -> (Vector<Vector<WebCore::TargetedElementInfo>> elements)
 
-    RequestTextExtraction(struct WebCore::TextExtraction::Request request) -> (struct WebCore::TextExtraction::Item item)
-    HandleTextExtractionInteraction(struct WebCore::TextExtraction::Interaction interaction) -> (bool succeeded, String description)
-    DescribeTextExtractionInteraction(struct WebCore::TextExtraction::Interaction interaction) -> (struct WebCore::TextExtraction::InteractionDescription description)
-    TakeSnapshotOfExtractedText(struct WebCore::TextExtraction::ExtractedText text) -> (RefPtr<WebCore::TextIndicator> textIndicator)
+    # Text extraction support
     HasTextExtractionFilterRules() -> (bool hasRules)
     UpdateTextExtractionFilterRules(Vector<WebCore::TextExtraction::FilterRuleData> ruleData)
     ApplyTextExtractionFilter(String input, std::optional<WebCore::NodeIdentifier> containerNodeID) -> (String output)


### PR DESCRIPTION
#### 45e6a6b0abe5aa9996d6376e68daafd2f1f64d07
<pre>
Move text extraction retrieval and interaction methods from WebPage(Proxy) to WebFrame(Proxy)
<a href="https://bugs.webkit.org/show_bug.cgi?id=304878">https://bugs.webkit.org/show_bug.cgi?id=304878</a>
<a href="https://rdar.apple.com/167460161">rdar://167460161</a>

Reviewed by Lily Spiniolas.

Move the following text extraction IPC methods:

• requestTextExtraction
• handleTextExtractionInteraction
• takeSnapshotOfExtractedText
• describeTextExtractionInteraction

…from `WebPageProxy` → `WebPage` to `WebFrameProxy` → `WebFrame`. This is the first step towards
making text extraction work for content in cross-origin subframes, with or without site isolation
enabled. For now, these methods are all called on the `WebPageProxy`&apos;s main frame; in a subsequent
patch, once we allow the client to specify a set of target frames to extract from, we&apos;ll request
text extraction from multiple frames in parallel and collate the results.

No change in behavior.

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractItem):
(WebCore::TextExtraction::dispatchSimulatedClick):
(WebCore::TextExtraction::resolveNodeWithBodyAsFallback):
(WebCore::TextExtraction::selectText):
(WebCore::TextExtraction::highlightText):
(WebCore::TextExtraction::scrollBy):
(WebCore::TextExtraction::simulateKeyPress):
(WebCore::TextExtraction::handleInteraction):
(WebCore::TextExtraction::textDescription):
(WebCore::TextExtraction::interactionDescription):
(WebCore::TextExtraction::applyRules):
(WebCore::TextExtraction::makeRootItem): Deleted.

Instead of taking a `WebCore::Page` and acting on the local main frame of the page, make these
methods directly take a `LocalFrame` that comes directly from `WebFrameProxy` (see changes below).

* Source/WebCore/page/text-extraction/TextExtraction.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _performInteraction:completionHandler:]):
(-[WKWebView _requestTextExtractionInternal:completion:]):
(-[WKWebView _describeInteraction:completionHandler:]):
(-[WKWebView _validateText:inNode:completionHandler:]):
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::requestTextExtraction):
(WebKit::WebFrameProxy::handleTextExtractionInteraction):
(WebKit::WebFrameProxy::takeSnapshotOfExtractedText):
(WebKit::WebFrameProxy::describeTextExtractionInteraction):
* Source/WebKit/UIProcess/WebFrameProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::requestTextExtraction): Deleted.
(WebKit::WebPageProxy::handleTextExtractionInteraction): Deleted.
(WebKit::WebPageProxy::takeSnapshotOfExtractedText): Deleted.
(WebKit::WebPageProxy::describeTextExtractionInteraction): Deleted.

Move these methods into `WebFrameProxy`.

* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::requestTextExtraction):
(WebKit::WebFrame::takeSnapshotOfExtractedText):
(WebKit::WebFrame::describeTextExtractionInteraction):
(WebKit::WebFrame::handleTextExtractionInteraction):
* Source/WebKit/WebProcess/WebPage/WebFrame.h:
* Source/WebKit/WebProcess/WebPage/WebFrame.messages.in:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::requestTextExtraction): Deleted.
(WebKit::WebPage::takeSnapshotOfExtractedText): Deleted.
(WebKit::WebPage::describeTextExtractionInteraction): Deleted.
(WebKit::WebPage::handleTextExtractionInteraction): Deleted.

Move these methods into `WebFrame`.

* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

Canonical link: <a href="https://commits.webkit.org/305065@main">https://commits.webkit.org/305065@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5560c2f1aaa49b1b6803e8fe13be38294a9abda

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137377 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9737 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48664 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145128 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90350 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/06736855-0463-4200-bf5b-100ce7dbd17a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139249 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10441 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9864 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105045 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5a3c09fe-89f6-4897-8db0-2cc5025854ee) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140322 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7720 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123121 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85901 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/23b9d2d1-07db-4c48-b8d1-dcf3aa9a045c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7356 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5076 "Found 25 new API test failures: TestWebKitAPI.SimulateClickOverText.ClickTargets, TestWebKitAPI.EditorStateTests.TypingAttributesTextColor, TestWebKitAPI.WKWebViewConfiguration.LoadsSubresources, TestWebKitAPI.WKWebExtensionController.BackgroundWithMultipleServiceWorkerScripts, TestWebKitAPI.GetUserMedia.OriginAndWebArchivePermission, TestWebKitAPI.WKWebViewThemeColor.KVO, TestWebKitAPI.SpellCheckerDocumentTag.SpellCheckerDocumentTagWhenCheckingString, TestWebKitAPI.LockdownMode.AllowedFontLoadingAPI, TestWebKitAPI.WKWebExtensionAPIExtension.GetViewsForMultipleTabs, TestWebKitAPI.WKWebExtensionController.CSSAuthorOrigin ... (failure)") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5715 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116722 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41275 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147885 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9420 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41833 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113420 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9438 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7930 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113761 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28883 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7277 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119363 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64017 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9469 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37416 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9199 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73034 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9409 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9261 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->