### PR TITLE
Fix clip-path reference breaking when removing SVG element with duplicate ID

### DIFF
--- a/LayoutTests/svg/clip-path-duplicate-id-removal-expected.html
+++ b/LayoutTests/svg/clip-path-duplicate-id-removal-expected.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    body {
+        background: white;
+    }
+    .target {
+        width: 50px;
+        height: 50px;
+        background: green;
+    }
+</style>
+</head>
+<body>
+<div class="target"></div>
+</body>
+</html>

--- a/LayoutTests/svg/clip-path-duplicate-id-removal.html
+++ b/LayoutTests/svg/clip-path-duplicate-id-removal.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>clip-path with duplicate IDs should work after removing non-registered element</title>
+<link rel="match" href="clip-path-duplicate-id-removal-expected.html">
+<style>
+    .target {
+        clip-path: url(#clipper);
+        width: 100px;
+        height: 100px;
+        background: green;
+    }
+</style>
+</head>
+<body>
+<div class="target"></div>
+
+<svg height="0" width="0">
+    <clipPath id="clipper" clipPathUnits="objectBoundingBox">
+        <rect width="0.5" height="0.5"/>
+    </clipPath>
+</svg>
+<svg height="0" width="0">
+    <clipPath id="clipper" clipPathUnits="objectBoundingBox">
+        <rect width="0.5" height="0.5"/>
+    </clipPath>
+</svg>
+<svg height="0" width="0">
+    <clipPath id="clipper" clipPathUnits="objectBoundingBox">
+        <rect width="0.5" height="0.5"/>
+    </clipPath>
+</svg>
+
+<script>
+    if (window.testRunner)
+        testRunner.waitUntilDone();
+
+    document.querySelector('svg').remove();
+
+    // Force repaint. A direct script removal doesn't force the repaint
+    // needed to re-resolve the clip-path reference and expose the bug.
+    document.body.style.background = 'white';
+
+    requestAnimationFrame(() => {
+        if (window.testRunner)
+            testRunner.notifyDone();
+    });
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/TreeScope.cpp
+++ b/Source/WebCore/dom/TreeScope.cpp
@@ -656,12 +656,15 @@ void TreeScope::addSVGResource(const AtomString& id, LegacyRenderSVGResourceCont
     svgResourcesMap().legacyResources.set(id, &resource);
 }
 
-void TreeScope::removeSVGResource(const AtomString& id)
+void TreeScope::removeSVGResource(const AtomString& id, LegacyRenderSVGResourceContainer& resource)
 {
     if (id.isEmpty())
         return;
 
-    svgResourcesMap().legacyResources.remove(id);
+    auto& resources = svgResourcesMap().legacyResources;
+    auto it = resources.find(id);
+    if (it != resources.end() && it->value == &resource)
+        resources.remove(it);
 }
 
 LegacyRenderSVGResourceContainer* TreeScope::lookupLegacySVGResoureById(const AtomString& id) const

--- a/Source/WebCore/dom/TreeScope.h
+++ b/Source/WebCore/dom/TreeScope.h
@@ -146,7 +146,7 @@ public:
     ExceptionOr<void> setAdoptedStyleSheets(Vector<Ref<CSSStyleSheet>>&&);
 
     void addSVGResource(const AtomString& id, LegacyRenderSVGResourceContainer&);
-    void removeSVGResource(const AtomString& id);
+    void removeSVGResource(const AtomString& id, LegacyRenderSVGResourceContainer&);
     LegacyRenderSVGResourceContainer* lookupLegacySVGResoureById(const AtomString& id) const;
 
     void addPendingSVGResource(const AtomString& id, SVGElement&);

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp
@@ -62,7 +62,7 @@ void LegacyRenderSVGResourceContainer::willBeDestroyed()
     SVGResourcesCache::resourceDestroyed(*this);
 
     if (m_registered) {
-        treeScopeForSVGReferences().removeSVGResource(m_id);
+        treeScopeForSVGReferences().removeSVGResource(m_id, *this);
         m_registered = false;
     }
 
@@ -85,7 +85,7 @@ void LegacyRenderSVGResourceContainer::idChanged()
     removeAllClientsFromCacheAndMarkForInvalidation();
 
     // Remove old id, that is guaranteed to be present in cache.
-    treeScopeForSVGReferences().removeSVGResource(m_id);
+    treeScopeForSVGReferences().removeSVGResource(m_id, *this);
     m_id = element().getIdAttribute();
 
     registerResource();


### PR DESCRIPTION
#### b61039ea91066dedbd9b8c01487c43a89041d4d3
<pre>
Fix clip-path reference breaking when removing SVG element with duplicate ID
<a href="https://bugs.webkit.org/show_bug.cgi?id=305001">https://bugs.webkit.org/show_bug.cgi?id=305001</a>
<a href="https://rdar.apple.com/147015037">rdar://147015037</a>

Reviewed by Simon Fraser.

When multiple SVG resource elements share the same ID, removing any
one breaks references for all elements using that ID, even though
other definitions remain in the DOM.

To fix this, we now verify the resource being removed matches the one
registered before removing.

Fixes the appearance of user avatar clipping in Slack i.e the
green activity ring. Slack uses multiple SVG clipPath definitions
with the same ID, and when elements are added/removed during virtual
scrolling, clip-path references would break.

Test: svg/clip-path-duplicate-id-removal.html

* LayoutTests/svg/clip-path-duplicate-id-removal-expected.html: Added.
* LayoutTests/svg/clip-path-duplicate-id-removal.html: Added.
* Source/WebCore/dom/TreeScope.cpp:
(WebCore::TreeScope::removeSVGResource):
* Source/WebCore/dom/TreeScope.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp:
(WebCore::LegacyRenderSVGResourceContainer::willBeDestroyed):
(WebCore::LegacyRenderSVGResourceContainer::idChanged):

Canonical link: <a href="https://commits.webkit.org/305197@main">https://commits.webkit.org/305197@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c34367bb270b56528b88ca78ae3902ed850bbd3e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137730 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10091 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49020 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145496 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90703 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6d60e4fc-a396-4b29-b919-d34ccbb09aca) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139602 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10794 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10222 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e49c2c1c-4fa8-4582-83f3-9d751d5bbc6c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140675 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8037 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123445 "Passed tests") | [⏳ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/API-Tests-WPE-EWS "Waiting to run tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7660 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5388 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6073 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117051 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41604 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148266 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9774 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42155 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113745 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9791 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8245 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114084 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28972 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7597 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119683 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64473 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9822 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37730 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9553 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73387 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9762 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9614 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->