### PR TITLE
Add a new constructor to CSSSelectorList so StyleRule doesn't need to know about its internals

### DIFF
--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -181,10 +181,6 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     bool isLastInSelectorList() const { return m_isLastInSelectorList; }
     bool isFirstInComplexSelector() const { return m_isFirstInComplexSelector; }
     bool isLastInComplexSelector() const { return m_isLastInComplexSelector; }
-
-    // FIXME: This should ideally be private, but StyleRule uses it.
-    void setLastInSelectorList() { m_isLastInSelectorList = true; }
-
     bool isForPage() const { return m_isForPage; }
 
     // Implicit means that this selector is not author/UA written.
@@ -201,6 +197,7 @@ private:
     friend class CSSSelectorList;
     friend class MutableCSSSelector;
 
+    void setLastInSelectorList() { m_isLastInSelectorList = true; }
     void setValue(const AtomString&, bool matchLowerCase = false);
 
     void setAttribute(const QualifiedName&, AttributeMatchType);

--- a/Source/WebCore/css/CSSSelectorList.cpp
+++ b/Source/WebCore/css/CSSSelectorList.cpp
@@ -81,6 +81,14 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     m_selectorArray[arrayIndex - 1].m_isLastInSelectorList = true;
 }
 
+CSSSelectorList::CSSSelectorList(std::span<const CSSSelector* const> selectors)
+    : m_selectorArray(FixedVector<CSSSelector>::map(selectors, [](auto* selector) {
+        return *selector;
+    }))
+{
+    m_selectorArray.last().setLastInSelectorList();
+}
+
 CSSSelectorList CSSSelectorList::makeCopyingSimpleSelector(const CSSSelector& simpleSelector)
 {
     FixedVector<CSSSelector> selectorArray { simpleSelector };

--- a/Source/WebCore/css/CSSSelectorList.h
+++ b/Source/WebCore/css/CSSSelectorList.h
@@ -43,8 +43,7 @@ public:
     CSSSelectorList(const CSSSelectorList&);
     CSSSelectorList(CSSSelectorList&&) = default;
     explicit CSSSelectorList(MutableCSSSelectorList&&);
-    explicit CSSSelectorList(FixedVector<CSSSelector>&& array)
-        : m_selectorArray(WTF::move(array)) { }
+    explicit CSSSelectorList(std::span<const CSSSelector* const>);
 
     static CSSSelectorList makeCopyingSimpleSelector(const CSSSelector&);
     static CSSSelectorList makeCopyingComplexSelector(const CSSSelector&);
@@ -120,6 +119,10 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     bool operator==(const CSSSelectorList&) const;
 
 private:
+    explicit CSSSelectorList(FixedVector<CSSSelector>&& array)
+        : m_selectorArray(WTF::move(array))
+    { }
+
     // End of a multipart selector is indicated by m_isLastInComplexSelector bit in the last item.
     // End of the array is indicated by m_isLastInSelectorList bit in the last item.
     FixedVector<CSSSelector> m_selectorArray;

--- a/Source/WebCore/css/StyleRule.cpp
+++ b/Source/WebCore/css/StyleRule.cpp
@@ -332,11 +332,7 @@ void StyleRuleWithNesting::wrapperAdoptOriginalSelectorList(CSSSelectorList&& se
 Ref<StyleRule> StyleRule::createForSplitting(const Vector<const CSSSelector*>& selectors, Ref<StyleProperties>&& properties, bool hasDocumentSecurityOrigin)
 {
     ASSERT_WITH_SECURITY_IMPLICATION(!selectors.isEmpty());
-    auto selectorListArray = FixedVector<CSSSelector>::map(selectors, [](auto* selector) {
-        return *selector;
-    });
-    selectorListArray[selectors.size() - 1].setLastInSelectorList();
-    auto styleRule = StyleRule::create(WTF::move(properties), hasDocumentSecurityOrigin, CSSSelectorList(WTF::move(selectorListArray)));
+    Ref styleRule = StyleRule::create(WTF::move(properties), hasDocumentSecurityOrigin, CSSSelectorList { selectors });
     styleRule->markAsSplitRule();
     return styleRule;
 }


### PR DESCRIPTION
#### 51b3f019cd6229304d6d56c4577ba622518b64ed
<pre>
Add a new constructor to CSSSelectorList so StyleRule doesn&apos;t need to know about its internals
<a href="https://bugs.webkit.org/show_bug.cgi?id=304980">https://bugs.webkit.org/show_bug.cgi?id=304980</a>

Reviewed by Darin Adler.

Add a new constructor to CSSSelectorList so StyleRule doesn&apos;t need to
know about its internals. This results in better encapsulation.

* Source/WebCore/css/CSSSelector.h:
(WebCore::CSSSelector::isLastInComplexSelector const):
(WebCore::CSSSelector::setLastInSelectorList):
* Source/WebCore/css/CSSSelectorList.cpp:
(WebCore::CSSSelectorList::CSSSelectorList):
* Source/WebCore/css/CSSSelectorList.h:
(WebCore::CSSSelectorList::CSSSelectorList):
* Source/WebCore/css/StyleRule.cpp:
(WebCore::StyleRule::createForSplitting):

Canonical link: <a href="https://commits.webkit.org/305192@main">https://commits.webkit.org/305192@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44f37adcf6e2387c74a9569d5c56e6a094893818

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137765 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10126 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49057 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145533 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/90738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1bb55883-ad0c-4b5a-8fe8-b80bc1587f25) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139637 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10829 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10258 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/105384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/90738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140710 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/8060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/123477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/86243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/85ae09f8-f6cf-4115-a695-7d385fe563ca) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/7683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/5417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6109 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/117073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/41641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148301 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9809 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/42186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/113765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9826 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/8274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114104 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28964 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7623 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119715 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/64508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9857 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/37759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9588 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/73422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9797 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9649 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->