### PR TITLE
[JSC] Optimize `String#startsWith` in DFG/FTL

### DIFF
--- a/JSTests/microbenchmarks/string-prototype-startswith-constant-folding.js
+++ b/JSTests/microbenchmarks/string-prototype-startswith-constant-folding.js
@@ -1,0 +1,34 @@
+// Benchmark for String.prototype.startsWith constant folding
+
+function testConstantFound() {
+    return "Hello World".startsWith("Hello");
+}
+noInline(testConstantFound);
+
+function testConstantNotFound() {
+    return "Hello World".startsWith("World");
+}
+noInline(testConstantNotFound);
+
+function testConstantWithIndex() {
+    return "Hello World".startsWith("World", 6);
+}
+noInline(testConstantWithIndex);
+
+function testConstantOneChar() {
+    return "Hello World".startsWith("H");
+}
+noInline(testConstantOneChar);
+
+function testConstantOneCharWithIndex() {
+    return "Hello World".startsWith("W", 6);
+}
+noInline(testConstantOneCharWithIndex);
+
+for (var i = 0; i < 1e6; ++i) {
+    testConstantFound();
+    testConstantNotFound();
+    testConstantWithIndex();
+    testConstantOneChar();
+    testConstantOneCharWithIndex();
+}

--- a/JSTests/microbenchmarks/string-prototype-startswith-with-index.js
+++ b/JSTests/microbenchmarks/string-prototype-startswith-with-index.js
@@ -1,0 +1,23 @@
+// Benchmark for String.prototype.startsWith with position argument
+
+function test(string, search, index) {
+    return string.startsWith(search, index);
+}
+noInline(test);
+
+function makeString(base) {
+    return base + "";
+}
+noInline(makeString);
+
+var string = makeString(".............................................okokHellookok................................");
+var search1 = makeString("Hello");
+var search2 = makeString("okok");
+
+for (var i = 0; i < 1e6; ++i) {
+    test(string, search1, 0);
+    test(string, search1, 49);
+    test(string, search1, 50);
+    test(string, search2, 0);
+    test(string, search2, 45);
+}

--- a/JSTests/microbenchmarks/string-prototype-startswith-with-one-char.js
+++ b/JSTests/microbenchmarks/string-prototype-startswith-with-one-char.js
@@ -1,0 +1,22 @@
+// Benchmark for String.prototype.startsWith (single-char search, no index)
+
+function test(string, search) {
+    return string.startsWith(search);
+}
+noInline(test);
+
+function makeString(base) {
+    return base + "";
+}
+noInline(makeString);
+
+var string = makeString(".............................................okokHellookok................................");
+var search1 = makeString(".");
+var search2 = makeString("H");
+var search3 = makeString("X");
+
+for (var i = 0; i < 1e6; ++i) {
+    test(string, search1);
+    test(string, search2);
+    test(string, search3);
+}

--- a/JSTests/microbenchmarks/string-prototype-startswith.js
+++ b/JSTests/microbenchmarks/string-prototype-startswith.js
@@ -1,0 +1,23 @@
+// Benchmark for String.prototype.startsWith (multi-char search, no index)
+
+function test(string, search) {
+    return string.startsWith(search);
+}
+noInline(test);
+
+// Create strings dynamically to avoid constant folding
+function makeString(base) {
+    return base + "";
+}
+noInline(makeString);
+
+var string = makeString(".............................................okokHellookok................................");
+var search1 = makeString(".....");
+var search2 = makeString("Hello");
+var search3 = makeString("NotFound");
+
+for (var i = 0; i < 1e6; ++i) {
+    test(string, search1);
+    test(string, search2);
+    test(string, search3);
+}

