### PR TITLE
[YARR] Look up character class table in interpreter

### DIFF
--- a/JSTests/microbenchmarks/yarr-interpreter-table-lookup.js
+++ b/JSTests/microbenchmarks/yarr-interpreter-table-lookup.js
@@ -1,0 +1,51 @@
+const testStrings = [
+    "a", "Z", "5", "_",  // word chars
+    "!", " ", "@", "#",  // non-word chars
+    " ", "\t", "\n",     // spaces
+    "x", "Y", "0"        // non-spaces
+];
+
+function benchWordChar() {
+    const reg = /\w/;
+    for (let i = 0; i < 1e5; i++) {
+        for (let j = 0; j < testStrings.length; j++) {
+            reg.test(testStrings[j]);
+        }
+    }
+}
+noInline(benchWordChar);
+
+function benchNonWordChar() {
+    const reg = /\W/;
+    for (let i = 0; i < 1e5; i++) {
+        for (let j = 0; j < testStrings.length; j++) {
+            reg.test(testStrings[j]);
+        }
+    }
+}
+noInline(benchNonWordChar);
+
+function benchSpaces() {
+    const reg = /\s/;
+    for (let i = 0; i < 1e5; i++) {
+        for (let j = 0; j < testStrings.length; j++) {
+            reg.test(testStrings[j]);
+        }
+    }
+}
+noInline(benchSpaces);
+
+function benchNonSpaces() {
+    const reg = /\S/;
+    for (let i = 0; i < 1e5; i++) {
+        for (let j = 0; j < testStrings.length; j++) {
+            reg.test(testStrings[j]);
+        }
+    }
+}
+noInline(benchNonSpaces);
+
+benchWordChar();
+benchNonWordChar();
+benchSpaces();
+benchNonSpaces();

--- a/JSTests/stress/yarr-interpreter-table-lookup.js
+++ b/JSTests/stress/yarr-interpreter-table-lookup.js
@@ -1,0 +1,118 @@
+//@ runDefault("--useRegExpJIT=0")
+
+const testStrings = [
+    "a", "Z", "5", "_",  // word chars
+    "!", " ", "@", "#",  // non-word chars
+    " ", "\t", "\n",     // spaces
+    "x", "Y", "0"        // non-spaces
+];
+
+function testWordChar() {
+    const reg = /\w/;
+    for (let j = 0; j < testStrings.length; j++) {
+        const expected = /[a-zA-Z0-9_]/.test(testStrings[j]);
+        if (reg.test(testStrings[j]) !== expected)
+            throw new Error(`\\w failed for "${testStrings[j]}"`);
+    }
+}
+
+function testNonWordChar() {
+    const reg = /\W/;
+    for (let j = 0; j < testStrings.length; j++) {
+        const expected = !/[a-zA-Z0-9_]/.test(testStrings[j]);
+        if (reg.test(testStrings[j]) !== expected)
+            throw new Error(`\\W failed for "${testStrings[j]}"`);
+    }
+}
+
+function testSpaces() {
+    const reg = /\s/;
+    for (let j = 0; j < testStrings.length; j++) {
+        const expected = /[ \t\n\r\f\v]/.test(testStrings[j]);
+        if (reg.test(testStrings[j]) !== expected)
+            throw new Error(`\\s failed for "${testStrings[j]}"`);
+    }
+}
+
+function testNonSpaces() {
+    const reg = /\S/;
+    for (let j = 0; j < testStrings.length; j++) {
+        const expected = !/[ \t\n\r\f\v]/.test(testStrings[j]);
+        if (reg.test(testStrings[j]) !== expected)
+            throw new Error(`\\S failed for "${testStrings[j]}"`);
+    }
+}
+
+function testDigit() {
+    const reg = /\d/;
+    for (let j = 0; j < testStrings.length; j++) {
+        const expected = /[0-9]/.test(testStrings[j]);
+        if (reg.test(testStrings[j]) !== expected)
+            throw new Error(`\\d failed for "${testStrings[j]}"`);
+    }
+}
+
+function testNonDigit() {
+    const reg = /\D/;
+    for (let j = 0; j < testStrings.length; j++) {
+        const expected = !/[0-9]/.test(testStrings[j]);
+        if (reg.test(testStrings[j]) !== expected)
+            throw new Error(`\\D failed for "${testStrings[j]}"`);
+    }
+}
+
+// Test table boundary (tableSize = 65536)
+function testTableBoundary() {
+    // U+FFFF (65535) - last character in table range
+    const charAtBoundary = String.fromCharCode(0xFFFF);
+    // U+10000 (65536) - first character outside table range (surrogate pair)
+    const charOutsideBoundary = String.fromCodePoint(0x10000);
+
+    // \w should not match these
+    if (/\w/.test(charAtBoundary))
+        throw new Error("\\w should not match U+FFFF");
+    if (/\w/.test(charOutsideBoundary))
+        throw new Error("\\w should not match U+10000");
+
+    // \W should match these
+    if (!/\W/.test(charAtBoundary))
+        throw new Error("\\W should match U+FFFF");
+    if (!/\W/.test(charOutsideBoundary))
+        throw new Error("\\W should match U+10000");
+}
+
+// Test Unicode whitespace characters within table range
+function testUnicodeSpaces() {
+    const unicodeSpaces = [
+        "\u00A0",  // NO-BREAK SPACE
+        "\u1680",  // OGHAM SPACE MARK
+        "\u2000",  // EN QUAD
+        "\u2001",  // EM QUAD
+        "\u2002",  // EN SPACE
+        "\u2003",  // EM SPACE
+        "\u2028",  // LINE SEPARATOR
+        "\u2029",  // PARAGRAPH SEPARATOR
+        "\u202F",  // NARROW NO-BREAK SPACE
+        "\u205F",  // MEDIUM MATHEMATICAL SPACE
+        "\u3000",  // IDEOGRAPHIC SPACE
+        "\uFEFF",  // ZERO WIDTH NO-BREAK SPACE
+    ];
+
+    for (const sp of unicodeSpaces) {
+        if (!/\s/.test(sp))
+            throw new Error("\\s should match U+" + sp.charCodeAt(0).toString(16).toUpperCase());
+        if (/\S/.test(sp))
+            throw new Error("\\S should not match U+" + sp.charCodeAt(0).toString(16).toUpperCase());
+    }
+}
+
+for (let i = 0; i < 1e4; i++) {
+    testWordChar();
+    testNonWordChar();
+    testSpaces();
+    testNonSpaces();
+    testDigit();
+    testNonDigit();
+    testTableBoundary();
+    testUnicodeSpaces();
+}

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
@@ -547,6 +547,9 @@ public:
         if (characterClass->m_anyCharacter)
             return true;
 
