### PR TITLE
Restrict devicemotion and deviceorientation IDL to secure contexts

### DIFF
--- a/LayoutTests/http/tests/events/device-orientation-motion-enumerable-expected.txt
+++ b/LayoutTests/http/tests/events/device-orientation-motion-enumerable-expected.txt
@@ -1,0 +1,11 @@
+Test that ondevicemotion and ondeviceorientation are enumerable.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Object.getOwnPropertyNames(window).includes('ondeviceorientation') is true
+PASS Object.getOwnPropertyNames(window).includes('ondevicemotion') is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/events/device-orientation-motion-enumerable.html
+++ b/LayoutTests/http/tests/events/device-orientation-motion-enumerable.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<body>
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Test that ondevicemotion and ondeviceorientation are enumerable.");
+
+shouldBeTrue("Object.getOwnPropertyNames(window).includes('ondeviceorientation')");
+shouldBeTrue("Object.getOwnPropertyNames(window).includes('ondevicemotion')");
+</script>

--- a/LayoutTests/platform/glib/http/tests/events/device-orientation-motion-enumerable-expected.txt
+++ b/LayoutTests/platform/glib/http/tests/events/device-orientation-motion-enumerable-expected.txt
@@ -1,0 +1,12 @@
+Test that ondevicemotion and ondeviceorientation are enumerable.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+FAIL Object.getOwnPropertyNames(window).includes('ondeviceorientation') should be true. Was false.
+FAIL Object.getOwnPropertyNames(window).includes('ondevicemotion') should be true. Was false.
+PASS successfullyParsed is true
+Some tests failed.
+
+TEST COMPLETE
+

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -191,6 +191,8 @@ namespace WebCore {
     macro(DecompressionStreamTransform) \
     macro(DelayNode) \
     macro(DeprecationReportBody) \
+    macro(DeviceMotionEvent) \
+    macro(DeviceOrientationEvent) \
     macro(DigitalCredential) \
     macro(DocumentTimeline) \
     macro(DynamicsCompressorNode) \
@@ -671,6 +673,8 @@ namespace WebCore {
     macro(onbeforematch) \
     macro(oncommand) \
     macro(oncookiechange) \
+    macro(ondevicemotion) \
+    macro(ondeviceorientation) \
     macro(onnotificationclick) \
     macro(onnotificationclose) \
     macro(onpush) \

--- a/Source/WebCore/dom/DeviceMotionEvent.idl
+++ b/Source/WebCore/dom/DeviceMotionEvent.idl
@@ -25,7 +25,8 @@
 
 [
     Conditional=DEVICE_ORIENTATION,
-    Exposed=Window
+    Exposed=Window,
+    SecureContext
 ] interface DeviceMotionEvent : Event {
     readonly attribute Acceleration? acceleration;
     readonly attribute Acceleration? accelerationIncludingGravity;

--- a/Source/WebCore/dom/DeviceOrientationEvent.idl
+++ b/Source/WebCore/dom/DeviceOrientationEvent.idl
@@ -25,7 +25,8 @@
 
 [
     Conditional=DEVICE_ORIENTATION,
-    Exposed=Window
+    Exposed=Window,
+    SecureContext
 ] interface DeviceOrientationEvent : Event {
     readonly attribute unrestricted double? alpha;
     readonly attribute unrestricted double? beta;

--- a/Source/WebCore/page/DOMWindow+DeviceMotion.idl
+++ b/Source/WebCore/page/DOMWindow+DeviceMotion.idl
@@ -27,7 +27,5 @@
 [
     Conditional=DEVICE_ORIENTATION
 ] partial interface DOMWindow {
-    // FIXME: 'ondevicemotion' should be enumerable.
-    // FIXME: 'ondevicemotion' should be [SecureContext].
-    [NotEnumerable] attribute EventHandler ondevicemotion;
+    [SecureContext] attribute EventHandler ondevicemotion;
 };

--- a/Source/WebCore/page/DOMWindow+DeviceOrientation.idl
+++ b/Source/WebCore/page/DOMWindow+DeviceOrientation.idl
@@ -27,7 +27,5 @@
 [
     Conditional=DEVICE_ORIENTATION
 ] partial interface DOMWindow {
-    // FIXME: 'ondeviceorientation' should be enumerable.
-    // FIXME: 'ondeviceorientation' should be [SecureContext].
-    [NotEnumerable] attribute EventHandler ondeviceorientation;
+    [SecureContext] attribute EventHandler ondeviceorientation;
 };


### PR DESCRIPTION
#### 29b34672b9010a4e6be41d927c1e3f4eb3c69da7
<pre>
Restrict devicemotion and deviceorientation IDL to secure contexts
<a href="https://bugs.webkit.org/show_bug.cgi?id=304985">https://bugs.webkit.org/show_bug.cgi?id=304985</a>
<a href="https://rdar.apple.com/44804273">rdar://44804273</a>

Reviewed by Ryosuke Niwa.

As of 207177@main these events have been restricted to secure contexts,
but the IDL has been available everywhere for no good reason.

The ondevicemotion and ondeviceorientation properties were also not
enumerable, but should be. As far as I can tell from blame nobody got
around to making the change. There&apos;s no real reason not to do this.

The SecureContext change is manually tested as this can only be tested
through WPT and the tests for this feature don&apos;t work in WebKit due to
missing WebDriver support. Since SecureContext is tested in general and
we already have tests that the events don&apos;t dispatch in secure contexts
this should be sufficient.

This matches the specification for these events:

    <a href="https://w3c.github.io/deviceorientation/">https://w3c.github.io/deviceorientation/</a>

Canonical link: <a href="https://commits.webkit.org/305266@main">https://commits.webkit.org/305266@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/caff1c70af4c73875d99bddee246b11c656c9482

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137963 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10327 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49329 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146031 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90938 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/92993d1b-cbc2-4bd1-8041-df67094cb031) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139836 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11029 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10471 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105504 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c7cd3199-9c52-40aa-a767-f41b39eb9a77) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140908 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8224 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123680 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86356 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/901075c0-bd14-425e-a73a-285089872360) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7838 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5590 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6313 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117234 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41850 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148741 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10010 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42409 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113906 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10027 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8447 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114237 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7777 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119936 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64734 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21232 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10056 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37929 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9787 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73624 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9997 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9848 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->