--- a/JSTests/stress/string-prototype-startswith-coerced-position.js
+++ b/JSTests/stress/string-prototype-startswith-coerced-position.js
@@ -1,0 +1,70 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+function test(string, search, index) {
+    return string.startsWith(search, index);
+}
+noInline(test);
+
+function makeString(base) {
+    return base + "";
+}
+noInline(makeString);
+
+var string = makeString("HelloWorld");
+var search = makeString("World");
+
+for (var i = 0; i < testLoopCount; ++i) {
+    // NaN should be treated as 0
+    shouldBe(test(string, makeString("Hello"), NaN), true);
+    shouldBe(test(string, search, NaN), false);
+
+    // Infinity should be clamped to string length
+    shouldBe(test(string, makeString(""), Infinity), true);
+    shouldBe(test(string, search, Infinity), false);
+    shouldBe(test(string, makeString("Hello"), Infinity), false);
+
+    // -Infinity should be treated as 0
+    shouldBe(test(string, makeString("Hello"), -Infinity), true);
+    shouldBe(test(string, search, -Infinity), false);
+
+    // Floating point numbers should be truncated
+    shouldBe(test(string, search, 5.0), true);
+    shouldBe(test(string, search, 5.9), true);
+    shouldBe(test(string, search, 5.1), true);
+    shouldBe(test(string, makeString("Hello"), 0.9), true);
+    shouldBe(test(string, makeString("ello"), 0.9), false);
+    shouldBe(test(string, makeString("ello"), 1.0), true);
+
+    // Negative floating point
+    shouldBe(test(string, makeString("Hello"), -0.5), true);
+    shouldBe(test(string, makeString("Hello"), -1.5), true);
+
+    // undefined should be treated as 0
+    shouldBe(test(string, makeString("Hello"), undefined), true);
+    shouldBe(test(string, search, undefined), false);
+
+    // null should be treated as 0
+    shouldBe(test(string, makeString("Hello"), null), true);
+    shouldBe(test(string, search, null), false);
+
+    // Boolean coercion
+    shouldBe(test(string, makeString("Hello"), false), true);
+    shouldBe(test(string, makeString("ello"), true), true);
+    shouldBe(test(string, makeString("Hello"), true), false);
+
+    // String coercion
+    shouldBe(test(string, makeString("Hello"), "0"), true);
+    shouldBe(test(string, search, "5"), true);
+    shouldBe(test(string, search, "5.9"), true);
+    shouldBe(test(string, makeString("Hello"), "notanumber"), true); // "notanumber" -> NaN -> 0
+
+    // Object with valueOf
+    shouldBe(test(string, search, { valueOf: function() { return 5; } }), true);
+    shouldBe(test(string, search, { valueOf: function() { return 4; } }), false);
+
+    // Object with toString
+    shouldBe(test(string, search, { toString: function() { return "5"; } }), true);
+}

--- a/JSTests/stress/string-prototype-startswith-constant-folding.js
+++ b/JSTests/stress/string-prototype-startswith-constant-folding.js
@@ -1,0 +1,67 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+function testConstantFound() {
+    return "Hello World".startsWith("Hello");
+}
+noInline(testConstantFound);
+
+function testConstantNotFound() {
+    return "Hello World".startsWith("World");
+}
+noInline(testConstantNotFound);
+
+function testConstantWithIndex() {
+    return "Hello World".startsWith("World", 6);
+}
+noInline(testConstantWithIndex);
+
+function testConstantWithIndexNotFound() {
+    return "Hello World".startsWith("World", 7);
+}
+noInline(testConstantWithIndexNotFound);
+
+function testConstantOneChar() {
+    return "Hello World".startsWith("H");
+}
+noInline(testConstantOneChar);
+
+function testConstantOneCharNotFound() {
+    return "Hello World".startsWith("W");
+}
+noInline(testConstantOneCharNotFound);
+
+function testConstantOneCharWithIndex() {
+    return "Hello World".startsWith("W", 6);
+}
+noInline(testConstantOneCharWithIndex);
+
+function testConstantOneCharWithIndexNotFound() {
+    return "Hello World".startsWith("W", 7);
+}
+noInline(testConstantOneCharWithIndexNotFound);
+
+function testEmptySearch() {
+    return "Hello World".startsWith("");
+}
+noInline(testEmptySearch);
+
+function testEmptySearchWithIndex() {
+    return "Hello World".startsWith("", 5);
+}
+noInline(testEmptySearchWithIndex);
+
+for (var i = 0; i < testLoopCount; ++i) {
+    shouldBe(testConstantFound(), true);
+    shouldBe(testConstantNotFound(), false);
+    shouldBe(testConstantWithIndex(), true);
+    shouldBe(testConstantWithIndexNotFound(), false);
+    shouldBe(testConstantOneChar(), true);
+    shouldBe(testConstantOneCharNotFound(), false);
+    shouldBe(testConstantOneCharWithIndex(), true);
+    shouldBe(testConstantOneCharWithIndexNotFound(), false);
+    shouldBe(testEmptySearch(), true);
+    shouldBe(testEmptySearchWithIndex(), true);
+}

