### PR TITLE
[JSC] Implement `Array.prototype.flat` in C++

### DIFF
--- a/JSTests/microbenchmarks/array-prototype-flat-depth-1-double.js
+++ b/JSTests/microbenchmarks/array-prototype-flat-depth-1-double.js
@@ -1,0 +1,15 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+const array = new Array(1024);
+array.fill(99.99);
+array[512] = [1.1, 2.2, 3.3, 4.4, 5.5];
+
+let r;
+for (let i = 0; i < 1e5; i++) {
+    r = array.flat();
+}
+
+shouldBe(r.length, 1023 + 5);

--- a/JSTests/microbenchmarks/array-prototype-flat-depth-1-int32.js
+++ b/JSTests/microbenchmarks/array-prototype-flat-depth-1-int32.js
@@ -1,0 +1,15 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+const array = new Array(1024);
+array.fill(99);
+array[512] = [1, 2, 3, 4, 5];
+
+let r;
+for (let i = 0; i < 1e5; i++) {
+    r = array.flat();
+}
+
+shouldBe(r.length, 1023 + 5);

--- a/JSTests/microbenchmarks/array-prototype-flat-depth-1-mixed.js
+++ b/JSTests/microbenchmarks/array-prototype-flat-depth-1-mixed.js
@@ -1,0 +1,21 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+const array = new Array(1024);
+for (let i = 0; i < array.length; i++) {
+    if (i % 3 === 0) array[i] = i;
+    else if (i % 3 === 1) array[i] = `str${i}`;
+    else array[i] = i * 1.1;
+}
+array[256] = [true, false, null, undefined, {}];
+array[512] = [42, "hello", 3.14, BigInt(100), Symbol.for("test")];
+array[768] = [[], {a: 1}, new Date(), /regex/, function() {}];
+
+let r;
+for (let i = 0; i < 1e5; i++) {
+    r = array.flat();
+}
+
+shouldBe(r.length, 1021 + 5 + 5 + 5);

--- a/JSTests/microbenchmarks/array-prototype-flat-depth-1-string.js
+++ b/JSTests/microbenchmarks/array-prototype-flat-depth-1-string.js
@@ -1,0 +1,15 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+const array = new Array(1024);
+array.fill("test");
+array[512] = ["hello", "world", "from", "webkit", "test"];
+
+let r;
+for (let i = 0; i < 1e5; i++) {
+    r = array.flat();
+}
+
+shouldBe(r.length, 1023 + 5);

--- a/JSTests/microbenchmarks/array-prototype-flat-depth-2.js
+++ b/JSTests/microbenchmarks/array-prototype-flat-depth-2.js
@@ -1,0 +1,17 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+const array = new Array(1024);
+array.fill(99);
+array[256] = [[1, 2], [3, 4], [5, 6]];
+array[512] = [[7, 8, 9], [10, 11, 12]];
+array[768] = [[13], [14, 15], [16, 17, 18]];
+
+let r;
+for (let i = 0; i < 1e5; i++) {
+    r = array.flat(2);
+}
+
+shouldBe(r.length, 1021 + 6 + 6 + 6);

--- a/JSTests/microbenchmarks/array-prototype-flat-depth-3.js
+++ b/JSTests/microbenchmarks/array-prototype-flat-depth-3.js
@@ -1,0 +1,17 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+const array = new Array(1024);
+array.fill(99);
+array[256] = [[[1, 2]], [[3], [4, 5]], [[[6]]]];
+array[512] = [[[7, 8, 9]], [[[10]], [[11, 12]]]];
+array[768] = [[[[13]]], [[[14, 15]], [[16]]], [[[17], [18]]]];
+
+let r;
+for (let i = 0; i < 1e5; i++) {
+    r = array.flat(3);
+}
+
+shouldBe(r.length, 1037);

--- a/JSTests/microbenchmarks/array-prototype-flat-depth-infinity.js
+++ b/JSTests/microbenchmarks/array-prototype-flat-depth-infinity.js
@@ -1,0 +1,17 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+const array = new Array(1024);
+array.fill(99);
+array[256] = [[[[[1, 2]]]], [[[3], [4, 5]]], [[[[[[6]]]]]]];
+array[512] = [[[[[[7, 8, 9]]]]], [[[[[10]]], [[[11, 12]]]]]];
+array[768] = [[[[[[[13]]]]]], [[[[[[14, 15]]]], [[[16]]]], [[[[17], [18]]]]]];
+
+let r;
+for (let i = 0; i < 1e5; i++) {
+    r = array.flat(Infinity);
+}
+
+shouldBe(r.length, 1021 + 6 + 6 + 6);

