### PR TITLE
[webkitpy] Reduce duplication across Apple embedded OS ports

### DIFF
--- a/Tools/Scripts/webkitpy/port/device_device.py
+++ b/Tools/Scripts/webkitpy/port/device_device.py
@@ -1,0 +1,124 @@
+# Copyright (C) 2014-2025 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import logging
+
+from abc import ABCMeta, abstractmethod
+
+from webkitcorepy import Version
+
+from webkitpy.common.memoized import memoized
+from webkitpy.common.system.crashlogs import CrashLogs
+from webkitpy.port.config import apple_additions
+from webkitpy.port.device import Device
+from webkitpy.port.device_port import DevicePort
+
+_log = logging.getLogger(__name__)
+
+
+class DeviceDevicePort(DevicePort, metaclass=ABCMeta):
+    """Base class for physical device ports (iOS, watchOS, visionOS devices)."""
+
+    DEVICE_MANAGER = apple_additions().device_manager() if apple_additions() else None
+
+    NO_ON_DEVICE_TESTING = 'On-device testing is not supported in this configuration'
+    NO_DEVICE_MANAGER = NO_ON_DEVICE_TESTING
+
+    def _driver_class(self):
+        if apple_additions():
+            return apple_additions().device_driver()
+        return super()._driver_class()
+
+    @classmethod
+    def determine_full_port_name(cls, host, options, port_name):
+        if port_name == cls.port_name:
+            sdk_version = host.platform.xcode_sdk_version(cls.SDK)
+            if not sdk_version:
+                raise Exception("Please install the {} SDK.".format(cls.DEVICE_TYPE.software_variant))
+            port_name = port_name + '-' + str(sdk_version.major)
+        return port_name
+
+    def path_to_crash_logs(self):
+        if not apple_additions():
+            raise RuntimeError(self.NO_ON_DEVICE_TESTING)
+        return apple_additions().device_crash_log_path()
+
+    def _look_for_all_crash_logs_in_log_dir(self, newer_than):
+        log_list = {}
+        for device in self.devices():
+            crash_log = CrashLogs(device, self.path_to_crash_logs(), crash_logs_to_skip=self._crash_logs_to_skip_for_host.get(device, []))
+            log_list.update(crash_log.find_all_logs(newer_than=newer_than))
+        return log_list
+
+    def _get_crash_log(self, name, pid, stdout, stderr, newer_than, time_fn=None, sleep_fn=None, wait_for_log=True, target_host=None):
+        if target_host:
+            return super()._get_crash_log(name, pid, stdout, stderr, newer_than, time_fn=time_fn, sleep_fn=sleep_fn, wait_for_log=wait_for_log, target_host=target_host)
+
+        # We need to search every device since one was not specified.
+        for device in self.devices():
+            stderr_out, crashlog = super()._get_crash_log(name, pid, stdout, stderr, newer_than, time_fn=time_fn, sleep_fn=sleep_fn, wait_for_log=False, target_host=device)
+            if crashlog:
+                return (stderr, crashlog)
+        return (stderr, None)
+
+    def supports_layout_tests(self):
+        return self.DEVICE_MANAGER is not None
+
+    def abspath_for_test(self, test_name, target_host=None):
+        if not apple_additions() or type(target_host) is not Device:
+            return super().abspath_for_test(test_name, target_host)
+        return apple_additions().device_abspath_for_test(test_name, target_host)
+
+    @memoized
+    def device_version(self):
+        if self.get_option('version'):
+            return Version.from_string(self.get_option('version'))
+
+        if not self.DEVICE_MANAGER:
+            raise RuntimeError(self.NO_ON_DEVICE_TESTING)
+
+        if not self.DEVICE_MANAGER.available_devices(host=self.host):
+            raise RuntimeError('No devices are available')
+        version = None
+        for device in self.DEVICE_MANAGER.available_devices(host=self.host):
+            if not self._is_device_platform_match(device):
+                continue
+            if not version:
+                version = device.platform.os_version
+            else:
+                if device.platform.os_version != version:
+                    raise RuntimeError('Multiple connected devices have different {} versions'.format(
+                        self.DEVICE_TYPE.software_variant))
+        return version
+
+    @abstractmethod
+    def _is_device_platform_match(self, device):
+        """Check if device matches the correct platform"""
+        ...
+
+    # FIXME: These need device implementations <rdar://problem/30497991>.
+    def check_for_leaks(self, process_name, process_id):
+        pass
+
+    def clean_up_test_run(self):
+        super().clean_up_test_run()
+        apple_additions().device_clean_up_test_run(self, self._path_to_driver(), self._build_path())