--- a/JSTests/stress/string-prototype-startswith-rope.js
+++ b/JSTests/stress/string-prototype-startswith-rope.js
@@ -1,0 +1,79 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+function test(string, search) {
+    return string.startsWith(search);
+}
+noInline(test);
+
+function testWithIndex(string, search, index) {
+    return string.startsWith(search, index);
+}
+noInline(testWithIndex);
+
+// Create rope strings by concatenation
+function makeRope(a, b) {
+    return a + b;
+}
+noInline(makeRope);
+
+function makeRope3(a, b, c) {
+    return a + b + c;
+}
+noInline(makeRope3);
+
+var part1 = "Hello";
+var part2 = "World";
+var part3 = "JavaScript";
+
+// Basic rope strings
+var rope1 = makeRope(part1, part2);
+var rope2 = makeRope3(part1, part2, part3);
+
+// Longer rope strings
+var longPart1 = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+var longPart2 = "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+var longPart3 = "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC";
+var longRope = makeRope3(longPart1, longPart2, longPart3);
+
+// Search strings as ropes
+var searchRope1 = makeRope("Hel", "lo");
+var searchRope2 = makeRope("Hello", "World");
+var searchRope3 = makeRope("AA", "AA");
+
+for (var i = 0; i < testLoopCount; ++i) {
+    // Basic rope tests
+    shouldBe(test(rope1, "Hello"), true);
+    shouldBe(test(rope1, "HelloWorld"), true);
+    shouldBe(test(rope1, "World"), false);
+    shouldBe(test(rope1, "HelloWorldExtra"), false);
+
+    // Rope with rope search
+    shouldBe(test(rope1, searchRope1), true);
+    shouldBe(test(rope1, searchRope2), true);
+
+    // Longer rope tests
+    shouldBe(test(rope2, "HelloWorld"), true);
+    shouldBe(test(rope2, "HelloWorldJavaScript"), true);
+    shouldBe(test(rope2, "JavaScript"), false);
+
+    // Long rope string tests
+    shouldBe(test(longRope, longPart1), true);
+    shouldBe(test(longRope, makeRope(longPart1, longPart2)), true);
+    shouldBe(test(longRope, longPart2), false);
+    shouldBe(test(longRope, searchRope3), true);
+
+    // Rope with index
+    shouldBe(testWithIndex(rope1, "World", 5), true);
+    shouldBe(testWithIndex(rope1, "World", 0), false);
+    shouldBe(testWithIndex(rope2, "JavaScript", 10), true);
+    shouldBe(testWithIndex(longRope, longPart2, 40), true);
+    shouldBe(testWithIndex(longRope, longPart3, 80), true);
+
+    // Cross-boundary searches (search spans multiple rope segments)
+    shouldBe(test(rope1, "loWo"), false);
+    shouldBe(testWithIndex(rope1, "oWo", 4), true);
+    shouldBe(testWithIndex(longRope, makeRope("A", "B"), 39), true);
+}

--- a/JSTests/stress/string-prototype-startswith-search-coercion.js
+++ b/JSTests/stress/string-prototype-startswith-search-coercion.js
@@ -1,0 +1,99 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+function shouldThrow(func, expectedError) {
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        error = e;
+    }
+    if (!error)
+        throw new Error('Expected error: ' + expectedError);
+    if (!(error instanceof expectedError))
+        throw new Error('Wrong error type: ' + error.constructor.name + ' expected: ' + expectedError.name);
+}
+
+function test(string, search) {
+    return string.startsWith(search);
+}
+noInline(test);
+
+function testWithIndex(string, search, index) {
+    return string.startsWith(search, index);
+}
+noInline(testWithIndex);
+
+function makeString(base) {
+    return base + "";
+}
+noInline(makeString);
+
+var string = makeString("HelloWorld123true[object Object]null");
+
+for (var i = 0; i < testLoopCount; ++i) {
+    // Number coercion to string
+    shouldBe(test(makeString("123Hello"), 123), true);
+    shouldBe(test(makeString("123Hello"), 124), false);
+    shouldBe(test(string, 123), false);
+    shouldBe(testWithIndex(string, 123, 10), true);
+
+    // Boolean coercion to string
+    shouldBe(test(makeString("trueHello"), true), true);
+    shouldBe(test(makeString("falseHello"), false), true);
+    shouldBe(test(makeString("trueHello"), false), false);
+    shouldBe(testWithIndex(string, true, 13), true);
+
+    // null coercion to string
+    shouldBe(test(makeString("nullHello"), null), true);
+    shouldBe(test(string, null), false);
+    shouldBe(testWithIndex(string, null, 32), true);
+
+    // undefined coercion to string
+    shouldBe(test(makeString("undefinedHello"), undefined), true);
+    shouldBe(test(string, undefined), false);
+
+    // Object coercion via toString
+    var objWithToString = { toString: function() { return "Hello"; } };
+    shouldBe(test(string, objWithToString), true);
+    shouldBe(test(makeString("World"), objWithToString), false);
+
+    // Object coercion via valueOf (toString takes precedence for string conversion)
+    var objWithValueOf = { valueOf: function() { return "Hello"; }, toString: function() { return "World"; } };
+    shouldBe(test(string, objWithValueOf), false);
+    shouldBe(test(makeString("WorldHello"), objWithValueOf), true);
+
+    // Plain object "[object Object]"
+    var plainObj = {};
+    shouldBe(test(string, plainObj), false);
+    shouldBe(testWithIndex(string, plainObj, 17), true);
+
+    // Array coercion
+    shouldBe(test(makeString("Hello"), ["Hello"]), true);
+    shouldBe(test(makeString("1,2,3Hello"), [1, 2, 3]), true);
+    shouldBe(test(makeString("Hello"), [1, 2, 3]), false);
+
+    // Empty array
+    shouldBe(test(makeString("Hello"), []), true);
+
+    // Symbol should throw TypeError
+    shouldThrow(function() {
+        test(string, Symbol("test"));
+    }, TypeError);
+
+    shouldThrow(function() {
+        testWithIndex(string, Symbol.iterator, 0);
+    }, TypeError);
+
+    // RegExp should throw TypeError (per spec)
+    shouldThrow(function() {
+        test(string, /Hello/);
+    }, TypeError);
+
+    // RegExp with Symbol.match set to falsy should work
+    var regexLike = /Hello/;
+    regexLike[Symbol.match] = false;
+    shouldBe(test(makeString("/Hello/Hello"), regexLike), true);
+}

