### PR TITLE
Support min(), max(), and clamp() math functions in sizes attribute

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-display-none-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-display-none-expected.txt
@@ -38,11 +38,11 @@ PASS <img srcset="/images/green-1x1.png?e33 50w, /images/green-16x16.png?e33 51w
 PASS <img srcset="/images/green-1x1.png?e34 50w, /images/green-16x16.png?e34 51w" sizes="\[,1px"> ref sizes="1px" (display:none)
 PASS <img srcset="/images/green-1x1.png?e35 50w, /images/green-16x16.png?e35 51w" sizes="1\p\x"> ref sizes="1px" (display:none)
 PASS <img srcset="/images/green-1x1.png?e36 50w, /images/green-16x16.png?e36 51w" sizes="calc(1px)"> ref sizes="1px" (display:none)
-FAIL <img srcset="/images/green-1x1.png?e36a 50w, /images/green-16x16.png?e36a 51w" sizes="min(1px, 100px)"> ref sizes="1px" (display:none) assert_equals: expected "http://web-platform.test:8800/images/green-1x1.png" but got "http://web-platform.test:8800/images/green-16x16.png"
-FAIL <img srcset="/images/green-1x1.png?e36b 50w, /images/green-16x16.png?e36b 51w" sizes="min(-100px, 1px)"> ref sizes="1px" (display:none) assert_equals: expected "http://web-platform.test:8800/images/green-1x1.png" but got "http://web-platform.test:8800/images/green-16x16.png"
+PASS <img srcset="/images/green-1x1.png?e36a 50w, /images/green-16x16.png?e36a 51w" sizes="min(1px, 100px)"> ref sizes="1px" (display:none)
+PASS <img srcset="/images/green-1x1.png?e36b 50w, /images/green-16x16.png?e36b 51w" sizes="min(-100px, 1px)"> ref sizes="1px" (display:none)
 PASS <img srcset="/images/green-1x1.png?e37 50w, /images/green-16x16.png?e37 51w" sizes="(min-width:0) calc(1px)"> ref sizes="1px" (display:none)
-FAIL <img srcset="/images/green-1x1.png?e37a 50w, /images/green-16x16.png?e37a 51w" sizes="(min-width:0) min(1px, 100px)"> ref sizes="1px" (display:none) assert_equals: expected "http://web-platform.test:8800/images/green-1x1.png" but got "http://web-platform.test:8800/images/green-16x16.png"
-FAIL <img srcset="/images/green-1x1.png?e37b 50w, /images/green-16x16.png?e37b 51w" sizes="(min-width:0) max(-100px, 1px)"> ref sizes="1px" (display:none) assert_equals: expected "http://web-platform.test:8800/images/green-1x1.png" but got "http://web-platform.test:8800/images/green-16x16.png"
+PASS <img srcset="/images/green-1x1.png?e37a 50w, /images/green-16x16.png?e37a 51w" sizes="(min-width:0) min(1px, 100px)"> ref sizes="1px" (display:none)
+PASS <img srcset="/images/green-1x1.png?e37b 50w, /images/green-16x16.png?e37b 51w" sizes="(min-width:0) max(-100px, 1px)"> ref sizes="1px" (display:none)
 PASS <img srcset="/images/green-1x1.png?e38 50w, /images/green-16x16.png?e38 51w" sizes="(min-width:calc(0)) 1px"> ref sizes="1px" (display:none)
 PASS <img srcset="/images/green-1x1.png?e39 50w, /images/green-16x16.png?e39 51w" sizes="(min-width:0) 1px, 100vw"> ref sizes="1px" (display:none)
 PASS <img srcset="/images/green-1x1.png?e40 50w, /images/green-16x16.png?e40 51w" sizes="(min-width:0) 1px, (min-width:0) 100vw, 100vw"> ref sizes="1px" (display:none)

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-quirks-mode-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-quirks-mode-expected.txt
@@ -38,11 +38,11 @@ PASS <img srcset="/images/green-1x1.png?e33 50w, /images/green-16x16.png?e33 51w
 PASS <img srcset="/images/green-1x1.png?e34 50w, /images/green-16x16.png?e34 51w" sizes="\[,1px"> ref sizes="1px" (quirks mode)
 PASS <img srcset="/images/green-1x1.png?e35 50w, /images/green-16x16.png?e35 51w" sizes="1\p\x"> ref sizes="1px" (quirks mode)
 PASS <img srcset="/images/green-1x1.png?e36 50w, /images/green-16x16.png?e36 51w" sizes="calc(1px)"> ref sizes="1px" (quirks mode)
