### PR TITLE
Update column-rule-width to match updated computed style resolution rules

### DIFF
--- a/LayoutTests/fast/css/getComputedStyle/computed-style-expected.txt
+++ b/LayoutTests/fast/css/getComputedStyle/computed-style-expected.txt
@@ -55,7 +55,7 @@ column-fill: balance;
 column-gap: normal;
 column-rule-color: rgb(0, 0, 0);
 column-rule-style: none;
-column-rule-width: 0px;
+column-rule-width: 3px;
 column-span: none;
 column-width: auto;
 content: normal;

--- a/LayoutTests/fast/css/getComputedStyle/computed-style-without-renderer-expected.txt
+++ b/LayoutTests/fast/css/getComputedStyle/computed-style-without-renderer-expected.txt
@@ -54,7 +54,7 @@ column-fill: balance
 column-gap: normal
 column-rule-color: rgb(0, 0, 0)
 column-rule-style: none
-column-rule-width: 0px
+column-rule-width: 3px
 column-span: none
 column-width: auto
 content: normal

--- a/LayoutTests/fast/css/getComputedStyle/getComputedStyle-column-rule-expected.txt
+++ b/LayoutTests/fast/css/getComputedStyle/getComputedStyle-column-rule-expected.txt
@@ -12,11 +12,11 @@ PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(1).getStringV
 PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(2).getRGBColorValue().red.getFloatValue(CSSPrimitiveValue.CSS_NUMBER) is 0
 PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(2).getRGBColorValue().green.getFloatValue(CSSPrimitiveValue.CSS_NUMBER) is 0
 PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(2).getRGBColorValue().blue.getFloatValue(CSSPrimitiveValue.CSS_NUMBER) is 0
-PASS computedStyle.getPropertyValue('-webkit-column-rule') is "0px none rgb(255, 0, 0)"
+PASS computedStyle.getPropertyValue('-webkit-column-rule') is "10px none rgb(255, 0, 0)"
 PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').toString() is "[object CSSValueList]"
-PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').cssText is "0px none rgb(255, 0, 0)"
+PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').cssText is "10px none rgb(255, 0, 0)"
 PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').length is 3
-PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(0).getFloatValue(CSSPrimitiveValue.CSS_PX) is 0
+PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(0).getFloatValue(CSSPrimitiveValue.CSS_PX) is 10
 PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(1).getStringValue() is "none"
 PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(2).getRGBColorValue().red.getFloatValue(CSSPrimitiveValue.CSS_NUMBER) is 255
 PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(2).getRGBColorValue().green.getFloatValue(CSSPrimitiveValue.CSS_NUMBER) is 0
@@ -30,20 +30,20 @@ PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(1).getStringV
 PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(2).getRGBColorValue().red.getFloatValue(CSSPrimitiveValue.CSS_NUMBER) is 255
 PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(2).getRGBColorValue().green.getFloatValue(CSSPrimitiveValue.CSS_NUMBER) is 0
 PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(2).getRGBColorValue().blue.getFloatValue(CSSPrimitiveValue.CSS_NUMBER) is 0
-PASS computedStyle.getPropertyValue('-webkit-column-rule') is "0px none rgb(0, 0, 255)"
+PASS computedStyle.getPropertyValue('-webkit-column-rule') is "10px none rgb(0, 0, 255)"
 PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').toString() is "[object CSSValueList]"
-PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').cssText is "0px none rgb(0, 0, 255)"
+PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').cssText is "10px none rgb(0, 0, 255)"
 PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').length is 3
-PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(0).getFloatValue(CSSPrimitiveValue.CSS_PX) is 0
+PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(0).getFloatValue(CSSPrimitiveValue.CSS_PX) is 10
 PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(1).getStringValue() is "none"
 PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(2).getRGBColorValue().red.getFloatValue(CSSPrimitiveValue.CSS_NUMBER) is 0
 PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(2).getRGBColorValue().green.getFloatValue(CSSPrimitiveValue.CSS_NUMBER) is 0
 PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(2).getRGBColorValue().blue.getFloatValue(CSSPrimitiveValue.CSS_NUMBER) is 255
-PASS computedStyle.getPropertyValue('-webkit-column-rule') is "0px hidden rgb(0, 0, 255)"
+PASS computedStyle.getPropertyValue('-webkit-column-rule') is "10px hidden rgb(0, 0, 255)"
 PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').toString() is "[object CSSValueList]"
-PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').cssText is "0px hidden rgb(0, 0, 255)"
+PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').cssText is "10px hidden rgb(0, 0, 255)"
 PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').length is 3
-PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(0).getFloatValue(CSSPrimitiveValue.CSS_PX) is 0
+PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(0).getFloatValue(CSSPrimitiveValue.CSS_PX) is 10
 PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(1).getStringValue() is "hidden"
 PASS successfullyParsed is true
 

