### PR TITLE
Change Vector<RefPtr<TrackBase>> to a Vector of Ref and reduce unsafeness

### DIFF
--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -774,13 +774,21 @@ public:
         removeLast();
         return result;
     }
-    
+
     bool contains(const auto&) const;
     bool containsIf(NOESCAPE const Invocable<bool(const T&)> auto&) const;
     size_t find(const auto&) const;
     size_t findIf(NOESCAPE const Invocable<bool(const T&)> auto&) const;
     size_t reverseFind(const auto&) const;
     size_t reverseFindIf(NOESCAPE const Invocable<bool(const T&)> auto&) const;
+
+    // Overloads for smart pointer element types that take raw pointer parameters.
+    template<SmartPtr U = T, typename V> requires std::same_as<U, T> && std::derived_from<V, typename GetPtrHelper<U>::UnderlyingType>
+    bool contains(V*) const;
+    template<SmartPtr U = T, typename V> requires std::same_as<U, T> && std::derived_from<V, typename GetPtrHelper<U>::UnderlyingType>
+    size_t find(V*) const;
+    template<SmartPtr U = T, typename V> requires std::same_as<U, T> && std::derived_from<V, typename GetPtrHelper<U>::UnderlyingType>
+    size_t reverseFind(V*) const;
 
     bool appendIfNotContains(const auto&);
 
@@ -1105,6 +1113,31 @@ bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::appendIfNo
         return false;
     append(value);
     return true;
+}
+
+template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
+template<SmartPtr U, typename V> requires std::same_as<U, T> && std::derived_from<V, typename GetPtrHelper<U>::UnderlyingType>
+bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::contains(V* ptr) const
+{
+    return find(ptr) != notFound;
+}
+
+template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
+template<SmartPtr U, typename V> requires std::same_as<U, T> && std::derived_from<V, typename GetPtrHelper<U>::UnderlyingType>
+size_t Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::find(V* ptr) const
+{
+    return findIf([&](auto& item) {
+        return GetPtrHelper<U>::getPtr(item) == ptr;
+    });
+}
+
+template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
+template<SmartPtr U, typename V> requires std::same_as<U, T> && std::derived_from<V, typename GetPtrHelper<U>::UnderlyingType>
+size_t Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::reverseFind(V* ptr) const
+{
+    return reverseFindIf([&](auto& item) {
+        return GetPtrHelper<U>::getPtr(item) == ptr;
+    });
 }
 
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -7769,10 +7769,10 @@ bool HTMLMediaElement::hasClosedCaptions() const
         return false;
 
     for (unsigned i = 0; i < m_textTracks->length(); ++i) {
-        auto& track = *m_textTracks->item(i);
-        if (track.readinessState() == TextTrack::FailedToLoad)
+        Ref track = m_textTracks->item(i).releaseNonNull();
+        if (track->readinessState() == TextTrack::FailedToLoad)
             continue;
-        if (track.kind() == TextTrack::Kind::Captions || track.kind() == TextTrack::Kind::Subtitles)
+        if (track->kind() == TextTrack::Kind::Captions || track->kind() == TextTrack::Kind::Subtitles)
             return true;
     }
 
@@ -8065,10 +8065,10 @@ void HTMLMediaElement::markCaptionAndSubtitleTracksAsUnconfigured(ReconfigureMod
     // captions and non-default tracks should be displayed based on language
     // preferences if the user has turned captions on).
     for (unsigned i = 0; i < m_textTracks->length(); ++i) {
-        auto& track = *m_textTracks->item(i);
-        auto kind = track.kind();
+        Ref track = m_textTracks->item(i).releaseNonNull();
+        auto kind = track->kind();
         if (kind == TextTrack::Kind::Subtitles || kind == TextTrack::Kind::Captions)
-            track.setHasBeenConfigured(false);
+            track->setHasBeenConfigured(false);
     }
 
     m_processingPreferenceChange = true;

--- a/Source/WebCore/html/track/AudioTrackList.cpp
+++ b/Source/WebCore/html/track/AudioTrackList.cpp
@@ -47,11 +47,11 @@ void AudioTrackList::append(Ref<AudioTrack>&& track)
     size_t index = track->inbandTrackIndex();
     size_t insertionIndex;
     for (insertionIndex = 0; insertionIndex < m_inbandTracks.size(); ++insertionIndex) {
-        Ref otherTrack = downcast<AudioTrack>(*m_inbandTracks[insertionIndex]);
+        Ref otherTrack = downcast<AudioTrack>(m_inbandTracks[insertionIndex]);
         if (otherTrack->inbandTrackIndex() > index)
             break;
     }
-    m_inbandTracks.insert(insertionIndex, track.ptr());
+    m_inbandTracks.insert(insertionIndex, track.copyRef());
 
     if (!track->trackList())
         track->setTrackList(*this);
@@ -68,18 +68,23 @@ void AudioTrackList::remove(TrackBase& track, bool scheduleEvent)
     TrackListBase::remove(track, scheduleEvent);
 }
 
