### PR TITLE
Clean-up extraneous safer CPP variables in ApplicationManifestParser.cpp

### DIFF
--- a/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp
+++ b/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp
@@ -313,10 +313,9 @@ Vector<ApplicationManifest::Icon> ApplicationManifestParser::parseIcons(const JS
 
     for (const auto& iconValue : *manifestIconsArray) {
         ApplicationManifest::Icon currentIcon;
-        auto iconObject = iconValue->asObject();
-        if (!iconObject)
+        RefPtr iconJSON = iconValue->asObject();
+        if (!iconJSON)
             continue;
-        Ref iconJSON = *iconObject;
 
         auto srcValue = iconJSON->getValue("src"_s);
         if (!srcValue)
@@ -335,9 +334,9 @@ Vector<ApplicationManifest::Icon> ApplicationManifestParser::parseIcons(const JS
         }
         currentIcon.src = srcURL;
 
-        currentIcon.sizes = parseGenericString(iconJSON, "sizes"_s).split(' ');
+        currentIcon.sizes = parseGenericString(*iconJSON, "sizes"_s).split(' ');
 
-        currentIcon.type = parseGenericString(iconJSON, "type"_s);
+        currentIcon.type = parseGenericString(*iconJSON, "type"_s);
 
         auto purposeValue = iconJSON->getValue("purpose"_s);
         OptionSet<ApplicationManifest::Icon::Purpose> purposes;
@@ -392,10 +391,9 @@ Vector<ApplicationManifest::Shortcut> ApplicationManifestParser::parseShortcuts(
 
     for (const auto& shortcutValue : *manifestShortcutsArray) {
         ApplicationManifest::Shortcut currentShortcut;
-        auto shortcutObject = shortcutValue->asObject();
-        if (!shortcutObject)
+        RefPtr shortcutJSON = shortcutValue->asObject();
+        if (!shortcutJSON)
             continue;
-        Ref shortcutJSON = *shortcutObject;
 
         auto urlValue = shortcutJSON->getValue("url"_s);
         if (!urlValue)
@@ -414,8 +412,8 @@ Vector<ApplicationManifest::Shortcut> ApplicationManifestParser::parseShortcuts(
             continue;
         }
         currentShortcut.url = WTF::move(shortcutURL);
-        currentShortcut.name = parseGenericString(shortcutJSON, "name"_s);
-        currentShortcut.icons = parseIcons(shortcutJSON);
+        currentShortcut.name = parseGenericString(*shortcutJSON, "name"_s);
+        currentShortcut.icons = parseIcons(*shortcutJSON);
 
         shortcutResources.append(WTF::move(currentShortcut));
     }


### PR DESCRIPTION
#### 101555da07321c1675ae17a72e0ca07736d6be65
<pre>
Clean-up extraneous safer CPP variables in ApplicationManifestParser.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=305013">https://bugs.webkit.org/show_bug.cgi?id=305013</a>
<a href="https://rdar.apple.com/167652038">rdar://167652038</a>

Reviewed by Anne van Kesteren.

This is a continuation of <a href="https://bugs.webkit.org/show_bug.cgi?id=304342.">https://bugs.webkit.org/show_bug.cgi?id=304342.</a>
There were some PR comments that I did not fully address, see <a href="https://github.com/WebKit/WebKit/pull/55569#issuecomment-3668949958.">https://github.com/WebKit/WebKit/pull/55569#issuecomment-3668949958.</a>

No new tests needed.

* Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp:
(WebCore::ApplicationManifestParser::parseIcons):
(WebCore::ApplicationManifestParser::parseShortcuts):

Canonical link: <a href="https://commits.webkit.org/305222@main">https://commits.webkit.org/305222@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eecbdd8671a84e1a389ec28174df84616c627516

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137751 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10112 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49041 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145519 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90724 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139623 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10815 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10243 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105373 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140696 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8063 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123456 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86232 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b9280f3c-9b63-4e5b-99f1-2cf023271bb1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7686 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5401 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6095 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117076 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41615 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148287 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9795 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42166 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113754 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9812 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8258 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114093 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7611 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119694 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64494 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21217 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9843 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37741 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9574 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73408 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9783 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9635 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->