-FAIL <img srcset="/images/green-1x1.png?e36a 50w, /images/green-16x16.png?e36a 51w" sizes="min(1px, 100px)"> ref sizes="1px" (quirks mode) assert_equals: expected "http://web-platform.test:8800/images/green-1x1.png" but got "http://web-platform.test:8800/images/green-16x16.png"
-FAIL <img srcset="/images/green-1x1.png?e36b 50w, /images/green-16x16.png?e36b 51w" sizes="min(-100px, 1px)"> ref sizes="1px" (quirks mode) assert_equals: expected "http://web-platform.test:8800/images/green-1x1.png" but got "http://web-platform.test:8800/images/green-16x16.png"
+PASS <img srcset="/images/green-1x1.png?e36a 50w, /images/green-16x16.png?e36a 51w" sizes="min(1px, 100px)"> ref sizes="1px" (quirks mode)
+PASS <img srcset="/images/green-1x1.png?e36b 50w, /images/green-16x16.png?e36b 51w" sizes="min(-100px, 1px)"> ref sizes="1px" (quirks mode)
 PASS <img srcset="/images/green-1x1.png?e37 50w, /images/green-16x16.png?e37 51w" sizes="(min-width:0) calc(1px)"> ref sizes="1px" (quirks mode)
-FAIL <img srcset="/images/green-1x1.png?e37a 50w, /images/green-16x16.png?e37a 51w" sizes="(min-width:0) min(1px, 100px)"> ref sizes="1px" (quirks mode) assert_equals: expected "http://web-platform.test:8800/images/green-1x1.png" but got "http://web-platform.test:8800/images/green-16x16.png"
-FAIL <img srcset="/images/green-1x1.png?e37b 50w, /images/green-16x16.png?e37b 51w" sizes="(min-width:0) max(-100px, 1px)"> ref sizes="1px" (quirks mode) assert_equals: expected "http://web-platform.test:8800/images/green-1x1.png" but got "http://web-platform.test:8800/images/green-16x16.png"
+PASS <img srcset="/images/green-1x1.png?e37a 50w, /images/green-16x16.png?e37a 51w" sizes="(min-width:0) min(1px, 100px)"> ref sizes="1px" (quirks mode)
+PASS <img srcset="/images/green-1x1.png?e37b 50w, /images/green-16x16.png?e37b 51w" sizes="(min-width:0) max(-100px, 1px)"> ref sizes="1px" (quirks mode)
 PASS <img srcset="/images/green-1x1.png?e38 50w, /images/green-16x16.png?e38 51w" sizes="(min-width:calc(0)) 1px"> ref sizes="1px" (quirks mode)
 PASS <img srcset="/images/green-1x1.png?e39 50w, /images/green-16x16.png?e39 51w" sizes="(min-width:0) 1px, 100vw"> ref sizes="1px" (quirks mode)
 PASS <img srcset="/images/green-1x1.png?e40 50w, /images/green-16x16.png?e40 51w" sizes="(min-width:0) 1px, (min-width:0) 100vw, 100vw"> ref sizes="1px" (quirks mode)

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-standards-mode-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-standards-mode-expected.txt
@@ -38,11 +38,11 @@ PASS <img srcset="/images/green-1x1.png?e33 50w, /images/green-16x16.png?e33 51w
 PASS <img srcset="/images/green-1x1.png?e34 50w, /images/green-16x16.png?e34 51w" sizes="\[,1px"> ref sizes="1px" (standards mode)
 PASS <img srcset="/images/green-1x1.png?e35 50w, /images/green-16x16.png?e35 51w" sizes="1\p\x"> ref sizes="1px" (standards mode)
 PASS <img srcset="/images/green-1x1.png?e36 50w, /images/green-16x16.png?e36 51w" sizes="calc(1px)"> ref sizes="1px" (standards mode)
