### PR TITLE
[CI Filters] FEConvolveMatrix in Core Image

### DIFF
--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -504,6 +504,7 @@ platform/graphics/coreimage/FEBlendCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/FEColorMatrixCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/FEComponentTransferCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/FECompositeCoreImageApplier.mm @nonARC
+platform/graphics/coreimage/FEConvolveMatrixCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/FEDropShadowCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/FEFloodCoreImageApplier.mm @nonARC
 platform/graphics/coreimage/FEGaussianBlurCoreImageApplier.mm @nonARC

--- a/Source/WebCore/platform/graphics/coreimage/FEConvolveMatrixCoreImageApplier.h
+++ b/Source/WebCore/platform/graphics/coreimage/FEConvolveMatrixCoreImageApplier.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(CORE_IMAGE)
+
+#import "FilterEffectApplier.h"
+#import <wtf/TZoneMalloc.h>
+
+namespace WebCore {
+
+class FEConvolveMatrix;
+
+class FEConvolveMatrixCoreImageApplier final : public FilterEffectConcreteApplier<FEConvolveMatrix> {
+    WTF_MAKE_TZONE_ALLOCATED(FEConvolveMatrixCoreImageApplier);
+    using Base = FilterEffectConcreteApplier<FEConvolveMatrix>;
+
+public:
+    FEConvolveMatrixCoreImageApplier(const FEConvolveMatrix&);
+
+    static bool supportsCoreImageRendering(const FEConvolveMatrix&);
+
+private:
+    bool apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const final;
+};
+
+} // namespace WebCore
+
+#endif // USE(CORE_IMAGE)

--- a/Source/WebCore/platform/graphics/coreimage/FEConvolveMatrixCoreImageApplier.mm
+++ b/Source/WebCore/platform/graphics/coreimage/FEConvolveMatrixCoreImageApplier.mm
@@ -1,0 +1,216 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "FEConvolveMatrixCoreImageApplier.h"
+
+#if USE(CORE_IMAGE)
+
+#import "FEConvolveMatrix.h"
+#import "Filter.h"
+#import "FilterImage.h"
+#import <CoreImage/CIFilterBuiltins.h>
+#import <CoreImage/CoreImage.h>
+#import <wtf/MathExtras.h>
+#import <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+static CIKernel* convolveMatrixKernel()
+{
+    static NeverDestroyed<RetainPtr<CIKernel>> kernel;
+    static std::once_flag onceFlag;
+
+    std::call_once(onceFlag, [] {
+        NSError *error = nil;
+        NSArray<CIKernel *> *kernels = [CIKernel kernelsWithMetalString:@R"( /* NOLINT */
+extern "C" {
+namespace coreimage {
+
+enum EdgeMode : uint8_t {
+    EdgeModeDuplicate,
+    EdgeModeWrap,
+    EdgeModeNone,
+};
+
+struct ConvolveMatrixConstants {
+    vector_int2 kernelSize;
+    vector_int2 target;
+    float divisor;
+    float bias;
+    EdgeMode edgeMode;
+    bool preserveAlpha;
+};
+
+[[stitchable]] float4 convolve(sampler src,
+    constant ConvolveMatrixConstants* constants,
+    constant float* convolveKernel,
+    destination dest)
+{
+    float2 srcPosition = src.transform(dest.coord());
+    float4 srcPixel = src.sample(srcPosition);
+
+    int2 kernelSize = constants->kernelSize;
+    int2 target = constants->target;
+
+    float4 pixelSum = 0;
+
+    // FIXME: Edge mode not supported yet.
+    for (int row = 0; row < kernelSize.y; ++row) {
+        for (int col = 0; col < kernelSize.x; ++col) {
+
+            int flippedRow = kernelSize.y - row - 1;
+            int flippedCol = kernelSize.x - col - 1;
+
+            float2 sampleOffset = { (float)flippedCol - target.x, (float)flippedRow - target.y };
+            float2 samplePosition = srcPosition + sampleOffset;
+
+            float4 nearbyPixel = src.sample(samplePosition);
+            nearbyPixel *= convolveKernel[kernelSize.x * flippedRow + col];
+            pixelSum += nearbyPixel;
+        }
+    }
+
+    float alpha = constants->preserveAlpha ? srcPixel.a : clamp(pixelSum.a / constants->divisor + constants->bias, 0.f, 1.f);
+    float4 resultPixel = pixelSum / constants->divisor + constants->bias * alpha;
+
+    resultPixel.a = alpha;
+
+    if (constants->preserveAlpha)
+        resultPixel = premultiply(clamp(resultPixel, 0, 1));
+    else
+        resultPixel = premultiply(clamp(resultPixel, 0, alpha));
+
+    return resultPixel;
+}
+
+} // namespace coreimage
+} // extern "C"
+        )" error:&error]; /* NOLINT */
+
+        if (error || !kernels || !kernels.count) {
+            LOG(Filters, "DisplacementMap kernel compilation failed: %@", error);
+            return;
+        }
+
+        kernel.get() = kernels[0];
+    });
+
+    return kernel.get().get();
+}
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FEConvolveMatrixCoreImageApplier);
+
+FEConvolveMatrixCoreImageApplier::FEConvolveMatrixCoreImageApplier(const FEConvolveMatrix& effect)
+    : Base(effect)
+{
+}
+
+bool FEConvolveMatrixCoreImageApplier::supportsCoreImageRendering(const FEConvolveMatrix& effect)
+{
+    return effect.edgeMode() == EdgeModeType::None;
+}
+
+bool FEConvolveMatrixCoreImageApplier::apply(const Filter& filter, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
+{
+    ASSERT(inputs.size() == 1);
+    Ref input = inputs[0].get();
+
+    RetainPtr inputImage = input->ciImage();
+    if (!inputImage)
+        return false;
+
+    RetainPtr kernel = convolveMatrixKernel();
+    if (!kernel)
+        return false;
+
+    auto extent = filter.flippedRectRelativeToAbsoluteEnclosingFilterRegion(result.absoluteImageRect());
+
+    enum class EdgeMode : uint8_t {
+        Duplicate,
+        Wrap,
+        None,
+    };
+    struct ConvolveMatrixConstants {
+        vector_int2 kernelSize;
+        vector_int2 target;
+        float divisor;
+        float bias;
+        EdgeMode edgeMode;
+        bool preserveAlpha;
+    };
+
+    auto edgeMode = [](EdgeModeType type) {
+        switch (type) {
+        case EdgeModeType::Unknown:
+            ASSERT_NOT_REACHED();
+            return EdgeMode::None;
+        case EdgeModeType::Duplicate: return EdgeMode::Duplicate;
+        case EdgeModeType::Wrap: return EdgeMode::Wrap;
+        case EdgeModeType::None: return EdgeMode::None;
+        }
+        return EdgeMode::None;
+    };
+
+    auto constants = ConvolveMatrixConstants {
+        .kernelSize = { m_effect->kernelSize().width(), m_effect->kernelSize().height() },
+        .target = { m_effect->targetOffset().x(), m_effect->kernelSize().height() - m_effect->targetOffset().y() - 1 }, // Flipped y coordinates.
+        .divisor = m_effect->divisor(),
+        .bias = m_effect->bias(),
+        .edgeMode = edgeMode(m_effect->edgeMode()),
+        .preserveAlpha = m_effect->preserveAlpha()
+    };
+
+    auto kernelValues = m_effect->kernel().map([](const auto& value) {
+        return normalizedFloat(value);
+    });
+
+    // https://drafts.csswg.org/filter-effects/#element-attrdef-feconvolvematrix-preservealpha
+    if (constants.preserveAlpha)
+        inputImage = [inputImage imageByUnpremultiplyingAlpha];
+
+    RetainPtr<NSArray> arguments = @[
+        inputImage.get(),
+        [NSData dataWithBytes:&constants length:sizeof(ConvolveMatrixConstants)],
+        [NSData dataWithBytes:kernelValues.span().data() length:kernelValues.sizeInBytes()],
+    ];
+
+    RetainPtr<CIImage> outputImage = [kernel applyWithExtent:extent
+        roiCallback:^CGRect(int, CGRect destRect) {
+            return destRect;
+        }
+        arguments:arguments.get()];
+
+    if (!outputImage)
+        return false;
+
+    outputImage = [outputImage imageByCroppingToRect:extent];
+    result.setCIImage(WTF::move(outputImage));
+    return true;
+}
+
+} // namespace WebCore
+
+#endif // USE(CORE_IMAGE)

