### PR TITLE
REGRESSION (Safari 26.2): Color font affects the color of other DOM elements

### DIFF
--- a/LayoutTests/fast/text/glyph-display-lists/colr-glyph-state-leak-expected.html
+++ b/LayoutTests/fast/text/glyph-display-lists/colr-glyph-state-leak-expected.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Reference for COLR glyph state leak test</title>
+<style>
+@font-face {
+    font-family: "Ahem COLR";
+    src: url("../resources/Ahem-COLR.ttf") format("truetype");
+}
+body {
+    font: 24px Ahem;
+}
+h1 {
+    font: 48px Ahem COLR;
+}
+</style>
+<body>
+<h1>AAA</h1>
+<p style="color: green">AAA</p>

--- a/LayoutTests/fast/text/glyph-display-lists/colr-glyph-state-leak.html
+++ b/LayoutTests/fast/text/glyph-display-lists/colr-glyph-state-leak.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Test that COLR glyph display list replay doesn't leak state to subsequent text</title>
+<style>
+@font-face {
+    font-family: "Ahem COLR";
+    src: url("../resources/Ahem-COLR.ttf") format("truetype");
+}
+body {
+    font: 24px Ahem;
+    color: green;
+}
+h1 {
+    font: 48px Ahem COLR;
+}
+</style>
+<body>
+<h1>AAA</h1>
+<p>AAA</p>

--- a/Source/WebCore/rendering/TextPainter.cpp
+++ b/Source/WebCore/rendering/TextPainter.cpp
@@ -132,9 +132,9 @@ void TextPainter::paintTextOrEmphasisMarks(const FontCascade& font, const TextRu
         m_context.drawText(font, textRun, textOrigin, startOffset, endOffset);
     else {
         // Replaying back a whole cached glyph run to the GraphicsContext.
+        GraphicsContextStateSaver stateSaver(m_context);
         m_context.translate(textOrigin);
         m_context.drawDisplayList(*glyphDisplayList);
-        m_context.translate(-textOrigin);
     }
 }
 


### PR DESCRIPTION
#### 66bd20a0579a9bd47daa50579dfad853999919d8
<pre>
REGRESSION (Safari 26.2): Color font affects the color of other DOM elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=304249">https://bugs.webkit.org/show_bug.cgi?id=304249</a>
<a href="https://rdar.apple.com/166631312">rdar://166631312</a>

Reviewed by Simon Fraser.

State changes from replayed glyph display lists contaminated the recorder&apos;s
lastDrawingState, causing subsequent text to render with incorrect colors.
This is fixed by adding GraphicsContextStateSaver in
TextPainter::paintTextOrEmphasisMarks() around cached glyph display list
replay to isolate state changes.

* LayoutTests/fast/text/glyph-display-lists/colr-glyph-state-leak-expected.html: Added.
* LayoutTests/fast/text/glyph-display-lists/colr-glyph-state-leak.html: Added.
* Source/WebCore/rendering/TextPainter.cpp:
(WebCore::TextPainter::paintTextOrEmphasisMarks):

Canonical link: <a href="https://commits.webkit.org/305254@main">https://commits.webkit.org/305254@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3696d29df4f0d5175d1f71d34fea3db15e262026

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137807 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10168 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49104 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145802 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90780 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139679 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10871 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10303 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105416 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140752 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8093 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123514 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86273 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7714 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5449 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6151 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/129768 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117107 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41677 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148579 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9851 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42283 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113802 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/137233 "Build is in progress. Recent messages:") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9868 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8306 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114134 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29009 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7655 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119752 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64550 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9899 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37792 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9630 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73464 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9839 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9691 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->