### PR TITLE
Timeline scubber for mac inline controls is pushed too far to the right and overlaps with the rightContainerButtons

### DIFF
--- a/LayoutTests/media/modern-media-controls/macos-inline-media-controls/mac-inline-controls-time-control-no-overlap-expected.txt
+++ b/LayoutTests/media/modern-media-controls/macos-inline-media-controls/mac-inline-controls-time-control-no-overlap-expected.txt
@@ -1,0 +1,10 @@
+Testing that time control doesn't overlap right button container in inline media controls.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS timeControlRect.right <= rightContainerRect.left is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/media/modern-media-controls/macos-inline-media-controls/mac-inline-controls-time-control-no-overlap.html
+++ b/LayoutTests/media/modern-media-controls/macos-inline-media-controls/mac-inline-controls-time-control-no-overlap.html
@@ -1,0 +1,18 @@
+<script src="../../../resources/js-test-pre.js"></script>
+<script src="../resources/media-controls-utils.js" type="text/javascript"></script>
+<script src="../resources/media-controls-loader.js" type="text/javascript"></script>
+<body>
+<script type="text/javascript">
+
+description("Testing that time control doesn't overlap right button container in inline media controls.");
+
+const mediaControls = new MacOSInlineMediaControls({ width: 600, height: 300 });
+
+const timeControlRect = mediaControls.timeControl.element.getBoundingClientRect();
+const rightContainerRect = mediaControls.rightContainer.element.getBoundingClientRect();
+
+shouldBeTrue("timeControlRect.right <= rightContainerRect.left");
+
+</script>
+<script src="../../../resources/js-test-post.js"></script>
+</body>

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -480,6 +480,7 @@ static const String& macOSInlineMediaControlsStyleSheet()
         "    min-width: fit-content;"
         "}"
         ".media-controls.mac.inline:not(.audio) > .controls-bar.bottom > .time-control {"
+        "    left: auto !important;"
         "    max-width: 540px;"
         "}"
         ".media-controls.mac.inline:not(.audio) > .controls-bar.bottom > .buttons-container.right {"


### PR DESCRIPTION
#### 65fc0c8b090e1ebfd7ee805312a2967e3960b41c
<pre>
Timeline scubber for mac inline controls is pushed too far to the right and overlaps with the rightContainerButtons
<a href="https://bugs.webkit.org/show_bug.cgi?id=304993">https://bugs.webkit.org/show_bug.cgi?id=304993</a>
<a href="https://rdar.apple.com/167634241">rdar://167634241</a>

This patch restores the expected positioning by ensuring the scrubber does not inherit a fixed left
offset from the shared controls.

Reviewed by Andy Estes.

* LayoutTests/media/modern-media-controls/macos-inline-media-controls/mac-inline-controls-time-control-no-overlap-expected.txt: Added.
* LayoutTests/media/modern-media-controls/macos-inline-media-controls/mac-inline-controls-time-control-no-overlap.html: Added.
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::macOSInlineMediaControlsStyleSheet):

Canonical link: <a href="https://commits.webkit.org/305177@main">https://commits.webkit.org/305177@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/899155aefff8f6d7a307ce65c2461bd95a048ad9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137705 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10066 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/48993 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145467 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90678 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139577 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10769 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10196 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105332 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/48d4429d-09cc-48c7-a00e-ea7753031a30) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140650 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8019 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123421 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86191 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/554b611c-1c44-4e83-b5b3-a0bff90c9c6f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7642 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5368 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6048 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117033 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41580 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148238 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9749 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42131 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113724 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9766 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8225 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114062 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28956 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7571 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119659 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/64440 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9797 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37707 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9528 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73362 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9737 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9589 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->