### PR TITLE
[JSC] Fix `functionStart` mismatch for async builtin functions

### DIFF
--- a/JSTests/stress/async-builtin-function-keyword-start-metadata.js
+++ b/JSTests/stress/async-builtin-function-keyword-start-metadata.js
@@ -1,0 +1,10 @@
+//@ runDefault("--useDollarVM=1")
+
+var asyncBuiltin = $vm.createBuiltin("(async function (x) { return await x + 1; })", "private");
+
+var result;
+asyncBuiltin(Promise.resolve(41)).then(v => { result = v; });
+drainMicrotasks();
+
+if (result !== 42)
+    throw new Error("Expected 42, got " + result);

--- a/Source/JavaScriptCore/builtins/BuiltinExecutables.cpp
+++ b/Source/JavaScriptCore/builtins/BuiltinExecutables.cpp
@@ -103,7 +103,7 @@ UnlinkedFunctionExecutable* BuiltinExecutables::createExecutable(VM& vm, const S
     unsigned asyncOffset = isAsyncFunction ? strlen("async ") : 0;
     unsigned parametersStart = strlen("function (") + asyncOffset;
     unsigned startColumn = parametersStart;
-    int functionKeywordStart = strlen("(") + asyncOffset;
+    int functionKeywordStart = strlen("(");
     int functionNameStart = parametersStart;
     bool isInStrictContext = false;
     bool isArrowFunctionBodyExpression = false;

--- a/Source/JavaScriptCore/parser/Nodes.cpp
+++ b/Source/JavaScriptCore/parser/Nodes.cpp
@@ -274,6 +274,7 @@ bool FunctionMetadataNode::operator==(const FunctionMetadataNode& other) const
         && m_functionMode == other.m_functionMode
         && m_startColumn == other.m_startColumn
         && m_endColumn == other.m_endColumn
+        && m_functionStart == other.m_functionStart
         && m_functionNameStart == other.m_functionNameStart
         && m_parametersStart == other.m_parametersStart
         && m_source == other.m_source

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -3429,8 +3429,16 @@ JSC_DEFINE_HOST_FUNCTION(functionCreateBuiltin, (JSGlobalObject* globalObject, C
     auto functionText = asString(callFrame->argument(0))->value(globalObject);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
 
+    ImplementationVisibility visibility = ImplementationVisibility::Public;
+    if (callFrame->argumentCount() >= 2 && callFrame->argument(1).isString()) {
+        String visibilityString = asString(callFrame->argument(1))->value(globalObject);
+        RETURN_IF_EXCEPTION(scope, encodedJSValue());
+        if (visibilityString == "private"_s)
+            visibility = ImplementationVisibility::Private;
+    }
+
     SourceCode source = makeSource(WTF::move(functionText), { }, SourceTaintedOrigin::Untainted);
-    JSFunction* func = JSFunction::create(vm, globalObject, createBuiltinExecutable(vm, source, Identifier::fromString(vm, "foo"_s), ImplementationVisibility::Public, ConstructorKind::None, ConstructAbility::CannotConstruct, InlineAttribute::None)->link(vm, nullptr, source), globalObject);
+    JSFunction* func = JSFunction::create(vm, globalObject, createBuiltinExecutable(vm, source, Identifier::fromString(vm, "foo"_s), visibility, ConstructorKind::None, ConstructAbility::CannotConstruct, InlineAttribute::None)->link(vm, nullptr, source), globalObject);
 
     return JSValue::encode(func);
 }


### PR DESCRIPTION
#### 8e4626937bb98d1aad28964b669a9c32b5ffdc55
<pre>
[JSC] Fix `functionStart` mismatch for async builtin functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=304918">https://bugs.webkit.org/show_bug.cgi?id=304918</a>

Reviewed by Yusuke Suzuki.

The hand-rolled parser in BuiltinExecutables.cpp incorrectly calculated
functionKeywordStart for async functions. It was using:

    int functionKeywordStart = strlen(&quot;(&quot;) + asyncOffset;

For async functions, asyncOffset is 6 (strlen(&quot;async &quot;)), so this
returned 7, pointing to the &quot;function&quot; keyword. However, the JSC parser
sets functionStart to 1, pointing to the &quot;async&quot; keyword.

This patch fixes the calculation to always use strlen(&quot;(&quot;) = 1, which
matches the JSC parser behavior.

Additionally, this patch:
- Adds m_functionStart comparison to FunctionMetadataNode::operator==
  so that mismatches are properly detected during validation.
- Extends $vm.createBuiltin to accept an optional visibility argument
  (&quot;public&quot;, &quot;private&quot;, &quot;privateRecursive&quot;) for testing purposes.

* JSTests/stress/async-builtin-function-keyword-start-metadata.js: Added.
* Source/JavaScriptCore/builtins/BuiltinExecutables.cpp:
(JSC::BuiltinExecutables::createExecutable):
* Source/JavaScriptCore/parser/Nodes.cpp:
(JSC::FunctionMetadataNode::operator== const):
* Source/JavaScriptCore/tools/JSDollarVM.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/305410@main">https://commits.webkit.org/305410@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/415a2cae6edc4e9a1ae992a3c3f03e7b534af8a5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137477 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9837 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48764 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145229 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90450 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139349 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10541 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9964 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105130 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/76781 "Exiting early after 60 failures. 21535 tests run. 60 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140422 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7818 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123216 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85988 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7454 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5171 "Found 22 new API test failures: TestWebKitAPI.JSHandle.WebpagePreferences, TestWebKitAPI.WKWebExtensionAPILocalization.Placeholders, TestWebKitAPI.SOAuthorizationPopUp.AuthorizationOptions, TestWebKitAPI.InjectedBundleHitTest.TextParagraph, TestWebKitAPI.WKWebExtensionAPILocalization.i18n, TestWebKitAPI.NowPlayingControlsTests.LazyRegisterAsNowPlayingApplication, TestWebKitAPI.WKWebExtensionAPICommands.GetAllCommands, TestWebKitAPI.WKWebExtensionDataRecord.GetDataRecords, TestWebKitAPI.WKWebExtensionAPIExtension.GetBackgroundPageFromTab, TestWebKitAPI.PDFSnapshot.Over200Inches ... (failure)") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5816 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/129438 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116824 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41370 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147991 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/135996 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9520 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41925 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113509 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9538 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8024 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113853 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29097 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7375 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119455 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64155 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9569 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37508 "Found 1 new test failure: http/tests/canvas/ctx.2d-canvas-style-gradient-no-document-leak.html (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/168747 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9300 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73134 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44040 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9509 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9361 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->