### PR TITLE
[JSC] Implement ccmp / ccmn chain

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
+++ b/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
@@ -1557,6 +1557,45 @@ arm64: CompareDoubleWithZero U:G:32, U:F:64, ZD:G:32
 arm64: CompareFloatWithZero U:G:32, U:F:32, ZD:G:32
     DoubleCond, Tmp, Tmp
 
+# Compare instructions that only set flags (for use with ccmp chains)
+# These perform comparison and set NZCV flags without storing result to register
+# IMPORTANT: /effects prevents Air from reordering or inserting flag-clobbering instructions.
+
+arm64: CompareOnFlags32 U:G:32, U:G:32 /effects
+    Tmp, Tmp
+    Tmp, Imm
+
+arm64: CompareOnFlags64 U:G:64, U:G:64 /effects
+    Tmp, Tmp
+    Tmp, Imm
+
+arm64: CompareOnFlagsFloat U:F:32, U:F:32 /effects
+    Tmp, Tmp
+
+arm64: CompareOnFlagsDouble U:F:64, U:F:64 /effects
+    Tmp, Tmp
+
+# Conditional compare instructions (ARM64 ccmp/fccmp).
+# These instructions conditionally update the NZCV flags based on a condition.
+# Operands: LHS, RHS, NZCV default flags (4-bit immediate), condition code
+# If the condition is true, performs the comparison and sets flags normally.
+# If the condition is false, sets flags to the NZCV default value.
+# /effects prevents Air from reordering or inserting flag-clobbering instructions.
+
+arm64: CompareConditionallyOnFlags32 U:G:32, U:G:32, U:G:8, U:G:8 /effects
+    Tmp, Tmp, Imm, RelCond
+    Tmp, Imm, Imm, RelCond
+
+arm64: CompareConditionallyOnFlags64 U:G:64, U:G:64, U:G:8, U:G:8 /effects
+    Tmp, Tmp, Imm, RelCond
+    Tmp, Imm, Imm, RelCond
+
+arm64: CompareConditionallyOnFlagsFloat U:F:32, U:F:32, U:G:8, U:G:8 /effects
+    Tmp, Tmp, Imm, RelCond
+
+arm64: CompareConditionallyOnFlagsDouble U:F:64, U:F:64, U:G:8, U:G:8 /effects
+    Tmp, Tmp, Imm, RelCond
+
 # Note that branches have some logic in AirOptimizeBlockOrder.cpp. If you add new branches, please make sure
 # you opt them into the block order optimizations.
 
@@ -1622,6 +1661,11 @@ arm64: BranchDoubleWithZero U:G:32, U:F:64 /branch
 
 arm64: BranchFloatWithZero U:G:32, U:F:32 /branch
     DoubleCond, Tmp
+
+# Branch on already-set condition flags (for use after ccmp)
+# /effects ensures this stays adjacent to the preceding ccmp instruction
+arm64: BranchOnFlags U:G:32 /branch /effects
+    RelCond
 
 BranchAdd32 U:G:32, U:G:32, U:G:32, ZD:G:32 /branch
     ResCond, Tmp, Tmp, Tmp

--- a/Source/JavaScriptCore/b3/air/AirOptimizeBlockOrder.cpp
+++ b/Source/JavaScriptCore/b3/air/AirOptimizeBlockOrder.cpp
@@ -416,6 +416,7 @@ void optimizeBlockOrder(Code& code)
         // certainly won't cause any correctness issues.
         
         switch (branch.kind.opcode) {
+        case BranchOnFlags:
         case Branch8:
         case Branch32:
         case Branch64:
@@ -441,7 +442,7 @@ void optimizeBlockOrder(Code& code)
                 branch.args[0] = branch.args[0].inverted();
             }
             break;
-            
+
         default:
             break;
         }

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -1407,4 +1407,33 @@ void testMemoryFillConstant();
 
 void testLoadImmutable();
 