--- a/LayoutTests/fast/css/getComputedStyle/getComputedStyle-column-rule.html
+++ b/LayoutTests/fast/css/getComputedStyle/getComputedStyle-column-rule.html
@@ -29,11 +29,11 @@ shouldBe("computedStyle.getPropertyCSSValue('-webkit-column-rule').item(2).getRG
 shouldBe("computedStyle.getPropertyCSSValue('-webkit-column-rule').item(2).getRGBColorValue().blue.getFloatValue(CSSPrimitiveValue.CSS_NUMBER)", "0");
 
 e.style.webkitColumnRule="10px red";
-shouldBeEqualToString("computedStyle.getPropertyValue('-webkit-column-rule')", '0px none rgb(255, 0, 0)');
+shouldBeEqualToString("computedStyle.getPropertyValue('-webkit-column-rule')", '10px none rgb(255, 0, 0)');
 shouldBeEqualToString("computedStyle.getPropertyCSSValue('-webkit-column-rule').toString()", '[object CSSValueList]');
-shouldBeEqualToString("computedStyle.getPropertyCSSValue('-webkit-column-rule').cssText", '0px none rgb(255, 0, 0)');
+shouldBeEqualToString("computedStyle.getPropertyCSSValue('-webkit-column-rule').cssText", '10px none rgb(255, 0, 0)');
 shouldBe("computedStyle.getPropertyCSSValue('-webkit-column-rule').length", "3");
-shouldBe("computedStyle.getPropertyCSSValue('-webkit-column-rule').item(0).getFloatValue(CSSPrimitiveValue.CSS_PX)", "0");
+shouldBe("computedStyle.getPropertyCSSValue('-webkit-column-rule').item(0).getFloatValue(CSSPrimitiveValue.CSS_PX)", "10");
 shouldBeEqualToString("computedStyle.getPropertyCSSValue('-webkit-column-rule').item(1).getStringValue()", "none");
 shouldBe("computedStyle.getPropertyCSSValue('-webkit-column-rule').item(2).getRGBColorValue().red.getFloatValue(CSSPrimitiveValue.CSS_NUMBER)", "255");
 shouldBe("computedStyle.getPropertyCSSValue('-webkit-column-rule').item(2).getRGBColorValue().green.getFloatValue(CSSPrimitiveValue.CSS_NUMBER)", "0");
@@ -53,22 +53,22 @@ shouldBe("computedStyle.getPropertyCSSValue('-webkit-column-rule').item(2).getRG
 
 e.style.webkitColumnRule="10px dotted blue"
 e.style.webkitColumnRuleStyle="none";
-shouldBeEqualToString("computedStyle.getPropertyValue('-webkit-column-rule')", '0px none rgb(0, 0, 255)');
+shouldBeEqualToString("computedStyle.getPropertyValue('-webkit-column-rule')", '10px none rgb(0, 0, 255)');
 shouldBeEqualToString("computedStyle.getPropertyCSSValue('-webkit-column-rule').toString()", '[object CSSValueList]');
-shouldBeEqualToString("computedStyle.getPropertyCSSValue('-webkit-column-rule').cssText", '0px none rgb(0, 0, 255)');
+shouldBeEqualToString("computedStyle.getPropertyCSSValue('-webkit-column-rule').cssText", '10px none rgb(0, 0, 255)');
 shouldBe("computedStyle.getPropertyCSSValue('-webkit-column-rule').length", "3");
-shouldBe("computedStyle.getPropertyCSSValue('-webkit-column-rule').item(0).getFloatValue(CSSPrimitiveValue.CSS_PX)", "0");
+shouldBe("computedStyle.getPropertyCSSValue('-webkit-column-rule').item(0).getFloatValue(CSSPrimitiveValue.CSS_PX)", "10");
 shouldBeEqualToString("computedStyle.getPropertyCSSValue('-webkit-column-rule').item(1).getStringValue()", "none");
 shouldBe("computedStyle.getPropertyCSSValue('-webkit-column-rule').item(2).getRGBColorValue().red.getFloatValue(CSSPrimitiveValue.CSS_NUMBER)", "0");
 shouldBe("computedStyle.getPropertyCSSValue('-webkit-column-rule').item(2).getRGBColorValue().green.getFloatValue(CSSPrimitiveValue.CSS_NUMBER)", "0");
 shouldBe("computedStyle.getPropertyCSSValue('-webkit-column-rule').item(2).getRGBColorValue().blue.getFloatValue(CSSPrimitiveValue.CSS_NUMBER)", "255");
 
 e.style.webkitColumnRuleStyle="hidden";
-shouldBeEqualToString("computedStyle.getPropertyValue('-webkit-column-rule')", '0px hidden rgb(0, 0, 255)');
+shouldBeEqualToString("computedStyle.getPropertyValue('-webkit-column-rule')", '10px hidden rgb(0, 0, 255)');
 shouldBeEqualToString("computedStyle.getPropertyCSSValue('-webkit-column-rule').toString()", '[object CSSValueList]');
-shouldBeEqualToString("computedStyle.getPropertyCSSValue('-webkit-column-rule').cssText", '0px hidden rgb(0, 0, 255)');
+shouldBeEqualToString("computedStyle.getPropertyCSSValue('-webkit-column-rule').cssText", '10px hidden rgb(0, 0, 255)');
 shouldBe("computedStyle.getPropertyCSSValue('-webkit-column-rule').length", "3");
-shouldBe("computedStyle.getPropertyCSSValue('-webkit-column-rule').item(0).getFloatValue(CSSPrimitiveValue.CSS_PX)", "0");
+shouldBe("computedStyle.getPropertyCSSValue('-webkit-column-rule').item(0).getFloatValue(CSSPrimitiveValue.CSS_PX)", "10");
 shouldBeEqualToString("computedStyle.getPropertyCSSValue('-webkit-column-rule').item(1).getStringValue()", "hidden");
 
 document.body.removeChild(testContainer);

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-multicol/parsing/column-rule-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-multicol/parsing/column-rule-computed-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL Property column-rule value '10px' assert_equals: expected "10px rgb(0, 255, 0)" but got "0px none rgb(0, 255, 0)"
+FAIL Property column-rule value '10px' assert_equals: expected "10px rgb(0, 255, 0)" but got "10px none rgb(0, 255, 0)"
 PASS Property column-rule value 'dotted'
 FAIL Property column-rule value '0px none rgb(255, 0, 255)' assert_equals: expected "0px rgb(255, 0, 255)" but got "0px none rgb(255, 0, 255)"
 PASS Property column-rule value '10px dotted rgb(255, 0, 255)'
-FAIL Property column-rule value 'medium hidden currentcolor' assert_equals: expected "3px hidden rgb(0, 255, 0)" but got "0px hidden rgb(0, 255, 0)"
+PASS Property column-rule value 'medium hidden currentcolor'
 PASS Property column-rule value 'medium solid currentcolor'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-multicol/parsing/column-rule-width-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-multicol/parsing/column-rule-width-computed-expected.txt
@@ -1,5 +1,5 @@
 
 PASS Property column-rule-width value 'calc(10px + 0.5em)'
 PASS Property column-rule-width value 'calc(10px - 0.5em)'
-FAIL column-rule-width is as specified when column-rule-style is none or hidden assert_equals: expected "10px" but got "0px"
+PASS column-rule-width is as specified when column-rule-style is none or hidden
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-rule-width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-rule-width-expected.txt
@@ -4,13 +4,13 @@ PASS Can set 'column-rule-width' to CSS-wide keywords: inherit
 PASS Can set 'column-rule-width' to CSS-wide keywords: unset
 PASS Can set 'column-rule-width' to CSS-wide keywords: revert
 PASS Can set 'column-rule-width' to var() references:  var(--A)
-PASS Can set 'column-rule-width' to the 'thin' keyword: thin
-PASS Can set 'column-rule-width' to the 'medium' keyword: medium
-PASS Can set 'column-rule-width' to the 'thick' keyword: thick
-PASS Can set 'column-rule-width' to a length: 0px
-PASS Can set 'column-rule-width' to a length: -3.14em
-PASS Can set 'column-rule-width' to a length: 3.14cm
-PASS Can set 'column-rule-width' to a length: calc(0px + 0em)
+FAIL Can set 'column-rule-width' to the 'thin' keyword: thin assert_class_string: expected "[object CSSStyleValue]" but got "[object CSSUnitValue]"
+FAIL Can set 'column-rule-width' to the 'medium' keyword: medium assert_class_string: expected "[object CSSStyleValue]" but got "[object CSSUnitValue]"
+FAIL Can set 'column-rule-width' to the 'thick' keyword: thick assert_class_string: expected "[object CSSStyleValue]" but got "[object CSSUnitValue]"
+FAIL Can set 'column-rule-width' to a length: 0px assert_class_string: expected "[object CSSStyleValue]" but got "[object CSSUnitValue]"
+FAIL Can set 'column-rule-width' to a length: -3.14em assert_class_string: expected "[object CSSStyleValue]" but got "[object CSSUnitValue]"
+FAIL Can set 'column-rule-width' to a length: 3.14cm assert_class_string: expected "[object CSSStyleValue]" but got "[object CSSUnitValue]"
+FAIL Can set 'column-rule-width' to a length: calc(0px + 0em) assert_class_string: expected "[object CSSStyleValue]" but got "[object CSSUnitValue]"
 PASS Setting 'column-rule-width' to a percent: 0% throws TypeError
 PASS Setting 'column-rule-width' to a percent: -3.14% throws TypeError
 PASS Setting 'column-rule-width' to a percent: 3.14% throws TypeError
@@ -33,4 +33,11 @@ PASS Setting 'column-rule-width' to a number: calc(2 + 3) throws TypeError
 PASS Setting 'column-rule-width' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'column-rule-width' to a transform: perspective(10em) throws TypeError
 PASS Setting 'column-rule-width' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'column-rule-width' does not support 'thin' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+FAIL 'column-rule-width' does not support 'medium' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+FAIL 'column-rule-width' does not support 'thick' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+FAIL 'column-rule-width' does not support '2px' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSUnitValue]"
+FAIL 'column-rule-width' does not support '3px' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSUnitValue]"
+FAIL 'column-rule-width' does not support '4px 5px' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object Undefined]"
+FAIL 'column-rule-width' does not support 'thin medium thick' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object Undefined]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-rule-width.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-rule-width.html
@@ -13,30 +13,29 @@
 <script>
 'use strict';
 