-FAIL <img srcset="/images/green-1x1.png?e36a 50w, /images/green-16x16.png?e36a 51w" sizes="min(1px, 100px)"> ref sizes="1px" (standards mode) assert_equals: expected "http://web-platform.test:8800/images/green-1x1.png" but got "http://web-platform.test:8800/images/green-16x16.png"
-FAIL <img srcset="/images/green-1x1.png?e36b 50w, /images/green-16x16.png?e36b 51w" sizes="min(-100px, 1px)"> ref sizes="1px" (standards mode) assert_equals: expected "http://web-platform.test:8800/images/green-1x1.png" but got "http://web-platform.test:8800/images/green-16x16.png"
+PASS <img srcset="/images/green-1x1.png?e36a 50w, /images/green-16x16.png?e36a 51w" sizes="min(1px, 100px)"> ref sizes="1px" (standards mode)
+PASS <img srcset="/images/green-1x1.png?e36b 50w, /images/green-16x16.png?e36b 51w" sizes="min(-100px, 1px)"> ref sizes="1px" (standards mode)
 PASS <img srcset="/images/green-1x1.png?e37 50w, /images/green-16x16.png?e37 51w" sizes="(min-width:0) calc(1px)"> ref sizes="1px" (standards mode)
-FAIL <img srcset="/images/green-1x1.png?e37a 50w, /images/green-16x16.png?e37a 51w" sizes="(min-width:0) min(1px, 100px)"> ref sizes="1px" (standards mode) assert_equals: expected "http://web-platform.test:8800/images/green-1x1.png" but got "http://web-platform.test:8800/images/green-16x16.png"
-FAIL <img srcset="/images/green-1x1.png?e37b 50w, /images/green-16x16.png?e37b 51w" sizes="(min-width:0) max(-100px, 1px)"> ref sizes="1px" (standards mode) assert_equals: expected "http://web-platform.test:8800/images/green-1x1.png" but got "http://web-platform.test:8800/images/green-16x16.png"
+PASS <img srcset="/images/green-1x1.png?e37a 50w, /images/green-16x16.png?e37a 51w" sizes="(min-width:0) min(1px, 100px)"> ref sizes="1px" (standards mode)
+PASS <img srcset="/images/green-1x1.png?e37b 50w, /images/green-16x16.png?e37b 51w" sizes="(min-width:0) max(-100px, 1px)"> ref sizes="1px" (standards mode)
 PASS <img srcset="/images/green-1x1.png?e38 50w, /images/green-16x16.png?e38 51w" sizes="(min-width:calc(0)) 1px"> ref sizes="1px" (standards mode)
 PASS <img srcset="/images/green-1x1.png?e39 50w, /images/green-16x16.png?e39 51w" sizes="(min-width:0) 1px, 100vw"> ref sizes="1px" (standards mode)
 PASS <img srcset="/images/green-1x1.png?e40 50w, /images/green-16x16.png?e40 51w" sizes="(min-width:0) 1px, (min-width:0) 100vw, 100vw"> ref sizes="1px" (standards mode)

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-width-1000px-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-width-1000px-expected.txt
@@ -38,11 +38,11 @@ PASS <img srcset="/images/green-1x1.png?e33 50w, /images/green-16x16.png?e33 51w
 PASS <img srcset="/images/green-1x1.png?e34 50w, /images/green-16x16.png?e34 51w" sizes="\[,1px"> ref sizes="1px" (width:1000px)
 PASS <img srcset="/images/green-1x1.png?e35 50w, /images/green-16x16.png?e35 51w" sizes="1\p\x"> ref sizes="1px" (width:1000px)
 PASS <img srcset="/images/green-1x1.png?e36 50w, /images/green-16x16.png?e36 51w" sizes="calc(1px)"> ref sizes="1px" (width:1000px)
-FAIL <img srcset="/images/green-1x1.png?e36a 50w, /images/green-16x16.png?e36a 51w" sizes="min(1px, 100px)"> ref sizes="1px" (width:1000px) assert_equals: expected "http://web-platform.test:8800/images/green-1x1.png" but got "http://web-platform.test:8800/images/green-16x16.png"
-FAIL <img srcset="/images/green-1x1.png?e36b 50w, /images/green-16x16.png?e36b 51w" sizes="min(-100px, 1px)"> ref sizes="1px" (width:1000px) assert_equals: expected "http://web-platform.test:8800/images/green-1x1.png" but got "http://web-platform.test:8800/images/green-16x16.png"
+PASS <img srcset="/images/green-1x1.png?e36a 50w, /images/green-16x16.png?e36a 51w" sizes="min(1px, 100px)"> ref sizes="1px" (width:1000px)
+PASS <img srcset="/images/green-1x1.png?e36b 50w, /images/green-16x16.png?e36b 51w" sizes="min(-100px, 1px)"> ref sizes="1px" (width:1000px)
 PASS <img srcset="/images/green-1x1.png?e37 50w, /images/green-16x16.png?e37 51w" sizes="(min-width:0) calc(1px)"> ref sizes="1px" (width:1000px)
