### PR TITLE
AX: Refactor six ancestor-finding methods in AXCoreObject from pure virtual, template-based implementations to non-virtual inline member functions.

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -673,7 +673,6 @@ public:
     AutoFillButtonType valueAutofillButtonType() const final;
 
     // ARIA live-region features.
-    AccessibilityObject* liveRegionAncestor(bool excludeIfOff = true) const final { return Accessibility::liveRegionAncestor(*this, excludeIfOff); }
     const String explicitLiveRegionStatus() const override { return String(); }
     const String explicitLiveRegionRelevant() const override { return nullAtom(); }
     bool liveRegionAtomic() const override { return false; }
@@ -799,11 +798,6 @@ public:
     bool hasCursorPointer() const override { return false; }
     bool hasPointerEventsNone() const override { return false; }
     bool showsCursorOnHover() const override { return false; }
-    AccessibilityObject* clickableSelfOrAncestor(ClickHandlerFilter filter = ClickHandlerFilter::ExcludeBody) const final { return Accessibility::clickableSelfOrAncestor(*this, filter); };
-    AccessibilityObject* focusableAncestor() final { return Accessibility::focusableAncestor(*this); }
-    AccessibilityObject* editableAncestor() const final { return Accessibility::editableAncestor(*this); };
-    AccessibilityObject* highestEditableAncestor() final { return Accessibility::highestEditableAncestor(*this); }
-    AccessibilityObject* exposedTableAncestor(bool includeSelf = false) const final { return Accessibility::exposedTableAncestor(*this, includeSelf); }
 
     const AccessibilityScrollView* ancestorAccessibilityScrollView(bool includeSelf) const;
     virtual AccessibilityObject* webAreaObject() const { return nullptr; }

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -1258,12 +1258,6 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
     return nil;
 }
 
-- (AccessibilityObject*)tableParent
-{
-    // Find the parent table for the table cell.
-    return self.axBackingObject->exposedTableAncestor(/* includeSelf */ true);
-}
-
 - (id)accessibilityTitleElement
 {
     if (![self _prepareAccessibilityCall])
@@ -1286,7 +1280,7 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
     if (!tableCell)
         return nil;
 
-    RefPtr table = [self tableParent];
+    RefPtr table = self.axBackingObject->exposedTableAncestor(true);
     if (!table)
         return nil;
 
@@ -1328,7 +1322,7 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
     if (![self _prepareAccessibilityCall])
         return nil;
 
-    RefPtr table = [self tableParent];
+    RefPtr table = self.axBackingObject->exposedTableAncestor(true);
     if (!table)
         return nil;
 
@@ -1341,7 +1335,7 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
     if (![self _prepareAccessibilityCall])
         return 0;
 
-    RefPtr table = [self tableParent];
+    RefPtr table = self.axBackingObject->exposedTableAncestor(true);
     return table ? table->rowCount() : 0;
 }
 
@@ -1350,7 +1344,7 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
     if (![self _prepareAccessibilityCall])
         return 0;
 
-    RefPtr table = [self tableParent];
+    RefPtr table = self.axBackingObject->exposedTableAncestor(true);
     return table ? table->columnCount() : 0;
 }
 
@@ -1359,9 +1353,8 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
     if (![self _prepareAccessibilityCall])
         return 0;
 
-    RefPtr table = [self tableParent];
-    NSInteger rowCount = table ? table->axRowCount() : 0;
-    return rowCount > 0 ? rowCount : 0;
+    RefPtr table = self.axBackingObject->exposedTableAncestor(true);
+    return table ? std::max(table->axRowCount(), 0) : 0;
 }
 
 - (NSUInteger)accessibilityARIAColumnCount
@@ -1369,9 +1362,8 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
     if (![self _prepareAccessibilityCall])
         return 0;
 
-    RefPtr table = [self tableParent];
-    NSInteger colCount = table ? table->axColumnCount() : 0;
-    return colCount > 0 ? colCount : 0;
+    RefPtr table = self.axBackingObject->exposedTableAncestor(true);
+    return table ? std::max(table->axColumnCount(), 0) : 0;
 }
 
 - (NSUInteger)accessibilityARIARowIndex

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -86,8 +86,6 @@ public:
     AXIsolatedObject* parentObject() const final { return parentObjectUnignored(); }
     AXIsolatedObject* parentObjectUnignored() const final { return tree()->objectForID(parent()); }
 #endif // ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
-    AXIsolatedObject* clickableSelfOrAncestor(ClickHandlerFilter filter = ClickHandlerFilter::ExcludeBody) const final { return Accessibility::clickableSelfOrAncestor(*this, filter); };
-    AXIsolatedObject* editableAncestor() const final { return Accessibility::editableAncestor(*this); };
     bool isEditableWebArea() const final { return boolAttributeValue(AXProperty::IsEditableWebArea); }
     bool canSetFocusAttribute() const final { return boolAttributeValue(AXProperty::CanSetFocusAttribute); }
     AttributedStringStyle stylesForAttributedString() const final;
@@ -240,7 +238,6 @@ private:
     bool isOutput() const final { return elementName() == ElementName::HTML_output; }
 
     // Table support.