+// ARM64 conditional compare (ccmp) tests
+void testCCmpAnd32(int32_t, int32_t, int32_t, int32_t);
+void testCCmpAnd64(int64_t, int64_t, int64_t, int64_t);
+void testCCmpOr32(int32_t, int32_t, int32_t, int32_t);
+void testCCmpOr64(int64_t, int64_t, int64_t, int64_t);
+// 3-comparison chain tests
+void testCCmpAndAnd32(int32_t, int32_t, int32_t, int32_t, int32_t, int32_t);
+void testCCmpOrOr32(int32_t, int32_t, int32_t, int32_t, int32_t, int32_t);
+void testCCmpAndOr32(int32_t, int32_t, int32_t, int32_t, int32_t, int32_t);
+// Tests for ccmn (negative immediates) and large immediates
+void testCCmnAnd32WithNegativeImm(int32_t, int32_t);
+void testCCmnAnd64WithNegativeImm(int64_t, int64_t);
+void testCCmpWithLargePositiveImm(int32_t, int32_t);
+void testCCmpWithLargeNegativeImm(int32_t, int32_t);
+// Tests for ccmp optimizations
+void testCCmpSmartOperandOrdering32(int32_t, int32_t);
+void testCCmpSmartOperandOrdering64(int64_t, int64_t);
+void testCCmpOperandCommutation32(int32_t, int32_t);
+void testCCmpOperandCommutation64(int64_t, int64_t);
+void testCCmpCombinedOptimizations(int32_t, int32_t);
+void testCCmpZeroRegisterOptimization32(int32_t, int32_t);
+void testCCmpZeroRegisterOptimization64(int64_t, int64_t);
+void testCCmpMixedAndOr32(int32_t, int32_t, int32_t);
+void testCCmpMixedOrAnd32(int32_t, int32_t, int32_t);
+void testCCmpNegatedAnd32(int32_t, int32_t);
+void testCCmpNegatedOr32(int32_t, int32_t);
+void testCCmpMixedWidth32And64(int32_t, int64_t, int32_t);
+void testCCmpMixedWidth64And32(int64_t, int32_t);
+
 #endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/testb3_1.cpp
+++ b/Source/JavaScriptCore/b3/testb3_1.cpp
@@ -888,6 +888,134 @@ void run(const TestConfig* config)
 
     RUN(testLoadImmutable());
 