-FAIL <img srcset="/images/green-1x1.png?e37a 50w, /images/green-16x16.png?e37a 51w" sizes="(min-width:0) min(1px, 100px)"> ref sizes="1px" (width:1000px) assert_equals: expected "http://web-platform.test:8800/images/green-1x1.png" but got "http://web-platform.test:8800/images/green-16x16.png"
-FAIL <img srcset="/images/green-1x1.png?e37b 50w, /images/green-16x16.png?e37b 51w" sizes="(min-width:0) max(-100px, 1px)"> ref sizes="1px" (width:1000px) assert_equals: expected "http://web-platform.test:8800/images/green-1x1.png" but got "http://web-platform.test:8800/images/green-16x16.png"
+PASS <img srcset="/images/green-1x1.png?e37a 50w, /images/green-16x16.png?e37a 51w" sizes="(min-width:0) min(1px, 100px)"> ref sizes="1px" (width:1000px)
+PASS <img srcset="/images/green-1x1.png?e37b 50w, /images/green-16x16.png?e37b 51w" sizes="(min-width:0) max(-100px, 1px)"> ref sizes="1px" (width:1000px)
 PASS <img srcset="/images/green-1x1.png?e38 50w, /images/green-16x16.png?e38 51w" sizes="(min-width:calc(0)) 1px"> ref sizes="1px" (width:1000px)
 PASS <img srcset="/images/green-1x1.png?e39 50w, /images/green-16x16.png?e39 51w" sizes="(min-width:0) 1px, 100vw"> ref sizes="1px" (width:1000px)
 PASS <img srcset="/images/green-1x1.png?e40 50w, /images/green-16x16.png?e40 51w" sizes="(min-width:0) 1px, (min-width:0) 100vw, 100vw"> ref sizes="1px" (width:1000px)

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-display-none-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-display-none-expected.txt
@@ -38,11 +38,11 @@ PASS <img srcset="/images/green-1x1.png?e33 50w, /images/green-16x16.png?e33 51w
 PASS <img srcset="/images/green-1x1.png?e34 50w, /images/green-16x16.png?e34 51w" sizes="\[,1px"> ref sizes="1px" (display:none)
 PASS <img srcset="/images/green-1x1.png?e35 50w, /images/green-16x16.png?e35 51w" sizes="1\p\x"> ref sizes="1px" (display:none)
 PASS <img srcset="/images/green-1x1.png?e36 50w, /images/green-16x16.png?e36 51w" sizes="calc(1px)"> ref sizes="1px" (display:none)
-FAIL <img srcset="/images/green-1x1.png?e36a 50w, /images/green-16x16.png?e36a 51w" sizes="min(1px, 100px)"> ref sizes="1px" (display:none) assert_equals: expected "http://web-platform.test:8800/images/green-1x1.png" but got "http://web-platform.test:8800/images/green-16x16.png"
-FAIL <img srcset="/images/green-1x1.png?e36b 50w, /images/green-16x16.png?e36b 51w" sizes="min(-100px, 1px)"> ref sizes="1px" (display:none) assert_equals: expected "http://web-platform.test:8800/images/green-1x1.png" but got "http://web-platform.test:8800/images/green-16x16.png"
+PASS <img srcset="/images/green-1x1.png?e36a 50w, /images/green-16x16.png?e36a 51w" sizes="min(1px, 100px)"> ref sizes="1px" (display:none)
+PASS <img srcset="/images/green-1x1.png?e36b 50w, /images/green-16x16.png?e36b 51w" sizes="min(-100px, 1px)"> ref sizes="1px" (display:none)
 PASS <img srcset="/images/green-1x1.png?e37 50w, /images/green-16x16.png?e37 51w" sizes="(min-width:0) calc(1px)"> ref sizes="1px" (display:none)
