### PR TITLE
[JSC] Allow same registers for src and dst in MacroAssemblerX86_64::negateDouble / negateFloat

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -1310,24 +1310,30 @@ public:
 
     void negateDouble(FPRegisterID src, FPRegisterID dst)
     {
-        ASSERT(src != dst);
-        static constexpr double negativeZeroConstant = -0.0;
-        loadDouble(TrustedImmPtr(&negativeZeroConstant), dst);
+        alignas(16) static constexpr double negativeZeroConstants[] = { -0.0, -0.0 };
+        static_assert(sizeof(negativeZeroConstants) == 16);
+        move(TrustedImmPtr(negativeZeroConstants), scratchRegister());
         if (supportsAVX())
-            m_assembler.vxorpd_rrr(src, dst, dst);
-        else
-            m_assembler.xorpd_rr(src, dst);
+            m_assembler.vxorpd_mrr(0, scratchRegister(), src, dst);
+        else {
+            if (src != dst)
+                moveDouble(src, dst);
+            m_assembler.xorpd_mr(0, scratchRegister(), dst);
+        }
     }
 
     void negateFloat(FPRegisterID src, FPRegisterID dst)
     {
-        ASSERT(src != dst);
-        static constexpr float negativeZeroConstant = -0.0f;
-        loadFloat(TrustedImmPtr(&negativeZeroConstant), dst);
+        alignas(16) static constexpr float negativeZeroConstants[] = { -0.0f, -0.0f, -0.0f, -0.0f };
+        static_assert(sizeof(negativeZeroConstants) == 16);
+        move(TrustedImmPtr(negativeZeroConstants), scratchRegister());
         if (supportsAVX())
-            m_assembler.vxorps_rrr(src, dst, dst);
-        else
-            m_assembler.xorps_rr(src, dst);
+            m_assembler.vxorps_mrr(0, scratchRegister(), src, dst);
+        else {
+            if (src != dst)
+                moveDouble(src, dst);
+            m_assembler.xorps_mr(0, scratchRegister(), dst);
+        }
     }
 
     void ceilDouble(FPRegisterID src, FPRegisterID dst)

--- a/Source/JavaScriptCore/assembler/X86Assembler.h
+++ b/Source/JavaScriptCore/assembler/X86Assembler.h
@@ -3943,6 +3943,11 @@ public:
         m_formatter.twoByteOp(OP2_XORPD_VpdWpd, (RegisterID)dst, (RegisterID)src);
     }
 
+    void xorps_mr(int offset, RegisterID base, XMMRegisterID dst)
+    {
+        m_formatter.twoByteOp(OP2_XORPS_VpsWps, (RegisterID)dst, base, offset);
+    }
+
     void xorpd_rr(XMMRegisterID src, XMMRegisterID dst)
     {
         if (src == dst) {
@@ -3951,6 +3956,12 @@ public:
         }
         m_formatter.prefix(PRE_SSE_66);
         m_formatter.twoByteOp(OP2_XORPD_VpdWpd, (RegisterID)dst, (RegisterID)src);
+    }
+
+    void xorpd_mr(int offset, RegisterID base, XMMRegisterID dst)
+    {
+        m_formatter.prefix(PRE_SSE_66);
+        m_formatter.twoByteOp(OP2_XORPD_VpdWpd, (RegisterID)dst, base, offset);
     }
 
     void andnpd_rr(XMMRegisterID src, XMMRegisterID dst)
@@ -5513,12 +5524,28 @@ public:
         m_formatter.vexNdsLigWigCommutativeTwoByteOp(PRE_SSE_00, OP2_XORPS_VpsWps, (RegisterID)dest, (RegisterID)b, (RegisterID)a);
     }
 
