### PR TITLE
[AutoFill Debugging] Add support for strikethrough text (s, strike, del)

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt
@@ -43,6 +43,10 @@ root
             subscript
                 'WebKit home page:',[…]
                 link,uid=…,[…],url='https://webkit.org/'
+            strikethrough
+                'This',[…]
+                link,uid=…,url='https://www.apple.com/','link',[…]
+                'was deleted',[…]
     role='contentinfo'
         'Footer content with',[…]
         role='img',aria-label='copyright symbol','©',[…]

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-basic.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-basic.html
@@ -100,6 +100,7 @@ canvas {
         <textarea rows="15" cols="40">This is a text box</textarea>
         Price: $11<sup>99</sup>
         Link to <sub>WebKit home page:<a href="https://webkit.org">webkit.org</a></sub>
+        <strike>This <a href="https://www.apple.com/">link</a> was deleted</strike>
     </section>
 </main>
 <footer role="contentinfo">

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-markdown-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-markdown-expected.txt
@@ -8,4 +8,10 @@ This is a list:
 - baz
 On sale for
 £10.99
+This
+~~text~~
+has a
+~~line through it~~
+. The price
+~~was \~\~$50~~
 <!-- version=2 -->

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-markdown.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-markdown.html
@@ -27,6 +27,7 @@ On sale for
     <sup>£</sup>
     10
     <sup>99</sup>
+    This <strike>text</strike> has a <del>line through it</del>. The price <s>was ~~$50</s>
 </p>
 <script>
 addEventListener("load", async () => {

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -595,6 +595,9 @@ static inline Variant<SkipExtraction, ItemData, URL, Editable> extractItemData(N
     if (element->hasTagName(HTMLNames::subTag))
         return { ItemData { ContainerType::Subscript } };
 
+    if (element->hasTagName(HTMLNames::delTag) || element->hasTagName(HTMLNames::sTag) || element->hasTagName(HTMLNames::strikeTag))
+        return { ItemData { ContainerType::Strikethrough } };
+
     if (CheckedPtr renderElement = dynamicDowncast<RenderBox>(*renderer); renderElement && renderElement->style().hasViewportConstrainedPosition())
         return { ItemData { ContainerType::ViewportConstrained } };
 
@@ -631,6 +634,7 @@ static inline bool shouldIncludeNodeIdentifier(NodeIdentifierInclusion inclusion
             case ContainerType::Nav:
             case ContainerType::Subscript:
             case ContainerType::Superscript:
+            case ContainerType::Strikethrough:
             case ContainerType::Generic:
                 return eventListeners || AccessibilityObject::isARIAControl(role);
             case ContainerType::Button:

--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -175,6 +175,7 @@ enum class ContainerType : uint8_t {
     Canvas,
     Subscript,
     Superscript,
+    Strikethrough,
     Generic,
 };
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6912,6 +6912,7 @@ header: <WebCore/TextExtractionTypes.h>
     Canvas,
     Subscript,
     Superscript,
+    Strikethrough,
     Generic
 };
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h
@@ -91,6 +91,7 @@ typedef NS_ENUM(NSInteger, WKTextExtractionContainer) {
     WKTextExtractionContainerCanvas,
     WKTextExtractionContainerSubscript,
     WKTextExtractionContainerSuperscript,
+    WKTextExtractionContainerStrikethrough,
     WKTextExtractionContainerGeneric
 };
 

--- a/Source/WebKit/UIProcess/Cocoa/TextExtraction/WKTextExtractionUtilities.mm
+++ b/Source/WebKit/UIProcess/Cocoa/TextExtraction/WKTextExtractionUtilities.mm
@@ -67,6 +67,8 @@ inline static WKTextExtractionContainer containerType(TextExtraction::ContainerT
         return WKTextExtractionContainerSubscript;
     case TextExtraction::ContainerType::Superscript:
         return WKTextExtractionContainerSuperscript;
+    case TextExtraction::ContainerType::Strikethrough:
+        return WKTextExtractionContainerStrikethrough;
     case TextExtraction::ContainerType::Generic:
         return WKTextExtractionContainerGeneric;
     }

--- a/Tools/WebKitTestRunner/cocoa/WKTextExtractionTestingHelpers.mm
+++ b/Tools/WebKitTestRunner/cocoa/WKTextExtractionTestingHelpers.mm
@@ -66,6 +66,8 @@ ASCIILiteral description(WKTextExtractionContainer container)
         return "SUBSCRIPT"_s;
     case WKTextExtractionContainerSuperscript:
         return "SUPERSCRIPT"_s;
+    case WKTextExtractionContainerStrikethrough:
+        return "STRIKETHROUGH"_s;
     case WKTextExtractionContainerGeneric:
         return "GENERIC"_s;
     }


### PR DESCRIPTION
#### b08e2712c1ff73d0aaa7cfa34d7f77f74c3cb9b0
<pre>
[AutoFill Debugging] Add support for strikethrough text (s, strike, del)
<a href="https://bugs.webkit.org/show_bug.cgi?id=304939">https://bugs.webkit.org/show_bug.cgi?id=304939</a>
<a href="https://rdar.apple.com/167555658">rdar://167555658</a>

Reviewed by Abrar Rahman Protyasha.

Add support for strikethrough text in text extraction output.
See below for more details.

* LayoutTests/fast/text-extraction/debug-text-extraction-markdown-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-markdown.html:
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractItemData):
(WebCore::TextExtraction::shouldIncludeNodeIdentifier):
* Source/WebCore/page/text-extraction/TextExtractionTypes.h:

Add `Strikethrough` as a container enum type, similar to `Superscript` / `Subscript`.

* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::escapeStringForMarkdown):

Escape `~~` here, so that occurrences of `~~` inside strikethrough text will not cause the
strikethrough text to end early.

(WebKit::TextExtractionAggregator::pushStrikethrough):
(WebKit::TextExtractionAggregator::isInsideStrikethrough const):
(WebKit::TextExtractionAggregator::popStrikethrough):

Add a mechanism to keep track of when we enter / exit strikethrough container items.

(WebKit::addPartsForItem):

When emitting strikethrough text, surround it with `~~` for markdown. Otherwise, for other output
formats, handle it as a container type named `strikethrough`.

(WebKit::addTextRepresentationRecursive):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h:
* Source/WebKit/UIProcess/Cocoa/TextExtraction/WKTextExtractionUtilities.mm:
(WebKit::containerType):
* Tools/WebKitTestRunner/cocoa/WKTextExtractionTestingHelpers.mm:
(WTR::description):

Canonical link: <a href="https://commits.webkit.org/305132@main">https://commits.webkit.org/305132@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41d2b1828c373747548be8c7428304b6a729a5d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137586 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9947 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48874 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145344 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90559 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0078cea4-fd22-42b0-b1ca-97b6a7be9971) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139458 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10650 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10077 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105226 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7cdd3c30-73a0-41fa-aaa6-8dcba57d8e4c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140531 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7902 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123302 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86078 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7536 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5260 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5926 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116908 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41460 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148108 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9629 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42013 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113605 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9647 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8115 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113949 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28926 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7461 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119542 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64285 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9678 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37594 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9409 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73243 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9618 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9470 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->