--- a/JSTests/microbenchmarks/array-prototype-flat-huge-arrays.js
+++ b/JSTests/microbenchmarks/array-prototype-flat-huge-arrays.js
@@ -1,0 +1,17 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+const array = new Array(100000);
+array.fill(42);
+for (let i = 0; i < 1000; i++) {
+    array[i * 100] = [1, 2, 3, 4, 5];
+}
+
+let r;
+for (let i = 0; i < 1e2; i++) {
+    r = array.flat();
+}
+
+shouldBe(r.length, 99000 + 1000 * 5);

--- a/JSTests/microbenchmarks/array-prototype-flat-large-nested.js
+++ b/JSTests/microbenchmarks/array-prototype-flat-large-nested.js
@@ -1,0 +1,28 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function createLargeNestedArray(depth, width) {
+    if (depth === 0) {
+        return Array(width).fill(1);
+    }
+    const arr = [];
+    for (let i = 0; i < width; i++) {
+        arr.push(createLargeNestedArray(depth - 1, width));
+    }
+    return arr;
+}
+
+const array = new Array(512);
+array.fill(99);
+array[100] = createLargeNestedArray(3, 10);
+array[200] = createLargeNestedArray(2, 20);
+array[300] = createLargeNestedArray(4, 5);
+
+let r;
+for (let i = 0; i < 1e3; i++) {
+    r = array.flat(Infinity);
+}
+
+shouldBe(r.length, 21634);

--- a/JSTests/microbenchmarks/array-prototype-flat-small-arrays.js
+++ b/JSTests/microbenchmarks/array-prototype-flat-small-arrays.js
@@ -1,0 +1,13 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+const array = [1, [2, 3], 4, [5], 6, [7, 8, 9], 10];
+
+let r;
+for (let i = 0; i < 1e5; i++) {
+    r = array.flat();
+}
+
+shouldBe(r.length, 10);

--- a/JSTests/microbenchmarks/array-prototype-flat-sparse-array.js
+++ b/JSTests/microbenchmarks/array-prototype-flat-sparse-array.js
@@ -1,0 +1,22 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+const array = new Array(2048);
+array[100] = 1;
+array[500] = [2, 3, 4];
+array[1000] = 5;
+array[1500] = [6, 7, 8, 9];
+array[2000] = [[10, 11], [12, 13]];
+
+let r;
+for (let i = 0; i < 1e5; i++) {
+    r = array.flat();
+}
+
+let count = 0;
+for (let i = 0; i < r.length; i++) {
+    if (r[i] !== undefined) count++;
+}
+shouldBe(count, 11);

--- a/JSTests/stress/array-prototype-flat-hole.js
+++ b/JSTests/stress/array-prototype-flat-hole.js
@@ -1,0 +1,14 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+Array.prototype[2] = 222;
+const arr = [0, 1, , 3];
+const f = arr.flat(0);
+
+shouldBe(f.length, 4);
+shouldBe(f[0], 0);
+shouldBe(f[1], 1);
+shouldBe(f[2], 222);
+shouldBe(f[3], 3);

--- a/JSTests/stress/array-prototype-flat-nested-proxy-array.js
+++ b/JSTests/stress/array-prototype-flat-nested-proxy-array.js
@@ -1,0 +1,25 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+const handler = {
+  get : function (t, p, r) { return Reflect.get(t, p, r); },
+  has : function (t, p, r) { return Reflect.has(t, p, r); }
+};
+
+const proxyArray = new Proxy([5, 6], handler);
+
+const array = [1, 2, 3, 4, proxyArray, 7, 8];
+shouldBe(array.length, 7);
+
+const flattened = array.flat();
+shouldBe(flattened.length, 8);
+shouldBe(flattened[0], 1);
+shouldBe(flattened[1], 2);
+shouldBe(flattened[2], 3);
+shouldBe(flattened[3], 4);
+shouldBe(flattened[4], 5);
+shouldBe(flattened[5], 6);
+shouldBe(flattened[6], 7);
+shouldBe(flattened[7], 8);