-function assert_is_zero_px(result) {
-  assert_style_value_equals(result, new CSSUnitValue(0, 'px'));
-}
-
 runPropertyTests('column-rule-width', [
-  // Computed value is 0 when column-rule-style is 'none'.
-  // FIXME: Add separate test where column-rule-style is not 'none' or 'hidden'.
   {
     syntax: 'thin',
-    computed: (_, result) => assert_is_zero_px(result)
+    computed: (_, result) => assert_class_string(result, 'CSSStyleValue')
   },
   {
     syntax: 'medium',
-    computed: (_, result) => assert_is_zero_px(result)
+    computed: (_, result) => assert_class_string(result, 'CSSStyleValue')
   },
   {
     syntax: 'thick',
-    computed: (_, result) => assert_is_zero_px(result)
+    computed: (_, result) => assert_class_string(result, 'CSSStyleValue')
   },
   {
     syntax: '<length>',
     specified: assert_is_equal_with_range_handling,
-    computed: (_, result) => assert_is_zero_px(result)
+    computed: (_, result) => assert_class_string(result, 'CSSStyleValue')
   },
+]);
+
+runUnsupportedPropertyTests('column-rule-width', [
+  'thin', 'medium', 'thick', '2px', '3px',
+  '4px 5px', 'thin medium thick',
 ]);
 
 </script>

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-multicol/animation/column-rule-width-interpolation-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-multicol/animation/column-rule-width-interpolation-expected.txt
@@ -28,25 +28,25 @@ PASS CSS Transitions: property <column-rule-width> from [initial] to [20px] at (
 FAIL CSS Transitions: property <column-rule-width> from [initial] to [20px] at (0.3) should be [8.1px] assert_equals: expected "8px " but got "8.1px "
 FAIL CSS Transitions: property <column-rule-width> from [initial] to [20px] at (0.6) should be [13.2px] assert_equals: expected "13px " but got "13.2px "
 PASS CSS Transitions: property <column-rule-width> from [initial] to [20px] at (1) should be [20px]
-FAIL CSS Transitions: property <column-rule-width> from [initial] to [20px] at (1.5) should be [28.5px] assert_equals: expected "28px " but got "28.5px "
+PASS CSS Transitions: property <column-rule-width> from [initial] to [20px] at (1.5) should be [28.5px]
 PASS CSS Transitions with transition: all: property <column-rule-width> from [initial] to [20px] at (-0.3) should be [0px]
 PASS CSS Transitions with transition: all: property <column-rule-width> from [initial] to [20px] at (0) should be [3px]
 FAIL CSS Transitions with transition: all: property <column-rule-width> from [initial] to [20px] at (0.3) should be [8.1px] assert_equals: expected "8px " but got "8.1px "
 FAIL CSS Transitions with transition: all: property <column-rule-width> from [initial] to [20px] at (0.6) should be [13.2px] assert_equals: expected "13px " but got "13.2px "
 PASS CSS Transitions with transition: all: property <column-rule-width> from [initial] to [20px] at (1) should be [20px]
-FAIL CSS Transitions with transition: all: property <column-rule-width> from [initial] to [20px] at (1.5) should be [28.5px] assert_equals: expected "28px " but got "28.5px "
+PASS CSS Transitions with transition: all: property <column-rule-width> from [initial] to [20px] at (1.5) should be [28.5px]
 PASS CSS Animations: property <column-rule-width> from [initial] to [20px] at (-0.3) should be [0px]
 PASS CSS Animations: property <column-rule-width> from [initial] to [20px] at (0) should be [3px]
 FAIL CSS Animations: property <column-rule-width> from [initial] to [20px] at (0.3) should be [8.1px] assert_equals: expected "8px " but got "8.1px "
 FAIL CSS Animations: property <column-rule-width> from [initial] to [20px] at (0.6) should be [13.2px] assert_equals: expected "13px " but got "13.2px "
 PASS CSS Animations: property <column-rule-width> from [initial] to [20px] at (1) should be [20px]
-FAIL CSS Animations: property <column-rule-width> from [initial] to [20px] at (1.5) should be [28.5px] assert_equals: expected "28px " but got "28.5px "
+PASS CSS Animations: property <column-rule-width> from [initial] to [20px] at (1.5) should be [28.5px]
 PASS Web Animations: property <column-rule-width> from [initial] to [20px] at (-0.3) should be [0px]
 PASS Web Animations: property <column-rule-width> from [initial] to [20px] at (0) should be [3px]
 FAIL Web Animations: property <column-rule-width> from [initial] to [20px] at (0.3) should be [8.1px] assert_equals: expected "8px " but got "8.1px "
 FAIL Web Animations: property <column-rule-width> from [initial] to [20px] at (0.6) should be [13.2px] assert_equals: expected "13px " but got "13.2px "
 PASS Web Animations: property <column-rule-width> from [initial] to [20px] at (1) should be [20px]
-FAIL Web Animations: property <column-rule-width> from [initial] to [20px] at (1.5) should be [28.5px] assert_equals: expected "28px " but got "28.5px "
+PASS Web Animations: property <column-rule-width> from [initial] to [20px] at (1.5) should be [28.5px]
 PASS CSS Transitions: property <column-rule-width> from [inherit] to [20px] at (-0.3) should be [33px]
 PASS CSS Transitions: property <column-rule-width> from [inherit] to [20px] at (0) should be [30px]
 PASS CSS Transitions: property <column-rule-width> from [inherit] to [20px] at (0.3) should be [27px]
@@ -76,25 +76,25 @@ PASS CSS Transitions: property <column-rule-width> from [unset] to [20px] at (0)
 FAIL CSS Transitions: property <column-rule-width> from [unset] to [20px] at (0.3) should be [8.1px] assert_equals: expected "8px " but got "8.1px "
 FAIL CSS Transitions: property <column-rule-width> from [unset] to [20px] at (0.6) should be [13.2px] assert_equals: expected "13px " but got "13.2px "
 PASS CSS Transitions: property <column-rule-width> from [unset] to [20px] at (1) should be [20px]
-FAIL CSS Transitions: property <column-rule-width> from [unset] to [20px] at (1.5) should be [28.5px] assert_equals: expected "28px " but got "28.5px "
+PASS CSS Transitions: property <column-rule-width> from [unset] to [20px] at (1.5) should be [28.5px]
 PASS CSS Transitions with transition: all: property <column-rule-width> from [unset] to [20px] at (-0.3) should be [0px]
 PASS CSS Transitions with transition: all: property <column-rule-width> from [unset] to [20px] at (0) should be [3px]
 FAIL CSS Transitions with transition: all: property <column-rule-width> from [unset] to [20px] at (0.3) should be [8.1px] assert_equals: expected "8px " but got "8.1px "
 FAIL CSS Transitions with transition: all: property <column-rule-width> from [unset] to [20px] at (0.6) should be [13.2px] assert_equals: expected "13px " but got "13.2px "
 PASS CSS Transitions with transition: all: property <column-rule-width> from [unset] to [20px] at (1) should be [20px]
-FAIL CSS Transitions with transition: all: property <column-rule-width> from [unset] to [20px] at (1.5) should be [28.5px] assert_equals: expected "28px " but got "28.5px "
+PASS CSS Transitions with transition: all: property <column-rule-width> from [unset] to [20px] at (1.5) should be [28.5px]
 PASS CSS Animations: property <column-rule-width> from [unset] to [20px] at (-0.3) should be [0px]
 PASS CSS Animations: property <column-rule-width> from [unset] to [20px] at (0) should be [3px]
 FAIL CSS Animations: property <column-rule-width> from [unset] to [20px] at (0.3) should be [8.1px] assert_equals: expected "8px " but got "8.1px "
 FAIL CSS Animations: property <column-rule-width> from [unset] to [20px] at (0.6) should be [13.2px] assert_equals: expected "13px " but got "13.2px "
 PASS CSS Animations: property <column-rule-width> from [unset] to [20px] at (1) should be [20px]
-FAIL CSS Animations: property <column-rule-width> from [unset] to [20px] at (1.5) should be [28.5px] assert_equals: expected "28px " but got "28.5px "
+PASS CSS Animations: property <column-rule-width> from [unset] to [20px] at (1.5) should be [28.5px]
 PASS Web Animations: property <column-rule-width> from [unset] to [20px] at (-0.3) should be [0px]
 PASS Web Animations: property <column-rule-width> from [unset] to [20px] at (0) should be [3px]
 FAIL Web Animations: property <column-rule-width> from [unset] to [20px] at (0.3) should be [8.1px] assert_equals: expected "8px " but got "8.1px "
 FAIL Web Animations: property <column-rule-width> from [unset] to [20px] at (0.6) should be [13.2px] assert_equals: expected "13px " but got "13.2px "
 PASS Web Animations: property <column-rule-width> from [unset] to [20px] at (1) should be [20px]
-FAIL Web Animations: property <column-rule-width> from [unset] to [20px] at (1.5) should be [28.5px] assert_equals: expected "28px " but got "28.5px "
+PASS Web Animations: property <column-rule-width> from [unset] to [20px] at (1.5) should be [28.5px]
 PASS CSS Transitions: property <column-rule-width> from [0px] to [10px] at (-0.3) should be [0px]
 PASS CSS Transitions: property <column-rule-width> from [0px] to [10px] at (0) should be [0px]
 PASS CSS Transitions: property <column-rule-width> from [0px] to [10px] at (0.3) should be [3px]

--- a/LayoutTests/svg/css/getComputedStyle-basic-expected.txt
+++ b/LayoutTests/svg/css/getComputedStyle-basic-expected.txt
@@ -53,7 +53,7 @@ rect: style.getPropertyValue(column-fill) : balance
 rect: style.getPropertyValue(column-gap) : normal
 rect: style.getPropertyValue(column-rule-color) : rgb(0, 0, 0)
 rect: style.getPropertyValue(column-rule-style) : none
-rect: style.getPropertyValue(column-rule-width) : 0px
+rect: style.getPropertyValue(column-rule-width) : 3px
 rect: style.getPropertyValue(column-span) : none
 rect: style.getPropertyValue(column-width) : auto
 rect: style.getPropertyValue(content) : normal
@@ -294,7 +294,7 @@ g: style.getPropertyValue(column-fill) : balance
 g: style.getPropertyValue(column-gap) : normal
 g: style.getPropertyValue(column-rule-color) : rgb(0, 0, 0)
 g: style.getPropertyValue(column-rule-style) : none
-g: style.getPropertyValue(column-rule-width) : 0px
+g: style.getPropertyValue(column-rule-width) : 3px
 g: style.getPropertyValue(column-span) : none
 g: style.getPropertyValue(column-width) : auto
 g: style.getPropertyValue(content) : normal

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -795,7 +795,6 @@ style/Styleable.h
 style/UserAgentStyle.cpp
 style/computed/StyleComputedStyle.cpp
 style/computed/StyleComputedStyleBase.cpp
-style/computed/StyleComputedStyleProperties+GettersCustomInlines.h
 style/values/primitives/StyleLengthWrapperData.cpp
 style/values/transforms/StyleRotate.cpp
 style/values/transforms/StyleScale.cpp

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -9976,12 +9976,12 @@
                 "style-builder-custom": "Initial",
                 "computed-style-initial-constexpr": true,
                 "computed-style-initial-custom": true,
-                "computed-style-getter-custom": true,
                 "computed-style-storage-name": "width",
                 "computed-style-storage-path": ["m_nonInheritedData", "miscData", "multiCol", "columnRule"],
                 "computed-style-storage-container": "struct",
-                "computed-style-storage-kind": "value",
+                "computed-style-storage-kind": "reference",
                 "computed-style-type": "Style::LineWidth",
+                "skip-render-style-getter": true,
                 "parser-grammar": "<line-width>"
             },
             "specification":  {

--- a/Source/WebCore/rendering/BorderEdge.cpp
+++ b/Source/WebCore/rendering/BorderEdge.cpp
@@ -58,10 +58,10 @@ BorderEdges borderEdges(const RenderStyle& style, float deviceScaleFactor, RectE
     };
 
     return {
-        constructBorderEdge.template operator()<CSSPropertyBorderTopColor>(style, style.usedBorderTopWidth(), inflation.height().toFloat(), style.borderTopStyle(), style.borderTopIsTransparent(), closedEdges.top()),
-        constructBorderEdge.template operator()<CSSPropertyBorderRightColor>(style, style.usedBorderRightWidth(), inflation.width().toFloat(), style.borderRightStyle(), style.borderRightIsTransparent(), closedEdges.right()),
-        constructBorderEdge.template operator()<CSSPropertyBorderBottomColor>(style, style.usedBorderBottomWidth(), inflation.height().toFloat(), style.borderBottomStyle(), style.borderBottomIsTransparent(), closedEdges.bottom()),
-        constructBorderEdge.template operator()<CSSPropertyBorderLeftColor>(style, style.usedBorderLeftWidth(), inflation.width().toFloat(), style.borderLeftStyle(), style.borderLeftIsTransparent(), closedEdges.left())
+        constructBorderEdge.template operator()<CSSPropertyBorderTopColor>(style, style.usedBorderTopWidth(), inflation.height().toFloat(), style.borderTopStyle(), style.borderTopColor().isKnownTransparent(), closedEdges.top()),
+        constructBorderEdge.template operator()<CSSPropertyBorderRightColor>(style, style.usedBorderRightWidth(), inflation.width().toFloat(), style.borderRightStyle(), style.borderRightColor().isKnownTransparent(), closedEdges.right()),
+        constructBorderEdge.template operator()<CSSPropertyBorderBottomColor>(style, style.usedBorderBottomWidth(), inflation.height().toFloat(), style.borderBottomStyle(), style.borderBottomColor().isKnownTransparent(), closedEdges.bottom()),
+        constructBorderEdge.template operator()<CSSPropertyBorderLeftColor>(style, style.usedBorderLeftWidth(), inflation.width().toFloat(), style.borderLeftStyle(), style.borderLeftColor().isKnownTransparent(), closedEdges.left())
     };
 }
 

