### PR TITLE
[JSC] Implement `RegExp#@@matchAll` in C++

### DIFF
--- a/JSTests/microbenchmarks/matchall-bench.js
+++ b/JSTests/microbenchmarks/matchall-bench.js
@@ -1,0 +1,6 @@
+const re1 = /test/g;
+const str1 = "test1test2test3";
+for (let i = 0; i < 1e5; i++) {
+    const iter = str1.matchAll(re1);
+    iter.next();
+}

--- a/Source/JavaScriptCore/builtins/RegExpPrototype.js
+++ b/Source/JavaScriptCore/builtins/RegExpPrototype.js
@@ -165,28 +165,6 @@ function match(strArg)
     return @matchSlow(this, str);
 }
 
-@overriddenName="[Symbol.matchAll]"
-function matchAll(strArg)
-{
-    "use strict";
-
-    var regExp = this;
-    if (!@isObject(regExp))
-        @throwTypeError("RegExp.prototype.@@matchAll requires |this| to be an Object");
-
-    var string = @toString(strArg);
-    var Matcher = @speciesConstructor(regExp, @RegExp);
-
-    var flags = @toString(regExp.flags);
-    var matcher = new Matcher(regExp, flags);
-    matcher.lastIndex = @toLength(regExp.lastIndex);
-
-    var global = @stringIncludesInternal.@call(flags, "g");
-    var fullUnicode = @stringIncludesInternal.@call(flags, "u") || @stringIncludesInternal.@call(flags, "v");
-
-    return @regExpStringIteratorCreate(matcher, string, global, fullUnicode);
-}
-
 @linkTimeConstant
 function hasObservableSideEffectsForRegExpSplit(regexp)
 {

--- a/Source/JavaScriptCore/runtime/JSRegExpStringIterator.h
+++ b/Source/JavaScriptCore/runtime/JSRegExpStringIterator.h
@@ -42,6 +42,7 @@ public:
     enum class Field : uint8_t {
         RegExp = 0,
         String,
+        // FIXME: Global and FullUnicode should be one bitset field
         Global,
         FullUnicode,
         Done,

--- a/Source/JavaScriptCore/runtime/RegExpPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/RegExpPrototypeInlines.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "JSGlobalObject.h"
+#include "RegExpObject.h"
 #include "RegExpPrototype.h"
 
 namespace JSC {
@@ -41,6 +42,30 @@ ALWAYS_INLINE bool regExpExecWatchpointIsValid(VM& vm, JSObject* thisObject)
         return true;
 
     return thisObject->getDirectOffset(vm, vm.propertyNames->exec) == invalidOffset;
+}
+
+ALWAYS_INLINE bool regExpMatchAllWathpointIsValid(RegExpObject* regExpObject)
+{
+    JSGlobalObject* globalObject = regExpObject->globalObject();
+    RegExpPrototype* regExpPrototype = globalObject->regExpPrototype();
+
+    if (regExpPrototype != regExpObject->getPrototypeDirect())
+        return false;
+
+    if (globalObject->regExpPrimordialPropertiesWatchpointSet().state() != IsWatched)
+        return false;
+
+    if (regExpObject->hasCustomProperties())
+        return false;
+
+    if (!regExpObject->lastIndexIsWritable())
+        return false;
+
+    JSValue lastIndex = regExpObject->getLastIndex();
+    if (!lastIndex.isNumber())
+        return false;
+
+    return true;
 }
 
 inline Structure* RegExpPrototype::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)


### PR DESCRIPTION
#### 4b4cd078895ca415b8eeba467d60b56c42c60bcc
<pre>
[JSC] Implement `RegExp#@@matchAll` in C++
<a href="https://bugs.webkit.org/show_bug.cgi?id=305096">https://bugs.webkit.org/show_bug.cgi?id=305096</a>

Reviewed by Yusuke Suzuki.

This patch changes to implement `RegExp#@@matchAll` in C++.

                        TipOfTree                  Patched

matchall-bench       41.0811+-0.2157     ^     22.2720+-0.9164        ^ definitely 1.8445x faster

* JSTests/microbenchmarks/matchall-bench.js: Added.
* Source/JavaScriptCore/builtins/RegExpPrototype.js:
Remove the matchAll JavaScript builtin function.
(overriddenName.string_appeared_here.matchAll): Deleted.
* Source/JavaScriptCore/runtime/JSRegExpStringIterator.h:
* Source/JavaScriptCore/runtime/RegExpPrototype.cpp:
(JSC::RegExpPrototype::finishCreation): Register native matchAll function
instead of builtin.
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/RegExpPrototypeInlines.h:
(JSC::regExpMatchAllWathpointIsValid):

Canonical link: <a href="https://commits.webkit.org/305270@main">https://commits.webkit.org/305270@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/adf495658cab7eacd4e1381b866a647244263c86

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137956 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10320 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49319 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146027 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90931 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11022 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10463 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105503 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140901 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8215 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123673 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86355 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7829 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5582 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6306 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/129920 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117224 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41843 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148734 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/136505 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10003 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42402 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113901 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10020 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8439 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114231 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29021 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7770 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119929 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64727 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10049 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37923 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/169228 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9780 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73617 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44130 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9990 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9841 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->