### PR TITLE
StabilityTracer: com.apple.WebKit.GPU at com.apple.WebCore:  WebCore::DecodeOrderSampleMap::findSamplesBetweenDecodeKeys

### DIFF
--- a/Source/WTF/wtf/MediaTime.cpp
+++ b/Source/WTF/wtf/MediaTime.cpp
@@ -339,39 +339,39 @@ MediaTime::operator bool() const
         && !isInvalid();
 }
 
-std::weak_ordering operator<=>(const MediaTime& a, const MediaTime& b)
+std::partial_ordering operator<=>(const MediaTime& a, const MediaTime& b)
 {
     auto andFlags = a.m_timeFlags & b.m_timeFlags;
     if (andFlags & (MediaTime::PositiveInfinite | MediaTime::NegativeInfinite | MediaTime::Indefinite))
-        return std::weak_ordering::equivalent;
+        return std::partial_ordering::equivalent;
 
     auto orFlags = a.m_timeFlags | b.m_timeFlags;
     if (!(orFlags & MediaTime::Valid))
-        return std::weak_ordering::equivalent;
+        return std::partial_ordering::equivalent;
 
     if (!(andFlags & MediaTime::Valid))
-        return a.isInvalid() ? std::weak_ordering::greater : std::weak_ordering::less;
+        return std::partial_ordering::unordered;
 
     if (orFlags & MediaTime::NegativeInfinite)
-        return a.isNegativeInfinite() ? std::weak_ordering::less : std::weak_ordering::greater;
+        return a.isNegativeInfinite() ? std::partial_ordering::less : std::partial_ordering::greater;
 
     if (orFlags & MediaTime::PositiveInfinite)
-        return a.isPositiveInfinite() ? std::weak_ordering::greater : std::weak_ordering::less;
+        return a.isPositiveInfinite() ? std::partial_ordering::greater : std::partial_ordering::less;
 
     if (orFlags & MediaTime::Indefinite)
-        return a.isIndefinite() ? std::weak_ordering::greater : std::weak_ordering::less;
+        return a.isIndefinite() ? std::partial_ordering::greater : std::partial_ordering::less;
 
     if (andFlags & MediaTime::DoubleValue)
-        return weakOrderingCast(a.m_timeValueAsDouble <=> b.m_timeValueAsDouble);
+        return a.m_timeValueAsDouble <=> b.m_timeValueAsDouble;
 
     if (orFlags & MediaTime::DoubleValue)
-        return weakOrderingCast(a.toDouble() <=> b.toDouble());
+        return a.toDouble() <=> b.toDouble();
 
     if ((a.m_timeValue < 0) != (b.m_timeValue < 0))
-        return a.m_timeValue < 0 ? std::weak_ordering::less : std::weak_ordering::greater;
+        return a.m_timeValue < 0 ? std::weak_ordering::less : std::partial_ordering::greater;
 
     if (!a.m_timeValue && !b.m_timeValue)
-        return std::weak_ordering::equivalent;
+        return std::partial_ordering::equivalent;
 
     if (a.m_timeScale == b.m_timeScale)
         return a.m_timeValue <=> b.m_timeValue;
@@ -381,16 +381,16 @@ std::weak_ordering operator<=>(const MediaTime& a, const MediaTime& b)
 
     if (a.m_timeValue >= 0) {
         if (a.m_timeValue < b.m_timeValue && a.m_timeScale > b.m_timeScale)
-            return std::weak_ordering::less;
+            return std::partial_ordering::less;
 
         if (a.m_timeValue > b.m_timeValue && a.m_timeScale < b.m_timeScale)
-            return std::weak_ordering::greater;
+            return std::partial_ordering::greater;
     } else {
         if (a.m_timeValue < b.m_timeValue && a.m_timeScale < b.m_timeScale)
-            return std::weak_ordering::less;
+            return std::partial_ordering::less;
 
         if (a.m_timeValue > b.m_timeValue && a.m_timeScale > b.m_timeScale)
-            return std::weak_ordering::greater;
+            return std::partial_ordering::greater;
     }
 
     int64_t aFactor;

--- a/Source/WTF/wtf/MediaTime.h
+++ b/Source/WTF/wtf/MediaTime.h
@@ -78,7 +78,7 @@ public:
     bool operator!() const;
     explicit operator bool() const;
 
-    WTF_EXPORT_PRIVATE friend std::weak_ordering operator<=>(const MediaTime&, const MediaTime&);
+    WTF_EXPORT_PRIVATE friend std::partial_ordering operator<=>(const MediaTime&, const MediaTime&);
     friend bool operator==(const MediaTime& a, const MediaTime& b) { return is_eq(a <=> b); }
     bool isBetween(const MediaTime&, const MediaTime&) const;
 

--- a/Source/WebCore/Modules/mediasource/SampleMap.cpp
+++ b/Source/WebCore/Modules/mediasource/SampleMap.cpp
@@ -326,7 +326,7 @@ DecodeOrderSampleMap::reverse_iterator_range DecodeOrderSampleMap::findDependent
 
 Vector<DecodeOrderSampleMap::value_type> DecodeOrderSampleMap::findSamplesBetweenDecodeKeys(const KeyType& beginKey, const KeyType& endKey)
 {
-    if (beginKey >= endKey)
+    if (endKey <= beginKey)
         return { };
 
     // beginKey is inclusive, so use lower_bound to include samples wich start exactly at beginKey.
@@ -337,7 +337,7 @@ Vector<DecodeOrderSampleMap::value_type> DecodeOrderSampleMap::findSamplesBetwee
 
     Vector<value_type> samples;
     auto upper_bound = m_samples.lower_bound(endKey);
-    for (auto iterator = lower_bound; iterator != upper_bound; ++iterator)
+    for (auto iterator = lower_bound; iterator != upper_bound && iterator != m_samples.end(); ++iterator)
         samples.append(*iterator);
     return samples;
 }

--- a/Source/WebCore/platform/MediaSamplesBlock.h
+++ b/Source/WebCore/platform/MediaSamplesBlock.h
@@ -43,7 +43,7 @@ public:
     struct MediaSampleItem {
         using MediaSampleDataType = RefPtr<FragmentedSharedBuffer>;
         MediaTime presentationTime;
-        MediaTime decodeTime { MediaTime::indefiniteTime() };
+        MediaTime decodeTime { MediaTime::invalidTime() };
         MediaTime duration { MediaTime::zeroTime() };
         std::pair<MediaTime, MediaTime> trimInterval { MediaTime::zeroTime(), MediaTime::zeroTime() };
         MediaSampleDataType data;

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -596,9 +596,13 @@ void SourceBufferPrivate::computeEvictionData(ComputeEvictionDataRule rule)
                 buffered.intersectWith(trackBuffer.buffered());
             });
 