-AudioTrack* AudioTrackList::item(unsigned index) const
+RefPtr<AudioTrack> AudioTrackList::item(unsigned index) const
 {
     if (index < m_inbandTracks.size())
-        return downcast<AudioTrack>(m_inbandTracks[index].get());
+        return downcast<AudioTrack>(m_inbandTracks[index]);
     return nullptr;
 }
 
-AudioTrack* AudioTrackList::firstEnabled() const
+RefPtr<AudioTrack> AudioTrackList::lastItem() const
+{
+    return item(length() - 1);
+}
+
+RefPtr<AudioTrack> AudioTrackList::firstEnabled() const
 {
     for (auto& item : m_inbandTracks) {
-        if (item && item->enabled())
-            return downcast<AudioTrack>(item.get());
+        if (item->enabled())
+            return downcast<AudioTrack>(item);
     }
     return nullptr;
 }
@@ -87,7 +92,7 @@ AudioTrack* AudioTrackList::firstEnabled() const
 RefPtr<AudioTrack> AudioTrackList::getTrackById(const AtomString& id) const
 {
     for (auto& inbandTrack : m_inbandTracks) {
-        Ref track = downcast<AudioTrack>(*inbandTrack);
+        Ref track = downcast<AudioTrack>(inbandTrack);
         if (track->id() == id)
             return track;
     }
@@ -97,7 +102,7 @@ RefPtr<AudioTrack> AudioTrackList::getTrackById(const AtomString& id) const
 RefPtr<AudioTrack> AudioTrackList::getTrackById(TrackID id) const
 {
     for (auto& inbandTrack : m_inbandTracks) {
-        Ref track = downcast<AudioTrack>(*inbandTrack);
+        Ref track = downcast<AudioTrack>(inbandTrack);
         if (track->trackId() == id)
             return track;
     }

--- a/Source/WebCore/html/track/AudioTrackList.h
+++ b/Source/WebCore/html/track/AudioTrackList.h
@@ -48,9 +48,9 @@ public:
     RefPtr<AudioTrack> getTrackById(TrackID) const;
 
     bool isSupportedPropertyIndex(unsigned index) const { return index < m_inbandTracks.size(); }
-    AudioTrack* item(unsigned index) const;
-    AudioTrack* lastItem() const { return item(length() - 1); }
-    AudioTrack* firstEnabled() const;
+    RefPtr<AudioTrack> item(unsigned index) const;
+    RefPtr<AudioTrack> lastItem() const;
+    RefPtr<AudioTrack> firstEnabled() const;
     void append(Ref<AudioTrack>&&);
     void remove(TrackBase&, bool scheduleEvent = true) final;
 

--- a/Source/WebCore/html/track/TextTrackList.h
+++ b/Source/WebCore/html/track/TextTrackList.h
@@ -52,10 +52,10 @@ public:
     int getTrackIndexRelativeToRenderedTracks(TextTrack&);
     bool contains(TrackBase&) const final;
 
-    TextTrack* item(unsigned index) const;
+    RefPtr<TextTrack> item(unsigned index) const;
     RefPtr<TextTrack> getTrackById(const AtomString&) const;
     RefPtr<TextTrack> getTrackById(TrackID) const;
-    TextTrack* lastItem() const { return item(length() - 1); }
+    RefPtr<TextTrack> lastItem() const;
 
     void append(Ref<TextTrack>&&);
     void remove(TrackBase&, bool scheduleEvent = true) final;
@@ -71,8 +71,8 @@ private:
 
     void invalidateTrackIndexesAfterTrack(TextTrack&);
 
-    Vector<RefPtr<TrackBase>> m_addTrackTracks;
-    Vector<RefPtr<TrackBase>> m_elementTracks;
+    Vector<Ref<TrackBase>> m_addTrackTracks;
+    Vector<Ref<TrackBase>> m_elementTracks;
     MediaTime m_duration;
 };
 

--- a/Source/WebCore/html/track/TrackListBase.cpp
+++ b/Source/WebCore/html/track/TrackListBase.cpp
@@ -54,7 +54,7 @@ ScriptExecutionContext* TrackListBase::scriptExecutionContext() const
 void TrackListBase::didMoveToNewDocument(Document& newDocument)
 {
     ActiveDOMObject::didMoveToNewDocument(newDocument);
-    for (RefPtr track : m_inbandTracks)
+    for (auto& track : m_inbandTracks)
         track->didMoveToNewDocument(newDocument);
 }
 
@@ -78,7 +78,7 @@ RefPtr<TrackBase> TrackListBase::find(TrackID trackID) const
     });
     if (index == notFound)
         return nullptr;
