### PR TITLE
Set containing block of grid-lanes items to container size in the stacking axis

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1709,7 +1709,6 @@ imported/w3c/web-platform-tests/css/css-grid/subgrid/standalone-axis-size-005.ht
 imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-button.html [ ImageOnlyFailure ]
 
 # grid-lanes
-imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/abspos/row-grid-lanes-positioned-item-dynamic-change.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/alignment/column-justify-items-center-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/alignment/grid-lanes-align-content-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/alignment/grid-lanes-align-content-002.html [ ImageOnlyFailure ]
@@ -1725,7 +1724,6 @@ imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/fragmentation/
 imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/fragmentation/grid-lanes-fragmentation-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/grid-placement/column-explicit-placement-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/grid-placement/grid-lanes-grid-placement-named-lines-002.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/grid-placement/row-explicit-placement-008.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/column-reverse-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/column-reverse-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/column-reverse-003.html [ ImageOnlyFailure ]
@@ -1770,9 +1768,6 @@ imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/items/column-i
 imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/items/column-item-percentage-sizes-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/items/column-item-percentage-sizes-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/items/row-item-minmax-img-002.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/items/row-item-percentage-sizes-001.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/items/row-item-percentage-sizes-002.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/items/row-item-percentage-sizes-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid-flex-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid-flex-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid-intrinsic-sizing.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/abspos/column-grid-lanes-positioned-item-dynamic-change.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/abspos/column-grid-lanes-positioned-item-dynamic-change.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html class="reftest-wait">
 <head>
   <meta charset="utf-8">
   <title>CSS Grid Lanes Layout Test: Grid Lanes positioned item dynamic change.</title>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/grid-lanes-track-sizing-check-grid-height-on-resize.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/grid-lanes-track-sizing-check-grid-height-on-resize.html
@@ -36,7 +36,6 @@
     var gridItem = document.querySelector('item');
     gridItem.style.height = '125px';
     gridItem.style.width = '300px';
-    document
     document.documentElement.className = '';
 </script>
 </html>

--- a/Source/WebCore/rendering/GridMasonryLayout.h
+++ b/Source/WebCore/rendering/GridMasonryLayout.h
@@ -63,7 +63,7 @@ private:
     GridArea gridAreaForDefiniteGridAxisItem(const RenderBox&) const;
 
     void placeMasonryItems(const GridTrackSizingAlgorithm&, GridMasonryLayout::MasonryLayoutPhase);
-    void setItemGridAxisContainingBlockToGridArea(const GridTrackSizingAlgorithm&, RenderBox&);
+    void setItemContainingBlockToGridArea(const GridTrackSizingAlgorithm&, RenderBox&);
     void insertIntoGridAndLayoutItem(const GridTrackSizingAlgorithm&, RenderBox&, const GridArea&, GridMasonryLayout::MasonryLayoutPhase);
     LayoutUnit calculateMasonryIntrinsicLogicalWidth(RenderBox&, GridMasonryLayout::MasonryLayoutPhase);
 

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -167,6 +167,9 @@ private:
     friend class GridMasonryLayout;
     friend class PositionedLayoutConstraints;
 
+    inline void updateGridAreaWithEstimate(RenderBox& gridItem, const GridTrackSizingAlgorithm&) const;
+    inline void updateGridAreaIncludingAlignment(RenderBox& gridItem) const;
+
     void computeLayoutRequirementsForItemsBeforeLayout(GridLayoutState&) const;
     bool canSetColumnAxisStretchRequirementForItem(const RenderBox&) const;
 


### PR DESCRIPTION
#### 3bdeec83c5f5bcda23a2844946913b3d45f14641
<pre>
Set containing block of grid-lanes items to container size in the stacking axis
<a href="https://bugs.webkit.org/show_bug.cgi?id=304715">https://bugs.webkit.org/show_bug.cgi?id=304715</a>
<a href="https://rdar.apple.com/167221488">rdar://167221488</a>

Reviewed by Brandon Stewart.

Because grid items have a grid area in both axes, there are many places in the
grid code where we set its containing block to a grid area in both axes.
However the containing block of a grid-lanes item in the stacking axis is its
grid container, not a grid area. Trying to use a grid area results in
nonsensical item sizes in cases where the item size depends on the container
(e.g. fit-content, percentages).

This patch factors out the places where we try to set the item&apos;s containing
block and ensures we set it correctly in the stacking axis for grid-lanes items.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/abspos/column-grid-lanes-positioned-item-dynamic-change.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/grid-lanes-track-sizing-check-grid-height-on-resize.html:
* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/rendering/GridMasonryLayout.cpp:
(WebCore::GridMasonryLayout::setItemContainingBlockToGridArea):
(WebCore::GridMasonryLayout::insertIntoGridAndLayoutItem):
(WebCore::GridMasonryLayout::setItemGridAxisContainingBlockToGridArea): Deleted.
* Source/WebCore/rendering/GridMasonryLayout.h:
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::selfAlignmentForGridItem const):
(WebCore::RenderGrid::performPreLayoutForGridItems const):
(WebCore::RenderGrid::updateGridAreaWithEstimate const):
(WebCore::RenderGrid::updateGridAreaIncludingAlignment const):
(WebCore::RenderGrid::updateGridAreaForAspectRatioItems):
(WebCore::RenderGrid::layoutGridItems):
(WebCore::RenderGrid::layoutMasonryItems):
(WebCore::RenderGrid::gridAreaBreadthForGridItemIncludingAlignmentOffsets const):
* Source/WebCore/rendering/RenderGrid.h:

Canonical link: <a href="https://commits.webkit.org/305319@main">https://commits.webkit.org/305319@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d38ac88c2cc1392d775045f5e9af93ab58e8330

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138053 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10418 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49455 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146125 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91028 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3cc29ec6-0ca6-464d-adcf-b7e2c0d72552) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139926 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11120 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10569 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105578 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/77038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d7ec0b92-2028-416a-9892-312524568f6c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140999 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8302 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123772 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86427 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/308078ce-db9d-4925-aaf8-12261532bfe5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7915 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5674 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6406 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117313 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41964 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148835 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10100 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42521 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113980 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10117 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8531 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114315 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29057 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7850 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120051 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64824 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10146 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38009 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9877 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73714 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10087 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9938 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->