--- a/JSTests/stress/array-prototype-flat-undefined-depth.js
+++ b/JSTests/stress/array-prototype-flat-undefined-depth.js
@@ -1,0 +1,91 @@
+// This test verifies that Array.prototype.flat handles undefined depth correctly.
+// Per ECMAScript spec, when depth is undefined, the default depth of 1 should be used.
+// This was a bug in the C++ optimization where flat(undefined) was treated as flat(0)
+// instead of flat(1), which broke Google Docs.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ', expected: ' + expected);
+}
+
+function shouldBeArray(actual, expected) {
+    shouldBe(actual.length, expected.length);
+    for (var i = 0; i < expected.length; ++i) {
+        if (Array.isArray(expected[i])) {
+            shouldBe(Array.isArray(actual[i]), true);
+            shouldBeArray(actual[i], expected[i]);
+        } else {
+            shouldBe(actual[i], expected[i]);
+        }
+    }
+}
+
+// Test: flat() with no arguments should use depth 1
+shouldBeArray([[1, 2], [3, 4]].flat(), [1, 2, 3, 4]);
+shouldBeArray([[[1]]].flat(), [[1]]);
+
+// Test: flat(undefined) should behave the same as flat() - using default depth 1
+// This was the bug: flat(undefined) was treating undefined as 0 instead of defaulting to 1
+shouldBeArray([[1, 2], [3, 4]].flat(undefined), [1, 2, 3, 4]);
+shouldBeArray([[[1]]].flat(undefined), [[1]]);
+
+// Verify flat() and flat(undefined) produce identical results
+var testArrays = [
+    [[1, 2], [3, 4]],
+    [[[1]]],
+    [[1], [[2]], [[[3]]]],
+    [[], [1], [], [2, 3]],
+    [[1, [2, [3]]]],
+];
+
+for (var arr of testArrays) {
+    var resultNoArg = arr.flat();
+    var resultUndefined = arr.flat(undefined);
+    shouldBeArray(resultNoArg, resultUndefined);
+}
+
+// Test: flat(0) should NOT flatten (different from undefined)
+shouldBeArray([[1, 2], [3, 4]].flat(0), [[1, 2], [3, 4]]);
+shouldBeArray([[[1]]].flat(0), [[[1]]]);
+
+// Test: flat(null) should convert to 0 via ToIntegerOrInfinity
+shouldBeArray([[1, 2], [3, 4]].flat(null), [[1, 2], [3, 4]]);
+
+// Test: flat(NaN) should convert to 0 via ToIntegerOrInfinity
+shouldBeArray([[1, 2], [3, 4]].flat(NaN), [[1, 2], [3, 4]]);
+
+// Test: explicit flat(1) should match flat() and flat(undefined)
+for (var arr of testArrays) {
+    var resultNoArg = arr.flat();
+    var resultOne = arr.flat(1);
+    shouldBeArray(resultNoArg, resultOne);
+}
+
+// Stress test: run many iterations to catch JIT issues
+for (var i = 0; i < 1000; i++) {
+    var arr = [[i, i + 1], [i + 2]];
+    var expected = [i, i + 1, i + 2];
+
+    // All three should produce the same result
+    shouldBeArray(arr.flat(), expected);
+    shouldBeArray(arr.flat(undefined), expected);
+    shouldBeArray(arr.flat(1), expected);
+}
+
+// Test with various array types (contiguous int, double, object)
+shouldBeArray([[1, 2], [3, 4]].flat(undefined), [1, 2, 3, 4]); // int32
+shouldBeArray([[1.5, 2.5], [3.5]].flat(undefined), [1.5, 2.5, 3.5]); // double
+
+// Test with objects (compare by reference)
+var obj1 = {a: 1};
+var obj2 = {b: 2};
+var objectResult = [[obj1], [obj2]].flat(undefined);
+shouldBe(objectResult.length, 2);
+shouldBe(objectResult[0], obj1);
+shouldBe(objectResult[1], obj2);
+
+// Edge case: deeply nested with undefined should flatten one level
+var deeplyNested = [[[[[[1]]]]]];
+shouldBeArray(deeplyNested.flat(undefined), [[[[[1]]]]]);
+
+print("PASSED");

--- a/Source/JavaScriptCore/builtins/ArrayPrototype.js
+++ b/Source/JavaScriptCore/builtins/ArrayPrototype.js
@@ -294,24 +294,6 @@ function flatIntoArray(target, source, sourceLength, targetIndex, depth)
     return targetIndex;
 }
 