+            if (!buffered.length())
+                return evictableSize;
+
             // We can evict everything from currentTime+timeChunk (3s) to the end of the buffer, not contiguous in current range.
             auto rangeStartAfterCurrentTime = currentTime + timeChunk;
             const auto rangeEndAfterCurrentTime = buffered.maximumBufferedTime();
+            ASSERT(rangeEndAfterCurrentTime.isValid());
 
             if (rangeStartAfterCurrentTime >= rangeEndAfterCurrentTime)
                 return evictableSize;
@@ -1501,7 +1505,7 @@ MediaTime SourceBufferPrivate::maximumBufferedTime() const
 
     MediaTime maximumTime = MediaTime::negativeInfiniteTime();
     iterateTrackBuffers([&](const TrackBuffer& trackBuffer) {
-        maximumTime = std::max(maximumTime, trackBuffer.buffered().maximumBufferedTime());
+        maximumTime = std::max(maximumTime, trackBuffer.maximumBufferedTime());
     });
     return maximumTime;
 }

--- a/Tools/TestWebKitAPI/Tests/WTF/MediaTime.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/MediaTime.cpp
@@ -78,10 +78,10 @@ TEST(WTF, MediaTime)
     EXPECT_EQ(MediaTime::invalidTime() == MediaTime::invalidTime(), true);
     EXPECT_EQ(MediaTime::invalidTime() != MediaTime::invalidTime(), false);
     EXPECT_EQ(MediaTime::invalidTime() != MediaTime::zeroTime(), true);