+        if (characterClass->m_table && ch < CharacterClass::tableSize)
+            return static_cast<bool>(characterClass->m_table[ch]);
+
         const size_t thresholdForBinarySearch = 6;
 
         if (!isASCII(ch)) {

--- a/Source/JavaScriptCore/yarr/YarrPattern.h
+++ b/Source/JavaScriptCore/yarr/YarrPattern.h
@@ -86,6 +86,7 @@ struct CharacterClass {
     WTF_MAKE_TZONE_ALLOCATED(CharacterClass);
 public:
     using Table = const char*;
+    static constexpr unsigned tableSize = 65536;
 
     // All CharacterClass instances have to have the full set of matches and ranges,
     // they may have an optional m_table for faster lookups (which must match the

--- a/Source/JavaScriptCore/yarr/create_regex_tables
+++ b/Source/JavaScriptCore/yarr/create_regex_tables
@@ -63,7 +63,8 @@ for name, classes in types.items():
     ranges.sort();
     
     if emitTables and classes["UseTable"] and (not "Inverse" in classes):
-        array = ("static constinit const char _%sData[65536] = {\n" % name);
+        array = ("static constinit const char _%sData[CharacterClass::tableSize] = {\n" % name);
+        tableSize = 65536
         i = 0
         for (min,max) in ranges:
             while i < min:
@@ -73,7 +74,7 @@ for name, classes in types.items():
                     array += ('\n')
             while i <= max:
                 i = i + 1
-                if (i == 65536):
+                if (i == tableSize):
                     array += ("1")
                 else:
                     array += ('1,')
@@ -134,4 +135,3 @@ if (len(sys.argv) > 1):
 else:
     print(arrays)
     print(functions)
-


### PR DESCRIPTION
#### 75ec398201d556dc3fbb05682471335c94f8dd4f
<pre>
[YARR] Look up character class table in interpreter
<a href="https://bugs.webkit.org/show_bug.cgi?id=304970">https://bugs.webkit.org/show_bug.cgi?id=304970</a>

Reviewed by Yusuke Suzuki.

This patch changes to look up character class table in Yarr interpreter as well as Yarr JIT.

The following bench results was measured with `useRegExpJIT=0`:

                                       TipOfTree                  Patched

yarr-interpreter-table-lookup      112.9213+-1.0854     ^    105.3390+-4.3467        ^ definitely 1.0720x faster

Test: JSTests/microbenchmarks/yarr-interpreter-table-lookup.js

* JSTests/microbenchmarks/yarr-interpreter-table-lookup.js: Added.
(benchWordChar):
(benchNonWordChar):
(benchSpaces):
(benchNonSpaces):
* JSTests/stress/yarr-interpreter-table-lookup.js: Added.
(testWordChar):
(testNonWordChar):
(testSpaces):
(testNonSpaces):
(testDigit):
(testNonDigit):
(testTableBoundary):
(testUnicodeSpaces):
* Source/JavaScriptCore/yarr/YarrInterpreter.cpp:
(JSC::Yarr::Interpreter::testCharacterClass):
* Source/JavaScriptCore/yarr/YarrPattern.h:
* Source/JavaScriptCore/yarr/create_regex_tables:

Canonical link: <a href="https://commits.webkit.org/305411@main">https://commits.webkit.org/305411@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/efbb43de951e7d2cc0d4ffbf81c1446aa00fab7f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138324 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10689 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49734 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146406 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91299 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11393 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10843 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105835 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77185 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141271 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8541 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124001 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86672 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8128 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5895 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6693 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/130288 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117545 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42202 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149117 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/136926 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10371 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42759 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114229 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10388 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8767 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114572 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29096 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8105 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120289 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65194 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10418 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38222 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/169597 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10151 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74007 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44206 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10358 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10209 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->