### PR TITLE
[CI Filters] Support all the FEComponentTransfer function types in Core Image

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -266,7 +266,6 @@ platform/graphics/ca/GraphicsLayerCA.cpp
 platform/graphics/ca/TileGrid.cpp
 [ iOS ] platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
 platform/graphics/coreimage/FEColorMatrixCoreImageApplier.mm
-platform/graphics/coreimage/FEComponentTransferCoreImageApplier.mm
 platform/graphics/coreimage/SourceGraphicCoreImageApplier.mm
 platform/graphics/filters/FilterOperations.cpp
 platform/graphics/filters/software/FEBlendSoftwareApplier.cpp

--- a/Source/WebCore/platform/graphics/coreimage/FEComponentTransferCoreImageApplier.h
+++ b/Source/WebCore/platform/graphics/coreimage/FEComponentTransferCoreImageApplier.h
@@ -41,14 +41,10 @@ class FEComponentTransferCoreImageApplier final : public FilterEffectConcreteApp
 public:
     FEComponentTransferCoreImageApplier(const FEComponentTransfer&);
 
-    static bool supportsCoreImageRendering(const FEComponentTransfer&);
-
 private:
     bool apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const final;
-    bool applyLinear(RetainPtr<CIImage>, FilterImage&) const;
-#if HAVE(CI_KERNEL)
-    bool applyGamma(RetainPtr<CIImage>, FilterImage&) const;
-#endif
+    RetainPtr<CIImage> applyLinear(RetainPtr<CIImage>&&) const;
+    RetainPtr<CIImage> applyOther(RetainPtr<CIImage>&&) const;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/filters/FEComponentTransfer.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEComponentTransfer.cpp
@@ -73,8 +73,7 @@ OptionSet<FilterRenderingMode> FEComponentTransfer::supportedFilterRenderingMode
     modes.add(FilterRenderingMode::Accelerated);
 #endif
 #if USE(CORE_IMAGE)
-    if (FEComponentTransferCoreImageApplier::supportsCoreImageRendering(*this))
-        modes.add(FilterRenderingMode::Accelerated);
+    modes.add(FilterRenderingMode::Accelerated);
 #endif
     return modes & preferredFilterRenderingModes;
 }


### PR DESCRIPTION
#### 1a6089e7b9ef239eecf3e5fb58c333816e82cd6f
<pre>
[CI Filters] Support all the FEComponentTransfer function types in Core Image
<a href="https://bugs.webkit.org/show_bug.cgi?id=304889">https://bugs.webkit.org/show_bug.cgi?id=304889</a>
<a href="https://rdar.apple.com/167484103">rdar://167484103</a>

Reviewed by Mike Wyrzykowski.

FEComponentTransferCoreImageApplier previously only supported either all the channels using
`linear`, or `gamma`. But each channel can use its own function, so we need a custom kernel
that supports this. We continue to use `CIColorPolynomial` when all channels are linear.

* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/platform/graphics/coreimage/FEComponentTransferCoreImageApplier.h:
* Source/WebCore/platform/graphics/coreimage/FEComponentTransferCoreImageApplier.mm:
(WebCore::FEComponentTransferCoreImageApplier::FEComponentTransferCoreImageApplier):
(WebCore::isType):
(WebCore::compontentTransferKernel):
(WebCore::gammaKernel): Deleted.
* Source/WebCore/platform/graphics/filters/FEComponentTransfer.cpp:
(WebCore::FEComponentTransfer::supportedFilterRenderingModes const):
* WebKitLibraries/SDKs/watchos26.0-additions.sdk/System/Library/Frameworks/CoreImage.framework/CoreImage.tbd:
* WebKitLibraries/SDKs/watchsimulator26.0-additions.sdk/System/Library/Frameworks/CoreImage.framework/CoreImage.tbd:

Canonical link: <a href="https://commits.webkit.org/305112@main">https://commits.webkit.org/305112@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/83dddedef6a93ed9692ae8583cbb3ee61d5051df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137445 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9805 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48732 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145196 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90418 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/317ca756-167e-4f91-8a28-303fc4ec42cd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139317 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10509 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9932 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105100 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e2c9f7a2-1da1-4b73-9fa6-e1878984cc61) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140390 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7785 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123185 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85955 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7421 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5144 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5783 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116790 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41339 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147954 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9488 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41894 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113478 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9506 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7997 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113820 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28911 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7341 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119424 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64109 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9537 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37477 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9267 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73102 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9477 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9329 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->