### PR TITLE
[JSC] Make math-hypot.js tolerant against platform's std::hypot difference

### DIFF
--- a/JSTests/stress/math-hypot.js
+++ b/JSTests/stress/math-hypot.js
@@ -1,36 +1,51 @@
-//@ skip if $architecture == "arm"
 function shouldBe(actual, expected) {
     if (!Object.is(actual, expected)) {
         throw new Error(`expected: ${expected}, actual: ${actual}`);
     }
 }
 
+function isCloseEnough(actual, expected, epsilon = Number.EPSILON * 32) {
+    if (actual === expected)
+        return true;
+
+    if (Number.isNaN(actual) && Number.isNaN(expected))
+        return true;
+
+    const diff = Math.abs(actual - expected);
+    const tolerance = epsilon * Math.max(1, Math.abs(actual), Math.abs(expected));
+    return diff <= tolerance;
+}
+
+function shouldBeCloseEnough(actual, expected) {
+    shouldBe(isCloseEnough(actual, expected), true);
+}
+
 for (var i = 0; i < testLoopCount; i++) {
     // basic
-    shouldBe(Math.hypot(3, 4), 5);
-    shouldBe(Math.hypot(-3, -4), 5);
-    shouldBe(Math.hypot(5, 12), 13);
-    shouldBe(Math.hypot(5, -12), 13);
-    shouldBe(Math.hypot(1, 2, 2), 3);
-    shouldBe(Math.hypot(1e308), 1e308);
-    shouldBe(Math.hypot(-1e308), 1e308);
-    shouldBe(Math.hypot(1e308, -1e308), 1.4142135623730951e308);
-    shouldBe(Math.hypot(1e308, 1e308, 1e308), 1.7320508075688772e308);
-    shouldBe(Math.hypot(-1e308, -1e308, -1e308), 1.7320508075688772e308);
-    shouldBe(Math.hypot(1e308, 1e308, 1e308, 1e308), Infinity);
-    shouldBe(Math.hypot(-1e308, -1e308, -1e308, -1e308), Infinity);
-    shouldBe(Math.hypot(1e308, 1e308, 1e308, 1e308, -1e308), Infinity);
-    shouldBe(Math.hypot(0.1), 0.1);
-    shouldBe(Math.hypot(0.1, 0.1), 0.14142135623730953);
-    shouldBe(Math.hypot(0.1, -0.1), 0.14142135623730953);
-    shouldBe(Math.hypot(1e308, 1e308, 0.1, 0.1, 1e30, 0.1, -1e30, -1e308, -1e308), Infinity);
+    shouldBeCloseEnough(Math.hypot(3, 4), 5);
+    shouldBeCloseEnough(Math.hypot(-3, -4), 5);
+    shouldBeCloseEnough(Math.hypot(5, 12), 13);
+    shouldBeCloseEnough(Math.hypot(5, -12), 13);
+    shouldBeCloseEnough(Math.hypot(1, 2, 2), 3);
+    shouldBeCloseEnough(Math.hypot(1e308), 1e308);
+    shouldBeCloseEnough(Math.hypot(-1e308), 1e308);
+    shouldBeCloseEnough(Math.hypot(1e308, -1e308), 1.4142135623730951e308);
+    shouldBeCloseEnough(Math.hypot(1e308, 1e308, 1e308), 1.7320508075688772e308);
+    shouldBeCloseEnough(Math.hypot(-1e308, -1e308, -1e308), 1.7320508075688772e308);
+    shouldBeCloseEnough(Math.hypot(1e308, 1e308, 1e308, 1e308), Infinity);
+    shouldBeCloseEnough(Math.hypot(-1e308, -1e308, -1e308, -1e308), Infinity);
+    shouldBeCloseEnough(Math.hypot(1e308, 1e308, 1e308, 1e308, -1e308), Infinity);
+    shouldBeCloseEnough(Math.hypot(0.1), 0.1);
+    shouldBeCloseEnough(Math.hypot(0.1, 0.1), 0.14142135623730953);
+    shouldBeCloseEnough(Math.hypot(0.1, -0.1), 0.14142135623730953);
+    shouldBeCloseEnough(Math.hypot(1e308, 1e308, 0.1, 0.1, 1e30, 0.1, -1e30, -1e308, -1e308), Infinity);
 
     // big and small numbers
-    shouldBe(Math.hypot(...Array(100).fill(1)), 10);
-    shouldBe(Math.hypot(...Array(10000).fill(1)), 100);
-    shouldBe(Math.hypot(8.98846567431158e307, 8.988465674311579e307, -1.7976931348623157e308), Infinity);
-    shouldBe(Math.hypot(-5.630637621603525e255, 9.565271205476345e307, 2.9937604643020797e292), 9.565271205476345e307);
-    shouldBe(
+    shouldBeCloseEnough(Math.hypot(...Array(100).fill(1)), 10);
+    shouldBeCloseEnough(Math.hypot(...Array(10000).fill(1)), 100);
+    shouldBeCloseEnough(Math.hypot(8.98846567431158e307, 8.988465674311579e307, -1.7976931348623157e308), Infinity);
+    shouldBeCloseEnough(Math.hypot(-5.630637621603525e255, 9.565271205476345e307, 2.9937604643020797e292), 9.565271205476345e307);
+    shouldBeCloseEnough(
         Math.hypot(
             6.739986666787661e66,
             2,
@@ -44,7 +59,7 @@ for (var i = 0; i < testLoopCount; i++) {
         ),
         Infinity
     );
-    shouldBe(
+    shouldBeCloseEnough(
         Math.hypot(
             0.31150493246968836,
             -8.988465674311582e307,
@@ -64,7 +79,7 @@ for (var i = 0; i < testLoopCount; i++) {
         ),
         1.2711610061536464e308
     );
-    shouldBe(
+    shouldBeCloseEnough(
         Math.hypot(
             -1.1442589134409902e308,
             9.593842098384855e138,
@@ -74,25 +89,25 @@ for (var i = 0; i < testLoopCount; i++) {
         ),
         Infinity
     );
-    shouldBe(
+    shouldBeCloseEnough(
         Math.hypot(-1.1442589134409902e308, 4.494232837155791e307, -1.3482698511467367e308, 4.494232837155792e307),
         Infinity
     );
-    shouldBe(
+    shouldBeCloseEnough(
         Math.hypot(9.593842098384855e138, -6.948356297254111e307, -1.3482698511467367e308, 4.494232837155792e307),
         1.5819637896591838e308
     );
-    shouldBe(Math.hypot(-2.534858246857893e115, 8.988465674311579e307, 8.98846567431158e307), 1.2711610061536462e308);
+    shouldBeCloseEnough(Math.hypot(-2.534858246857893e115, 8.988465674311579e307, 8.98846567431158e307), 1.2711610061536462e308);
     // FIXME: This test result differs from Chrome and Firefox,
     // although it matches the behavior of Swift, C++, Rust, and Python. Commenting out this test case for now.
-    // shouldBe(Math.hypot(1.3588124894186193e308, 1.4803986201152006e223, 6.741349255733684e307), 1.5168484694516577e308);
-    shouldBe(Math.hypot(6.741349255733684e307, 1.7976931348623155e308, -7.388327292663961e41), Infinity);
-    shouldBe(Math.hypot(-1.9807040628566093e28, 1.7976931348623157e308, 9.9792015476736e291), 1.7976931348623157e308);
-    shouldBe(
+    // shouldBeCloseEnough(Math.hypot(1.3588124894186193e308, 1.4803986201152006e223, 6.741349255733684e307), 1.5168484694516577e308);
+    shouldBeCloseEnough(Math.hypot(6.741349255733684e307, 1.7976931348623155e308, -7.388327292663961e41), Infinity);
+    shouldBeCloseEnough(Math.hypot(-1.9807040628566093e28, 1.7976931348623157e308, 9.9792015476736e291), 1.7976931348623157e308);
+    shouldBeCloseEnough(
         Math.hypot(-1.0214557991173964e61, 1.7976931348623157e308, 8.98846567431158e307, -8.988465674311579e307),
         Infinity
     );
-    shouldBe(
+    shouldBeCloseEnough(
         Math.hypot(
             1.7976931348623157e308,
             7.999999999999999,
@@ -102,11 +117,11 @@ for (var i = 0; i < testLoopCount; i++) {
         ),
         1.7976931348623157e308
     );
-    shouldBe(
+    shouldBeCloseEnough(
         Math.hypot(6.197409167220438e-223, -9.979201547673601e291, -1.7976931348623157e308),
         1.7976931348623157e308
     );
-    shouldBe(
+    shouldBeCloseEnough(
         Math.hypot(
             4.49423283715579e307,
             8.944251746776101e307,
@@ -117,7 +132,7 @@ for (var i = 0; i < testLoopCount; i++) {
         ),
         Infinity
     );
-    shouldBe(
+    shouldBeCloseEnough(
         Math.hypot(
             8.988465674311579e307,
             7.999999999999998,
@@ -128,64 +143,64 @@ for (var i = 0; i < testLoopCount; i++) {
         ),
         Infinity
     );
-    shouldBe(Math.hypot(8.98846567431158e307, 8.98846567431158e307), 1.2711610061536464e308);
+    shouldBeCloseEnough(Math.hypot(8.98846567431158e307, 8.98846567431158e307), 1.2711610061536464e308);
 
     // nan infinity
-    shouldBe(Math.hypot(NaN), NaN);
-    shouldBe(Math.hypot(NaN, 0), NaN);
-    shouldBe(Math.hypot(NaN, 3), NaN);
-    shouldBe(Math.hypot(NaN, 0, 0, 0), NaN);
-    shouldBe(Math.hypot(NaN, 0, 0, 0, 0), NaN);
-    shouldBe(Math.hypot(NaN, 0, 0, 0, 0, Infinity), Infinity);
-    shouldBe(Math.hypot(0, 0, 0, 0, 0, Infinity), Infinity);
-    shouldBe(Math.hypot(0, NaN, 0, 1e-308), NaN);
-    shouldBe(Math.hypot(0, NaN, 0, Infinity), Infinity);
-    shouldBe(Math.hypot(0, 0, 1, Infinity), Infinity);
-    shouldBe(Math.hypot(Infinity, -Infinity), Infinity);
-    shouldBe(Math.hypot(-Infinity, Infinity), Infinity);
-    shouldBe(Math.hypot(Infinity, NaN), Infinity);
-    shouldBe(Math.hypot(Infinity, Infinity, Infinity, NaN), Infinity);
-    shouldBe(Math.hypot(Infinity, NaN, NaN, NaN), Infinity);
-    shouldBe(Math.hypot(-Infinity, NaN), Infinity);
-    shouldBe(Math.hypot(Infinity), Infinity);
-    shouldBe(Math.hypot(Infinity, 1), Infinity);
-    shouldBe(Math.hypot(Infinity, Infinity), Infinity);
-    shouldBe(Math.hypot(-Infinity), Infinity);
-    shouldBe(Math.hypot(-Infinity, -Infinity), Infinity);
+    shouldBeCloseEnough(Math.hypot(NaN), NaN);
+    shouldBeCloseEnough(Math.hypot(NaN, 0), NaN);
+    shouldBeCloseEnough(Math.hypot(NaN, 3), NaN);
+    shouldBeCloseEnough(Math.hypot(NaN, 0, 0, 0), NaN);
+    shouldBeCloseEnough(Math.hypot(NaN, 0, 0, 0, 0), NaN);
+    shouldBeCloseEnough(Math.hypot(NaN, 0, 0, 0, 0, Infinity), Infinity);
+    shouldBeCloseEnough(Math.hypot(0, 0, 0, 0, 0, Infinity), Infinity);
+    shouldBeCloseEnough(Math.hypot(0, NaN, 0, 1e-308), NaN);
+    shouldBeCloseEnough(Math.hypot(0, NaN, 0, Infinity), Infinity);
+    shouldBeCloseEnough(Math.hypot(0, 0, 1, Infinity), Infinity);
+    shouldBeCloseEnough(Math.hypot(Infinity, -Infinity), Infinity);
+    shouldBeCloseEnough(Math.hypot(-Infinity, Infinity), Infinity);
+    shouldBeCloseEnough(Math.hypot(Infinity, NaN), Infinity);
+    shouldBeCloseEnough(Math.hypot(Infinity, Infinity, Infinity, NaN), Infinity);
+    shouldBeCloseEnough(Math.hypot(Infinity, NaN, NaN, NaN), Infinity);
+    shouldBeCloseEnough(Math.hypot(-Infinity, NaN), Infinity);
+    shouldBeCloseEnough(Math.hypot(Infinity), Infinity);
+    shouldBeCloseEnough(Math.hypot(Infinity, 1), Infinity);
+    shouldBeCloseEnough(Math.hypot(Infinity, Infinity), Infinity);
+    shouldBeCloseEnough(Math.hypot(-Infinity), Infinity);
+    shouldBeCloseEnough(Math.hypot(-Infinity, -Infinity), Infinity);
 
     // string
-    shouldBe(Math.hypot(""), 0);
-    shouldBe(Math.hypot(" "), 0);
-    shouldBe(Math.hypot("  "), 0);
-    shouldBe(Math.hypot("\t"), 0);
-    shouldBe(Math.hypot("\n"), 0);
-    shouldBe(Math.hypot("w"), NaN);
-    shouldBe(Math.hypot(13, "a"), NaN);
-    shouldBe(Math.hypot(1, "1"), 1.4142135623730951);
-    shouldBe(Math.hypot("3", "4"), 5);
-    shouldBe(Math.hypot("3", "五"), NaN);
-    shouldBe(Math.hypot(1, "🐟"), NaN);
+    shouldBeCloseEnough(Math.hypot(""), 0);
+    shouldBeCloseEnough(Math.hypot(" "), 0);
+    shouldBeCloseEnough(Math.hypot("  "), 0);
+    shouldBeCloseEnough(Math.hypot("\t"), 0);
+    shouldBeCloseEnough(Math.hypot("\n"), 0);
+    shouldBeCloseEnough(Math.hypot("w"), NaN);
+    shouldBeCloseEnough(Math.hypot(13, "a"), NaN);
+    shouldBeCloseEnough(Math.hypot(1, "1"), 1.4142135623730951);
+    shouldBeCloseEnough(Math.hypot("3", "4"), 5);
+    shouldBeCloseEnough(Math.hypot("3", "五"), NaN);
+    shouldBeCloseEnough(Math.hypot(1, "🐟"), NaN);
 
     // object
-    shouldBe(Math.hypot([]), 0);
-    shouldBe(Math.hypot([1, 2, 3]), NaN);
-    shouldBe(Math.hypot({}), NaN);
-    shouldBe(Math.hypot({ valueOf: 1 }), NaN);
+    shouldBeCloseEnough(Math.hypot([]), 0);
+    shouldBeCloseEnough(Math.hypot([1, 2, 3]), NaN);
+    shouldBeCloseEnough(Math.hypot({}), NaN);
+    shouldBeCloseEnough(Math.hypot({ valueOf: 1 }), NaN);
 
     // bool
-    shouldBe(Math.hypot(true), 1);
-    shouldBe(Math.hypot(false), 0);
-    shouldBe(Math.hypot(false, true), 1);
-    shouldBe(Math.hypot(false, true, 1, 1, 1), 2);
-    shouldBe(Math.hypot(...Array(100).fill(true)), 10);
+    shouldBeCloseEnough(Math.hypot(true), 1);
+    shouldBeCloseEnough(Math.hypot(false), 0);
+    shouldBeCloseEnough(Math.hypot(false, true), 1);
+    shouldBeCloseEnough(Math.hypot(false, true, 1, 1, 1), 2);
+    shouldBeCloseEnough(Math.hypot(...Array(100).fill(true)), 10);
 
     // zero
-    shouldBe(Math.hypot(), 0);
-    shouldBe(Math.hypot(-0), 0);
-    shouldBe(Math.hypot(-0, -0), 0);
-    shouldBe(Math.hypot(-0, 0), 0);
-    shouldBe(Math.hypot(0), 0);
-    shouldBe(Math.hypot(0, 0), 0);
+    shouldBeCloseEnough(Math.hypot(), 0);
+    shouldBeCloseEnough(Math.hypot(-0), 0);
+    shouldBeCloseEnough(Math.hypot(-0, -0), 0);
+    shouldBeCloseEnough(Math.hypot(-0, 0), 0);
+    shouldBeCloseEnough(Math.hypot(0), 0);
+    shouldBeCloseEnough(Math.hypot(0, 0), 0);
 
     // valueOf
     var mutable = 0;
@@ -198,36 +213,36 @@ for (var i = 0; i < testLoopCount; i++) {
         };
     }
 
-    shouldBe(Math.hypot(generateObj(3), 4), 5);
-    shouldBe(mutable, 10);
+    shouldBeCloseEnough(Math.hypot(generateObj(3), 4), 5);
+    shouldBeCloseEnough(mutable, 10);
 
-    shouldBe(Math.hypot(generateObj(3), Infinity), Infinity);
-    shouldBe(mutable, 20);
+    shouldBeCloseEnough(Math.hypot(generateObj(3), Infinity), Infinity);
+    shouldBeCloseEnough(mutable, 20);
 
-    shouldBe(Math.hypot(generateObj(3), generateObj(NaN), Infinity), Infinity);
-    shouldBe(mutable, 40);
+    shouldBeCloseEnough(Math.hypot(generateObj(3), generateObj(NaN), Infinity), Infinity);
+    shouldBeCloseEnough(mutable, 40);
 
-    shouldBe(Math.hypot(generateObj(3), generateObj(NaN)), NaN);
-    shouldBe(mutable, 60);
+    shouldBeCloseEnough(Math.hypot(generateObj(3), generateObj(NaN)), NaN);
+    shouldBeCloseEnough(mutable, 60);
 
-    shouldBe(Math.hypot(generateObj(3), generateObj([])), NaN);
-    shouldBe(mutable, 80);
+    shouldBeCloseEnough(Math.hypot(generateObj(3), generateObj([])), NaN);
+    shouldBeCloseEnough(mutable, 80);
 
-    shouldBe(Math.hypot(generateObj(NaN), generateObj(3)), NaN);
-    shouldBe(mutable, 100);
+    shouldBeCloseEnough(Math.hypot(generateObj(NaN), generateObj(3)), NaN);
+    shouldBeCloseEnough(mutable, 100);
 
-    shouldBe(Math.hypot(Infinity, generateObj(3)), Infinity);
-    shouldBe(mutable, 110);
+    shouldBeCloseEnough(Math.hypot(Infinity, generateObj(3)), Infinity);
+    shouldBeCloseEnough(mutable, 110);
 
-    shouldBe(Math.hypot(-Infinity, generateObj(3)), Infinity);
-    shouldBe(mutable, 120);
+    shouldBeCloseEnough(Math.hypot(-Infinity, generateObj(3)), Infinity);
+    shouldBeCloseEnough(mutable, 120);
 
-    shouldBe(Math.hypot(Infinity, Infinity, Infinity, generateObj(3)), Infinity);
-    shouldBe(mutable, 130);
+    shouldBeCloseEnough(Math.hypot(Infinity, Infinity, Infinity, generateObj(3)), Infinity);
+    shouldBeCloseEnough(mutable, 130);
     
-    shouldBe(Math.hypot(NaN, Infinity, Infinity, Infinity, generateObj(3)), Infinity);
-    shouldBe(mutable, 140);
+    shouldBeCloseEnough(Math.hypot(NaN, Infinity, Infinity, Infinity, generateObj(3)), Infinity);
+    shouldBeCloseEnough(mutable, 140);
 
-    shouldBe(Math.hypot(NaN, generateObj(Infinity), Infinity, Infinity, generateObj(3)), Infinity);
-    shouldBe(mutable, 160);
+    shouldBeCloseEnough(Math.hypot(NaN, generateObj(Infinity), Infinity, Infinity, generateObj(3)), Infinity);
+    shouldBeCloseEnough(mutable, 160);
 }


### PR DESCRIPTION
#### 805ad6bfc4b6fd140f31291b35889f1d52b8a2f4
<pre>
[JSC] Make math-hypot.js tolerant against platform&apos;s std::hypot difference
<a href="https://bugs.webkit.org/show_bug.cgi?id=304895">https://bugs.webkit.org/show_bug.cgi?id=304895</a>
<a href="https://rdar.apple.com/167491232">rdar://167491232</a>

Reviewed by Sosuke Suzuki.

Due to libm&apos;s different implementations in each platform, std::hypot
result can be slightly different. This patch introduces
shouldBeCloseEnough which accepts some epsilons from the results.

* JSTests/stress/math-hypot.js:
(shouldBeCloseEnough):

Canonical link: <a href="https://commits.webkit.org/305088@main">https://commits.webkit.org/305088@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/158734aa9e5e7f4637cb3eb9da3bb0d3ae53caf5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137430 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9790 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48717 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145181 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90403 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/40e7b973-5bdc-4ec3-a814-6c3c1e97b311) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10494 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9917 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105087 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d16bc532-798e-4e34-8481-128d54da6171) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140375 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7770 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123170 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85942 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e682c669-3c63-4e01-9eed-49ae7254d54f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7406 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5129 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5768 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/129391 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116775 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147938 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/135945 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9473 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41879 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113464 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9491 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7982 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113805 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7327 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119409 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64088 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21170 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9522 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37462 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/168700 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9252 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44027 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9462 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9314 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->