### PR TITLE
imported/w3c/web-platform-tests/fetch/api/response/response-body-read-task-handling.html is flaky without JS built-in streams

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -681,8 +681,6 @@ imported/w3c/web-platform-tests/background-fetch/fetch-uploads.https.window.html
 imported/w3c/web-platform-tests/background-fetch/update-ui.https.window.html [ Skip ]
 imported/w3c/web-platform-tests/background-fetch/fetch.https.window.html [ Skip ]
 
-webkit.org/b/303084 imported/w3c/web-platform-tests/fetch/api/response/response-body-read-task-handling.html [ Pass Failure ]
-
 # Skip some reporting tests that now timeout
 imported/w3c/web-platform-tests/reporting/cross-origin-same-site-credentials.https.sub.html [ Skip ]
 imported/w3c/web-platform-tests/reporting/document-reporting-bypass-report-to.https.sub.html [ Skip ]

--- a/Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp
+++ b/Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,6 +31,7 @@
 #include "EventLoop.h"
 #include "JSDOMExceptionHandling.h"
 #include "JSDOMPromise.h"
+#include "JSExecState.h"
 #include "LocalDOMWindow.h"
 #include "ScriptController.h"
 #include "ScriptDisallowedScope.h"
@@ -85,7 +86,17 @@ void DeferredPromise::callFunction(JSGlobalObject& lexicalGlobalObject, ResolveM
     // https://bugs.webkit.org/show_bug.cgi?id=203402
     switch (mode) {
     case ResolveMode::Resolve:
-        deferred()->resolve(&lexicalGlobalObject, resolution);
+        {
+            auto& data = threadGlobalDataSingleton();
+            bool shouldSetCurrentState = !data.currentState();
+            if (shouldSetCurrentState)
+                data.setCurrentState(&lexicalGlobalObject);
+
+            deferred()->resolve(&lexicalGlobalObject, resolution);
+
+            if (shouldSetCurrentState)
+                data.setCurrentState(nullptr);
+        }
         break;
     case ResolveMode::Reject:
         deferred()->reject(vm, &lexicalGlobalObject, resolution);


### PR DESCRIPTION
#### f8dd5342df32e060f207ff181494e0308d4f7fee
<pre>
imported/w3c/web-platform-tests/fetch/api/response/response-body-read-task-handling.html is flaky without JS built-in streams
<a href="https://rdar.apple.com/165386906">rdar://165386906</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=303084">https://bugs.webkit.org/show_bug.cgi?id=303084</a>

Reviewed by Chris Dumez.

When resolving a promise, we synchronously get the `then` value, which can trigger JavaScript execution.
We should normally do this execution in an event loop task as per spec, but we are not always doing so.

If resolving a promise outside of an event loop task, we would execute the then getter with an empty execution context stack.
In that case, if calling a callback from the JS code, for instance as done by response-body-read-task-handling.html with acceptNode callback,
we would trigger a microtask checkpoint when exiting of the acceptNode callback, as the execution context stack is empty,
as per <a href="https://webidl.spec.whatwg.org/#call-a-user-objects-operation">https://webidl.spec.whatwg.org/#call-a-user-objects-operation</a> step 15, which calls <a href="https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-script.">https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-script.</a>

To still allow to resolve a promise outside of an event loop task without causing unnecessary microtask checkpoints, we are making sure that the execution context stack is not empty.
This is done by setting the currentState of threadGlobalDataSingleton to a non null value before resolving the promise if the currentState is nullptr.
We make sure to set the currentState back to nullptr just after the promise resolution.

* LayoutTests/TestExpectations:
* Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp:
(WebCore::DeferredPromise::callFunction):

Canonical link: <a href="https://commits.webkit.org/305209@main">https://commits.webkit.org/305209@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db92620b9a0814abaf0ae1cb2c112bf2f0fb5de1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137813 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10174 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49114 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145832 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90786 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ef3d5ac1-14e3-49fd-abd9-358890fb03db) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139685 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10877 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10309 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105419 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140758 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8100 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123523 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86275 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7721 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5452 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6158 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117114 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41686 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148584 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9857 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42234 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113798 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9874 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8309 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114136 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28981 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7657 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119761 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64557 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9905 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37799 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9636 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73470 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9845 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9697 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->