### PR TITLE
[JSC] Use createDumpFile for JSC text markers file

### DIFF
--- a/Source/JavaScriptCore/assembler/PerfLog.h
+++ b/Source/JavaScriptCore/assembler/PerfLog.h
@@ -56,7 +56,6 @@ private:
     void flush(const AbstractLocker&) WTF_REQUIRES_LOCK(m_lock);
 
     WTF::FileSystemImpl::FileHandle m_file { };
-    void* m_marker { nullptr };
     uint64_t m_codeIndex { 0 };
     Lock m_lock;
 };

--- a/Source/JavaScriptCore/runtime/ProfilerSupport.h
+++ b/Source/JavaScriptCore/runtime/ProfilerSupport.h
@@ -27,7 +27,7 @@
 
 #include <JavaScriptCore/JSExportMacros.h>
 #include <stdio.h>
-#include <wtf/FilePrintStream.h>
+#include <wtf/FileHandle.h>
 #include <wtf/HashMap.h>
 #include <wtf/JSONValues.h>
 #include <wtf/Lock.h>
@@ -70,15 +70,16 @@ public:
 
     static void dumpIonGraphFunction(const String& functionName, Ref<JSON::Object>&&);
 
+    static uint32_t getCurrentThreadID();
+
 private:
     ProfilerSupport();
 
     void write(const AbstractLocker&, uint64_t start, uint64_t end, const CString& message) WTF_REQUIRES_LOCK(m_lock);
 
     const Ref<WorkQueue> m_queue;
-    std::unique_ptr<FilePrintStream> m_fileStream;
     std::array<HashMap<const void*, uint64_t>, numberOfCategories> m_markers;
-    int m_fd { -1 };
+    WTF::FileSystemImpl::FileHandle m_file { };
     Lock m_tableLock;
     Lock m_lock;
 };


### PR DESCRIPTION
#### 31942b876cd64f3c2a4ebc646f71b7ff0aab5a34
<pre>
[JSC] Use createDumpFile for JSC text markers file
<a href="https://bugs.webkit.org/show_bug.cgi?id=304886">https://bugs.webkit.org/show_bug.cgi?id=304886</a>
<a href="https://rdar.apple.com/167476288">rdar://167476288</a>

Reviewed by Yijia Huang.

Generate markers file in a similar way to JITDump.

* Source/JavaScriptCore/assembler/PerfLog.cpp:
(JSC::PerfLog::PerfLog):
(JSC::PerfLog::log):
(JSC::getCurrentThreadID): Deleted.
* Source/JavaScriptCore/assembler/PerfLog.h:
* Source/JavaScriptCore/runtime/ProfilerSupport.cpp:
(JSC::ProfilerSupport::ProfilerSupport):
(JSC::ProfilerSupport::getCurrentThreadID):
(JSC::ProfilerSupport::write):
* Source/JavaScriptCore/runtime/ProfilerSupport.h:

Canonical link: <a href="https://commits.webkit.org/305092@main">https://commits.webkit.org/305092@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18e9af25ed34edba1abd21e8cce4a34e8e33b49f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137395 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9755 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48682 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145146 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90368 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10459 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9882 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105061 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c99f9bba-492d-499e-b341-265697accd14) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140340 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7738 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123139 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85916 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4c57b2c2-ac0c-44e6-ab69-72f3fac5d30c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7374 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5094 "Found 1 new API test failure: TestWebKitAPI.WebKit.PreferenceChanges (failure)") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5733 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/129356 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116741 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41293 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147903 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/135907 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9438 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41850 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113437 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9456 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7948 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113778 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7292 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119380 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64040 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21171 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9487 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37433 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/168665 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9217 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73052 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44019 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9427 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9279 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->