+    // ARM64 conditional compare (ccmp) tests
+    RUN(testCCmpAnd32(1, 1, 2, 2));  // both true
+    RUN(testCCmpAnd32(1, 2, 2, 2));  // first false
+    RUN(testCCmpAnd32(1, 1, 2, 3));  // second false
+    RUN(testCCmpAnd32(1, 2, 2, 3));  // both false
+
+    RUN(testCCmpAnd64(1, 1, 2, 2));  // both true
+    RUN(testCCmpAnd64(1, 2, 2, 2));  // first false
+    RUN(testCCmpAnd64(1, 1, 2, 3));  // second false
+    RUN(testCCmpAnd64(1, 2, 2, 3));  // both false
+
+    RUN(testCCmpOr32(1, 1, 2, 2));   // both true
+    RUN(testCCmpOr32(1, 1, 2, 3));   // first true
+    RUN(testCCmpOr32(1, 2, 2, 2));   // second true
+    RUN(testCCmpOr32(1, 2, 2, 3));   // both false
+
+    RUN(testCCmpOr64(1, 1, 2, 2));   // both true
+    RUN(testCCmpOr64(1, 1, 2, 3));   // first true
+    RUN(testCCmpOr64(1, 2, 2, 2));   // second true
+    RUN(testCCmpOr64(1, 2, 2, 3));   // both false
+
+    // 3-comparison chain tests
+    RUN(testCCmpAndAnd32(1, 1, 2, 2, 3, 3));  // all true
+    RUN(testCCmpAndAnd32(1, 1, 2, 2, 3, 4));  // first two true, last false
+    RUN(testCCmpAndAnd32(1, 1, 2, 3, 3, 3));  // first true, second false
+    RUN(testCCmpAndAnd32(1, 2, 2, 2, 3, 3));  // first false
+    RUN(testCCmpAndAnd32(1, 2, 2, 3, 3, 4));  // all false
+
+    RUN(testCCmpOrOr32(1, 1, 2, 2, 3, 3));   // all true
+    RUN(testCCmpOrOr32(1, 1, 2, 3, 3, 4));   // first true
+    RUN(testCCmpOrOr32(1, 2, 2, 2, 3, 4));   // second true
+    RUN(testCCmpOrOr32(1, 2, 2, 3, 3, 3));   // third true
+    RUN(testCCmpOrOr32(1, 2, 2, 3, 3, 4));   // all false
+
+    RUN(testCCmpAndOr32(1, 1, 2, 2, 3, 4));  // (true && true) || false = true
+    RUN(testCCmpAndOr32(1, 1, 2, 3, 3, 3));  // (true && false) || true = true
+    RUN(testCCmpAndOr32(1, 2, 2, 2, 3, 3));  // (false && true) || true = true
+    RUN(testCCmpAndOr32(1, 2, 2, 3, 3, 4));  // (false && false) || false = false
+    RUN(testCCmpAndOr32(1, 1, 2, 2, 3, 3));  // (true && true) || true = true
+
+    // Tests for ccmn (negative immediates) and large immediates
+    RUN(testCCmnAnd32WithNegativeImm(15, -5));  // both true
+    RUN(testCCmnAnd32WithNegativeImm(5, -5));   // first false
+    RUN(testCCmnAnd32WithNegativeImm(15, 0));   // second false
+    RUN(testCCmnAnd32WithNegativeImm(5, 0));    // both false
+
+    RUN(testCCmnAnd64WithNegativeImm(15, -31)); // both true
+    RUN(testCCmnAnd64WithNegativeImm(5, -31));  // first false
+    RUN(testCCmnAnd64WithNegativeImm(15, 0));   // second false
+    RUN(testCCmnAnd64WithNegativeImm(5, 0));    // both false
+
+    RUN(testCCmpWithLargePositiveImm(15, 100)); // both true
+    RUN(testCCmpWithLargePositiveImm(5, 100));  // first false
+    RUN(testCCmpWithLargePositiveImm(15, 0));   // second false
+    RUN(testCCmpWithLargePositiveImm(5, 0));    // both false
+
+    RUN(testCCmpWithLargeNegativeImm(15, -100)); // both true
+    RUN(testCCmpWithLargeNegativeImm(5, -100));  // first false
+    RUN(testCCmpWithLargeNegativeImm(15, 0));    // second false
+    RUN(testCCmpWithLargeNegativeImm(5, 0));     // both false
+
+    // Tests for ccmp optimizations
+    RUN(testCCmpSmartOperandOrdering32(5, 1000));    // both true
+    RUN(testCCmpSmartOperandOrdering32(5, 999));     // first true, second false
+    RUN(testCCmpSmartOperandOrdering32(4, 1000));    // first false, second true
+    RUN(testCCmpSmartOperandOrdering32(4, 999));     // both false
+
+    RUN(testCCmpSmartOperandOrdering64(10, 5000));   // both true
+    RUN(testCCmpSmartOperandOrdering64(10, 4999));   // first true, second false
+    RUN(testCCmpSmartOperandOrdering64(9, 5000));    // first false, second true
+    RUN(testCCmpSmartOperandOrdering64(9, 4999));    // both false
+
+    RUN(testCCmpOperandCommutation32(15, 101));      // both true
+    RUN(testCCmpOperandCommutation32(15, 100));      // first true, second false
+    RUN(testCCmpOperandCommutation32(14, 101));      // first false, second true
+    RUN(testCCmpOperandCommutation32(14, 100));      // both false
+
+    RUN(testCCmpOperandCommutation64(49, 20));       // both true
+    RUN(testCCmpOperandCommutation64(49, 21));       // first true, second false
+    RUN(testCCmpOperandCommutation64(50, 20));       // first false, second true
+    RUN(testCCmpOperandCommutation64(50, 21));       // both false
+
+    RUN(testCCmpCombinedOptimizations(10, 2000));    // both true
+    RUN(testCCmpCombinedOptimizations(10, 1999));    // first true, second false
+    RUN(testCCmpCombinedOptimizations(9, 2000));     // first false, second true
+    RUN(testCCmpCombinedOptimizations(9, 1999));     // both false
+
+    RUN(testCCmpZeroRegisterOptimization32(0, 6));   // both true
+    RUN(testCCmpZeroRegisterOptimization32(0, 5));   // first true, second false
+    RUN(testCCmpZeroRegisterOptimization32(1, 6));   // first false, second true
+    RUN(testCCmpZeroRegisterOptimization32(1, 5));   // both false
+
+    RUN(testCCmpZeroRegisterOptimization64(0, 99));  // both true
+    RUN(testCCmpZeroRegisterOptimization64(0, 100)); // first true, second false
+    RUN(testCCmpZeroRegisterOptimization64(1, 99));  // first false, second true
+    RUN(testCCmpZeroRegisterOptimization64(1, 100)); // both false
+
+    // Mixed AND/OR tests - now supported with tree canonicalization
+    RUN(testCCmpMixedAndOr32(5, 5, 5));              // AND true, OR false -> true
+    RUN(testCCmpMixedAndOr32(101, 5, 5));            // AND false, OR true -> true
+    RUN(testCCmpMixedAndOr32(5, 6, 5));              // AND false, OR false -> false
+    RUN(testCCmpMixedAndOr32(50, 50, 50));           // AND true, OR false -> true
+
+    RUN(testCCmpMixedOrAnd32(-1, 10, 10));           // OR true, AND false -> true
+    RUN(testCCmpMixedOrAnd32(0, 60, 60));            // OR false, AND true -> true
+    RUN(testCCmpMixedOrAnd32(0, 10, 20));            // OR false, AND false -> false
+    RUN(testCCmpMixedOrAnd32(-5, 40, 40));           // OR true, AND false -> true
+
+    // Negation tests - V8's (chain) == 0 optimization
+    RUN(testCCmpNegatedAnd32(15, 20));               // !(true && true) = false
+    RUN(testCCmpNegatedAnd32(15, 10));               // !(true && false) = true
+    RUN(testCCmpNegatedAnd32(5, 20));                // !(false && true) = true
+    RUN(testCCmpNegatedAnd32(5, 10));                // !(false && false) = true
+
+    RUN(testCCmpNegatedOr32(3, 50));                 // !(true || false) = false
+    RUN(testCCmpNegatedOr32(3, 100));                // !(true || true) = false
+    RUN(testCCmpNegatedOr32(10, 100));               // !(false || true) = false
+    RUN(testCCmpNegatedOr32(10, 50));                // !(false || false) = true
+
+    // Mixed-width compare chain tests (per-ccmp width handling)
+    RUN(testCCmpMixedWidth32And64(5, 1000, 10));    // all match
+    RUN(testCCmpMixedWidth32And64(5, 1000, 9));     // last doesn't match
+    RUN(testCCmpMixedWidth32And64(5, 999, 10));     // middle doesn't match
+    RUN(testCCmpMixedWidth32And64(4, 1000, 10));    // first doesn't match
+    RUN(testCCmpMixedWidth64And32(5000, 10));       // both match
+    RUN(testCCmpMixedWidth64And32(5000, 9));        // second doesn't match
+    RUN(testCCmpMixedWidth64And32(4999, 10));       // first doesn't match
+
     RUN_UNARY(testSShrCompare32, int32OperandsMore());
     RUN_UNARY(testSShrCompare64, int64OperandsMore());
 


