### PR TITLE
[CI Filters] Add a trace point for CI filter rendering

### DIFF
--- a/Source/WTF/wtf/SystemTracing.h
+++ b/Source/WTF/wtf/SystemTracing.h
@@ -125,6 +125,8 @@ enum TracePointCode {
     ThreadTimersEnd,
     TimerFiredStart,
     TimerFiredEnd,
+    CoreImageRenderStart,
+    CoreImageRenderEnd,
 
     WebKitRange = 10000,
     WebHTMLViewPaintStart,

--- a/Source/WTF/wtf/glib/SysprofAnnotator.h
+++ b/Source/WTF/wtf/glib/SysprofAnnotator.h
@@ -167,6 +167,7 @@ public:
         case WakeUpAndApplyDisplayListStart:
         case ThreadTimersStart:
         case TimerFiredStart:
+        case CoreImageRenderStart:
         case TextExtractionStart:
             beginMark(nullptr, tracePointCodeName(code).spanIncludingNullTerminator(), "%s", "");
             break;
@@ -232,6 +233,7 @@ public:
         case WakeUpAndApplyDisplayListEnd:
         case ThreadTimersEnd:
         case TimerFiredEnd:
+        case CoreImageRenderEnd:
         case TextExtractionEnd:
             endMark(nullptr, tracePointCodeName(code).spanIncludingNullTerminator(), "%s", "");
             break;
@@ -420,6 +422,9 @@ private:
         case TimerFiredStart:
         case TimerFiredEnd:
             return "WebCoreTimerExecution"_s;
+        case CoreImageRenderStart:
+        case CoreImageRenderEnd:
+            return "CoreImageRender"_s;
 
         case WebHTMLViewPaintStart:
         case WebHTMLViewPaintEnd:

--- a/Source/WebCore/platform/graphics/coreimage/FilterImageCoreImage.mm
+++ b/Source/WebCore/platform/graphics/coreimage/FilterImageCoreImage.mm
@@ -34,6 +34,7 @@
 #import <CoreImage/CoreImage.h>
 #import <wtf/BlockObjCExceptions.h>
 #import <wtf/NeverDestroyed.h>
+#import <wtf/SystemTracing.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 
 #define DEBUG_WASH_COLOR 0
@@ -66,6 +67,7 @@ size_t FilterImage::memoryCostOfCIImage() const
 
 ImageBuffer* FilterImage::filterResultImageBuffer(FloatRect absoluteFilterRegion)
 {
+    TraceScope traceScope(CoreImageRenderStart, CoreImageRenderEnd);
     BEGIN_BLOCK_OBJC_EXCEPTIONS
 
     if (!m_ciImage)

--- a/Source/WebKit/Resources/Signposts/SystemTracePoints.plist
+++ b/Source/WebKit/Resources/Signposts/SystemTracePoints.plist
@@ -586,6 +586,18 @@
              </dict>
              <dict>
                  <key>Name</key>
+                 <string>Filters Core Image render</string>
+                 <key>Type</key>
+                 <string>Interval</string>
+                 <key>Component</key>
+                 <string>47</string>
+                 <key>CodeBegin</key>
+                 <string>5062</string>
+                 <key>CodeEnd</key>
+                 <string>5063</string>
+             </dict>
+             <dict>
+                 <key>Name</key>
                  <string>Paint WebHTMLView</string>
                  <key>Type</key>
                  <string>Interval</string>


### PR DESCRIPTION
#### 84eae2292e16fad58b51ccc8f7830a42a69b5a8b
<pre>
[CI Filters] Add a trace point for CI filter rendering
<a href="https://bugs.webkit.org/show_bug.cgi?id=304891">https://bugs.webkit.org/show_bug.cgi?id=304891</a>
<a href="https://rdar.apple.com/167486618">rdar://167486618</a>

Reviewed by Wenson Hsieh.

Add a trace point for Filter Core Image rendering, so it shows up in perf tools.

* Source/WTF/wtf/SystemTracing.h:
* Source/WTF/wtf/glib/SysprofAnnotator.h:
* Source/WebCore/platform/graphics/coreimage/FilterImageCoreImage.mm:
(WebCore::FilterImage::filterResultImageBuffer):
* Source/WebKit/Resources/Signposts/SystemTracePoints.plist:

Canonical link: <a href="https://commits.webkit.org/305076@main">https://commits.webkit.org/305076@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3688b33af8b03572d7f0b0f08010d14cd066827e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137420 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9780 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48707 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145171 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90393 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f435099e-2f9d-49ba-88a0-70e83115eda4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139292 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10484 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9907 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105084 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/23900080-2d75-4113-98ba-8f8d66122dcb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140365 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7762 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123163 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85937 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1f27ec7a-d733-4874-8663-dab361585ddd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7398 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5119 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5758 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/129381 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116767 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41315 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147928 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/135934 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9463 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41872 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113459 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9481 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7972 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113800 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28889 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7318 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119402 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64076 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9512 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37455 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/168690 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9242 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73077 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44023 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9452 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9304 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->