### PR TITLE
[GTK][GStreamer] REGRESSION(303623@main) webrtc/peer-connection-audio-mute2.html is failing

### DIFF
--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -128,7 +128,6 @@ webkit.org/b/303375 inspector/debugger/async-stack-trace-truncate.html [ Crash T
 # Crash on EWS bot.
 webrtc/vp8-then-h264-gpu-process-crash.html [ Skip ]
 
-webkit.org/b/303924 webrtc/peer-connection-audio-mute2.html [ Failure ]
 webkit.org/b/303925 webrtc/audio-replace-track.html [ Failure ]
 
 #//////////////////////////////////////////////////////////////////////////////////////////

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCapturer.cpp
@@ -87,7 +87,7 @@ GstElement* GStreamerAudioCapturer::createConverter()
     gst_bin_add_many(GST_BIN_CAST(bin), audioconvert, audioresample, nullptr);
     gst_element_link(audioconvert, audioresample);
 
-#if USE(GSTREAMER_WEBRTC)
+#if 0 // USE(GSTREAMER_WEBRTC)
     if (auto audioFilter = makeGStreamerElement("audiornnoise"_s)) {
         auto audioconvert2 = makeGStreamerElement("audioconvert"_s);
         auto audioresample2 = makeGStreamerElement("audioresample"_s);

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
@@ -522,13 +522,13 @@ public:
             return;
 
         const auto& data = static_cast<const GStreamerAudioData&>(audioData);
+        GRefPtr<GstSample> sample = data.getSample();
         if (m_track->enabled()) {
-            GRefPtr<GstSample> sample = data.getSample();
             pushSample(sample, "Pushing audio sample from enabled track"_s);
             return;
         }
 
-        pushSilentSample();
+        pushSilentSample(GST_BUFFER_PTS(gst_sample_get_buffer(sample.get())));
     }
 
     Lock* eosLocker() { return &m_eosLock; }
@@ -741,24 +741,24 @@ private:
         pushSample(sample, "Pushing black video frame"_s);
     }
 
-    void pushSilentSample()
+    void pushSilentSample(GstClockTime timestamp)
     {
-        DisableMallocRestrictionsForCurrentThreadScope disableMallocRestrictions;
         if (!m_silentSampleCaps) {
+            DisableMallocRestrictionsForCurrentThreadScope disableMallocRestrictions;
             GstAudioInfo info;
             gst_audio_info_set_format(&info, GST_AUDIO_FORMAT_F32LE, 44100, 1, nullptr);
             m_silentSampleCaps = adoptGRef(gst_audio_info_to_caps(&info));
+
+            m_silentBuffer = adoptGRef(gst_buffer_new_and_alloc(128 * GST_AUDIO_INFO_BPF(&info)));
+            {
+                GstMappedBuffer map(m_silentBuffer.get(), GST_MAP_WRITE);
+                webkitGstAudioFormatFillSilence(info.finfo, map.data(), map.size());
+            }
+            gst_buffer_add_audio_meta(m_silentBuffer.get(), &info, 128, nullptr);
         }
 
-        auto buffer = adoptGRef(gst_buffer_new_and_alloc(512));
-        GST_BUFFER_DTS(buffer.get()) = GST_BUFFER_PTS(buffer.get()) = gst_element_get_current_running_time(m_parent);
-        GstAudioInfo info;
-        gst_audio_info_from_caps(&info, m_silentSampleCaps.get());
-        {
-            GstMappedBuffer map(buffer.get(), GST_MAP_WRITE);
-            webkitGstAudioFormatFillSilence(info.finfo, map.data(), map.size());
-        }
-        auto sample = adoptGRef(gst_sample_new(buffer.get(), m_silentSampleCaps.get(), nullptr, nullptr));
+        GST_BUFFER_DTS(m_silentBuffer.get()) = GST_BUFFER_PTS(m_silentBuffer.get()) = timestamp;
+        auto sample = adoptGRef(gst_sample_new(m_silentBuffer.get(), m_silentSampleCaps.get(), nullptr, nullptr));
         pushSample(sample, "Pushing audio silence from disabled track"_s);
     }
 
@@ -853,6 +853,7 @@ private:
     IntSize m_lastKnownSize;
     GRefPtr<GstCaps> m_blackFrameCaps;
     GRefPtr<GstCaps> m_silentSampleCaps;
+    GRefPtr<GstBuffer> m_silentBuffer;
     VideoFrame::Rotation m_videoRotation { VideoFrame::Rotation::None };
     bool m_videoMirrored { false };
     bool m_isEnded { false };


### PR DESCRIPTION
#### 51c09051e2bd7c7499bc8fe5be17d759bbd1b967
<pre>
[GTK][GStreamer] REGRESSION(<a href="https://commits.webkit.org/303623@main">303623@main</a>) webrtc/peer-connection-audio-mute2.html is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=303924">https://bugs.webkit.org/show_bug.cgi?id=303924</a>

Reviewed by NOBODY (OOPS!).

The test was failing to detect non-silent audio frames on receiving side because nothing was
received anymore after disabling the sending audio track, due to timestamp inconsistencies on the
audio source. The proposed solution is to reuse timestamps from the capturer in the silent buffers
produced by mediastreamsrc when the track has been disabled. This approach is already used for black
video frames timestamping.

Driving by, improve GStreamer logging in the AudioSourceProvider and make the mock audio source add
audio meta to the buffers it produces.

* LayoutTests/platform/gtk/TestExpectations:
* Source/WebCore/platform/audio/gstreamer/AudioSourceProviderGStreamer.cpp:
(WebCore::AudioSourceProviderGStreamer::copyGStreamerBuffersToAudioChannel):
(WebCore::AudioSourceProviderGStreamer::AudioSourceProviderGStreamer):
(WebCore::AudioSourceProviderGStreamer::initialize):
(WebCore::AudioSourceProviderGStreamer::~AudioSourceProviderGStreamer):
(WebCore::AudioSourceProviderGStreamer::provideInput):
(WebCore::AudioSourceProviderGStreamer::handleSample):
(WebCore::AudioSourceProviderGStreamer::setClient):
(WebCore::AudioSourceProviderGStreamer::handleNewDeinterleavePad):
(WebCore::AudioSourceProviderGStreamer::handleRemovedDeinterleavePad):
(WebCore::AudioSourceProviderGStreamer::deinterleavePadsConfigured):
(WebCore::copyGStreamerBuffersToAudioChannel): Deleted.
* Source/WebCore/platform/audio/gstreamer/AudioSourceProviderGStreamer.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp:
* Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.cpp:
(WebCore::MockRealtimeAudioSourceGStreamer::render):
(WebCore::MockRealtimeAudioSourceGStreamer::reconfigure):
* Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75cc2943f192d9ec6c0901d0d19e02e461ea7933

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137669 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10030 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48957 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145427 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90642 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139541 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10733 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10160 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105300 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/76865 "Exiting early after 60 failures. 21468 tests run. 60 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140614 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7978 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123381 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86156 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7605 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5330 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6010 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116994 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41541 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148196 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9713 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42091 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113688 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9730 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8187 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114029 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7534 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119620 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64391 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9761 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37669 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9492 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73326 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9701 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9553 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->