--- a/JSTests/stress/string-prototype-startswith-unicode.js
+++ b/JSTests/stress/string-prototype-startswith-unicode.js
@@ -1,0 +1,66 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+function test(string, search) {
+    return string.startsWith(search);
+}
+noInline(test);
+
+function testWithIndex(string, search, index) {
+    return string.startsWith(search, index);
+}
+noInline(testWithIndex);
+
+function makeString(base) {
+    return base + "";
+}
+noInline(makeString);
+
+// Basic Unicode characters
+var unicodeString = makeString("こんにちは世界");
+var unicodeSearch1 = makeString("こんにちは");
+var unicodeSearch2 = makeString("世界");
+var unicodeSearch3 = makeString("こん");
+
+// Surrogate pairs (emoji)
+var emojiString = makeString("😀🎉Hello🌍World");
+var emojiSearch1 = makeString("😀");
+var emojiSearch2 = makeString("😀🎉");
+var emojiSearch3 = makeString("🎉");
+var emojiSearch4 = makeString("😀🎉Hello");
+
+// Mixed ASCII and Unicode
+var mixedString = makeString("Hello世界こんにちは");
+var mixedSearch1 = makeString("Hello");
+var mixedSearch2 = makeString("Hello世界");
+var mixedSearch3 = makeString("世界");
+
+for (var i = 0; i < testLoopCount; ++i) {
+    // Basic Unicode tests
+    shouldBe(test(unicodeString, unicodeSearch1), true);
+    shouldBe(test(unicodeString, unicodeSearch2), false);
+    shouldBe(test(unicodeString, unicodeSearch3), true);
+    shouldBe(test(unicodeString, makeString("")), true);
+
+    // Surrogate pair tests
+    shouldBe(test(emojiString, emojiSearch1), true);
+    shouldBe(test(emojiString, emojiSearch2), true);
+    shouldBe(test(emojiString, emojiSearch3), false);
+    shouldBe(test(emojiString, emojiSearch4), true);
+
+    // Mixed ASCII and Unicode tests
+    shouldBe(test(mixedString, mixedSearch1), true);
+    shouldBe(test(mixedString, mixedSearch2), true);
+    shouldBe(test(mixedString, mixedSearch3), false);
+
+    // Unicode with index
+    shouldBe(testWithIndex(unicodeString, makeString("世界"), 5), true);
+    shouldBe(testWithIndex(unicodeString, makeString("世界"), 4), false);
+
+    // Emoji with index (note: emoji are 2 UTF-16 code units each)
+    shouldBe(testWithIndex(emojiString, makeString("🎉"), 2), true);
+    shouldBe(testWithIndex(emojiString, makeString("Hello"), 4), true);
+    shouldBe(testWithIndex(emojiString, makeString("🌍"), 9), true);
+}

--- a/JSTests/stress/string-prototype-startswith-with-index.js
+++ b/JSTests/stress/string-prototype-startswith-with-index.js
@@ -1,0 +1,45 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+function test(string, search, index) {
+    return string.startsWith(search, index);
+}
+noInline(test);
+
+function makeString(base) {
+    return base + "";
+}
+noInline(makeString);
+
+var string = makeString(".............................................okokHellookok................................");
+var search1 = makeString("Hello");
+var search2 = makeString("okok");
+var search3 = makeString("NotFound");
+
+for (var i = 0; i < testLoopCount; ++i) {
+    // Basic tests with index
+    shouldBe(test(string, search1, 0), false);
+    shouldBe(test(string, search1, 49), true);
+    shouldBe(test(string, search1, 50), false);
+    shouldBe(test(string, search1, string.length), false);
+
+    shouldBe(test(string, search2, 0), false);
+    shouldBe(test(string, search2, 45), true);
+    shouldBe(test(string, search2, 46), false);
+
+    shouldBe(test(string, search3, 0), false);
+    shouldBe(test(string, search3, 20), false);
+
+    // Negative index should be treated as 0
+    shouldBe(test(string, makeString("."), -10), true);
+    shouldBe(test(string, makeString("."), -1), true);
+    shouldBe(test(string, search1, -1), false);
+
+    // Edge cases
+    shouldBe(test(makeString("Hello"), makeString("ello"), 1), true);
+    shouldBe(test(makeString("Hello"), makeString("ello"), 0), false);
+    shouldBe(test(makeString("Hello"), makeString("lo"), 3), true);
+    shouldBe(test(makeString("Hello"), makeString(""), 3), true);
+}