--- a/Tools/Scripts/webkitpy/port/device_port.py
+++ b/Tools/Scripts/webkitpy/port/device_port.py
@@ -23,6 +23,8 @@
 import logging
 import traceback
 
+from abc import abstractmethod
+
 from webkitpy.common.version_name_map import VersionNameMap, PUBLIC_TABLE, INTERNAL_TABLE
 from webkitpy.layout_tests.models.test_configuration import TestConfiguration
 from webkitpy.port.darwin import DarwinPort
@@ -39,6 +41,17 @@ class DevicePort(DarwinPort):
 
     DEVICE_MANAGER = None
     NO_DEVICE_MANAGER = 'No device manager found for port'
+
+    @property
+    @abstractmethod
+    def SDK(self) -> str:
+        """SDK name"""
+        ...
+
+    @abstractmethod
+    def operating_system(self):
+        """Platform name"""
+        ...
 
     def __init__(self, *args, **kwargs):
         super(DevicePort, self).__init__(*args, **kwargs)
@@ -244,6 +257,7 @@ class DevicePort(DarwinPort):
         env['XML_CATALOG_FILES'] = ''  # work around missing /etc/catalog <rdar://problem/4292995>
         return env
 
+    @abstractmethod
     def device_version(self):
         raise NotImplementedError
 

--- a/Tools/Scripts/webkitpy/port/ios_device.py
+++ b/Tools/Scripts/webkitpy/port/ios_device.py
@@ -22,103 +22,24 @@
 
 import logging
 
-from webkitcorepy import Version
-
-from webkitpy.common.memoized import memoized
-from webkitpy.common.system.crashlogs import CrashLogs
 from webkitpy.port.config import apple_additions
-from webkitpy.port.device import Device
+from webkitpy.port.device_device import DeviceDevicePort
 from webkitpy.port.ios import IOSPort
 
 _log = logging.getLogger(__name__)
 
 
-class IOSDevicePort(IOSPort):
+class IOSDevicePort(DeviceDevicePort, IOSPort):
     port_name = 'ios-device'
 
     ARCHITECTURES = ['armv7', 'armv7s', 'arm64']
     DEFAULT_ARCHITECTURE = 'arm64'
     VERSION_FALLBACK_ORDER = ['ios-7', 'ios-8', 'ios-9', 'ios-10']
 
-    DEVICE_MANAGER = apple_additions().device_manager() if apple_additions() else None
-
     SDK = apple_additions().get_sdk('iphoneos') if apple_additions() else 'iphoneos'
-    NO_ON_DEVICE_TESTING = 'On-device testing is not supported in this configuration'
-    NO_DEVICE_MANAGER = NO_ON_DEVICE_TESTING
 
