### PR TITLE
[ macOS, iOS Release ] http/tests/security/clipboard/copy-paste-html-cross-origin-iframe-across-origin.html is a flaky text failure

### DIFF
--- a/LayoutTests/http/tests/security/clipboard/resources/subdirectory/paste-html.html
+++ b/LayoutTests/http/tests/security/clipboard/resources/subdirectory/paste-html.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <script>
-let loadedContent = [];
+let loadedContent = new Map();
 onmessage = function (event) {
     if (event.data.type == 'paste') {
         document.body.focus();
@@ -10,31 +10,36 @@ onmessage = function (event) {
         if (window.testRunner)
             document.execCommand('paste');
     } else if (event.data.type == 'contentLoaded') {
-        loadedContent.push(event.data);
+        for (const frame of Array.from(document.body.querySelectorAll('iframe'))) {
+            if (frame.contentWindow === event.source) {
+                loadedContent.set(frame, event.data);
+                break;
+            }
+        }
         checkIfLoadCompleted();
     }
 }
 
-let frames = [];
 function doPaste(event) {
     top.postMessage({type: 'pasted', html: event.clipboardData.getData('text/html')}, '*');
 }
 
 function checkIfLoadCompleted() {
     const frames = Array.from(document.body.querySelectorAll('iframe'));
-    if (loadedContent.length < frames.length)
+    if (loadedContent.size < frames.length)
         return;
 
     top.postMessage({
         type: 'checkedState',
         html: document.body.innerHTML,
-        frames: frames.map((frame, i) => {
+        frames: frames.map((frame) => {
+            const content = loadedContent.get(frame);
             return {
                 src: frame.src,
                 class: frame.className,
                 canAccessContentDocument: !!frame.contentDocument,
-                imageSrc: loadedContent[i].imageSrc,
-                imageWidth: loadedContent[i].imageWidth,
+                imageSrc: content.imageSrc,
+                imageWidth: content.imageWidth,
             }
         })}, '*');
 }

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8241,8 +8241,6 @@ webkit.org/b/297674 [ Release ] http/wpt/mediarecorder/MediaRecorder-matroska-AV
 
 webkit.org/b/295435 compositing/layer-creation/overlap-animation-container.html [ Pass Failure ]
 
-webkit.org/b/298042 [ Release ] http/tests/security/clipboard/copy-paste-html-cross-origin-iframe-across-origin.html [ Pass Failure ]
-
 imported/w3c/web-platform-tests/css/css-break/block-in-inline-012.html [ ImageOnlyFailure ]
 
 webkit.org/b/300905 imported/w3c/web-platform-tests/css/css-scroll-anchoring/shadow-dom-subscroller.html [ Pass Failure ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2433,8 +2433,6 @@ webkit.org/b/297609 compositing/backing/backing-store-attachment-empty-keyframe.
 
 webkit.org/b/297691 fast/canvas/webgl/tex-image-and-sub-image-2d-with-video.html [ Pass Failure ]
 
-webkit.org/b/298042 http/tests/security/clipboard/copy-paste-html-cross-origin-iframe-across-origin.html [ Pass Failure ]
-
 webkit.org/b/298402 inspector/worker/dom-debugger-event-after-terminate-crash.html [ Pass Crash ]
 
 webkit.org/b/298476 gamepad/gamepad-visibility-1.html [ Crash ]


### PR DESCRIPTION
#### 11b19351f780a5c7d0f5cb2c44c2506a8ef256e9
<pre>
[ macOS, iOS Release ] http/tests/security/clipboard/copy-paste-html-cross-origin-iframe-across-origin.html is a flaky text failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=298042">https://bugs.webkit.org/show_bug.cgi?id=298042</a>
<a href="https://rdar.apple.com/159374149">rdar://159374149</a>

Reviewed by Pascoe.

This test pushed contentLoaded messages into an array in arrival order, then matched them to iframes by
index. We can&apos;t rely on the load order of the iframes, so the data was being mismatched.

This change fixes this by using a Map keyed by the iframe DOM element to ensure we comparing the iframes
correctly.

* LayoutTests/http/tests/security/clipboard/resources/subdirectory/paste-html.html:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/305169@main">https://commits.webkit.org/305169@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11d893062d0c66e55c4a9781423efe59f4ee1c4c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137603 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9964 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48891 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145361 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90576 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10667 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10094 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105239 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140548 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7921 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123326 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86095 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7552 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5275 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5944 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116925 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41490 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148128 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9646 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42036 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113621 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9664 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8130 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113965 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7479 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119565 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64310 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21199 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9695 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37615 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9426 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9635 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9487 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->