### PR TITLE
[CI FIlters] Show a debug indicator for filters being rendered via Core Image

### DIFF
--- a/LayoutTests/ipc/decode-feConvolveMatrix-kernelSize-overflow.html
+++ b/LayoutTests/ipc/decode-feConvolveMatrix-kernelSize-overflow.html
@@ -232,7 +232,8 @@ setTimeout(async () => {
                         height : 1.4142135623730951
                     }
                 },
-                filterRenderingModes : 135
+                filterRenderingModes : 135,
+                isShowingDebugOverlay : false
             }
             }
         }

--- a/LayoutTests/ipc/empty-svgfilterrenderer-expression-crash.html
+++ b/LayoutTests/ipc/empty-svgfilterrenderer-expression-crash.html
@@ -121,6 +121,7 @@
                                 }
                             },
                             filterRenderingModes: 0,
+                            isShowingDebugOverlay : false,
                             renderingResourceIdentifierIfExists: {},
                             },
                         },

--- a/LayoutTests/ipc/insufficient-svgfilter-inputs-crash.html
+++ b/LayoutTests/ipc/insufficient-svgfilter-inputs-crash.html
@@ -92,6 +92,7 @@
                             }
                         },
                         filterRenderingModes: 1,
+                        isShowingDebugOverlay : false,
                         renderingResourceIdentifierIfExists: {},
                     }
                 },

--- a/LayoutTests/ipc/invalid-feConvolveMatrix-crash.html
+++ b/LayoutTests/ipc/invalid-feConvolveMatrix-crash.html
@@ -118,6 +118,7 @@
                                     }
                                 },
                                 filterRenderingModes: 1,
+                                isShowingDebugOverlay : false,
                                 renderingResourceIdentifierIfExists: {},
                             }
                         }

--- a/LayoutTests/ipc/invalid-svgfilter-expression-crash.html
+++ b/LayoutTests/ipc/invalid-svgfilter-expression-crash.html
@@ -89,6 +89,7 @@ window.setTimeout(async () => {
                             }
                         },
                         filterRenderingModes: 1,
+                        isShowingDebugOverlay : false,
                         renderingResourceIdentifierIfExists: {},
                     }
                 },

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
@@ -130,7 +130,7 @@ RefPtr<Filter> CanvasRenderingContext2D::createFilter(const FloatRect& bounds) c
             .referenceBox = bounds,
             .filterRegion = filterRegion,
             .scale = { 1, 1 },
-        }, preferredFilterRenderingModes, *context);
+        }, preferredFilterRenderingModes, false, *context);
     if (!filter)
         return nullptr;
 

