### PR TITLE
[WTF] Remove Unused Class `StringTypeAdapter<Indentation<N>>`

### DIFF
--- a/Source/WTF/wtf/text/StringConcatenate.h
+++ b/Source/WTF/wtf/text/StringConcatenate.h
@@ -380,32 +380,6 @@ struct IndentationScope {
     Indentation<N>& m_indentation;
 };
 
-template<unsigned N> class StringTypeAdapter<Indentation<N>> {
-public:
-    StringTypeAdapter(Indentation<N> indentation)
-        : m_indentation { indentation }
-    {
-    }
-
-    unsigned length() const
-    {
-        return m_indentation.value * N;
-    }
-
-    bool is8Bit() const
-    {
-        return true;
-    }
-
-    template<typename CharacterType> void writeTo(std::span<CharacterType> destination) const
-    {
-        std::fill_n(destination.data(), m_indentation.value * N, ' ');
-    }
-
-private:
-    Indentation<N> m_indentation;
-};
-
 struct ASCIICaseConverter {
     StringView::CaseConvertType type;
     StringView string;


### PR DESCRIPTION
#### 7c27f34ead7bb551508a6cb4d287dd2e8616a645
<pre>
[WTF] Remove Unused Class `StringTypeAdapter&lt;Indentation&lt;N&gt;&gt;`
<a href="https://bugs.webkit.org/show_bug.cgi?id=304925">https://bugs.webkit.org/show_bug.cgi?id=304925</a>

Reviewed by NOBODY (OOPS!).

This patch removes unused class `StringTypeAdapter&lt;Indentation&lt;N&gt;&gt;`.

* Source/WTF/wtf/text/StringConcatenate.h:
(WTF::StringTypeAdapter&lt;Indentation&lt;N&gt;&gt;::StringTypeAdapter): Deleted.
(WTF::StringTypeAdapter&lt;Indentation&lt;N&gt;&gt;::length const): Deleted.
(WTF::StringTypeAdapter&lt;Indentation&lt;N&gt;&gt;::is8Bit const): Deleted.
(WTF::StringTypeAdapter&lt;Indentation&lt;N&gt;&gt;::writeTo const): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c27f34ead7bb551508a6cb4d287dd2e8616a645

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137496 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/9860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48783 "Hash 7c27f34e for PR 56076 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145250 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/90469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10560 "Hash 7c27f34e for PR 56076 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9983 "Hash 7c27f34e for PR 56076 does not build (failure)") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/105156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/90469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140441 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/10560 "Hash 7c27f34e for PR 56076 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/48783 "Hash 7c27f34e for PR 56076 does not build (failure)") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/86010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/10560 "Hash 7c27f34e for PR 56076 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/138/builds/48783 "Hash 7c27f34e for PR 56076 does not build (failure)") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5835 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/129457 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/10560 "Hash 7c27f34e for PR 56076 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/48783 "Hash 7c27f34e for PR 56076 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148016 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/136015 "Built successfully and passed tests") | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9539 "Hash 7c27f34e for PR 56076 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/48783 "Hash 7c27f34e for PR 56076 does not build (failure)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/113537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9557 "Hash 7c27f34e for PR 56076 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/9983 "Hash 7c27f34e for PR 56076 does not build (failure)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/113875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/48783 "Hash 7c27f34e for PR 56076 does not build (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/64174 "The change is no longer eligible for processing.") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9588 "Hash 7c27f34e for PR 56076 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/48783 "Hash 7c27f34e for PR 56076 does not build (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/168766 "Built successfully") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9319 "Hash 7c27f34e for PR 56076 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73153 "Failed to build and analyze WebKit") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/44045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9528 "Hash 7c27f34e for PR 56076 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9380 "Hash 7c27f34e for PR 56076 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->