-    AXIsolatedObject* exposedTableAncestor(bool includeSelf = false) const final { return Accessibility::exposedTableAncestor(*this, includeSelf); }
     AccessibilityChildrenVector columns() final { return tree()->objectsForIDs(vectorAttributeValue<AXID>(AXProperty::Columns)); }
     AccessibilityChildrenVector rows() final { return tree()->objectsForIDs(vectorAttributeValue<AXID>(AXProperty::Rows)); }
     unsigned columnCount() final { return static_cast<unsigned>(columns().size()); }
@@ -407,15 +404,12 @@ private:
     AccessibilityChildrenVector allSortedLiveRegions() const final;
     AccessibilityChildrenVector allSortedNonRootWebAreas() const final;
 #endif
-    AXIsolatedObject* focusableAncestor() final { return Accessibility::focusableAncestor(*this); }
-    AXIsolatedObject* highestEditableAncestor() final { return Accessibility::highestEditableAncestor(*this); }
     std::optional<AccessibilityOrientation> explicitOrientation() const { return optionalAttributeValue<AccessibilityOrientation>(AXProperty::ExplicitOrientation); }
     unsigned ariaLevel() const final { return unsignedAttributeValue(AXProperty::ARIALevel); }
     String language() const final { return stringAttributeValue(AXProperty::Language); }
     void setSelectedChildren(const AccessibilityChildrenVector&) final;
     AccessibilityChildrenVector visibleChildren() final { return tree()->objectsForIDs(vectorAttributeValue<AXID>(AXProperty::VisibleChildren)); }
     void setChildrenIDs(Vector<AXID>&&);
-    AXIsolatedObject* liveRegionAncestor(bool excludeIfOff = true) const final { return Accessibility::liveRegionAncestor(*this, excludeIfOff); }
     const String explicitLiveRegionStatus() const final { return stringAttributeValue(AXProperty::ExplicitLiveRegionStatus); }
     const String explicitLiveRegionRelevant() const final { return stringAttributeValue(AXProperty::ExplicitLiveRegionRelevant); }
     bool liveRegionAtomic() const final { return boolAttributeValue(AXProperty::LiveRegionAtomic); }


### PR DESCRIPTION
#### a1f5e0b127616791f89c55dfce1e2e4f2d9016a5
<pre>
AX: Refactor six ancestor-finding methods in AXCoreObject from pure virtual, template-based implementations to non-virtual inline member functions.
<a href="https://bugs.webkit.org/show_bug.cgi?id=304967">https://bugs.webkit.org/show_bug.cgi?id=304967</a>
&lt;<a href="https://rdar.apple.com/problem/167591275">rdar://problem/167591275</a>&gt;

Reviewed by Tyler Wilcock.

No change in functionality.

This patch refactors six ancestor-finding methods in AXCoreObject from pure virtual, template-based implementations to non-virtual inline member functions. The refactoring improves const-correctness, simplifies the inheritance hierarchy, and eliminates virtual dispatch overhead.

* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::AXCoreObject::editableAncestor const):
(WebCore::AXCoreObject::highestEditableAncestor const):
(WebCore::AXCoreObject::focusableAncestor const):
(WebCore::AXCoreObject::clickableSelfOrAncestor const):
(WebCore::AXCoreObject::liveRegionAncestor const):
(WebCore::AXCoreObject::exposedTableAncestor const):
(WebCore::Accessibility::focusableAncestor): Deleted.
(WebCore::Accessibility::editableAncestor): Deleted.
(WebCore::Accessibility::highestEditableAncestor): Deleted.
(WebCore::Accessibility::liveRegionAncestor): Deleted.
(WebCore::Accessibility::exposedTableAncestor): Deleted.
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper accessibilityHeaderElements]):
(-[WebAccessibilityObjectWrapper accessibilityElementForRow:andColumn:]):
(-[WebAccessibilityObjectWrapper accessibilityRowCount]):
(-[WebAccessibilityObjectWrapper accessibilityColumnCount]):
(-[WebAccessibilityObjectWrapper accessibilityARIARowCount]):
(-[WebAccessibilityObjectWrapper accessibilityARIAColumnCount]):
(-[WebAccessibilityObjectWrapper tableParent]): Deleted.
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
In both derived classes, removed simple forwarding functions to the template implementations. With the base class now providing concrete implementations, these overrides are no longer needed.

Canonical link: <a href="https://commits.webkit.org/305170@main">https://commits.webkit.org/305170@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8e513c97dacbd18676a540249c974eec5d35e09

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137695 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10056 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48983 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145457 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90668 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1dfad0fd-7313-4856-a680-32c402f7123f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139567 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10759 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10186 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105323 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/aee4ef59-56d2-4b01-9f16-bed0d7c7ea1b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140640 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8008 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123410 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86182 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/765f1d59-4ba1-4331-bf60-09e823a105f5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7634 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5357 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6038 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117025 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41567 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148227 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9739 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42118 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113716 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9756 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8214 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114052 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28952 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7564 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119646 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64430 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9787 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37695 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9518 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73352 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9727 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9579 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->