### PR TITLE
REGRESSION(300277@main): [iOS] music.apple.com: Hover effect on playlist rolls with scrolling

### DIFF
--- a/LayoutTests/pointerevents/ios/hover-state-not-updated-on-layout-change-without-mouse-expected.txt
+++ b/LayoutTests/pointerevents/ios/hover-state-not-updated-on-layout-change-without-mouse-expected.txt
@@ -1,0 +1,12 @@
+Test that hover states are not updated after layout changes on iOS when no mouse device is connected.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+
+Triggering layout change (expanding spacer by 120px)...
+PASS Hover states correctly remained unchanged during layout change without mouse device
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Item 1Item 2

--- a/LayoutTests/pointerevents/ios/hover-state-not-updated-on-layout-change-without-mouse.html
+++ b/LayoutTests/pointerevents/ios/hover-state-not-updated-on-layout-change-without-mouse.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<style>
+#spacer {
+    height: 0px;
+}
+
+#item1, #item2 {
+    position: absolute;
+    left: 100px;
+    width: 200px;
+    height: 100px;
+    background-color: lightblue;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 20px;
+}
+
+#item1 {
+    top: 100px;
+}
+
+#item2 {
+    top: 220px;
+}
+
+#item1:hover, #item2:hover {
+    background-color: yellow;
+}
+</style>
+</head>
+<body>
+<div id="spacer"></div>
+<div id="item1">Item 1</div>
+<div id="item2">Item 2</div>
+
+<script>
+description("Test that hover states are not updated after layout changes on iOS when no mouse device is connected.");
+window.jsTestIsAsync = true;
+
+if (!window.testRunner || !window.eventSender) {
+    testFailed("This test requires testRunner and eventSender");
+    finishJSTest();
+}
+
+function checkHovered(elementId) {
+    const elem = document.getElementById(elementId);
+    const bgColor = window.getComputedStyle(elem).backgroundColor;
+    return bgColor === 'rgb(255, 255, 0)';
+}
+
+async function runTest() {
+    try {
+        testRunner.setHasMouseDeviceForTesting(false);
+        await UIHelper.renderingUpdate();
+
+        const item1 = document.getElementById('item1');
+        const rect1 = item1.getBoundingClientRect();
+        const pointerX = rect1.left + rect1.width / 2;
+        const pointerY = rect1.top + rect1.height / 2;
+
+        await eventSender.asyncMouseMoveTo(pointerX, pointerY);
+        await UIHelper.renderingUpdate();
+
+        debug("\nTriggering layout change (expanding spacer by 120px)...");
+        const spacer = document.getElementById('spacer');
+        spacer.style.height = '120px';
+        window.internals?.updateLayoutAndStyleForAllFrames();
+        await UIHelper.renderingUpdate();
+
+        const item1HoveredAfter = checkHovered('item1');
+        const item2HoveredAfter = checkHovered('item2');
+
+        if (!item1HoveredAfter && !item2HoveredAfter) {
+            testPassed("Hover states correctly remained unchanged during layout change without mouse device");
+        } else {
+            if (item2HoveredAfter) {
+                testFailed("item2 incorrectly gained hover state after moving under pointer position");
+            }
+            if (item1HoveredAfter) {
+                testFailed("item1 unexpectedly hovered");
+            }
+        }
+
+    } catch (error) {
+        testFailed(`Test error: ${error}`);
+    } finally {
+        finishJSTest();
+    }
+}
+
+window.addEventListener('load', async () => {
+    runTest();
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -140,6 +140,7 @@ extern const unsigned InvalidTouchIdentifier;
 
 enum AppendTrailingWhitespace { ShouldAppendTrailingWhitespace, DontAppendTrailingWhitespace };
 enum CheckDragHysteresis { ShouldCheckDragHysteresis, DontCheckDragHysteresis };
+enum class LastKnownMousePositionSource : uint8_t { Mouse, Wheel, Touch };
 
 class EventHandler final : public CanMakeCheckedPtr<EventHandler> {
     WTF_MAKE_TZONE_ALLOCATED(EventHandler);
@@ -242,7 +243,7 @@ public:
     void defaultWheelEventHandler(Node*, WheelEvent&);
     void wheelEventWasProcessedByMainThread(const PlatformWheelEvent&, OptionSet<EventHandling>);
 
-    WEBCORE_EXPORT void setLastKnownMousePosition(const DoublePoint& position, const DoublePoint& globalPosition);
+    WEBCORE_EXPORT void setLastKnownMousePosition(const DoublePoint& position, const DoublePoint& globalPosition, std::optional<LastKnownMousePositionSource>&& = std::nullopt);
 
     bool handlePasteGlobalSelection();
 
@@ -704,6 +705,7 @@ private:
 
     std::optional<DoublePoint> m_lastKnownMousePosition; // Same coordinates as PlatformMouseEvent::position().
     DoublePoint m_lastKnownMouseGlobalPosition;
+    std::optional<LastKnownMousePositionSource> m_lastKnownMousePositionSource;
     IntPoint m_mouseDownContentsPosition;
     MonotonicTime m_mouseDownTimestamp;
     PlatformMouseEvent m_mouseDownEvent;

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1234,6 +1234,7 @@ def headers_for_type(type, for_implementation_file=False):
         'WebCore::IDBResourceObjectIdentifier': ['<WebCore/IDBResourceIdentifier.h>'],
         'WebCore::ISOWebVTTCue': ['<WebCore/ISOVTTCue.h>'],
         'WebCore::KeypressCommand': ['<WebCore/KeyboardEvent.h>'],
+        'WebCore::LastKnownMousePositionSource': ['<WebCore/EventHandler.h>'],
         'WebCore::LastNavigationWasAppInitiated': ['<WebCore/ServiceWorkerClientData.h>'],
         'WebCore::LegacyCDMSessionClient::MediaKeyErrorCode': ['<WebCore/LegacyCDMSession.h>'],
         'WebCore::LineCap': ['<WebCore/GraphicsTypes.h>'],

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -9221,3 +9221,10 @@ header: <WebCore/ResolvedCaptionDisplaySettingsOptions.h>
     std::optional<WebCore::ResolvedCaptionDisplaySettingsOptionsXPositionArea> xPositionArea;
     std::optional<WebCore::ResolvedCaptionDisplaySettingsOptionsYPositionArea> yPositionArea;
 };
+
+header: <WebCore/EventHandler.h>
+[CustomHeader] enum class WebCore::LastKnownMousePositionSource : uint8_t {
+    Mouse,
+    Wheel,
+    Touch
+};

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -231,6 +231,7 @@
 #include <WebCore/DragController.h>
 #include <WebCore/DragData.h>
 #include <WebCore/ElementContext.h>
+#include <WebCore/EventHandler.h>
 #include <WebCore/EventNames.h>
 #include <WebCore/ExceptionCode.h>
 #include <WebCore/ExceptionData.h>
@@ -4294,7 +4295,7 @@ void WebPageProxy::continueWheelEventHandling(const WebWheelEvent& wheelEvent, c
     if (!result.needsMainThreadProcessing()) {
         if (m_mainFrame && wheelEvent.phase() == WebWheelEvent::Phase::Began) {
             // When wheel events are handled entirely in the UI process, we still need to tell the web process where the mouse is for cursor updates.
-            sendToProcessContainingFrame(m_mainFrame->frameID(), Messages::WebPage::SetLastKnownMousePosition(m_mainFrame->frameID(), wheelEvent.position(), wheelEvent.globalPosition()));
+            sendToProcessContainingFrame(m_mainFrame->frameID(), Messages::WebPage::SetLastKnownMousePosition(m_mainFrame->frameID(), wheelEvent.position(), wheelEvent.globalPosition(), WebCore::LastKnownMousePositionSource::Wheel));
         }
 
         wheelEventHandlingCompleted(result.wasHandled);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -3685,13 +3685,13 @@ void WebPage::mouseEvent(FrameIdentifier frameID, const WebMouseEvent& mouseEven
 #endif
 }
 
-void WebPage::setLastKnownMousePosition(WebCore::FrameIdentifier frameID, const DoublePoint& eventPoint, const DoublePoint& globalPoint)
+void WebPage::setLastKnownMousePosition(WebCore::FrameIdentifier frameID, const DoublePoint& eventPoint, const DoublePoint& globalPoint, std::optional<WebCore::LastKnownMousePositionSource>&& source)
 {
     RefPtr frame = WebProcess::singleton().webFrame(frameID);
     if (!frame || !frame->coreLocalFrame() || !frame->coreLocalFrame()->view())
         return;
 
-    frame->coreLocalFrame()->eventHandler().setLastKnownMousePosition(eventPoint, globalPoint);
+    frame->coreLocalFrame()->eventHandler().setLastKnownMousePosition(eventPoint, globalPoint, WTF::move(source));
 }
 
 void WebPage::startDeferringResizeEvents()

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -245,6 +245,7 @@ enum class HighlightRequestOriginatedInApp : bool;
 enum class ImageDecodingError : uint8_t;
 enum class InputMode : uint8_t;
 enum class IsLoggedIn : uint8_t;
+enum class LastKnownMousePositionSource : uint8_t;
 enum class LayerTreeAsTextOptions : uint16_t;
 enum class LayoutMilestone : uint16_t;
 enum class LinkDecorationFilteringTrigger : uint8_t;
@@ -2278,7 +2279,7 @@ private:
     void mouseEvent(WebCore::FrameIdentifier, const WebMouseEvent&, std::optional<Vector<SandboxExtensionHandle>>&& sandboxExtensions);
     void keyEvent(WebCore::FrameIdentifier, const WebKeyboardEvent&);
 
-    void setLastKnownMousePosition(WebCore::FrameIdentifier, const WebCore::DoublePoint&, const WebCore::DoublePoint&);
+    void setLastKnownMousePosition(WebCore::FrameIdentifier, const WebCore::DoublePoint&, const WebCore::DoublePoint&, std::optional<WebCore::LastKnownMousePositionSource>&& = std::nullopt);
 
 #if ENABLE(IOS_TOUCH_EVENTS)
     void touchEventSync(const WebTouchEvent&, CompletionHandler<void(bool)>&&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -59,7 +59,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
     ExecuteEditCommandWithCallback(String name, String argument) -> ()
     KeyEvent(WebCore::FrameIdentifier frameID, WebKit::WebKeyboardEvent event)
     MouseEvent(WebCore::FrameIdentifier frameID, WebKit::WebMouseEvent event, std::optional<Vector<WebKit::SandboxExtensionHandle>> sandboxExtensions)
-    SetLastKnownMousePosition(WebCore::FrameIdentifier frameID, WebCore::DoublePoint eventPoint, WebCore::DoublePoint globalPoint);
+    SetLastKnownMousePosition(WebCore::FrameIdentifier frameID, WebCore::DoublePoint eventPoint, WebCore::DoublePoint globalPoint, enum:uint8_t std::optional<WebCore::LastKnownMousePositionSource> source);
 
 #if PLATFORM(IOS_FAMILY)
     SetSceneIdentifier(String sceneIdentifier)


### PR DESCRIPTION
#### fb2234a1edb84a2bfee94974bda4db434291a246
<pre>
REGRESSION(300277@main): [iOS] music.apple.com: Hover effect on playlist rolls with scrolling
<a href="https://bugs.webkit.org/show_bug.cgi?id=304955">https://bugs.webkit.org/show_bug.cgi?id=304955</a>
<a href="https://rdar.apple.com/165386975">rdar://165386975</a>

Reviewed by Wenson Hsieh and Lily Spiniolas.

Scrolling on sites like music.apple.com caused hover states to
inappropriately change as elements moved under the stored &quot;mouse
position&quot; from wheel events. This made it appear as if different items
were being &quot;selected&quot; while scrolling.

The regression was introduced in 300277@main, which added
updateMouseEventTargetAfterLayoutIfNeeded() to fire boundary events when
layout changes cause different elements to be under the pointer. However,
on iOS (or other touch-primary platforms), if we interact on the web
page through touch, this sets m_lastKnownMousePosition because of the
synthetic click codepath. Once set, even though there is no real pointer
to track, we trigger hover semantics (since we hit test over regular web
content).

The fix adds an early return when the last known mouse position is
sourced from touch, rather than a pointing device or wheel event
handling. This preserves correct behavior on iPads with connected
mice or trackpads while preventing inappropriate hover updates on
touch-only devices.

Test: pointerevents/ios/hover-state-not-updated-on-layout-change-without-mouse.html

* LayoutTests/pointerevents/ios/hover-state-not-updated-on-layout-change-without-mouse-expected.txt: Added.
* LayoutTests/pointerevents/ios/hover-state-not-updated-on-layout-change-without-mouse.html: Added.
* Source/WebCore/page/EventHandler.cpp:
(WebCore::mousePositionSource):
(WebCore::EventHandler::handleMousePressEvent):
(WebCore::EventHandler::handleMouseDoubleClickEvent):
(WebCore::EventHandler::handleMouseMoveEvent):
(WebCore::EventHandler::handleMouseReleaseEvent):
(WebCore::EventHandler::handleMouseForceEvent):
(WebCore::EventHandler::updateMouseEventTargetAfterLayoutIfNeeded):
(WebCore::EventHandler::handleWheelEventInternal):
(WebCore::EventHandler::setLastKnownMousePosition):
* Source/WebCore/page/EventHandler.h:
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::continueWheelEventHandling):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::setLastKnownMousePosition):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

Canonical link: <a href="https://commits.webkit.org/305561@main">https://commits.webkit.org/305561@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b2f680285d1fa00cea216ef688dde6b0f551295

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138714 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11080 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/196 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146847 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91689 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d1642ae6-ab6b-4011-a1d1-90ad4d046b78) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140587 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11784 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11235 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106159 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77453 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ac01f13a-d105-4abe-bdeb-11eaf5b78891) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141661 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8881 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124318 "Found 1 new API test failure: TestWebKitAPI.ContextMenuTests.ContextMenuElementInfoContainsQRCodePayloadString (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87030 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/55b9c7f0-a541-45ce-8ce8-944871ba6f60) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/138061 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8468 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6222 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7126 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117889 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/160 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149584 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10762 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/160 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114531 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10780 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/9185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114869 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8723 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120616 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65657 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21382 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10810 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/160 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10545 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74451 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10748 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10599 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->