### PR TITLE
SVG filter referencing element with huge stroke fails to display

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/feimage-element-ref-geometry-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/feimage-element-ref-geometry-expected.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<style>
+    svg, .box {
+        position: absolute;
+        top: 20px;
+        left: 20px;
+        width: 400px;
+        height: 300px;
+    }
+    .test {
+        width: 400px;
+        height: 300px;
+        filter: url(#filter);
+    }
+    .indicator {
+        border: 1px solid black;
+    }
+    /* This also hides any antialiasing of the filter content */
+    .filter-indicator {
+        top: 38px;
+        left: 38px;
+        width: 354px;
+        height: 254px;
+        box-sizing: border-box;
+        border: 4px solid orange;
+    }
+</style>
+</head>
+<body>
+  <svg width="400" height="300">
+    <defs>
+      <g id="group">
+        <rect x="20" y="20" width="350" height="250" fill="green"></rect>
+        <!-- The large offset triggers buffer scaling in some UAs -->
+        <rect x="4000" y="4000" width="500" height="400" fill="red"></rect>
+      </g>
+    </defs>
+    <use href="#group">
+  </svg>
+</div>
+
+<div class="indicator box"></div>
+<div class="filter-indicator box"></div>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/feimage-element-ref-geometry-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/feimage-element-ref-geometry-ref.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<style>
+    svg, .box {
+        position: absolute;
+        top: 20px;
+        left: 20px;
+        width: 400px;
+        height: 300px;
+    }
+    .test {
+        width: 400px;
+        height: 300px;
+        filter: url(#filter);
+    }
+    .indicator {
+        border: 1px solid black;
+    }
+    /* This also hides any antialiasing of the filter content */
+    .filter-indicator {
+        top: 38px;
+        left: 38px;
+        width: 354px;
+        height: 254px;
+        box-sizing: border-box;
+        border: 4px solid orange;
+    }
+</style>
+</head>
+<body>
+  <svg width="400" height="300">
+    <defs>
+      <g id="group">
+        <rect x="20" y="20" width="350" height="250" fill="green"></rect>
+        <!-- The large offset triggers buffer scaling in some UAs -->
+        <rect x="4000" y="4000" width="500" height="400" fill="red"></rect>
+      </g>
+    </defs>
+    <use href="#group">
+  </svg>
+</div>
+
+<div class="indicator box"></div>
+<div class="filter-indicator box"></div>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/feimage-element-ref-geometry.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/feimage-element-ref-geometry.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<title>feImage</title>
+<link rel="author" title="Apple Inc" href="http://www.apple.com/">
+<link rel="match" href="feimage-element-ref-geometry-ref.html">
+<link rel="help" href="https://drafts.csswg.org/filter-effects/#feImageElement">
+<style>
+    .box {
+        position: absolute;
+        top: 20px;
+        left: 20px;
+        width: 400px;
+        height: 300px;
+    }
+    .test {
+        width: 400px;
+        height: 300px;
+        filter: url(#filter);
+    }
+    .indicator {
+        border: 1px solid black;
+    }
+    /* This also hides any antialiasing of the filter content due to scaling */
+    .filter-indicator {
+        top: 38px;
+        left: 38px;
+        width: 354px;
+        height: 254px;
+        box-sizing: border-box;
+        border: 4px solid orange;
+    }
+</style>
+</head>
+<body>
+  <svg width="100%" height="100%">
+    <filter id="filter" x="-10%" y="0" width="120%" height="100%">
+      <feImage href="#group"></feImage>
+    </filter>
+    <defs>
+      <g id="group">
+        <rect x="60" y="20" width="350" height="250" fill="green"></rect>
+        <!-- The large offset triggers buffer scaling in some UAs -->
+        <rect x="4000" y="4000" width="500" height="400" fill="red"></rect>
+      </g>
+    </defs>
+  </svg>
+</div>
+
+<div class="test box"></div>
+<div class="indicator box"></div>
+<div class="filter-indicator box"></div>
+
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/filters/software/FEImageSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEImageSoftwareApplier.cpp
@@ -57,11 +57,13 @@ bool FEImageSoftwareApplier::apply(const Filter& filter, std::span<const Ref<Fil
     }
 
     if (auto imageBuffer = sourceImage.imageBufferIfExists()) {
-        auto imageRect = primitiveSubregion;
-        imageRect.moveBy(m_effect->sourceImageRect().location());
-        imageRect.scale(filter.filterScale());
-        imageRect = IntRect(imageRect) - result.absoluteImageRect().location();
-        context.drawImageBuffer(*imageBuffer, imageRect.location());
+        auto destRect = m_effect->sourceImageRect();
+        destRect.moveBy(primitiveSubregion.location());
+        destRect.scale(filter.filterScale());
+        destRect.moveBy(-result.absoluteImageRect().location());
+
+        auto bufferBounds = FloatRect { { }, imageBuffer->logicalSize() };
+        context.drawImageBuffer(*imageBuffer, destRect, bufferBounds);
         return true;
     }
     

--- a/Source/WebCore/rendering/CSSFilterRenderer.cpp
+++ b/Source/WebCore/rendering/CSSFilterRenderer.cpp
@@ -353,6 +353,7 @@ RefPtr<FilterImage> CSSFilterRenderer::apply(FilterImage* sourceImage, FilterRes
     if (!sourceImage)
         return nullptr;
 
+    LOG_WITH_STREAM(Filters, stream << "\nCSSFilterRenderer " << this << " apply - filterRegion " << filterRegion() << " scale " << filterScale());
     RefPtr<FilterImage> result = sourceImage;
 
     for (auto& function : m_functions) {

--- a/Source/WebCore/svg/graphics/filters/SVGFilterRenderer.cpp
+++ b/Source/WebCore/svg/graphics/filters/SVGFilterRenderer.cpp
@@ -323,6 +323,8 @@ RefPtr<FilterImage> SVGFilterRenderer::apply(FilterImage* sourceImage, FilterRes
     ASSERT(filterRenderingModes().contains(FilterRenderingMode::Software));
     ASSERT(isValidSVGFilterExpression(m_expression, m_effects));
 
+    LOG_WITH_STREAM(Filters, stream << "\nSVGFilterRenderer " << this << " apply - filterRegion " << filterRegion() << " scale " << filterScale());
+
     FilterImageVector stack;
 
     for (auto& term : m_expression) {


### PR DESCRIPTION
#### c08dafc2c51aed8683846a0b22c9902af46ad542
<pre>
SVG filter referencing element with huge stroke fails to display
<a href="https://bugs.webkit.org/show_bug.cgi?id=304911">https://bugs.webkit.org/show_bug.cgi?id=304911</a>
<a href="https://rdar.apple.com/167516452">rdar://167516452</a>

Reviewed by Mike Wyrzykowski.

The input buffer to feImage may be scaled if it exceeds the 4kx4k threshold; this happened in the reported
case because of a line with a huge stroke. When this happens, the logic in `FEImageSoftwareApplier::apply()`
fails to take the buffer scaling into account, rendering just part of the buffer in the wrong location,
so fix the logic to handle scaling.

Tests: imported/w3c/web-platform-tests/css/filter-effects/feimage-element-ref-geometry-ref.html
       imported/w3c/web-platform-tests/css/filter-effects/feimage-element-ref-geometry.html

* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/feimage-element-ref-geometry-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/feimage-element-ref-geometry-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/feimage-element-ref-geometry.html: Added.
* Source/WebCore/platform/graphics/filters/software/FEImageSoftwareApplier.cpp:
(WebCore::FEImageSoftwareApplier::apply const):
* Source/WebCore/rendering/CSSFilterRenderer.cpp:
(WebCore::CSSFilterRenderer::apply):
* Source/WebCore/svg/graphics/filters/SVGFilterRenderer.cpp:
(WebCore::SVGFilterRenderer::apply):

Canonical link: <a href="https://commits.webkit.org/305136@main">https://commits.webkit.org/305136@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d03316b3bcecad8908a61181120c67a0599d817

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137595 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9956 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48883 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145353 "") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90568 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139467 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10659 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10086 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/145353 "") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140540 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7914 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123314 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/145353 "") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/bef5c4e6-97d6-456b-a366-fd198a5483ff) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7546 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5269 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5935 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116919 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41473 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148117 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9638 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42025 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113614 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9656 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8124 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113959 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28929 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7472 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119554 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64294 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9687 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37604 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9418 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73252 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9627 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9479 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->