### PR TITLE
[CI Filters] Implement all the FEColorMatrix options in Core Image

### DIFF
--- a/Source/WebCore/platform/graphics/ColorMatrix.h
+++ b/Source/WebCore/platform/graphics/ColorMatrix.h
@@ -142,6 +142,17 @@ constexpr ColorMatrix<5, 4> opacityColorMatrix(float amount)
     };
 }
 
+constexpr ColorMatrix<5, 4> luminanceToAlphaColorMatrix()
+{
+    // https://drafts.csswg.org/filter-effects/#attr-valuedef-type-luminancetoalpha
+    return ColorMatrix<5, 4> {
+        0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
+        0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
+        0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
+        0.2126f, 0.7152f, 0.0722f, 0.0f, 0.0f
+    };
+}
+
 constexpr ColorMatrix<3, 3> sepiaColorMatrix(float amount)
 {
     // Values from https://www.w3.org/TR/filter-effects-1/#sepiaEquivalent

--- a/Source/WebCore/platform/graphics/filters/software/FEColorMatrixSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEColorMatrixSoftwareApplier.cpp
@@ -161,6 +161,7 @@ void FEColorMatrixSoftwareApplier::applyPlatformAccelerated(PixelBuffer& pixelBu
         break;
     }
     case ColorMatrixType::FECOLORMATRIX_TYPE_LUMINANCETOALPHA: {
+        // FIXME: Use luminanceToAlphaColorMatrix(), but the coefficients are slightly different. Have these been selected for integer math?
         const int16_t matrix[4 * 4] = {
             0,
             0,


### PR DESCRIPTION
#### 5fb0c86557b33c96da7978716151e0aca920d166
<pre>
[CI Filters] Implement all the FEColorMatrix options in Core Image
<a href="https://bugs.webkit.org/show_bug.cgi?id=304890">https://bugs.webkit.org/show_bug.cgi?id=304890</a>
<a href="https://rdar.apple.com/167484500">rdar://167484500</a>

Reviewed by Mike Wyrzykowski.

Add support for the `luminanceToAlpha` type of FEColorMatrix, by defining a function
in ColorMatrix.h to return the relevant matrix. The coefficients are from the spec,
but slightly different from what we use in `FEColorMatrixSoftwareApplier` for
unknown reasons. Also clamp the output from the color matrix filter.

* Source/WebCore/platform/graphics/ColorMatrix.h:
(WebCore::luminanceToAlphaColorMatrix):
* Source/WebCore/platform/graphics/coreimage/FEColorMatrixCoreImageApplier.mm:
(WebCore::FEColorMatrixCoreImageApplier::FEColorMatrixCoreImageApplier):
(WebCore::FEColorMatrixCoreImageApplier::supportsCoreImageRendering):
(WebCore::FEColorMatrixCoreImageApplier::apply const):
* Source/WebCore/platform/graphics/filters/software/FEColorMatrixSoftwareApplier.cpp:
(WebCore::FEColorMatrixSoftwareApplier::applyPlatformAccelerated const):

Canonical link: <a href="https://commits.webkit.org/305085@main">https://commits.webkit.org/305085@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e35f180cb154b9257f4338193182d0ba811b048

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137407 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9767 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48694 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145158 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90380 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e0dc3b46-6da2-477e-9adb-9f86d87b5d5f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139279 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10471 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9894 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105072 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ef412962-bd14-4261-98cc-7fed89b1ca70) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140352 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7750 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123151 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85927 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d518c7b8-e696-41f1-8354-fef418833505) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7386 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5107 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5745 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116754 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41303 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147915 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9450 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41860 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113449 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9468 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7960 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113790 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28894 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7306 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119390 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64060 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9499 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37443 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9229 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73064 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9439 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9291 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->