### PR TITLE
Simplify CSSSelectorList::componentCount() & CSSSelectorList::listSize()

### DIFF
--- a/Source/WebCore/css/CSSSelectorList.cpp
+++ b/Source/WebCore/css/CSSSelectorList.cpp
@@ -153,31 +153,10 @@ CSSSelectorList CSSSelectorList::makeJoining(const Vector<const CSSSelectorList*
     return CSSSelectorList { WTF::move(selectorArray) };
 }
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-unsigned CSSSelectorList::componentCount() const
-{
-    if (m_selectorArray.isEmpty())
-        return 0;
-    auto* current = m_selectorArray.begin();
-    while (!current->isLastInSelectorList())
-        ++current;
-    return (current - m_selectorArray.begin()) + 1;
-}
-
 unsigned CSSSelectorList::listSize() const
 {
-    if (m_selectorArray.isEmpty())
-        return 0;
-    unsigned size = 1;
-    auto* current = m_selectorArray.begin();
-    while (!current->isLastInSelectorList()) {
-        if (current->isFirstInComplexSelector())
-            ++size;
-        ++current;
-    }
-    return size;
+    return std::ranges::count_if(m_selectorArray, [](auto& selector) { return selector.isFirstInComplexSelector(); });
 }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 String CSSSelectorList::selectorsText() const
 {

--- a/Source/WebCore/css/CSSSelectorList.h
+++ b/Source/WebCore/css/CSSSelectorList.h
@@ -112,7 +112,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     String selectorsText() const;
     void buildSelectorsText(StringBuilder&) const;
 
-    unsigned componentCount() const;
+    unsigned componentCount() const { return m_selectorArray.size(); }
     unsigned listSize() const;
 
     CSSSelectorList& operator=(CSSSelectorList&&) = default;


### PR DESCRIPTION
#### 9e59562c7c83a707bd837c5140827b19b4ea8045
<pre>
Simplify CSSSelectorList::componentCount() &amp; CSSSelectorList::listSize()
<a href="https://bugs.webkit.org/show_bug.cgi?id=304964">https://bugs.webkit.org/show_bug.cgi?id=304964</a>

Reviewed by Darin Adler.

Simplify CSSSelectorList::componentCount() &amp; CSSSelectorList::listSize()
now that the selectors are stored in a FixedVector and we know the size.

In a follow-up, we should be able to get rid of the `m_isLastInSelectorList`
flag on CSSSelector but the CSSSelectorList iterator will need updating
first (which will require performance A/B testing).

This change also reduces the use of WTF_ALLOW_UNSAFE_BUFFER_USAGE and
thus improves code safety.

* Source/WebCore/css/CSSSelectorList.cpp:
(WebCore::CSSSelectorList::listSize const):
(WebCore::CSSSelectorList::componentCount const):
* Source/WebCore/css/CSSSelectorList.h:
(WebCore::CSSSelectorList::componentCount const):

Canonical link: <a href="https://commits.webkit.org/305179@main">https://commits.webkit.org/305179@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c1c3a87c9cc2fc09d350361db128ad7cf68cc1d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137629 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/9990 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48917 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145387 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90602 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/be0c949f-fab3-476b-a564-c7a322fc9af5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139501 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10693 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10120 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105263 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f14d4327-b53c-4e3a-a725-bf1058bd856e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140574 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7944 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123348 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86123 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3bc56aab-0045-4355-82e2-d0ed0695338e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7572 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5296 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5970 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116960 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41507 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148154 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9673 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42058 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113646 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9690 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8152 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113989 "Found 1 new API test failure: TestWebKit:WebKit.NewFirstVisuallyNonEmptyLayoutFrames (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28957 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7503 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119587 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64337 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9721 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37636 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9452 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73286 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9661 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9513 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->