### PR TITLE
[webkitpy] Fix simulated device resolution with no explicit default device type match.

### DIFF
--- a/Tools/Scripts/webkitpy/port/visionos_simulator.py
+++ b/Tools/Scripts/webkitpy/port/visionos_simulator.py
@@ -36,7 +36,7 @@ class VisionOSSimulatorPort(EmbeddedSimulatorPort, VisionOSPort):
     ARCHITECTURES = ['arm64']
     DEFAULT_ARCHITECTURE = 'arm64'
 
-    DEFAULT_DEVICE_TYPES = apple_additions().get_default_visionos_device_types() if apple_additions() else [
+    DEFAULT_DEVICE_TYPES = [
         DeviceType(software_variant='visionOS', hardware_family='Vision', hardware_type='Pro')
     ]
     SDK = apple_additions().get_sdk('xrsimulator') if apple_additions() else 'xrsimulator'


### PR DESCRIPTION
#### d1c750f5144b5444e7c646fd2718b6396981d117
<pre>
[webkitpy] Fix simulated device resolution with no explicit default device type match.
<a href="https://bugs.webkit.org/show_bug.cgi?id=305000">https://bugs.webkit.org/show_bug.cgi?id=305000</a>
<a href="https://rdar.apple.com/167641789">rdar://167641789</a>

Reviewed by Jonathan Bedard.

All simulated device ports have default device types. Currently, if there are
no exact name matches with the devices created on the system, webkitpy fails
to resolve a device to use.

So, this change determines usable devices by pulling the supported devices
from the available runtimes on the machine.

* Tools/Scripts/webkitpy/port/embedded_port.py:
(EmbeddedPort.get_available_simulators_of_type_from_xcrun): Determine available simulator device types from available runtimes.
(EmbeddedPort.supported_device_types): Fallback to another embedded simulator of the desired software type.
* Tools/Scripts/webkitpy/port/visionos_simulator.py:
(VisionOSSimulatorPort): Remove apple_additions.

Canonical link: <a href="https://commits.webkit.org/305227@main">https://commits.webkit.org/305227@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cca4f9f6b3ae31560bdb9e7601d04f40e53a838d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137756 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10117 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49046 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145524 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90729 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a05753c3-8edc-4ab1-b6f4-3f9200491065) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139628 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10820 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10248 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105376 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/246d3667-38ae-4bb2-8a9a-65d50d87a85c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140701 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8046 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123460 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86235 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/137104 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7669 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5404 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6100 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117060 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41619 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148292 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9800 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42170 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113756 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9817 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8261 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114095 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7609 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119698 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64499 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21219 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9848 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37745 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9579 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9788 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9640 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->