-    def _driver_class(self):
-        if apple_additions():
-            return apple_additions().device_driver()
-        return super(IOSDevicePort, self)._driver_class()
-
-    @classmethod
-    def determine_full_port_name(cls, host, options, port_name):
-        if port_name == cls.port_name:
-            iphoneos_sdk_version = host.platform.xcode_sdk_version(cls.SDK)
-            if not iphoneos_sdk_version:
-                raise Exception("Please install the iOS SDK.")
-            port_name = port_name + '-' + str(iphoneos_sdk_version.major)
-        return port_name
-
-    def path_to_crash_logs(self):
-        if not apple_additions():
-            raise RuntimeError(self.NO_ON_DEVICE_TESTING)
-        return apple_additions().device_crash_log_path()
-
-    def _look_for_all_crash_logs_in_log_dir(self, newer_than):
-        log_list = {}
-        for device in self.devices():
-            crash_log = CrashLogs(device, self.path_to_crash_logs(), crash_logs_to_skip=self._crash_logs_to_skip_for_host.get(device, []))
-            log_list.update(crash_log.find_all_logs(newer_than=newer_than))
-        return log_list
-
-    def _get_crash_log(self, name, pid, stdout, stderr, newer_than, time_fn=None, sleep_fn=None, wait_for_log=True, target_host=None):
-        if target_host:
-            return super(IOSDevicePort, self)._get_crash_log(name, pid, stdout, stderr, newer_than, time_fn=time_fn, sleep_fn=sleep_fn, wait_for_log=wait_for_log, target_host=target_host)
-
-        # We need to search every device since one was not specified.
-        for device in self.devices():
-            stderr_out, crashlog = super(IOSDevicePort, self)._get_crash_log(name, pid, stdout, stderr, newer_than, time_fn=time_fn, sleep_fn=sleep_fn, wait_for_log=False, target_host=device)
-            if crashlog:
-                return (stderr, crashlog)
-        return (stderr, None)
-
-    def supports_layout_tests(self):
-        return self.DEVICE_MANAGER is not None
-
-    def abspath_for_test(self, test_name, target_host=None):
-        if not apple_additions() or type(target_host) is not Device:
-            return super(IOSDevicePort, self).abspath_for_test(test_name, target_host)
-        return apple_additions().device_abspath_for_test(test_name, target_host)
-
-    @memoized
-    def device_version(self):
-        if self.get_option('version'):
-            return Version.from_string(self.get_option('version'))
-
-        if not self.DEVICE_MANAGER:
-            raise RuntimeError(self.NO_ON_DEVICE_TESTING)
-
-        if not self.DEVICE_MANAGER.available_devices(host=self.host):
-            raise RuntimeError('No devices are available')
-        version = None
-        for device in self.DEVICE_MANAGER.available_devices(host=self.host):
-            if not device.platform.is_ios():
-                continue
-            if not version:
-                version = device.platform.os_version
-            else:
-                if device.platform.os_version != version:
-                    raise RuntimeError('Multiple connected devices have different iOS versions')
-        return version
-
-    # FIXME: These need device implementations <rdar://problem/30497991>.
-    def check_for_leaks(self, process_name, process_id):
-        pass
+    def _is_device_platform_match(self, device):
+        return device.platform.is_ios()
 
     def operating_system(self):
         return 'ios-device'
-
-    def clean_up_test_run(self):
-        super(IOSDevicePort, self).clean_up_test_run()
-        apple_additions().device_clean_up_test_run(self, self._path_to_driver(), self._build_path())

--- a/Tools/Scripts/webkitpy/port/simulator_device.py
+++ b/Tools/Scripts/webkitpy/port/simulator_device.py
@@ -1,0 +1,78 @@
+# Copyright (C) 2014-2025 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import logging
+
+from webkitcorepy import Version
+
+from webkitpy.common.memoized import memoized
+from webkitpy.port.device_port import DevicePort
+from webkitpy.xcode.simulated_device import SimulatedDeviceManager
+
+_log = logging.getLogger(__name__)
+
+
+class SimulatorDevicePort(DevicePort):
+    """Base class for simulator ports (iOS, watchOS, visionOS simulators)."""
+
+    DEVICE_MANAGER = SimulatedDeviceManager
+
+    @staticmethod
+    def _version_from_name(name):
+        if len(name.split('-')) > 2 and name.split('-')[2].isdigit():
+            return Version.from_string(name.split('-')[2])
+        return None
+
+    @memoized
+    def device_version(self):
+        if self.get_option('version'):
+            return Version.from_string(self.get_option('version'))
+        return self._version_from_name(self._name) if self._version_from_name(self._name) else self.host.platform.xcode_sdk_version(self.SDK)
+
+    def environment_for_api_tests(self):
+        inherited_env = super().environment_for_api_tests()
+        new_environment = {}
+        SIMCTL_ENV_PREFIX = 'SIMCTL_CHILD_'
+        for value in inherited_env:
+            if not value.startswith(SIMCTL_ENV_PREFIX):
+                new_environment[SIMCTL_ENV_PREFIX + value] = inherited_env[value]
+            else:
+                new_environment[value] = inherited_env[value]
+        return new_environment
+
+    def setup_environ_for_server(self, server_name=None):
+        _log.debug('Setting up environment for server on {}'.format(self.operating_system()))
+        env = super().setup_environ_for_server(server_name)
+        if server_name == self.driver_name() and self.get_option('leaks'):
+            env['MallocStackLogging'] = '1'
+            env['__XPC_MallocStackLogging'] = '1'
+            env['MallocScribble'] = '1'
+            env['__XPC_MallocScribble'] = '1'
+        return env
+
+    def reset_preferences(self):
+        SimulatedDeviceManager.tear_down(self.host)
+
+    @property
+    @memoized
+    def developer_dir(self):
+        return self._executive.run_command(['xcode-select', '--print-path']).rstrip()

