### PR TITLE
[Site Isolation] Add tests for touch event regions

### DIFF
--- a/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/active-passive-nesting-expected.txt
+++ b/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/active-passive-nesting-expected.txt
@@ -1,0 +1,1 @@
+no event region

--- a/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/active-passive-nesting.html
+++ b/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/active-passive-nesting.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+
+<html>
+<head>
+    <style>
+        .container {
+            width: 150px;
+            height: 150px;
+            margin: 40px;
+            padding: 10px;
+            border: 4px solid gray;
+        }
+
+        .box {
+            width: 100px;
+            height: 100px;
+            border: 4px solid black;
+            margin-left: 100px;
+        }
+        
+        .active {
+            border-color: orange;
+        }
+
+        .passive {
+            border-color: gray;
+        }
+    </style>
+    <script src="resources/touch-regions-helper.js"></script>
+    <script>
+        prepareForTest();
+
+        function doTest()
+        {
+            var activeElements = document.querySelectorAll('.active');
+            for (var element of activeElements) {
+                element.addEventListener('touchstart', function(e) { });
+            }
+
+            var passiveElements = document.querySelectorAll('.passive');
+            for (var element of passiveElements) {
+                element.addEventListener('touchstart', function(e) { }, { 'passive': true });
+            }
+            
+            dumpRegions();
+        }
+
+        window.addEventListener('load', doTest, false);
+    </script>
+</head>
+<body>
+
+<div class="passive container">
+    Passive
+    <div class="active box">
+        Active
+    </div>
+</div>
+
+<div class="active container">
+    Active
+    <div class="passive box">
+        Passive
+    </div>
+</div>
+
+</body>
+</html>

--- a/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/columns-expected.txt
+++ b/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/columns-expected.txt
@@ -1,0 +1,1 @@
+no event region

--- a/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/columns.html
+++ b/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/columns.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+
+<html>
+<head>
+    <style>
+        .columns {
+            margin: 20px;
+            width: 400px;
+            height: 320px;
+            column-width: 120px;
+        }
+        .target {
+            color: blue;
+        }
+    </style>
+    <script src="resources/touch-regions-helper.js"></script>
+    <script>
+        prepareForTest();
+
+        window.addEventListener('load', dumpRegions, false);
+    </script>
+</head>
+<body>
+
+<div class="columns">
+    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+    <p class="target" ontouchstart="(void)0">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
+</div>
+
+</body>
+</html>

--- a/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/complex-expected.txt
+++ b/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/complex-expected.txt
@@ -1,0 +1,1 @@
+no event region

--- a/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/complex.html
+++ b/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/complex.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+
+<html>
+<head>
+    <style>
+        .box {
+            width: 100px;
+            height: 100px;
+            margin: 20px;
+            border: 4px solid black;
+            position: relative;
+        }
+        
+        #target {
+            margin-top: 200px;
+            background-color: cyan;
+        }
+
+        .overflowing-transformed {
+            position: absolute;
+            top: 100px;
+            left: 300px;
+            width: 200px;
+            height: 100px;
+            border: 1px solid green;
+            transform: rotate(30deg);
+        }
+
+        .container {
+            position: absolute;
+            top: 350px;
+            height: 100px;
+            border: 1px solid green;
+        }
+
+        .inner {
+            position: relative;
+            top: 20px;
+            left: 200px;
+            padding: 10px;
+            background-color: orange;
+        }
+    </style>
+    <script src="resources/touch-regions-helper.js"></script>
+    <script>
+        prepareForTest();
+        window.addEventListener('load', dumpRegions, false);
+    </script>
+</head>
+<body>
+
+<div class="box" style="position: relative" ontouchstart="(void)0">
+    touch start
+    <div class="box" style="position: relative; left: 170px; top: 40px">positioned child</div>
+</div>
+
+<div style="height: 100px"></div>
+
+<span id="target" ontouchstart="(void)0">inline with positioned and transformed children
+    <div class="box">
+        box
+        <div class="overflowing-transformed">
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        </div>
+    </div>
+here</span>
+
+<!-- Handler on skipped containing block -->
+<div class="container" ontouchstart="(void)0" style="top: 600px;">
+    positioned block
+    <div class="intermediate">
+        in-flow block
+        <div class="inner">
+            positioned child
+        </div>
+    </div>
+</div>
+
+<div class="container" style="top: 800px;">
+    positioned block
+    <!-- Handler on skipped containing block -->
+    <div class="intermediate" ontouchstart="(void)0">
+        in-flow block
+        <div class="inner">
+            positioned child
+        </div>
+    </div>
+</div>
+
+</body>
+</html>

