### PR TITLE
REGRESSION(305160@main): Caused CLoop testapi to fail

### DIFF
--- a/Source/JavaScriptCore/API/tests/VMManagerStopTheWorldTest.cpp
+++ b/Source/JavaScriptCore/API/tests/VMManagerStopTheWorldTest.cpp
@@ -801,8 +801,10 @@ static int test()
     dataLogLn("Starting VMManager StopTheWorld Test");
 
     auto* originalWasmDebugger = g_jscConfig.wasmDebuggerOnStop;
+    auto* originalWasmDebuggerOnResume = g_jscConfig.wasmDebuggerOnResume;
     auto* originalMemoryDebugger = g_jscConfig.memoryDebuggerStopTheWorld;
     VMManager::setWasmDebuggerOnStop(wasmDebuggerTestCallback);
+    VMManager::setWasmDebuggerOnResume([] { /* no-op for test */ });
     VMManager::setMemoryDebuggerCallback(memoryDebuggerTestCallback);
 
     // FIXME: for now, VMTraps doesn't completely work on JIT runs yet. Once we fix that, we'll need
@@ -814,6 +816,7 @@ static int test()
     auto resetSettings = makeScopeExit([&] {
         Options::setOptions(savedOptionsBuilder.toString().ascii().data());
         VMManager::setWasmDebuggerOnStop(originalWasmDebugger);
+        VMManager::setWasmDebuggerOnResume(originalWasmDebuggerOnResume);
         VMManager::setMemoryDebuggerCallback(originalMemoryDebugger);
     });
 


### PR DESCRIPTION
#### 08c3671b85fc84897681e1e0a61adef1fd0d8df7
<pre>
REGRESSION(305160@main): Caused CLoop testapi to fail
<a href="https://rdar.apple.com/167651308">rdar://167651308</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=305011">https://bugs.webkit.org/show_bug.cgi?id=305011</a>

Reviewed by Mark Lam.

testVMManagerStopTheWorld was crashing on CLoop builds because it only registered
wasmDebuggerOnStop callback but not the corresponding wasmDebuggerOnResume callback.

When the test triggered stop-the-world and then resumed all VMs, VMManager called
g_jscConfig.wasmDebuggerOnResume() which was NULL.

The wasmDebuggerOnStop and wasmDebuggerOnResume callbacks are a pair introduced in

<a href="https://commits.webkit.org/305160@main.">https://commits.webkit.org/305160@main.</a> Tests that override one must override both.
Canonical link: <a href="https://commits.webkit.org/305223@main">https://commits.webkit.org/305223@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bdab9c5e30ee769590e6acd674142c90c3ffa99a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137768 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10129 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49060 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145536 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90741 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5a9f4fd5-9933-46e0-a224-75d53bea8b12) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10832 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10261 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105382 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140713 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8057 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123467 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86241 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a7204c27-9f01-4689-9903-773fc023396d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7680 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5412 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6112 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/129729 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117071 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41625 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148304 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/136314 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9812 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42175 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113764 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9829 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8269 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114103 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7618 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119704 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64511 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21218 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9860 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37749 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/169039 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9591 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73425 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44086 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9800 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9652 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->