### PR TITLE
Reduce unsafeness in WebCore/testing

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -670,7 +670,6 @@ svg/animation/SVGSMILElement.cpp
 svg/graphics/SVGImage.cpp
 svg/properties/SVGAnimatedString.cpp
 testing/Internals.cpp
-[ Mac ] testing/Internals.mm
 workers/WorkerGlobalScope.cpp
 workers/WorkerMessagingProxy.cpp
 workers/WorkerNotificationClient.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -492,8 +492,6 @@ svg/SVGUseElement.cpp
 svg/graphics/SVGImage.cpp
 svg/properties/SVGAnimatedString.cpp
 testing/Internals.cpp
-[ Mac ] testing/Internals.mm
-testing/ServiceWorkerInternals.cpp
 testing/js/WebCoreTestSupport.cpp
 workers/WorkerGlobalScope.cpp
 workers/WorkerOrWorkletThread.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -881,11 +881,8 @@ svg/properties/SVGValuePropertyListAnimator.h
 svg/properties/SVGValuePropertyListAnimatorImpl.h
 testing/InternalSettings.cpp
 testing/Internals.cpp
-[ Mac ] testing/Internals.mm
 testing/LegacyMockCDM.cpp
 [ Mac ] testing/MockMediaSessionCoordinator.cpp
-testing/MockPageOverlay.cpp
-testing/MockPageOverlayClient.cpp
 testing/ServiceWorkerInternals.cpp
 testing/js/WebCoreTestSupport.cpp
 workers/shared/SharedWorker.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -428,10 +428,5 @@ svg/graphics/SVGImage.cpp
 svg/graphics/SVGImageCache.cpp
 svg/properties/SVGAnimatedString.cpp
 svg/properties/SVGPropertyOwnerRegistry.h
-testing/InternalSettings.cpp
 testing/Internals.cpp
-[ Mac ] testing/Internals.mm
 testing/LegacyMockCDM.cpp
-testing/MockCDMFactory.cpp
-testing/MockPageOverlayClient.cpp
-testing/ServiceWorkerInternals.cpp

--- a/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -1,5 +1,9 @@
+[ iOS ] Modules/async-clipboard/ios/ClipboardImageReaderIOS.mm
+[ iOS ] Modules/system-preview/ARKitBadgeSystemImage.mm
 [ Mac ] accessibility/cocoa/AXCoreObjectCocoa.mm
 accessibility/cocoa/AccessibilityObjectCocoa.mm
+[ iOS ] accessibility/ios/AccessibilityObjectIOS.mm
+[ iOS ] accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
 [ Mac ] accessibility/mac/AXObjectCacheMac.mm
 [ Mac ] accessibility/mac/AccessibilityObjectMac.mm
 accessibility/mac/WebAccessibilityObjectWrapperBase.mm
@@ -15,21 +19,25 @@ editing/cocoa/DataDetection.mm
 editing/cocoa/EditingHTMLConverter.mm
 editing/cocoa/NodeHTMLConverter.mm
 loader/archive/cf/LegacyWebArchive.cpp
+[ iOS ] page/ios/EventHandlerIOS.mm
 page/mac/ChromeMac.mm
 [ Mac ] page/mac/EventHandlerMac.mm
 [ Mac ] page/scrolling/mac/ScrollingStateScrollingNodeMac.mm
-[ Mac ]page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm
-[ Mac ]page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
+[ Mac ] page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm
+[ Mac ] page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
 platform/audio/cocoa/AudioEncoderCocoa.cpp
 platform/audio/cocoa/AudioFileReaderCocoa.cpp
 platform/audio/cocoa/PlatformRawAudioDataCocoa.cpp
+[ iOS ] platform/audio/ios/AudioSessionIOS.mm
 platform/cf/KeyedDecoderCF.cpp
+[ iOS ] platform/cocoa/ContentFilterUnblockHandlerCocoa.mm
 [ Mac ] platform/cocoa/DragImageCocoa.mm
 platform/cocoa/PlatformPasteboardCocoa.mm
 platform/cocoa/RemoteCommandListenerCocoa.mm
 platform/cocoa/SearchPopupMenuCocoa.mm
 platform/cocoa/SerializedPlatformDataCueValue.mm
 platform/cocoa/SystemVersion.mm