-function flat()
-{
-    "use strict";
-
-    var array = @toObject(this, "Array.prototype.flat requires that |this| not be null or undefined");
-    var length = @toLength(array.length);
-
-    var depthNum = 1;
-    var depth = @argument(0);
-    if (depth !== @undefined)
-        depthNum = @toIntegerOrInfinity(depth);
-
-    var result = @newArrayWithSpecies(0, array);
-
-    @flatIntoArray(result, array, length, 0, depthNum);
-    return result;
-}
-
 @linkTimeConstant
 function flatIntoArrayWithCallback(target, source, sourceLength, targetIndex, callback, thisArg)
 {

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -71,6 +71,7 @@ static JSC_DECLARE_HOST_FUNCTION(arrayProtoFuncWith);
 static JSC_DECLARE_HOST_FUNCTION(arrayProtoFuncIncludes);
 static JSC_DECLARE_HOST_FUNCTION(arrayProtoFuncCopyWithin);
 static JSC_DECLARE_HOST_FUNCTION(arrayProtoFuncToSpliced);
+static JSC_DECLARE_HOST_FUNCTION(arrayProtoFuncFlat);
 
 // ------------------------------ ArrayPrototype ----------------------------
 
@@ -117,7 +118,7 @@ void ArrayPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
     JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().indexOfPublicName(), arrayProtoFuncIndexOf, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public, ArrayIndexOfIntrinsic);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("lastIndexOf"_s, arrayProtoFuncLastIndexOf, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().filterPublicName(), arrayPrototypeFilterCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
-    JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().flatPublicName(), arrayPrototypeFlatCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->flat, arrayProtoFuncFlat, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().flatMapPublicName(), arrayPrototypeFlatMapCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().reducePublicName(), arrayPrototypeReduceCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().reduceRightPublicName(), arrayPrototypeReduceRightCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
@@ -155,7 +156,7 @@ void ArrayPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
         &vm.propertyNames->builtinNames().findIndexPublicName(),
         &vm.propertyNames->builtinNames().findLastPublicName(),
         &vm.propertyNames->builtinNames().findLastIndexPublicName(),
-        &vm.propertyNames->builtinNames().flatPublicName(),
+        &vm.propertyNames->flat,
         &vm.propertyNames->builtinNames().flatMapPublicName(),
         &vm.propertyNames->includes,
         &vm.propertyNames->builtinNames().keysPublicName(),
@@ -2108,6 +2109,114 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncToSpliced, (JSGlobalObject* globalObject,
         RETURN_IF_EXCEPTION(scope, { });
     }
 
+    return JSValue::encode(result);
+}
+
+static uint64_t flatIntoArray(JSGlobalObject* globalObject, JSObject* target, JSObject* source, uint64_t sourceLength, uint64_t targetIndex, uint64_t depth)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    if (!vm.isSafeToRecurseSoft()) [[unlikely]] {
+        throwStackOverflowError(globalObject, scope);
+        return std::numeric_limits<uint64_t>::max();
+    }
+
+    for (uint64_t sourceIndex = 0; sourceIndex < sourceLength; ++sourceIndex) {
+        JSValue element = source->getIfPropertyExists(globalObject, sourceIndex);
+        RETURN_IF_EXCEPTION(scope, { });
+        if (!element)
+            continue;
+
+        bool elementIsArray = isArray(globalObject, element);
+        RETURN_IF_EXCEPTION(scope, { });
+        if (depth > 0 && elementIsArray) {
+            uint64_t newDepth = depth - 1;
+            if (depth == std::numeric_limits<uint64_t>::max()) [[unlikely]]
+                newDepth = depth;
+            JSObject* elementObject = asObject(element);
+            uint64_t elementLength = toLength(globalObject, elementObject);
+            RETURN_IF_EXCEPTION(scope, { });
+            targetIndex = flatIntoArray(globalObject, target, elementObject, elementLength, targetIndex, newDepth);
+            RETURN_IF_EXCEPTION(scope, { });
+        } else {
+            if (targetIndex >= maxSafeIntegerAsUInt64()) [[unlikely]] {
+                throwTypeError(globalObject, scope, "flatten array exceeds 2**52 - 1");
+                return { };
+            }
+            target->putDirectIndex(globalObject, targetIndex, element, 0, PutDirectIndexShouldThrow);
+            RETURN_IF_EXCEPTION(scope, { });
+            targetIndex++;
+        }
+    }
+
+    return targetIndex;
+}
+
+JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncFlat, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue thisValue = callFrame->thisValue();
+
+    thisValue = thisValue.toThis(globalObject, ECMAMode::strict());
+    RETURN_IF_EXCEPTION(scope, { });
+    if (thisValue.isUndefinedOrNull()) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "Array.prototype.flat requires that |this| not be null or undefined"_s);
+
+    auto* thisObject = thisValue.toObject(globalObject);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    uint64_t length = toLength(globalObject, thisObject);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    uint64_t depthNum = 1;
+    if (callFrame->argumentCount()) {
+        JSValue depthValue = callFrame->uncheckedArgument(0);
+        if (!depthValue.isUndefined()) {
+            depthNum = [&]() -> uint64_t {
+                if (depthValue.isInt32()) [[likely]] {
+                    int32_t depthInt32 = depthValue.asInt32();
+                    if (depthInt32 < 0) [[unlikely]]
+                        return 0;
+                    return static_cast<uint64_t>(depthInt32);
+                }
+                double depthDouble = depthValue.toIntegerOrInfinity(globalObject);
+                RETURN_IF_EXCEPTION(scope, { });
+                if (depthDouble < 0) [[unlikely]]
+                    return 0;
+                if (std::isinf(depthDouble)) [[unlikely]]
+                    return std::numeric_limits<uint64_t>::max();
+                return static_cast<uint64_t>(depthDouble);
+            }();
+            RETURN_IF_EXCEPTION(scope, { });
+        }
+    }
+
+    if (isJSArray(thisObject) && arraySpeciesWatchpointIsValid(vm, thisObject)) [[likely]] {
+        JSArray* thisArray = jsCast<JSArray*>(thisObject);
+        auto fastResult = thisArray->fastFlat(globalObject, depthNum, length);
+        RETURN_IF_EXCEPTION(scope, { });
+        if (fastResult) [[likely]]
+            return JSValue::encode(fastResult);
+    }
+
+    std::pair<SpeciesConstructResult, JSObject*> speciesResult = speciesConstructArray(globalObject, thisObject, 0);
+    EXCEPTION_ASSERT(!!scope.exception() == (speciesResult.first == SpeciesConstructResult::Exception));
+    if (speciesResult.first == SpeciesConstructResult::Exception) [[unlikely]]
+        return { };
+
+    JSObject* result;
+    if (speciesResult.first == SpeciesConstructResult::CreatedObject) [[unlikely]]
+        result = speciesResult.second;
+    else {
+        result = constructEmptyArray(globalObject, nullptr);
+        RETURN_IF_EXCEPTION(scope, { });
+    }
+
+    scope.release();
+    flatIntoArray(globalObject, asObject(result), thisObject, length, /* start */ 0, depthNum);
     return JSValue::encode(result);
 }
 

