### PR TITLE
Remove unsafe local variables in WebCore/page/Performance*

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -234,7 +234,6 @@ page/LocalFrameView.cpp
 page/LocalFrameViewLayoutContext.cpp
 page/PageColorSampler.cpp
 page/PageSerializer.cpp
-page/PerformanceTiming.cpp
 page/PrintContext.cpp
 page/RemoteFrame.cpp
 page/ResizeObservation.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -241,12 +241,6 @@ page/PageGroup.cpp
 page/PageGroupLoadDeferrer.cpp
 page/PageOverlayController.cpp
 page/PageSerializer.cpp
-page/PerformanceLogging.cpp
-page/PerformanceMark.cpp
-page/PerformanceNavigation.cpp
-page/PerformanceObserver.cpp
-page/PerformanceTiming.cpp
-page/PerformanceUserTiming.cpp
 page/PrintContext.cpp
 [ iOS ] page/Quirks.cpp
 page/RemoteDOMWindow.cpp

--- a/Source/WebCore/page/PerformanceLogging.cpp
+++ b/Source/WebCore/page/PerformanceLogging.cpp
@@ -99,7 +99,7 @@ void PerformanceLogging::didReachPointOfInterest(PointOfInterest poi)
     UNUSED_VARIABLE(m_page);
 #else
     // Ignore synthetic main frames used internally by SVG and web inspector.
-    if (auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame())) {
+    if (RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame())) {
         if (localMainFrame->loader().client().isEmptyFrameLoaderClient())
             return;
     }

--- a/Source/WebCore/page/PerformanceMark.cpp
+++ b/Source/WebCore/page/PerformanceMark.cpp
@@ -46,7 +46,7 @@ static double performanceNow(ScriptExecutionContext& scriptExecutionContext)
     // the ScriptExecutionContext to avoid this.
 
     if (RefPtr document = dynamicDowncast<Document>(scriptExecutionContext)) {
-        if (auto window = document->window())
+        if (RefPtr window = document->window())
             return window->performance().now();
     } else if (RefPtr workerGlobal = dynamicDowncast<WorkerGlobalScope>(scriptExecutionContext))
         return workerGlobal->performance().now();

--- a/Source/WebCore/page/PerformanceNavigation.cpp
+++ b/Source/WebCore/page/PerformanceNavigation.cpp
@@ -45,11 +45,11 @@ PerformanceNavigation::PerformanceNavigation(LocalDOMWindow* window)
 
 unsigned short PerformanceNavigation::type() const
 {
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame)
         return TYPE_NAVIGATE;
 
-    DocumentLoader* documentLoader = frame->loader().documentLoader();
+    RefPtr documentLoader = frame->loader().documentLoader();
     if (!documentLoader)
         return TYPE_NAVIGATE;
 
@@ -70,11 +70,11 @@ unsigned short PerformanceNavigation::redirectCount() const
     if (!frame)
         return 0;
 
-    RefPtr loader = frame->loader().documentLoader();
-    if (!loader)
+    RefPtr documentLoader = frame->loader().documentLoader();
+    if (!documentLoader)
         return 0;
 
-    auto* metrics = loader->response().deprecatedNetworkLoadMetricsOrNull();
+    auto* metrics = documentLoader->response().deprecatedNetworkLoadMetricsOrNull();
     if (!metrics)
         return 0;
 

--- a/Source/WebCore/page/PerformanceObserver.cpp
+++ b/Source/WebCore/page/PerformanceObserver.cpp
@@ -42,7 +42,7 @@ PerformanceObserver::PerformanceObserver(ScriptExecutionContext& scriptExecution
     , m_durationThreshold(PerformanceEventTiming::defaultDurationThreshold)
 {
     if (RefPtr document = dynamicDowncast<Document>(scriptExecutionContext)) {
-        if (auto* window = document->window())
+        if (RefPtr window = document->window())
             m_performance = window->performance();
     } else if (RefPtr workerGlobalScope = dynamicDowncast<WorkerGlobalScope>(scriptExecutionContext))
         m_performance = workerGlobalScope->performance();

--- a/Source/WebCore/page/PerformanceTiming.cpp
+++ b/Source/WebCore/page/PerformanceTiming.cpp
@@ -351,7 +351,7 @@ unsigned long long PerformanceTiming::loadEventEnd() const
 
 const DocumentLoader* PerformanceTiming::documentLoader() const
 {
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame)
         return nullptr;
 
@@ -360,11 +360,11 @@ const DocumentLoader* PerformanceTiming::documentLoader() const
 
 const DocumentEventTiming* PerformanceTiming::documentEventTiming() const
 {
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame)
         return nullptr;
 
-    auto* document = frame->document();
+    RefPtr document = frame->document();
     if (!document)
         return nullptr;
 
@@ -373,7 +373,7 @@ const DocumentEventTiming* PerformanceTiming::documentEventTiming() const
 
 const DocumentLoadTiming* PerformanceTiming::documentLoadTiming() const
 {
-    auto* loader = documentLoader();
+    RefPtr loader = documentLoader();
     if (!loader)
         return nullptr;
 
@@ -382,7 +382,7 @@ const DocumentLoadTiming* PerformanceTiming::documentLoadTiming() const
 
 const NetworkLoadMetrics* PerformanceTiming::networkLoadMetrics() const
 {
-    auto* loader = documentLoader();
+    RefPtr loader = documentLoader();
     if (!loader)
         return nullptr;
     return loader->response().deprecatedNetworkLoadMetricsOrNull();

--- a/Source/WebCore/page/PerformanceUserTiming.cpp
+++ b/Source/WebCore/page/PerformanceUserTiming.cpp
@@ -138,7 +138,7 @@ ExceptionOr<double> PerformanceUserTiming::convertMarkToTimestamp(const String& 
 
             // PerformanceTiming should always be non-null for the Document ScriptExecutionContext.
             ASSERT(m_performance->timing());
-            auto timing = m_performance->timing();
+            RefPtr timing = m_performance->timing();
             auto startTime = timing->navigationStart();
             auto endTime = ((*timing).*(*function))();
             if (!endTime)


### PR DESCRIPTION
#### e70862ec50cf3b5d74295150852f6c1c44a960c2
<pre>
Remove unsafe local variables in WebCore/page/Performance*
<a href="https://bugs.webkit.org/show_bug.cgi?id=304885">https://bugs.webkit.org/show_bug.cgi?id=304885</a>

Reviewed by Chris Dumez.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

Canonical link: <a href="https://commits.webkit.org/305099@main">https://commits.webkit.org/305099@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e2408eca27fa8ed193e82f90a61674f2ea514cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137488 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9848 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48775 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145241 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/90461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fb44269c-43b6-4ac2-a983-5db7d469adbb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139360 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10552 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9975 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105138 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/90461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cfd3cbcf-c239-4025-a718-7c1d4f933ca7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140433 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7828 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123225 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85994 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/13c80996-cdb0-4ecf-a960-7883acff9535) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7464 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5180 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5827 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116834 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41379 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148008 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9531 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41934 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113524 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9549 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8033 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113863 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7378 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119464 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64166 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21176 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9580 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37517 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9311 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73145 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9520 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9372 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->