--- a/JSTests/stress/string-prototype-startswith.js
+++ b/JSTests/stress/string-prototype-startswith.js
@@ -1,0 +1,33 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+function test(string, search) {
+    return string.startsWith(search);
+}
+noInline(test);
+
+function makeString(base) {
+    return base + "";
+}
+noInline(makeString);
+
+var string = makeString(".............................................okokHellookok................................");
+var search1 = makeString(".....");
+var search2 = makeString("okok");
+var search3 = makeString("NotFound");
+var search4 = makeString("");
+
+for (var i = 0; i < testLoopCount; ++i) {
+    shouldBe(test(string, search1), true);
+    shouldBe(test(string, search2), false);
+    shouldBe(test(string, search3), false);
+    shouldBe(test(string, search4), true);
+
+    shouldBe(test(string, makeString("")), true);
+    shouldBe(test(makeString(""), search1), false);
+    shouldBe(test(makeString("Hello"), makeString("Hello")), true);
+    shouldBe(test(makeString("Hello"), makeString("Hell")), true);
+    shouldBe(test(makeString("Hello"), makeString("ello")), false);
+}

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -2599,6 +2599,10 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         setNonCellTypeForNode(node, SpecInt32Only);
         break;
 
+    case StringStartsWith:
+        setNonCellTypeForNode(node, SpecBoolean);
+        break;
+
     case StringFromCharCode: {
         if (node->child1().useKind() == Int32Use || node->child1().useKind() == KnownInt32Use) {
             if (node->child1()->isInt32Constant() && node->child1()->asUInt32() <= maxSingleCharacterString) {

--- a/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp
@@ -358,6 +358,14 @@ private:
             break;
         }
 
+        case StringStartsWith: {
+            node->child1()->mergeFlags(NodeBytecodeUsesAsValue);
+            node->child2()->mergeFlags(NodeBytecodeUsesAsValue);
+            if (node->child3())
+                node->child3()->mergeFlags(NodeBytecodeUsesAsValue | NodeBytecodeUsesAsInt | NodeBytecodePrefersArrayIndex);
+            break;
+        }
+
         case StringSlice:
         case StringSubstring: {
             node->child1()->mergeFlags(NodeBytecodeUsesAsValue);

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -3081,6 +3081,28 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             return CallOptimizationResult::Inlined;
         }
 
+        case StringPrototypeStartsWithIntrinsic: {
+            if (argumentCountIncludingThis < 2)
+                return CallOptimizationResult::DidNothing;
+
+            if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, Uncountable) || m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadType))
+                return CallOptimizationResult::DidNothing;
+
+            insertChecks();
+            Node* thisValue = get(virtualRegisterForArgumentIncludingThis(0, registerOffset));
+            Node* search = get(virtualRegisterForArgumentIncludingThis(1, registerOffset));
+            Node* result = nullptr;
+            if (argumentCountIncludingThis == 2)
+                result = addToGraph(StringStartsWith, thisValue, search);
+            else {
+                Node* index = get(virtualRegisterForArgumentIncludingThis(2, registerOffset));
+                result = addToGraph(StringStartsWith, thisValue, search, index);
+            }
+
+            setResult(result);
+            return CallOptimizationResult::Inlined;
+        }
+
         case CharAtIntrinsic: {
             if (argumentCountIncludingThis < 1)
                 return CallOptimizationResult::DidNothing;

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -236,6 +236,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
     case StringCharCodeAt:
     case StringCodePointAt:
     case StringIndexOf:
+    case StringStartsWith:
     case CompareStrictEq:
     case SameValue:
     case IsEmpty:

--- a/Source/JavaScriptCore/dfg/DFGCloneHelper.h
+++ b/Source/JavaScriptCore/dfg/DFGCloneHelper.h
@@ -339,6 +339,7 @@ BasicBlock* CloneHelper::cloneBlock(BasicBlock* const block, const CustomizeSucc
     CLONE_STATUS(StringCodePointAt, Common) \
     CLONE_STATUS(StringFromCharCode, Common) \
     CLONE_STATUS(StringIndexOf, Common) \
+    CLONE_STATUS(StringStartsWith, Common) \
     CLONE_STATUS(StringLocaleCompare, Common) \
     CLONE_STATUS(StringReplace, Common) \
     CLONE_STATUS(StringReplaceString, Common) \

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -482,6 +482,7 @@ bool doesGC(Graph& graph, Node* node)
     case ValueNegate:
     case DateSetTime:
     case StringIndexOf:
+    case StringStartsWith:
     case ResolvePromiseFirstResolving:
     case RejectPromiseFirstResolving:
     case FulfillPromiseFirstResolving:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -1109,6 +1109,14 @@ private:
             break;
         }
 
+        case StringStartsWith: {
+            fixEdge<StringUse>(node->child1());
+            fixEdge<StringUse>(node->child2());
+            if (node->child3())
+                fixEdge<Int32Use>(node->child3());
+            break;
+        }
+
         case StringLocaleCompare: {
             fixEdge<StringUse>(node->child1());
             fixEdge<StringUse>(node->child2());

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -359,6 +359,7 @@ namespace JSC { namespace DFG {
     macro(StringReplaceRegExp, NodeResultJS | NodeMustGenerate) \
     macro(StringReplaceString, NodeResultJS | NodeMustGenerate) \
     macro(StringIndexOf, NodeResultInt32) \
+    macro(StringStartsWith, NodeResultBoolean) \
     \
     /* Optimizations for string access */ \
     macro(StringAt, NodeResultJS) \

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -3348,6 +3348,45 @@ JSC_DEFINE_JIT_OPERATION(operationStringIndexOfWithIndexWithOneChar, UCPUStrictI
     OPERATION_RETURN(scope, toUCPUStrictInt32(result));
 }
 
+JSC_DEFINE_JIT_OPERATION(operationStringStartsWith, bool, (JSGlobalObject* globalObject, JSString* base, JSString* prefix))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto baseView = base->view(globalObject);
+    OPERATION_RETURN_IF_EXCEPTION(scope, false);
+
+    auto prefixView = prefix->view(globalObject);
+    OPERATION_RETURN_IF_EXCEPTION(scope, false);
+
+    OPERATION_RETURN(scope, baseView->startsWith(prefixView));
+}
+
+JSC_DEFINE_JIT_OPERATION(operationStringStartsWithWithIndex, bool, (JSGlobalObject* globalObject, JSString* base, JSString* prefix, int32_t position))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto baseView = base->view(globalObject);
+    OPERATION_RETURN_IF_EXCEPTION(scope, false);
+
+    auto prefixView = prefix->view(globalObject);
+    OPERATION_RETURN_IF_EXCEPTION(scope, false);
+
+    int32_t length = baseView->length();
+    unsigned start = 0;
+    if (position >= 0)
+        start = std::min<uint32_t>(position, length);
+
+    OPERATION_RETURN(scope, baseView->hasInfixStartingAt(prefixView, start));
+}
+
 JSC_DEFINE_JIT_OPERATION(operationStringProtoFuncReplaceGeneric, JSCell*, (JSGlobalObject* globalObject, EncodedJSValue thisValue, EncodedJSValue searchValue, EncodedJSValue replaceValue))
 {
     VM& vm = globalObject->vm();

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -292,6 +292,8 @@ JSC_DECLARE_JIT_OPERATION(operationStringIndexOf, UCPUStrictInt32, (JSGlobalObje
 JSC_DECLARE_JIT_OPERATION(operationStringIndexOfWithOneChar, UCPUStrictInt32, (JSGlobalObject*, JSString*, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationStringIndexOfWithIndex, UCPUStrictInt32, (JSGlobalObject*, JSString*, JSString*, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationStringIndexOfWithIndexWithOneChar, UCPUStrictInt32, (JSGlobalObject*, JSString*, int32_t, int32_t));
+JSC_DECLARE_JIT_OPERATION(operationStringStartsWith, bool, (JSGlobalObject*, JSString*, JSString*));
+JSC_DECLARE_JIT_OPERATION(operationStringStartsWithWithIndex, bool, (JSGlobalObject*, JSString*, JSString*, int32_t));
 
 JSC_DECLARE_JIT_OPERATION(operationStringProtoFuncReplaceGeneric, JSCell*, (JSGlobalObject*, EncodedJSValue thisValue, EncodedJSValue searchValue, EncodedJSValue replaceValue));
 JSC_DECLARE_JIT_OPERATION(operationStringProtoFuncReplaceAllGeneric, JSCell*, (JSGlobalObject*, EncodedJSValue thisValue, EncodedJSValue searchValue, EncodedJSValue replaceValue));

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -1187,6 +1187,11 @@ private:
             break;
         }
 
+        case StringStartsWith: {
+            setPrediction(SpecBoolean);
+            break;
+        }
+
         case StringLocaleCompare: {
             setPrediction(SpecInt32Only);
             break;

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -345,6 +345,7 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case NumberIsFinite:
     case NumberIsSafeInteger:
     case StringIndexOf:
+    case StringStartsWith:
         return true;
 
     case GlobalIsFinite:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -17236,6 +17236,46 @@ void SpeculativeJIT::compileStringIndexOf(Node* node)
     strictInt32Result(resultGPR, node);
 }
 
+void SpeculativeJIT::compileStringStartsWith(Node* node)
+{
+    if (node->child3()) {
+        SpeculateCellOperand base(this, node->child1());
+        SpeculateCellOperand argument(this, node->child2());
+        SpeculateInt32Operand index(this, node->child3());
+
+        GPRReg baseGPR = base.gpr();
+        GPRReg argumentGPR = argument.gpr();
+        GPRReg indexGPR = index.gpr();
+
+        speculateString(node->child1(), baseGPR);
+        speculateString(node->child2(), argumentGPR);
+
+        flushRegisters();
+        GPRFlushedCallResult result(this);
+        GPRReg resultGPR = result.gpr();
+        callOperation(operationStringStartsWithWithIndex, resultGPR, LinkableConstant::globalObject(*this, node), baseGPR, argumentGPR, indexGPR);
+
+        unblessedBooleanResult(resultGPR, node);
+        return;
+    }
+
+    SpeculateCellOperand base(this, node->child1());
+    SpeculateCellOperand argument(this, node->child2());
+
+    GPRReg baseGPR = base.gpr();
+    GPRReg argumentGPR = argument.gpr();
+
+    speculateString(node->child1(), baseGPR);
+    speculateString(node->child2(), argumentGPR);
+
+    flushRegisters();
+    GPRFlushedCallResult result(this);
+    GPRReg resultGPR = result.gpr();
+    callOperation(operationStringStartsWith, resultGPR, LinkableConstant::globalObject(*this, node), baseGPR, argumentGPR);
+
+    unblessedBooleanResult(resultGPR, node);
+}
+
 void SpeculativeJIT::compileGlobalIsNaN(Node* node)
 {
     switch (node->child1().useKind()) {

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1788,6 +1788,7 @@ public:
     void compileStringCodePointAt(Node*);
     void compileStringLocaleCompare(Node*);
     void compileStringIndexOf(Node*);
+    void compileStringStartsWith(Node*);
     void compileDateGet(Node*);
     void compileDateSet(Node*);
     void compileGlobalIsNaN(Node*);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -3152,6 +3152,11 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
+    case StringStartsWith: {
+        compileStringStartsWith(node);
+        break;
+    }
+
     case FunctionToString:
         compileFunctionToString(node);
         break;

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -3782,6 +3782,11 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
+    case StringStartsWith: {
+        compileStringStartsWith(node);
+        break;
+    }
+
     case StringAt:
     case StringCharAt: {
         // Relies on StringCharAt and StringAt node having same basic layout as GetByVal

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -176,6 +176,7 @@ inline CapabilityLevel canCompile(Node* node)
     case StringCodePointAt:
     case StringFromCharCode:
     case StringIndexOf:
+    case StringStartsWith:
     case AllocatePropertyStorage:
     case ReallocatePropertyStorage:
     case NukeStructureAndSetButterfly:

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -1364,6 +1364,9 @@ private:
         case StringIndexOf:
             compileStringIndexOf();
             break;
+        case StringStartsWith:
+            compileStringStartsWith();
+            break;
         case GetByOffset:
         case GetGetterSetterByOffset:
             compileGetByOffset();
@@ -11607,6 +11610,17 @@ IGNORE_CLANG_WARNINGS_END
             setInt32(vmCall(Int32, operationStringIndexOfWithOneChar, weakPointer(globalObject), base, m_out.constInt32(character.value())));
         else
             setInt32(vmCall(Int32, operationStringIndexOf, weakPointer(globalObject), base, search));
+    }
+
+    void compileStringStartsWith()
+    {
+        LValue base = lowString(m_node->child1());
+        LValue search = lowString(m_node->child2());
+        auto* globalObject = m_graph.globalObjectFor(m_origin.semantic);
+        if (m_node->child3())
+            setBoolean(vmCall(Int32, operationStringStartsWithWithIndex, weakPointer(globalObject), base, search, lowInt32(m_node->child3())));
+        else
+            setBoolean(vmCall(Int32, operationStringStartsWith, weakPointer(globalObject), base, search));
     }
 
     void compileGetByOffset()

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -120,6 +120,7 @@ namespace JSC {
     macro(StringPrototypeCodePointAtIntrinsic) \
     macro(StringPrototypeIndexOfIntrinsic) \
     macro(StringPrototypeIncludesIntrinsic) \
+    macro(StringPrototypeStartsWithIntrinsic) \
     macro(StringPrototypeLocaleCompareIntrinsic) \
     macro(StringPrototypeValueOfIntrinsic) \
     macro(StringPrototypeReplaceIntrinsic) \

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -166,7 +166,7 @@ void StringPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("toLocaleLowerCase"_s, stringProtoFuncToLocaleLowerCase, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("toLocaleUpperCase"_s, stringProtoFuncToLocaleUpperCase, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("trim"_s, stringProtoFuncTrim, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
-    JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("startsWith"_s, stringProtoFuncStartsWith, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
+    JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION("startsWith"_s, stringProtoFuncStartsWith, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public, StringPrototypeStartsWithIntrinsic);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("endsWith"_s, stringProtoFuncEndsWith, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
     JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION("includes"_s, stringProtoFuncIncludes, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public, StringPrototypeIncludesIntrinsic);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("normalize"_s, stringProtoFuncNormalize, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);


### PR DESCRIPTION
#### 1f7d7d5a8c2357656d17d4d6474b9cc3b38423b1
<pre>
[JSC] Optimize `String#startsWith` in DFG/FTL
<a href="https://bugs.webkit.org/show_bug.cgi?id=304932">https://bugs.webkit.org/show_bug.cgi?id=304932</a>

Reviewed by Yusuke Suzuki.

This patch changes to optimize `String#startsWith` in DFG/FTL.

                                                  TipOfTree                  Patched

string-prototype-startswith                    22.6393+-0.3554     ^     15.9425+-0.8382        ^ definitely 1.4201x faster
string-prototype-startswith-constant-folding
                                               34.3708+-1.4274     ^      5.9707+-0.6009        ^ definitely 5.7566x faster
string-prototype-startswith-with-index         34.9549+-2.0886     ^     28.5803+-2.2877        ^ definitely 1.2230x faster
string-prototype-startswith-with-one-char
                                               24.2620+-12.1058          12.8071+-0.3200          might be 1.8944x faster

Tests: JSTests/microbenchmarks/string-prototype-startswith-constant-folding.js
       JSTests/microbenchmarks/string-prototype-startswith-with-index.js
       JSTests/microbenchmarks/string-prototype-startswith-with-one-char.js
       JSTests/microbenchmarks/string-prototype-startswith.js
       JSTests/stress/string-prototype-startswith-coerced-position.js
       JSTests/stress/string-prototype-startswith-constant-folding.js
       JSTests/stress/string-prototype-startswith-rope.js
       JSTests/stress/string-prototype-startswith-search-coercion.js
       JSTests/stress/string-prototype-startswith-unicode.js
       JSTests/stress/string-prototype-startswith-with-index.js
       JSTests/stress/string-prototype-startswith.js

* JSTests/microbenchmarks/string-prototype-startswith-constant-folding.js: Added.
(testConstantFound):
(testConstantNotFound):
(testConstantWithIndex):
(testConstantOneChar):
(testConstantOneCharWithIndex):
* JSTests/microbenchmarks/string-prototype-startswith-with-index.js: Added.
(test):
(makeString):
* JSTests/microbenchmarks/string-prototype-startswith-with-one-char.js: Added.
(test):
(makeString):
* JSTests/microbenchmarks/string-prototype-startswith.js: Added.
(test):
(makeString):
* JSTests/stress/string-prototype-startswith-coerced-position.js: Added.
(shouldBe):
(test):
(makeString):
(i.valueOf):
(i.toString):
* JSTests/stress/string-prototype-startswith-constant-folding.js: Added.
(shouldBe):
(testConstantFound):
(testConstantNotFound):
(testConstantWithIndex):
(testConstantWithIndexNotFound):
(testConstantOneChar):
(testConstantOneCharNotFound):
(testConstantOneCharWithIndex):
(testConstantOneCharWithIndexNotFound):
(testEmptySearch):
(testEmptySearchWithIndex):
* JSTests/stress/string-prototype-startswith-rope.js: Added.
(shouldBe):
(test):
(testWithIndex):
(makeRope):
(makeRope3):
* JSTests/stress/string-prototype-startswith-search-coercion.js: Added.
(shouldBe):
(shouldThrow):
(test):
(testWithIndex):
(makeString):
(i.objWithToString.toString):
(i.objWithValueOf.valueOf):
(i.objWithValueOf.toString):
(i.shouldThrow):
* JSTests/stress/string-prototype-startswith-unicode.js: Added.
(shouldBe):
(test):
(testWithIndex):
(makeString):
* JSTests/stress/string-prototype-startswith-with-index.js: Added.
(shouldBe):
(test):
(makeString):
* JSTests/stress/string-prototype-startswith.js: Added.
(shouldBe):
(test):
(makeString):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp:
(JSC::DFG::BackwardsPropagationPhase::propagate):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGCloneHelper.h:
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGNodeType.h:
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::safeToExecute):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
(JSC::DFG::StrengthReductionPhase::handleNode):
* Source/JavaScriptCore/ftl/FTLCapabilities.cpp:
(JSC::FTL::canCompile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::compileStringStartsWith):
* Source/JavaScriptCore/runtime/Intrinsic.h:
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::StringPrototype::finishCreation):

Canonical link: <a href="https://commits.webkit.org/306324@main">https://commits.webkit.org/306324@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68ae8dc49fd7c1f20bbe7f38244e7ceca9a344f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139850 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12231 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1361 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147992 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92919 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12941 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12383 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107088 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77946 "2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142800 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9966 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125245 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87966 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9619 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7132 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8282 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/131824 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118839 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1246 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150776 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/646 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11916 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1313 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115501 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11928 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10210 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115815 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29695 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10598 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121725 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66921 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11958 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1200 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/171122 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11698 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75645 "Built successfully") | [⏳ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11894 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11746 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->