-    return m_inbandTracks[index];
+    return m_inbandTracks[index].copyRef();
 }
 
 void TrackListBase::remove(TrackID trackID, bool scheduleEvent)
@@ -96,7 +96,7 @@ void TrackListBase::remove(TrackBase& track, bool scheduleEvent)
     if (track.trackList() == this)
         track.clearTrackList();
 
-    Ref<TrackBase> trackRef = *m_inbandTracks[index];
+    Ref trackRef = m_inbandTracks[index];
 
     m_inbandTracks.removeAt(index);
 
@@ -106,7 +106,7 @@ void TrackListBase::remove(TrackBase& track, bool scheduleEvent)
 
 bool TrackListBase::contains(TrackBase& track) const
 {
-    return m_inbandTracks.find(&track) != notFound;
+    return m_inbandTracks.contains(&track);
 }
 
 bool TrackListBase::contains(TrackID trackID) const

--- a/Source/WebCore/html/track/TrackListBase.h
+++ b/Source/WebCore/html/track/TrackListBase.h
@@ -80,7 +80,7 @@ protected:
     void scheduleAddTrackEvent(Ref<TrackBase>&&);
     void scheduleRemoveTrackEvent(Ref<TrackBase>&&);
 
-    Vector<RefPtr<TrackBase>> m_inbandTracks;
+    Vector<Ref<TrackBase>> m_inbandTracks;
 
 private:
     void scheduleTrackEvent(const AtomString& eventName, Ref<TrackBase>&&);

--- a/Source/WebCore/html/track/VideoTrackList.cpp
+++ b/Source/WebCore/html/track/VideoTrackList.cpp
@@ -48,11 +48,11 @@ void VideoTrackList::append(Ref<VideoTrack>&& track)
     size_t index = track->inbandTrackIndex();
     size_t insertionIndex;
     for (insertionIndex = 0; insertionIndex < m_inbandTracks.size(); ++insertionIndex) {
-        Ref otherTrack = downcast<VideoTrack>(*m_inbandTracks[insertionIndex]);
+        Ref otherTrack = downcast<VideoTrack>(m_inbandTracks[insertionIndex]);
         if (otherTrack->inbandTrackIndex() > index)
             break;
     }
-    m_inbandTracks.insert(insertionIndex, track.ptr());
+    m_inbandTracks.insert(insertionIndex, track.copyRef());
 
     if (!track->trackList())
         track->setTrackList(*this);
@@ -60,17 +60,22 @@ void VideoTrackList::append(Ref<VideoTrack>&& track)
     scheduleAddTrackEvent(WTF::move(track));
 }
 
