### PR TITLE
Stop relying on the `isLastInSelectorList` flag in CSSSelectorList's const_iterator

### DIFF
--- a/Source/WebCore/css/CSSSelectorList.h
+++ b/Source/WebCore/css/CSSSelectorList.h
@@ -88,7 +88,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
             // Skip subparts of compound selectors.
             while (!m_ptr->isFirstInComplexSelector())
                 ++m_ptr;
-            m_ptr = m_ptr->isLastInSelectorList() ? nullptr : m_ptr + 1;
+            ++m_ptr;
             return *this;
         }
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
@@ -103,8 +103,8 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     private:
         pointer m_ptr = nullptr;
     };
-    const_iterator begin() const LIFETIME_BOUND { return { first() }; };
-    const_iterator end() const LIFETIME_BOUND { return { }; }
+    const_iterator begin() const LIFETIME_BOUND { return { m_selectorArray.begin() }; };
+    const_iterator end() const LIFETIME_BOUND { return { m_selectorArray.end() }; }
 
     bool hasExplicitNestingParent() const;
     bool hasOnlyNestingSelector() const;


### PR DESCRIPTION
#### 9ec630888d868706b9c2bcad21370efe0aa294b9
<pre>
Stop relying on the `isLastInSelectorList` flag in CSSSelectorList&apos;s const_iterator
<a href="https://bugs.webkit.org/show_bug.cgi?id=304971">https://bugs.webkit.org/show_bug.cgi?id=304971</a>

Reviewed by Darin Adler and Sam Weinig.

Stop relying on the `isLastInSelectorList` flag in CSSSelectorList&apos;s
const_iterator. This is in preparation for removing the `isLastInSelectorList`
flag now that the CSSSelectors are stored in a FixedVector.

* Source/WebCore/css/CSSSelectorList.h:
(WebCore::CSSSelectorList::const_iterator::operator++):

Canonical link: <a href="https://commits.webkit.org/305184@main">https://commits.webkit.org/305184@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ae7eec72c7cb4b3048600c9fd1d6730471eebbf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137648 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10009 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48936 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145406 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90621 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139520 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10712 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10139 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105281 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5eac7688-5f15-45c4-ae6c-43780b23bdd4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140593 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7960 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123361 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86137 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/47b0fa26-4fe6-47c6-869e-8fe7a214d9f7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7587 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5312 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5989 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116976 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41520 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148175 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9692 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42071 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113667 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9709 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8169 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114008 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28963 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7518 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119600 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64356 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9740 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37649 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9471 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73305 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9680 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9532 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->