### PR TITLE
Change Apple embedded port naming schemes.

### DIFF
--- a/Tools/Scripts/webkitpy/port/embedded_device.py
+++ b/Tools/Scripts/webkitpy/port/embedded_device.py
@@ -30,12 +30,12 @@ from webkitpy.common.memoized import memoized
 from webkitpy.common.system.crashlogs import CrashLogs
 from webkitpy.port.config import apple_additions
 from webkitpy.port.device import Device
-from webkitpy.port.device_port import DevicePort
+from webkitpy.port.embedded_port import EmbeddedPort
 
 _log = logging.getLogger(__name__)
 
 
-class DeviceDevicePort(DevicePort, metaclass=ABCMeta):
+class EmbeddedDevicePort(EmbeddedPort, metaclass=ABCMeta):
     """Base class for physical device ports (iOS, watchOS, visionOS devices)."""
 
     DEVICE_MANAGER = apple_additions().device_manager() if apple_additions() else None

--- a/Tools/Scripts/webkitpy/port/embedded_port.py
+++ b/Tools/Scripts/webkitpy/port/embedded_port.py
@@ -37,7 +37,7 @@ from webkitpy.xcode.simulated_device import DeviceRequest, SimulatedDeviceManage
 _log = logging.getLogger(__name__)
 
 
-class DevicePort(DarwinPort):
+class EmbeddedPort(DarwinPort):
 
     DEVICE_MANAGER = None
     NO_DEVICE_MANAGER = 'No device manager found for port'
@@ -54,7 +54,7 @@ class DevicePort(DarwinPort):
         ...
 
     def __init__(self, *args, **kwargs):
-        super(DevicePort, self).__init__(*args, **kwargs)
+        super(EmbeddedPort, self).__init__(*args, **kwargs)
         self._test_runner_process_constructor = SimulatorProcess
         self._printing_cmd_line = False
 
@@ -67,7 +67,7 @@ class DevicePort(DarwinPort):
     def driver_cmd_line_for_logging(self):
         # Avoid creating/connecting to devices just for command line logging.
         self._printing_cmd_line = True
-        result = super(DevicePort, self).driver_cmd_line_for_logging()
+        result = super(EmbeddedPort, self).driver_cmd_line_for_logging()
         self._printing_cmd_line = False
         return result
 
@@ -82,7 +82,7 @@ class DevicePort(DarwinPort):
         return int(self.get_option('child_processes'))
 
     def driver_name(self):
-        parent = super(DevicePort, self).driver_name()
+        parent = super(EmbeddedPort, self).driver_name()
         if parent == 'WebKitTestRunner':
             return 'WebKitTestRunnerApp.app'
         return f'{parent}.app'
@@ -153,7 +153,7 @@ class DevicePort(DarwinPort):
     def max_child_processes(self, device_type=None):
         result = self.default_child_processes(device_type=device_type)
         if result and self.is_simulator():
-            return super(DevicePort, self).max_child_processes(device_type=None)
+            return super(EmbeddedPort, self).max_child_processes(device_type=None)
         return result
 
     def supported_device_types(self):
@@ -215,7 +215,7 @@ class DevicePort(DarwinPort):
             self._crash_logs_to_skip_for_host[host] = host.filesystem.files_under(self.path_to_crash_logs())
 
     def clean_up_test_run(self):
-        super(DevicePort, self).clean_up_test_run()
+        super(EmbeddedPort, self).clean_up_test_run()
 
         # Best effort to let every device teardown before throwing any exceptions here.
         # Failure to teardown devices can leave things in a bad state.
@@ -245,12 +245,12 @@ class DevicePort(DarwinPort):
             raise RuntimeError('Multiple failures when teardown devices')
 
     def did_spawn_worker(self, worker_number):
-        super(DevicePort, self).did_spawn_worker(worker_number)
+        super(EmbeddedPort, self).did_spawn_worker(worker_number)
 
         self.target_host(worker_number).release_worker_resources()
 
     def setup_environ_for_server(self, server_name=None):
-        env = super(DevicePort, self).setup_environ_for_server(server_name)
+        env = super(EmbeddedPort, self).setup_environ_for_server(server_name)
         if server_name == self.driver_name() and self.get_option('guard_malloc'):
             self._append_value_colon_separated(env, 'DYLD_INSERT_LIBRARIES', '/usr/lib/libgmalloc.dylib')
             self._append_value_colon_separated(env, '__XPC_DYLD_INSERT_LIBRARIES', '/usr/lib/libgmalloc.dylib')

--- a/Tools/Scripts/webkitpy/port/embedded_simulator.py
+++ b/Tools/Scripts/webkitpy/port/embedded_simulator.py
@@ -25,13 +25,13 @@ import logging
 from webkitcorepy import Version
 
 from webkitpy.common.memoized import memoized
