### PR TITLE
Change Vector<RefPtr<TrackBase>> to a Vector of Ref, take 2

### DIFF
--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -774,13 +774,21 @@ public:
         removeLast();
         return result;
     }
-    
+
     bool contains(const auto&) const;
     bool containsIf(NOESCAPE const Invocable<bool(const T&)> auto&) const;
     size_t find(const auto&) const;
     size_t findIf(NOESCAPE const Invocable<bool(const T&)> auto&) const;
     size_t reverseFind(const auto&) const;
     size_t reverseFindIf(NOESCAPE const Invocable<bool(const T&)> auto&) const;
+
+    // Overloads for smart pointer element types that take raw pointer parameters.
+    template<SmartPtr U = T, typename V> requires std::same_as<U, T> && std::derived_from<V, typename GetPtrHelper<U>::UnderlyingType>
+    bool contains(V*) const;
+    template<SmartPtr U = T, typename V> requires std::same_as<U, T> && std::derived_from<V, typename GetPtrHelper<U>::UnderlyingType>
+    size_t find(V*) const;
+    template<SmartPtr U = T, typename V> requires std::same_as<U, T> && std::derived_from<V, typename GetPtrHelper<U>::UnderlyingType>
+    size_t reverseFind(V*) const;
 
     bool appendIfNotContains(const auto&);
 
@@ -1105,6 +1113,31 @@ bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::appendIfNo
         return false;
     append(value);
     return true;
+}
+
+template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
+template<SmartPtr U, typename V> requires std::same_as<U, T> && std::derived_from<V, typename GetPtrHelper<U>::UnderlyingType>
+bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::contains(V* ptr) const
+{
+    return find(ptr) != notFound;
+}
+
+template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
+template<SmartPtr U, typename V> requires std::same_as<U, T> && std::derived_from<V, typename GetPtrHelper<U>::UnderlyingType>
+size_t Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::find(V* ptr) const
+{
+    return findIf([&](auto& item) {
+        return GetPtrHelper<U>::getPtr(item) == ptr;
+    });
+}
+
+template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
+template<SmartPtr U, typename V> requires std::same_as<U, T> && std::derived_from<V, typename GetPtrHelper<U>::UnderlyingType>
+size_t Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::reverseFind(V* ptr) const
+{
+    return reverseFindIf([&](auto& item) {
+        return GetPtrHelper<U>::getPtr(item) == ptr;
+    });
 }
 
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>

--- a/Source/WebCore/html/track/AudioTrackList.cpp
+++ b/Source/WebCore/html/track/AudioTrackList.cpp
@@ -47,11 +47,11 @@ void AudioTrackList::append(Ref<AudioTrack>&& track)
     size_t index = track->inbandTrackIndex();
     size_t insertionIndex;
     for (insertionIndex = 0; insertionIndex < m_inbandTracks.size(); ++insertionIndex) {
-        Ref otherTrack = downcast<AudioTrack>(*m_inbandTracks[insertionIndex]);
+        Ref otherTrack = downcast<AudioTrack>(m_inbandTracks[insertionIndex]);
         if (otherTrack->inbandTrackIndex() > index)
             break;
     }
-    m_inbandTracks.insert(insertionIndex, track.ptr());
+    m_inbandTracks.insert(insertionIndex, track.copyRef());
 
     if (!track->trackList())
         track->setTrackList(*this);
@@ -71,15 +71,15 @@ void AudioTrackList::remove(TrackBase& track, bool scheduleEvent)
 AudioTrack* AudioTrackList::item(unsigned index) const
 {
     if (index < m_inbandTracks.size())
-        return downcast<AudioTrack>(m_inbandTracks[index].get());
+        return downcast<AudioTrack>(m_inbandTracks[index].ptr());
     return nullptr;
 }
 
 AudioTrack* AudioTrackList::firstEnabled() const
 {
     for (auto& item : m_inbandTracks) {
-        if (item && item->enabled())
-            return downcast<AudioTrack>(item.get());
+        if (item->enabled())
+            return downcast<AudioTrack>(item.ptr());
     }
     return nullptr;
 }