-FAIL <img srcset="/images/green-1x1.png?e37a 50w, /images/green-16x16.png?e37a 51w" sizes="(min-width:0) min(1px, 100px)"> ref sizes="1px" (display:none) assert_equals: expected "http://web-platform.test:8800/images/green-1x1.png" but got "http://web-platform.test:8800/images/green-16x16.png"
-FAIL <img srcset="/images/green-1x1.png?e37b 50w, /images/green-16x16.png?e37b 51w" sizes="(min-width:0) max(-100px, 1px)"> ref sizes="1px" (display:none) assert_equals: expected "http://web-platform.test:8800/images/green-1x1.png" but got "http://web-platform.test:8800/images/green-16x16.png"
+PASS <img srcset="/images/green-1x1.png?e37a 50w, /images/green-16x16.png?e37a 51w" sizes="(min-width:0) min(1px, 100px)"> ref sizes="1px" (display:none)
+PASS <img srcset="/images/green-1x1.png?e37b 50w, /images/green-16x16.png?e37b 51w" sizes="(min-width:0) max(-100px, 1px)"> ref sizes="1px" (display:none)
 PASS <img srcset="/images/green-1x1.png?e38 50w, /images/green-16x16.png?e38 51w" sizes="(min-width:calc(0)) 1px"> ref sizes="1px" (display:none)
 PASS <img srcset="/images/green-1x1.png?e39 50w, /images/green-16x16.png?e39 51w" sizes="(min-width:0) 1px, 100vw"> ref sizes="1px" (display:none)
 PASS <img srcset="/images/green-1x1.png?e40 50w, /images/green-16x16.png?e40 51w" sizes="(min-width:0) 1px, (min-width:0) 100vw, 100vw"> ref sizes="1px" (display:none)

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-quirks-mode-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-quirks-mode-expected.txt
@@ -38,11 +38,11 @@ PASS <img srcset="/images/green-1x1.png?e33 50w, /images/green-16x16.png?e33 51w
 PASS <img srcset="/images/green-1x1.png?e34 50w, /images/green-16x16.png?e34 51w" sizes="\[,1px"> ref sizes="1px" (quirks mode)
 PASS <img srcset="/images/green-1x1.png?e35 50w, /images/green-16x16.png?e35 51w" sizes="1\p\x"> ref sizes="1px" (quirks mode)
 PASS <img srcset="/images/green-1x1.png?e36 50w, /images/green-16x16.png?e36 51w" sizes="calc(1px)"> ref sizes="1px" (quirks mode)
-FAIL <img srcset="/images/green-1x1.png?e36a 50w, /images/green-16x16.png?e36a 51w" sizes="min(1px, 100px)"> ref sizes="1px" (quirks mode) assert_equals: expected "http://web-platform.test:8800/images/green-1x1.png" but got "http://web-platform.test:8800/images/green-16x16.png"
-FAIL <img srcset="/images/green-1x1.png?e36b 50w, /images/green-16x16.png?e36b 51w" sizes="min(-100px, 1px)"> ref sizes="1px" (quirks mode) assert_equals: expected "http://web-platform.test:8800/images/green-1x1.png" but got "http://web-platform.test:8800/images/green-16x16.png"
+PASS <img srcset="/images/green-1x1.png?e36a 50w, /images/green-16x16.png?e36a 51w" sizes="min(1px, 100px)"> ref sizes="1px" (quirks mode)
+PASS <img srcset="/images/green-1x1.png?e36b 50w, /images/green-16x16.png?e36b 51w" sizes="min(-100px, 1px)"> ref sizes="1px" (quirks mode)
 PASS <img srcset="/images/green-1x1.png?e37 50w, /images/green-16x16.png?e37 51w" sizes="(min-width:0) calc(1px)"> ref sizes="1px" (quirks mode)