### PR DESCRIPTION
#### 2cd6a734ed6c4f1201d1adf4aedd04f6d03f96ea
<pre>
[JSC] Implement ccmp / ccmn chain
<a href="https://bugs.webkit.org/show_bug.cgi?id=304917">https://bugs.webkit.org/show_bug.cgi?id=304917</a>
<a href="https://rdar.apple.com/167529315">rdar://167529315</a>

Reviewed by Marcus Plutowski.

This patch implements chain of compare with ARM64 ccmp / ccmn.
Let&apos;s say,

    if (x0 == 0 &amp;&amp; x1 == 1) {
        // target-block
    }

Then this will be compiled via LLVM into wasm. And this will create
BitAnd(Equal(a, 0), Equal(b, 1)).
Then ARM64 ccmp can handle it as follows.

    cmp x0, #0
    ccmp x1, #1, #0, eq  // cmp x1, #1 when flag is eq and override, otherwise set #0 to flag
    b.eq target-block

This reduces small weird basic blocks and reduces prediction miss, and
reduces code size.

We introduce CompareOnFlags, CompareConditionallyOnFlags, and
BranchOnFlags Air opcodes. All of them are annotated as /effects since
this relies on the current flag, and they are not producing register
output while it has side effects. This ensures that we are not removing
these instructions, and we are not hoisting etc. randomly.

