### PR TITLE
[CI Filters] FEDisplacementMap in Core Image

### DIFF
--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -505,6 +505,7 @@ platform/graphics/coreimage/FEColorMatrixCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/FEComponentTransferCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/FECompositeCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/FEConvolveMatrixCoreImageApplier.mm @nonARC
+platform/graphics/coreimage/FEDisplacementMapCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/FEDropShadowCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/FEFloodCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/FEGaussianBlurCoreImageApplier.mm @nonARC

--- a/Source/WebCore/platform/graphics/coreimage/FEDisplacementMapCoreImageApplier.h
+++ b/Source/WebCore/platform/graphics/coreimage/FEDisplacementMapCoreImageApplier.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(CORE_IMAGE)
+
+#import "FilterEffectApplier.h"
+#import <wtf/TZoneMalloc.h>
+
+namespace WebCore {
+
+class FEDisplacementMap;
+
+class FEDisplacementMapCoreImageApplier final : public FilterEffectConcreteApplier<FEDisplacementMap> {
+    WTF_MAKE_TZONE_ALLOCATED(FEDisplacementMapCoreImageApplier);
+    using Base = FilterEffectConcreteApplier<FEDisplacementMap>;
+
+public:
+    FEDisplacementMapCoreImageApplier(const FEDisplacementMap&);
+
+private:
+    bool apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const final;
+};
+
+} // namespace WebCore
+
+#endif // USE(CORE_IMAGE)

--- a/Source/WebCore/platform/graphics/coreimage/FEDisplacementMapCoreImageApplier.mm
+++ b/Source/WebCore/platform/graphics/coreimage/FEDisplacementMapCoreImageApplier.mm
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "FEDisplacementMapCoreImageApplier.h"
+
+#if USE(CORE_IMAGE)
+
+#import "FEDisplacementMap.h"
+#import "Filter.h"
+#import "FilterImage.h"
+#import "Logging.h"
+#import <CoreImage/CoreImage.h>
+#import <wtf/BlockObjCExceptions.h>
+#import <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+static CIKernel* displacementMapKernel()
+{
+    static NeverDestroyed<RetainPtr<CIKernel>> kernel;
+    static std::once_flag onceFlag;
+
+    std::call_once(onceFlag, [] {
+        NSError *error = nil;
+        // FIXME: Why not a CIColorKernel?
+        NSArray<CIKernel *> *kernels = [CIKernel kernelsWithMetalString:@R"( /* NOLINT */
+extern "C" {
+namespace coreimage {
+
+[[stitchable]] float4 displacement_map(sampler src, sampler map,
+    float2 scale, float2 channelIndex, destination dest)
+{
+    unsigned xChannelIndex = (unsigned)channelIndex.x;
+    unsigned yChannelIndex = (unsigned)channelIndex.y;
+
+    float2 sc = dest.coord();
+    float2 mapCoord = map.transform(sc);
+    float4 mapPixel = map.sample(mapCoord);
+    // According to spec (https://drafts.csswg.org/filter-effects/#feDisplacementMapElement) we should unpremultiply mapPixel,
+    // but that doesn't match implementations: https://github.com/w3c/fxtf-drafts/issues/113
+
+    float2 offset = {
+        scale.x * (mapPixel[xChannelIndex] - 0.5),
+        scale.y * (mapPixel[yChannelIndex] - 0.5)
+    };
+
+    float2 positionInInputTexture = sc + offset;
+    float2 srcPosition = src.transform(positionInInputTexture);
+
+    return src.sample(srcPosition);
+}
+
+} // namespace coreimage
+} // extern "C"
+
+        )" error:&error]; /* NOLINT */
+
+        if (error || !kernels || !kernels.count) {
+            LOG(Filters, "DisplacementMap kernel compilation failed: %@", error);
+            return;
+        }
+
+        kernel.get() = kernels[0];
+    });
+
+    return kernel.get().get();
+}
+
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FEDisplacementMapCoreImageApplier);
+
+FEDisplacementMapCoreImageApplier::FEDisplacementMapCoreImageApplier(const FEDisplacementMap& effect)
+    : Base(effect)
+{
+}
+
+bool FEDisplacementMapCoreImageApplier::apply(const Filter& filter, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
+{
+    BEGIN_BLOCK_OBJC_EXCEPTIONS
+
+    ASSERT(inputs.size() == 2);
+    Ref input = inputs[0].get();
+    Ref mapInput = inputs[1].get();
+
+    RetainPtr inputImage = input->ciImage();
+    if (!inputImage)
+        return false;
+
+    RetainPtr mapImage = mapInput->ciImage();
+    if (!mapImage)
+        return false;
+
+    RetainPtr kernel = displacementMapKernel();
+    if (!kernel)
+        return false;
+
+    auto extent = filter.flippedRectRelativeToAbsoluteEnclosingFilterRegion(result.absoluteImageRect());
+    auto scale = filter.resolvedSize({ m_effect->scale(), m_effect->scale() });
+    scale = filter.scaledByFilterScale(scale);
+
+    int channelXIndex = clampTo(static_cast<int>(m_effect->xChannelSelector()) - 1, 0, 3);
+    int channelYIndex = clampTo(static_cast<int>(m_effect->yChannelSelector()) - 1, 0, 3);
+
+    RetainPtr<NSArray> arguments = @[
+        inputImage.get(),
+        mapImage.get(),
+        [CIVector vectorWithX:scale.width() Y:-scale.height()], // Flip the y scale because CI coordinates are flipped.
+        [CIVector vectorWithX:channelXIndex Y:channelYIndex],
+    ];
+
+    RetainPtr<CIImage> outputImage = [kernel applyWithExtent:extent
+        roiCallback:^CGRect(int, CGRect destRect) {
+            return destRect;
+        }
+        arguments:arguments.get()];
+
+
+    outputImage = [outputImage imageByCroppingToRect:extent];
+    result.setCIImage(WTF::move(outputImage));
+    return true;
+
+    END_BLOCK_OBJC_EXCEPTIONS
+    return false;
+}
+
+} // namespace WebCore
+
+#endif // USE(CORE_IMAGE)

