### PR TITLE
REGRESSION(304905@main): [macOS iOS] imported/w3c/web-platform-tests/workers/worker-performance.worker.html is flaky failure

### DIFF
--- a/LayoutTests/http/tests/ipc/ipc-fetch-task-message-crash.html
+++ b/LayoutTests/http/tests/ipc/ipc-fetch-task-message-crash.html
@@ -50,9 +50,6 @@
           firstInterimResponseStart: {
               secondsSinceEpochSeconds: 0
           },
-          finalResponseHeadersStart: {
-              secondsSinceEpochSeconds: 0
-          },
           protocol: '',
           redirectCount: 384,
           complete: false,

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/worker-performance.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/worker-performance.worker-expected.txt
@@ -6,7 +6,7 @@ PASS Can use performance.getEntriesByName in workers
 PASS Can use performance.getEntriesByType in workers
 PASS Performance marks and measures seem to be working correctly in workers
 PASS Can use clearMarks and clearMeasures in workers
-FAIL Resource timing seems to work in workers assert_greater_than: Resource timing numbers reflect reality somewhat expected a number greater than 230 but got 0
+PASS Resource timing seems to work in workers
 PASS performance.clearResourceTimings in workers
 PASS performance.setResourceTimingBufferSize in workers
 PASS performance.timing is not available in workers

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8442,6 +8442,4 @@ webkit.org/b/304427 fast/html/HTMLPluginElement-renderer-destroyed-crash.html [ 
 [ Release ] http/tests/site-isolation/focus-click-navigation-activeElement.html [ Skip ]
 [ Release ] http/tests/site-isolation/history/add-iframes-and-go-back.html [ Skip ]
 
-webkit.org/b/304851 imported/w3c/web-platform-tests/workers/worker-performance.worker.html [ Pass Failure ]
-
 webkit.org/b/304995 [ Release ] imported/w3c/web-platform-tests/largest-contentful-paint/video-poster.html [ Pass Failure ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2438,8 +2438,6 @@ webkit.org/b/304616 fast/images/mac/play-all-pause-all-animations-context-menu-i
 [ Release ] http/tests/site-isolation/focus-click-navigation-activeElement.html [ Skip ]
 [ Release ] http/tests/site-isolation/history/add-iframes-and-go-back.html [ Skip ]
 
-webkit.org/b/304851 imported/w3c/web-platform-tests/workers/worker-performance.worker.html [ Pass Failure ]
-
 # webkit.org/b/304865 [macOS Debug ] ASSERTION FAILED: m_wrapper /Volumes/Data/worker/macOS-Tahoe-Debug-Build-EWS/build/Source/WebCore/bindings/js/ in fast/webgpu/repro_301290.html
 [ Debug ] fast/webgpu/repeated-out-of-memory-error.html [ Skip ]
 [ Debug ] fast/webgpu/repro_301290.html [ Skip ]

--- a/Source/WebCore/page/PerformanceResourceTiming.cpp
+++ b/Source/WebCore/page/PerformanceResourceTiming.cpp
@@ -237,10 +237,10 @@ double PerformanceResourceTiming::finalResponseHeadersStart() const
         return 0.0;
 
     // Return 0 if no final response headers timing was captured.
-    if (!m_resourceTiming.networkLoadMetrics().finalResponseHeadersStart)
+    if (!m_resourceTiming.networkLoadMetrics().responseStart)
         return 0.0;
 
-    return networkLoadTimeToDOMHighResTimeStamp(m_timeOrigin, m_resourceTiming.networkLoadMetrics().finalResponseHeadersStart);
+    return networkLoadTimeToDOMHighResTimeStamp(m_timeOrigin, m_resourceTiming.networkLoadMetrics().responseStart);
 }
 
 double PerformanceResourceTiming::firstInterimResponseStart() const
@@ -265,14 +265,7 @@ double PerformanceResourceTiming::responseStart() const
     if (m_resourceTiming.networkLoadMetrics().firstInterimResponseStart)
         return networkLoadTimeToDOMHighResTimeStamp(m_timeOrigin, m_resourceTiming.networkLoadMetrics().firstInterimResponseStart);
 
-    if (m_resourceTiming.networkLoadMetrics().finalResponseHeadersStart)
-        return networkLoadTimeToDOMHighResTimeStamp(m_timeOrigin, m_resourceTiming.networkLoadMetrics().finalResponseHeadersStart);
-
-    // Fallback to legacy responseStart for backward compatibility.
-    if (!m_resourceTiming.networkLoadMetrics().responseStart)
-        return requestStart();
-
-    return networkLoadTimeToDOMHighResTimeStamp(m_timeOrigin, m_resourceTiming.networkLoadMetrics().responseStart);
+    return finalResponseHeadersStart();
 }
 
 double PerformanceResourceTiming::responseEnd() const