--- a/Source/JavaScriptCore/runtime/CommonIdentifiers.h
+++ b/Source/JavaScriptCore/runtime/CommonIdentifiers.h
@@ -333,6 +333,7 @@
     macro(AsyncDisposableStack) \
     macro(disposeAsync) \
     macro(keys) \
+    macro(flat) \
     macro(promise) \
     macro(resumeMode) \
 

--- a/Source/JavaScriptCore/runtime/JSArray.cpp
+++ b/Source/JavaScriptCore/runtime/JSArray.cpp
@@ -2212,6 +2212,233 @@ JSArray* tryCloneArrayFromFast(JSGlobalObject* globalObject, JSValue arrayValue)
 template JSArray* tryCloneArrayFromFast<ArrayFillMode::Undefined>(JSGlobalObject*, JSValue);
 template JSArray* tryCloneArrayFromFast<ArrayFillMode::Empty>(JSGlobalObject*, JSValue);
 
+static uint64_t calculateFlattenedLength(JSGlobalObject* globalObject, JSArray* sourceArray, uint64_t sourceLength, uint64_t depth)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    if (!vm.isSafeToRecurseSoft()) [[unlikely]] {
+        throwStackOverflowError(globalObject, scope);
+        return std::numeric_limits<uint64_t>::max();
+    }
+
+    CheckedUint64 resultLength = 0;
+    auto lengthExceeded = [&]() -> bool {
+        return resultLength.hasOverflowed() || resultLength > maxSafeIntegerAsUInt64();
+    };
+
+    IndexingType sourceType = sourceArray->indexingType();
+    switch (sourceType) {
+    case ArrayWithInt32: {
+        auto* sourceBuffer = sourceArray->butterfly()->contiguous().data();
+        for (uint64_t i = 0; i < sourceLength; ++i) {
+            JSValue element = sourceBuffer[i].get();
+            if (!element) [[unlikely]]
+                continue;
+            resultLength++;
+            if (lengthExceeded()) [[unlikely]] {
+                throwTypeError(globalObject, scope, "flatten array exceeds 2**52 - 1");
+                return std::numeric_limits<uint64_t>::max();
+            }
+        }
+        break;
+    }
+    case ArrayWithContiguous: {
+        auto* sourceBuffer = sourceArray->butterfly()->contiguous().data();
+        for (uint64_t i = 0; i < sourceLength; ++i) {
+            JSValue element = sourceBuffer[i].get();
+            if (!element) [[unlikely]]
+                continue;
+            if (depth > 0 && isJSArray(element)) {
+                JSArray* elementArray = jsCast<JSArray*>(element);
+                uint64_t newDepth = (depth == std::numeric_limits<uint64_t>::max()) ? depth : depth - 1;
+                uint64_t flatLength = calculateFlattenedLength(globalObject, elementArray, elementArray->length(), newDepth);
+                RETURN_IF_EXCEPTION(scope, flatLength);
+                if (flatLength == std::numeric_limits<uint64_t>::max()) [[unlikely]]
+                    return flatLength;
+                resultLength += flatLength;
+                if (lengthExceeded()) [[unlikely]] {
+                    throwTypeError(globalObject, scope, "flatten array exceeds 2**52 - 1");
+                    return std::numeric_limits<uint64_t>::max();
+                }
+            } else {
+                if (element.isObject()) {
+                    auto elementObject = asObject(element);
+                    if (elementObject->isProxy()) [[unlikely]]
+                        return std::numeric_limits<uint64_t>::max();
+                }
+                resultLength++;
+                if (lengthExceeded()) [[unlikely]] {
+                    throwTypeError(globalObject, scope, "flatten array exceeds 2**52 - 1");
+                    return std::numeric_limits<uint64_t>::max();
+                }
+            }
+        }
+        break;
+    }
+    case ArrayWithDouble: {
+        auto* sourceBuffer = sourceArray->butterfly()->contiguousDouble().data();
+        for (uint64_t i = 0; i < sourceLength; ++i) {
+            double value = sourceBuffer[i];
+            if (std::isnan(value)) [[unlikely]]
+                continue;
+            resultLength++;
+            if (lengthExceeded()) [[unlikely]] {
+                throwTypeError(globalObject, scope, "flatten array exceeds 2**52 - 1");
+                return std::numeric_limits<uint64_t>::max();
+            }
+        }
+        break;
+    }
+    default:
+        return std::numeric_limits<uint64_t>::max();
+    }
+
+    return resultLength;
+}
+
+template<typename T>
+static uint64_t fastFlatIntoBuffer(JSGlobalObject* globalObject, T* resultBuffer, uint64_t& resultIndex, JSArray* sourceArray, uint64_t sourceLength, uint64_t depth, uint64_t vectorLength)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    if (!vm.isSafeToRecurseSoft()) [[unlikely]] {
+        throwStackOverflowError(globalObject, scope);
+        return std::numeric_limits<uint64_t>::max();
+    }
+
+    IndexingType sourceType = sourceArray->indexingType();
+
+    switch (sourceType) {
+    case ArrayWithInt32: {
+        auto* sourceBuffer = sourceArray->butterfly()->contiguous().data();
+        for (uint64_t i = 0; i < sourceLength; ++i) {
+            if (resultIndex >= vectorLength) [[unlikely]]
+                return std::numeric_limits<uint64_t>::max();
+            JSValue element = sourceBuffer[i].get();
+            if (!element) [[unlikely]]
+                continue;
+            if constexpr (std::is_same_v<T, double>)
+                resultBuffer[resultIndex] = element.asNumber();
+            else
+                resultBuffer[resultIndex].setWithoutWriteBarrier(element);
+            ++resultIndex;
+        }
+        break;
+    }
+    case ArrayWithContiguous: {
+        auto* sourceBuffer = sourceArray->butterfly()->contiguous().data();
+        for (uint64_t i = 0; i < sourceLength; ++i) {
+            if (resultIndex >= vectorLength) [[unlikely]]
+                return std::numeric_limits<uint64_t>::max();
+            JSValue element = sourceBuffer[i].get();
+            if (!element) [[unlikely]]
+                continue;
+            if (depth > 0 && isJSArray(element)) {
+                JSArray* elementArray = jsCast<JSArray*>(element);
+                uint64_t newDepth = (depth == std::numeric_limits<uint64_t>::max()) ? depth : depth - 1;
+                resultIndex = fastFlatIntoBuffer(globalObject, resultBuffer, resultIndex, elementArray, elementArray->length(), newDepth, vectorLength);
+                RETURN_IF_EXCEPTION(scope, resultIndex);
+                if (resultIndex == std::numeric_limits<uint64_t>::max())
+                    return std::numeric_limits<uint64_t>::max();
+            } else {
+                if constexpr (std::is_same_v<T, double>)
+                    resultBuffer[resultIndex] = element.asNumber();
+                else
+                    resultBuffer[resultIndex].setWithoutWriteBarrier(element);
+                ++resultIndex;
+            }
+        }
+        break;
+    }
+    case ArrayWithDouble: {
+        auto* sourceBuffer = sourceArray->butterfly()->contiguousDouble().data();
+        for (uint64_t i = 0; i < sourceLength; ++i) {
+            if (resultIndex >= vectorLength) [[unlikely]]
+                return std::numeric_limits<uint64_t>::max();
+            double value = sourceBuffer[i];
+            if (std::isnan(value)) [[unlikely]]
+                continue;
+            if constexpr (std::is_same_v<T, double>)
+                resultBuffer[resultIndex] = value;
+            else
+                resultBuffer[resultIndex].setWithoutWriteBarrier(JSValue(value));
+            ++resultIndex;
+        }
+        break;
+    }
+    default: {
+        RELEASE_ASSERT_NOT_REACHED();
+        return std::numeric_limits<uint64_t>::max();
+    }
+    }
+    return resultIndex;
+}
+
+JSArray* JSArray::fastFlat(JSGlobalObject* globalObject, uint64_t depth, uint64_t length)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_CATCH_SCOPE(vm);
+
+    IndexingType sourceType = this->indexingType();
+
+    switch (sourceType) {
+    case ArrayWithInt32:
+    case ArrayWithDouble:
+    case ArrayWithContiguous: {
+        if (length > this->butterfly()->vectorLength()) [[unlikely]]
+            return nullptr;
+
+        if (holesMustForwardToPrototype()) [[unlikely]]
+            return nullptr;
+
+        uint64_t flattenedLength = calculateFlattenedLength(globalObject, this, length, depth);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        if (flattenedLength == std::numeric_limits<uint64_t>::max()) [[unlikely]]
+            return nullptr;
+
+        Structure* resultStructure = globalObject->arrayStructureForIndexingTypeDuringAllocation(sourceType);
+
+        IndexingType indexingType = resultStructure->indexingType();
+        if (hasAnyArrayStorage(indexingType)) [[unlikely]]
+            return nullptr;
+        ASSERT(!globalObject->isHavingABadTime());
+
+        auto vectorLength = Butterfly::optimalContiguousVectorLength(resultStructure, flattenedLength);
+
+        void* memory = vm.auxiliarySpace().allocate(
+            vm,
+            Butterfly::totalSize(0, 0, true, vectorLength * sizeof(EncodedJSValue)),
+            nullptr, AllocationFailureMode::ReturnNull);
+        if (!memory) [[unlikely]]
+            return nullptr;
+
+        auto* butterfly = Butterfly::fromBase(memory, 0, 0);
+        butterfly->setVectorLength(vectorLength);
+        butterfly->setPublicLength(flattenedLength);
+
+        uint64_t resultIndex = 0;
+        if (indexingType == ArrayWithDouble) {
+            auto* resultBuffer = butterfly->contiguousDouble().data();
+            resultIndex = fastFlatIntoBuffer(globalObject, resultBuffer, resultIndex, this, length, depth, vectorLength);
+        } else {
+            auto* resultBuffer = butterfly->contiguous().data();
+            resultIndex = fastFlatIntoBuffer(globalObject, resultBuffer, resultIndex, this, length, depth, vectorLength);
+        }
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        if (resultIndex == std::numeric_limits<uint64_t>::max())
+            return nullptr;
+
+        Butterfly::clearRange(indexingType, butterfly, resultIndex, vectorLength);
+        return createWithButterfly(vm, nullptr, resultStructure, butterfly);
+    }
+    default: {
+        return nullptr;
+    }
+    }
+}
+
 } // namespace JSC
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/runtime/JSArray.h
+++ b/Source/JavaScriptCore/runtime/JSArray.h
@@ -133,6 +133,8 @@ public:
 
     JSString* fastToString(JSGlobalObject*);
 
