### PR TITLE
[GFC][Integration] hasValidRowEnd should be returning an unsupported row placement

### DIFF
--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
@@ -125,18 +125,18 @@ static std::optional<GridAvoidanceReason> hasValidRowEnd(const Style::GridPositi
 {
     return WTF::switchOn(rowEnd,
         [&](const CSS::Keyword::Auto&) -> std::optional<GridAvoidanceReason> {
-            return GridAvoidanceReason::GridItemHasUnsupportedColumnPlacement;
+            return GridAvoidanceReason::GridItemHasUnsupportedRowPlacement;
         },
         [&](const Style::GridPositionExplicit&) -> std::optional<GridAvoidanceReason> {
             if (!rowEnd.namedGridLine().isEmpty() || rowEnd.explicitPosition() < 0 || rowEnd.explicitPosition() > static_cast<int>(linesFromGridTemplateRowsCount))
-                return GridAvoidanceReason::GridItemHasUnsupportedColumnPlacement;
+                return GridAvoidanceReason::GridItemHasUnsupportedRowPlacement;
             return { };
         },
         [&](const Style::GridPositionSpan&) -> std::optional<GridAvoidanceReason> {
-            return GridAvoidanceReason::GridItemHasUnsupportedColumnPlacement;
+            return GridAvoidanceReason::GridItemHasUnsupportedRowPlacement;
         },
         [&](const CustomIdentifier&) -> std::optional<GridAvoidanceReason> {
-            return GridAvoidanceReason::GridItemHasUnsupportedColumnPlacement;
+            return GridAvoidanceReason::GridItemHasUnsupportedRowPlacement;
         }
     );
 }


### PR DESCRIPTION
#### bb97e4dbaebe02abd90b470b44a81ada21a79890
<pre>
[GFC][Integration] hasValidRowEnd should be returning an unsupported row placement
<a href="https://bugs.webkit.org/show_bug.cgi?id=305009">https://bugs.webkit.org/show_bug.cgi?id=305009</a>
<a href="https://rdar.apple.com/167649436">rdar://167649436</a>

Reviewed by Tim Nguyen.

In 303864@main we did a bit of a refactoring to move some logic that
checks the placement of grid items to some helper functions. In
particular, we added some functions to check it the -end placement is
one that we currently support. In that process I made a copy paste
mistake and ended up causing hasValidRowPlacement to return
GridItemHasUnsupportedColumnPlacement. Looking at the diff from that
patch we were previously returning GridItemHasUnsupportedColumnPlacement
which is more in line with what this function was intended to do.

Canonical link: <a href="https://commits.webkit.org/305190@main">https://commits.webkit.org/305190@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e01042d6a04c85b61958b9f8a0665f395b478900

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137739 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10100 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49029 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145506 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90712 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cdcc4c66-0d83-48d0-8068-a91da4af9aab) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139611 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10803 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10231 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105361 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140684 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8041 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123438 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86221 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/02b69480-1cc8-4ae3-ba9e-a03f84729029) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7664 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5391 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6083 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117055 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41597 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148275 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9783 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42148 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113747 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9800 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8248 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114086 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28967 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7598 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119676 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64482 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9831 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37724 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9562 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73396 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9771 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9623 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->