### PR TITLE
Layout tests in `LayoutTests/site-isolation/` should run in cross-origin frame with site-isolation enabled

### DIFF
--- a/LayoutTests/site-isolation/basic-test-expected.txt
+++ b/LayoutTests/site-isolation/basic-test-expected.txt
@@ -1,0 +1,10 @@
+
+
+--------
+Frame: '<!--frame1-->'
+--------
+This test verifies that tests in the site-isolation/ directory automatically run in a cross-origin iframe.
+
+PASS: Test is running in cross-origin frame at 127.0.0.1:8000
+
+PASS: Test is running inside an iframe

--- a/LayoutTests/site-isolation/basic-test.html
+++ b/LayoutTests/site-isolation/basic-test.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Basic Site Isolation Test</title>
+</head>
+<body>
+    <p>This test verifies that tests in the site-isolation/ directory automatically run in a cross-origin iframe.</p>
+    <div id="output"></div>
+    <script>
+        testRunner.dumpAsText();
+
+        function log(message) {
+            const output = document.getElementById('output');
+            const p = document.createElement('p');
+            p.textContent = message;
+            output.appendChild(p);
+        }
+
+        if (window.testRunner) {
+            testRunner.waitUntilDone();
+            testRunner.dumpAsText();
+        }
+
+        const expectedHost = "127.0.0.1:8000";
+        const actualHost = location.host;
+
+        if (actualHost === expectedHost)
+            log("PASS: Test is running in cross-origin frame at " + expectedHost);
+        else
+            log("FAIL: Expected host " + expectedHost + " but got " + actualHost);
+
+        if (window.parent !== window)
+            log("PASS: Test is running inside an iframe");
+        else
+            log("FAIL: Test is NOT running inside an iframe");
+
+        if (window.testRunner)
+            testRunner.notifyDone();
+    </script>
+</body>
+</html>

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder.py
@@ -436,7 +436,7 @@ class LayoutTestFinder(object):
                 reference_files=(
                     tuple(reference_files) if reference_files is not None else None
                 ),
-                is_http_test="http/test" in trimmed_path,
+                is_http_test="http/test" in trimmed_path or ("site-isolation/" in trimmed_path and "http/tests/" not in trimmed_path),
                 is_websocket_test=(
                     "websocket/" in trimmed_path
                     or "http/test" in trimmed_path

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_runner.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_runner.py
@@ -282,10 +282,14 @@ class LayoutTestRunner(object):
                 self._current_run_results.change_result_to_failure(existing_result, new_result, was_expected, now_expected)
 
     def _additional_dirs_for_http_server(self):
-        if not self._options.load_in_cross_origin_iframe:
-            return {}
+        additional_dirs = {}
 
-        return {"root": "."}
+        if self._options.load_in_cross_origin_iframe:
+            additional_dirs["root"] = "."
+        else:
+            additional_dirs["/root/site-isolation"] = self._port.layout_tests_dir() + "/site-isolation"
+
+        return additional_dirs
 
     def start_servers(self):
         if self._needs_http and not self._did_start_http_server and not self._port.is_http_server_running():

--- a/Tools/Scripts/webkitpy/port/driver.py
+++ b/Tools/Scripts/webkitpy/port/driver.py
@@ -353,6 +353,8 @@ class Driver(object):
     def is_http_test(self, driver_input):
         if driver_input.additional_header and "runInCrossOriginFrame=true" in driver_input.additional_header:
             return True
+        if "site-isolation/" in driver_input.test_name and "http/tests/" not in driver_input.test_name:
+            return True
         return driver_input.test_name.startswith(self.HTTP_DIR) and not driver_input.test_name.startswith(self.HTTP_LOCAL_DIR)
 
     def is_webkit_specific_web_platform_test(self, test_name):

--- a/Tools/TestRunnerShared/TestFeatures.cpp
+++ b/Tools/TestRunnerShared/TestFeatures.cpp
@@ -140,6 +140,11 @@ static bool shouldEnableEnhancedSecurity(const std::string& pathOrURL)
     return pathContains(pathOrURL, "enhanced-security/");
 }
 
+static bool shouldEnableSiteIsolation(const std::string& pathOrURL)
+{
+    return pathContains(pathOrURL, "site-isolation/") && !pathContains(pathOrURL, "http/tests/");
+}
+
 static bool shouldUseBackForwardCache(const std::string& pathOrURL)
 {
     return pathContains(pathOrURL, "navigation-api/")
@@ -175,6 +180,10 @@ TestFeatures hardcodedFeaturesBasedOnPathForTest(const TestCommand& command)
         features.boolTestRunnerFeatures.insert({ "enhancedSecurityEnabled", true });
     if (shouldUseBackForwardCache(command.pathOrURL))
         features.boolWebPreferenceFeatures.insert({ "UsesBackForwardCache", true });
+    if (shouldEnableSiteIsolation(command.pathOrURL)) {
+        features.boolTestRunnerFeatures.insert({ "runInCrossOriginFrame", true });
+        features.boolWebPreferenceFeatures.insert({ "SiteIsolationEnabled", true });
+    }
 
     return features;
 }


### PR DESCRIPTION
#### 1a243b7466bccdbb3b08fcc45215bc59335857d0
<pre>
Layout tests in `LayoutTests/site-isolation/` should run in cross-origin frame with site-isolation enabled
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

WIP DO NOT REVIEW

* LayoutTests/site-isolation/basic-test-expected.txt: Added.
* LayoutTests/site-isolation/basic-test.html: Added.
* Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder.py:
(LayoutTestFinder):
* Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_runner.py:
(LayoutTestRunner._additional_dirs_for_http_server):
* Tools/Scripts/webkitpy/port/driver.py:
(Driver.is_http_test):
* Tools/TestRunnerShared/TestFeatures.cpp:
(WTR::shouldEnableSiteIsolation):
(WTR::hardcodedFeaturesBasedOnPathForTest):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a243b7466bccdbb3b08fcc45215bc59335857d0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137712 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10073 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/49526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145500 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90685 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7fe4ec5e-2408-43f6-8470-f88d354628ac) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139584 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10776 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/10636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105358 "") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76885 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Running run-layout-tests-in-stress-mode; layout-tests (failure) (timed out); Uploaded test results; layout-tests (exception)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ffdfe2fe-d1d3-4e0c-bae6-7508f9715145) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140657 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8022 "Too many flaky failures: http/tests/site-isolation/basic-iframe-render-output.html, http/tests/site-isolation/cross-site-noopener-uses-different-process.html, http/tests/site-isolation/cross-site-window-open-uses-different-process.html, http/tests/site-isolation/document-access.html, http/tests/site-isolation/domwindow-length-with-remote-frames.html, http/tests/site-isolation/frame-access-after-window-open.html, http/tests/site-isolation/frame-index.html, http/tests/site-isolation/history/add-iframe-while-changing-document-title.html, http/tests/site-isolation/history/navigate-same-site-iframe-into-new-process-and-go-back.html, http/tests/site-isolation/history/redirect-main-frame-into-new-process-then-go-back.html (failure)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/123816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86218 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ea144735-957d-48f8-83fa-83d5359b18b0) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/137060 "Passed tests") | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7645 "layout-tests (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5700 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6055 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117036 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/42014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148251 "Failed to compile WebKit") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9756 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/42570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113731 "layout-tests (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9773 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8558 "Unable to confirm if test failures are introduced by change, retrying build") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114069 "Passed tests") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7578 "layout-tests (failure)") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/120101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64447 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9804 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/38046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9535 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9744 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9596 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->