+    void vxorps_mrr(int offset, RegisterID base, XMMRegisterID src2, XMMRegisterID dest)
+    {
+        // https://www.felixcloutier.com/x86/xorps
+        // VEX.128.0F.WIG 57 /r VXORPS xmm1,xmm2, xmm3/m128
+        // B    NA    ModRM:reg (w)    VEX.vvvv (r)    ModRM:r/m (r)    NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_00, OP2_XORPS_VpsWps, (RegisterID)dest, (RegisterID)src2, base, offset);
+    }
+
     void vxorpd_rrr(XMMRegisterID a, XMMRegisterID b, XMMRegisterID dest)
     {
         // https://www.felixcloutier.com/x86/xorpd
         // VEX.128.66.0F.WIG 57 /r VXORPD xmm1,xmm2, xmm3/m128
         // B    NA    ModRM:reg (w)    VEX.vvvv (r)    ModRM:r/m (r)    NA
         m_formatter.vexNdsLigWigCommutativeTwoByteOp(PRE_SSE_66, OP2_XORPD_VpdWpd, (RegisterID)dest, (RegisterID)b, (RegisterID)a);
+    }
+
+    void vxorpd_mrr(int offset, RegisterID base, XMMRegisterID src2, XMMRegisterID dest)
+    {
+        // https://www.felixcloutier.com/x86/xorpd
+        // VEX.128.66.0F.WIG 57 /r VXORPD xmm1,xmm2, xmm3/m128
+        // B    NA    ModRM:reg (w)    VEX.vvvv (r)    ModRM:r/m (r)    NA
+        m_formatter.vexNdsLigWigTwoByteOp(PRE_SSE_66, OP2_XORPD_VpdWpd, (RegisterID)dest, (RegisterID)src2, base, offset);
     }
 
     void vandnps_rrr(XMMRegisterID a, XMMRegisterID b, XMMRegisterID dest)

--- a/Source/JavaScriptCore/assembler/testmasm.cpp
+++ b/Source/JavaScriptCore/assembler/testmasm.cpp
@@ -76,8 +76,6 @@ static Vector<double> doubleOperands()
     };
 }
 
-
-#if CPU(X86_64) || CPU(ARM64) || CPU(RISCV64)
 static Vector<float> floatOperands()
 {
     return Vector<float> {
@@ -95,7 +93,6 @@ static Vector<float> floatOperands()
         -std::numeric_limits<float>::infinity(),
     };
 }
-#endif
 
 static Vector<int32_t> int32Operands()
 {
@@ -5879,6 +5876,72 @@ void testAndOrDouble()
     }
 }
 
+void testNegateDouble()
+{
+    double arg = 0;
+
+    auto negateDoubleDifferentRegs = compile([&] (CCallHelpers& jit) {
+        emitFunctionPrologue(jit);
+        jit.loadDouble(CCallHelpers::TrustedImmPtr(&arg), FPRInfo::fpRegT1);
+        jit.negateDouble(FPRInfo::fpRegT1, FPRInfo::returnValueFPR);
+        emitFunctionEpilogue(jit);
+        jit.ret();
+    });
+
+    auto negateDoubleSameReg = compile([&] (CCallHelpers& jit) {
+        emitFunctionPrologue(jit);
+        jit.loadDouble(CCallHelpers::TrustedImmPtr(&arg), FPRInfo::returnValueFPR);
+        jit.negateDouble(FPRInfo::returnValueFPR, FPRInfo::returnValueFPR);
+        emitFunctionEpilogue(jit);
+        jit.ret();
+    });
+
+    auto operands = doubleOperands();
+    for (auto value : operands) {
+        arg = value;
+        double resultDifferent = invoke<double>(negateDoubleDifferentRegs);
+        double resultSame = invoke<double>(negateDoubleSameReg);
+        uint64_t expectedBits = std::bit_cast<uint64_t>(value) ^ 0x8000000000000000ULL; // Flip sign bit
+        uint64_t resultDifferentBits = std::bit_cast<uint64_t>(resultDifferent);
+        uint64_t resultSameBits = std::bit_cast<uint64_t>(resultSame);
+        CHECK_EQ(resultDifferentBits, expectedBits);
+        CHECK_EQ(resultSameBits, expectedBits);
+    }
+}
+
+void testNegateFloat()
+{
+    float arg = 0;
+
+    auto negateFloatDifferentRegs = compile([&] (CCallHelpers& jit) {
+        emitFunctionPrologue(jit);
+        jit.loadFloat(CCallHelpers::TrustedImmPtr(&arg), FPRInfo::fpRegT1);
+        jit.negateFloat(FPRInfo::fpRegT1, FPRInfo::returnValueFPR);
+        emitFunctionEpilogue(jit);
+        jit.ret();
+    });
+
+    auto negateFloatSameReg = compile([&] (CCallHelpers& jit) {
+        emitFunctionPrologue(jit);
+        jit.loadFloat(CCallHelpers::TrustedImmPtr(&arg), FPRInfo::returnValueFPR);
+        jit.negateFloat(FPRInfo::returnValueFPR, FPRInfo::returnValueFPR);
+        emitFunctionEpilogue(jit);
+        jit.ret();
+    });
+
+    auto operands = floatOperands();
+    for (auto value : operands) {
+        arg = value;
+        float resultDifferent = invoke<float>(negateFloatDifferentRegs);
+        float resultSame = invoke<float>(negateFloatSameReg);
+        uint32_t expectedBits = std::bit_cast<uint32_t>(value) ^ 0x80000000U; // Flip sign bit
+        uint32_t resultDifferentBits = std::bit_cast<uint32_t>(resultDifferent);
+        uint32_t resultSameBits = std::bit_cast<uint32_t>(resultSame);
+        CHECK_EQ(resultDifferentBits, expectedBits);
+        CHECK_EQ(resultSameBits, expectedBits);
+    }
+}
+
 void testByteSwap()
 {
 #if CPU(X86_64) || CPU(ARM64)
@@ -7017,6 +7080,10 @@ void run(const char* filter) WTF_IGNORES_THREAD_SAFETY_ANALYSIS
     RUN(testOrImmMem());
 
     RUN(testAndOrDouble());
+
+    RUN(testNegateDouble());
+
+    RUN(testNegateFloat());
 
     RUN(testGPRInfoConsistency());
 

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -3023,13 +3023,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Neg(Value operand, Value& result)
         "F32Neg", TypeKind::F32,
         BLOCK(Value::fromF32(-operand.asF32())),
         BLOCK(
-#if CPU(X86_64)
-            m_jit.moveFloatTo32(operandLocation.asFPR(), wasmScratchGPR);
-            m_jit.xor32(TrustedImm32(std::bit_cast<uint32_t>(static_cast<float>(-0.0))), wasmScratchGPR);
-            m_jit.move32ToFloat(wasmScratchGPR, resultLocation.asFPR());
-#else
             m_jit.negateFloat(operandLocation.asFPR(), resultLocation.asFPR());
-#endif
         )
     )
 }