-FAIL <img srcset="/images/green-1x1.png?e37a 50w, /images/green-16x16.png?e37a 51w" sizes="(min-width:0) min(1px, 100px)"> ref sizes="1px" (quirks mode) assert_equals: expected "http://web-platform.test:8800/images/green-1x1.png" but got "http://web-platform.test:8800/images/green-16x16.png"
-FAIL <img srcset="/images/green-1x1.png?e37b 50w, /images/green-16x16.png?e37b 51w" sizes="(min-width:0) max(-100px, 1px)"> ref sizes="1px" (quirks mode) assert_equals: expected "http://web-platform.test:8800/images/green-1x1.png" but got "http://web-platform.test:8800/images/green-16x16.png"
+PASS <img srcset="/images/green-1x1.png?e37a 50w, /images/green-16x16.png?e37a 51w" sizes="(min-width:0) min(1px, 100px)"> ref sizes="1px" (quirks mode)
+PASS <img srcset="/images/green-1x1.png?e37b 50w, /images/green-16x16.png?e37b 51w" sizes="(min-width:0) max(-100px, 1px)"> ref sizes="1px" (quirks mode)
 PASS <img srcset="/images/green-1x1.png?e38 50w, /images/green-16x16.png?e38 51w" sizes="(min-width:calc(0)) 1px"> ref sizes="1px" (quirks mode)
 PASS <img srcset="/images/green-1x1.png?e39 50w, /images/green-16x16.png?e39 51w" sizes="(min-width:0) 1px, 100vw"> ref sizes="1px" (quirks mode)
 PASS <img srcset="/images/green-1x1.png?e40 50w, /images/green-16x16.png?e40 51w" sizes="(min-width:0) 1px, (min-width:0) 100vw, 100vw"> ref sizes="1px" (quirks mode)

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-standards-mode-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-standards-mode-expected.txt
@@ -38,11 +38,11 @@ PASS <img srcset="/images/green-1x1.png?e33 50w, /images/green-16x16.png?e33 51w
 PASS <img srcset="/images/green-1x1.png?e34 50w, /images/green-16x16.png?e34 51w" sizes="\[,1px"> ref sizes="1px" (standards mode)
 PASS <img srcset="/images/green-1x1.png?e35 50w, /images/green-16x16.png?e35 51w" sizes="1\p\x"> ref sizes="1px" (standards mode)
 PASS <img srcset="/images/green-1x1.png?e36 50w, /images/green-16x16.png?e36 51w" sizes="calc(1px)"> ref sizes="1px" (standards mode)
-FAIL <img srcset="/images/green-1x1.png?e36a 50w, /images/green-16x16.png?e36a 51w" sizes="min(1px, 100px)"> ref sizes="1px" (standards mode) assert_equals: expected "http://web-platform.test:8800/images/green-1x1.png" but got "http://web-platform.test:8800/images/green-16x16.png"
-FAIL <img srcset="/images/green-1x1.png?e36b 50w, /images/green-16x16.png?e36b 51w" sizes="min(-100px, 1px)"> ref sizes="1px" (standards mode) assert_equals: expected "http://web-platform.test:8800/images/green-1x1.png" but got "http://web-platform.test:8800/images/green-16x16.png"
+PASS <img srcset="/images/green-1x1.png?e36a 50w, /images/green-16x16.png?e36a 51w" sizes="min(1px, 100px)"> ref sizes="1px" (standards mode)
+PASS <img srcset="/images/green-1x1.png?e36b 50w, /images/green-16x16.png?e36b 51w" sizes="min(-100px, 1px)"> ref sizes="1px" (standards mode)
 PASS <img srcset="/images/green-1x1.png?e37 50w, /images/green-16x16.png?e37 51w" sizes="(min-width:0) calc(1px)"> ref sizes="1px" (standards mode)
