### PR TITLE
[CSS Zoom] Store InheritedFlag to indicate zooming

### DIFF
--- a/Source/WebCore/style/computed/StyleComputedStyleBase+ConstructionInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+ConstructionInlines.h
@@ -62,6 +62,7 @@ inline ComputedStyleBase::ComputedStyleBase(CreateDefaultStyleTag)
     m_inheritedFlags.printColorAdjust = static_cast<unsigned>(ComputedStyle::initialPrintColorAdjust());
     m_inheritedFlags.pointerEvents = static_cast<unsigned>(ComputedStyle::initialPointerEvents());
     m_inheritedFlags.insideLink = static_cast<unsigned>(InsideLink::NotInside);
+    m_inheritedFlags.isZoomed = 0;
 #if ENABLE(TEXT_AUTOSIZING)
     m_inheritedFlags.autosizeStatus = 0;
 #endif

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h
@@ -323,13 +323,17 @@ inline float ComputedStyleBase::usedZoom() const
 
 inline ZoomFactor ComputedStyleBase::usedZoomForLength() const
 {
+    static constexpr ZoomFactor unzoomed(1.0f);
+    if (!inheritedFlags().isZoomed)
+        return unzoomed;
+
     if (useSVGZoomRulesForLength())
-        return ZoomFactor(1.0f);
+        return unzoomed;
 
     if (evaluationTimeZoomEnabled())
         return ZoomFactor(usedZoom());
 
-    return ZoomFactor(1.0f);
+    return unzoomed;
 }
 
 // MARK: - Fonts

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h
@@ -256,6 +256,7 @@ inline bool ComputedStyleBase::setUsedZoom(float zoomLevel)
 {
     if (compareEqual(m_inheritedRareData->usedZoom, zoomLevel))
         return false;
+    m_inheritedFlags.isZoomed = zoomLevel != 1.0f;
     m_inheritedRareData.access().usedZoom = zoomLevel;
     return true;
 }

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.h
@@ -817,10 +817,12 @@ public:
         PREFERRED_TYPE(PrintColorAdjust) unsigned char printColorAdjust : 1;
         PREFERRED_TYPE(InsideLink) unsigned char insideLink : 2;
 
+        PREFERRED_TYPE(bool) unsigned char isZoomed : 1;
+
 #if ENABLE(TEXT_AUTOSIZING)
         unsigned autosizeStatus : 5;
 #endif
-        // Total = 56 bits (fits in 8 bytes)
+        // Total = 63 bits (fits in 8 bytes)
     };
 
 protected:


### PR DESCRIPTION
#### 5903d8eb1065a84ca796d840d7b0597f4ada0214
<pre>
[CSS Zoom] Store InheritedFlag to indicate zooming
<a href="https://bugs.webkit.org/show_bug.cgi?id=305017">https://bugs.webkit.org/show_bug.cgi?id=305017</a>
<a href="https://rdar.apple.com/164052832">rdar://164052832</a>

Reviewed by Sam Weinig.

It seems that attempting to access the zoom value ends up causing a
performance regression on benchmarks, such as Speedometer 3. Whenever we
attempt to get the zoom value, for example during layout, we end up
calling into the style&apos;s InheritedRareData since that is where the
usedZoom (and previously deviceScaleFactor before 305180@main) value
lives.

However, it turns out that the common case for the benchmarks is
content that is unzoomed and if we end up avoiding this access we
recover from the regression. This patch attempts to avoid the accesses
to InheritedRareData during these hot codepaths by storing an additional
bit on InheritedFlags to indicate whether the content is zoomed. If it
is not we can just return a ZoomFactor of 1.0f instead of looking up the
value.

(WebCore::Style::ComputedStyleBase::ComputedStyleBase):
* Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h:
Just return a ZoomFactor(1.0f) if we are not zoomed as indicated by our
new bit.

(WebCore::Style::ComputedStyleBase::usedZoomForLength const):
* Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h:
Set the bit if the new zoom level we are setting is not 1.0f.

(WebCore::Style::ComputedStyleBase::setUsedZoom):
* Source/WebCore/style/computed/StyleComputedStyleBase.h:
dump-class-layout indicates that InheritedFlags is now 63 bits as
opposed to the 57 that would have been the new value with reference to
the comment here.

+0 &lt;  8&gt; WebCore::Style::ComputedStyleBase::InheritedFlags
+0 &lt;  1&gt;     WebCore::WritingMode writingMode
+0 &lt;  1&gt;         WebCore::WritingMode::Data m_bits
+1 &lt; :3&gt;     WebCore::WhiteSpaceCollapse whiteSpaceCollapse : 3
+1 &lt; :1&gt;     WebCore::TextWrapMode textWrapMode : 1
+1 &lt; :4&gt;     WebCore::Style::TextAlign textAlign : 4
+2 &lt; :2&gt;     WebCore::TextWrapStyle textWrapStyle : 2
+2 &lt; :6&gt;     unsigned char textTransform : 6
+3 &lt; :1&gt;     int None : 1
+3 &lt; :5&gt;     unsigned char textDecorationLineInEffect : 5
+3 &lt; :2&gt;     int None : 2
+4 &lt; :4&gt;     WebCore::PointerEvents pointerEvents : 4
+4 &lt; :2&gt;     WebCore::Visibility visibility : 2
+4 &lt; :2&gt;     int None : 2
+5 &lt; :6&gt;     WebCore::CursorType cursorType : 6
+5 &lt; :1&gt;     WebCore::CursorVisibility cursorVisibility : 1
+5 &lt; :1&gt;     WebCore::ListStylePosition listStylePosition : 1
+6 &lt; :1&gt;     WebCore::EmptyCell emptyCells : 1
+6 &lt; :1&gt;     WebCore::BorderCollapse borderCollapse : 1
+6 &lt; :2&gt;     WebCore::CaptionSide captionSide : 2
+6 &lt; :1&gt;     WebCore::BoxDirection boxDirection : 1
+6 &lt; :1&gt;     WebCore::Order rtlOrdering : 1
+6 &lt; :1&gt;     bool hasExplicitlySetColor : 1
+6 &lt; :1&gt;     WebCore::PrintColorAdjust printColorAdjust : 1
+7 &lt; :2&gt;     WebCore::InsideLink insideLink : 2
+7 &lt; :5&gt;     unsigned int autosizeStatus : 5
+7 &lt; :1&gt;     &lt;UNUSED BITS: 1 bit&gt;

Canonical link: <a href="https://commits.webkit.org/305217@main">https://commits.webkit.org/305217@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e84c60da01b7eb7c5dbfbb3842da8a38ba2fb33c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137785 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10146 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49077 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145555 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90758 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139657 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10849 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10278 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105398 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140730 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8073 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123489 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86257 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7694 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5426 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6129 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117086 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41653 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148321 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9829 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42199 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113776 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9846 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8283 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114115 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28987 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7634 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119728 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64528 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9877 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37769 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9608 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73442 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9817 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9669 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->