+[ iOS ] platform/cocoa/WebAVPlayerLayerView.mm
 platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm
 platform/graphics/avfoundation/FormatDescriptionUtilities.cpp
 platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp
@@ -46,6 +54,7 @@ platform/graphics/cg/GradientRendererCG.cpp
 platform/graphics/cg/GraphicsContextCG.cpp
 platform/graphics/cg/GraphicsContextGLCG.cpp
 platform/graphics/cg/ImageDecoderCG.cpp
+[ iOS ] platform/graphics/cg/PDFDocumentImage.cpp
 platform/graphics/cg/PathCG.cpp
 platform/graphics/cocoa/AV1UtilitiesCocoa.mm
 platform/graphics/cocoa/CMUtilities.mm
@@ -62,27 +71,6 @@ platform/graphics/cocoa/VideoMediaSampleRenderer.mm
 [ Mac ] platform/graphics/mac/controls/SwitchMacUtilities.mm
 [ Mac ] platform/graphics/mac/controls/SwitchThumbMac.mm
 [ Mac ] platform/graphics/mac/controls/SwitchTrackMac.mm
-platform/ios/PlaybackSessionInterfaceAVKitLegacy.mm
-platform/ios/WebAVPlayerController.mm
-platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp
-platform/mediastream/mac/AVVideoCaptureSource.mm
-platform/mediastream/mac/CoreAudioCaptureUnit.mm
-platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.mm
-platform/network/mac/ResourceHandleMac.mm
-platform/network/mac/WebCoreResourceHandleAsOperationQueueDelegate.mm
-platform/text/cocoa/LocaleCocoa.mm
-rendering/AttachmentLayout.mm
-testing/Internals.mm
-testing/cocoa/WebViewVisualIdentificationOverlay.mm
-[ iOS ] Modules/async-clipboard/ios/ClipboardImageReaderIOS.mm
-[ iOS ] Modules/system-preview/ARKitBadgeSystemImage.mm
-[ iOS ] accessibility/ios/AccessibilityObjectIOS.mm
-[ iOS ] accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
-[ iOS ] page/ios/EventHandlerIOS.mm
-[ iOS ] platform/audio/ios/AudioSessionIOS.mm
-[ iOS ] platform/cocoa/ContentFilterUnblockHandlerCocoa.mm
-[ iOS ] platform/cocoa/WebAVPlayerLayerView.mm
-[ iOS ] platform/graphics/cg/PDFDocumentImage.cpp
 [ iOS ] platform/ios/DragImageIOS.mm
 [ iOS ] platform/ios/LegacyTileCache.mm
 [ iOS ] platform/ios/LegacyTileGrid.mm
@@ -91,12 +79,14 @@ testing/cocoa/WebViewVisualIdentificationOverlay.mm
 [ iOS ] platform/ios/PasteboardIOS.mm
 [ iOS ] platform/ios/PlatformPasteboardIOS.mm
 [ iOS ] platform/ios/PlatformScreenIOS.mm
+platform/ios/PlaybackSessionInterfaceAVKitLegacy.mm
 [ iOS ] platform/ios/QuickLook.mm
 [ iOS ] platform/ios/ScrollViewIOS.mm
 [ iOS ] platform/ios/UIViewControllerUtilities.mm
 [ iOS ] platform/ios/ValidationBubbleIOS.mm
 [ iOS ] platform/ios/VideoPresentationInterfaceAVKitLegacy.mm
 [ iOS ] platform/ios/VideoPresentationInterfaceIOS.mm
+platform/ios/WebAVPlayerController.mm
 [ iOS ] platform/ios/WebItemProviderPasteboard.mm
 [ iOS ] platform/ios/WidgetIOS.mm
 [ iOS ] platform/ios/wak/WAKScrollView.mm
@@ -105,7 +95,16 @@ testing/cocoa/WebViewVisualIdentificationOverlay.mm
 [ iOS ] platform/ios/wak/WAKWindow.mm
 [ iOS ] platform/ios/wak/WKView.mm
 [ iOS ] platform/ios/wak/WebCoreThread.mm
+platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp
+platform/mediastream/mac/AVVideoCaptureSource.mm
+platform/mediastream/mac/CoreAudioCaptureUnit.mm
+platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.mm
 [ iOS ] platform/network/ios/WebCoreURLResponseIOS.mm
 [ iOS ] platform/network/mac/ResourceErrorMac.mm
