### PR TITLE
Add SwiftReceiverBuildEnabledBy

### DIFF
--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -331,7 +331,6 @@ $(PROJECT_DIR)/Shared/IPCStreamTesterProxy.messages.in
 $(PROJECT_DIR)/Shared/IPCTester.messages.in
 $(PROJECT_DIR)/Shared/IPCTester.serialization.in
 $(PROJECT_DIR)/Shared/IPCTesterReceiver.messages.in
-$(PROJECT_DIR)/Shared/IPCTesterReceiverSwift.messages.in
 $(PROJECT_DIR)/Shared/ImageOptions.serialization.in
 $(PROJECT_DIR)/Shared/InspectorExtensionTypes.serialization.in
 $(PROJECT_DIR)/Shared/JavaScriptCore.serialization.in

--- a/Source/WebKit/DerivedSources-output.xcfilelist
+++ b/Source/WebKit/DerivedSources-output.xcfilelist
@@ -53,12 +53,9 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/IPCStreamTesterProxyMessages.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/IPCTesterMessageReceiver.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/IPCTesterMessages.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/IPCTesterReceiverMessageReceiver.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/IPCTesterReceiverMessageReceiver.swift
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/IPCTesterReceiverMessages.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/IPCTesterReceiverMessagesReplies.h
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/IPCTesterReceiverSwiftMessageReceiver.cpp
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/IPCTesterReceiverSwiftMessageReceiver.swift
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/IPCTesterReceiverSwiftMessages.h
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/IPCTesterReceiverSwiftMessagesReplies.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/ISO18013MobileDocumentRequest+Extras.swift
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIAction.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIAction.mm

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -159,7 +159,6 @@ MESSAGE_RECEIVERS = \
 	Shared/IPCStreamTesterProxy \
 	Shared/IPCTester \
 	Shared/IPCTesterReceiver \
-	Shared/IPCTesterReceiverSwift \
 	UIProcess/WebFullScreenManagerProxy \
 	UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy \
 	UIProcess/GPU/GPUProcessProxy \

--- a/Source/WebKit/Modules/Internal/WebKitInternalCxx.h
+++ b/Source/WebKit/Modules/Internal/WebKitInternalCxx.h
@@ -25,5 +25,5 @@
 
 // Add project-level C++ header files here to be able to access them from within Swift sources.
 
-#import "IPCTesterReceiverSwiftMessages.h"
+#import "IPCTesterReceiverMessages.h"
 #import "UIProcess/SwiftDemoLogoConfirmation.h"

--- a/Source/WebKit/Scripts/generate-message-receiver.py
+++ b/Source/WebKit/Scripts/generate-message-receiver.py
@@ -77,7 +77,7 @@ def main(argv):
             continue
         with open('%sMessageReceiver.cpp' % receiver.name, "w+") as implementation_output:
             implementation_output.write(webkit.messages.generate_message_handler(receiver))
-        if receiver.swift_receiver:
+        if receiver.swift_receiver or receiver.swift_receiver_build_enabled_by:
             with open('%sMessageReceiver.swift' % receiver.name, "w+") as swift_implementation_output:
                 swift_implementation_output.write(webkit.messages.generate_swift_message_handler(receiver))
 

