### PR TITLE
REGRESSION (301306@main): Drag image location is incorrect when dragging images in non-remote subframes

### DIFF
--- a/Source/WebCore/page/DragController.cpp
+++ b/Source/WebCore/page/DragController.cpp
@@ -1360,7 +1360,7 @@ void DragController::doImageDrag(Element& element, const IntPoint& dragOrigin, c
         return;
 
     dragImageOffset = mouseDownPoint + scaledOrigin;
-    doSystemDrag(WTF::move(dragImage), dragImageOffset, dragOrigin, frame, state, WTF::move(attachmentInfo), frame.frameID());
+    doSystemDrag(WTF::move(dragImage), dragImageOffset, dragOrigin, frame, state, WTF::move(attachmentInfo), frame.rootFrame().frameID());
 }
 
 void DragController::beginDrag(DragItem dragItem, LocalFrame& frame, const IntPoint& mouseDownPoint, const IntPoint& mouseDraggedPoint, DataTransfer& dataTransfer, DragSourceAction dragSourceAction)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -13684,6 +13684,8 @@ void WebPageProxy::updateWebsitePolicies(const API::WebsitePolicies& policies)
 
 void WebPageProxy::convertPointToMainFrameCoordinates(WebCore::FloatPoint point, std::optional<WebCore::FrameIdentifier> frameID, CompletionHandler<void(std::optional<WebCore::FloatPoint>)>&& completionHandler)
 {
+    // FIXME: This method returns a point in main frame content coordinates when site isolation is disabled,
+    // but returns a point in root view coordinates when site isolation is enabled.
     RefPtr frame = WebFrameProxy::webFrame(frameID);
     if (!frame)
         return completionHandler(std::nullopt);

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -4522,6 +4522,8 @@ void WebViewImpl::startDrag(const WebCore::DragItem& item, ShareableBitmap::Hand
     auto protector = m_view.get();
 
     if (RefPtr frame = WebFrameProxy::webFrame(item.rootFrameID)) {
+        // FIXME: The `dragLocationInWindowCoordinates` is in window coordinates (equivalent to root view), but `convertPointToMainFrameCoordinates`
+        // expects the input to be in content coordinates of the frame corresponding to the given frame ID.
         m_page->convertPointToMainFrameCoordinates(item.dragLocationInWindowCoordinates, item.rootFrameID, [weakThis = WeakPtr { *this }, promisedAttachmentInfo = item.promisedAttachmentInfo, dragNSImage = WTF::move(dragNSImage), size, lastMouseDownEvent = m_lastMouseDownEvent] (std::optional<FloatPoint> dragLocationInMainFrameCoordinates) mutable {
             CheckedPtr protectedThis = weakThis.get();
             if (!protectedThis || !dragLocationInMainFrameCoordinates)

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1445,6 +1445,7 @@
 		F42A9E702CC2FE84002280C0 /* subframes.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F42A9E6F2CC2FE84002280C0 /* subframes.html */; };
 		F42D634422A1729F00D2FB3A /* AutocorrectionTestsIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = F42D634322A1729F00D2FB3A /* AutocorrectionTestsIOS.mm */; };
 		F434CA1A22E65BCA005DDB26 /* ScrollToRevealSelection.mm in Sources */ = {isa = PBXBuildFile; fileRef = F434CA1922E65BCA005DDB26 /* ScrollToRevealSelection.mm */; };
+		F439524E2F0DBE2900C08066 /* image-in-scrolled-subframe.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F43952462F0DBAD100C08066 /* image-in-scrolled-subframe.html */; };
 		F43B320E2C9C801100838ABA /* audio-fingerprinting.js in Copy Resources */ = {isa = PBXBuildFile; fileRef = F43B320C2C9C801100838ABA /* audio-fingerprinting.js */; };
 		F43B320F2C9C801100838ABA /* canvas-fingerprinting.js in Copy Resources */ = {isa = PBXBuildFile; fileRef = F43B320D2C9C801100838ABA /* canvas-fingerprinting.js */; };
 		F43CAB1D278A326500C8D0A2 /* CloseWhileCommittingLoad.mm in Sources */ = {isa = PBXBuildFile; fileRef = F43CAB1C278A326500C8D0A2 /* CloseWhileCommittingLoad.mm */; };
@@ -2077,6 +2078,7 @@
 				A17C47852C98E5C20023F3C7 /* image-and-textarea.html in Copy Resources */,
 				A17C47862C98E5C20023F3C7 /* image-controls.html in Copy Resources */,
 				A17C47872C98E5C20023F3C7 /* image-in-link-and-input.html in Copy Resources */,
+				F439524E2F0DBE2900C08066 /* image-in-scrolled-subframe.html in Copy Resources */,
 				A17C47882C98E5C20023F3C7 /* image-map.html in Copy Resources */,
 				A17C47892C98E5C20023F3C7 /* image-with-text.html in Copy Resources */,
 				A17C478A2C98E5C20023F3C7 /* image.html in Copy Resources */,
@@ -4263,6 +4265,7 @@
 		F434CA1922E65BCA005DDB26 /* ScrollToRevealSelection.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ScrollToRevealSelection.mm; sourceTree = "<group>"; };
 		F4352F9E26D4037000E605E4 /* editable-responsive-body.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "editable-responsive-body.html"; sourceTree = "<group>"; };
 		F4365E232BB1181A005E8C1A /* element-targeting-2.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "element-targeting-2.html"; sourceTree = "<group>"; };
+		F43952462F0DBAD100C08066 /* image-in-scrolled-subframe.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "image-in-scrolled-subframe.html"; sourceTree = "<group>"; };
 		F43B320C2C9C801100838ABA /* audio-fingerprinting.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = "audio-fingerprinting.js"; sourceTree = "<group>"; };
 		F43B320D2C9C801100838ABA /* canvas-fingerprinting.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = "canvas-fingerprinting.js"; sourceTree = "<group>"; };
 		F43C3823278133190099ABCE /* NSResponderTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = NSResponderTests.mm; sourceTree = "<group>"; };
@@ -4943,6 +4946,7 @@
 				510477751D298E03009747EB /* IDBDeleteRecovery.mm */,
 				5110FCEF1E01CBAA006F8D0B /* IDBIndexUpgradeToV2.mm */,
 				93BCBC8023CC6EE800CA2221 /* IDBObjectStoreInfoUpgradeToV2.mm */,
+				F43952462F0DBAD100C08066 /* image-in-scrolled-subframe.html */,
 				F44A7D1F268D5C6900B49BB8 /* ImageAnalysisTests.mm */,
 				51CF3E8E2EE7F09900EEAFDD /* ImmersiveVideoMetadata.mm */,
 				49AEEF6B2407358600C87E4C /* InAppBrowserPrivacy.mm */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/image-in-scrolled-subframe.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/image-in-scrolled-subframe.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta name="viewport" content="width=device-width,initial-scale=1">
+        <style>
+            iframe {
+                width: 400px;
+                height: 400px;
+            }
+        </style>
+    </head>
+    <body>
+        <iframe frameBorder="none"></iframe>
+        <script>
+            doneLoadingSubframe = false;
+            addEventListener("load", () => {
+                let iframe = document.querySelector("iframe");
+                iframe.addEventListener("load", () => doneLoadingSubframe = true);
+                iframe.srcdoc = `
+                    <html>
+                        <head>
+                            <style>
+                                body, html {
+                                    margin: 0;
+                                }
+
+                                img {
+                                    display: block;
+                                    margin-top: 8000px;
+                                }
+                            </style>
+                        </head>
+                        <body>
+                            <img src='400x400-green.png' />
+                            <script>
+                                addEventListener('load', () => scrollBy(0, 10000));
+                            </script` + `>
+                        </body>
+                    </html>
+                `;
+            });
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
#### 877e4daa3bc718be3371dc74a756a6801b4d564f
<pre>
REGRESSION (301306@main): Drag image location is incorrect when dragging images in non-remote subframes
<a href="https://bugs.webkit.org/show_bug.cgi?id=305012">https://bugs.webkit.org/show_bug.cgi?id=305012</a>
<a href="https://rdar.apple.com/165119210">rdar://165119210</a>

Reviewed by Abrar Rahman Protyasha.

After the changes in 301306@main, dragging an image in a subframe fails in the case where either
site isolation is disabled, or site isolation is enabled but the image is in a same-origin frame.
This is due to multiple bugs, regarding how the drag image location is determined:

1.  The `rootFrameID` passed into `doSystemDrag` is currently the source `Frame` where the drag is
    initiated, as opposed to being the root frame of the drag initator.

2.  `dragLocationInWindowCoordinates` is being passed into `convertPointToMainFrameCoordinates`.
    The former is in window coordinates (which is incorrectly computed in the site isolation remote
    frame case), and the latter expects coordinates in the content coordinate space of the frame
    corresponding to the frame ID.

3.  `convertPointToMainFrameCoordinates` itself returns a point in different coordinate spaces,
    depending on whether site isolation is enabled or disabled. When disabled, the resulting
    coordinates are in main frame content coordinates. When enabled, the resulting coordinates
    appear to be in root view coordinates (relative to the mainframe). It&apos;s unclear in the first
    place whether &quot;mainframe coordinates&quot; here was intended to refer to content coordinates in the
    main frame, or root view coordinates in the main frame.

To limit risk for now, this patch only fixes (1), which is sufficient to ensure that the drag image
location is correct in the following 3 scenarios:

a. Site isolation disabled: dragging an image in any subframe.
b. Site isolation enabled: dragging an image in a remote subframe under the main frame.
c. Site isolation enabled: dragging an image in a local subframe under the main frame.

We leave (2) and (3) as FIXMEs for now.

Tests: DragAndDropTests.DragLocationForImageInScrolledSubframe

* Source/WebCore/page/DragController.cpp:
(WebCore::DragController::doImageDrag):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::convertPointToMainFrameCoordinates):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::startDrag):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/image-in-scrolled-subframe.html: Added.
* Tools/TestWebKitAPI/Tests/mac/DragAndDropTestsMac.mm:
(TEST(DragAndDropTests, DragLocationForImageInScrolledSubframe)):

Add a test to exercise this fix. The drag location is (incorrectly) far outside the bounds of the
view without these changes.

Canonical link: <a href="https://commits.webkit.org/305198@main">https://commits.webkit.org/305198@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f61f561fc359f5030de95e89b2cf09ecd6d12a7a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137761 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10122 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49051 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145529 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90734 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a8d340f7-d8d1-4c9f-800c-aae2d7ef0ea1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139633 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10825 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10253 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105378 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/be396442-8c26-4590-97b5-807888000b50) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140706 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8050 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123470 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86237 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7673 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5405 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6105 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117064 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41633 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148297 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9805 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42179 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113758 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9822 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8262 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114097 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28973 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7610 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119708 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64504 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9853 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37752 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9584 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73418 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9793 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9645 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->