--- a/Source/WebCore/rendering/BorderEdge.h
+++ b/Source/WebCore/rendering/BorderEdge.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -48,7 +49,7 @@ public:
     bool isTransparent() const { return m_isTransparent; }
     bool isPresent() const { return m_isPresent; }
 
-    inline bool hasVisibleColorAndStyle() const { return m_style > BorderStyle::Hidden && !m_isTransparent; }
+    inline bool hasVisibleColorAndStyle() const { return isVisibleBorderStyle(m_style) && !m_isTransparent; }
     inline bool shouldRender() const { return m_isPresent && widthForPainting() && hasVisibleColorAndStyle(); }
     inline bool presentButInvisible() const { return widthForPainting() && !hasVisibleColorAndStyle(); }
     inline float widthForPainting() const { return m_isPresent ? m_flooredToDevicePixelWidth : 0; }

--- a/Source/WebCore/rendering/RenderMultiColumnSet.cpp
+++ b/Source/WebCore/rendering/RenderMultiColumnSet.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2015 Google Inc. All rights reserved.
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -627,20 +628,20 @@ void RenderMultiColumnSet::paintColumnRules(PaintInfo& paintInfo, const LayoutPo
     if (paintInfo.context().paintingDisabled())
         return;
 
-    RenderMultiColumnFlow* fragmentedFlow = multiColumnFlow();
-    const RenderStyle& blockStyle = parent()->style();
-    const Color& ruleColor = blockStyle.visitedDependentColumnRuleColorApplyingColorFilter();
-    bool ruleTransparent = blockStyle.columnRuleIsTransparent();
+    auto* fragmentedFlow = multiColumnFlow();
+    auto& blockStyle = parent()->style();
+
     auto ruleStyle = collapsedBorderStyle(blockStyle.columnRuleStyle());
-    auto ruleThickness = Style::evaluate<LayoutUnit>(blockStyle.columnRuleWidth(), Style::ZoomNeeded { });
-    auto colGap = columnGap();
-    bool renderRule = ruleStyle > BorderStyle::Hidden && !ruleTransparent;
-    if (!renderRule)
+    if (!isVisibleBorderStyle(ruleStyle) || blockStyle.columnRuleColor().isKnownTransparent())
         return;
 
-    unsigned colCount = columnCount();
+    auto colCount = columnCount();
     if (colCount <= 1)
         return;
+
+    auto ruleColor = blockStyle.visitedDependentColumnRuleColorApplyingColorFilter();
+    auto ruleThickness = Style::evaluate<LayoutUnit>(blockStyle.usedColumnRuleWidth(), Style::ZoomNeeded { });
+    auto colGap = columnGap();
 
     bool antialias = BorderPainter::shouldAntialiasLines(paintInfo.context());
 

--- a/Source/WebCore/rendering/style/BorderValue.cpp
+++ b/Source/WebCore/rendering/style/BorderValue.cpp
@@ -4,7 +4,7 @@
  *           (C) 2000 Dirk Mueller (mueller@kde.org)
  * Copyright (C) 2003, 2005, 2006, 2007, 2008, 2022 Apple Inc. All rights reserved.
  * Copyright (C) 2006 Graham Dennis (graham.dennis@gmail.com)
- * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2025-2026 Samuel Weinig <sam@webkit.org>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -32,14 +32,9 @@
 
 namespace WebCore {
 
-bool BorderValue::isTransparent() const
-{
-    return color.isResolvedColor() && color.resolvedColor().isValid() && !color.resolvedColor().isVisible();
-}
-
 bool BorderValue::isVisible() const
 {
-    return nonZero() && !isTransparent() && static_cast<BorderStyle>(style) != BorderStyle::Hidden;
+    return nonZero() && !color.isKnownTransparent() && static_cast<BorderStyle>(style) != BorderStyle::Hidden;
 }
 
 TextStream& operator<<(TextStream& ts, const BorderValue& borderValue)

--- a/Source/WebCore/rendering/style/BorderValue.h
+++ b/Source/WebCore/rendering/style/BorderValue.h
@@ -4,7 +4,7 @@
  *           (C) 2000 Dirk Mueller (mueller@kde.org)
  * Copyright (C) 2003, 2005, 2006, 2007, 2008 Apple Inc. All rights reserved.
  * Copyright (C) 2006 Graham Dennis (graham.dennis@gmail.com)
- * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2025-2026 Samuel Weinig <sam@webkit.org>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -38,10 +38,9 @@ struct BorderValue {
 
     bool isVisible() const;
     bool nonZero() const;
-    bool isTransparent() const;
 
     bool hasHiddenStyle() const { return static_cast<BorderStyle>(style) == BorderStyle::Hidden; }
-    bool hasVisibleStyle() const { return static_cast<BorderStyle>(style) > BorderStyle::Hidden; }
+    bool hasVisibleStyle() const { return isVisibleBorderStyle(static_cast<BorderStyle>(style)); }
 
     bool operator==(const BorderValue&) const = default;
 };

--- a/Source/WebCore/rendering/style/CollapsedBorderValue.h
+++ b/Source/WebCore/rendering/style/CollapsedBorderValue.h
@@ -4,6 +4,7 @@
  *           (C) 2000 Dirk Mueller (mueller@kde.org)
  * Copyright (C) 2003, 2005, 2006, 2007, 2008 Apple Inc. All rights reserved.
  * Copyright (C) 2006 Graham Dennis (graham.dennis@gmail.com)
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -43,11 +44,11 @@ public:
         , m_color(color)
         , m_style(static_cast<unsigned>(border.style))
         , m_precedence(static_cast<unsigned>(precedence))
-        , m_transparent(border.isTransparent())
+        , m_transparent(border.color.isKnownTransparent())
     {
     }
 
-    LayoutUnit width() const { return style() > BorderStyle::Hidden ? m_width : 0_lu; }
+    LayoutUnit width() const { return isVisibleBorderStyle(style()) ? m_width : 0_lu; }
     BorderStyle style() const { return static_cast<BorderStyle>(m_style); }
     bool exists() const { return precedence() != BorderPrecedence::Off; }
     const Color& color() const { return m_color; }
@@ -64,9 +65,9 @@ public:
 private:
     LayoutUnit m_width;
     Color m_color;
-    unsigned m_style : 4; // BorderStyle
-    unsigned m_precedence : 3; // BorderPrecedence
-    unsigned m_transparent : 1;
+    PREFERRED_TYPE(BorderStyle) unsigned m_style : 4;
+    PREFERRED_TYPE(BorderPrecedence) unsigned m_precedence : 3;
+    PREFERRED_TYPE(bool) unsigned m_transparent : 1;
 };
 
 inline LayoutUnit CollapsedBorderValue::adjustedCollapsedBorderWidth(float borderWidth, float deviceScaleFactor, bool roundUp)

--- a/Source/WebCore/rendering/style/OutlineValue.cpp
+++ b/Source/WebCore/rendering/style/OutlineValue.cpp
@@ -4,7 +4,7 @@
  *           (C) 2000 Dirk Mueller (mueller@kde.org)
  * Copyright (C) 2003, 2005, 2006, 2007, 2008, 2022 Apple Inc. All rights reserved.
  * Copyright (C) 2006 Graham Dennis (graham.dennis@gmail.com)
- * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2025-2026 Samuel Weinig <sam@webkit.org>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -38,14 +38,9 @@ bool OutlineValue::nonZero() const
     return outlineWidth && static_cast<OutlineStyle>(outlineStyle) != OutlineStyle::None;
 }
 
