### PR TITLE
Address feedback post 305077@main (early return, otpimizations and clearer code)

### DIFF
--- a/Source/WebCore/rendering/svg/RenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGShape.cpp
@@ -396,7 +396,10 @@ float RenderSVGShape::strokeWidth() const
 
 float RenderSVGShape::strokeWidthForMarkerUnits() const
 {
-    float strokeWidth = RenderSVGShape::strokeWidth();
+    float strokeWidth = this->strokeWidth();
+    if (!hasNonScalingStroke())
+        return strokeWidth;
+
     if (hasNonScalingStroke()) {
         auto nonScalingTransform = nonScalingStrokeTransform();
         if (!nonScalingTransform.isInvertible())
@@ -406,7 +409,10 @@ float RenderSVGShape::strokeWidthForMarkerUnits() const
         double yScale = nonScalingTransform.yScale();
         float scaleFactor = clampTo<float>(std::sqrt((xScale * xScale + yScale * yScale) / 2));
 
-        strokeWidth /= scaleFactor;
+        if (xScale == yScale) [[likely]]
+            return strokeWidth / xScale;
+
+        return strokeWidth / scaleFactor;
     }
     return strokeWidth;
 }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
@@ -467,7 +467,10 @@ float LegacyRenderSVGShape::strokeWidth() const
 
 float LegacyRenderSVGShape::strokeWidthForMarkerUnits() const
 {
-    float strokeWidth = LegacyRenderSVGShape::strokeWidth();
+    float strokeWidth = this->strokeWidth();
+    if (!hasNonScalingStroke())
+        return strokeWidth;
+
     if (hasNonScalingStroke()) {
         auto nonScalingTransform = nonScalingStrokeTransform();
         if (!nonScalingTransform.isInvertible())
@@ -477,7 +480,10 @@ float LegacyRenderSVGShape::strokeWidthForMarkerUnits() const
         double yScale = nonScalingTransform.yScale();
         float scaleFactor = clampTo<float>(std::sqrt((xScale * xScale + yScale * yScale) / 2));
 
-        strokeWidth /= scaleFactor;
+        if (xScale == yScale) [[likely]]
+            return strokeWidth / xScale;
+
+        return strokeWidth / scaleFactor;
     }
     return strokeWidth;
 }


### PR DESCRIPTION
#### 82674607be4621a3022aa4e06c38e2376b70bdc8
<pre>
Address feedback post <a href="https://commits.webkit.org/305077@main">305077@main</a> (early return, otpimizations and clearer code)
<a href="https://bugs.webkit.org/show_bug.cgi?id=304947">https://bugs.webkit.org/show_bug.cgi?id=304947</a>
<a href="https://rdar.apple.com/167563795">rdar://167563795</a>

Reviewed by NOBODY (OOPS!).

This patch addresses Said&apos;s feedback post <a href="https://commits.webkit.org/305077@main">305077@main</a> landing, it adds
following:

&gt; Use `this-&gt;` pattern to call function.
&gt; Early return to avoid doing work when path is not `non-scaling`.
&gt; Adds optimization where `xScale = yScale`.
&gt; Use `return strokeWidth / scaleFactor` consistent with codebsae.

* Source/WebCore/rendering/svg/RenderSVGShape.cpp:
(WebCore::RenderSVGShape::strokeWidthForMarkerUnits const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp:
(WebCore::LegacyRenderSVGShape::strokeWidthForMarkerUnits const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82674607be4621a3022aa4e06c38e2376b70bdc8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137565 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9926 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48852 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145322 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/90538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/098fa5c7-0f55-42c9-a9bf-93887e6f81ad) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139437 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10629 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10056 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105208 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/90538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3d0210f4-5b7d-4763-aa50-e0e9eb730be6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140510 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7890 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123283 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86061 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7526 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5246 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5905 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116896 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41440 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148086 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9608 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41994 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113589 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9626 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8099 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113931 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7443 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119523 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64264 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9657 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37576 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9388 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73222 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9597 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9449 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->