### PR TITLE
REGRESSION(304297@main) Increased CPU usage in audiomxd during playback

### DIFF
--- a/Source/WebCore/platform/audio/ios/AudioSessionIOS.h
+++ b/Source/WebCore/platform/audio/ios/AudioSessionIOS.h
@@ -51,6 +51,8 @@ public:
     using CategoryChangedObserver = WTF::Observer<void(AudioSession&, CategoryType)>;
     WEBCORE_EXPORT static void addAudioSessionCategoryChangedObserver(const CategoryChangedObserver&);
 
+    void sessionMediaServicesWereReset();
+
 private:
     AudioSessionIOS();
 
@@ -77,6 +79,8 @@ private:
 
     void setSoundStageSize(SoundStageSize) final;
     SoundStageSize soundStageSize() const final { return m_soundStageSize; }
+
+    mutable std::optional<size_t> m_preferredBufferSize;
 
     String m_lastSetPreferredMicrophoneID;
     const RetainPtr<WebInterruptionObserverHelper> m_interruptionObserverHelper;


### PR DESCRIPTION
#### d4ab1891c608410ee20bfffa1e7028d11e25bcf5
<pre>
REGRESSION(304297@main) Increased CPU usage in audiomxd during playback
<a href="https://rdar.apple.com/166810468">rdar://166810468</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=305010">https://bugs.webkit.org/show_bug.cgi?id=305010</a>

Reviewed by Eric Carlson.

304297@main fixed a behavior issue by calling HTMLMediaElement::canProduceAudioChanged()
in more circumstances than previously, but this had the side effect of increasing the
CPU usage in audiomxd as a result of certain properties being changed more often.

Specifically, the excess CPU time was spent executing -setPreferredIOBufferDuration:.
Reduce the cost of calling this method by caching the set value and returing early if
the same value is passed into AudioSessionIOS::setPreferredBufferSize().

* Source/WebCore/platform/audio/ios/AudioSessionIOS.h:
* Source/WebCore/platform/audio/ios/AudioSessionIOS.mm:
(-[WebInterruptionObserverHelper initWithCallback:]):
(-[WebInterruptionObserverHelper sessionMediaServicesWereReset:]):

Canonical link: <a href="https://commits.webkit.org/305191@main">https://commits.webkit.org/305191@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fee62053b4b2253572650b5334f704a7e111b676

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137744 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10105 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49034 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145511 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90717 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5f1532a5-51ae-4a23-939c-dfd7a91d33ad) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139616 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10808 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10236 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105364 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e2be8634-7c60-4345-ac35-a355bf90b36b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140689 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8053 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123443 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86224 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4389144d-ce82-4746-acd8-0da8b1e46b7e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/7676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5397 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6088 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117067 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41602 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148280 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9788 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42153 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113749 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9805 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8254 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114088 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28969 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7603 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119681 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64487 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9836 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37728 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9567 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73401 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9776 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9628 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->