--- a/Source/WebKit/Scripts/webkit/messages_unittest.py
+++ b/Source/WebKit/Scripts/webkit/messages_unittest.py
@@ -63,6 +63,7 @@ _test_receiver_names = [
     'TestWithSuperclassAndWantsAsyncDispatch',
     'TestWithSuperclassAndWantsDispatch',
     'TestWithSwift',
+    'TestWithSwiftConditionally',
     'TestWithValidator',
     'TestWithWantsAsyncDispatch',
     'TestWithWantsDispatch',
@@ -115,7 +116,7 @@ class GeneratedFileContentsTest(unittest.TestCase):
             self.assertGeneratedFileContentsEqual(header_contents, os.path.join(tests_directory, '{}Messages.h'.format(receiver_name)))
             implementation_contents = messages.generate_message_handler(receiver)
             self.assertGeneratedFileContentsEqual(implementation_contents, os.path.join(tests_directory, '{}MessageReceiver.cpp'.format(receiver_name)))
-            if receiver.swift_receiver:
+            if receiver.swift_receiver or receiver.swift_receiver_build_enabled_by:
                 swift_implementation_contents = messages.generate_swift_message_handler(receiver)
                 self.assertGeneratedFileContentsEqual(swift_implementation_contents, os.path.join(tests_directory, '{}MessageReceiver.swift'.format(receiver_name)))
 

--- a/Source/WebKit/Scripts/webkit/model.py
+++ b/Source/WebKit/Scripts/webkit/model.py
@@ -34,7 +34,7 @@ SYNCHRONOUS_ATTRIBUTE = 'Synchronous'
 STREAM_ATTRIBUTE = "Stream"
 
 class MessageReceiver(object):
-    def __init__(self, name, superclass, attributes, receiver_enabled_by, receiver_enabled_by_exception, receiver_enabled_by_conjunction, receiver_dispatched_from, receiver_dispatched_from_exception, receiver_dispatched_to, receiver_dispatched_to_exception, shared_preferences_needs_connection, messages, condition, namespace, wants_send_cancel_reply, swift_receiver):
+    def __init__(self, name, superclass, attributes, receiver_enabled_by, receiver_enabled_by_exception, receiver_enabled_by_conjunction, receiver_dispatched_from, receiver_dispatched_from_exception, receiver_dispatched_to, receiver_dispatched_to_exception, shared_preferences_needs_connection, messages, condition, namespace, wants_send_cancel_reply, swift_receiver, swift_receiver_build_enabled_by):
         self.name = name
         self.superclass = superclass
         self.attributes = frozenset(attributes or [])
@@ -51,6 +51,7 @@ class MessageReceiver(object):
         self.namespace = namespace
         self.wants_send_cancel_reply = wants_send_cancel_reply
         self.swift_receiver = swift_receiver
+        self.swift_receiver_build_enabled_by = swift_receiver_build_enabled_by
 
     def iterparameters(self):
         return itertools.chain((parameter for message in self.messages for parameter in message.parameters),
@@ -108,7 +109,7 @@ class Parameter(object):
         return attribute in self.attributes
 
 
-ipc_receiver = MessageReceiver(name="IPC", superclass=None, attributes=[BUILTIN_ATTRIBUTE], receiver_enabled_by=None, receiver_enabled_by_exception=False, receiver_enabled_by_conjunction=None, receiver_dispatched_from=None, receiver_dispatched_from_exception=None, receiver_dispatched_to=None, receiver_dispatched_to_exception=None, shared_preferences_needs_connection=False, swift_receiver=False, messages=[
+ipc_receiver = MessageReceiver(name="IPC", superclass=None, attributes=[BUILTIN_ATTRIBUTE], receiver_enabled_by=None, receiver_enabled_by_exception=False, receiver_enabled_by_conjunction=None, receiver_dispatched_from=None, receiver_dispatched_from_exception=None, receiver_dispatched_to=None, receiver_dispatched_to_exception=None, shared_preferences_needs_connection=False, swift_receiver=False, swift_receiver_build_enabled_by=None, messages=[
     Message('WrappedAsyncMessageForTesting', [], [], attributes=[BUILTIN_ATTRIBUTE, SYNCHRONOUS_ATTRIBUTE, ALLOWEDWHENWAITINGFORSYNCREPLY_ATTRIBUTE], condition=None),
     Message('SyncMessageReply', [], [], attributes=[BUILTIN_ATTRIBUTE], condition=None),
     Message('CancelSyncMessageReply', [], [], attributes=[BUILTIN_ATTRIBUTE], condition=None),

--- a/Source/WebKit/Scripts/webkit/parser.py
+++ b/Source/WebKit/Scripts/webkit/parser.py
@@ -54,6 +54,7 @@ def parse(file):
     shared_preferences_needs_connection = False
     wants_send_cancel_reply = False
     swift_receiver = False
+    swift_receiver_build_enabled_by = None
     destination = None
     messages = []
     conditions = []
@@ -75,6 +76,9 @@ def parse(file):
                     continue
                 if match.group('name') == 'DispatchedTo':
                     receiver_dispatched_to = parse_process_name_string(match.group('value'))
+                    continue
+                if match.group('name') == 'SwiftReceiverBuildEnabledBy':
+                    swift_receiver_build_enabled_by = match.group('value')
                     continue
                 raise Exception("ERROR: Unknown extended attribute  '%s'" % attribute)
             elif attribute == 'SharedPreferencesNeedsConnection':
@@ -98,6 +102,8 @@ def parse(file):
             raise Exception("ERROR: Unknown extended attribute: '%s'" % attribute)
     if receiver_enabled_by and receiver_enabled_by_exception:
         raise Exception("ERROR: 'ExceptionForEnabledBy' cannot be used together with 'EnabledBy=%s'" % receiver_enabled_by)
+    if swift_receiver and swift_receiver_build_enabled_by:
+        raise Exception("ERROR: 'SwiftReceiver' cannot be used together with 'SwiftReceiverBuildEnabledBy=%s'" % swift_receiver_build_enabled_by)
 
     for line in file_contents:
         line = line.strip()
@@ -196,7 +202,7 @@ def parse(file):
     if receiver_dispatched_to and receiver_dispatched_to_exception:
         raise Exception("ERROR: 'ExceptionForDispatchedTo' cannot be used together with 'DispatchedTo=%s'" % receiver_dispatched_to)
 
-    return model.MessageReceiver(destination, superclass, receiver_attributes, receiver_enabled_by, receiver_enabled_by_exception, receiver_enabled_by_conjunction, receiver_dispatched_from, receiver_dispatched_from_exception, receiver_dispatched_to, receiver_dispatched_to_exception, shared_preferences_needs_connection, messages, combine_condition(master_condition), namespace, wants_send_cancel_reply, swift_receiver)
+    return model.MessageReceiver(destination, superclass, receiver_attributes, receiver_enabled_by, receiver_enabled_by_exception, receiver_enabled_by_conjunction, receiver_dispatched_from, receiver_dispatched_from_exception, receiver_dispatched_to, receiver_dispatched_to_exception, shared_preferences_needs_connection, messages, combine_condition(master_condition), namespace, wants_send_cancel_reply, swift_receiver, swift_receiver_build_enabled_by)
 
 
 def parse_attributes_string(attributes_string):

--- a/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
@@ -327,6 +327,12 @@ std::optional<JSC::JSValue> jsValueForArguments(JSC::JSGlobalObject* globalObjec
         return jsValueForDecodedMessage<MessageName::TestWithSwift_TestSyncMessage>(globalObject, decoder);
     case MessageName::TestWithSwift_TestAsyncMessageReply:
         return jsValueForDecodedMessage<MessageName::TestWithSwift_TestAsyncMessageReply>(globalObject, decoder);
+    case MessageName::TestWithSwiftConditionally_TestAsyncMessage:
+        return jsValueForDecodedMessage<MessageName::TestWithSwiftConditionally_TestAsyncMessage>(globalObject, decoder);
+    case MessageName::TestWithSwiftConditionally_TestSyncMessage:
+        return jsValueForDecodedMessage<MessageName::TestWithSwiftConditionally_TestSyncMessage>(globalObject, decoder);
+    case MessageName::TestWithSwiftConditionally_TestAsyncMessageReply:
+        return jsValueForDecodedMessage<MessageName::TestWithSwiftConditionally_TestAsyncMessageReply>(globalObject, decoder);
     case MessageName::TestWithValidator_AlwaysEnabled:
         return jsValueForDecodedMessage<MessageName::TestWithValidator_AlwaysEnabled>(globalObject, decoder);
     case MessageName::TestWithValidator_EnabledIfPassValidation:
@@ -442,6 +448,10 @@ std::optional<JSC::JSValue> jsValueForReplyArguments(JSC::JSGlobalObject* global
         return jsValueForDecodedMessageReply<MessageName::TestWithSwift_TestAsyncMessage>(globalObject, decoder);
     case MessageName::TestWithSwift_TestSyncMessage:
         return jsValueForDecodedMessageReply<MessageName::TestWithSwift_TestSyncMessage>(globalObject, decoder);
+    case MessageName::TestWithSwiftConditionally_TestAsyncMessage:
+        return jsValueForDecodedMessageReply<MessageName::TestWithSwiftConditionally_TestAsyncMessage>(globalObject, decoder);
+    case MessageName::TestWithSwiftConditionally_TestSyncMessage:
+        return jsValueForDecodedMessageReply<MessageName::TestWithSwiftConditionally_TestSyncMessage>(globalObject, decoder);
     case MessageName::TestWithValidator_MessageWithReply:
         return jsValueForDecodedMessageReply<MessageName::TestWithValidator_MessageWithReply>(globalObject, decoder);
     case MessageName::TestWithWantsAsyncDispatch_TestSyncMessage:
@@ -1113,6 +1123,18 @@ std::optional<Vector<ArgumentDescription>> messageArgumentDescriptions(MessageNa
         return Vector<ArgumentDescription> {
             { "reply"_s, "uint8_t"_s },
         };
+    case MessageName::TestWithSwiftConditionally_TestAsyncMessage:
+        return Vector<ArgumentDescription> {
+            { "param"_s, "uint32_t"_s },
+        };
+    case MessageName::TestWithSwiftConditionally_TestSyncMessage:
+        return Vector<ArgumentDescription> {
+            { "param"_s, "uint32_t"_s },
+        };
+    case MessageName::TestWithSwiftConditionally_TestAsyncMessageReply:
+        return Vector<ArgumentDescription> {
+            { "reply"_s, "uint8_t"_s },
+        };
     case MessageName::TestWithValidator_AlwaysEnabled:
         return Vector<ArgumentDescription> {
             { "url"_s, "String"_s },
@@ -1303,6 +1325,14 @@ std::optional<Vector<ArgumentDescription>> messageReplyArgumentDescriptions(Mess
             { "reply"_s, "uint8_t"_s },
         };
     case MessageName::TestWithSwift_TestSyncMessage:
+        return Vector<ArgumentDescription> {
+            { "reply"_s, "uint8_t"_s },
+        };
+    case MessageName::TestWithSwiftConditionally_TestAsyncMessage:
+        return Vector<ArgumentDescription> {
+            { "reply"_s, "uint8_t"_s },
+        };
+    case MessageName::TestWithSwiftConditionally_TestSyncMessage:
         return Vector<ArgumentDescription> {
             { "reply"_s, "uint8_t"_s },
         };

--- a/Source/WebKit/Scripts/webkit/tests/MessageNames.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageNames.cpp
@@ -120,6 +120,8 @@ const MessageDescriptionsArray messageDescriptions {
     MessageDescription { "TestWithSuperclass_TestAsyncMessageWithNoArguments"_s, ReceiverName::TestWithSuperclass, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithSuperclass_TestAsyncMessageWithNoArgumentsReply"_s, ReceiverName::TestWithSuperclass, false, false, true, ProcessName::Unknown, ProcessName::Unknown },
 #endif
+    MessageDescription { "TestWithSwiftConditionally_TestAsyncMessage"_s, ReceiverName::TestWithSwiftConditionally, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
+    MessageDescription { "TestWithSwiftConditionally_TestAsyncMessageReply"_s, ReceiverName::TestWithSwiftConditionally, false, false, true, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithSwift_TestAsyncMessage"_s, ReceiverName::TestWithSwift, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithSwift_TestAsyncMessageReply"_s, ReceiverName::TestWithSwift, false, false, true, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithValidator_AlwaysEnabled"_s, ReceiverName::TestWithValidator, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
@@ -199,6 +201,7 @@ const MessageDescriptionsArray messageDescriptions {
     MessageDescription { "TestWithSuperclassAndWantsDispatch_TestSyncMessage"_s, ReceiverName::TestWithSuperclassAndWantsDispatch, true, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithSuperclass_TestSyncMessage"_s, ReceiverName::TestWithSuperclass, true, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithSuperclass_TestSynchronousMessage"_s, ReceiverName::TestWithSuperclass, true, false, false, ProcessName::Unknown, ProcessName::Unknown },
+    MessageDescription { "TestWithSwiftConditionally_TestSyncMessage"_s, ReceiverName::TestWithSwiftConditionally, true, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithSwift_TestSyncMessage"_s, ReceiverName::TestWithSwift, true, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithWantsAsyncDispatch_TestSyncMessage"_s, ReceiverName::TestWithWantsAsyncDispatch, true, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithWantsDispatch_TestSyncMessage"_s, ReceiverName::TestWithWantsDispatch, true, false, false, ProcessName::Unknown, ProcessName::Unknown },

--- a/Source/WebKit/Scripts/webkit/tests/MessageNames.h
+++ b/Source/WebKit/Scripts/webkit/tests/MessageNames.h
@@ -62,14 +62,15 @@ enum class ReceiverName : uint8_t {
     , TestWithSuperclassAndWantsAsyncDispatch = 18
     , TestWithSuperclassAndWantsDispatch = 19
     , TestWithSwift = 20
-    , TestWithValidator = 21
-    , TestWithWantsAsyncDispatch = 22
-    , TestWithWantsDispatch = 23
-    , TestWithWantsDispatchNoSyncMessages = 24
-    , TestWithoutAttributes = 25
-    , TestWithoutUsingIPCConnection = 26
-    , IPC = 27
-    , Invalid = 28
+    , TestWithSwiftConditionally = 21
+    , TestWithValidator = 22
+    , TestWithWantsAsyncDispatch = 23
+    , TestWithWantsDispatch = 24
+    , TestWithWantsDispatchNoSyncMessages = 25
+    , TestWithoutAttributes = 26
+    , TestWithoutUsingIPCConnection = 27
+    , IPC = 28
+    , Invalid = 29
 };
 
 enum class MessageName : uint16_t {
@@ -165,6 +166,8 @@ enum class MessageName : uint16_t {
     TestWithSuperclass_TestAsyncMessageWithNoArguments,
     TestWithSuperclass_TestAsyncMessageWithNoArgumentsReply,
 #endif
+    TestWithSwiftConditionally_TestAsyncMessage,
+    TestWithSwiftConditionally_TestAsyncMessageReply,
     TestWithSwift_TestAsyncMessage,
     TestWithSwift_TestAsyncMessageReply,
     TestWithValidator_AlwaysEnabled,
@@ -246,6 +249,7 @@ enum class MessageName : uint16_t {
     TestWithSuperclassAndWantsDispatch_TestSyncMessage,
     TestWithSuperclass_TestSyncMessage,
     TestWithSuperclass_TestSynchronousMessage,
+    TestWithSwiftConditionally_TestSyncMessage,
     TestWithSwift_TestSyncMessage,
     TestWithWantsAsyncDispatch_TestSyncMessage,
     TestWithWantsDispatch_TestSyncMessage,

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSwiftConditionally.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSwiftConditionally.messages.in
@@ -20,16 +20,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#if ENABLE(IPC_TESTING_API) && ENABLE(IPC_TESTING_SWIFT)
-
 [
-    ExceptionForDispatchedFrom,
-    ExceptionForDispatchedTo,
     ExceptionForEnabledBy,
-    SwiftReceiver
+    SwiftReceiverBuildEnabledBy=SWIFT_TEST_CONDITION
 ]
-messages -> IPCTesterReceiverSwift {
-    void AsyncMessage(uint32_t arg1) -> (uint32_t reply) Asynchronous
+messages -> TestWithSwiftConditionally {
+    TestAsyncMessage(uint32_t param) -> (uint8_t reply)
+    TestSyncMessage(uint32_t param) -> (uint8_t reply) Synchronous
 }
-
-#endif

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSwiftConditionallyMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSwiftConditionallyMessageReceiver.cpp
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#if ENABLE(SWIFT_TEST_CONDITION)
+#include "Shared/WebKit-Swift.h" // NOLINT
+#else // ENABLE(SWIFT_TEST_CONDITION)
+#include "TestWithSwiftConditionally.h"
+
+#endif // ENABLE(SWIFT_TEST_CONDITION)
+#include "Decoder.h" // NOLINT
+#include "HandleMessage.h" // NOLINT
+#include "TestWithSwiftConditionallyMessages.h" // NOLINT
+
+#if ENABLE(IPC_TESTING_API)
+#include "JSIPCBinding.h"
+#endif
+
+namespace WebKit {
+
+#if ENABLE(SWIFT_TEST_CONDITION)
+void TestWithSwiftConditionallyMessageForwarder::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+#else // ENABLE(SWIFT_TEST_CONDITION)
+void TestWithSwiftConditionally::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+#endif // ENABLE(SWIFT_TEST_CONDITION)
+{
+    Ref protectedThis { *this };
+#if ENABLE(SWIFT_TEST_CONDITION)
+    auto target = getMessageTarget();
+    if (!target) {
+        FATAL("Something is keeping a reference to the message forwarder");
+        decoder.markInvalid();
+        return;
+    }
+#endif // ENABLE(SWIFT_TEST_CONDITION)
+    if (decoder.messageName() == Messages::TestWithSwiftConditionally::TestAsyncMessage::name()) {
+#if ENABLE(SWIFT_TEST_CONDITION)
+        IPC::handleMessageAsync<Messages::TestWithSwiftConditionally::TestAsyncMessage>(connection, decoder, target.get(), &TestWithSwiftConditionally::testAsyncMessage);
+#else // ENABLE(SWIFT_TEST_CONDITION)
+        IPC::handleMessageAsync<Messages::TestWithSwiftConditionally::TestAsyncMessage>(connection, decoder, this, &TestWithSwiftConditionally::testAsyncMessage);
+#endif // ENABLE(SWIFT_TEST_CONDITION)
+        return;
+    }
+    UNUSED_PARAM(connection);
+    RELEASE_LOG_ERROR(IPC, "Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()).characters(), decoder.destinationID());
+    decoder.markInvalid();
+}
+
+#if ENABLE(SWIFT_TEST_CONDITION)
+void TestWithSwiftConditionallyMessageForwarder::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
+#else // ENABLE(SWIFT_TEST_CONDITION)
+void TestWithSwiftConditionally::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
+#endif // ENABLE(SWIFT_TEST_CONDITION)
+{
+    Ref protectedThis { *this };
+#if ENABLE(SWIFT_TEST_CONDITION)
+    auto target = getMessageTarget();
+    if (!target) {
+        FATAL("Something is keeping a reference to the message forwarder");
+        decoder.markInvalid();
+        return;
+    }
+#endif // ENABLE(SWIFT_TEST_CONDITION)
+    if (decoder.messageName() == Messages::TestWithSwiftConditionally::TestSyncMessage::name()) {
+#if ENABLE(SWIFT_TEST_CONDITION)
+        IPC::handleMessageSynchronous<Messages::TestWithSwiftConditionally::TestSyncMessage>(connection, decoder, replyEncoder, target.get(), &TestWithSwiftConditionally::testSyncMessage);
+#else // ENABLE(SWIFT_TEST_CONDITION)
+        IPC::handleMessageSynchronous<Messages::TestWithSwiftConditionally::TestSyncMessage>(connection, decoder, replyEncoder, this, &TestWithSwiftConditionally::testSyncMessage);
+#endif // ENABLE(SWIFT_TEST_CONDITION)
+        return;
+    }
+    UNUSED_PARAM(connection);
+    UNUSED_PARAM(replyEncoder);
+    RELEASE_LOG_ERROR(IPC, "Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()).characters(), decoder.destinationID());
+    decoder.markInvalid();
+}
+#if ENABLE(SWIFT_TEST_CONDITION)
+
+static std::unique_ptr<TestWithSwiftConditionallyWeakRef> makeTestWithSwiftConditionallyWeakRefUniquePtr(TestWithSwiftConditionallyWeakRef* _Nonnull handler)
+{
+    auto newRef = _impl::_impl_TestWithSwiftConditionallyWeakRef::makeRetained(handler);
+    return WTF::makeUniqueWithoutFastMallocCheck<TestWithSwiftConditionallyWeakRef>(newRef);
+}
+
+TestWithSwiftConditionallyMessageForwarder::TestWithSwiftConditionallyMessageForwarder(TestWithSwiftConditionallyWeakRef* _Nonnull target)
+    : m_handler(makeTestWithSwiftConditionallyWeakRefUniquePtr(target))
+{
+}
+
+std::unique_ptr<TestWithSwiftConditionally> TestWithSwiftConditionallyMessageForwarder::getMessageTarget()
+{
+    auto target = m_handler->getMessageTarget();
+    if (target)
+        return WTF::makeUniqueWithoutFastMallocCheck<TestWithSwiftConditionally>(target.get());
+    return nullptr;
+}
+
+TestWithSwiftConditionallyMessageForwarder::~TestWithSwiftConditionallyMessageForwarder()
+{
+}
+
+#endif // ENABLE(SWIFT_TEST_CONDITION)
+
+} // namespace WebKit
+
+#if ENABLE(IPC_TESTING_API)
+
+namespace IPC {
+
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithSwiftConditionally_TestAsyncMessage>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+{
+    return jsValueForDecodedArguments<Messages::TestWithSwiftConditionally::TestAsyncMessage::Arguments>(globalObject, decoder);
+}
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithSwiftConditionally_TestAsyncMessage>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+{
+    return jsValueForDecodedArguments<Messages::TestWithSwiftConditionally::TestAsyncMessage::ReplyArguments>(globalObject, decoder);
+}
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithSwiftConditionally_TestSyncMessage>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+{
+    return jsValueForDecodedArguments<Messages::TestWithSwiftConditionally::TestSyncMessage::Arguments>(globalObject, decoder);
+}
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithSwiftConditionally_TestSyncMessage>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+{
+    return jsValueForDecodedArguments<Messages::TestWithSwiftConditionally::TestSyncMessage::ReplyArguments>(globalObject, decoder);
+}
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithSwiftConditionally_TestAsyncMessageReply>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+{
+    return jsValueForDecodedArguments<Messages::TestWithSwiftConditionally::TestAsyncMessageReply::Arguments>(globalObject, decoder);
+}
+
+}
+
+#endif
+

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSwiftConditionallyMessageReceiver.swift
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSwiftConditionallyMessageReceiver.swift
@@ -1,0 +1,87 @@
+//
+// Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1.  Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// 2.  Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#if ENABLE_SWIFT_TEST_CONDITION
+internal import WebKit_Internal
+#endif
+
+#if compiler(>=6.2)
+
+#if ENABLE_SWIFT_TEST_CONDITION
+final class TestWithSwiftConditionallyWeakRef {
+    private weak var target: TestWithSwiftConditionally?
+    init(target: TestWithSwiftConditionally) {
+        self.target = target
+    }
+
+    func getMessageTarget() -> TestWithSwiftConditionally? {
+        target
+    }
+}
+
+extension WebKit.TestWithSwiftConditionallyMessageForwarder {
+    static func create(target: TestWithSwiftConditionally) -> RefTestWithSwiftConditionallyMessageForwarder {
+        let weakRefContainer = TestWithSwiftConditionallyWeakRef(target: target)
+        // Safety: we're creating a pointer which will immediately be stored in a
+        // proper ref-counted reference on the C++ side before this call returns.
+        // Workaround for rdar://163107752.
+        return unsafe WebKit.TestWithSwiftConditionallyMessageForwarder.createFromWeak(
+            OpaquePointer(
+                Unmanaged.passRetained(weakRefContainer).toOpaque()
+            )
+        )
+    }
+}
+#endif
+
+#else
+
+#if ENABLE_SWIFT_TEST_CONDITION
+final class TestWithSwiftConditionallyWeakRef {
+    private weak var target: TestWithSwiftConditionally?
+    init(target: TestWithSwiftConditionally) {
+        self.target = target
+    }
+
+    func getMessageTarget() -> TestWithSwiftConditionally? {
+        target
+    }
+}
+
+extension WebKit.TestWithSwiftConditionallyMessageForwarder {
+    static func create(target: TestWithSwiftConditionally) -> RefTestWithSwiftConditionallyMessageForwarder {
+        let weakRefContainer = TestWithSwiftConditionallyWeakRef(target: target)
+        // Safety: we're creating a pointer which will immediately be stored in a
+        // proper ref-counted reference on the C++ side before this call returns.
+        // Workaround for rdar://163107752.
+        return WebKit.TestWithSwiftConditionallyMessageForwarder.createFromWeak(
+            OpaquePointer(
+                Unmanaged.passRetained(weakRefContainer).toOpaque()
+            )
+        )
+    }
+}
+#endif
+
+#endif

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSwiftConditionallyMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSwiftConditionallyMessages.h
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ArgumentCoders.h"
+#include "Connection.h"
+#include "MessageNames.h"
+#include <wtf/Forward.h>
+#include <wtf/RuntimeApplicationChecks.h>
+#include <wtf/ThreadSafeRefCounted.h>
+
+#if ENABLE(SWIFT_TEST_CONDITION)
+namespace WebKit {
+class TestWithSwiftConditionally;
+class TestWithSwiftConditionallyMessageForwarder;
+class TestWithSwiftConditionallyWeakRef;
+}
+#endif // ENABLE(SWIFT_TEST_CONDITION)
+
+#if ENABLE(SWIFT_TEST_CONDITION)
+namespace WebKit {
+
+class TestWithSwiftConditionallyMessageForwarder: public RefCounted<TestWithSwiftConditionallyMessageForwarder>, public IPC::MessageReceiver {
+public:
+    static Ref<TestWithSwiftConditionallyMessageForwarder> createFromWeak(WebKit::TestWithSwiftConditionallyWeakRef* _Nonnull handler)
+    {
+        return adoptRef(*new TestWithSwiftConditionallyMessageForwarder(handler));
+    }
+    ~TestWithSwiftConditionallyMessageForwarder();
+    void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+private:
+    TestWithSwiftConditionallyMessageForwarder(WebKit::TestWithSwiftConditionallyWeakRef* _Nonnull);
+    std::unique_ptr<WebKit::TestWithSwiftConditionally> getMessageTarget();
+    std::unique_ptr<WebKit::TestWithSwiftConditionallyWeakRef> m_handler;
+} SWIFT_SHARED_REFERENCE(.ref, .deref);
+
+}
+
+using RefTestWithSwiftConditionallyMessageForwarder = Ref<WebKit::TestWithSwiftConditionallyMessageForwarder>;
+
+#endif // ENABLE(SWIFT_TEST_CONDITION)
+namespace Messages {
+namespace TestWithSwiftConditionally {
+
+static inline IPC::ReceiverName messageReceiverName()
+{
+    return IPC::ReceiverName::TestWithSwiftConditionally;
+}
+
+class TestAsyncMessage {
+public:
+    using Arguments = std::tuple<uint32_t>;
+
+    static IPC::MessageName name() { return IPC::MessageName::TestWithSwiftConditionally_TestAsyncMessage; }
+    static constexpr bool isSync = false;
+    static constexpr bool canDispatchOutOfOrder = false;
+    static constexpr bool replyCanDispatchOutOfOrder = false;
+    static constexpr bool deferSendingIfSuspended = false;
+
+    static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithSwiftConditionally_TestAsyncMessageReply; }
+    static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
+    using ReplyArguments = std::tuple<uint8_t>;
+    using Reply = CompletionHandler<void(uint8_t)>;
+    using Promise = WTF::NativePromise<uint8_t, IPC::Error>;
+    explicit TestAsyncMessage(uint32_t param)
+        : m_param(param)
+    {
+    }
+
+    template<typename Encoder>
+    void encode(Encoder& encoder)
+    {
+        encoder << m_param;
+    }
+
+private:
+    uint32_t m_param;
+};
+
+class TestSyncMessage {
+public:
+    using Arguments = std::tuple<uint32_t>;
+
+    static IPC::MessageName name() { return IPC::MessageName::TestWithSwiftConditionally_TestSyncMessage; }
+    static constexpr bool isSync = true;
+    static constexpr bool canDispatchOutOfOrder = false;
+    static constexpr bool replyCanDispatchOutOfOrder = false;
+    static constexpr bool deferSendingIfSuspended = false;
+
+    static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
+    using ReplyArguments = std::tuple<uint8_t>;
+    using Reply = CompletionHandler<void(uint8_t)>;
+    explicit TestSyncMessage(uint32_t param)
+        : m_param(param)
+    {
+    }
+
+    template<typename Encoder>
+    void encode(Encoder& encoder)
+    {
+        encoder << m_param;
+    }
+
+private:
+    uint32_t m_param;
+};
+
+class TestAsyncMessageReply {
+public:
+    using Arguments = std::tuple<uint8_t>;
+
+    static IPC::MessageName name() { return IPC::MessageName::TestWithSwiftConditionally_TestAsyncMessageReply; }
+    static constexpr bool isSync = false;
+    static constexpr bool canDispatchOutOfOrder = false;
+    static constexpr bool replyCanDispatchOutOfOrder = false;
+    static constexpr bool deferSendingIfSuspended = false;
+
+    explicit TestAsyncMessageReply(uint8_t reply)
+        : m_reply(reply)
+    {
+    }
+
+    template<typename Encoder>
+    void encode(Encoder& encoder)
+    {
+        encoder << m_reply;
+    }
+
+private:
+    uint8_t m_reply;
+};
+
+} // namespace TestWithSwiftConditionally
+} // namespace Messages
+#if ENABLE(SWIFT_TEST_CONDITION)
+
+namespace CompletionHandlers {
+namespace TestWithSwiftConditionally {
+using TestAsyncMessageCompletionHandler = WTF::RefCountable<Messages::TestWithSwiftConditionally::TestAsyncMessage::Reply>;
+using TestSyncMessageCompletionHandler = WTF::RefCountable<Messages::TestWithSwiftConditionally::TestSyncMessage::Reply>;
+} // namespace TestWithSwiftConditionally
+} // namespace CompletionHandlers
+
+#endif // ENABLE(SWIFT_TEST_CONDITION)

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSwiftMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSwiftMessageReceiver.cpp
@@ -23,8 +23,7 @@
  */
 
 #include "config.h"
-#include "Shared/WebKit-Swift.h"
-
+#include "Shared/WebKit-Swift.h" // NOLINT
 #include "Decoder.h" // NOLINT
 #include "HandleMessage.h" // NOLINT
 #include "TestWithSwiftMessages.h" // NOLINT

--- a/Source/WebKit/Shared/IPCTester.cpp
+++ b/Source/WebKit/Shared/IPCTester.cpp
@@ -33,9 +33,6 @@
 #include "IPCStreamTester.h"
 #include "IPCTesterMessages.h"
 #include "IPCTesterReceiverMessages.h"
-#if ENABLE(IPC_TESTING_SWIFT)
-#include "IPCTesterReceiverSwiftMessages.h"
-#endif
 #include "IPCUtilities.h"
 #include "Logging.h"
 #include "TestParameter.h"
@@ -191,12 +188,10 @@ void IPCTester::sendAsyncMessageToReceiverRequestingReply(IPC::Connection& conne
 {
 #if ENABLE(IPC_TESTING_SWIFT)
     constexpr bool usingSwift = true;
-    using Message = Messages::IPCTesterReceiverSwift::AsyncMessage;
 #else
     constexpr bool usingSwift = false;
-    using Message = Messages::IPCTesterReceiver::AsyncMessage;
 #endif
-    connection.sendWithAsyncReply(Message(arg0 + 1), [completionHandler = WTF::move(completionHandler)](uint32_t newArg0) mutable {
+    connection.sendWithAsyncReply(Messages::IPCTesterReceiver::AsyncMessage(arg0 + 1), [completionHandler = WTF::move(completionHandler)](uint32_t newArg0) mutable {
         completionHandler(newArg0, usingSwift);
     }, 0);
 }

--- a/Source/WebKit/Shared/IPCTesterReceiver.cpp
+++ b/Source/WebKit/Shared/IPCTesterReceiver.cpp
@@ -26,7 +26,7 @@
 #include "config.h"
 #include "IPCTesterReceiver.h"
 
-#if ENABLE(IPC_TESTING_API)
+#if ENABLE(IPC_TESTING_API) && !ENABLE(IPC_TESTING_SWIFT)
 
 namespace WebKit {
 

--- a/Source/WebKit/Shared/IPCTesterReceiver.h
+++ b/Source/WebKit/Shared/IPCTesterReceiver.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#if ENABLE(IPC_TESTING_API)
+#if ENABLE(IPC_TESTING_API) && !ENABLE(IPC_TESTING_SWIFT)
 
 #include "MessageReceiver.h"
 

--- a/Source/WebKit/Shared/IPCTesterReceiver.messages.in
+++ b/Source/WebKit/Shared/IPCTesterReceiver.messages.in
@@ -25,7 +25,8 @@
 [
     ExceptionForDispatchedFrom,
     ExceptionForDispatchedTo,
-    ExceptionForEnabledBy
+    ExceptionForEnabledBy,
+    SwiftReceiverBuildEnabledBy=IPC_TESTING_SWIFT
 ]
 messages -> IPCTesterReceiver {
     void AsyncMessage(uint32_t arg1) -> (uint32_t reply) Asynchronous

--- a/Source/WebKit/Shared/IPCTesterReceiver.swift
+++ b/Source/WebKit/Shared/IPCTesterReceiver.swift
@@ -27,22 +27,22 @@ internal import WebKit_Internal
 internal import wtf
 
 // Proxy interface to test IPC activities related to receiving messages in Swift.
-final class IPCTesterReceiverSwift {
+final class IPCTesterReceiver {
     // Optional just because of an initialization order issue. Always occupied after initialization finished.
-    private var messageForwarder: RefIPCTesterReceiverSwiftMessageForwarder?
+    private var messageForwarder: RefIPCTesterReceiverMessageForwarder?
 
     init() {
-        self.messageForwarder = WebKit.IPCTesterReceiverSwiftMessageForwarder.create(target: self)
+        self.messageForwarder = WebKit.IPCTesterReceiverMessageForwarder.create(target: self)
     }
 
-    func getMessageReceiver() -> RefIPCTesterReceiverSwiftMessageForwarder {
+    func getMessageReceiver() -> RefIPCTesterReceiverMessageForwarder {
         guard let messageForwarder = self.messageForwarder else {
             fatalError("Unreachable - guaranteed to exist")
         }
         return messageForwarder
     }
 
-    func asyncMessage(data: UInt32, completionHandler: CompletionHandlers.IPCTesterReceiverSwift.AsyncMessageCompletionHandler) {
+    func asyncMessage(data: UInt32, completionHandler: CompletionHandlers.IPCTesterReceiver.AsyncMessageCompletionHandler) {
         completionHandler.pointee(data + 2)
     }
 }

--- a/Source/WebKit/Shared/WebKit-Swift.h
+++ b/Source/WebKit/Shared/WebKit-Swift.h
@@ -35,7 +35,7 @@
 // #include statements should go here when the generated header
 // file depends upon C++ types. rdar://165068038 may resolve the need for
 // this.
-#include "IPCTesterReceiverSwiftMessages.h"
+#include "IPCTesterReceiverMessages.h"
 
 // rdar://165192318
 IGNORE_CLANG_WARNINGS_BEGIN("arc-bridge-casts-disallowed-in-nonarc")

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -916,7 +916,6 @@ DrawingAreaMessageReceiver.cpp
 DrawingAreaProxyMessageReceiver.cpp
 DigitalCredentialsCoordinatorMessageReceiver.cpp
 EventDispatcherMessageReceiver.cpp
-IPCTesterReceiverSwiftMessageReceiver.cpp
 GPUConnectionToWebProcessMessageReceiver.cpp
 GPUProcessConnectionMessageReceiver.cpp
 GPUProcessMessageReceiver.cpp

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1481,7 +1481,7 @@
 		5C411DAC27CED4220068241A /* UnifiedSource127.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5C411DA227CED4210068241A /* UnifiedSource127.cpp */; };
 		5C411DAD27CED4220068241A /* UnifiedSource129.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5C411DA327CED4220068241A /* UnifiedSource129.cpp */; };
 		5C411DAE27CED4220068241A /* UnifiedSource124.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5C411DA427CED4220068241A /* UnifiedSource124.cpp */; };
-		5C448C662EE06E11008931C7 /* IPCTesterReceiverSwiftMessageReceiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C448C652EE06E11008931C7 /* IPCTesterReceiverSwiftMessageReceiver.swift */; };
+		5C448C662EE06E11008931C7 /* IPCTesterReceiverMessageReceiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C448C652EE06E11008931C7 /* IPCTesterReceiverMessageReceiver.swift */; };
 		5C4609E7224317B4009943C2 /* _WKContentRuleListAction.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C4609E222430E4C009943C2 /* _WKContentRuleListAction.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5C4609E8224317BB009943C2 /* _WKContentRuleListActionInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C4609E422430E4D009943C2 /* _WKContentRuleListActionInternal.h */; };
 		5C4B9D8B210A8CCF008F14D1 /* UndoOrRedo.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C4B9D8A210A8C46008F14D1 /* UndoOrRedo.h */; };
@@ -1540,7 +1540,7 @@
 		5CE912112293C278005BEC78 /* AuxiliaryProcessMain.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5CE9120F2293C25F005BEC78 /* AuxiliaryProcessMain.cpp */; };
 		5CE912122293C278005BEC78 /* AuxiliaryProcessMain.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5CE9120F2293C25F005BEC78 /* AuxiliaryProcessMain.cpp */; };
 		5CE912142293C280005BEC78 /* WKMain.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CE9120B2293C1E0005BEC78 /* WKMain.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		5CF250AF2EE06491006A7172 /* IPCTesterReceiverSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF250AE2EE06491006A7172 /* IPCTesterReceiverSwift.swift */; };
+		5CF250AF2EE06491006A7172 /* IPCTesterReceiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF250AE2EE06491006A7172 /* IPCTesterReceiver.swift */; };
 		5CF62B9628D4436A00C0EAE0 /* DaemonCoders.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CF62B9428D4436A00C0EAE0 /* DaemonCoders.h */; };
 		5CFC9C812B71809600F8D289 /* CoreIPCCFDictionary.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5CFC9C7F2B717EFA00F8D289 /* CoreIPCCFDictionary.mm */; };
 		5CFFD8482DEF511C00C421F5 /* SwiftDemoLogo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CFFD8472DEF511B00C421F5 /* SwiftDemoLogo.swift */; };
@@ -6489,7 +6489,7 @@
 		5C411DA327CED4220068241A /* UnifiedSource129.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UnifiedSource129.cpp; sourceTree = "<group>"; };
 		5C411DA427CED4220068241A /* UnifiedSource124.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UnifiedSource124.cpp; sourceTree = "<group>"; };
 		5C426B5A28BEC8D200C695CF /* WebCoreArgumentCoders.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebCoreArgumentCoders.serialization.in; sourceTree = "<group>"; };
-		5C448C652EE06E11008931C7 /* IPCTesterReceiverSwiftMessageReceiver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = IPCTesterReceiverSwiftMessageReceiver.swift; path = "$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/IPCTesterReceiverSwiftMessageReceiver.swift"; sourceTree = "<absolute>"; };
+		5C448C652EE06E11008931C7 /* IPCTesterReceiverSwiftMessageReceiver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = IPCTesterReceiverMessageReceiver.swift; path = "$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/IPCTesterReceiverMessageReceiver.swift"; sourceTree = "<absolute>"; };
 		5C4609E222430E4C009943C2 /* _WKContentRuleListAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKContentRuleListAction.h; sourceTree = "<group>"; };
 		5C4609E322430E4D009943C2 /* _WKContentRuleListAction.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKContentRuleListAction.mm; sourceTree = "<group>"; };
 		5C4609E422430E4D009943C2 /* _WKContentRuleListActionInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKContentRuleListActionInternal.h; sourceTree = "<group>"; };
@@ -6694,8 +6694,7 @@
 		5CEB40A22A534EE100563C91 /* RemotePageVisitedLinkStoreRegistration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemotePageVisitedLinkStoreRegistration.h; sourceTree = "<group>"; };
 		5CEB40A32A535E8E00563C91 /* WebPageProxyMessageReceiverRegistration.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebPageProxyMessageReceiverRegistration.cpp; sourceTree = "<group>"; };
 		5CEB40A42A535E8E00563C91 /* WebPageProxyMessageReceiverRegistration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebPageProxyMessageReceiverRegistration.h; sourceTree = "<group>"; };
-		5CF250AE2EE06491006A7172 /* IPCTesterReceiverSwift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPCTesterReceiverSwift.swift; sourceTree = "<group>"; };
-		5CF250B02EE06499006A7172 /* IPCTesterReceiverSwift.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = IPCTesterReceiverSwift.messages.in; sourceTree = "<group>"; };
+		5CF250AE2EE06491006A7172 /* IPCTesterReceiver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPCTesterReceiver.swift; sourceTree = "<group>"; };
 		5CF62B9428D4436A00C0EAE0 /* DaemonCoders.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DaemonCoders.h; sourceTree = "<group>"; };
 		5CF62B9528D4436A00C0EAE0 /* DaemonCoders.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DaemonCoders.cpp; sourceTree = "<group>"; };
 		5CFC9C7E2B717EFA00F8D289 /* CoreIPCCFDictionary.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreIPCCFDictionary.serialization.in; sourceTree = "<group>"; };
@@ -10084,8 +10083,7 @@
 				86EFFA402B03A6B900ABE77D /* IPCTester.messages.in */,
 				7BF19B60290FC5B400EF322A /* IPCTesterReceiver.cpp */,
 				7BF19B5F290FC5B400EF322A /* IPCTesterReceiver.h */,
-				5CF250B02EE06499006A7172 /* IPCTesterReceiverSwift.messages.in */,
-				5CF250AE2EE06491006A7172 /* IPCTesterReceiverSwift.swift */,
+				5CF250AE2EE06491006A7172 /* IPCTesterReceiver.swift */,
 				FAC7C0B12D70229C00E7297E /* JavaScriptEvaluationResult.cpp */,
 				FAC7C0AF2D70225500E7297E /* JavaScriptEvaluationResult.h */,
 				FAC7C0B22D7022AF00E7297E /* JavaScriptEvaluationResult.mm */,
@@ -21497,8 +21495,8 @@
 				522F792928D50EBB0069B45B /* HidService.mm in Sources */,
 				2749F6442146561B008380BF /* InjectedBundleNodeHandle.cpp in Sources */,
 				2749F6452146561E008380BF /* InjectedBundleRangeHandle.cpp in Sources */,
-				5CF250AF2EE06491006A7172 /* IPCTesterReceiverSwift.swift in Sources */,
-				5C448C662EE06E11008931C7 /* IPCTesterReceiverSwiftMessageReceiver.swift in Sources */,
+				5CF250AF2EE06491006A7172 /* IPCTesterReceiver.swift in Sources */,
+				5C448C662EE06E11008931C7 /* IPCTesterReceiverMessageReceiver.swift in Sources */,
 				1C0F05BE2CFA5D2E007D1F62 /* JSWebExtensionAPIUnified.mm in Sources */,
 				E385F3672E86D6C900461B0C /* LaunchLogHook.mm in Sources */,
 				C14D37FE24ACE086007FF014 /* LaunchServicesDatabaseManager.mm in Sources */,

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -413,9 +413,10 @@ private:
     JSIPC(WebPage& webPage, WebFrame& webFrame)
         : m_webPage(webPage)
         , m_webFrame(webFrame)
-        , m_testerProxy(IPCTesterReceiver::create())
 #if ENABLE(IPC_TESTING_SWIFT)
-        , m_swiftTesterProxy(IPCTesterReceiverSwift::init())
+        , m_testerProxy(IPCTesterReceiver::init())
+#else
+        , m_testerProxy(IPCTesterReceiver::create())
 #endif
     { }
 
@@ -462,9 +463,10 @@ private:
     WeakPtr<WebPage> m_webPage;
     WeakPtr<WebFrame> m_webFrame;
     Vector<Ref<JSMessageListener>> m_messageListeners;
-    const Ref<IPCTesterReceiver> m_testerProxy;
 #if ENABLE(IPC_TESTING_SWIFT)
-    IPCTesterReceiverSwift m_swiftTesterProxy;
+    IPCTesterReceiver m_testerProxy;
+#else
+    const Ref<IPCTesterReceiver> m_testerProxy;
 #endif
     RefPtr<JSIPCConnection> m_uiConnection;
     RefPtr<JSIPCConnection> m_networkConnection;
@@ -2741,9 +2743,10 @@ JSValueRef JSIPC::addTesterReceiver(JSContextRef context, JSObjectRef, JSObjectR
         return JSValueMakeUndefined(context);
     }
     // Currently supports only UI process, as there's no uniform way to add message receivers.
-    WebProcess::singleton().addMessageReceiver(Messages::IPCTesterReceiver::messageReceiverName(), jsIPC->m_testerProxy.get());
 #if ENABLE(IPC_TESTING_SWIFT)
-    WebProcess::singleton().addMessageReceiver(Messages::IPCTesterReceiverSwift::messageReceiverName(), jsIPC->m_swiftTesterProxy.getMessageReceiver());
+    WebProcess::singleton().addMessageReceiver(Messages::IPCTesterReceiver::messageReceiverName(), jsIPC->m_testerProxy.getMessageReceiver());
+#else
+    WebProcess::singleton().addMessageReceiver(Messages::IPCTesterReceiver::messageReceiverName(), jsIPC->m_testerProxy.get());
 #endif
     return JSValueMakeUndefined(context);
 }
@@ -2761,9 +2764,6 @@ JSValueRef JSIPC::removeTesterReceiver(JSContextRef context, JSObjectRef, JSObje
     }
 
     WebProcess::singleton().removeMessageReceiver(Messages::IPCTesterReceiver::messageReceiverName());
-#if ENABLE(IPC_TESTING_SWIFT)
-    WebProcess::singleton().removeMessageReceiver(Messages::IPCTesterReceiverSwift::messageReceiverName());
-#endif
     return JSValueMakeUndefined(context);
 }
 


### PR DESCRIPTION
#### dd8bdc771fa0fdf8eb174f8cfc886309cd0cf863
<pre>
Add SwiftReceiverBuildEnabledBy
<a href="https://bugs.webkit.org/show_bug.cgi?id=304930">https://bugs.webkit.org/show_bug.cgi?id=304930</a>
<a href="https://rdar.apple.com/167541410">rdar://167541410</a>

Reviewed by Richard Robinson.

Until now, our autogenerated CoreIPC code has been able to call into either C++
or Swift message handlers, chosen using an attribute in the messages.in file
called &apos;SwiftReceiver&apos;. (The calling conventions are slightly different due to
limitations in Swift/C++ interop and the general nature of the Swift language).

However, for upcoming features such as the Swift BackForwardList, we intend
temporarily to have both C++ and Swift implementations in-tree, chosen using
a build-time option. The &apos;SwiftReceiver&apos; attribute in the messages.in file
therefore needs to be conditional.

However, the code which interprets the messages.in file does not really use
the preprocessor (it just looks like it). It&apos;s not currently possible to
apply an #ifdef around an attribute in the messages.in file.

This PR adds an alternative attribute, &apos;SwiftReceiverBuildEnabledBy&apos;, which
allows what we want. Everywhere that there&apos;s a difference between Swift
and C++ calling conventions, these will now be guarded by an
ifdef / else / endif section within the generated C++ code.

The functional part of this PR is really just in messages.py, model.py
and parser.py. All the rest is test code. Specifically, this fits in
with the existing split in the way the IPC message handling is tested:

* We add a new TestWithSwiftConditionally.messages.in test, and include
  the expected output of the code generator. This generated code is not
  compiled, but tests confirm that the output is as expected.
* We modify the existing (actually compiled) IPCTesterReceiver code.
  This previously included two separate IPC message handlers - one for
  Swift, one for C++. We now can remove all the extra code which
  was added for the Swift message handler, and just selectively use
  Swift or C++. This is therefore a simplification in the test code.

Canonical link: <a href="https://commits.webkit.org/305539@main">https://commits.webkit.org/305539@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3eb395c328fed3c946955336bc2e07ea0c38665a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138626 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10991 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/107 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146739 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91602 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/31c747c9-b61a-4902-ba1f-3a0b3f0c795a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11695 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11225 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106075 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77405 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/62c3c9f4-f830-43ab-b700-e9fc984ec3d3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141573 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8811 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124260 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86944 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/14feb8d8-7d65-4a20-9689-2e8ac03608f2) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/137974 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8402 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/6216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7030 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117821 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149492 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10673 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/103 "Found 1 new test failure: http/tests/performance/performance-resource-timing-redirection-cross-origin-media.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114457 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10690 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9096 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114794 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29190 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8616 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120551 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65570 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10722 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/95 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10457 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74365 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10660 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10511 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->