-    EXPECT_EQ(MediaTime::invalidTime() > MediaTime::negativeInfiniteTime(), true);
-    EXPECT_EQ(MediaTime::invalidTime() > MediaTime::positiveInfiniteTime(), true);
-    EXPECT_EQ(MediaTime::negativeInfiniteTime() < MediaTime::invalidTime(), true);
-    EXPECT_EQ(MediaTime::positiveInfiniteTime() < MediaTime::invalidTime(), true);
+    EXPECT_EQ(MediaTime::invalidTime() > MediaTime::negativeInfiniteTime(), false);
+    EXPECT_EQ(MediaTime::invalidTime() > MediaTime::positiveInfiniteTime(), false);
+    EXPECT_EQ(MediaTime::negativeInfiniteTime() < MediaTime::invalidTime(), false);
+    EXPECT_EQ(MediaTime::positiveInfiniteTime() < MediaTime::invalidTime(), false);
     EXPECT_EQ(MediaTime::indefiniteTime() == MediaTime::indefiniteTime(), true);
     EXPECT_EQ(MediaTime::indefiniteTime() != MediaTime::indefiniteTime(), false);
     EXPECT_EQ(MediaTime::indefiniteTime() != MediaTime::zeroTime(), true);

--- a/Tools/TestWebKitAPI/Tests/WebCore/SampleMap.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/SampleMap.cpp
@@ -124,9 +124,14 @@ public:
         map.addSample(TestSample::create(MediaTime(27, 1), MediaTime(26, 1), MediaTime(1, 1), MediaSample::None));
         map.addSample(TestSample::create(MediaTime(26, 1), MediaTime(27, 1), MediaTime(1, 1), MediaSample::None));
         map.addSample(TestSample::create(MediaTime(25, 1), MediaTime(28, 1), MediaTime(1, 1), MediaSample::None));
+
+        mapWithNan.addSample(TestSample::create(MediaTime(0, 1), MediaTime::invalidTime(), MediaTime(1, 1), MediaSample::IsSync));
+        mapWithNan.addRange(map.decodeOrder().begin(), map.decodeOrder().end());
+        mapWithNan.addSample(TestSample::create(MediaTime::invalidTime(), MediaTime(29, 1), MediaTime(1, 1), MediaSample::IsSync));
     }
 
     SampleMap map;
+    SampleMap mapWithNan;
 };
 
 TEST_F(SampleMapTest, findSampleWithPresentationTime)
@@ -278,7 +283,6 @@ TEST_F(SampleMapTest, reverseFindSampleBeforePresentationTime)
 TEST_F(SampleMapTest, findSamplesBetweenDecodeKeys)
 {
     auto& decodeMap = map.decodeOrder();
-    DecodeOrderSampleMap::MapType dependentSamples;
     DecodeOrderSampleMap::KeyType decodeKeyStart(MediaTime(0, 1), MediaTime(0, 1));
     DecodeOrderSampleMap::KeyType decodeKeyEnd(MediaTime(28, 1), MediaTime(25, 1));
 
@@ -343,6 +347,15 @@ TEST_F(SampleMapTest, findSamplesBetweenDecodeKeys)
     samplesWithHigherDecodeTimes = decodeMap.findSamplesBetweenDecodeKeys(decodeKeyStart, decodeKeyEnd);
     EXPECT_FALSE(samplesWithHigherDecodeTimes.isEmpty());
     EXPECT_EQ(*decodeMap.rbegin(), *samplesWithHigherDecodeTimes.rbegin());
+}
+
+TEST_F(SampleMapTest, findSamplesBetweenDecodeKeysWithNaN)
+{
+    auto& decodeMap = mapWithNan.decodeOrder();
+    DecodeOrderSampleMap::KeyType decodeKey(MediaTime::invalidTime(), MediaTime::invalidTime());
+
+    auto samplesWithHigherDecodeTimes = decodeMap.findSamplesBetweenDecodeKeys(decodeKey, mapWithNan.decodeOrder().rbegin()->first);
+    EXPECT_TRUE(samplesWithHigherDecodeTimes.isEmpty());
 }
 
 }


