### PR TITLE
Fix SVG clipPath bounding box transform order with objectBoundingBox units

### DIFF
--- a/LayoutTests/svg/clip-path/hittest-transformed-clip-objectboundingbox-expected.txt
+++ b/LayoutTests/svg/clip-path/hittest-transformed-clip-objectboundingbox-expected.txt
@@ -1,0 +1,19 @@
+Test that hit-testing correctly handles clipPath with objectBoundingBox units and a local transform. The clip should be at (50, 50) with size 100x100.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS document.elementFromPoint(75, 75).id is "target"
+PASS document.elementFromPoint(100, 100).id is "target"
+PASS document.elementFromPoint(140, 140).id is "target"
+PASS document.elementFromPoint(25, 25).id is ''
+PASS document.elementFromPoint(175, 175).id is ''
+PASS document.elementFromPoint(10, 100).id is ''
+PASS document.elementFromPoint(100, 10).id is ''
+PASS document.elementFromPoint(51, 51).id is "target"
+PASS document.elementFromPoint(149, 149).id is "target"
+PASS document.elementFromPoint(49, 49).id is ''
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/svg/clip-path/hittest-transformed-clip-objectboundingbox.html
+++ b/LayoutTests/svg/clip-path/hittest-transformed-clip-objectboundingbox.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Hit testing with transformed clipPath using objectBoundingBox units</title>
+<script src="../../resources/js-test.js"></script>
+<style>
+svg {
+    position: absolute;
+    top: 0;
+    left: 0;
+}
+</style>
+</head>
+<body>
+<svg width="400" height="400">
+    <defs>
+        <clipPath id="clip" clipPathUnits="objectBoundingBox" transform="translate(50, 50)">
+            <rect width="0.5" height="0.5"/>
+        </clipPath>
+    </defs>
+
+    <rect id="target" width="200" height="200" fill="green" clip-path="url(#clip)"/>
+</svg>
+
+<script>
+description('Test that hit-testing correctly handles clipPath with objectBoundingBox units and a local transform. The clip should be at (50, 50) with size 100x100.');
+
+shouldBeEqualToString("document.elementFromPoint(75, 75).id", "target");
+shouldBeEqualToString("document.elementFromPoint(100, 100).id", "target");
+shouldBeEqualToString("document.elementFromPoint(140, 140).id", "target");
+
+// Points outside the clipped region but inside the original rect bounds
+// These should NOT hit the target because they're clipped away
+shouldBe("document.elementFromPoint(25, 25).id", "''");
+shouldBe("document.elementFromPoint(175, 175).id", "''");
+shouldBe("document.elementFromPoint(10, 100).id", "''");
+shouldBe("document.elementFromPoint(100, 10).id", "''");
+
+// Edge cases - just inside the clip boundary
+shouldBeEqualToString("document.elementFromPoint(51, 51).id", "target");
+shouldBeEqualToString("document.elementFromPoint(149, 149).id", "target");
+
+// Edge cases - just outside the clip boundary
+shouldBe("document.elementFromPoint(49, 49).id", "''");
+</script>
+</body>
+</html>

--- a/LayoutTests/svg/clip-path/transformed-clip-expected.svg
+++ b/LayoutTests/svg/clip-path/transformed-clip-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <rect x="10" y="10" width="100" height="100" fill="green"/>
+</svg>

--- a/LayoutTests/svg/clip-path/transformed-clip.svg
+++ b/LayoutTests/svg/clip-path/transformed-clip.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <clipPath id="clip" clipPathUnits="objectBoundingBox" transform="translate(10, 10)">
+      <rect width="0.5" height="0.5"/>
+    </clipPath>
+  </defs>
+  <rect x="10" y="10" width="100" height="100" fill="red"/>
+  <rect width="200" height="200" fill="green" clip-path="url(#clip)"/>
+</svg>


### PR DESCRIPTION
#### 83bf26fdb1d12bdd474d9de61a35c63251a306b0
<pre>
Fix SVG clipPath bounding box transform order with objectBoundingBox units
<a href="https://bugs.webkit.org/show_bug.cgi?id=304836">https://bugs.webkit.org/show_bug.cgi?id=304836</a>
<a href="https://rdar.apple.com/167417135">rdar://167417135</a>

Reviewed by Simon Fraser.

When a clipPath has both clipPathUnits=&quot;objectBoundingBox&quot; and a local transform,
the bounding box calculation applied transforms in the wrong order. The local transform
was applied before the objectBoundingBox transform, causing it to be scaled incorrectly.

The correct order is: OBB transform first (to realize 0-1 coordinates to pixels),
then local transform (in pixel space).

Tests: svg/clip-path/hittest-transformed-clip-objectboundingbox.html
       svg/clip-path/transformed-clip-expected.svg
       svg/clip-path/transformed-clip.svg

* LayoutTests/svg/clip-path/hittest-transformed-clip-objectboundingbox-expected.txt: Added.
* LayoutTests/svg/clip-path/hittest-transformed-clip-objectboundingbox.html: Added.
* LayoutTests/svg/clip-path/transformed-clip-expected.svg: Added.
* LayoutTests/svg/clip-path/transformed-clip.svg: Added.
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp:
(WebCore::LegacyRenderSVGResourceClipper::calculateClipContentRepaintRect):
(WebCore::LegacyRenderSVGResourceClipper::hitTestClipContent):
(WebCore::LegacyRenderSVGResourceClipper::resourceBoundingBox):

Canonical link: <a href="https://commits.webkit.org/305078@main">https://commits.webkit.org/305078@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/714ceab76262bf9e6b80ec5ee853fa56bbfa5a0c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137417 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9777 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48704 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145168 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90390 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c0345bc2-f23a-4042-9e34-77e08d6e09af) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139289 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10481 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9904 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105080 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b972a309-290d-40ce-9d50-e414567b1f6a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140362 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7758 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123157 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85935 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/501f1011-b4c3-4c7f-8b3c-7103ee60ebd5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7394 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5116 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5755 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116762 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41309 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147925 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9460 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41866 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113457 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9478 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7969 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113798 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28891 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7315 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119396 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64072 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9509 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37449 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9239 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73074 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9449 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9301 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->