### PR TITLE
Web Inspector: FIXME: The location link should include stack trace information

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.js
@@ -90,7 +90,6 @@ WI.ConsoleMessageView = class ConsoleMessageView extends WI.Object
             break;
         }
 
-        // FIXME: The location link should include stack trace information.
         this._appendLocationLink();
 
         this._messageBodyElement = this._element.appendChild(document.createElement("span"));
@@ -447,24 +446,21 @@ WI.ConsoleMessageView = class ConsoleMessageView extends WI.Object
             this._messageBodyElement.appendChild(savedVariableElement);
     }
 
-    _appendLocationLink()
-    {
-        if (this._message.source === WI.ConsoleMessage.MessageSource.Network) {
-            if (this._message.url) {
-                var anchor = WI.linkifyURLAsNode(this._message.url, this._message.url, "console-message-url");
-                anchor.classList.add("console-message-location");
-                this._element.appendChild(anchor);
-            }
-            return;
-        }
+    _appendLocationLink(stackTrace) {
+        // If no stackTrace is passed, use the message’s stackTrace.
+        stackTrace = stackTrace || this._message.stackTrace;
 
-        var callFrame;
-        let firstNonNativeNonAnonymousNotBlackboxedCallFrame = this._message.stackTrace?.firstNonNativeNonAnonymousNotBlackboxedCallFrame;
-        if (firstNonNativeNonAnonymousNotBlackboxedCallFrame) {
-            // JavaScript errors and console.* methods.
-            callFrame = firstNonNativeNonAnonymousNotBlackboxedCallFrame;
-        } else if (this._message.url && !this._shouldHideURL(this._message.url)) {
-            // CSS warnings have no stack traces.
+        // Ensure we have a stackTrace object with frames.
+        if (!stackTrace || !stackTrace.callFrames.length)
+        return;
+
+        console.assert(stackTrace instanceof WI.StackTrace);
+
+        // Pick the first non-native, non-anonymous, not blackboxed frame
+        let callFrame = stackTrace.firstNonNativeNonAnonymousNotBlackboxedCallFrame;
+
+        // If no suitable frame, fall back to message URL (for CSS warnings, etc.)
+        if (!callFrame && this._message.url && !this._shouldHideURL(this._message.url)) {
             callFrame = WI.CallFrame.fromPayload(this._message.target, {
                 functionName: "",
                 url: this._message.url,
@@ -473,6 +469,7 @@ WI.ConsoleMessageView = class ConsoleMessageView extends WI.Object
             });
         }
 
+        // If we have a callFrame, create and append the link
         if (callFrame && (!callFrame.isConsoleEvaluation || WI.settings.debugShowConsoleEvaluations.value)) {
             let existingCallFrameView = this._callFrameView;
 
@@ -482,12 +479,14 @@ WI.ConsoleMessageView = class ConsoleMessageView extends WI.Object
             if (existingCallFrameView)
                 this._element.replaceChild(this._callFrameView, existingCallFrameView);
             else
-                this._element.appendChild(this._callFrameView);
+                this._element.insertBefore(this._callFrameView, this._element.firstChild);
+
             return;
         }
 
+        // If no callFrame, but there's exactly one parameter, attempt to resolve a location from it
         if (this._message.parameters && this._message.parameters.length === 1) {
-            var parameter = this._createRemoteObjectIfNeeded(this._message.parameters[0]);
+            let parameter = this._createRemoteObjectIfNeeded(this._message.parameters[0]);
 
             parameter.findFunctionSourceCodeLocation().then((result) => {
                 if (result === WI.RemoteObject.SourceCodeLocationPromise.NoSourceFound || result === WI.RemoteObject.SourceCodeLocationPromise.MissingObjectId)


### PR DESCRIPTION
Web Inspector: FIXME: The location link should include stack trace information 
https://bugs.webkit.org/show_bug.cgi?id=304881

Reviewed by NOBODY (OOPS!).

Update _appendLocationLink to accept an optional stackTrace parameter.
Add a console.assert to ensure that stackTrace, if provided, is an instance of WI.StackTrace.
Fallback to this._message.stackTrace if no stackTrace is provided.

No new tests (OOPS!).
* Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.js:
</pre>

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d786e4b87375a17025237883bd39312c8b4342cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137434 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9794 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48721 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145185 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90407 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10498 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9921 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105090 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/76761 "Exiting early after 60 failures. 21519 tests run. 60 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140379 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7775 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123174 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85945 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7411 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5133 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5772 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116780 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41326 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147942 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9477 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41883 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113467 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9495 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7986 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113809 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7332 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119413 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/64092 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9526 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37466 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9256 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73091 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9466 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9318 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->