### PR TITLE
[JSC] Fix Value Conversion in `%TypedArray%.prototype.set` that Shrinks and then Grows `ArrayBuffer` for ECMA-262 Alignment

### DIFF
--- a/JSTests/stress/typedarray-set-resize.js
+++ b/JSTests/stress/typedarray-set-resize.js
@@ -1,0 +1,52 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected) {
+        throw new Error(`actual: ${actual}, expected: ${expected}`);
+    }
+}
+
+var rab = new ArrayBuffer(5, { maxByteLength: 10 });
+var typedArray = new Int8Array(rab);
+var log = [];
+
+var growNumber = 0;
+var grow = {
+    valueOf() {
+        log.push("grow");
+        rab.resize(rab.byteLength + 1);
+        return --growNumber;
+    },
+};
+
+var shrinkNumber = 0;
+var shrink = {
+    valueOf() {
+        log.push("shrink");
+        rab.resize(rab.byteLength - 1);
+        return ++shrinkNumber;
+    },
+};
+
+var array = {
+    get length() {
+        return 5;
+    },
+    0: shrink,
+    1: shrink,
+    2: shrink,
+    3: grow,
+    4: grow,
+};
+
+typedArray.set(array);
+
+var expectedLogs = ["shrink", "shrink", "shrink", "grow", "grow"];
+shouldBe(log.length, expectedLogs.length);
+for (var i = 0; i < expectedLogs.length; ++i) {
+    shouldBe(log[i], expectedLogs[i]);
+}
+
+var expectedTypedArray = [1, 2, 0, 0];
+shouldBe(typedArray.length, expectedTypedArray.length);
+for (var i = 0; i < expectedTypedArray.length; ++i) {
+    shouldBe(typedArray[i], expectedTypedArray[i]);
+}

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -367,9 +367,6 @@ test/built-ins/Temporal/PlainTime/prototype/toString/order-of-operations.js:
 test/built-ins/Temporal/getOwnPropertyNames.js:
   default: 'Test262Error: ZonedDateTime'
   strict mode: 'Test262Error: ZonedDateTime'
-test/built-ins/TypedArray/prototype/set/array-arg-value-conversion-resizes-array-buffer.js:
-  default: 'Test262Error: Actual [shrink, shrink, shrink] and expected [shrink, shrink, shrink, grow, grow] should have the same contents. '
-  strict mode: 'Test262Error: Actual [shrink, shrink, shrink] and expected [shrink, shrink, shrink, grow, grow] should have the same contents. '
 test/built-ins/TypedArray/prototype/slice/speciesctor-return-same-buffer-with-offset.js:
   default: 'Test262Error: Actual [20, 30, 40, 60] and expected [20, 20, 20, 60] should have the same contents.  (Testing with Float64Array.)'
   strict mode: 'Test262Error: Actual [20, 30, 40, 60] and expected [20, 20, 20, 60] should have the same contents.  (Testing with Float64Array.)'

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
@@ -449,20 +449,16 @@ bool JSGenericTypedArrayView<Adaptor>::setFromArrayLike(JSGlobalObject* globalOb
         ASSERT(i + objectOffset <= MAX_ARRAY_INDEX);
         JSValue value = object->get(globalObject, static_cast<unsigned>(i + objectOffset));
         RETURN_IF_EXCEPTION(scope, false);
-        bool success = setIndex(globalObject, offset + i, value);
+        success &= setIndex(globalObject, offset + i, value);
         EXCEPTION_ASSERT(!scope.exception() || !success);
-        if (!success)
-            return false;
     }
     for (size_t i = safeLength; i < length; ++i) {
         JSValue value = object->get(globalObject, static_cast<uint64_t>(i + objectOffset));
         RETURN_IF_EXCEPTION(scope, false);
-        bool success = setIndex(globalObject, offset + i, value);
+        success &= setIndex(globalObject, offset + i, value);
         EXCEPTION_ASSERT(!scope.exception() || !success);
-        if (!success)
-            return false;
     }
-    return true;
+    return success;
 }
 
 template<typename Adaptor>
@@ -499,24 +495,21 @@ bool JSGenericTypedArrayView<Adaptor>::setFromArrayLike(JSGlobalObject* globalOb
     // It is not valid to ever call source->get() with an index of more than MAX_ARRAY_INDEX.
     // So we iterate in the optimized loop up to MAX_ARRAY_INDEX, then if there is anything to do beyond this, we rely on slower code.
     size_t safeLength = std::min(sourceLength, static_cast<size_t>(MAX_ARRAY_INDEX) + 1);
+    bool success = true;
     for (size_t i = 0; i < safeLength; ++i) {
         ASSERT(i <= MAX_ARRAY_INDEX);
         JSValue value = source->get(globalObject, static_cast<unsigned>(i));
         RETURN_IF_EXCEPTION(scope, false);
-        bool success = setIndex(globalObject, offset + i, value);
+        success &= setIndex(globalObject, offset + i, value);
         EXCEPTION_ASSERT(!scope.exception() || !success);
-        if (!success) [[unlikely]]
-            return false;
     }
     for (size_t i = safeLength; i < sourceLength; ++i) {
         JSValue value = source->get(globalObject, static_cast<uint64_t>(i));
         RETURN_IF_EXCEPTION(scope, false);
-        bool success = setIndex(globalObject, offset + i, value);
+        success &= setIndex(globalObject, offset + i, value);
         EXCEPTION_ASSERT(!scope.exception() || !success);
-        if (!success) [[unlikely]]
-            return false;
     }
-    return true;
+    return success;
 }
 
 template<typename Adaptor>


### PR DESCRIPTION
#### 841a8a56e8cdbc1404d2972b3031f5bb620c340c
<pre>
[JSC] Fix Value Conversion in `%TypedArray%.prototype.set` that Shrinks and then Grows `ArrayBuffer` for ECMA-262 Alignment
<a href="https://bugs.webkit.org/show_bug.cgi?id=304899">https://bugs.webkit.org/show_bug.cgi?id=304899</a>

Reviewed by Keith Miller.

Previously, the for loops had early returns
which do not align with ECMA-262 behavior.
This patch fixes value conversion in `%TypedArray%.prototype.set`
that shrinks and then grows `ArrayBuffer` for ECMA-262 alignment[1][2].

[1]: <a href="https://tc39.es/ecma262/#sec-%typedarray%.prototype.set">https://tc39.es/ecma262/#sec-%typedarray%.prototype.set</a>
[2]: <a href="https://tc39.es/ecma262/#sec-settypedarrayfromarraylike">https://tc39.es/ecma262/#sec-settypedarrayfromarraylike</a>

Test: JSTests/stress/typedarray-set-resize.js

* JSTests/stress/typedarray-set-resize.js: Added.
(shouldBe):
(grow.valueOf):
(shrink.valueOf):
(array.get length):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h:
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::setFromArrayLike):

Canonical link: <a href="https://commits.webkit.org/306594@main">https://commits.webkit.org/306594@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21e6272e7b308698f7f7ec56e5ff540c5e13a5fc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141186 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13570 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2876 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149789 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94283 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14281 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13722 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108490 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78533 "2 flakes 6 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144137 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11014 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126352 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89396 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10597 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8203 "Passed tests") | [⏳ 🛠 wpe-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/133166 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119854 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2330 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152151 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/1987 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13256 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2764 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116564 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13272 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11580 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116906 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29901 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12962 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123013 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/68430 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13299 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2413 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/172479 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13038 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77004 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44694 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13237 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13082 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->