--- a/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/document-expected.txt
+++ b/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/document-expected.txt
@@ -1,0 +1,1 @@
+no event region

--- a/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/document.html
+++ b/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/document.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+
+<html>
+<head>
+    <script src="resources/touch-regions-helper.js"></script>
+    <script>
+        prepareForTest();
+        window.addEventListener('load', dumpRegions, false);
+    </script>
+</head>
+<body>
+    <script>
+        document.addEventListener('touchstart', function() { }, { passive: false });
+    </script>
+</body>
+</html>

--- a/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/iframes-expected.txt
+++ b/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/iframes-expected.txt
@@ -1,0 +1,1 @@
+no event region

--- a/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/iframes.html
+++ b/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/iframes.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+
+<html>
+<head>
+    <style>
+        iframe {
+            display: block;
+            border: 10px solid silver;
+            padding: 8px;
+            margin: 10px 10px 120px 10px;
+        }
+    </style>
+    <script src="resources/touch-regions-helper.js"></script>
+    <script>
+        prepareForTest();
+        window.addEventListener('load', dumpRegions, false);
+    </script>
+</head>
+<body>
+
+<iframe scrolling="no" width="200" height="120" srcdoc="
+    <div ontouchstart='(void)0'>This has a touchstart</div>
+    <div style='width: 100px; height: 100px; margin: 100px;' ontouchstart='(void)0'>This has a touchstart</div>
+"></iframe>
+
+<iframe width="200" height="120" srcdoc="
+    iframe with window touchstart listener
+    <script>
+        window.addEventListener('touchstart', function() { }, false);
+    </script>
+"></iframe>
+
+<iframe style="transform: rotate(10deg)" srcdoc="
+    <div style='width: 100px; height: 100px; margin: 50px;' ontouchstart='(void)0'>This has a touchstart</div>
+"></iframe>
+
+</body>
+</html>

--- a/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/input-type-change-expected.txt
+++ b/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/input-type-change-expected.txt
@@ -1,0 +1,1 @@
+no event region

--- a/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/input-type-change.html
+++ b/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/input-type-change.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="resources/touch-regions-helper.js"></script>
+</head>
+<body>
+    <input id="rangeToText" type="range">
+    <input id="switchToText" type="switch">
+    <input id="textToEnabledRange" type="text">
+    <input id="textToDisabledRange" type="text" disabled>
+    <input id="textToEnabledSwitch" type="text">
+    <input id="textToDisabledSwitch" type="text" disabled>
+    <input id="enabledCheckboxToSwitch" type="checkbox">
+    <input id="disabledCheckboxToSwitch" type="checkbox" disabled>
+    <input id="enabledSwitchToCheckbox" type="checkbox" switch>
+</body>
+<script>
+    prepareForTest();
+    rangeToText.type = "text";
+    switchToText.type = "text";
+    textToEnabledRange.type = "range";
+    textToDisabledRange.type = "range";
+    textToEnabledSwitch.setAttribute("switch", "");
+    textToEnabledSwitch.type = "checkbox";
+    textToDisabledSwitch.setAttribute("switch", "");
+    textToDisabledSwitch.type = "checkbox";
+    enabledCheckboxToSwitch.setAttribute("switch", "");
+    disabledCheckboxToSwitch.setAttribute("switch", "");
+    enabledSwitchToCheckbox.removeAttribute("switch");
+    dumpRegions();
+</script>
+</html>

--- a/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/overflow-expected.txt
+++ b/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/overflow-expected.txt
@@ -1,0 +1,1 @@
+no event region

--- a/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/overflow.html
+++ b/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/overflow.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+
+<html>
+<head>
+    <style>
+        .container {
+            height: 200px;
+            width: 200px;
+            border: 1px solid black;
+            margin: 50px;
+            overflow: hidden;
+        }
+        .box {
+            height: 100px;
+            width: 120px;
+            border: 1px solid black;
+            margin: 150px 10px;
+        }
+        .contents {
+            height: 500px;
+            background-color: silver;
+        }
+    </style>
+    <script src="resources/touch-regions-helper.js"></script>
+    <script>
+        prepareForTest();
+        window.addEventListener('load', dumpRegions, false);
+    </script>
+</head>
+<body>
+
+    <div class="container" ontouchstart="(void)0">
+        <div class="contents">
+            touch start on container
+        </div>
+    </div>
+
+    <div class="container">
+        <div class="box" ontouchstart="(void)0">touchstart inside overflow</div>
+    </div>
+
+</body>
+</html>

--- a/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/range-enablement-expected.txt
+++ b/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/range-enablement-expected.txt
@@ -1,0 +1,1 @@
+no event region