@@ -87,7 +87,7 @@ AudioTrack* AudioTrackList::firstEnabled() const
 RefPtr<AudioTrack> AudioTrackList::getTrackById(const AtomString& id) const
 {
     for (auto& inbandTrack : m_inbandTracks) {
-        Ref track = downcast<AudioTrack>(*inbandTrack);
+        Ref track = downcast<AudioTrack>(inbandTrack);
         if (track->id() == id)
             return track;
     }
@@ -97,7 +97,7 @@ RefPtr<AudioTrack> AudioTrackList::getTrackById(const AtomString& id) const
 RefPtr<AudioTrack> AudioTrackList::getTrackById(TrackID id) const
 {
     for (auto& inbandTrack : m_inbandTracks) {
-        Ref track = downcast<AudioTrack>(*inbandTrack);
+        Ref track = downcast<AudioTrack>(inbandTrack);
         if (track->trackId() == id)
             return track;
     }

--- a/Source/WebCore/html/track/TextTrackList.cpp
+++ b/Source/WebCore/html/track/TextTrackList.cpp
@@ -73,25 +73,25 @@ int TextTrackList::getTrackIndexRelativeToRenderedTracks(TextTrack& textTrack)
     int trackIndex = 0;
 
     for (auto& elementTrack : m_elementTracks) {
-        if (!downcast<TextTrack>(*elementTrack).isRendered())
+        if (!downcast<TextTrack>(elementTrack.get()).isRendered())
             continue;
-        if (elementTrack == &textTrack)
+        if (elementTrack.ptr() == &textTrack)
             return trackIndex;
         ++trackIndex;
     }
 
     for (auto& addTrack : m_addTrackTracks) {
-        if (!downcast<TextTrack>(*addTrack).isRendered())
+        if (!downcast<TextTrack>(addTrack.get()).isRendered())
             continue;
-        if (addTrack == &textTrack)
+        if (addTrack.ptr() == &textTrack)
             return trackIndex;
         ++trackIndex;
     }
 
     for (auto& inbandTrack : m_inbandTracks) {
-        if (!downcast<TextTrack>(*inbandTrack).isRendered())
+        if (!downcast<TextTrack>(inbandTrack.get()).isRendered())
             continue;
-        if (inbandTrack == &textTrack)
+        if (inbandTrack.ptr() == &textTrack)
             return trackIndex;
         ++trackIndex;
     }
@@ -109,15 +109,15 @@ TextTrack* TextTrackList::item(unsigned index) const
     // resource), in the order defined by the media resource's format specification.
 
     if (index < m_elementTracks.size())
-        return downcast<TextTrack>(m_elementTracks[index].get());
+        return downcast<TextTrack>(m_elementTracks[index].ptr());
 
     index -= m_elementTracks.size();
     if (index < m_addTrackTracks.size())
-        return downcast<TextTrack>(m_addTrackTracks[index].get());
+        return downcast<TextTrack>(m_addTrackTracks[index].ptr());
 
     index -= m_addTrackTracks.size();
     if (index < m_inbandTracks.size())
-        return downcast<TextTrack>(m_inbandTracks[index].get());
+        return downcast<TextTrack>(m_inbandTracks[index].ptr());
 
     return nullptr;
 }
@@ -150,20 +150,20 @@ RefPtr<TextTrack> TextTrackList::getTrackById(TrackID id) const
 
 void TextTrackList::invalidateTrackIndexesAfterTrack(TextTrack& track)
 {
-    Vector<RefPtr<TrackBase>>* tracks = nullptr;
+    Vector<Ref<TrackBase>>* tracks = nullptr;
 
     switch (track.trackType()) {
     case TextTrack::TrackElement:
         tracks = &m_elementTracks;
         for (auto& addTrack : m_addTrackTracks)
-            downcast<TextTrack>(addTrack.get())->invalidateTrackIndex();
+            downcast<TextTrack>(addTrack.get()).invalidateTrackIndex();
         for (auto& inbandTrack : m_inbandTracks)
-            downcast<TextTrack>(inbandTrack.get())->invalidateTrackIndex();
+            downcast<TextTrack>(inbandTrack.get()).invalidateTrackIndex();
         break;
     case TextTrack::AddTrack:
         tracks = &m_addTrackTracks;
         for (auto& inbandTrack : m_inbandTracks)
-            downcast<TextTrack>(inbandTrack.get())->invalidateTrackIndex();
+            downcast<TextTrack>(inbandTrack.get()).invalidateTrackIndex();
         break;
     case TextTrack::InBand:
         tracks = &m_inbandTracks;
@@ -177,21 +177,21 @@ void TextTrackList::invalidateTrackIndexesAfterTrack(TextTrack& track)
         return;
 
     for (size_t i = index; i < tracks->size(); ++i)
-        downcast<TextTrack>(*tracks->at(index)).invalidateTrackIndex();
+        downcast<TextTrack>(tracks->at(index).get()).invalidateTrackIndex();
 }
 
 void TextTrackList::append(Ref<TextTrack>&& track)
 {
     if (track->trackType() == TextTrack::AddTrack)
-        m_addTrackTracks.append(track.ptr());
+        m_addTrackTracks.append(track.copyRef());
     else if (auto* textTrack = dynamicDowncast<LoadableTextTrack>(track.get())) {
         // Insert tracks added for <track> element in tree order.
         size_t index = textTrack->trackElementIndex();
-        m_elementTracks.insert(index, track.ptr());
+        m_elementTracks.insert(index, track.copyRef());
     } else if (track->trackType() == TextTrack::InBand) {
         // Insert tracks added for in-band in the media file order.
         size_t index = downcast<InbandTextTrack>(track.get()).inbandTrackIndex();
-        m_inbandTracks.insert(index, track.ptr());
+        m_inbandTracks.insert(index, track.copyRef());
     } else
         ASSERT_NOT_REACHED();
 
@@ -206,7 +206,7 @@ void TextTrackList::append(Ref<TextTrack>&& track)
 void TextTrackList::remove(TrackBase& track, bool scheduleEvent)
 {
     auto& textTrack = downcast<TextTrack>(track);
-    Vector<RefPtr<TrackBase>>* tracks = nullptr;
+    Vector<Ref<TrackBase>>* tracks = nullptr;
     switch (textTrack.trackType()) {
     case TextTrack::TrackElement:
         tracks = &m_elementTracks;
@@ -230,7 +230,7 @@ void TextTrackList::remove(TrackBase& track, bool scheduleEvent)
     if (track.trackList() == this)
         track.clearTrackList();
 
-    Ref<TrackBase> trackRef = *(*tracks)[index];
+    Ref trackRef = (*tracks)[index];
     tracks->removeAt(index);
 
     if (scheduleEvent)
@@ -239,7 +239,7 @@ void TextTrackList::remove(TrackBase& track, bool scheduleEvent)
 
 bool TextTrackList::contains(TrackBase& track) const
 {
-    const Vector<RefPtr<TrackBase>>* tracks = nullptr;
+    const Vector<Ref<TrackBase>>* tracks = nullptr;
     switch (downcast<TextTrack>(track).trackType()) {
     case TextTrack::TrackElement:
         tracks = &m_elementTracks;
@@ -253,8 +253,8 @@ bool TextTrackList::contains(TrackBase& track) const
     default:
         ASSERT_NOT_REACHED();
     }
-    
-    return tracks->find(&track) != notFound;
+
+    return tracks->contains(&track);
 }
 
 enum EventTargetInterfaceType TextTrackList::eventTargetInterface() const

--- a/Source/WebCore/html/track/TextTrackList.h
+++ b/Source/WebCore/html/track/TextTrackList.h
@@ -71,8 +71,8 @@ private:
 
     void invalidateTrackIndexesAfterTrack(TextTrack&);
 
-    Vector<RefPtr<TrackBase>> m_addTrackTracks;
-    Vector<RefPtr<TrackBase>> m_elementTracks;
+    Vector<Ref<TrackBase>> m_addTrackTracks;
+    Vector<Ref<TrackBase>> m_elementTracks;
     MediaTime m_duration;
 };
 

--- a/Source/WebCore/html/track/TrackListBase.cpp
+++ b/Source/WebCore/html/track/TrackListBase.cpp
@@ -54,7 +54,7 @@ ScriptExecutionContext* TrackListBase::scriptExecutionContext() const
 void TrackListBase::didMoveToNewDocument(Document& newDocument)
 {
     ActiveDOMObject::didMoveToNewDocument(newDocument);
-    for (RefPtr track : m_inbandTracks)
+    for (Ref track : m_inbandTracks)
         track->didMoveToNewDocument(newDocument);
 }
 
@@ -78,7 +78,7 @@ RefPtr<TrackBase> TrackListBase::find(TrackID trackID) const
     });
     if (index == notFound)
         return nullptr;
-    return m_inbandTracks[index];
+    return m_inbandTracks[index].copyRef();
 }
 
 void TrackListBase::remove(TrackID trackID, bool scheduleEvent)
@@ -96,7 +96,7 @@ void TrackListBase::remove(TrackBase& track, bool scheduleEvent)
     if (track.trackList() == this)
         track.clearTrackList();
 
-    Ref<TrackBase> trackRef = *m_inbandTracks[index];
+    Ref trackRef = m_inbandTracks[index];
 
     m_inbandTracks.removeAt(index);
 
@@ -106,7 +106,7 @@ void TrackListBase::remove(TrackBase& track, bool scheduleEvent)
 
 bool TrackListBase::contains(TrackBase& track) const
 {
-    return m_inbandTracks.find(&track) != notFound;
+    return m_inbandTracks.contains(&track);
 }
 
 bool TrackListBase::contains(TrackID trackID) const

--- a/Source/WebCore/html/track/TrackListBase.h
+++ b/Source/WebCore/html/track/TrackListBase.h
@@ -80,7 +80,7 @@ protected:
     void scheduleAddTrackEvent(Ref<TrackBase>&&);
     void scheduleRemoveTrackEvent(Ref<TrackBase>&&);
 
-    Vector<RefPtr<TrackBase>> m_inbandTracks;
+    Vector<Ref<TrackBase>> m_inbandTracks;
 
 private:
     void scheduleTrackEvent(const AtomString& eventName, Ref<TrackBase>&&);

--- a/Source/WebCore/html/track/VideoTrackList.cpp
+++ b/Source/WebCore/html/track/VideoTrackList.cpp
@@ -48,11 +48,11 @@ void VideoTrackList::append(Ref<VideoTrack>&& track)
     size_t index = track->inbandTrackIndex();
     size_t insertionIndex;
     for (insertionIndex = 0; insertionIndex < m_inbandTracks.size(); ++insertionIndex) {
-        Ref otherTrack = downcast<VideoTrack>(*m_inbandTracks[insertionIndex]);
+        Ref otherTrack = downcast<VideoTrack>(m_inbandTracks[insertionIndex]);
         if (otherTrack->inbandTrackIndex() > index)
             break;
     }
-    m_inbandTracks.insert(insertionIndex, track.ptr());
+    m_inbandTracks.insert(insertionIndex, track.copyRef());
 
     if (!track->trackList())
         track->setTrackList(*this);
@@ -63,14 +63,14 @@ void VideoTrackList::append(Ref<VideoTrack>&& track)
 VideoTrack* VideoTrackList::item(unsigned index) const
 {
     if (index < m_inbandTracks.size())
-        return downcast<VideoTrack>(m_inbandTracks[index].get());
+        return downcast<VideoTrack>(m_inbandTracks[index].ptr());
     return nullptr;
 }
 
 RefPtr<VideoTrack> VideoTrackList::getTrackById(const AtomString& id) const
 {
-    for (auto& inbandTracks : m_inbandTracks) {
-        Ref track = downcast<VideoTrack>(*inbandTracks);
+    for (auto& inbandTrack : m_inbandTracks) {
+        Ref track = downcast<VideoTrack>(inbandTrack);
         if (track->id() == id)
             return track;
     }
@@ -79,8 +79,8 @@ RefPtr<VideoTrack> VideoTrackList::getTrackById(const AtomString& id) const
 
 RefPtr<VideoTrack> VideoTrackList::getTrackById(TrackID id) const
 {
-    for (auto& inbandTracks : m_inbandTracks) {
-        Ref track = downcast<VideoTrack>(*inbandTracks);
+    for (auto& inbandTrack : m_inbandTracks) {
+        Ref track = downcast<VideoTrack>(inbandTrack);
         if (track->trackId() == id)
             return track;
     }
@@ -95,7 +95,7 @@ int VideoTrackList::selectedIndex() const
     // currently represent any tracks, or if none of the tracks are selected,
     // it must instead return −1.
     for (unsigned i = 0; i < length(); ++i) {
-        if (downcast<VideoTrack>(*m_inbandTracks[i]).selected())
+        if (downcast<VideoTrack>(m_inbandTracks[i].get()).selected())
             return i;
     }
     return -1;


### PR DESCRIPTION
#### 5e709e58852625a76b20078bc6887a339e017bbd
<pre>
Change Vector&lt;RefPtr&lt;TrackBase&gt;&gt; to a Vector of Ref, take 2
<a href="https://bugs.webkit.org/show_bug.cgi?id=304974">https://bugs.webkit.org/show_bug.cgi?id=304974</a>

Reviewed by Chris Dumez.

This is 305142@main except for the changes to return values of methods
as those were unwarranted and caused it to be reverted in 305144@main.

* Source/WTF/wtf/Vector.h:

In order to preserve the rather clean calls to find() Claude AI
assisted me in adding support for that to Vector, inspired by similar
code in HashMap.

Canonical link: <a href="https://commits.webkit.org/305151@main">https://commits.webkit.org/305151@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8e847eba1076c860456d2271d6f85c28b757ab4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137651 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10012 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48939 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145409 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90624 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3da2cb22-f86c-4e34-ad99-e0c9b7fc3f0e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139523 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10715 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10142 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105284 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140596 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7963 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123364 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86140 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b3c02c49-6536-40a0-b4fa-73a189237094) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7590 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5315 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/5992 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/129612 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116979 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41523 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148178 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/136174 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9695 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42074 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113671 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9712 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8172 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114013 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7521 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119603 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64361 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21193 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9743 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37652 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/168921 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9474 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73308 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44062 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9683 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9535 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->