-from webkitpy.port.device_port import DevicePort
+from webkitpy.port.embedded_port import EmbeddedPort
 from webkitpy.xcode.simulated_device import SimulatedDeviceManager
 
 _log = logging.getLogger(__name__)
 
 
-class SimulatorDevicePort(DevicePort):
+class EmbeddedSimulatorPort(EmbeddedPort):
     """Base class for simulator ports (iOS, watchOS, visionOS simulators)."""
 
     DEVICE_MANAGER = SimulatedDeviceManager

--- a/Tools/Scripts/webkitpy/port/ios.py
+++ b/Tools/Scripts/webkitpy/port/ios.py
@@ -26,14 +26,14 @@ from webkitcorepy import Version
 
 from webkitpy.common.version_name_map import VersionNameMap, INTERNAL_TABLE
 from webkitpy.port.config import apple_additions
-from webkitpy.port.device_port import DevicePort
+from webkitpy.port.embedded_port import EmbeddedPort
 from webkitpy.port.simulator_process import SimulatorProcess
 from webkitpy.xcode.device_type import DeviceType
 
 _log = logging.getLogger(__name__)
 
 
-class IOSPort(DevicePort):
+class IOSPort(EmbeddedPort):
     port_name = "ios"
 
     DEVICE_TYPE = DeviceType(software_variant='iOS')

--- a/Tools/Scripts/webkitpy/port/ios_device.py
+++ b/Tools/Scripts/webkitpy/port/ios_device.py
@@ -23,13 +23,13 @@
 import logging
 
 from webkitpy.port.config import apple_additions
-from webkitpy.port.device_device import DeviceDevicePort
+from webkitpy.port.embedded_device import EmbeddedDevicePort
 from webkitpy.port.ios import IOSPort
 
 _log = logging.getLogger(__name__)
 
 
-class IOSDevicePort(DeviceDevicePort, IOSPort):
+class IOSDevicePort(EmbeddedDevicePort, IOSPort):
     port_name = 'ios-device'
 
     ARCHITECTURES = ['armv7', 'armv7s', 'arm64']

--- a/Tools/Scripts/webkitpy/port/ios_simulator.py
+++ b/Tools/Scripts/webkitpy/port/ios_simulator.py
@@ -23,7 +23,7 @@
 import logging
 
 from webkitpy.port.config import apple_additions, Config
-from webkitpy.port.simulator_device import SimulatorDevicePort
+from webkitpy.port.embedded_simulator import EmbeddedSimulatorPort
 from webkitpy.port.ios import IOSPort
 from webkitpy.xcode.device_type import DeviceType
 from webkitpy.xcode.simulated_device import SimulatedDeviceManager
@@ -31,7 +31,7 @@ from webkitpy.xcode.simulated_device import SimulatedDeviceManager
 _log = logging.getLogger(__name__)
 
 
-class IOSSimulatorPort(SimulatorDevicePort, IOSPort):
+class IOSSimulatorPort(EmbeddedSimulatorPort, IOSPort):
     port_name = "ios-simulator"
 
     FUTURE_VERSION = 'future'

--- a/Tools/Scripts/webkitpy/port/visionos.py
+++ b/Tools/Scripts/webkitpy/port/visionos.py
@@ -26,14 +26,14 @@ from webkitcorepy import Version
 
 from webkitpy.common.version_name_map import VersionNameMap, INTERNAL_TABLE
 from webkitpy.port.config import apple_additions
-from webkitpy.port.device_port import DevicePort
+from webkitpy.port.embedded_port import EmbeddedPort
 from webkitpy.xcode.device_type import DeviceType
 
 
 _log = logging.getLogger(__name__)
 
 
-class VisionOSPort(DevicePort):
+class VisionOSPort(EmbeddedPort):
     port_name = 'visionos'
 
     DEVICE_TYPE = DeviceType(software_variant='visionOS')

--- a/Tools/Scripts/webkitpy/port/visionos_device.py
+++ b/Tools/Scripts/webkitpy/port/visionos_device.py
@@ -23,13 +23,13 @@
 import logging
 
 from webkitpy.port.config import apple_additions
-from webkitpy.port.device_device import DeviceDevicePort
+from webkitpy.port.embedded_device import EmbeddedDevicePort
 from webkitpy.port.visionos import VisionOSPort
 
 _log = logging.getLogger(__name__)
 
 
-class VisionOSDevicePort(DeviceDevicePort, VisionOSPort):
+class VisionOSDevicePort(EmbeddedDevicePort, VisionOSPort):
     port_name = 'visionos-device'
 
     ARCHITECTURES = ['arm64e', 'arm64']

--- a/Tools/Scripts/webkitpy/port/visionos_simulator.py
+++ b/Tools/Scripts/webkitpy/port/visionos_simulator.py
@@ -23,14 +23,14 @@
 import logging
 
 from webkitpy.port.config import apple_additions