-bool OutlineValue::isTransparent() const
-{
-    return outlineColor.isResolvedColor() && outlineColor.resolvedColor().isValid() && !outlineColor.resolvedColor().isVisible();
-}
-
 bool OutlineValue::isVisible() const
 {
-    return nonZero() && !isTransparent();
+    return nonZero() && !outlineColor.isKnownTransparent();
 }
 
 TextStream& operator<<(TextStream& ts, const OutlineValue& value)

--- a/Source/WebCore/rendering/style/OutlineValue.h
+++ b/Source/WebCore/rendering/style/OutlineValue.h
@@ -4,7 +4,7 @@
  *           (C) 2000 Dirk Mueller (mueller@kde.org)
  * Copyright (C) 2003, 2005, 2006, 2007, 2008 Apple Inc. All rights reserved.
  * Copyright (C) 2006 Graham Dennis (graham.dennis@gmail.com)
- * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2025-2026 Samuel Weinig <sam@webkit.org>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -39,7 +39,6 @@ struct OutlineValue {
 
     bool isVisible() const;
     bool nonZero() const;
-    bool isTransparent() const;
 
     bool operator==(const OutlineValue&) const = default;
 };

--- a/Source/WebCore/rendering/style/RenderStyle+GettersInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyle+GettersInlines.h
@@ -143,31 +143,6 @@ inline bool RenderStyle::autoWrap() const
     return textWrapMode() != TextWrapMode::NoWrap;
 }
 