--- a/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/range-enablement.html
+++ b/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/range-enablement.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="resources/touch-regions-helper.js"></script>
+</head>
+<body>
+    <input id="startDisabled" type="range" disabled>
+    <input id="startEnabled" type="range">
+</body>
+<script>
+    prepareForTest();
+    startDisabled.disabled = false;
+    startEnabled.disabled = true;
+    dumpRegions();
+</script>
+</html>

--- a/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/range-sliders-expected.txt
+++ b/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/range-sliders-expected.txt
@@ -1,0 +1,1 @@
+no event region

--- a/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/range-sliders.html
+++ b/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/range-sliders.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+
+<html>
+<head>
+    <script src="resources/touch-regions-helper.js"></script>
+    <script>
+        prepareForTest();
+        window.addEventListener('load', dumpRegions, false);
+    </script>
+</head>
+<body>
+
+    <input type="range" style="width: 10px; height: 200px; -webkit-appearance: slider-vertical;">
+    <input type="range">
+    <input type="range" disabled>
+    <input type="range" style="transform: scale(2); transform-origin: top left;">
+
+</body>
+</html>

--- a/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/resources/touch-regions-helper.js
+++ b/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/resources/touch-regions-helper.js
@@ -1,0 +1,47 @@
+function extractEventRegionFromLayerTree(output) {
+    const startMarker = '(event region';
+    const startIndex = output.indexOf(startMarker);
+
+    if (startIndex === -1)
+        return "no event region";
+
+    let depth = 0;
+    let endIndex = startIndex;
+
+    for (let i = startIndex; i < output.length; i++) {
+        if (output[i] === '(') {
+            depth++;
+        } else if (output[i] === ')') {
+            depth--;
+            if (depth === 0) {
+                endIndex = i + 1;
+                break;
+            }
+        }
+    }
+
+    return output.substring(startIndex, endIndex).trim();
+}
+
+function prepareForTest() {
+    if (!window.internals)
+        return;
+
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+    testRunner.dontForceRepaint();
+}
+
+function dumpRegions() {
+    if (!window.internals)
+        return;
+
+    var layerTree = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+    var resultString = extractEventRegionFromLayerTree(layerTree);
+
+    document.documentElement.innerHTML = '';
+    var resultsPre = document.createElement('pre');
+    resultsPre.textContent = resultString;
+    document.body.appendChild(resultsPre);
+    testRunner.notifyDone();
+}

--- a/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/scrolled-overflow-expected.txt
+++ b/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/scrolled-overflow-expected.txt
@@ -1,0 +1,1 @@
+no event region

--- a/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/scrolled-overflow.html
+++ b/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/scrolled-overflow.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        #scroller {
+            height: 200px;
+            width: 200px;
+            border: 1px solid black;
+            margin: 50px;
+            overflow: scroll;
+        }
+        .box {
+            position: relative;
+            height: 100px;
+            width: 120px;
+            border: 1px solid black;
+            margin: 250px 10px;
+        }
+    </style>
+    <script src="resources/touch-regions-helper.js"></script>
+    <script>
+        prepareForTest();
+        window.addEventListener('load', () => {
+            scroller.scrollTo(0, 200);
+            dumpRegions();
+        }, false);
+    </script>
+</head>
+<body>
+    <div id="scroller">
+        <div class="box" ontouchstart="(void)0">touchstart inside overflow</div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/switch-enablement-expected.txt
+++ b/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/switch-enablement-expected.txt
@@ -1,0 +1,1 @@
+no event region

--- a/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/switch-enablement.html
+++ b/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/switch-enablement.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="resources/touch-regions-helper.js"></script>
+</head>
+<body>
+    <input id="startDisabled" type="checkbox" switch disabled>
+    <input id="startEnabled" type="checkbox" switch>
+</body>
+<script>
+    prepareForTest();
+    startDisabled.disabled = false;
+    startEnabled.disabled = true;
+    dumpRegions();
+</script>
+</html>

--- a/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/switch-expected.txt
+++ b/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/switch-expected.txt
@@ -1,0 +1,1 @@
+no event region

--- a/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/switch.html
+++ b/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/switch.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+
+<html>
+<head>
+    <script src="resources/touch-regions-helper.js"></script>
+    <script>
+        prepareForTest();
+        window.addEventListener('load', dumpRegions, false);
+    </script>
+</head>
+<body>
+
+    <input type="checkbox" switch>
+    <input type="checkbox" switch disabled>
+    <input type="checkbox" switch style="transform: scale(2); transform-origin: top left;">
+
+</body>
+</html>

--- a/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/transparent-expected.txt
+++ b/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/transparent-expected.txt
@@ -1,0 +1,1 @@
+no event region

