### PR TITLE
[Temporal] Add toPlainMonthDay and toPlainYearMonth methods for PlainDate

### DIFF
--- a/JSTests/stress/temporal-plaindate.js
+++ b/JSTests/stress/temporal-plaindate.js
@@ -428,3 +428,12 @@ shouldBe(Temporal.PlainDate.prototype.until.length, 1);
 {
     shouldBe(new Temporal.PlainDate(2000, 5, 2, "iso8601").calendarId, "iso8601");
 }
+
+shouldBe(Temporal.PlainDate.prototype.toPlainMonthDay.length, 0);
+shouldBe(Temporal.PlainDate.prototype.toPlainYearMonth.length, 0);
+{
+    const date = Temporal.PlainDate.from('2020-02-28');
+
+    shouldBe(date.toPlainMonthDay().toString(), '02-28');
+    shouldBe(date.toPlainYearMonth().toString(), '2020-02');
+}

--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -79,25 +79,6 @@ skip:
     - test/built-ins/RegExp/regexp-modifiers/add-ignoreCase-affects-slash-upper-p.js
     - test/built-ins/RegExp/regexp-modifiers/add-ignoreCase-affects-slash-lower-p.js
 
-    # Depends on Temporal.PlainMonthDay
-    - test/built-ins/Temporal/PlainDate/prototype/toPlainMonthDay/basic.js
-    - test/built-ins/Temporal/PlainDate/prototype/toPlainMonthDay/branding.js
-    - test/built-ins/Temporal/PlainDate/prototype/toPlainMonthDay/builtin.js
-    - test/built-ins/Temporal/PlainDate/prototype/toPlainMonthDay/length.js
-    - test/built-ins/Temporal/PlainDate/prototype/toPlainMonthDay/name.js
-    - test/built-ins/Temporal/PlainDate/prototype/toPlainMonthDay/not-a-constructor.js
-    - test/built-ins/Temporal/PlainDate/prototype/toPlainMonthDay/prop-desc.js
-
-    # Depends on Temporal.PlainYearMonth
-    - test/built-ins/Temporal/PlainDate/prototype/toPlainYearMonth/basic.js
-    - test/built-ins/Temporal/PlainDate/prototype/toPlainYearMonth/branding.js
-    - test/built-ins/Temporal/PlainDate/prototype/toPlainYearMonth/builtin.js
-    - test/built-ins/Temporal/PlainDate/prototype/toPlainYearMonth/length.js
-    - test/built-ins/Temporal/PlainDate/prototype/toPlainYearMonth/limits.js
-    - test/built-ins/Temporal/PlainDate/prototype/toPlainYearMonth/name.js
-    - test/built-ins/Temporal/PlainDate/prototype/toPlainYearMonth/not-a-constructor.js
-    - test/built-ins/Temporal/PlainDate/prototype/toPlainYearMonth/prop-desc.js
-
     # Depends on Temporal.Duration relativeTo option
     - test/built-ins/Temporal/Duration/compare/basic.js
     - test/built-ins/Temporal/Duration/compare/calendar-possibly-required.js


### PR DESCRIPTION
#### a05334f6848b4433928b4a0b5120e6a765a55f69
<pre>
[Temporal] Add toPlainMonthDay and toPlainYearMonth methods for PlainDate
<a href="https://bugs.webkit.org/show_bug.cgi?id=305021">https://bugs.webkit.org/show_bug.cgi?id=305021</a>

Reviewed by Yusuke Suzuki.

Add these methods.

* JSTests/stress/temporal-plaindate.js:
(shouldBe):
* JSTests/test262/config.yaml:
* Source/JavaScriptCore/runtime/TemporalPlainDatePrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/305207@main">https://commits.webkit.org/305207@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aaa03edf3e7fd6f065b1a06512defd29aaf8a1eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137778 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10139 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49070 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145546 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90751 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10842 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10271 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105390 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140723 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8067 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123474 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86249 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7689 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5420 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6122 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/129739 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117080 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41638 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148314 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/136311 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9822 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42183 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113771 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9839 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8277 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114110 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7622 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119712 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/64521 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21213 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9870 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37756 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/169049 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9601 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73435 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44088 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9810 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9662 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->