### PR TITLE
Expose CopyOnWrite as part of SharedMemory object mappings

### DIFF
--- a/Source/WebCore/platform/SharedMemory.h
+++ b/Source/WebCore/platform/SharedMemory.h
@@ -113,11 +113,12 @@ class SharedMemory : public ThreadSafeRefCounted<SharedMemory> {
 public:
     using Handle = SharedMemoryHandle;
     using Protection = SharedMemoryProtection;
+    enum class CopyOnWrite : bool { No, Yes };
 
     // FIXME: Change these factory functions to return Ref<SharedMemory> and crash on failure.
     WEBCORE_EXPORT static RefPtr<SharedMemory> allocate(size_t);
     WEBCORE_EXPORT static RefPtr<SharedMemory> copyBuffer(const WebCore::FragmentedSharedBuffer&);
-    WEBCORE_EXPORT static RefPtr<SharedMemory> map(Handle&&, Protection);
+    WEBCORE_EXPORT static RefPtr<SharedMemory> map(Handle&&, Protection, CopyOnWrite = CopyOnWrite::No);
 #if USE(UNIX_DOMAIN_SOCKETS)
     WEBCORE_EXPORT static RefPtr<SharedMemory> wrapMap(void*, size_t, int fileDescriptor);
 #elif OS(DARWIN)

--- a/Source/WebCore/platform/android/SharedMemoryAndroid.cpp
+++ b/Source/WebCore/platform/android/SharedMemoryAndroid.cpp
@@ -104,8 +104,12 @@ RefPtr<SharedMemory> SharedMemory::allocate(size_t size)
     return instance;
 }
 