-FAIL <img srcset="/images/green-1x1.png?e37a 50w, /images/green-16x16.png?e37a 51w" sizes="(min-width:0) min(1px, 100px)"> ref sizes="1px" (standards mode) assert_equals: expected "http://web-platform.test:8800/images/green-1x1.png" but got "http://web-platform.test:8800/images/green-16x16.png"
-FAIL <img srcset="/images/green-1x1.png?e37b 50w, /images/green-16x16.png?e37b 51w" sizes="(min-width:0) max(-100px, 1px)"> ref sizes="1px" (standards mode) assert_equals: expected "http://web-platform.test:8800/images/green-1x1.png" but got "http://web-platform.test:8800/images/green-16x16.png"
+PASS <img srcset="/images/green-1x1.png?e37a 50w, /images/green-16x16.png?e37a 51w" sizes="(min-width:0) min(1px, 100px)"> ref sizes="1px" (standards mode)
+PASS <img srcset="/images/green-1x1.png?e37b 50w, /images/green-16x16.png?e37b 51w" sizes="(min-width:0) max(-100px, 1px)"> ref sizes="1px" (standards mode)
 PASS <img srcset="/images/green-1x1.png?e38 50w, /images/green-16x16.png?e38 51w" sizes="(min-width:calc(0)) 1px"> ref sizes="1px" (standards mode)
 PASS <img srcset="/images/green-1x1.png?e39 50w, /images/green-16x16.png?e39 51w" sizes="(min-width:0) 1px, 100vw"> ref sizes="1px" (standards mode)
 PASS <img srcset="/images/green-1x1.png?e40 50w, /images/green-16x16.png?e40 51w" sizes="(min-width:0) 1px, (min-width:0) 100vw, 100vw"> ref sizes="1px" (standards mode)

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-width-1000px-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-width-1000px-expected.txt
@@ -38,11 +38,11 @@ PASS <img srcset="/images/green-1x1.png?e33 50w, /images/green-16x16.png?e33 51w
 PASS <img srcset="/images/green-1x1.png?e34 50w, /images/green-16x16.png?e34 51w" sizes="\[,1px"> ref sizes="1px" (width:1000px)
 PASS <img srcset="/images/green-1x1.png?e35 50w, /images/green-16x16.png?e35 51w" sizes="1\p\x"> ref sizes="1px" (width:1000px)
 PASS <img srcset="/images/green-1x1.png?e36 50w, /images/green-16x16.png?e36 51w" sizes="calc(1px)"> ref sizes="1px" (width:1000px)
-FAIL <img srcset="/images/green-1x1.png?e36a 50w, /images/green-16x16.png?e36a 51w" sizes="min(1px, 100px)"> ref sizes="1px" (width:1000px) assert_equals: expected "http://web-platform.test:8800/images/green-1x1.png" but got "http://web-platform.test:8800/images/green-16x16.png"
-FAIL <img srcset="/images/green-1x1.png?e36b 50w, /images/green-16x16.png?e36b 51w" sizes="min(-100px, 1px)"> ref sizes="1px" (width:1000px) assert_equals: expected "http://web-platform.test:8800/images/green-1x1.png" but got "http://web-platform.test:8800/images/green-16x16.png"
+PASS <img srcset="/images/green-1x1.png?e36a 50w, /images/green-16x16.png?e36a 51w" sizes="min(1px, 100px)"> ref sizes="1px" (width:1000px)
+PASS <img srcset="/images/green-1x1.png?e36b 50w, /images/green-16x16.png?e36b 51w" sizes="min(-100px, 1px)"> ref sizes="1px" (width:1000px)
 PASS <img srcset="/images/green-1x1.png?e37 50w, /images/green-16x16.png?e37 51w" sizes="(min-width:0) calc(1px)"> ref sizes="1px" (width:1000px)
-FAIL <img srcset="/images/green-1x1.png?e37a 50w, /images/green-16x16.png?e37a 51w" sizes="(min-width:0) min(1px, 100px)"> ref sizes="1px" (width:1000px) assert_equals: expected "http://web-platform.test:8800/images/green-1x1.png" but got "http://web-platform.test:8800/images/green-16x16.png"
-FAIL <img srcset="/images/green-1x1.png?e37b 50w, /images/green-16x16.png?e37b 51w" sizes="(min-width:0) max(-100px, 1px)"> ref sizes="1px" (width:1000px) assert_equals: expected "http://web-platform.test:8800/images/green-1x1.png" but got "http://web-platform.test:8800/images/green-16x16.png"
+PASS <img srcset="/images/green-1x1.png?e37a 50w, /images/green-16x16.png?e37a 51w" sizes="(min-width:0) min(1px, 100px)"> ref sizes="1px" (width:1000px)
+PASS <img srcset="/images/green-1x1.png?e37b 50w, /images/green-16x16.png?e37b 51w" sizes="(min-width:0) max(-100px, 1px)"> ref sizes="1px" (width:1000px)
 PASS <img srcset="/images/green-1x1.png?e38 50w, /images/green-16x16.png?e38 51w" sizes="(min-width:calc(0)) 1px"> ref sizes="1px" (width:1000px)
 PASS <img srcset="/images/green-1x1.png?e39 50w, /images/green-16x16.png?e39 51w" sizes="(min-width:0) 1px, 100vw"> ref sizes="1px" (width:1000px)
 PASS <img srcset="/images/green-1x1.png?e40 50w, /images/green-16x16.png?e40 51w" sizes="(min-width:0) 1px, (min-width:0) 100vw, 100vw"> ref sizes="1px" (width:1000px)

