### PR TITLE
Style::ZoomFactor::deviceScaleFactor is unused

### DIFF
--- a/Source/WebCore/layout/formattingContexts/FormattingGeometry.cpp
+++ b/Source/WebCore/layout/formattingContexts/FormattingGeometry.cpp
@@ -104,7 +104,7 @@ template<FormattingGeometry::HeightType heightType> std::optional<LayoutUnit> Fo
                     return { containingBlock.style().logicalHeight(), containingBlock.style().usedZoomForLength() };
                 }
                 ASSERT_NOT_REACHED();
-                return { CSS::Keyword::Auto { }, Style::ZoomFactor { 1.0f, layoutBox.style().deviceScaleFactor() } };
+                return { CSS::Keyword::Auto { }, Style::ZoomFactor { 1.0f } };
             }();
             containingBlockHeight = fixedValue(nonAnonymousContainingBlockLogicalHeight, nonAnonymousContainingBlockUsedZoom);
         }

--- a/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.h
+++ b/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.h
@@ -82,7 +82,7 @@ private:
     const StyleSelfAlignmentData m_inlineAxisAlignment;
     const StyleSelfAlignmentData m_blockAxisAlignment;
 
-    const Style::ZoomFactor m_usedZoom { 1.0f, 1.0f };
+    const Style::ZoomFactor m_usedZoom { 1.0f };
 
     GridAreaLines m_gridAreaLines;
 };

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLevelBox.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLevelBox.h
@@ -167,7 +167,7 @@ private:
         TextBoxTrim textBoxTrim;
         WebCore::Style::TextBoxEdge textBoxEdge;
         WebCore::Style::LineFitEdge lineFitEdge;
-        WebCore::Style::ZoomFactor zoomFactor { 1.0f, 1.0f };
+        WebCore::Style::ZoomFactor zoomFactor { 1.0f };
         WebCore::Style::WebkitLineBoxContain lineBoxContain;
         InlineLayoutUnit primaryFontSize { 0 };
         VerticalAlignment verticalAlignment { };