-from webkitpy.port.simulator_device import SimulatorDevicePort
+from webkitpy.port.embedded_simulator import EmbeddedSimulatorPort
 from webkitpy.port.visionos import VisionOSPort
 from webkitpy.xcode.device_type import DeviceType
 
 _log = logging.getLogger(__name__)
 
 
-class VisionOSSimulatorPort(SimulatorDevicePort, VisionOSPort):
+class VisionOSSimulatorPort(EmbeddedSimulatorPort, VisionOSPort):
     port_name = 'visionos-simulator'
 
     ARCHITECTURES = ['arm64']

--- a/Tools/Scripts/webkitpy/port/watch.py
+++ b/Tools/Scripts/webkitpy/port/watch.py
@@ -26,14 +26,14 @@ from webkitcorepy import Version
 
 from webkitpy.common.version_name_map import VersionNameMap, INTERNAL_TABLE
 from webkitpy.port.config import apple_additions
-from webkitpy.port.device_port import DevicePort
+from webkitpy.port.embedded_port import EmbeddedPort
 from webkitpy.xcode.device_type import DeviceType
 
 
 _log = logging.getLogger(__name__)
 
 
-class WatchPort(DevicePort):
+class WatchPort(EmbeddedPort):
     port_name = 'watchos'
 
     DEVICE_TYPE = DeviceType(software_variant='watchOS')

--- a/Tools/Scripts/webkitpy/port/watch_device.py
+++ b/Tools/Scripts/webkitpy/port/watch_device.py
@@ -23,13 +23,13 @@
 import logging
 
 from webkitpy.port.config import apple_additions
-from webkitpy.port.device_device import DeviceDevicePort
+from webkitpy.port.embedded_device import EmbeddedDevicePort
 from webkitpy.port.watch import WatchPort
 
 _log = logging.getLogger(__name__)
 
 
-class WatchDevicePort(DeviceDevicePort, WatchPort):
+class WatchDevicePort(EmbeddedDevicePort, WatchPort):
     port_name = 'watchos-device'
 
     ARCHITECTURES = ['armv7k', 'arm64e', 'arm64_32']

--- a/Tools/Scripts/webkitpy/port/watch_simulator.py
+++ b/Tools/Scripts/webkitpy/port/watch_simulator.py
@@ -23,14 +23,14 @@
 import logging
 
 from webkitpy.port.config import apple_additions
-from webkitpy.port.simulator_device import SimulatorDevicePort
+from webkitpy.port.embedded_simulator import EmbeddedSimulatorPort
 from webkitpy.port.watch import WatchPort
 from webkitpy.xcode.device_type import DeviceType
 
 _log = logging.getLogger(__name__)
 
 
-class WatchSimulatorPort(SimulatorDevicePort, WatchPort):
+class WatchSimulatorPort(EmbeddedSimulatorPort, WatchPort):
     port_name = 'watchos-simulator'
 
     ARCHITECTURES = ['i386', 'arm64_32']


### PR DESCRIPTION
#### 55536ef0968e79c341e6b9cd24a172312e43e47e
<pre>
Change Apple embedded port naming schemes.
<a href="https://bugs.webkit.org/show_bug.cgi?id=304969">https://bugs.webkit.org/show_bug.cgi?id=304969</a>
<a href="https://rdar.apple.com/167594748">rdar://167594748</a>

Reviewed by Jonathan Bedard.

Changing embedded port names to reduce ambiguity. Also changed class names on
inheritance in child ports (see changed files for full list).

* Tools/Scripts/webkitpy/port/embedded_device.py: Renamed from Tools/Scripts/webkitpy/port/device_device.py.
(EmbeddedDevicePort): Renamed from DeviceDevicePort.
* Tools/Scripts/webkitpy/port/embedded_port.py: Renamed from Tools/Scripts/webkitpy/port/device_port.py.
(EmbeddedPort): Renamed from DevicePort.
* Tools/Scripts/webkitpy/port/embedded_simulator.py: Renamed from Tools/Scripts/webkitpy/port/simulator_device.py.
(EmbeddedSimulatorPort): Renamed from SimulatorDevicePort.

Canonical link: <a href="https://commits.webkit.org/305164@main">https://commits.webkit.org/305164@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0aaa5fa2370e2d6eea3ca92e52fd7cb43b0a4a77

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137644 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10005 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48932 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145402 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90617 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/68b55330-5526-4982-8611-4032262f23b3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139516 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10708 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10135 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105276 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a50fdcc9-6777-4547-901c-bed58f213f90) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140589 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7956 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123359 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86133 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ff752966-22d4-4a77-b6a1-bd64ca054b93) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/136992 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7583 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5308 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5985 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116972 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41518 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148173 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9688 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42069 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113665 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9705 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8165 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114006 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28949 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7514 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119598 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64352 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9736 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37647 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9467 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9676 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9528 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->