--- a/Tools/Scripts/webkitpy/port/visionos_device.py
+++ b/Tools/Scripts/webkitpy/port/visionos_device.py
@@ -22,103 +22,24 @@
 
 import logging
 
-from webkitcorepy import Version
-
-from webkitpy.common.memoized import memoized
-from webkitpy.common.system.crashlogs import CrashLogs
 from webkitpy.port.config import apple_additions
-from webkitpy.port.device import Device
+from webkitpy.port.device_device import DeviceDevicePort
 from webkitpy.port.visionos import VisionOSPort
 
 _log = logging.getLogger(__name__)
 
 
-class VisionOSDevicePort(VisionOSPort):
+class VisionOSDevicePort(DeviceDevicePort, VisionOSPort):
     port_name = 'visionos-device'
 
     ARCHITECTURES = ['arm64e', 'arm64']
     DEFAULT_ARCHITECTURE = 'arm64'
     VERSION_FALLBACK_ORDER = ['visionos-1', 'visionos-2']
 
-    DEVICE_MANAGER = apple_additions().device_manager() if apple_additions() else None
-
     SDK = apple_additions().get_sdk('xros') if apple_additions() else 'xros'
-    NO_ON_DEVICE_TESTING = 'On-device testing is not supported in this configuration'
-    NO_DEVICE_MANAGER = NO_ON_DEVICE_TESTING
 
-    def _driver_class(self):
-        if apple_additions():
-            return apple_additions().device_driver()
-        return super(VisionOSDevicePort, self)._driver_class()
-
-    @classmethod
-    def determine_full_port_name(cls, host, options, port_name):
-        if port_name == cls.port_name:
-            xros_sdk_version = host.platform.xcode_sdk_version(cls.SDK)
-            if not xros_sdk_version:
-                raise Exception("Please install the visionOS SDK.")
-            port_name = port_name + '-' + str(xros_sdk_version.major)
-        return port_name
-
-    def path_to_crash_logs(self):
-        if not apple_additions():
-            raise RuntimeError(self.NO_ON_DEVICE_TESTING)
-        return apple_additions().device_crash_log_path()
-
-    def _look_for_all_crash_logs_in_log_dir(self, newer_than):
-        log_list = {}
-        for device in self.devices():
-            crash_log = CrashLogs(device, self.path_to_crash_logs(), crash_logs_to_skip=self._crash_logs_to_skip_for_host.get(device, []))
-            log_list.update(crash_log.find_all_logs(newer_than=newer_than))
-        return log_list
-
-    def _get_crash_log(self, name, pid, stdout, stderr, newer_than, time_fn=None, sleep_fn=None, wait_for_log=True, target_host=None):
-        if target_host:
-            return super(VisionOSDevicePort, self)._get_crash_log(name, pid, stdout, stderr, newer_than, time_fn=time_fn, sleep_fn=sleep_fn, wait_for_log=wait_for_log, target_host=target_host)
-
-        # We need to search every device since one was not specified.
-        for device in self.devices():
-            stderr_out, crashlog = super(VisionOSDevicePort, self)._get_crash_log(name, pid, stdout, stderr, newer_than, time_fn=time_fn, sleep_fn=sleep_fn, wait_for_log=False, target_host=device)
-            if crashlog:
-                return (stderr, crashlog)
-        return (stderr, None)
-
-    def supports_layout_tests(self):
-        return self.DEVICE_MANAGER is not None
-
-    def abspath_for_test(self, test_name, target_host=None):
-        if not apple_additions() or type(target_host) is not Device:
-            return super(VisionOSDevicePort, self).abspath_for_test(test_name, target_host)
-        return apple_additions().device_abspath_for_test(test_name, target_host)
-
-    @memoized
-    def device_version(self):
-        if self.get_option('version'):
-            return Version.from_string(self.get_option('version'))
-
-        if not self.DEVICE_MANAGER:
-            raise RuntimeError(self.NO_ON_DEVICE_TESTING)
-
-        if not self.DEVICE_MANAGER.available_devices(host=self.host):
-            raise RuntimeError('No devices are available')
-        version = None
-        for device in self.DEVICE_MANAGER.available_devices(host=self.host):
-            if not device.platform.is_visionos():
-                continue
-            if not version:
-                version = device.platform.os_version
-            else:
-                if device.platform.os_version != version:
-                    raise RuntimeError('Multiple connected devices have different visionOS versions')
-        return version
-
-    # FIXME: These need device implementations <rdar://problem/30497991>.
-    def check_for_leaks(self, process_name, process_id):
-        pass
+    def _is_device_platform_match(self, device):
+        return device.platform.is_visionos()
 
     def operating_system(self):
         return 'visionos-device'