--- a/Source/WebCore/rendering/FixedTableLayout.cpp
+++ b/Source/WebCore/rendering/FixedTableLayout.cpp
@@ -161,7 +161,7 @@ float FixedTableLayout::calcWidthArray()
             if (m_width[currentColumn].isAuto() && !logicalWidth.isAuto()) {
                 if (auto fixedLogicalWidth = logicalWidth.tryFixed()) {
                     // Zoom was applied when we called adjustBorderBoxLogicalWidthForBoxSizing
-                    m_width[currentColumn] = Style::PreferredSize::Fixed { fixedLogicalWidth->resolveZoom(Style::ZoomFactor { 1.0f, 1.0f }) * eSpan / span };
+                    m_width[currentColumn] = Style::PreferredSize::Fixed { fixedLogicalWidth->resolveZoom(Style::ZoomFactor { 1.0f }) * eSpan / span };
                 }
                 else if (auto percentageLogicalWidth = logicalWidth.tryPercentage())
                     m_width[currentColumn] = Style::PreferredSize::Percentage { percentageLogicalWidth->value * eSpan / span };
@@ -237,7 +237,7 @@ void FixedTableLayout::layout()
         if (auto fixedWidth = m_width[i].tryFixed()) {
             // We zoomed the widths inside of calcWidthArray so here we pass in a zoom
             // factor of 1.0f to avoid double zooming.
-            calcWidth[i] = Style::evaluate<float>(*fixedWidth, Style::ZoomFactor { 1.0f, 1.0f });
+            calcWidth[i] = Style::evaluate<float>(*fixedWidth, Style::ZoomFactor { 1.0f });
             totalFixedWidth += calcWidth[i];
         } else if (auto percentageWidth = m_width[i].tryPercentage()) {
             calcWidth[i] = Style::evaluate<float>(*percentageWidth, tableLogicalWidth);

--- a/Source/WebCore/rendering/RenderTableCellInlines.h
+++ b/Source/WebCore/rendering/RenderTableCellInlines.h
@@ -59,7 +59,7 @@ inline std::pair<Style::PreferredSize, Style::ZoomFactor> RenderTableCell::style
     if (RenderTableCol* firstColumn = table()->colElement(col())) {
         // logicalWidthFromColumns will return a zoomed size so we return a zoom
         // factor of 1.0 to avoid double zooming.
-        return { logicalWidthFromColumns(firstColumn, styleWidth), Style::ZoomFactor { 1.0f, style.deviceScaleFactor() } };
+        return { logicalWidthFromColumns(firstColumn, styleWidth), Style::ZoomFactor { 1.0f } };
     }
     return { styleWidth, style.usedZoomForLength() };
 }

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -1441,7 +1441,7 @@ void RenderTheme::adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioStyle
     // Width / Height
     // The width and height here are affected by the zoom.
     // FIXME: Check is flawed, since it doesn't take min-width/max-width into account.
-    auto zoomForDeterminingControlSize = Style::ZoomFactor { usedZoomForComputedStyle(style), style.deviceScaleFactor() };
+    auto zoomForDeterminingControlSize = Style::ZoomFactor { usedZoomForComputedStyle(style) };
     auto controlSize = this->controlSize(appearance, fontCascade.get(), { style.width(), style.height() }, zoomForDeterminingControlSize.value);
     if (controlSize.width() != style.width())
         style.setWidth(Style::PreferredSize { controlSize.width() });

--- a/Source/WebCore/rendering/TextAutoSizing.cpp
+++ b/Source/WebCore/rendering/TextAutoSizing.cpp
@@ -157,7 +157,7 @@ auto TextAutoSizingValue::adjustTextNodeSizes() -> StillHasNodes
                 return 0;
             },
             [&](const Style::LineHeight::Fixed& fixed) {
-                return Style::evaluate<LayoutUnit>(fixed, Style::ZoomFactor { 1.0f, parentStyle.deviceScaleFactor() }).toInt();
+                return Style::evaluate<LayoutUnit>(fixed, Style::ZoomFactor { 1.0f }).toInt();
             },
             [&](const Style::LineHeight::Percentage& percentage) {
                 return Style::evaluate<LayoutUnit>(percentage, LayoutUnit { fontDescription.specifiedSize() }).toInt();
@@ -169,7 +169,7 @@ auto TextAutoSizingValue::adjustTextNodeSizes() -> StillHasNodes
 
         // This calculation matches the line-height computed size calculation in StyleBuilderCustom::applyValueLineHeight().
         int lineHeight = specifiedLineHeight * scaleChange;
-        if (auto fixedLineHeight = lineHeightLength.tryFixed(); fixedLineHeight && fixedLineHeight->resolveZoom(Style::ZoomFactor { 1.0f, parentStyle.deviceScaleFactor() }) == lineHeight)
+        if (auto fixedLineHeight = lineHeightLength.tryFixed(); fixedLineHeight && fixedLineHeight->resolveZoom(Style::ZoomFactor { 1.0f }) == lineHeight)
             continue;
 
         auto newParentStyle = cloneRenderStyleWithState(parentStyle);

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -2712,7 +2712,7 @@ bool RenderThemeCocoa::adjustButtonStyleForVectorBasedControls(RenderStyle& styl
     if (!style.logicalWidth().isSpecified() || style.logicalHeight().isAuto()) {
         auto minimumHeight = controlBaseHeight / controlBaseFontSize * style.fontDescription().computedSizeForRangeZoomOption(CSS::RangeZoomOptions::Unzoomed);
         if (auto fixedValue = style.logicalMinHeight().tryFixed())
-            minimumHeight = std::max(minimumHeight, fixedValue->resolveZoom(Style::ZoomFactor { 1.0f, 1.0f }));
+            minimumHeight = std::max(minimumHeight, fixedValue->resolveZoom(Style::ZoomFactor { 1.0f }));
         // FIXME: This may need to be a layout time adjustment to support various
         // values like fit-content etc.
         style.setLogicalMinHeight(Style::MinimumSize::Fixed { minimumHeight });

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -233,7 +233,7 @@ bool RenderStyle::isIdempotentTextAutosizingCandidate(AutosizeStatus status) con
                 if (auto fixedHeight = height().tryFixed(); specifiedLineHeight().isFixed() && fixedHeight) {
                     if (auto fixedSpecifiedLineHeight = specifiedLineHeight().tryFixed()) {
                         float specifiedSize = specifiedFontSize();
-                        if (fixedSpecifiedLineHeight->resolveZoom(Style::ZoomFactor { 1.0f, deviceScaleFactor() }) - specifiedSize > smallMinimumDifferenceThresholdBetweenLineHeightAndSpecifiedFontSizeForBoostingText
+                        if (fixedSpecifiedLineHeight->resolveZoom(Style::ZoomFactor { 1.0f }) - specifiedSize > smallMinimumDifferenceThresholdBetweenLineHeightAndSpecifiedFontSizeForBoostingText
                             && fixedHeight->resolveZoom(usedZoomForLength()) - specifiedSize > smallMinimumDifferenceThresholdBetweenLineHeightAndSpecifiedFontSizeForBoostingText)
                             return true;
                     }

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -1285,7 +1285,7 @@ auto Adjuster::adjustmentForTextAutosizing(const RenderStyle& style, const Eleme
 
         constexpr static float boostFactor = 1.25;
         auto minimumLineHeight = boostFactor * computedFontSize;
-        if (auto fixedLineHeight = lineHeight.tryFixed(); !fixedLineHeight || fixedLineHeight->resolveZoom(ZoomFactor { 1.0f, style.deviceScaleFactor() }) >= minimumLineHeight)
+        if (auto fixedLineHeight = lineHeight.tryFixed(); !fixedLineHeight || fixedLineHeight->resolveZoom(ZoomFactor { 1.0f }) >= minimumLineHeight)
             return;
 
         if (AutosizeStatus::probablyContainsASmallFixedNumberOfLines(style))

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -716,7 +716,7 @@ template<> struct PropertyExtractorAdaptor<CSSPropertyLineHeight> {
             [&](const LineHeight::Calc& calc) {
                 // FIXME: We pass 1.0f here to get the unzoomed value but it really is not clear why we are even
                 // evaluating calc here. We should probably revisit this and figure out another way to do this.
-                return functor(Length<CSS::Nonnegative> { evaluate<float>(calc, 0.0f, Style::ZoomFactor { 1.0f, 1.0f }) });
+                return functor(Length<CSS::Nonnegative> { evaluate<float>(calc, 0.0f, Style::ZoomFactor { 1.0f }) });
             }
         );
     }

--- a/Source/WebCore/style/calc/StyleCalculationTree+Evaluation.cpp
+++ b/Source/WebCore/style/calc/StyleCalculationTree+Evaluation.cpp
@@ -163,7 +163,7 @@ double evaluate(const Tree& tree, double percentResolutionLength, const ZoomFact
 
 double evaluate(const Tree& tree, double percentResolutionLength, const ZoomNeeded&)
 {
-    return evaluate(tree.root, percentResolutionLength, Style::ZoomFactor { 1.0f, 1.0f });
+    return evaluate(tree.root, percentResolutionLength, Style::ZoomFactor { 1.0f });
 }
 
 } // namespace Calculation

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h
@@ -324,12 +324,12 @@ inline float ComputedStyleBase::usedZoom() const
 inline ZoomFactor ComputedStyleBase::usedZoomForLength() const
 {
     if (useSVGZoomRulesForLength())
-        return ZoomFactor(1.0f, deviceScaleFactor());
+        return ZoomFactor(1.0f);
 
     if (evaluationTimeZoomEnabled())
-        return ZoomFactor(usedZoom(), deviceScaleFactor());
+        return ZoomFactor(usedZoom());
 
-    return ZoomFactor(1.0f, deviceScaleFactor());
+    return ZoomFactor(1.0f);
 }
 
 // MARK: - Fonts

--- a/Source/WebCore/style/values/inline/StyleLineHeight.cpp
+++ b/Source/WebCore/style/values/inline/StyleLineHeight.cpp
@@ -64,8 +64,8 @@ auto CSSValueConversion<LineHeight>::operator()(BuilderState& state, const CSSPr
     // since EvaluationTimeZoom will set the appropriate value.
     auto zoomFactor = [&] {
         if (!state.style().evaluationTimeZoomEnabled())
-            return Style::ZoomFactor { 1.0f, state.style().deviceScaleFactor() };
-        return Style::ZoomFactor { conversionData.zoom(), state.style().deviceScaleFactor() };
+            return Style::ZoomFactor { 1.0f };
+        return Style::ZoomFactor { conversionData.zoom() };
     };
 
     if (primitiveValue.isLength() || primitiveValue.isCalculatedPercentageWithLength()) {

--- a/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
+++ b/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
@@ -307,7 +307,7 @@ double computeNonCalcLengthDouble(double value, CSS::LengthUnit lengthUnit, cons
             // We can't use computedLineHeightForFontUnits if the line height is fixed since
             // that will apply the usedZoomFactor. We probably should refactor it so that
             // does not happen and we don't have to special case this scenario.
-            value *= Style::evaluate<LayoutUnit>(*fixedLineHeight, Style::ZoomFactor { conversionData.zoom(), conversionData.style()->deviceScaleFactor() }).toFloat();
+            value *= Style::evaluate<LayoutUnit>(*fixedLineHeight, Style::ZoomFactor { conversionData.zoom() }).toFloat();
         } else
             value *= conversionData.computedLineHeightForFontUnits();
         break;

--- a/Source/WebCore/style/values/viewport/StyleZoomPrimitives.h
+++ b/Source/WebCore/style/values/viewport/StyleZoomPrimitives.h
@@ -33,13 +33,7 @@ struct ZoomNeeded { };
 struct ZoomFactor {
     float value;
 
-    // FIXME: Transitional member to preserve pixel-snapping behavior during evaluation.
-    // This allows values like LineWidth to apply floorToDevicePixel() at evaluation time.
-    // Should be removed once pixel-snapping is eliminated entirely.
-    // https://bugs.webkit.org/show_bug.cgi?id=300658
-    float deviceScaleFactor { 1.0f };
-
-    constexpr explicit ZoomFactor(float v, float dsf) : value(v), deviceScaleFactor(dsf) { }
+    constexpr explicit ZoomFactor(float v) : value(v) { }
 };
 
 } // namespace Style


### PR DESCRIPTION
#### 2a7c5c6ac9b7deb729c7f348a2014e7994ccbeea
<pre>
Style::ZoomFactor::deviceScaleFactor is unused
<a href="https://bugs.webkit.org/show_bug.cgi?id=304991">https://bugs.webkit.org/show_bug.cgi?id=304991</a>
<a href="https://rdar.apple.com/167632286">rdar://167632286</a>

Reviewed by Vitor Roriz.

We currently need a deviceScaleFactor in order to create a ZoomFactor,
but we never end up using it anywhere. We previously used it for
LineWidth but unfortunately that is no longer the case as of
301536@main. We can remove it from this struct for now and add it back
in once we need it. This ends up removing some unnecessary calls into
InheritedRareData that end up occurring because we need it to create the ZoomFactor.

Canonical link: <a href="https://commits.webkit.org/305180@main">https://commits.webkit.org/305180@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/393e3b2e8b9894a11bbbc7990378793b5d6f8845

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137708 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10069 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48996 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145470 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90681 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f442546a-1f98-4718-967b-0191ff596e77) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139580 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10772 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10199 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105335 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/55be10fa-5b4a-4768-89e5-8df2504a79e4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140653 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8021 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123425 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86194 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fbea0fff-9af6-4331-9b54-9894df513427) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7644 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5370 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6051 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117035 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41584 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148241 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9752 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42135 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113728 "") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9769 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8227 "Found 1 new test failure: imported/w3c/web-platform-tests/media-source/mediasource-changetype-play-without-codecs-parameter.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114066 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28958 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7579 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119663 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64443 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9800 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37711 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9531 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73365 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9740 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9592 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->