--- a/Source/WebCore/platform/graphics/filters/FEDisplacementMap.h
+++ b/Source/WebCore/platform/graphics/filters/FEDisplacementMap.h
@@ -66,6 +66,8 @@ private:
     const DestinationColorSpace& resultColorSpace(std::span<const Ref<FilterImage>>) const override;
     void transformInputsColorSpace(std::span<const Ref<FilterImage>> inputs) const override;
 
+    OptionSet<FilterRenderingMode> supportedFilterRenderingModes(OptionSet<FilterRenderingMode>) const override;
+    std::unique_ptr<FilterEffectApplier> createAcceleratedApplier() const override;
     std::unique_ptr<FilterEffectApplier> createSoftwareApplier() const override;
 
     WTF::TextStream& externalRepresentation(WTF::TextStream&, FilterRepresentation) const override;


### PR DESCRIPTION
#### 452bf001ddd493cec2bb64e8c2d0286a007b5738
<pre>
[CI Filters] FEDisplacementMap in Core Image
<a href="https://bugs.webkit.org/show_bug.cgi?id=304874">https://bugs.webkit.org/show_bug.cgi?id=304874</a>
<a href="https://rdar.apple.com/167458156">rdar://167458156</a>

Reviewed by Mike Wyrzykowski.

Add a Core Image implementation of FEDisplacementMap, with a simple custom kernel.

* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/coreimage/FEDisplacementMapCoreImageApplier.h: Added.
* Source/WebCore/platform/graphics/coreimage/FEDisplacementMapCoreImageApplier.mm: Added.
(WebCore::displacementMapKernel):
* Source/WebCore/platform/graphics/filters/FEDisplacementMap.cpp:
(WebCore::FEDisplacementMap::supportedFilterRenderingModes const):
(WebCore::FEDisplacementMap::createAcceleratedApplier const):
* Source/WebCore/platform/graphics/filters/FEDisplacementMap.h:

Canonical link: <a href="https://commits.webkit.org/305161@main">https://commits.webkit.org/305161@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/322dea62315b43fcc65a5ce0ca776c41f72cc7a6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137683 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10044 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48971 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145444 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90656 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/14832f82-3b82-43b2-a703-78585e02af14) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139555 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10747 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10174 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105311 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/69ed14e6-9c05-47f8-a5bd-85394af75700) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140628 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7994 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123393 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86167 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/bfcdb2b6-7a34-47da-9660-c4a39038ba43) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7621 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/5346 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6026 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117010 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41553 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148214 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9727 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42103 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113701 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9744 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8203 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114041 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28947 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7552 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119632 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64415 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9775 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37681 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9506 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73340 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9715 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9567 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->