-VideoTrack* VideoTrackList::item(unsigned index) const
+RefPtr<VideoTrack> VideoTrackList::item(unsigned index) const
 {
     if (index < m_inbandTracks.size())
-        return downcast<VideoTrack>(m_inbandTracks[index].get());
+        return downcast<VideoTrack>(m_inbandTracks[index]);
     return nullptr;
+}
+
+RefPtr<VideoTrack> VideoTrackList::lastItem() const
+{
+    return item(length() - 1);
 }
 
 RefPtr<VideoTrack> VideoTrackList::getTrackById(const AtomString& id) const
 {
-    for (auto& inbandTracks : m_inbandTracks) {
-        Ref track = downcast<VideoTrack>(*inbandTracks);
+    for (auto& inbandTrack : m_inbandTracks) {
+        Ref track = downcast<VideoTrack>(inbandTrack);
         if (track->id() == id)
             return track;
     }
@@ -79,8 +84,8 @@ RefPtr<VideoTrack> VideoTrackList::getTrackById(const AtomString& id) const
 
 RefPtr<VideoTrack> VideoTrackList::getTrackById(TrackID id) const
 {
-    for (auto& inbandTracks : m_inbandTracks) {
-        Ref track = downcast<VideoTrack>(*inbandTracks);
+    for (auto& inbandTrack : m_inbandTracks) {
+        Ref track = downcast<VideoTrack>(inbandTrack);
         if (track->trackId() == id)
             return track;
     }
@@ -95,13 +100,13 @@ int VideoTrackList::selectedIndex() const
     // currently represent any tracks, or if none of the tracks are selected,
     // it must instead return −1.
     for (unsigned i = 0; i < length(); ++i) {
-        if (downcast<VideoTrack>(*m_inbandTracks[i]).selected())
+        if (downcast<VideoTrack>(m_inbandTracks[i].get()).selected())
             return i;
     }
     return -1;
 }
 
-VideoTrack* VideoTrackList::selectedItem() const
+RefPtr<VideoTrack> VideoTrackList::selectedItem() const
 {
     auto selectedIndex = this->selectedIndex();
     if (selectedIndex < 0)

--- a/Source/WebCore/html/track/VideoTrackList.h
+++ b/Source/WebCore/html/track/VideoTrackList.h
@@ -49,9 +49,9 @@ public:
     int selectedIndex() const;
 
     bool isSupportedPropertyIndex(unsigned index) const { return index < m_inbandTracks.size(); }
-    VideoTrack* item(unsigned) const;
-    VideoTrack* lastItem() const { return item(length() - 1); }
-    VideoTrack* selectedItem() const;
+    RefPtr<VideoTrack> item(unsigned) const;
+    RefPtr<VideoTrack> lastItem() const;
+    RefPtr<VideoTrack> selectedItem() const;
     void append(Ref<VideoTrack>&&);
 
     // EventTarget

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
@@ -541,7 +541,7 @@ void PlaybackSessionModelMediaElement::maybeUpdateVideoMetadata()
     if (!mediaElement)
         return;
     RefPtr videoTracks = mediaElement->videoTracks();
-    auto* selectedItem = videoTracks ? videoTracks->selectedItem() : nullptr;
+    RefPtr selectedItem = videoTracks ? videoTracks->selectedItem() : nullptr;
 
     // Occasionally, when tearing down an AVAssetTrack in a HLS stream, the tracks
     // exposed to web content are recreated, and a "removetrack" event is fired before


### PR DESCRIPTION
#### 896cb9dcb969ffd0f773bf01bf4bd5dbeb3a00c1
<pre>
Change Vector&lt;RefPtr&lt;TrackBase&gt;&gt; to a Vector of Ref and reduce unsafeness
<a href="https://bugs.webkit.org/show_bug.cgi?id=304941">https://bugs.webkit.org/show_bug.cgi?id=304941</a>

Reviewed by Alex Christensen.

As part of this we also change a number of methods to return a RefPtr
rather than an ordinary pointer as not doing that would be unsafe. The
reason the compiler currently does not complain about them is because
the lack of safety is being masked by downcast&lt;&gt; calls.

* Source/WTF/wtf/Vector.h:

In order to preserve the rather clean calls to find() Claude AI
assisted me in adding support for that to Vector, inspired by similar
code in HashMap.

Canonical link: <a href="https://commits.webkit.org/305142@main">https://commits.webkit.org/305142@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eec385f04153845ac82cfb10381066abdd7cc9e2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137545 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9906 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48832 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145302 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90518 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b658907f-b126-4bba-b744-090ffc99acf0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139417 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10609 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10036 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105196 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ca53dbaf-1d4c-4a11-995e-bbda44d3cfdb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140490 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7882 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123277 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86049 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e8fcec45-ea1a-4a82-8523-f32c7b6345cc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7518 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5234 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5885 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/129506 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116888 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41433 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148066 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/136066 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9588 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41987 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113585 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9606 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8086 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113921 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7438 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119516 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64244 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21192 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9637 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37569 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/168815 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9368 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73202 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44053 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9577 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9429 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->