@@ -3040,13 +3034,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Neg(Value operand, Value& result)
         "F64Neg", TypeKind::F64,
         BLOCK(Value::fromF64(-operand.asF64())),
         BLOCK(
-#if CPU(X86_64)
-            m_jit.moveDoubleTo64(operandLocation.asFPR(), wasmScratchGPR);
-            m_jit.xor64(TrustedImm64(std::bit_cast<uint64_t>(static_cast<double>(-0.0))), wasmScratchGPR);
-            m_jit.move64ToDouble(wasmScratchGPR, resultLocation.asFPR());
-#else
             m_jit.negateDouble(operandLocation.asFPR(), resultLocation.asFPR());
-#endif
         )
     )
 }


### PR DESCRIPTION
#### 2fe3a6e9c518ae48b0de0a5e131d3f8250a28ae1
<pre>
[JSC] Allow same registers for src and dst in MacroAssemblerX86_64::negateDouble / negateFloat
<a href="https://bugs.webkit.org/show_bug.cgi?id=304897">https://bugs.webkit.org/show_bug.cgi?id=304897</a>
<a href="https://rdar.apple.com/167491947">rdar://167491947</a>

Reviewed by Sosuke Suzuki.

Relax X86_64&apos;s negateDouble / negateFloat invariants. loadDouble /
loadFloat are already using scratchRegister() so it is still requiring
scratchRegister(), but by using _mr variant, we can avoid
`ASSEERT(src != dst)` restriction. This simplifies BBQ implementations.

Test: Source/JavaScriptCore/assembler/testmasm.cpp

* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::negateDouble):
(JSC::MacroAssemblerX86_64::negateFloat):
* Source/JavaScriptCore/assembler/X86Assembler.h:
(JSC::X86Assembler::xorps_mr):
(JSC::X86Assembler::xorpd_mr):
(JSC::X86Assembler::vxorps_mrr):
(JSC::X86Assembler::vxorpd_mrr):
* Source/JavaScriptCore/assembler/testmasm.cpp:
(floatOperands):
(JSC::testNegateDouble):
(JSC::testNegateFloat):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Neg):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Neg):

Canonical link: <a href="https://commits.webkit.org/305087@main">https://commits.webkit.org/305087@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9e3193daef370b5cf75048b9ff784deaa17b9a2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137429 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9789 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48716 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145180 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90402 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/11716745-ccdb-4512-98bd-9af0fff421e0) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10493 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9916 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/76762 "Build is in progress. Recent messages:") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8f694e1d-1af5-4cab-8bdb-ff3e1522d313) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140374 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7771 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123171 "Passed tests") | [⏳ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/API-Tests-WPE-EWS "Waiting to run tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a0b96da7-2792-4a1a-a529-bec046357a04) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7407 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5128 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5767 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/129390 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116776 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41323 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147937 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/135943 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9472 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41880 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113466 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9490 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7981 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113808 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7326 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119410 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64087 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21169 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9521 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37463 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/168699 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9251 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73086 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44026 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9461 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9313 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->