### PR TITLE
REGRESSION(304859@main): Made TestWebKitAPI.WebKit2.RTCDataChannelPostMessage flakey

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WebRTC.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebRTC.mm
@@ -53,7 +53,7 @@ namespace TestWebKitAPI {
 
 static bool isReady = false;
 
-TEST(WebKit2, DISABLED_RTCDataChannelPostMessage)
+TEST(WebKit2, RTCDataChannelPostMessage)
 {
     __block bool removedAnyExistingData = false;
     [[WKWebsiteDataStore defaultDataStore] removeDataOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] modifiedSince:[NSDate distantPast] completionHandler:^() {
@@ -115,11 +115,9 @@ TEST(WebKit2, DISABLED_RTCDataChannelPostMessage)
     "}"
     ""
     "async function closePCTest(pc) {"
-    "    const promise1 = new Promise(resolve => navigator.serviceWorker.onmessage = (event) => resolve(event.data));"
-    "    const promise2 = new Promise(resolve => channel2.onclose = resolve);"
+    "    const promise = new Promise(resolve => navigator.serviceWorker.onmessage = (event) => resolve(event.data));"
     "    pc.close();"
-    "    await promise2;"
-    "    window.webkit.messageHandlers.webrtc.postMessage(await promise1);"
+    "    window.webkit.messageHandlers.webrtc.postMessage(await promise);"
     "}"
     ""
     "function closePC1() {"


### PR DESCRIPTION
#### c965aea043315991e4d5df60c542eafcbc70ded1
<pre>
REGRESSION(304859@main): Made TestWebKitAPI.WebKit2.RTCDataChannelPostMessage flakey
<a href="https://rdar.apple.com/167439369">rdar://167439369</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=304848">https://bugs.webkit.org/show_bug.cgi?id=304848</a>

Reviewed by Eric Carlson.

The test is about channel close events being fired in case of explicit closing of a peer connection.
In the API test, we are ensuring that this close event is firing.

We were also testing that the close event of the remote data channel would fire when the other peer is closing.
As per bot results, this is not guaranteed, which is unexpected.
This is a separate issue though, that does not require changes to 304859@main.

We update the RTCDataChannelPostMessage test to only check local channel close event.

Canonical link: <a href="https://commits.webkit.org/305150@main">https://commits.webkit.org/305150@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ffe6cb797cf2839abb9a5b4e941beb14555e691

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137505 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9866 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48792 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145260 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90478 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c0e082ec-2584-404f-ab05-55bcceeac699) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139377 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10569 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/9992 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105155 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/25bc4411-2f8b-4639-909d-2df488de2c33) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140450 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7840 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123239 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86009 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/55453bf5-7468-481f-9530-c8e082afd8e8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7476 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5195 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5844 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116846 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41393 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148026 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9548 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41949 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113538 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9566 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8048 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113876 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28940 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7396 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119478 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64188 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9597 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37531 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9328 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9537 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9389 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->