+    JSArray* fastFlat(JSGlobalObject*, uint64_t depth, uint64_t length);
+
     ALWAYS_INLINE bool definitelyNegativeOneMiss() const;
 
     enum ShiftCountMode {


### PR DESCRIPTION
#### 546d47afe6bf2406ad983b5c35e074b85d1643e1
<pre>
[JSC] Implement `Array.prototype.flat` in C++
<a href="https://bugs.webkit.org/show_bug.cgi?id=294503">https://bugs.webkit.org/show_bug.cgi?id=294503</a>

Reviewed by Yusuke Suzuki.

This patch reverts 300343@main to reland 298127@main.

The only change from the original patch is to treat depthNum
as 1 instead of 0 in patterns like `array.flat(undefined)`.

I confirmed that Google Docs works with this patch on my local
Minibrowser build.

-----
(commit message of the original patch)

This patch implements `Array.prototype.flat` in C++.

The new fast path for `Array#flat` first calculates the length
of the resulting array using O(n) `calculateFlattenedLength`,
then directly sets values into the butterfly buffer of the
resulting array using O(n) `fastFlatIntoBuffer`.

                                             TipOfTree                  Patched

array-prototype-flat-depth-1-string      474.3101+-47.2922    ^    146.0750+-46.3992       ^ definitely 3.2470x faster
array-prototype-flat-depth-1-double      352.0065+-14.2086    ^    156.4253+-54.2939       ^ definitely 2.2503x faster
array-prototype-flat-large-nested        110.8177+-40.8710    ^     46.0452+-18.8216       ^ definitely 2.4067x faster
array-prototype-flat-huge-arrays          41.7200+-14.7628    ^     20.4875+-5.9254        ^ definitely 2.0364x faster
array-prototype-flat-small-arrays         10.1293+-4.8824     ^      3.8282+-0.4837        ^ definitely 2.6460x faster
array-prototype-flat-depth-infinity      536.4026+-177.3859   ^    222.0425+-35.8608       ^ definitely 2.4158x faster
array-prototype-flat-depth-2             475.2299+-93.6660    ^    179.1500+-63.5912       ^ definitely 2.6527x faster
array-prototype-flat-depth-1-int32       453.2263+-184.5728   ^    154.1721+-56.2397       ^ definitely 2.9397x faster
array-prototype-flat-depth-3             471.8799+-105.4956   ^    151.9625+-72.1298       ^ definitely 3.1052x faster
array-prototype-flat-sparse-array        172.9858+-58.6417    ?    219.7328+-64.4558       ? might be 1.2702x slower
array-prototype-flat-depth-1-mixed       465.5951+-149.2841   ^    177.5621+-96.3248       ^ definitely 2.6222x faster

* JSTests/microbenchmarks/array-prototype-flat-depth-1-double.js: Added.
(shouldBe):
* JSTests/microbenchmarks/array-prototype-flat-depth-1-int32.js: Added.
(shouldBe):
* JSTests/microbenchmarks/array-prototype-flat-depth-1-mixed.js: Added.
(shouldBe):
* JSTests/microbenchmarks/array-prototype-flat-depth-1-string.js: Added.
(shouldBe):
* JSTests/microbenchmarks/array-prototype-flat-depth-2.js: Added.
(shouldBe):
* JSTests/microbenchmarks/array-prototype-flat-depth-3.js: Added.
(shouldBe):
* JSTests/microbenchmarks/array-prototype-flat-depth-infinity.js: Added.
(shouldBe):
* JSTests/microbenchmarks/array-prototype-flat-huge-arrays.js: Added.
(shouldBe):
* JSTests/microbenchmarks/array-prototype-flat-large-nested.js: Added.
(shouldBe):
(createLargeNestedArray):
* JSTests/microbenchmarks/array-prototype-flat-small-arrays.js: Added.
(shouldBe):
* JSTests/microbenchmarks/array-prototype-flat-sparse-array.js: Added.
(shouldBe):
* JSTests/stress/array-prototype-flat-hole.js: Added.
(shouldBe):
* JSTests/stress/array-prototype-flat-nested-proxy-array.js: Added.
(shouldBe):
(const.handler.has):
* JSTests/stress/array-prototype-flat-undefined-depth.js: Added.
(shouldBe):
(shouldBeArray):
* Source/JavaScriptCore/builtins/ArrayPrototype.js:
(flat): Deleted.
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::ArrayPrototype::finishCreation):
(JSC::flatIntoArray):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/CommonIdentifiers.h:
* Source/JavaScriptCore/runtime/JSArray.cpp:
(JSC::calculateFlattenedLength):
(JSC::fastFlatIntoBuffer):
(JSC::JSArray::fastFlat):
* Source/JavaScriptCore/runtime/JSArray.h:

Canonical link: <a href="https://commits.webkit.org/305324@main">https://commits.webkit.org/305324@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8853b3102fb8d00652a70d25a3b33e61d17cb4e7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137955 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10319 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49317 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146022 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90930 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11021 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10462 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105495 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/76989 "Exiting early after 60 failures. 21584 tests run. 60 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140900 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8216 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123671 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86348 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7830 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5581 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6305 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/129919 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117225 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41841 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148733 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/136515 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10002 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42400 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113898 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10019 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8438 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114228 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29059 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7768 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119927 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64726 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10048 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37921 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/169227 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9779 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73616 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44129 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9989 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9840 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->