-inline bool RenderStyle::borderBottomIsTransparent() const
-{
-    return border().bottom().isTransparent();
-}
-
-inline bool RenderStyle::borderLeftIsTransparent() const
-{
-    return border().left().isTransparent();
-}
-
-inline bool RenderStyle::borderRightIsTransparent() const
-{
-    return border().right().isTransparent();
-}
-
-inline bool RenderStyle::borderTopIsTransparent() const
-{
-    return border().top().isTransparent();
-}
-
-inline bool RenderStyle::columnRuleIsTransparent() const
-{
-    return columnRule().isTransparent();
-}
-
 inline bool RenderStyle::hasExplicitlySetBorderRadius() const
 {
     return hasExplicitlySetBorderBottomLeftRadius()

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -462,6 +462,13 @@ Color RenderStyle::usedAccentColor(OptionSet<StyleColorOptions> styleColorOption
     );
 }
 
+Style::LineWidth RenderStyle::usedColumnRuleWidth() const
+{
+    if (!isVisibleBorderStyle(m_computedStyle.columnRuleStyle()))
+        return 0_css_px;
+    return m_computedStyle.columnRuleWidth();
+}
+
 Style::Length<> RenderStyle::usedOutlineOffset() const
 {
     auto& outline = m_computedStyle.outline();

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -183,6 +183,8 @@ public:
     static UsedFloat usedFloat(const RenderElement&); // Returns logical left/right (block-relative).
     static UsedClear usedClear(const RenderElement&); // Returns logical left/right (block-relative).
 
+    Style::LineWidth usedColumnRuleWidth() const;
+
     Style::Length<> usedOutlineOffset() const;
     Style::LineWidth usedOutlineWidth() const;
     float usedOutlineSize() const; // used value combining `outline-width` and `outline-offset`
@@ -291,12 +293,6 @@ public:
     constexpr bool doesDisplayGenerateBlockContainer() const;
 
     inline bool specifiesColumns() const;
-
-    inline bool columnRuleIsTransparent() const;
-    inline bool borderLeftIsTransparent() const;
-    inline bool borderRightIsTransparent() const;
-    inline bool borderTopIsTransparent() const;
-    inline bool borderBottomIsTransparent() const;
 
     inline bool usesStandardScrollbarStyle() const;
     inline bool usesLegacyScrollbarStyle() const;

--- a/Source/WebCore/rendering/style/RenderStyleBase+GettersInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleBase+GettersInlines.h
@@ -518,11 +518,6 @@ inline const BorderValue& RenderStyleBase::borderTop() const
     return m_computedStyle.borderTop();
 }
 
