### PR TITLE
[JSC] Fix `%TypedArray%.prototype.slice` Behavior when `ArrayBuffer` is the same to Align with ECMA-262

### DIFF
--- a/JSTests/microbenchmarks/typed-array-slice-with-same-buffer.js
+++ b/JSTests/microbenchmarks/typed-array-slice-with-same-buffer.js
@@ -1,0 +1,12 @@
+var count = 0;
+for (var i = 0; i < testLoopCount; ++i) {
+    var ta = new Float64Array([10, 20, 30, 40, 50, 60]);
+    ta.constructor = {
+        [Symbol.species]: function () {
+            return new Float64Array(ta.buffer, 2 * Float64Array.BYTES_PER_ELEMENT);
+        },
+    };
+    var result = ta.slice(1, 4);
+    if (result.length === 4 && result[0] === 20 && result[1] === 20 && result[2] === 20 && result[3] === 60) count++;
+}
+// if (count !== testLoopCount * 1) throw "Error: bad: " + count;

--- a/JSTests/stress/typed-array-return-same-buffer-with-offset.js
+++ b/JSTests/stress/typed-array-return-same-buffer-with-offset.js
@@ -1,0 +1,20 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected) {
+        throw new Error(`actual: ${actual}, expected: ${expected}`);
+    }
+}
+
+for (var TA of [Float32Array, Float64Array, Int8Array, Int16Array, Int32Array, Uint8Array, Uint16Array, Uint32Array]) {
+    var ta = new TA([10, 20, 30, 40, 50, 60]);
+    ta.constructor = {
+        [Symbol.species]: function () {
+            return new TA(ta.buffer, 2 * TA.BYTES_PER_ELEMENT);
+        },
+    };
+    var result = ta.slice(1, 4);
+    shouldBe(result.length, 4);
+    shouldBe(result[0], 20);
+    shouldBe(result[1], 20);
+    shouldBe(result[2], 20);
+    shouldBe(result[3], 60);
+}

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -370,9 +370,6 @@ test/built-ins/Temporal/getOwnPropertyNames.js:
 test/built-ins/TypedArray/prototype/set/array-arg-value-conversion-resizes-array-buffer.js:
   default: 'Test262Error: Actual [shrink, shrink, shrink] and expected [shrink, shrink, shrink, grow, grow] should have the same contents. '
   strict mode: 'Test262Error: Actual [shrink, shrink, shrink] and expected [shrink, shrink, shrink, grow, grow] should have the same contents. '
-test/built-ins/TypedArray/prototype/slice/speciesctor-return-same-buffer-with-offset.js:
-  default: 'Test262Error: Actual [20, 30, 40, 60] and expected [20, 20, 20, 60] should have the same contents.  (Testing with Float64Array.)'
-  strict mode: 'Test262Error: Actual [20, 30, 40, 60] and expected [20, 20, 20, 60] should have the same contents.  (Testing with Float64Array.)'
 test/built-ins/TypedArrayConstructors/ctors/object-arg/iterated-array-changed-by-tonumber.js:
   default: 'Test262Error: Expected SameValue(«NaN», «2») to be true (Testing with Float64Array.)'
   strict mode: 'Test262Error: Expected SameValue(«NaN», «2») to be true (Testing with Float64Array.)'
@@ -764,9 +761,6 @@ test/staging/sm/TypedArray/iterator-next-with-detached.js:
 test/staging/sm/TypedArray/set-with-receiver.js:
   default: 'Test262Error: Expected SameValue(«47», «0») to be true'
   strict mode: 'Test262Error: Expected SameValue(«47», «0») to be true'
-test/staging/sm/TypedArray/slice-memcpy.js:
-  default: 'Test262Error: Actual [1, 2, 1, 2, 3, 4] and expected [1, 2, 1, 2, 1, 2] should have the same contents. '
-  strict mode: 'Test262Error: Actual [1, 2, 1, 2, 3, 4] and expected [1, 2, 1, 2, 1, 2] should have the same contents. '
 test/staging/sm/class/defaultConstructorDerivedSpread.js:
   default: 'Error: unexpected call'
   strict mode: 'Error: unexpected call'

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
@@ -299,7 +299,16 @@ bool JSGenericTypedArrayView<Adaptor>::setFromTypedArray(JSGlobalObject* globalO
             return false;
 
         RELEASE_ASSERT(JSC::elementSize(Adaptor::typeValue) == JSC::elementSize(other->type()));
-        memmove(typedVector() + offset, std::bit_cast<typename Adaptor::Type*>(other->vector()) + objectOffset, length * elementSize);
+        auto* dst = typedVector() + offset;
+        auto* src = std::bit_cast<typename Adaptor::Type*>(other->vector()) + objectOffset;
+        auto* dstEnd = dst + length;
+        auto* srcEnd = src + length;
+        bool overlapped = (src < dstEnd) && (dst < srcEnd);
+        if (src < dst && overlapped && type == CopyType::LeftToRight) {
+            for (size_t i = 0; i < length; ++i)
+                dst[i] = src[i];
+        } else
+            memmove(dst, src, length * elementSize);
         return true;
     };
 


### PR DESCRIPTION
#### b6d3c23e93337f14b69a4d1123780566d2068258
<pre>
[JSC] Fix `%TypedArray%.prototype.slice` Behavior when `ArrayBuffer` is the same to Align with ECMA-262
<a href="https://bugs.webkit.org/show_bug.cgi?id=304984">https://bugs.webkit.org/show_bug.cgi?id=304984</a>

Reviewed by NOBODY (OOPS!).

This patch fixes `%TypedArray%.prototype.slice` behavior
when ArrayBuffer is the same to align with ECMA-262[1].
If the destination and source arrays overlap in the same ArrayBuffer
and the copy direction is left-to-right (forward), using memmove
in memmoveFastPath can result in incorrect behavior for TypedArrays.

[1]: <a href="https://tc39.es/ecma262/#sec-%typedarray%.prototype.slice">https://tc39.es/ecma262/#sec-%typedarray%.prototype.slice</a>

Tests: JSTests/microbenchmarks/typed-array-slice-with-same-buffer.js
       JSTests/stress/typed-array-return-same-buffer-with-offset.js

* JSTests/microbenchmarks/typed-array-slice-with-same-buffer.js: Added.
(i.ta.Symbol.species):
* JSTests/stress/typed-array-return-same-buffer-with-offset.js: Added.
(shouldBe):
(Uint32Array.ta.Symbol.species):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h:
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::setFromTypedArray):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6d3c23e93337f14b69a4d1123780566d2068258

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139499 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11875 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1001 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147627 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92567 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12583 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12025 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106802 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77762 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142446 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9626 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124945 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87665 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9248 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6867 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7925 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/131472 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118552 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/929 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150410 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/294 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11559 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/945 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115203 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11573 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9878 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115514 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10046 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121374 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/66565 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11603 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/883 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/170771 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11339 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75287 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44436 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11539 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11390 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->