-RefPtr<SharedMemory> SharedMemory::map(Handle&& handle, Protection protection)
+RefPtr<SharedMemory> SharedMemory::map(Handle&& handle, Protection protection, CopyOnWrite copyOnWrite)
 {
+    // Copy-on-write is not supported on this platform.
+    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305633
+    ASSERT_UNUSED(copyOnWrite, copyOnWrite == CopyOnWrite::No);
+
     void* data = mmap(0, handle.size(), accessModeMMap(protection), MAP_SHARED, handle.m_handle.value(), 0);
     if (data == MAP_FAILED)
         return nullptr;

--- a/Source/WebCore/platform/cocoa/SharedMemoryCocoa.mm
+++ b/Source/WebCore/platform/cocoa/SharedMemoryCocoa.mm
@@ -168,12 +168,12 @@ RefPtr<SharedMemory> SharedMemory::wrapMap(std::span<const uint8_t> data, Protec
     return sharedMemory;
 }
 
-RefPtr<SharedMemory> SharedMemory::map(Handle&& handle, Protection protection)
+RefPtr<SharedMemory> SharedMemory::map(Handle&& handle, Protection protection, CopyOnWrite copyOnWrite)
 {
     vm_prot_t vmProtection = machProtection(protection);
     mach_vm_address_t mappedAddress = 0;
 
-    kern_return_t kr = mach_vm_map(mach_task_self(), &mappedAddress, handle.m_size, 0, VM_FLAGS_ANYWHERE | VM_FLAGS_RETURN_DATA_ADDR, handle.m_handle.sendRight(), 0, false, vmProtection, vmProtection, VM_INHERIT_NONE);
+    kern_return_t kr = mach_vm_map(mach_task_self(), &mappedAddress, handle.m_size, 0, VM_FLAGS_ANYWHERE | VM_FLAGS_RETURN_DATA_ADDR, handle.m_handle.sendRight(), 0, copyOnWrite == CopyOnWrite::Yes, vmProtection, vmProtection, VM_INHERIT_NONE);
     if (kr != KERN_SUCCESS) {
         RELEASE_LOG_ERROR(VirtualMemory, "%p - SharedMemory::map: Failed to map shared memory. %" PUBLIC_LOG_STRING " (%x)", nullptr, mach_error_string(kr), kr);
         return nullptr;

--- a/Source/WebCore/platform/graphics/ShareableBitmap.cpp
+++ b/Source/WebCore/platform/graphics/ShareableBitmap.cpp
@@ -136,9 +136,9 @@ RefPtr<ShareableBitmap> ShareableBitmap::createFromImageDraw(NativeImage& image,
     return bitmap;
 }
 
-RefPtr<ShareableBitmap> ShareableBitmap::create(Handle&& handle, SharedMemory::Protection protection)
+RefPtr<ShareableBitmap> ShareableBitmap::create(Handle&& handle, SharedMemory::Protection protection, SharedMemory::CopyOnWrite copyOnWrite)
 {
-    auto sharedMemory = SharedMemory::map(WTF::move(handle.m_handle), protection);
+    auto sharedMemory = SharedMemory::map(WTF::move(handle.m_handle), protection, copyOnWrite);
     if (!sharedMemory)
         return nullptr;
 
@@ -150,7 +150,7 @@ std::optional<Ref<ShareableBitmap>> ShareableBitmap::createReadOnly(std::optiona
     if (!handle)
         return std::nullopt;
 
-    auto sharedMemory = SharedMemory::map(WTF::move(handle->m_handle), SharedMemory::Protection::ReadOnly);
+    auto sharedMemory = SharedMemory::map(WTF::move(handle->m_handle), SharedMemory::Protection::ReadOnly, defaultCopyOnWrite);
     if (!sharedMemory)
         return std::nullopt;
 

--- a/Source/WebCore/platform/graphics/ShareableBitmap.h
+++ b/Source/WebCore/platform/graphics/ShareableBitmap.h
@@ -47,6 +47,13 @@ class GraphicsContext;
 class Image;
 class NativeImage;
 
+#if OS(DARWIN)
+inline constexpr auto defaultCopyOnWrite = SharedMemory::CopyOnWrite::Yes;
+#else
+// FIXME: https://bugs.webkit.org/show_bug.cgi?id=305633
+inline constexpr auto defaultCopyOnWrite = SharedMemory::CopyOnWrite::No;
+#endif
+
 class ShareableBitmapConfiguration {
 public:
     ShareableBitmapConfiguration() = default;
@@ -151,7 +158,7 @@ public:
     WEBCORE_EXPORT static RefPtr<ShareableBitmap> createFromImageDraw(NativeImage&, const DestinationColorSpace&, const IntSize& destinationSize, const IntSize& sourceSize);
 
     // Create a shareable bitmap from a handle.
-    WEBCORE_EXPORT static RefPtr<ShareableBitmap> create(Handle&&, SharedMemory::Protection = SharedMemory::Protection::ReadWrite);
+    WEBCORE_EXPORT static RefPtr<ShareableBitmap> create(Handle&&, SharedMemory::Protection = SharedMemory::Protection::ReadWrite, SharedMemory::CopyOnWrite = defaultCopyOnWrite);
 
     // Create a shareable bitmap from a ReadOnly handle.
     WEBCORE_EXPORT static std::optional<Ref<ShareableBitmap>> createReadOnly(std::optional<Handle>&&);

--- a/Source/WebCore/platform/unix/SharedMemoryUnix.cpp
+++ b/Source/WebCore/platform/unix/SharedMemoryUnix.cpp
@@ -143,8 +143,12 @@ RefPtr<SharedMemory> SharedMemory::allocate(size_t size)
     return instance;
 }
 
-RefPtr<SharedMemory> SharedMemory::map(Handle&& handle, Protection protection)
+RefPtr<SharedMemory> SharedMemory::map(Handle&& handle, Protection protection, CopyOnWrite copyOnWrite)
 {
+    // Copy-on-write is not supported on this platform.
+    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305633
+    ASSERT_UNUSED(copyOnWrite, copyOnWrite == CopyOnWrite::No);
+
     void* data = mmap(0, handle.size(), accessModeMMap(protection), MAP_SHARED, handle.m_handle.value(), 0);
     if (data == MAP_FAILED)
         return nullptr;

--- a/Source/WebCore/platform/win/SharedMemoryWin.cpp
+++ b/Source/WebCore/platform/win/SharedMemoryWin.cpp
@@ -62,8 +62,12 @@ static DWORD accessRights(SharedMemory::Protection protection)
     return 0;
 }
 
-RefPtr<SharedMemory> SharedMemory::map(Handle&& handle, Protection protection)
+RefPtr<SharedMemory> SharedMemory::map(Handle&& handle, Protection protection, CopyOnWrite copyOnWrite)
 {
+    // Copy-on-write is not supported on this platform.
+    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305633
+    ASSERT_UNUSED(copyOnWrite, copyOnWrite == CopyOnWrite::No);
+
     void* data = ::MapViewOfFile(handle.m_handle.get(), accessRights(protection), 0, 0, handle.size());
     ASSERT_WITH_MESSAGE(data, "::MapViewOfFile failed with error %lu %p", ::GetLastError(), handle.m_handle.get());
     if (!data)

--- a/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp
@@ -92,7 +92,7 @@ std::unique_ptr<ImageBufferShareableBitmapBackend> ImageBufferShareableBitmapBac
 
 std::unique_ptr<ImageBufferShareableBitmapBackend> ImageBufferShareableBitmapBackend::create(const Parameters& parameters, ShareableBitmap::Handle handle)
 {
-    auto bitmap = ShareableBitmap::create(WTF::move(handle));
+    auto bitmap = ShareableBitmap::create(WTF::move(handle), SharedMemory::Protection::ReadWrite, SharedMemory::CopyOnWrite::No);
     if (!bitmap)
         return nullptr;
 

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -228,6 +228,7 @@ if (ENABLE_WEBCORE)
         Tests/WebCore/RegionTests.cpp
         Tests/WebCore/RenderStyleChange.cpp
         Tests/WebCore/SecurityOrigin.cpp
+        Tests/WebCore/ShareableBitmap.cpp
         Tests/WebCore/SharedBuffer.cpp
         Tests/WebCore/SharedBufferTest.cpp
         Tests/WebCore/StyleGradient.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -652,6 +652,7 @@
 		83B6DE6F1EE75221001E792F /* RestoreSessionState.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 83B6DE6E1EE7520F001E792F /* RestoreSessionState.cpp */; };
 		83BC5AC020E6C0DF00F5879F /* StartLoadInDidFailProvisionalLoad.mm in Sources */ = {isa = PBXBuildFile; fileRef = 83BC5ABF20E6C0D300F5879F /* StartLoadInDidFailProvisionalLoad.mm */; };
 		83F22C6420B355F80034277E /* NoPolicyDelegateResponse.mm in Sources */ = {isa = PBXBuildFile; fileRef = 83F22C6320B355EB0034277E /* NoPolicyDelegateResponse.mm */; };
+		86AF7A742F11406800EC5DB2 /* ShareableBitmap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86AF7A722F11406800EC5DB2 /* ShareableBitmap.cpp */; };
 		8E4A85371E1D1AB200F53B0F /* GridPosition.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8E4A85361E1D1AA100F53B0F /* GridPosition.cpp */; };
 		919B50762C177055009FE7B0 /* Base64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 919B506E2C177055009FE7B0 /* Base64.cpp */; };
 		9310CD381EF708FB0050FFE0 /* Function.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9310CD361EF708FB0050FFE0 /* Function.cpp */; };
@@ -3514,6 +3515,7 @@
 		83BC5ABF20E6C0D300F5879F /* StartLoadInDidFailProvisionalLoad.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = StartLoadInDidFailProvisionalLoad.mm; sourceTree = "<group>"; };
 		83F22C6320B355EB0034277E /* NoPolicyDelegateResponse.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = NoPolicyDelegateResponse.mm; sourceTree = "<group>"; };
 		869429BF2E53635100E0DA9D /* EnhancedSecurity.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = EnhancedSecurity.mm; sourceTree = "<group>"; };
+		86AF7A722F11406800EC5DB2 /* ShareableBitmap.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ShareableBitmap.cpp; sourceTree = "<group>"; };
 		86BD19971A2DB05B006DCF0A /* RefCounter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RefCounter.cpp; sourceTree = "<group>"; };
 		8A2C750D16CED9550024F352 /* ResizeWindowAfterCrash.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ResizeWindowAfterCrash.cpp; sourceTree = "<group>"; };
 		8A3AF93A16C9ED2700D248C1 /* ReloadPageAfterCrash.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ReloadPageAfterCrash.cpp; sourceTree = "<group>"; };
@@ -5371,6 +5373,7 @@
 				CE06DF9A1E1851F200E570C9 /* SecurityOrigin.cpp */,
 				9464220C2BC8306D001B42B3 /* SerializedScriptValue.cpp */,
 				4102EE1627845ED500D6BE74 /* ServiceWorkerRoutines.cpp */,
+				86AF7A722F11406800EC5DB2 /* ShareableBitmap.cpp */,
 				41973B5C1AF22875006C7B36 /* SharedBuffer.cpp */,
 				A17991891E1CA24100A505ED /* SharedBufferTest.cpp */,
 				A179918A1E1CA24100A505ED /* SharedBufferTest.h */,
@@ -8108,6 +8111,7 @@
 				7CCE7ECB1A411A7E00447C4C /* SetAndUpdateCacheModel.mm in Sources */,
 				7CCE7ECC1A411A7E00447C4C /* SetDocumentURI.mm in Sources */,
 				CE6E81A020A6935F00E2C80F /* SetTimeoutFunction.mm in Sources */,
+				86AF7A742F11406800EC5DB2 /* ShareableBitmap.cpp in Sources */,
 				7C83E0521D0A641800FEBCF3 /* SharedBuffer.cpp in Sources */,
 				A17991881E1C994E00A505ED /* SharedBuffer.mm in Sources */,
 				A179918B1E1CA24100A505ED /* SharedBufferTest.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebCore/ShareableBitmap.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ShareableBitmap.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "Test.h"
+#if USE(CG)
+#include <CoreGraphics/CGImage.h>
+#endif
+#include <WebCore/ShareableBitmap.h>
+
+#if OS(DARWIN)
+
+namespace TestWebKitAPI {
+
+static void fillTestPattern(std::span<uint8_t> data, size_t seed)
+{
+    for (size_t i = 0; i < 5 && i < data.size(); ++i)
+        data[i] = seed + i;
+    if (data.size() < 12)
+        return;
+    for (size_t i = 1; i < 6; ++i)
+        data[data.size() - i] = seed + i + 77u;
+    auto mid = data.size() / 2;
+    data[mid] = seed + 99;
+}
+
+static void expectTestPattern(std::span<uint8_t> data, size_t seed)
+{
+    for (size_t i = 0; i < 5 && i < data.size(); ++i)
+        EXPECT_EQ(data[i], static_cast<uint8_t>(seed + i));
+    if (data.size() < 12)
+        return;
+    for (size_t i = 1; i < 6; ++i)
+        EXPECT_EQ(data[data.size() - i], static_cast<uint8_t>(seed + i + 77u));
+    auto mid = data.size() / 2;
+    EXPECT_EQ(data[mid], static_cast<uint8_t>(seed + 99));
+}
+
+TEST(ShareableBitmap, ensureCOWBothMapsRWSenderWrite)
+{
+    WebCore::ShareableBitmapConfiguration configuration = { WebCore::IntSize(100, 100) };
+    auto bitmap = WebCore::ShareableBitmap::create(configuration);
+    fillTestPattern(bitmap->mutableSpan(), 0);
+    expectTestPattern(bitmap->mutableSpan(), 0);
+
+    auto handle = bitmap->createHandle(WebCore::SharedMemory::Protection::ReadWrite);
+    auto bitmap2 = WebCore::ShareableBitmap::create(WTF::move(*handle));
+    expectTestPattern(bitmap2->mutableSpan(), 0);
+    fillTestPattern(bitmap->mutableSpan(), 1);
+    expectTestPattern(bitmap->mutableSpan(), 1);
+    expectTestPattern(bitmap2->mutableSpan(), 0);
+}
+
+TEST(ShareableBitmap, ensureCOWBothMapsRWSenderWriteReceiverWrite)
+{
+    WebCore::ShareableBitmapConfiguration configuration = { WebCore::IntSize(100, 100) };
+    auto bitmap = WebCore::ShareableBitmap::create(configuration);
+    fillTestPattern(bitmap->mutableSpan(), 0);
+    expectTestPattern(bitmap->mutableSpan(), 0);
+
+    auto handle = bitmap->createHandle(WebCore::SharedMemory::Protection::ReadWrite);
+    auto bitmap2 = WebCore::ShareableBitmap::create(WTF::move(*handle));
+    expectTestPattern(bitmap2->mutableSpan(), 0);
+    fillTestPattern(bitmap2->mutableSpan(), 1);
+    expectTestPattern(bitmap->mutableSpan(), 0);
+    expectTestPattern(bitmap2->mutableSpan(), 1);
+}
+
+TEST(ShareableBitmap, ensureCOWBothMapsROSenderWrite)
+{
+    WebCore::ShareableBitmapConfiguration configuration = { WebCore::IntSize(100, 100) };
+    auto bitmap = WebCore::ShareableBitmap::create(configuration);
+    fillTestPattern(bitmap->mutableSpan(), 0);
+    expectTestPattern(bitmap->mutableSpan(), 0);
+
+    auto handle = bitmap->createReadOnlyHandle();
+    auto bitmap2 = *WebCore::ShareableBitmap::createReadOnly(WTF::move(handle));
+    expectTestPattern(bitmap2->mutableSpan(), 0);
+    fillTestPattern(bitmap->mutableSpan(), 1);
+    expectTestPattern(bitmap->mutableSpan(), 1);
+    expectTestPattern(bitmap2->mutableSpan(), 0);
+}
+
+}
+
+#endif // OS(DARWIN)


### PR DESCRIPTION
#### 649a89a5f4628f38549bf2a18969873a5fe86eaf
<pre>
Expose CopyOnWrite as part of SharedMemory object mappings
<a href="https://bugs.webkit.org/show_bug.cgi?id=304934">https://bugs.webkit.org/show_bug.cgi?id=304934</a>
<a href="https://rdar.apple.com/167545782">rdar://167545782</a>

Reviewed by Simon Fraser.

Expose the ability to map using CopyOnWrite as part of our SharedMemory
implementation. This is then adopted for ShareableBitmap.

Note: This change supports Darwin platforms only. The CopyOnWrite behavior
for Windows &amp; Unix differ when it comes to writes to the mapping, by the
originator, after the receiver requests a private/copy on write
mapping. On Darwin platforms, these changes are caught by CoW and are not
visible in the receiver. On Unix &amp; Windows, these writes are visible by
the receiver.

* Source/WebCore/platform/SharedMemory.h:
* Source/WebCore/platform/android/SharedMemoryAndroid.cpp:
(WebCore::SharedMemory::map):
* Source/WebCore/platform/cocoa/SharedMemoryCocoa.mm:
(WebCore::SharedMemory::map):
* Source/WebCore/platform/graphics/ShareableBitmap.cpp:
(WebCore::ShareableBitmap::create):
(WebCore::ShareableBitmap::createReadOnly):
* Source/WebCore/platform/graphics/ShareableBitmap.h:
* Source/WebCore/platform/unix/SharedMemoryUnix.cpp:
(WebCore::SharedMemory::map):
* Source/WebCore/platform/win/SharedMemoryWin.cpp:
(WebCore::SharedMemory::map):
* Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp:
(WebKit::ImageBufferShareableBitmapBackend::create):
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/ShareableBitmap.cpp: Added.
(TestWebKitAPI::fillTestPattern):
(TestWebKitAPI::expectTestPattern):
(TestWebKitAPI::TEST(ShareableBitmap, ensureCOWBothMapsRWSenderWrite)):
(TestWebKitAPI::TEST(ShareableBitmap, ensureCOWBothMapsRWSenderWriteReceiverWrite)):
(TestWebKitAPI::TEST(ShareableBitmap, ensureCOWBothMapsROSenderWrite)):
* Tools/TestWebKitAPI/Tests/WebCore/SharedMemoryTests.cpp:
(TestWebKitAPI::TEST_P):

Canonical link: <a href="https://commits.webkit.org/305762@main">https://commits.webkit.org/305762@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3bd4e41e8b885ebfd46a708764ba8fdede4a6469

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139206 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11580 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/703 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147333 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92273 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141078 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12288 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11730 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106572 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77607 "3 flakes 1 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/145ee3a6-9a5b-43b0-9aad-eb992279a689) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142153 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9304 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124692 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87432 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7c0f7ae7-aa65-4534-a9ed-d59044aec316) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8855 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6609 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7627 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118310 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/588 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150112 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11265 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/606 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114955 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11277 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9536 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115268 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29313 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9309 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121035 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66181 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11307 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/567 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11042 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74978 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11245 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11095 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->