-
-    def clean_up_test_run(self):
-        super(VisionOSDevicePort, self).clean_up_test_run()
-        apple_additions().device_clean_up_test_run(self, self._path_to_driver(), self._build_path())

--- a/Tools/Scripts/webkitpy/port/watch_device.py
+++ b/Tools/Scripts/webkitpy/port/watch_device.py
@@ -22,95 +22,23 @@
 
 import logging
 
-from webkitcorepy import Version
-
-from webkitpy.common.memoized import memoized
-from webkitpy.common.system.crashlogs import CrashLogs
 from webkitpy.port.config import apple_additions
+from webkitpy.port.device_device import DeviceDevicePort
 from webkitpy.port.watch import WatchPort
 
 _log = logging.getLogger(__name__)
 
 
-class WatchDevicePort(WatchPort):
+class WatchDevicePort(DeviceDevicePort, WatchPort):
     port_name = 'watchos-device'
 
     ARCHITECTURES = ['armv7k', 'arm64e', 'arm64_32']
     DEFAULT_ARCHITECTURE = 'armv7k'
 
     SDK = apple_additions().get_sdk('watchos') if apple_additions() else 'watchos'
-    DEVICE_MANAGER = apple_additions().device_manager() if apple_additions() else None
-    NO_ON_DEVICE_TESTING = 'On-device testing is not supported in this configuration'
-    NO_DEVICE_MANAGER = NO_ON_DEVICE_TESTING
 
-    def _driver_class(self):
-        if apple_additions():
-            return apple_additions().device_driver()
-        return super(WatchDevicePort, self)._driver_class()
-
-    @classmethod
-    def determine_full_port_name(cls, host, options, port_name):
-        if port_name == cls.port_name:
-            watchos_sdk_version = host.platform.xcode_sdk_version(cls.SDK)
-            if not watchos_sdk_version:
-                raise Exception("Please install the watchOS SDK.")
-            port_name = port_name + '-' + str(watchos_sdk_version.major)
-        return port_name
-
-    def path_to_crash_logs(self):
-        if not apple_additions():
-            raise RuntimeError(self.NO_ON_DEVICE_TESTING)
-        return apple_additions().device_crash_log_path()
-
-    def _look_for_all_crash_logs_in_log_dir(self, newer_than):
-        log_list = {}
-        for device in self.devices():
-            crash_log = CrashLogs(device, self.path_to_crash_logs(), crash_logs_to_skip=self._crash_logs_to_skip_for_host.get(device, []))
-            log_list.update(crash_log.find_all_logs(newer_than=newer_than))
-        return log_list
-
-    def _get_crash_log(self, name, pid, stdout, stderr, newer_than, time_fn=None, sleep_fn=None, wait_for_log=True, target_host=None):
-        if target_host:
-            return super(WatchDevicePort, self)._get_crash_log(name, pid, stdout, stderr, newer_than, time_fn=time_fn, sleep_fn=sleep_fn, wait_for_log=wait_for_log, target_host=target_host)
-
-        # We need to search every device since one was not specified.
-        for device in self.devices():
-            stderr_out, crashlog = super(WatchDevicePort, self)._get_crash_log(name, pid, stdout, stderr, newer_than, time_fn=time_fn, sleep_fn=sleep_fn, wait_for_log=False, target_host=device)
-            if crashlog:
-                return (stderr, crashlog)
-        return (stderr, None)
-
-    def supports_layout_tests(self):
-        return self.DEVICE_MANAGER is not None
-
-    @memoized
-    def device_version(self):
-        if self.get_option('version'):
-            return Version.from_string(self.get_option('version'))
-
-        if not self.DEVICE_MANAGER:
-            raise RuntimeError(self.NO_ON_DEVICE_TESTING)
-
-        if not self.DEVICE_MANAGER.available_devices(host=self.host):
-            raise RuntimeError('No devices are available')
-        version = None
-        for device in self.DEVICE_MANAGER.available_devices(host=self.host):
-            if not device.platform.is_watchos():
-                continue
-            if not version:
-                version = device.platform.os_version
-            else:
-                if device.platform.os_version != version:
-                    raise RuntimeError('Multiple connected devices have different watchOS versions')
-        return version
-
-    # FIXME: These need device implementations <rdar://problem/30497991>.
-    def check_for_leaks(self, process_name, process_id):
-        pass
+    def _is_device_platform_match(self, device):
+        return device.platform.is_watchos()
 
     def operating_system(self):
         return 'watchos-device'
