### PR TITLE
Add Cmd-T tab support to MiniBrowser with native macOS tabbing

### DIFF
--- a/Tools/MiniBrowser/mac/AppDelegate.h
+++ b/Tools/MiniBrowser/mac/AppDelegate.h
@@ -51,6 +51,8 @@
 - (void)didCreateBrowserWindowController:(BrowserWindowController *)controller;
 - (void)browserWindowWillClose:(NSWindow *)window;
 
+- (IBAction)newTab:(id)sender;
+
 - (void)didChangeSettings;
 
 + (NSNumber *)currentBadge;

--- a/Tools/MiniBrowser/mac/BrowserWindow.xib
+++ b/Tools/MiniBrowser/mac/BrowserWindow.xib
@@ -23,7 +23,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" frameAutosaveName="Main Window" animationBehavior="default" id="1">
+        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" frameAutosaveName="Main Window" animationBehavior="default" tabbingMode="preferred" id="1">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" fullSizeContentView="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="517" y="330" width="776" height="608"/>

--- a/Tools/MiniBrowser/mac/BrowserWindowController.m
+++ b/Tools/MiniBrowser/mac/BrowserWindowController.m
@@ -49,6 +49,9 @@
     // somewhere to put the window/page title.
     self.window.toolbarStyle = NSWindowToolbarStyleExpanded;
 
+    // Enable tabbing - group regular windows together
+    self.window.tabbingIdentifier = @"MiniBrowserMainWindow";
+
     NSString *sizeString = [[NSUserDefaults standardUserDefaults] stringForKey:@"WindowSize"];
     if (sizeString) {
         NSSize size = NSSizeFromString(sizeString);
@@ -58,6 +61,11 @@
 
     [share sendActionOn:NSEventMaskLeftMouseDown];
     [super windowDidLoad];
+}
+
+- (void)newWindowForTab:(id)sender
+{
+    [[NSApp browserAppDelegate] newTab:sender];
 }
 
 - (IBAction)openLocation:(id)sender

--- a/Tools/MiniBrowser/mac/MainMenu.xib
+++ b/Tools/MiniBrowser/mac/MainMenu.xib
@@ -104,6 +104,14 @@
                                     <action selector="newEditorWindow:" target="-1" id="kk6-R4-iec"/>
                                 </connections>
                             </menuItem>
+                            <menuItem isSeparatorItem="YES" id="mbt-ab-Cdt">
+                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
+                            </menuItem>
+                            <menuItem title="New Tab" keyEquivalent="t" id="nTb-mn-ItM">
+                                <connections>
+                                    <action selector="newTab:" target="-1" id="nTb-ac-Tion"/>
+                                </connections>
+                            </menuItem>
                             <menuItem title="Open…" keyEquivalent="o" id="72">
                                 <connections>
                                     <action selector="openDocument:" target="-1" id="374"/>

--- a/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
+++ b/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
@@ -171,9 +171,18 @@ static const int testFooterBannerHeight = 58;
     [_webView removeObserver:self forKeyPath:@"URL"];
     [_webView removeObserver:self forKeyPath:@"hasOnlySecureContent"];
     [_webView removeObserver:self forKeyPath:@"_gpuProcessIdentifier"];
-    
+
     [progressIndicator unbind:NSHiddenBinding];
     [progressIndicator unbind:NSValueBinding];
+}
+
+- (void)windowDidLoad
+{
+    [super windowDidLoad];
+
+    // Private windows get separate identifier so they can't merge with regular windows
+    if (_isPrivateBrowsingWindow)
+        self.window.tabbingIdentifier = @"MiniBrowserPrivateWindow";
 }
 
 - (void)userAgentDidChange:(NSNotification *)notification


### PR DESCRIPTION
#### 0280081ab6aaac803e2d58bdb17802f602b1646f
<pre>
Add Cmd-T tab support to MiniBrowser with native macOS tabbing
<a href="https://bugs.webkit.org/show_bug.cgi?id=304998">https://bugs.webkit.org/show_bug.cgi?id=304998</a>
<a href="https://rdar.apple.com/167638810">rdar://167638810</a>

Reviewed by Simon Fraser.

Currently, to enter into the multi-tab view creating a new window from
the menu bar, then &quot;merging&quot; windows.

Since the functionality is already there, wire up Cmd-T support, and use
the native macOS application tabbing behavior to make it less &quot;awkward&quot;
to add new tabs.

By using the native macOS tabbing behavior, we get a lot of functionality
&quot;for free&quot;, such as:
- Cmd-T to create new tabs
- Window &gt; Merge All Windows
- Window &gt; Move Tab to New Window
- Dragging tabs between windows

In this patch,
- Added tabbingMode=&quot;preferred&quot; to BrowserWindow.xib to enable native tab bar
- Added &quot;New Tab&quot; menu item (Cmd-T) to File menu
- Implement newTab: action that creates tabs inheriting the current
window&apos;s type (WK1/WK2) and configuration (private browsing, site isolation)
- Added tabbingIdentifier to group windows properly
- Use separate tabbingIdentifier for private windows to prevent merging
 with regular windows
- Implemented newWindowForTab: delegate for the tab bar &quot;+&quot; button

* Tools/MiniBrowser/mac/AppDelegate.h:
* Tools/MiniBrowser/mac/AppDelegate.m:
(-[BrowserAppDelegate newTab:]):
* Tools/MiniBrowser/mac/BrowserWindow.xib:
* Tools/MiniBrowser/mac/BrowserWindowController.m:
(-[BrowserWindowController windowDidLoad]):
(-[BrowserWindowController newWindowForTab:]):
* Tools/MiniBrowser/mac/MainMenu.xib:
* Tools/MiniBrowser/mac/WK2BrowserWindowController.m:
(-[WK2BrowserWindowController dealloc]):
(-[WK2BrowserWindowController windowDidLoad]):

Canonical link: <a href="https://commits.webkit.org/305262@main">https://commits.webkit.org/305262@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ad73224280bda9b39ee586c889d848493f7d7a5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137713 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10074 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49001 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145475 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90686 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139585 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10777 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10204 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105340 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/76886 "Exiting early after 60 failures. 21520 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9fc1d422-6225-4fca-8321-d7d318c13339) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140658 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8023 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123422 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86199 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c6022f12-93fa-424a-b57d-6a760432d95b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7646 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5374 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6056 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117037 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41581 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148246 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9757 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42132 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113732 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9774 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8231 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114071 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29019 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7580 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119660 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64448 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9805 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37708 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9536 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9745 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9597 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->