--- a/Source/WebCore/platform/graphics/filters/FEConvolveMatrix.h
+++ b/Source/WebCore/platform/graphics/filters/FEConvolveMatrix.h
@@ -75,6 +75,8 @@ private:
 
     FloatRect calculateImageRect(const Filter&, std::span<const FloatRect> inputImageRects, const FloatRect& primitiveSubregion) const override;
 
+    OptionSet<FilterRenderingMode> supportedFilterRenderingModes(OptionSet<FilterRenderingMode>) const override;
+    std::unique_ptr<FilterEffectApplier> createAcceleratedApplier() const override;
     std::unique_ptr<FilterEffectApplier> createSoftwareApplier() const override;
 
     WTF::TextStream& externalRepresentation(WTF::TextStream&, FilterRepresentation) const override;


### PR DESCRIPTION
#### 2dca434beb2309763bad81d56d31af8b3f3c51f2
<pre>
[CI Filters] FEConvolveMatrix in Core Image
<a href="https://bugs.webkit.org/show_bug.cgi?id=304875">https://bugs.webkit.org/show_bug.cgi?id=304875</a>
<a href="https://rdar.apple.com/167458206">rdar://167458206</a>

Reviewed by Mike Wyrzykowski.

Add a Core Image implementation of FEConvolveMatrix. This is a fairly simple kernel filter,
it just needs to take care with alpha premultiplication, and `preserveAlpha`.

* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/coreimage/FEConvolveMatrixCoreImageApplier.h: Added.
* Source/WebCore/platform/graphics/coreimage/FEConvolveMatrixCoreImageApplier.mm: Added.
(WebCore::convolveMatrixKernel):
* Source/WebCore/platform/graphics/filters/FEConvolveMatrix.cpp:
(WebCore::FEConvolveMatrix::supportedFilterRenderingModes const):
(WebCore::FEConvolveMatrix::createAcceleratedApplier const):
* Source/WebCore/platform/graphics/filters/FEConvolveMatrix.h:

Canonical link: <a href="https://commits.webkit.org/305137@main">https://commits.webkit.org/305137@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04da3e986c4e21eb833f0278f672591530be2f2c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137605 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9966 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48893 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145363 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90578 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/319d915c-9172-46a6-8d12-49c7d59c9314) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139477 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10669 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10096 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105242 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4c4d2e63-900a-4043-b545-ffbfc23a8a28) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140550 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7922 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123328 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86098 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4a06aa5d-8d1c-41f4-bd0b-a7dd6f65eac6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7553 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/5276 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5946 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116926 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41487 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148130 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9648 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42038 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113624 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9666 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8131 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113967 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28931 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7480 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119567 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64312 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9697 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37617 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9428 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73262 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9637 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9489 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->