-
-    def clean_up_test_run(self):
-        super(WatchDevicePort, self).clean_up_test_run()
-        apple_additions().device_clean_up_test_run(self, self._path_to_driver(), self._build_path())


### PR DESCRIPTION
#### 726c36d9079f5d64c20f223813db2bd550635b94
<pre>
[webkitpy] Reduce duplication across Apple embedded OS ports
<a href="https://bugs.webkit.org/show_bug.cgi?id=304943">https://bugs.webkit.org/show_bug.cgi?id=304943</a>
<a href="https://rdar.apple.com/167559974">rdar://167559974</a>

Reviewed by Jonathan Bedard.

This introduces two new base classes:

 * DeviceDevicePort, for physical device ports, and
 * SimulatorDevicePort, for Simulator device ports.

With this, we can eliminate the majority of duplicated code across all
the Apple embedded ports.

* Tools/Scripts/webkitpy/port/device_device.py: Copied from Tools/Scripts/webkitpy/port/ios_device.py.
(DeviceDevicePort):  Add new base class for physical device ports.
(DeviceDevicePort._driver_class):
(DeviceDevicePort.determine_full_port_name):
(DeviceDevicePort.path_to_crash_logs):
(DeviceDevicePort._look_for_all_crash_logs_in_log_dir):
(DeviceDevicePort._get_crash_log):
(DeviceDevicePort.supports_layout_tests):
(DeviceDevicePort.abspath_for_test):
(DeviceDevicePort.device_version):
(DeviceDevicePort._is_device_platform_match):
(DeviceDevicePort.check_for_leaks):
(DeviceDevicePort.clean_up_test_run):
* Tools/Scripts/webkitpy/port/device_port.py:
(DevicePort): Make abstract.
(DevicePort.SDK): Move abstract definition here.
(DevicePort.operating_system): Mark as abstract.
* Tools/Scripts/webkitpy/port/ios_device.py:
(IOSDevicePort): Move to inheriting from DeviceDevicePort.
(IOSDevicePort._is_device_platform_match):
(IOSDevicePort.operating_system):
(IOSDevicePort._driver_class): Deleted.
(IOSDevicePort.determine_full_port_name): Deleted.
(IOSDevicePort.path_to_crash_logs): Deleted.
(IOSDevicePort._look_for_all_crash_logs_in_log_dir): Deleted.
(IOSDevicePort._get_crash_log): Deleted.
(IOSDevicePort.supports_layout_tests): Deleted.
(IOSDevicePort.abspath_for_test): Deleted.
(IOSDevicePort.device_version): Deleted.
(IOSDevicePort.check_for_leaks): Deleted.
(IOSDevicePort.clean_up_test_run): Deleted.
* Tools/Scripts/webkitpy/port/ios_simulator.py:
(IOSSimulatorPort): Move to inheriting from SimulatorDevicePort.
(IOSSimulatorPort.architecture):
(IOSSimulatorPort.clean_up_test_run):
(IOSSimulatorPort.operating_system):
(IOSSimulatorPort._version_from_name): Deleted.
(IOSSimulatorPort.device_version): Deleted.
(IOSSimulatorPort.environment_for_api_tests): Deleted.
(IOSSimulatorPort.setup_environ_for_server): Deleted.
(IOSSimulatorPort.reset_preferences): Deleted.
(IOSSimulatorPort.developer_dir): Deleted.
* Tools/Scripts/webkitpy/port/simulator_device.py: Copied from Tools/Scripts/webkitpy/port/watch_simulator.py.
(SimulatorDevicePort): Add new base class for Simulator device ports.
(SimulatorDevicePort._version_from_name):
(SimulatorDevicePort.device_version):
(SimulatorDevicePort.environment_for_api_tests):
(SimulatorDevicePort.setup_environ_for_server):
(SimulatorDevicePort.reset_preferences):
(SimulatorDevicePort.developer_dir):
* Tools/Scripts/webkitpy/port/visionos_device.py:
(VisionOSDevicePort): Move to inheriting from DeviceDevicePort.
(VisionOSDevicePort._is_device_platform_match):
(VisionOSDevicePort.operating_system):
(VisionOSDevicePort._driver_class): Deleted.
(VisionOSDevicePort.determine_full_port_name): Deleted.
(VisionOSDevicePort.path_to_crash_logs): Deleted.
(VisionOSDevicePort._look_for_all_crash_logs_in_log_dir): Deleted.
(VisionOSDevicePort._get_crash_log): Deleted.
(VisionOSDevicePort.supports_layout_tests): Deleted.
(VisionOSDevicePort.abspath_for_test): Deleted.
(VisionOSDevicePort.device_version): Deleted.
(VisionOSDevicePort.check_for_leaks): Deleted.
(VisionOSDevicePort.clean_up_test_run): Deleted.
* Tools/Scripts/webkitpy/port/visionos_simulator.py:
(VisionOSSimulatorPort): Move to inheriting from SimulatorDevicePort.
(VisionOSSimulatorPort.architecture):
(VisionOSSimulatorPort.operating_system):
(VisionOSSimulatorPort._version_from_name): Deleted.
(VisionOSSimulatorPort.device_version): Deleted.
(VisionOSSimulatorPort.environment_for_api_tests): Deleted.
(VisionOSSimulatorPort.setup_environ_for_server): Deleted.
(VisionOSSimulatorPort.reset_preferences): Deleted.
(VisionOSSimulatorPort.developer_dir): Deleted.
* Tools/Scripts/webkitpy/port/watch_device.py:
(WatchDevicePort): Move to inheriting from DeviceDevicePort.
(WatchDevicePort._is_device_platform_match):
(WatchDevicePort.operating_system):
(WatchDevicePort._driver_class): Deleted.
(WatchDevicePort.determine_full_port_name): Deleted.
(WatchDevicePort.path_to_crash_logs): Deleted.
(WatchDevicePort._look_for_all_crash_logs_in_log_dir): Deleted.
(WatchDevicePort._get_crash_log): Deleted.
(WatchDevicePort.supports_layout_tests): Deleted.
(WatchDevicePort.device_version): Deleted.
(WatchDevicePort.check_for_leaks): Deleted.
(WatchDevicePort.clean_up_test_run): Deleted.
* Tools/Scripts/webkitpy/port/watch_simulator.py:
(WatchSimulatorPort): Move to inheriting from SimulatorDevicePort.
(WatchSimulatorPort.architecture):
(WatchSimulatorPort.operating_system):
(WatchSimulatorPort._version_from_name): Deleted.
(WatchSimulatorPort.device_version): Deleted.
(WatchSimulatorPort.environment_for_api_tests): Deleted.
(WatchSimulatorPort.setup_environ_for_server): Deleted.
(WatchSimulatorPort.reset_preferences): Deleted.
(WatchSimulatorPort.developer_dir): Deleted.

Canonical link: <a href="https://commits.webkit.org/305127@main">https://commits.webkit.org/305127@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4818986d367e4166d7c04adeb4bc874187a90320

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137572 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9933 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48859 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145329 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90545 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3dc05082-909b-43f1-bce8-75fcf483d204) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139444 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10636 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10063 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105214 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/33c7eed5-8598-4118-a8ce-ee1664e5bb7b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140517 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7894 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123293 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86067 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/02b5a975-a803-4f05-b25c-e86364ea87e5) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/136920 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7530 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5253 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5912 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116900 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41450 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148093 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9615 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42004 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113596 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9633 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8106 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113938 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28923 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7449 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119533 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64271 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9664 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37585 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9395 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9604 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9456 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->