--- a/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/transparent.html
+++ b/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/transparent.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+
+<html>
+<head>
+    <style>
+        #transparent {
+            display: block;
+            width:400px;
+            height:400px;
+            opacity: 0;
+        }
+    </style>
+    <script src="resources/touch-regions-helper.js"></script>
+    <script>
+        prepareForTest();
+        window.addEventListener('load', dumpRegions, false);
+    </script>
+</head>
+<body>
+
+<div id="transparent" ontouchstart="(void)0">
+</div>
+
+</body>
+</html>

--- a/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/window-expected.txt
+++ b/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/window-expected.txt
@@ -1,0 +1,1 @@
+no event region

--- a/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/window.html
+++ b/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/window.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+
+<html>
+<head>
+    <script src="resources/touch-regions-helper.js"></script>
+    <script>
+        prepareForTest();
+        window.addEventListener('load', dumpRegions, false);
+    </script>
+</head>
+<body>
+    <script>
+        window.addEventListener('touchstart', function() { }, { passive: false });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
#### 2b7d604d873a161ba55b258a9182e0b6511aa270
<pre>
[Site Isolation] Add tests for touch event regions
<a href="https://bugs.webkit.org/show_bug.cgi?id=304958">https://bugs.webkit.org/show_bug.cgi?id=304958</a>
<a href="https://rdar.apple.com/167579810">rdar://167579810</a>

Reviewed by Wenson Hsieh.

Create versions of tests in fast/events/touch/ios/touch-event-regions
which dump the layer tree, including the event region. Add brand-new
tests as well:

fast/events/touch/ios/touch-event-regions-layer-tree/input-type-change.html:
Test touch event regions when input types change between types which have
internal touch handling, and types which don&apos;t. This test includes cases
for enabled and disabled states as well.

fast/events/touch/ios/touch-event-regions-layer-tree/range-enablement.html:
Test touch event regions for range controls which go from enabled to disabled,
and vice versa.

fast/events/touch/ios/touch-event-regions-layer-tree/switch.html:
Test touch event regions for &lt;input type=&apos;checkbox&apos; switch&gt;. Includes enabled
and disabled state, and transformed case.

fast/events/touch/ios/touch-event-regions-layer-tree/switch-enablement.html:
Test touch event regions for switch controls which go from enabled to disabled,
and vice versa.

fast/events/touch/ios/touch-event-regions-layer-tree/transparent.html:
Test touch event regions for an element with `opacity: 0`;

fast/events/touch/ios/touch-event-regions-layer-tree/window.html:
Test touch event regions when a touch event listener is added to the window.

* LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/active-passive-nesting-expected.txt: Added.
* LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/active-passive-nesting.html: Added.
* LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/columns-expected.txt: Added.
* LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/columns.html: Added.
* LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/complex-expected.txt: Added.
* LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/complex.html: Added.
* LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/document-expected.txt: Added.
* LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/document.html: Added.
* LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/iframes-expected.txt: Added.
* LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/iframes.html: Added.
* LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/input-type-change-expected.txt: Added.
* LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/input-type-change.html: Added.
* LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/overflow-expected.txt: Added.
* LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/overflow.html: Added.
* LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/range-enablement-expected.txt: Added.
* LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/range-enablement.html: Added.
* LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/range-sliders-expected.txt: Added.
* LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/range-sliders.html: Added.
* LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/resources/touch-regions-helper.js: Added.
(extractEventRegionFromLayerTree):
(prepareForTest):
(dumpRegions):
* LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/scrolled-overflow-expected.txt: Added.
* LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/scrolled-overflow.html: Added.
* LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/switch-enablement-expected.txt: Added.
* LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/switch-enablement.html: Added.
* LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/switch-expected.txt: Added.
* LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/switch.html: Added.
* LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/transparent-expected.txt: Added.
* LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/transparent.html: Added.
* LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/window-expected.txt: Added.
* LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/window.html: Added.

Canonical link: <a href="https://commits.webkit.org/305143@main">https://commits.webkit.org/305143@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/094062869ecfd2e77ca65376ae2790f4fedecddb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137626 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9987 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48914 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145384 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90599 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/da4351af-9fbf-47f9-ad2e-afdaccd98fe1) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10690 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10117 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105260 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2c4e801d-142f-4cad-b4a8-26c13f845362) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140571 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7945 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123342 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86114 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e279e57c-f556-4d42-8be4-8d66e0b8f424) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7573 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5295 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5967 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116961 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41501 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148151 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9670 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42052 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113643 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9687 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8150 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113986 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28934 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7499 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119581 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64334 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9718 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37630 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9449 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9658 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9510 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->