--- a/Source/WebCore/css/parser/SizesCalcParser.h
+++ b/Source/WebCore/css/parser/SizesCalcParser.h
@@ -69,6 +69,8 @@ private:
     void appendNumber(const CSSParserToken&);
     bool appendLength(const CSSParserToken&);
     bool handleOperator(Vector<CSSParserToken>& stack, const CSSParserToken&);
+    bool handleRightParenthesis(Vector<CSSParserToken>& stack);
+    bool handleComma(Vector<CSSParserToken>& stack, const CSSParserToken&);
     void appendOperator(const CSSParserToken&);
 
     Vector<SizesCalcValue> m_valueList;


### PR DESCRIPTION
#### 0850a6e3f28536d1e54e16c3f8fa95c4254176cc
<pre>
Support min(), max(), and clamp() math functions in sizes attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=304915">https://bugs.webkit.org/show_bug.cgi?id=304915</a>
<a href="https://rdar.apple.com/167526292">rdar://167526292</a>

Reviewed by Antti Koivisto.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/fe60ab1062ae0a308620ac59009c3669b6259c6a">https://chromium.googlesource.com/chromium/src.git/+/fe60ab1062ae0a308620ac59009c3669b6259c6a</a> &amp;
<a href="https://chromium.googlesource.com/chromium/src.git/+/eafadb8499839e4afba29dd2cd15ae33a7e85fed">https://chromium.googlesource.com/chromium/src.git/+/eafadb8499839e4afba29dd2cd15ae33a7e85fed</a>

The CSS Values and Units Level 4 specification extends mathematical
functions beyond calc() to include min(), max(), and clamp() [1].
The HTML Standard references these functions in the context of the
sizes attribute on &lt;img&gt; elements [2].

&quot;A &lt;source-size-value&gt; that is a &lt;length&gt; must not be negative, and must
not use CSS functions other than the math functions.&quot;

When the &apos;sizes&apos; attribute involves math functions, it uses a custom
code path to resolve calculations by augmenting the custom parser to handle
min(), max(), and clamp() in addition to the existing calc() support.

For clamp(), the function clamp(MIN, VAL, MAX) is converted to
max(MIN, min(VAL, MAX)) following the CSS specification [3].

[1] <a href="https://drafts.csswg.org/css-values-4/#math-function">https://drafts.csswg.org/css-values-4/#math-function</a>
[2] <a href="https://html.spec.whatwg.org/#sizes-attributes">https://html.spec.whatwg.org/#sizes-attributes</a>
[3] <a href="https://www.w3.org/TR/css-values-4/#calc-notation">https://www.w3.org/TR/css-values-4/#calc-notation</a>

* Source/WebCore/css/parser/SizesCalcParser.cpp:
(WebCore::SizesCalcParser::handleRightParenthesis):
(WebCore::SizesCalcParser::handleComma):
(WebCore::SizesCalcParser::calcToReversePolishNotation):
(WebCore::operateOnStack):
(WebCore::SizesCalcParser::calculate):
* Source/WebCore/css/parser/SizesCalcParser.h:

&gt; Progressions:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-display-none-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-quirks-mode-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-standards-mode-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-width-1000px-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-display-none-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-quirks-mode-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-standards-mode-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-width-1000px-expected.txt:

Canonical link: <a href="https://commits.webkit.org/305226@main">https://commits.webkit.org/305226@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0adf4e9a93a33c7749b6152a76da52de87a42f97

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137506 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9867 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48793 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145261 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90479 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/38409bdc-991a-42a7-85d4-62c161b66fe6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139378 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10570 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9993 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105157 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f4e94ee2-68ef-49db-aa57-dd87d9bb9af2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140451 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7843 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123240 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86011 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8cd0c829-d86f-41a1-a6e1-e34e33082953) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7479 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5197 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5845 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116849 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41394 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148027 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9549 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41950 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113539 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9567 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8050 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113877 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28992 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7395 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119479 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64189 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9598 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37532 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 7 flakes") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9329 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73163 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9538 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9390 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->