--- a/Source/WebCore/platform/network/NetworkLoadMetrics.cpp
+++ b/Source/WebCore/platform/network/NetworkLoadMetrics.cpp
@@ -32,7 +32,7 @@ namespace WebCore {
 
 NetworkLoadMetrics::NetworkLoadMetrics() = default;
 
-NetworkLoadMetrics::NetworkLoadMetrics(MonotonicTime&& redirectStart, MonotonicTime&& fetchStart, MonotonicTime&& domainLookupStart, MonotonicTime&& domainLookupEnd, MonotonicTime&& connectStart, MonotonicTime&& secureConnectionStart, MonotonicTime&& connectEnd, MonotonicTime&& requestStart, MonotonicTime&& responseStart, MonotonicTime&& responseEnd, MonotonicTime&& workerStart, MonotonicTime&& firstInterimResponseStart, MonotonicTime&& finalResponseHeadersStart, String&& protocol, uint16_t redirectCount, bool complete, bool cellular, bool expensive, bool constrained, bool multipath, bool isReusedConnection, bool failsTAOCheck, bool hasCrossOriginRedirect, bool fromPrefetch, bool fromCache, PrivacyStance privacyStance, uint64_t responseBodyBytesReceived, uint64_t responseBodyDecodedSize, RefPtr<AdditionalNetworkLoadMetricsForWebInspector>&& additionalNetworkLoadMetricsForWebInspector)
+NetworkLoadMetrics::NetworkLoadMetrics(MonotonicTime&& redirectStart, MonotonicTime&& fetchStart, MonotonicTime&& domainLookupStart, MonotonicTime&& domainLookupEnd, MonotonicTime&& connectStart, MonotonicTime&& secureConnectionStart, MonotonicTime&& connectEnd, MonotonicTime&& requestStart, MonotonicTime&& responseStart, MonotonicTime&& responseEnd, MonotonicTime&& workerStart, MonotonicTime&& firstInterimResponseStart, String&& protocol, uint16_t redirectCount, bool complete, bool cellular, bool expensive, bool constrained, bool multipath, bool isReusedConnection, bool failsTAOCheck, bool hasCrossOriginRedirect, bool fromPrefetch, bool fromCache, PrivacyStance privacyStance, uint64_t responseBodyBytesReceived, uint64_t responseBodyDecodedSize, RefPtr<AdditionalNetworkLoadMetricsForWebInspector>&& additionalNetworkLoadMetricsForWebInspector)
     : redirectStart(WTF::move(redirectStart))
     , fetchStart(WTF::move(fetchStart))
     , domainLookupStart(WTF::move(domainLookupStart))
@@ -45,7 +45,6 @@ NetworkLoadMetrics::NetworkLoadMetrics(MonotonicTime&& redirectStart, MonotonicT
     , responseEnd(WTF::move(responseEnd))
     , workerStart(WTF::move(workerStart))
     , firstInterimResponseStart(WTF::move(firstInterimResponseStart))
-    , finalResponseHeadersStart(WTF::move(finalResponseHeadersStart))
     , protocol(protocol)
     , redirectCount(redirectCount)
     , complete(complete)
@@ -79,7 +78,6 @@ void NetworkLoadMetrics::updateFromFinalMetrics(const NetworkLoadMetrics& other)
     MonotonicTime originalResponseEnd = responseEnd;
     MonotonicTime originalWorkerStart = workerStart;
     MonotonicTime originalFirstInterimResponseStart = firstInterimResponseStart;
-    MonotonicTime originalFinalResponseHeadersStart = finalResponseHeadersStart;
     bool originalFromPrefetch = fromPrefetch;
     bool originalFromCache = fromCache;
 
@@ -109,8 +107,6 @@ void NetworkLoadMetrics::updateFromFinalMetrics(const NetworkLoadMetrics& other)
         workerStart = originalWorkerStart;
     if (!firstInterimResponseStart)
         firstInterimResponseStart = originalFirstInterimResponseStart;
-    if (!finalResponseHeadersStart)
-        finalResponseHeadersStart = originalFinalResponseHeadersStart;
     if (!fromPrefetch)
         fromPrefetch = originalFromPrefetch;
     if (!fromCache)
@@ -159,7 +155,6 @@ NetworkLoadMetrics NetworkLoadMetrics::isolatedCopy() const
     copy.responseEnd = responseEnd.isolatedCopy();
     copy.workerStart = workerStart.isolatedCopy();
     copy.firstInterimResponseStart = firstInterimResponseStart.isolatedCopy();
-    copy.finalResponseHeadersStart = finalResponseHeadersStart.isolatedCopy();
 
     copy.protocol = protocol.isolatedCopy();
 

--- a/Source/WebCore/platform/network/NetworkLoadMetrics.h
+++ b/Source/WebCore/platform/network/NetworkLoadMetrics.h
@@ -65,7 +65,7 @@ class NetworkLoadMetrics {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(NetworkLoadMetrics);
 public:
     WEBCORE_EXPORT NetworkLoadMetrics();
-    WEBCORE_EXPORT NetworkLoadMetrics(MonotonicTime&& redirectStart, MonotonicTime&& fetchStart, MonotonicTime&& domainLookupStart, MonotonicTime&& domainLookupEnd, MonotonicTime&& connectStart, MonotonicTime&& secureConnectionStart, MonotonicTime&& connectEnd, MonotonicTime&& requestStart, MonotonicTime&& responseStart, MonotonicTime&& responseEnd, MonotonicTime&& workerStart, MonotonicTime&& firstInterimResponseStart, MonotonicTime&& finalResponseHeadersStart, String&& protocol, uint16_t redirectCount, bool complete, bool cellular, bool expensive, bool constrained, bool multipath, bool isReusedConnection, bool failsTAOCheck, bool hasCrossOriginRedirect, bool fromPrefetch, bool fromCache, PrivacyStance, uint64_t responseBodyBytesReceived, uint64_t responseBodyDecodedSize, RefPtr<AdditionalNetworkLoadMetricsForWebInspector>&&);
+    WEBCORE_EXPORT NetworkLoadMetrics(MonotonicTime&& redirectStart, MonotonicTime&& fetchStart, MonotonicTime&& domainLookupStart, MonotonicTime&& domainLookupEnd, MonotonicTime&& connectStart, MonotonicTime&& secureConnectionStart, MonotonicTime&& connectEnd, MonotonicTime&& requestStart, MonotonicTime&& responseStart, MonotonicTime&& responseEnd, MonotonicTime&& workerStart, MonotonicTime&& firstInterimResponseStart, String&& protocol, uint16_t redirectCount, bool complete, bool cellular, bool expensive, bool constrained, bool multipath, bool isReusedConnection, bool failsTAOCheck, bool hasCrossOriginRedirect, bool fromPrefetch, bool fromCache, PrivacyStance, uint64_t responseBodyBytesReceived, uint64_t responseBodyDecodedSize, RefPtr<AdditionalNetworkLoadMetricsForWebInspector>&&);
 
     WEBCORE_EXPORT static const NetworkLoadMetrics& emptyMetrics();
 
@@ -99,7 +99,6 @@ public:
     // https://github.com/w3c/resource-timing/pull/408
     // Timing for interim (1xx) vs final (2xx/3xx/4xx/5xx) responses
     MonotonicTime firstInterimResponseStart; // When first 1xx response arrived (if any)
-    MonotonicTime finalResponseHeadersStart; // When final response headers arrived
 
     // ALPN Protocol ID: https://w3c.github.io/resource-timing/#bib-RFC7301
     String protocol;

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -858,10 +858,6 @@ static NSDictionary<NSString *, id> *extractResolutionReport(NSError *error)
     if (auto networkDataTask = [self existingTask:dataTask]) {
         ASSERT(RunLoop::isMain());
 
-        // Capture the timestamp when the final (non-1xx) response headers are received.
-        // https://github.com/w3c/resource-timing/pull/408
-        networkDataTask->networkLoadMetrics().finalResponseHeadersStart = MonotonicTime::now();
-
         NegotiatedLegacyTLS negotiatedLegacyTLS = NegotiatedLegacyTLS::No;
         RetainPtr<NSURLSessionTaskMetrics> taskMetrics = dataTask._incompleteTaskMetrics;
 

--- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
@@ -1085,8 +1085,8 @@ void NetworkDataTaskSoup::didGetHeaders()
             m_networkLoadMetrics.firstInterimResponseStart = responseStartTime;
     } else {
         // This is a final response (2xx, 3xx, 4xx, 5xx) - capture final response timing
-        if (!m_networkLoadMetrics.finalResponseHeadersStart)
-            m_networkLoadMetrics.finalResponseHeadersStart = responseStartTime;
+        if (!m_networkLoadMetrics.responseStart)
+            m_networkLoadMetrics.responseStart = responseStartTime;
     }
 
     m_networkLoadMetrics.responseStart = responseStartTime;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7465,7 +7465,6 @@ class WebCore::NetworkLoadMetrics {
     MonotonicTime responseEnd;
     MonotonicTime workerStart;
     MonotonicTime firstInterimResponseStart;
-    MonotonicTime finalResponseHeadersStart;
 
     String protocol;
 


### PR DESCRIPTION
#### 9efcc7af593d529114bf0ee9ff4244a7d00fb36a
<pre>
REGRESSION(304905@main): [macOS iOS] imported/w3c/web-platform-tests/workers/worker-performance.worker.html is flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=304851">https://bugs.webkit.org/show_bug.cgi?id=304851</a>
<a href="https://rdar.apple.com/167443296">rdar://167443296</a>

Reviewed by David Kilzer.

304905@main added two new times to NetworkLoadMetrics, but it should&apos;ve just added one and made responseStart
an alias for finalResponseHeadersStart.  This fixes the broken test by doing just that.  No redundant
responseStart/finalResponseHeadersStart.  responseStart is the time when the final header fields are starting
to be received.

* LayoutTests/http/tests/ipc/ipc-fetch-task-message-crash.html:
* LayoutTests/imported/w3c/web-platform-tests/workers/worker-performance.worker-expected.txt:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/page/PerformanceResourceTiming.cpp:
(WebCore::PerformanceResourceTiming::finalResponseHeadersStart const):
(WebCore::PerformanceResourceTiming::responseStart const):
* Source/WebCore/platform/network/NetworkLoadMetrics.cpp:
(WebCore::NetworkLoadMetrics::NetworkLoadMetrics):
(WebCore::NetworkLoadMetrics::updateFromFinalMetrics):
(WebCore::NetworkLoadMetrics::isolatedCopy const):
* Source/WebCore/platform/network/NetworkLoadMetrics.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(-[WKNetworkSessionDelegate URLSession:dataTask:didReceiveResponse:completionHandler:]):
* Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp:
(WebKit::NetworkDataTaskSoup::didGetHeaders):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/305317@main">https://commits.webkit.org/305317@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81a009e73f913238ad3ffbf7382688ad3625a956

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137908 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10272 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49264 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145975 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90883 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/27f60423-115c-44cd-b398-e7d4ae69e010) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139780 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10974 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10413 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105470 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/76967 "Exiting early after 60 failures. 21514 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ada5725c-6aca-45ba-9aa6-9758dae78227) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140853 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8174 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123631 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86321 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6811b399-75bb-4c48-950a-ac3777615aa9) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7795 "Exiting early after 10 failures. 16 tests run. 1 flakes") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5546 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6256 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117189 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41795 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148685 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9955 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42354 "Exiting early after 10 failures. 20 tests run. 1 flakes") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113876 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9972 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8403 "Exiting early after 10 failures. 13 tests run. 1 flakes") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114206 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7733 "Passed tests") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119881 "Exiting early after 10 failures. 43 tests run. 1 flakes") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64679 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21254 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10001 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37887 "10 flakes 1 failures") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9731 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73569 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9942 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9793 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->