### PR TITLE
[AutoFill Debugging] Add support for JSON text extraction output format

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-expected.txt
@@ -106,4 +106,357 @@ version=2
 </body>
 <!-- version=2 -->
 
+-- json
+
+{
+  "type": "root",
+  "children": [
+    {
+      "type": "container",
+      "nodeName": "div",
+      "role": "banner",
+      "children": [
+        {
+          "type": "container",
+          "nodeName": "h1",
+          "aria-label": "Main Page Title",
+          "children": [
+            {
+              "type": "text",
+              "content": "Welcome to Test Page"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "navigation",
+      "nodeName": "nav",
+      "role": "navigation",
+      "aria-label": "Main navigation",
+      "children": [
+        {
+          "type": "list",
+          "nodeName": "ul",
+          "children": [
+            {
+              "type": "list-item",
+              "nodeName": "li",
+              "children": [
+                {
+                  "type": "link",
+                  "nodeName": "a",
+                  "children": [
+                    {
+                      "type": "text",
+                      "content": "Section 1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "list-item",
+              "nodeName": "li",
+              "children": [
+                {
+                  "type": "link",
+                  "nodeName": "a",
+                  "children": [
+                    {
+                      "type": "text",
+                      "content": "Section 2"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "container",
+      "nodeName": "main",
+      "role": "main",
+      "children": [
+        {
+          "type": "section",
+          "nodeName": "section",
+          "aria-label": "Interactive Elements",
+          "children": [
+            {
+              "type": "button",
+              "nodeName": "button",
+              "aria-label": "Test button",
+              "aria-describedby": "This button does nothing",
+              "children": [
+                {
+                  "type": "text",
+                  "content": "Click Me"
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "content": "This button does nothing"
+            },
+            {
+              "type": "input",
+              "nodeName": "input",
+              "uid": "…",
+              "controlType": "text",
+              "placeholder": "Enter text here",
+              "children": [
+                {
+                  "type": "text",
+                  "content": "Enter text here"
+                }
+              ]
+            },
+            {
+              "type": "container",
+              "nodeName": "div",
+              "role": "button",
+              "title": "Test action",
+              "children": [
+                {
+                  "type": "text",
+                  "content": "Clickable Div"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "section",
+          "nodeName": "section",
+          "aria-label": "Content with Roles",
+          "children": [
+            {
+              "type": "article",
+              "nodeName": "article",
+              "role": "article",
+              "children": [
+                {
+                  "type": "text",
+                  "content": "Article Title January 1, 2024 This is some article content with highlighted text."
+                }
+              ]
+            },
+            {
+              "type": "container",
+              "nodeName": "aside",
+              "role": "complementary",
+              "aria-label": "Related information",
+              "children": [
+                {
+                  "type": "text",
+                  "content": "Related Links"
+                },
+                {
+                  "type": "list",
+                  "nodeName": "ul",
+                  "children": [
+                    {
+                      "type": "list-item",
+                      "nodeName": "li",
+                      "children": [
+                        {
+                          "type": "link",
+                          "nodeName": "a",
+                          "children": [
+                            {
+                              "type": "text",
+                              "content": "Example Link"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "list-item",
+                      "nodeName": "li",
+                      "children": [
+                        {
+                          "type": "link",
+                          "nodeName": "a",
+                          "children": [
+                            {
+                              "type": "text",
+                              "content": "Test Link"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "container",
+              "nodeName": "div",
+              "role": "region",
+              "children": [
+                {
+                  "type": "container",
+                  "nodeName": "div",
+                  "role": "status",
+                  "children": [
+                    {
+                      "type": "text",
+                      "content": "Ready"
+                    }
+                  ]
+                },
+                {
+                  "type": "button",
+                  "nodeName": "button",
+                  "children": [
+                    {
+                      "type": "text",
+                      "content": "Update Status"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "textarea",
+              "nodeName": "textarea",
+              "uid": "…",
+              "controlType": "textarea",
+              "children": [
+                {
+                  "type": "text",
+                  "content": "This is a text box"
+                }
+              ]
+            },
+            {
+              "type": "contentEditable",
+              "nodeName": "div",
+              "uid": "…",
+              "role": "textbox",
+              "children": [
+                {
+                  "type": "subscript",
+                  "nodeName": "sub",
+                  "children": [
+                    {
+                      "type": "text",
+                      "content": "WebKit home page:"
+                    },
+                    {
+                      "type": "link",
+                      "nodeName": "a",
+                      "children": [
+                        {
+                          "type": "text",
+                          "content": "webkit.org"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "form",
+              "nodeName": "form",
+              "autocomplete": "on",
+              "name": "signup",
+              "children": [
+                {
+                  "type": "text",
+                  "content": "Sign up for our newsletter"
+                },
+                {
+                  "type": "input",
+                  "nodeName": "input",
+                  "uid": "…",
+                  "controlType": "text",
+                  "placeholder": "Username",
+                  "name": "username",
+                  "minLength": 3,
+                  "maxLength": 20,
+                  "required": true,
+                  "children": [
+                    {
+                      "type": "text",
+                      "content": "Username"
+                    }
+                  ]
+                },
+                {
+                  "type": "input",
+                  "nodeName": "input",
+                  "uid": "…",
+                  "controlType": "text",
+                  "placeholder": "Email",
+                  "pattern": "[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}$",
+                  "name": "email",
+                  "required": true,
+                  "children": [
+                    {
+                      "type": "text",
+                      "content": "Email"
+                    }
+                  ]
+                },
+                {
+                  "type": "input",
+                  "nodeName": "input",
+                  "uid": "…",
+                  "controlType": "text",
+                  "placeholder": "Zip Code",
+                  "pattern": "[0-9]{5}",
+                  "name": "zipcode",
+                  "minLength": 5,
+                  "maxLength": 5,
+                  "children": [
+                    {
+                      "type": "text",
+                      "content": "Zip Code"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "container",
+      "nodeName": "footer",
+      "role": "contentinfo",
+      "children": [
+        {
+          "type": "text",
+          "content": "Footer content with"
+        },
+        {
+          "type": "container",
+          "nodeName": "span",
+          "role": "img",
+          "aria-label": "copyright symbol",
+          "children": [
+            {
+              "type": "text",
+              "content": "©"
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "content": "2024"
+        }
+      ]
+    }
+  ],
+  "version": 2
+}
+
 

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls.html
@@ -92,13 +92,13 @@ addEventListener("load", async () => {
     testRunner.waitUntilDone();
 
     const results = [];
-    for (let outputFormat of ["texttree", "html"]) {
+    for (let outputFormat of ["texttree", "html", "json"]) {
         const heading = document.createElement("h1");
         heading.textContent = `-- ${outputFormat}`;
 
         const container = document.createElement("pre");
         container.classList.add("text-representation");
-        container.textContent = await UIHelper.requestDebugText({
+        let textContent = await UIHelper.requestDebugText({
             normalize: true,
             includeRects: false,
             includeURLs: false,
@@ -108,6 +108,13 @@ addEventListener("load", async () => {
             includeTextInAutoFilledControls: true,
             outputFormat,
         });
+
+        if (outputFormat === "json") {
+            // Make sure output JSON is pretty-printed, so that text diffs are easy to read.
+            textContent = JSON.stringify(JSON.parse(textContent), null, "  ");
+        }
+
+        container.textContent = textContent;
         results.push(heading);
         results.push(container);
         results.push(document.createElement("br"));

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -2585,6 +2585,7 @@ window.UIHelper = class UIHelper {
                 if (options.normalize) {
                     debugText = debugText
                         .replace(/uid=\d+/g, "uid=…")
+                        .replace(/"uid":\d+/g, "\"uid\":\"…\"")
                         .replace(/\[\d+,\d+;\d+x\d+\]/g, "[…]")
                         .replace(/\t/g, "    ");
                 }

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.h
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.h
@@ -59,7 +59,8 @@ enum class TextExtractionOptionFlag : uint8_t {
 enum class TextExtractionOutputFormat : uint8_t {
     TextTree,
     HTMLMarkup,
-    Markdown
+    Markdown,
+    MinifiedJSON,
 };
 
 using TextExtractionOptionFlags = OptionSet<TextExtractionOptionFlag>;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -6722,6 +6722,8 @@ static WebKit::TextExtractionOutputFormat textExtractionOutputFormat(_WKTextExtr
         return WebKit::TextExtractionOutputFormat::HTMLMarkup;
     case _WKTextExtractionOutputFormatMarkdown:
         return WebKit::TextExtractionOutputFormat::Markdown;
+    case _WKTextExtractionOutputFormatJSON:
+        return WebKit::TextExtractionOutputFormat::MinifiedJSON;
     default:
         ASSERT_NOT_REACHED();
         return WebKit::TextExtractionOutputFormat::TextTree;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
@@ -50,6 +50,7 @@ typedef NS_ENUM(NSInteger, _WKTextExtractionOutputFormat) {
     _WKTextExtractionOutputFormatTextTree = 0,
     _WKTextExtractionOutputFormatHTML,
     _WKTextExtractionOutputFormatMarkdown,
+    _WKTextExtractionOutputFormatJSON,
 } WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
@@ -382,6 +382,9 @@ RetainPtr<_WKTextExtractionConfiguration> createTextExtractionConfiguration(WKWe
         if (equalLettersIgnoringASCIICase(outputFormat, "texttree"_s))
             return _WKTextExtractionOutputFormatTextTree;
 
+        if (equalLettersIgnoringASCIICase(outputFormat, "json"_s))
+            return _WKTextExtractionOutputFormatJSON;
+
         return std::nullopt;
     }();
     if (outputFormat)


### PR DESCRIPTION
#### b5d818a30aeece178c6fa5d42815d496a0c8328c
<pre>
[AutoFill Debugging] Add support for JSON text extraction output format
<a href="https://bugs.webkit.org/show_bug.cgi?id=304963">https://bugs.webkit.org/show_bug.cgi?id=304963</a>
<a href="https://rdar.apple.com/167571934">rdar://167571934</a>

Reviewed by Abrar Rahman Protyasha.

Add support for minified JSON as a text extraction output format. See below for more details.

* LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-expected.txt:

Augment an existing test to exercise this change. We intentionally parse and pretty-print the JSON
output here, so that any diffs in the layout test will be easier to understand and/or rebaseline.

* LayoutTests/fast/text-extraction/debug-text-extraction-form-controls.html:
* LayoutTests/resources/ui-helper.js:

Adjust `uid` normalization so that `uid`s in test output is consistent when dumping as JSON.

(window.UIHelper.prototype.async requestDebugText):
* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::TextExtractionAggregator::TextExtractionAggregator):
(WebKit::TextExtractionAggregator::~TextExtractionAggregator):
(WebKit::TextExtractionAggregator::takeResults):
(WebKit::TextExtractionAggregator::useJSONOutput const):
(WebKit::TextExtractionAggregator::rootJSONObject):

Add an `m_rootJSONObject` to the aggregator helper class, which represents the root JSON object when
using JSON output format. To ensure that we always produce valid JSON, we build up a JSON object as
we recurse through the tree, rather than building the output text line by line, and after extraction
and filtering are done, stringify the results.

(WebKit::TextExtractionAggregator::addNativeMenuItemsIfNeeded):
(WebKit::TextExtractionAggregator::addVersionNumberIfNeeded):

Rename these to reflect their more general role (since the new JSON output format doesn&apos;t just
append lines to the end).

(WebKit::containerTypeString):
(WebKit::jsonTypeStringForItem):
(WebKit::eventListenerTypesToJSONArray):
(WebKit::setCommonJSONProperties):
(WebKit::addJSONTextContent):
(WebKit::createJSONForChildItem):
(WebKit::populateJSONForItem):

Add helpers to populate JSON data.

(WebKit::addPartsForItem):
(WebKit::convertToText):
(WebKit::TextExtractionAggregator::addLineForNativeMenuItemsIfNeeded): Deleted.
(WebKit::TextExtractionAggregator::addLineForVersionNumberIfNeeded): Deleted.
* Source/WebKit/Shared/TextExtractionToStringConversion.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(textExtractionOutputFormat):
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h:
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm:
(WTR::createTextExtractionConfiguration):

Canonical link: <a href="https://commits.webkit.org/305165@main">https://commits.webkit.org/305165@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f0ea89f2386ba2f153a5d38b23b3ec26c385f00

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137647 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10008 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48935 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145405 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90620 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0ee0f819-cb80-45a3-a202-507d6969b19a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139519 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10711 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10138 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105280 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b92c3f22-d8fd-4807-b45a-8b4ce91d2823) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140592 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7959 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123360 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86136 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/685244e0-3aae-4fce-840d-95821717d281) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7586 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5311 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5988 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116975 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41519 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148174 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9691 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42070 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113666 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9708 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8168 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114007 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28950 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7517 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119599 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64355 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9739 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37648 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9470 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73304 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9679 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9531 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->