+platform/network/mac/ResourceHandleMac.mm
+platform/network/mac/WebCoreResourceHandleAsOperationQueueDelegate.mm
+platform/text/cocoa/LocaleCocoa.mm
 [ iOS ] platform/text/mac/TextBoundaries.mm
+rendering/AttachmentLayout.mm
 [ iOS ] rendering/ios/RenderThemeIOS.mm
+testing/cocoa/WebViewVisualIdentificationOverlay.mm

--- a/Source/WebCore/testing/InternalSettings.cpp
+++ b/Source/WebCore/testing/InternalSettings.cpp
@@ -447,16 +447,16 @@ ExceptionOr<void> InternalSettings::setShouldDisplayTrackKind(TrackKind kind, bo
     if (!m_page)
         return Exception { ExceptionCode::InvalidAccessError };
 #if ENABLE(VIDEO)
-    auto& captionPreferences = m_page->checkedGroup()->ensureCaptionPreferences();
+    Ref captionPreferences = m_page->checkedGroup()->ensureCaptionPreferences();
     switch (kind) {
     case TrackKind::Subtitles:
-        captionPreferences.setUserPrefersSubtitles(enabled);
+        captionPreferences->setUserPrefersSubtitles(enabled);
         break;
     case TrackKind::Captions:
-        captionPreferences.setUserPrefersCaptions(enabled);
+        captionPreferences->setUserPrefersCaptions(enabled);
         break;
     case TrackKind::TextDescriptions:
-        captionPreferences.setUserPrefersTextDescriptions(enabled);
+        captionPreferences->setUserPrefersTextDescriptions(enabled);
         break;
     }
 #else
@@ -471,14 +471,14 @@ ExceptionOr<bool> InternalSettings::shouldDisplayTrackKind(TrackKind kind)
     if (!m_page)
         return Exception { ExceptionCode::InvalidAccessError };
 #if ENABLE(VIDEO)
-    auto& captionPreferences = m_page->checkedGroup()->ensureCaptionPreferences();
+    Ref captionPreferences = m_page->checkedGroup()->ensureCaptionPreferences();
     switch (kind) {
     case TrackKind::Subtitles:
-        return captionPreferences.userPrefersSubtitles();
+        return captionPreferences->userPrefersSubtitles();
     case TrackKind::Captions:
-        return captionPreferences.userPrefersCaptions();
+        return captionPreferences->userPrefersCaptions();
     case TrackKind::TextDescriptions:
-        return captionPreferences.userPrefersTextDescriptions();
+        return captionPreferences->userPrefersTextDescriptions();
     }
 #else
     UNUSED_PARAM(kind);

--- a/Source/WebCore/testing/Internals.mm
+++ b/Source/WebCore/testing/Internals.mm
@@ -156,7 +156,7 @@ bool Internals::userPrefersReducedMotion() const
 
 ExceptionOr<RefPtr<Range>> Internals::rangeForDictionaryLookupAtLocation(int x, int y)
 {
-    auto* document = contextDocument();
+    RefPtr document = contextDocument();
     if (!document || !document->frame())
         return Exception { ExceptionCode::InvalidAccessError };
 
@@ -164,7 +164,7 @@ ExceptionOr<RefPtr<Range>> Internals::rangeForDictionaryLookupAtLocation(int x, 
 
     constexpr OptionSet<HitTestRequest::Type> hitType { HitTestRequest::Type::ReadOnly, HitTestRequest::Type::Active, HitTestRequest::Type::DisallowUserAgentShadowContent, HitTestRequest::Type::AllowChildFrameContent };
     
-    auto* localFrame = dynamicDowncast<LocalFrame>(document->frame()->mainFrame());
+    RefPtr localFrame = dynamicDowncast<LocalFrame>(document->frame()->mainFrame());
     if (!localFrame)
         return nullptr; 
 
@@ -191,15 +191,15 @@ void Internals::setUsesOverlayScrollbars(bool enabled)
     NSScrollerStyle style = enabled ? NSScrollerStyleOverlay : NSScrollerStyleLegacy;
     [NSScrollerImpPair _updateAllScrollerImpPairsForNewRecommendedScrollerStyle:style];
 
-    auto* document = contextDocument();
+    RefPtr document = contextDocument();
     if (!document || !document->frame())
         return;
 
-    auto* localFrame = dynamicDowncast<LocalFrame>(document->frame()->mainFrame());
+    RefPtr localFrame = dynamicDowncast<LocalFrame>(document->frame()->mainFrame());
     if (!localFrame)
         return;
 
-    localFrame->view()->scrollbarStyleDidChange();
+    localFrame->protectedView()->scrollbarStyleDidChange();
 }
 
 #endif
@@ -210,7 +210,7 @@ double Internals::privatePlayerVolume(const HTMLMediaElement& element)
     RefPtr corePlayer = element.player();
     if (!corePlayer)
         return 0;
-    auto player = corePlayer->objCAVFoundationAVPlayer();
+    RetainPtr player = corePlayer->objCAVFoundationAVPlayer();
     if (!player)
         return 0;
     return [player volume];
@@ -221,7 +221,7 @@ bool Internals::privatePlayerMuted(const HTMLMediaElement& element)
     RefPtr corePlayer = element.player();
     if (!corePlayer)
         return false;
-    auto player = corePlayer->objCAVFoundationAVPlayer();
+    RetainPtr player = corePlayer->objCAVFoundationAVPlayer();
     if (!player)
         return false;
     return [player isMuted];

--- a/Source/WebCore/testing/MockCDMFactory.cpp
+++ b/Source/WebCore/testing/MockCDMFactory.cpp
@@ -263,7 +263,7 @@ void MockCDMInstance::initializeWithConfiguration(const MediaKeySystemConfigurat
         if (!cdm || !cdm->supportsConfiguration(configuration))
             return CDMInstanceSuccessValue::Failed;
 
-        MockCDMFactory* factory = cdm->factory();
+        RefPtr factory = cdm->factory();
         if (!factory)
             return CDMInstanceSuccessValue::Failed;
 
@@ -319,7 +319,7 @@ MockCDMInstanceSession::MockCDMInstanceSession(WeakPtr<MockCDMInstance>&& instan
 
 void MockCDMInstanceSession::requestLicense(LicenseType licenseType, KeyGroupingStrategy, const String& initDataType, Ref<SharedBuffer>&& initData, LicenseCallback&& callback)
 {
-    MockCDMFactory* factory = m_instance ? m_instance->factory() : nullptr;
+    RefPtr factory = m_instance ? m_instance->factory() : nullptr;
     if (!factory) {
         callback(SharedBuffer::create(), emptyString(), false, SuccessValue::Failed);
         return;
@@ -345,7 +345,7 @@ void MockCDMInstanceSession::requestLicense(LicenseType licenseType, KeyGrouping
 
 void MockCDMInstanceSession::updateLicense(const String& sessionID, LicenseType, Ref<SharedBuffer>&& response, LicenseUpdateCallback&& callback)
 {
-    MockCDMFactory* factory = m_instance ? m_instance->factory() : nullptr;
+    RefPtr factory = m_instance ? m_instance->factory() : nullptr;
     if (!factory) {
         callback(false, std::nullopt, std::nullopt, std::nullopt, SuccessValue::Failed);
         return;
@@ -376,7 +376,7 @@ void MockCDMInstanceSession::updateLicense(const String& sessionID, LicenseType,
 
 void MockCDMInstanceSession::loadSession(LicenseType, const String&, const String&, LoadSessionCallback&& callback)
 {
-    MockCDMFactory* factory = m_instance ? m_instance->factory() : nullptr;
+    RefPtr factory = m_instance ? m_instance->factory() : nullptr;
     if (!factory) {
         callback(std::nullopt, std::nullopt, std::nullopt, SuccessValue::Failed, SessionLoadFailure::Other);
         return;
@@ -392,7 +392,7 @@ void MockCDMInstanceSession::loadSession(LicenseType, const String&, const Strin
 
 void MockCDMInstanceSession::closeSession(const String& sessionID, CloseSessionCallback&& callback)
 {
-    MockCDMFactory* factory = m_instance ? m_instance->factory() : nullptr;
+    RefPtr factory = m_instance ? m_instance->factory() : nullptr;
     if (!factory) {
         callback();
         return;
@@ -404,7 +404,7 @@ void MockCDMInstanceSession::closeSession(const String& sessionID, CloseSessionC
 
 void MockCDMInstanceSession::removeSessionData(const String& id, LicenseType, RemoveSessionDataCallback&& callback)
 {
-    MockCDMFactory* factory = m_instance ? m_instance->factory() : nullptr;
+    RefPtr factory = m_instance ? m_instance->factory() : nullptr;
     if (!factory) {
         callback({ }, nullptr, SuccessValue::Failed);
         return;

--- a/Source/WebCore/testing/MockCDMFactory.h
+++ b/Source/WebCore/testing/MockCDMFactory.h
@@ -160,7 +160,7 @@ private:
 
 class MockCDMInstanceSession : public CDMInstanceSession {
 public:
-    MockCDMInstanceSession(WeakPtr<MockCDMInstance>&&);
+    explicit MockCDMInstanceSession(WeakPtr<MockCDMInstance>&&);
 
 private:
     void requestLicense(LicenseType, KeyGroupingStrategy, const String& initDataType, Ref<SharedBuffer>&& initData, LicenseCallback&&) final;

--- a/Source/WebCore/testing/MockPageOverlay.h
+++ b/Source/WebCore/testing/MockPageOverlay.h
@@ -40,7 +40,7 @@ public:
 private:
     explicit MockPageOverlay(PageOverlay*);
 
-    RefPtr<PageOverlay> m_overlay;
+    const RefPtr<PageOverlay> m_overlay;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/testing/MockPageOverlayClient.cpp
+++ b/Source/WebCore/testing/MockPageOverlayClient.cpp
@@ -62,7 +62,7 @@ Ref<MockPageOverlay> MockPageOverlayClient::installOverlay(Page& page, PageOverl
 void MockPageOverlayClient::uninstallAllOverlays()
 {
     while (!m_overlays.isEmpty()) {
-        RefPtr<MockPageOverlay> mockOverlay = m_overlays.takeAny();
+        RefPtr mockOverlay = m_overlays.takeAny();
         PageOverlayController* overlayController = mockOverlay->overlay()->controller();
         ASSERT(overlayController);
         overlayController->uninstallPageOverlay(*mockOverlay->overlay(), PageOverlay::FadeMode::DoNotFade);
@@ -71,8 +71,8 @@ void MockPageOverlayClient::uninstallAllOverlays()
 
 String MockPageOverlayClient::layerTreeAsText(Page& page, OptionSet<LayerTreeAsTextOptions> options)
 {
-    GraphicsLayer* viewOverlayRoot = page.pageOverlayController().viewOverlayRootLayer();
-    GraphicsLayer* documentOverlayRoot = page.pageOverlayController().documentOverlayRootLayer();
+    RefPtr viewOverlayRoot = page.pageOverlayController().viewOverlayRootLayer();
+    RefPtr documentOverlayRoot = page.pageOverlayController().documentOverlayRootLayer();
     
     return makeString("View-relative:\n"_s, (viewOverlayRoot ? viewOverlayRoot->layerTreeAsText(options | LayerTreeAsTextOptions::IncludePageOverlayLayers) : "(no view-relative overlay root)"_s)
         , "\n\nDocument-relative:\n"_s, (documentOverlayRoot ? documentOverlayRoot->layerTreeAsText(options | LayerTreeAsTextOptions::IncludePageOverlayLayers) : "(no document-relative overlay root)"_s));


### PR DESCRIPTION
#### ab41f45a06baa6d5a93c0b45e13e51d38bcb57f1
<pre>
Reduce unsafeness in WebCore/testing
<a href="https://bugs.webkit.org/show_bug.cgi?id=304888">https://bugs.webkit.org/show_bug.cgi?id=304888</a>

Reviewed by Chris Dumez.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

Canonical link: <a href="https://commits.webkit.org/305100@main">https://commits.webkit.org/305100@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/057e13ef2ac37fa5fc993bde2b56d1b5148b0623

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137489 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9849 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48776 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145242 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90462 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6c91d9c6-9275-441f-bb22-c04a3d311503) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139361 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10553 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9976 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105139 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/92a9fca7-d5b0-4180-b774-fe4e6a96c43e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140434 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7825 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123226 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85995 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5d4a3bc7-8a7c-470d-8314-bc9e911735a6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7461 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5181 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5828 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116831 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41380 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148006 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9532 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41935 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113518 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9550 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8034 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113861 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7384 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119465 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64167 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21177 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9581 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37518 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9312 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73146 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9521 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9373 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->