-inline const BorderValue& RenderStyleBase::columnRule() const
-{
-    return m_computedStyle.columnRule();
-}
-
 // MARK: - Properties/descriptors that are not yet generated
 
 inline CursorType RenderStyleBase::cursorType() const

--- a/Source/WebCore/rendering/style/RenderStyleBase.h
+++ b/Source/WebCore/rendering/style/RenderStyleBase.h
@@ -255,7 +255,6 @@ public:
     inline const BorderValue& borderLeft() const;
     inline const BorderValue& borderRight() const;
     inline const BorderValue& borderTop() const;
-    inline const BorderValue& columnRule() const;
     inline const Style::Animations& animations() const;
     inline const Style::BackgroundLayers& backgroundLayers() const;
     inline const Style::BorderImage& borderImage() const;

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -5,6 +5,7 @@
  * Copyright (C) 2003-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2006 Graham Dennis (graham.dennis@gmail.com)
  * Copyright (C) 2009 Torch Mobile Inc. All rights reserved. (http://www.torchmobile.com/)
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -155,6 +156,11 @@ enum class BorderStyle : uint8_t {
     Solid,
     Double
 };
+
+inline bool isVisibleBorderStyle(BorderStyle value)
+{
+    return value > BorderStyle::Hidden;
+}
 
 enum class BorderPrecedence : uint8_t {
     Off,

--- a/Source/WebCore/style/computed/StyleComputedStyleProperties+GettersCustomInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleProperties+GettersCustomInlines.h
@@ -129,13 +129,6 @@ inline TextOrientation ComputedStyleProperties::computedTextOrientation() const
     return writingMode().computedTextOrientation();
 }
 
-// FIXME: Support properties where the getter returns a different value than the setter checks for equality or rename these to be used*() and generate the real getters.
-
-inline LineWidth ComputedStyleProperties::columnRuleWidth() const
-{
-    return m_nonInheritedData->miscData->multiCol->columnRuleWidth();
-}
-
 // FIXME: Support font properties.
 
 float ComputedStyleProperties::specifiedFontSize() const

--- a/Source/WebCore/style/computed/data/StyleMultiColumnData.cpp
+++ b/Source/WebCore/style/computed/data/StyleMultiColumnData.cpp
@@ -88,12 +88,5 @@ void MultiColumnData::dumpDifferences(TextStream& ts, const MultiColumnData& oth
 }
 #endif // !LOG_DISABLED
 
-LineWidth MultiColumnData::columnRuleWidth() const
-{
-    if (!columnRule.hasVisibleStyle())
-        return LineWidth { 0_css_px };
-    return columnRule.width;
-}
-
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/computed/data/StyleMultiColumnData.h
+++ b/Source/WebCore/style/computed/data/StyleMultiColumnData.h
@@ -49,8 +49,6 @@ public:
     void dumpDifferences(TextStream&, const MultiColumnData&) const;
 #endif
 
-    LineWidth columnRuleWidth() const;
-
     ColumnWidth columnWidth { CSS::Keyword::Auto { } };
     ColumnCount columnCount { CSS::Keyword::Auto { } };
     BorderValue columnRule;

--- a/Source/WebCore/style/values/color/StyleColor.cpp
+++ b/Source/WebCore/style/values/color/StyleColor.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2015 Google Inc. All rights reserved.
  * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
- * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2025-2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -302,6 +302,11 @@ const WebCore::Color& Color::resolvedColor() const
 {
     ASSERT(isResolvedColor());
     return std::get<ResolvedColor>(value).color;
+}
+
+bool Color::isKnownTransparent() const
+{
+    return isResolvedColor() && resolvedColor().isValid() && !resolvedColor().isVisible();
 }
 
 template<typename T> Color::ColorKind Color::makeIndirectColor(T&& colorType)

--- a/Source/WebCore/style/values/color/StyleColor.h
+++ b/Source/WebCore/style/values/color/StyleColor.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2013 Google Inc. All rights reserved.
  * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
- * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2025-2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -154,6 +154,8 @@ public:
     const WebCore::Color& resolvedColor() const;
 
     WEBCORE_EXPORT WebCore::Color resolveColor(const WebCore::Color& currentColor) const;
+
+    bool isKnownTransparent() const;
 
     // This helper allows us to treat all the alternatives in ColorKind
     // as const references, pretending the UniqueRefs don't exist.


### PR DESCRIPTION
#### 8c44752f8ddb2a2856f4d6dfd6474b3ffea5e657
<pre>
Update column-rule-width to match updated computed style resolution rules
<a href="https://bugs.webkit.org/show_bug.cgi?id=304940">https://bugs.webkit.org/show_bug.cgi?id=304940</a>

Reviewed by Darin Adler.

The rules for the `column-rule-width` property&apos;s computed value resolution were updated with
<a href="https://github.com/w3c/csswg-drafts/issues/11494">https://github.com/w3c/csswg-drafts/issues/11494</a> to disentangle `column-rule-width` and
`column-rule-style` for computed style, making `column-rule-style` only effect the used value.

As was done with `outline-width`, which had the same change made, `RenderStyle::columnRuleWidth()`
has been removed and replaced by `RenderStyle::usedColumnRuleWidth()`. To get the computed style
one can use RenderStyle::computedStyle().columnRuleWidth()` as the extractor does.

A few related cleanups were also performed.

- Replaced the `isTransparent` member functions on `BorderValue` and `OutlineValue` by adding
  a `Style::Color::isKnownTransparent()` member function that does the same thing. With that
  available, the `RenderStyle::{...}IsTransparent()` member functions were no longer useful,
  as the corresponding `{...}Color.isKnownTransparent()` now works just as well.

- Added an inline helper function `isVisibleBorderStyle()` to replace explicit range checks
  against BorderStyle.

- Moved some conditions in RenderMultiColumnSet::paintColumnRules() to only run after an
  early return to avoid unnecessary work.

While it looks like `css/css-multicol/animation/column-rule-width-interpolation.html` is a regression
the test was previously not really testing anything, as it only looks at getComputedStyle values
and since no `column-rule-style` was set, we always returned 0. This looked like passing because the
test normalizes the expected values by setting them to an element and running getComputedStyle, which
was also always returning 0. To fix this test further, we will need to ensure that pixel snapping
is also applied during interpolation (see <a href="https://bugs.webkit.org/show_bug.cgi?id=304945).">https://bugs.webkit.org/show_bug.cgi?id=304945).</a>

* LayoutTests/fast/css/getComputedStyle/computed-style-expected.txt:
* LayoutTests/fast/css/getComputedStyle/computed-style-without-renderer-expected.txt:
* LayoutTests/fast/css/getComputedStyle/getComputedStyle-column-rule-expected.txt:
* LayoutTests/fast/css/getComputedStyle/getComputedStyle-column-rule.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-multicol/animation/column-rule-width-interpolation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-multicol/parsing/column-rule-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-multicol/parsing/column-rule-width-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-rule-width-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/column-rule-width.html:
* LayoutTests/svg/css/getComputedStyle-basic-expected.txt:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/rendering/BorderEdge.cpp:
* Source/WebCore/rendering/BorderEdge.h:
* Source/WebCore/rendering/RenderMultiColumnSet.cpp:
* Source/WebCore/rendering/style/BorderValue.cpp:
* Source/WebCore/rendering/style/BorderValue.h:
* Source/WebCore/rendering/style/CollapsedBorderValue.h:
* Source/WebCore/rendering/style/OutlineValue.cpp:
* Source/WebCore/rendering/style/OutlineValue.h:
* Source/WebCore/rendering/style/RenderStyle+GettersInlines.h:
* Source/WebCore/rendering/style/RenderStyle.cpp:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleBase+GettersInlines.h:
* Source/WebCore/rendering/style/RenderStyleBase.h:
* Source/WebCore/rendering/style/RenderStyleConstants.h:
* Source/WebCore/style/computed/StyleComputedStyleProperties+GettersCustomInlines.h:
* Source/WebCore/style/computed/data/StyleMultiColumnData.cpp:
* Source/WebCore/style/computed/data/StyleMultiColumnData.h:
* Source/WebCore/style/values/color/StyleColor.cpp:
* Source/WebCore/style/values/color/StyleColor.h:

Canonical link: <a href="https://commits.webkit.org/305240@main">https://commits.webkit.org/305240@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5f046aba572c6ebbdf28b74965be4b0bd975c5b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137855 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10219 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49203 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/145921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90830 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139727 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10921 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10357 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/145921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140800 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8135 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123586 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/145921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7756 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5500 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6201 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117150 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41746 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148631 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9902 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42307 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/113844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9919 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8357 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114176 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28999 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7698 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119835 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64622 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9948 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37849 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9678 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73516 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9889 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9740 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->