### PR DESCRIPTION
#### fd06c147ae1974257528ecbb7c3b2ef7ac65126e
<pre>
StabilityTracer: com.apple.WebKit.GPU at com.apple.WebCore:  WebCore::DecodeOrderSampleMap::findSamplesBetweenDecodeKeys
<a href="https://bugs.webkit.org/show_bug.cgi?id=304975">https://bugs.webkit.org/show_bug.cgi?id=304975</a>
<a href="https://rdar.apple.com/161260966">rdar://161260966</a>

Reviewed by Youenn Fablet.

A comparison with MediaTime::invalidTime could incorrectly yield true.
(Such as MediaTime::invalidTime() &gt; MediaTime::zeroTime() or MediaTime::invalidTime() &gt; MediaTime::positiveInfiniteTime())

MediaTime::invalidTime() should be treated as a NaN double. We change the spaceship operator to return a partial_ordering
instead of weak_ordering.
Otherwise, the comparison to determine if we are searching past the end key could fail and we would iterate over the table infinitely.

We amend code that didn&apos;t handle the case where the buffered range was empty or could use an invalidTime in their calculations.
For all those, an early exit was required but missing.

Tests: Tools/TestWebKitAPI/Tests/WTF/MediaTime.cpp
       Tools/TestWebKitAPI/Tests/WebCore/SampleMap.cpp
* Source/WTF/wtf/MediaTime.cpp:
(WTF::operator&lt;=&gt;):
* Source/WTF/wtf/MediaTime.h:
* Source/WebCore/Modules/mediasource/SampleMap.cpp: Add an extra safeguard to make sure we can never iterate past the end of the map.
(WebCore::DecodeOrderSampleMap::findSamplesBetweenDecodeKeys):
* Source/WebCore/platform/MediaSamplesBlock.h:
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::computeEvictionData): Handle case where the buffered range is empty as we could have provided
an invalid iterator otherwise.
(WebCore::SourceBufferPrivate::maximumBufferedTime const): Do not
* Source/WebCore/platform/graphics/TrackBuffer.cpp:
(WebCore::TrackBuffer::maximumBufferedTime const): Return MediaTime::zeroTime() instead of invalidTime when buffered is empty.
MediaSource is by spec starting at 0.
(WebCore::TrackBuffer::removeCodedFrames): Fix exposed an existing issue if we attempted to remove samples in invalid interval (start past presentationOrder().end())
We now exit early if the iterator found is invalid.
(WebCore::TrackBuffer::codedFramesIntervalSize): same as above.
* Tools/TestWebKitAPI/Tests/WTF/MediaTime.cpp:
(TestWebKitAPI::TEST(WTF, MediaTime)):
* Tools/TestWebKitAPI/Tests/WebCore/SampleMap.cpp:
(TestWebKitAPI::TEST_F(SampleMapTest, findSamplesBetweenDecodeKeys)):
(TestWebKitAPI::TEST_F(SampleMapTest, findSamplesBetweenDecodeKeysWithNaN)):

Canonical link: <a href="https://commits.webkit.org/305199@main">https://commits.webkit.org/305199@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c3966535a6037480fbc20d300453e1c9d470706

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137674 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10035 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48962 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145439 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90647 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/92d6a229-c268-41a7-b377-3ed6f8dd78ca) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139546 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10738 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10165 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105305 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/923a2c81-ed78-4ee3-8a04-69c42350d4fc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140619 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7987 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123386 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86161 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e9162dbb-025c-4bb0-a3a2-ab9e706e1194) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/137022 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7614 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5337 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6015 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/129635 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117003 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41546 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148210 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/136199 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9718 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42096 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113696 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9735 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8194 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114036 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28974 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7543 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119625 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64402 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9766 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37674 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/168945 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9497 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73331 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44071 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9706 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9558 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->