### PR TITLE
Drop CSSSelector::m_isLastInSelectorList flag now that it is no longer used

### DIFF
--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -839,7 +839,6 @@ CSSSelector::CSSSelector(const CSSSelector& other)
     : m_relation(other.m_relation)
     , m_match(other.m_match)
     , m_pseudoType(other.m_pseudoType)
-    , m_isLastInSelectorList(other.m_isLastInSelectorList)
     , m_isFirstInComplexSelector(other.m_isFirstInComplexSelector)
     , m_isLastInComplexSelector(other.m_isLastInComplexSelector)
     , m_hasRareData(other.m_hasRareData)
@@ -864,7 +863,6 @@ CSSSelector::CSSSelector(const CSSSelector& other, MutableSelectorCopyTag)
     : CSSSelector(other)
 {
     // Restore the selector list bits to the initial state when copying to a MutableCSSSelector.
-    m_isLastInSelectorList = false;
     m_isFirstInComplexSelector = true;
     m_isLastInComplexSelector = true;
 }

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -178,7 +178,6 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     Relation relation() const { return static_cast<Relation>(m_relation); }
     Match match() const { return static_cast<Match>(m_match); }
 
-    bool isLastInSelectorList() const { return m_isLastInSelectorList; }
     bool isFirstInComplexSelector() const { return m_isFirstInComplexSelector; }
     bool isLastInComplexSelector() const { return m_isLastInComplexSelector; }
     bool isForPage() const { return m_isForPage; }
@@ -197,7 +196,6 @@ private:
     friend class CSSSelectorList;
     friend class MutableCSSSelector;
 
-    void setLastInSelectorList() { m_isLastInSelectorList = true; }
     void setValue(const AtomString&, bool matchLowerCase = false);
 
     void setAttribute(const QualifiedName&, AttributeMatchType);
@@ -220,8 +218,7 @@ private:
     unsigned m_relation : 4 { enumToUnderlyingType(Relation::DescendantSpace) };
     mutable unsigned m_match : 5 { enumToUnderlyingType(Match::Unknown) };
     mutable unsigned m_pseudoType : 8 { 0 }; // PseudoType.
-    // 17 bits
-    unsigned m_isLastInSelectorList : 1 { false };
+    // 18 bits
 
     // These are in logical order, which is reversed from the memory order.
     unsigned m_isFirstInComplexSelector : 1 { true };

--- a/Source/WebCore/css/CSSSelectorList.h
+++ b/Source/WebCore/css/CSSSelectorList.h
@@ -124,7 +124,6 @@ private:
     { }
 
     // End of a multipart selector is indicated by m_isLastInComplexSelector bit in the last item.
-    // End of the array is indicated by m_isLastInSelectorList bit in the last item.
     FixedVector<CSSSelector> m_selectorArray;
 };
 


### PR DESCRIPTION
#### 9ba0add0ae5c26079e81526c3b49f68d8d940a47
<pre>
Drop CSSSelector::m_isLastInSelectorList flag now that it is no longer used
<a href="https://bugs.webkit.org/show_bug.cgi?id=305022">https://bugs.webkit.org/show_bug.cgi?id=305022</a>

Reviewed by Tim Nguyen.

* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::CSSSelector):
* Source/WebCore/css/CSSSelector.h:
(WebCore::CSSSelector::isLastInSelectorList const): Deleted.
(WebCore::CSSSelector::setLastInSelectorList): Deleted.
* Source/WebCore/css/CSSSelectorList.cpp:
(WebCore::CSSSelectorList::CSSSelectorList):
(WebCore::CSSSelectorList::makeCopyingSimpleSelector):
(WebCore::CSSSelectorList::makeCopyingComplexSelector):
(WebCore::CSSSelectorList::makeJoining):
* Source/WebCore/css/CSSSelectorList.h:

Canonical link: <a href="https://commits.webkit.org/305201@main">https://commits.webkit.org/305201@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9b0a081f1060916684a4a920f16ffd8a7dc2822

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137796 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10157 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49090 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145673 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/90769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/64782ffc-93a2-4b17-929a-4d0eb50a9ccb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139668 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10860 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10290 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/105408 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/90769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/20d65227-5ceb-47da-8c31-6f770a556d4e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140741 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8082 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123498 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86264 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7f70b3dd-ec0a-4c59-90da-3dc10d40eaf7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7703 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5434 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6140 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117095 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41661 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148389 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9840 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42207 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/113787 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9857 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8291 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114124 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28976 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7643 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119736 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64539 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9888 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37776 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9619 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/73453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9828 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9680 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->