We introduced V8&apos;s compare chain detection mechanism and using it for
chained cmp code generation.

Tests: Source/JavaScriptCore/b3/testb3_1.cpp
       Source/JavaScriptCore/b3/testb3_8.cpp

* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::compareOnFlags32):
(JSC::MacroAssemblerARM64::compareOnFlags64):
(JSC::MacroAssemblerARM64::compareOnFlagsFloat):
(JSC::MacroAssemblerARM64::compareOnFlagsDouble):
(JSC::MacroAssemblerARM64::compareConditionallyOnFlags32):
(JSC::MacroAssemblerARM64::compareConditionallyOnFlags64):
(JSC::MacroAssemblerARM64::compareConditionallyOnFlagsFloat):
(JSC::MacroAssemblerARM64::compareConditionallyOnFlagsDouble):
(JSC::MacroAssemblerARM64::branchOnFlags):
* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/air/AirOpcode.opcodes:
* Source/JavaScriptCore/b3/air/AirOptimizeBlockOrder.cpp:
(JSC::B3::Air::optimizeBlockOrder):
* Source/JavaScriptCore/b3/testb3.h:
* Source/JavaScriptCore/b3/testb3_1.cpp:
(run):
* Source/JavaScriptCore/b3/testb3_8.cpp:
(testCCmpAnd32):
(testCCmpAnd64):
(testCCmpOr32):
(testCCmpOr64):
(testCCmpAndAnd32):
(testCCmpOrOr32):
(testCCmpAndOr32):
(testCCmnAnd32WithNegativeImm):
(testCCmnAnd64WithNegativeImm):
(testCCmpWithLargePositiveImm):
(testCCmpWithLargeNegativeImm):
(testCCmpSmartOperandOrdering32):
(testCCmpSmartOperandOrdering64):
(testCCmpOperandCommutation32):
(testCCmpOperandCommutation64):
(testCCmpCombinedOptimizations):
(testCCmpZeroRegisterOptimization32):
(testCCmpZeroRegisterOptimization64):
(testCCmpMixedAndOr32):
(testCCmpMixedOrAnd32):
(testCCmpNegatedAnd32):
(testCCmpNegatedOr32):
(testCCmpMixedWidth32And64):
(testCCmpMixedWidth64And32):

Canonical link: <a href="https://commits.webkit.org/305493@main">https://commits.webkit.org/305493@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5feaf38d5f9e71fa3b2a176695881b0039e1a67a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138545 "106 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10910 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/146652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91520 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a4838c42-eb5a-4873-b234-65b1beed2317) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11614 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11065 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/146652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/77351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/061107f6-4d98-4268-9705-6d9d6e14265e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141492 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8739 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/124191 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/146652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d57757e5-3d09-4294-9725-0a7b3fc973bd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8328 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6088 "Passed tests") | [  ~~🛠 wpe-cairo-libwebrtc~~](https://ews-build.webkit.org/#/builders/166/builds/6946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/130511 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117744 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149404 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/137137 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10592 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/22 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/114397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10609 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8961 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114733 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8493 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120480 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65482 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21338 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10641 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/169819 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10375 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74272 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44271 "Found 1 new JSC binary failure: testb3 (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10579 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10430 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->