--- a/Source/WebCore/platform/graphics/filters/Filter.cpp
+++ b/Source/WebCore/platform/graphics/filters/Filter.cpp
@@ -151,7 +151,7 @@ FilterStyleVector Filter::createFilterStyles(GraphicsContext& context, const Flo
 ImageBuffer* Filter::filterResultBuffer(FilterImage& filterImage) const
 {
 #if USE(CORE_IMAGE)
-    return filterImage.filterResultImageBuffer(absoluteEnclosingFilterRegion());
+    return filterImage.filterResultImageBuffer(*this);
 #endif
 
     return filterImage.imageBuffer();

--- a/Source/WebCore/platform/graphics/filters/Filter.h
+++ b/Source/WebCore/platform/graphics/filters/Filter.h
@@ -51,6 +51,9 @@ public:
     OptionSet<FilterRenderingMode> filterRenderingModes() const { return m_filterRenderingModes; }
     WEBCORE_EXPORT void setFilterRenderingModes(OptionSet<FilterRenderingMode> preferredFilterRenderingModes);
 
+    void setIsShowingDebugOverlay(bool showOverlay) { m_isShowingDebugOverlay = showOverlay; }
+    bool isShowingDebugOverlay() const { return m_isShowingDebugOverlay; }
+
     const FilterGeometry& geometry() const { return m_geometry; }
 
     FloatSize filterScale() const { return m_geometry.scale; }
@@ -104,6 +107,7 @@ private:
     FloatRect m_enclosingFilterRegion;
 #endif
     OptionSet<FilterRenderingMode> m_filterRenderingModes { FilterRenderingMode::Software };
+    bool m_isShowingDebugOverlay { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/filters/FilterImage.h
+++ b/Source/WebCore/platform/graphics/filters/FilterImage.h
@@ -81,7 +81,7 @@ public:
     void transformToColorSpace(const DestinationColorSpace&);
 
 #if USE(CORE_IMAGE)
-    ImageBuffer* filterResultImageBuffer(FloatRect absoluteFilterRegion);
+    ImageBuffer* filterResultImageBuffer(const Filter&);
 
     RetainPtr<CIImage> ciImage() const { return m_ciImage; }
     void setCIImage(RetainPtr<CIImage>&&);

--- a/Source/WebCore/rendering/CSSFilterRenderer.h
+++ b/Source/WebCore/rendering/CSSFilterRenderer.h
@@ -44,11 +44,11 @@ class CSSFilterRenderer final : public Filter {
     WTF_MAKE_TZONE_ALLOCATED(CSSFilterRenderer);
 public:
 
-    static RefPtr<CSSFilterRenderer> create(RenderElement&, const Style::Filter&, const FilterGeometry&, OptionSet<FilterRenderingMode>, const GraphicsContext& destinationContext);
-    static RefPtr<CSSFilterRenderer> create(RenderElement&, const FilterOperations&, const FilterGeometry&, OptionSet<FilterRenderingMode>, const GraphicsContext& destinationContext);
+    static RefPtr<CSSFilterRenderer> create(RenderElement&, const Style::Filter&, const FilterGeometry&, OptionSet<FilterRenderingMode>, bool showDebugOverlay, const GraphicsContext& destinationContext);
+    static RefPtr<CSSFilterRenderer> create(RenderElement&, const FilterOperations&, const FilterGeometry&, OptionSet<FilterRenderingMode>, bool showDebugOverlay, const GraphicsContext& destinationContext);
 
     WEBCORE_EXPORT static Ref<CSSFilterRenderer> create(Vector<Ref<FilterFunction>>&&);
-    WEBCORE_EXPORT static Ref<CSSFilterRenderer> create(Vector<Ref<FilterFunction>>&&, const FilterGeometry&, OptionSet<FilterRenderingMode> preferredFilterRenderingModes);
+    WEBCORE_EXPORT static Ref<CSSFilterRenderer> create(Vector<Ref<FilterFunction>>&&, const FilterGeometry&, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, bool showDebugOverlay);
 
     const Vector<Ref<FilterFunction>>& functions() const { return m_functions; }
     void setFilterRegion(const FloatRect&);
@@ -67,7 +67,7 @@ public:
     static IntOutsets calculateOutsets(RenderElement&, const FilterOperations&, const FloatRect& targetBoundingBox);
 
 private:
-    static RefPtr<CSSFilterRenderer> createGeneric(RenderElement&, const auto&, const FilterGeometry&, OptionSet<FilterRenderingMode>, const GraphicsContext& destinationContext);
+    static RefPtr<CSSFilterRenderer> createGeneric(RenderElement&, const auto&, const FilterGeometry&, OptionSet<FilterRenderingMode>, bool showDebugOverlay, const GraphicsContext& destinationContext);
 
     CSSFilterRenderer(const FilterGeometry&, bool hasFilterThatMovesPixels, bool hasFilterThatShouldBeRestrictedBySecurityOrigin);
     CSSFilterRenderer(Vector<Ref<FilterFunction>>&&, const FilterGeometry&);

--- a/Source/WebCore/rendering/RenderLayerFilters.cpp
+++ b/Source/WebCore/rendering/RenderLayerFilters.cpp
@@ -199,7 +199,7 @@ GraphicsContext* RenderLayerFilters::beginFilterEffect(RenderElement& renderer, 
     bool hasUpdatedBackingStore = false;
     if (!m_filter || geometryReferenceGeometryChanged(m_filter->geometry(), geometry) || m_preferredFilterRenderingModes != preferredFilterRenderingModes) {
         // FIXME: This rebuilds the entire effects chain even if the filter style didn't change.
-        m_filter = CSSFilterRenderer::create(renderer, renderer.style().filter(), geometry, preferredFilterRenderingModes, context);
+        m_filter = CSSFilterRenderer::create(renderer, renderer.style().filter(), geometry, preferredFilterRenderingModes, renderer.settings().showDebugBorders(), context);
         hasUpdatedBackingStore = true;
     } else if (filterRegion != m_filter->filterRegion()) {
         m_filter->setFilterRegion(filterRegion);

--- a/Source/WebCore/rendering/style/StyleFilterImage.cpp
+++ b/Source/WebCore/rendering/style/StyleFilterImage.cpp
@@ -39,6 +39,7 @@
 #include "ReferenceFilterOperation.h"
 #include "RenderElement.h"
 #include "RenderObjectInlines.h"
+#include "Settings.h"
 #include "StyleFilter.h"
 #include <wtf/PointerComparison.h>
 
@@ -117,8 +118,9 @@ void StyleFilterImage::load(CachedResourceLoader& cachedResourceLoader, const Re
     m_inputImageIsReady = true;
 }
 
-RefPtr<Image> StyleFilterImage::image(const RenderElement* renderer, const FloatSize& size, const GraphicsContext& destinationContext, bool isForFirstLine) const
+RefPtr<Image> StyleFilterImage::image(const RenderElement* renderElement, const FloatSize& size, const GraphicsContext& destinationContext, bool isForFirstLine) const
 {
+    CheckedPtr renderer = renderElement;
     if (!renderer)
         return &Image::nullImage();
 
@@ -129,7 +131,7 @@ RefPtr<Image> StyleFilterImage::image(const RenderElement* renderer, const Float
     if (!styleImage)
         return &Image::nullImage();
 
-    auto image = styleImage->image(renderer, size, destinationContext, isForFirstLine);
+    auto image = styleImage->image(renderer.get(), size, destinationContext, isForFirstLine);
     if (!image || image->isNull())
         return &Image::nullImage();
 
@@ -140,7 +142,7 @@ RefPtr<Image> StyleFilterImage::image(const RenderElement* renderer, const Float
             .referenceBox = sourceImageRect,
             .filterRegion = sourceImageRect,
             .scale = { 1, 1 },
-        }, preferredFilterRenderingModes, NullGraphicsContext());
+        }, preferredFilterRenderingModes, renderer->settings().showDebugBorders(), NullGraphicsContext());
     if (!cssFilter)
         return &Image::nullImage();
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp
@@ -35,6 +35,7 @@
 #include "RenderObjectInlines.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGRenderingContext.h"
+#include "Settings.h"
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
@@ -132,11 +133,13 @@ auto LegacyRenderSVGResourceFilter::applyResource(RenderElement& renderer, const
         .filterRegion = filterRegion,
         .scale = filterScale,
     }, preferredFilterModes, *context, RenderingResourceIdentifier::generate());
+
     if (!filterData->filter) {
         m_rendererFilterDataMap.remove(renderer);
         return { };
     }
 
+    filterData->filter->setIsShowingDebugOverlay(renderer.settings().showDebugBorders());
     filterData->filter->clampFilterRegionIfNeeded();
 
 #if USE(CAIRO)

--- a/Source/WebCore/svg/graphics/filters/SVGFilterRenderer.cpp
+++ b/Source/WebCore/svg/graphics/filters/SVGFilterRenderer.cpp
@@ -59,12 +59,13 @@ RefPtr<SVGFilterRenderer> SVGFilterRenderer::create(SVGElement *contextElement, 
     return filter;
 }
 
-Ref<SVGFilterRenderer> SVGFilterRenderer::create(SVGUnitTypes::SVGUnitType primitiveUnits, SVGFilterExpression&& expression, FilterEffectVector&& effects, const FilterGeometry& geometry, OptionSet<FilterRenderingMode> preferredRenderingModes, std::optional<RenderingResourceIdentifier> renderingResourceIdentifier)
+Ref<SVGFilterRenderer> SVGFilterRenderer::create(SVGUnitTypes::SVGUnitType primitiveUnits, SVGFilterExpression&& expression, FilterEffectVector&& effects, const FilterGeometry& geometry, OptionSet<FilterRenderingMode> preferredRenderingModes, bool showDebugOverlay, std::optional<RenderingResourceIdentifier> renderingResourceIdentifier)
 {
     Ref filter = adoptRef(*new SVGFilterRenderer(geometry, primitiveUnits, WTF::move(expression), WTF::move(effects), renderingResourceIdentifier));
     // Setting filter rendering modes cannot be moved to the constructor because it ends up
     // calling supportedFilterRenderingModes() which is a virtual function.
     filter->setFilterRenderingModes(preferredRenderingModes);
+    filter->setIsShowingDebugOverlay(showDebugOverlay);
     return filter;
 }
 

--- a/Source/WebCore/svg/graphics/filters/SVGFilterRenderer.h
+++ b/Source/WebCore/svg/graphics/filters/SVGFilterRenderer.h
@@ -39,7 +39,7 @@ class SVGFilterElement;
 class SVGFilterRenderer final : public Filter {
 public:
     static RefPtr<SVGFilterRenderer> create(SVGElement* contextElement, SVGFilterElement&, const FilterGeometry&, OptionSet<FilterRenderingMode>, const GraphicsContext& destinationContext, std::optional<RenderingResourceIdentifier> = std::nullopt);
-    WEBCORE_EXPORT static Ref<SVGFilterRenderer> create(SVGUnitTypes::SVGUnitType primitiveUnits, SVGFilterExpression&&, FilterEffectVector&&, const FilterGeometry&, OptionSet<FilterRenderingMode>, std::optional<RenderingResourceIdentifier>);
+    WEBCORE_EXPORT static Ref<SVGFilterRenderer> create(SVGUnitTypes::SVGUnitType primitiveUnits, SVGFilterExpression&&, FilterEffectVector&&, const FilterGeometry&, OptionSet<FilterRenderingMode>, bool showDebugOverlay, std::optional<RenderingResourceIdentifier>);
 
     static bool isIdentity(SVGFilterElement&);
     static IntOutsets calculateOutsets(SVGFilterElement&, const FloatRect& targetBoundingBox);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7676,6 +7676,7 @@ header: <WebCore/Filter.h>
     Vector<Ref<WebCore::FilterFunction>> functions();
     WebCore::FilterGeometry geometry();
     OptionSet<WebCore::FilterRenderingMode> filterRenderingModes();
+    bool isShowingDebugOverlay();
 }
 
 [AdditionalEncoder=StreamConnectionEncoder, RefCounted] class WebCore::SVGFilterRenderer {
@@ -7684,6 +7685,7 @@ header: <WebCore/Filter.h>
     [Validator='WebCore::SVGFilterRenderer::isValidSVGFilterExpression(*expression, *effects)'] Vector<Ref<WebCore::FilterEffect>> effects();
     WebCore::FilterGeometry geometry();
     OptionSet<WebCore::FilterRenderingMode> filterRenderingModes();
+    bool isShowingDebugOverlay();
     std::optional<WebCore::RenderingResourceIdentifier> renderingResourceIdentifierIfExists();
 }
 


### PR DESCRIPTION
#### a601d6659c531c4bb1cabb68c2cd056553c0de1a
<pre>
[CI FIlters] Show a debug indicator for filters being rendered via Core Image
<a href="https://bugs.webkit.org/show_bug.cgi?id=304960">https://bugs.webkit.org/show_bug.cgi?id=304960</a>
<a href="https://rdar.apple.com/167581311">rdar://167581311</a>

Reviewed by Mike Wyrzykowski.

Wire up a &quot;is showing debug overlay&quot; bit in Filter to the layer borders
setting, and consult it in FilterImageCoreImage where we use it to
render translucent yellow stripes over the result image.

* LayoutTests/ipc/decode-feConvolveMatrix-kernelSize-overflow.html:
* LayoutTests/ipc/empty-svgfilterrenderer-expression-crash.html:
* LayoutTests/ipc/insufficient-svgfilter-inputs-crash.html:
* LayoutTests/ipc/invalid-feConvolveMatrix-crash.html:
* LayoutTests/ipc/invalid-svgfilter-expression-crash.html:
* Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp:
(WebCore::CanvasRenderingContext2D::createFilter const):
* Source/WebCore/platform/graphics/coreimage/FilterImageCoreImage.mm:
(WebCore::FilterImage::filterResultImageBuffer):
* Source/WebCore/platform/graphics/filters/Filter.cpp:
(WebCore::Filter::filterResultBuffer const):
* Source/WebCore/platform/graphics/filters/Filter.h:
(WebCore::Filter::setIsShowingDebugOverlay):
(WebCore::Filter::isShowingDebugOverlay const):
* Source/WebCore/platform/graphics/filters/FilterImage.h:
* Source/WebCore/rendering/CSSFilterRenderer.cpp:
(WebCore::CSSFilterRenderer::createGeneric):
(WebCore::CSSFilterRenderer::create):
(WebCore::createReferenceFilter):
* Source/WebCore/rendering/CSSFilterRenderer.h:
* Source/WebCore/rendering/RenderLayerFilters.cpp:
(WebCore::RenderLayerFilters::beginFilterEffect):
* Source/WebCore/rendering/style/StyleFilterImage.cpp:
(WebCore::StyleFilterImage::image const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp:
(WebCore::LegacyRenderSVGResourceFilter::applyResource):
* Source/WebCore/svg/graphics/filters/SVGFilterRenderer.cpp:
(WebCore::SVGFilterRenderer::create):
* Source/WebCore/svg/graphics/filters/SVGFilterRenderer.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/305206@main">https://commits.webkit.org/305206@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2adc57b34b533d4cc834cea2d5953251ce646699

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137795 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10156 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49089 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145656 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90768 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9c6a8645-407b-4133-bc65-76c17d42b782) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139667 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10859 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10289 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105402 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b7f4a2fc-e10c-4190-b32c-3e267d866a88) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140740 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8083 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123500 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86261 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7704 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5436 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6139 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117096 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41663 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/148568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9839 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42209 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/148568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9856 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8293 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/148568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28979 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7641 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119738 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64538 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9887 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37778 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9618 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73452 "Found 1 new failure in rendering/style/StyleFilterImage.cpp") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9827 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9679 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->