### PR TITLE
REGRESSION (Safari 26, 292627@main): Translate on semi transparent background sometimes makes background darker

### DIFF
--- a/LayoutTests/compositing/iframes/transparent-background-layer-promotion-expected.txt
+++ b/LayoutTests/compositing/iframes/transparent-background-layer-promotion-expected.txt
@@ -1,0 +1,2 @@
+
+PASS. The viewport repaint occurred

--- a/LayoutTests/compositing/iframes/transparent-background-layer-promotion.html
+++ b/LayoutTests/compositing/iframes/transparent-background-layer-promotion.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Iframe must repaint when child layer is promoted</title>
+<style>
+iframe {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    border: none;
+}
+</style>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+function runTest() {
+    const iframe = document.getElementById('testFrame').contentDocument;
+    const target = iframe.getElementById('target');
+
+    if (window.internals)
+        internals.startTrackingRepaints();
+
+    // Trigger layer promotion
+    target.classList.add('promoted');
+
+    requestAnimationFrame(() => setTimeout(() => {
+        if (window.internals) {
+            const layerTree = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_REPAINT_RECTS);
+            internals.stopTrackingRepaints();
+
+            // Assert that a viewport-sized repaint occurred (the iframe covers the viewport)
+            const viewportRepaintCount = (layerTree.match(/\(rect 0\.00 0\.00 800\.00 600\.00\)/g) || []).length;
+
+            if (viewportRepaintCount >= 1)
+                document.getElementById('result').textContent = 'PASS. The viewport repaint occurred';
+            else
+                document.getElementById('result').textContent = 'FAIL: no viewport repaint occurred';
+        }
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }, 0));
+}
+
+window.addEventListener('load', () => {
+    requestAnimationFrame(() => setTimeout(runTest, 0));
+});
+</script>
+</head>
+<body>
+<iframe id="testFrame" srcdoc="
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+body { background: rgba(0 0 0 / 50%); }
+#target.promoted { will-change: transform; }
+</style>
+</head>
+<body>
+<p id='target'>When a compositing layer is created inside an iframe, the iframe element in the outer document must repaint to clear its old content. Without this repaint, the old iframe background persists in the outer document layers while the new iframe layers also paint it, causing transparent backgrounds to appear darker when composited together.</p>
+</body>
+</html>
+"></iframe>
+<pre id="result"></pre>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -5251,8 +5251,11 @@ void RenderLayerCompositor::attachRootLayer(RootLayerAttachment attachment)
         case RootLayerAttachedViaEnclosingFrame: {
             // The layer will get hooked up via RenderLayerBacking::updateConfiguration()
             // for the frame's renderer in the parent document.
-            if (RefPtr ownerElement = m_renderView.protectedDocument()->ownerElement())
+            if (RefPtr ownerElement = m_renderView.protectedDocument()->ownerElement()) {
                 ownerElement->scheduleInvalidateStyleAndLayerComposition();
+                if (CheckedPtr renderer = ownerElement->renderer())
+                    renderer->repaint();
+            }
             break;
         }
     }


### PR DESCRIPTION
#### 366280b0f89654fd3cbe11d6d3b5b807766439a2
<pre>
REGRESSION (Safari 26, 292627@main): Translate on semi transparent background sometimes makes background darker
<a href="https://bugs.webkit.org/show_bug.cgi?id=301462">https://bugs.webkit.org/show_bug.cgi?id=301462</a>
<a href="https://rdar.apple.com/163509267">rdar://163509267</a>

Reviewed by Simon Fraser.

When an element inside an iframe gains its own compositing layer (via
will-change, transforms, animations, etc.), the iframe&apos;s compositing structure
changes. The iframe&apos;s background gets painted into the updated
layers, but the old background painting in the outer document&apos;s layers is never
invalidated. These stale and new layers composite together.
If the iframe&apos;s background is transparent, this causes the
transparent background to appear darker than intended.

Add renderer()-&gt;repaint() when the iframe&apos;s internal compositing changes.
This forces the iframe element in the outer document to repaint and clear
its old content, ensuring the background only exists in the correct layer.

Test: transparent-background-layer-promotion.html

* LayoutTests/compositing/iframes/transparent-background-layer-promotion-expected.txt: Added.
* LayoutTests/compositing/iframes/transparent-background-layer-promotion.html: Added.
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::attachRootLayer):

Canonical link: <a href="https://commits.webkit.org/305492@main">https://commits.webkit.org/305492@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78933785f9525c289db64d0fb28ba933516d0e77

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137909 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10273 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49266 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145976 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90884 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139781 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10975 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10414 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105469 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/76968 "Exiting early after 60 failures. 21517 tests run. 60 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/774afbd8-87ae-418d-8d9c-c8a146ff1e1c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140854 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8171 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123632 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86320 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cd30633e-cd84-472c-9c7e-d32d96d2f279) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7792 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5544 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6257 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117186 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41797 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148686 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9956 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42356 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113869 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9973 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8401 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114199 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29154 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7736 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119883 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64680 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10002 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37888 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9732 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73570 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9943 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9794 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->