### PR TITLE
Use move constructor instead of memcpy() for CSSSelector in CSSSelectorList constructor

### DIFF
--- a/Source/WebCore/css/CSSSelectorList.cpp
+++ b/Source/WebCore/css/CSSSelectorList.cpp
@@ -58,15 +58,7 @@ CSSSelectorList::CSSSelectorList(MutableCSSSelectorList&& selectorVector)
         auto* last = selectorVector[i].get();
         auto* current = last;
         while (current) {
-            {
-                // Move item from the parser selector vector into m_selectorArray without invoking destructor (Ugh.)
-                auto* currentSelector = current->releaseSelector().release();
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-                memcpy(static_cast<void*>(&m_selectorArray[arrayIndex]), static_cast<void*>(currentSelector), sizeof(CSSSelector));
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-                // Free the underlying memory without invoking the destructor.
-                operator delete (currentSelector);
-            }
+            new (NotNull, &m_selectorArray[arrayIndex]) CSSSelector(WTF::move(*current->releaseSelector()));
             if (current != last)
                 m_selectorArray[arrayIndex].m_isLastInComplexSelector = false;
             current = current->precedingInComplexSelector();


### PR DESCRIPTION
#### e222b940921b873bfcb23b09f42cffc19c7a695f
<pre>
Use move constructor instead of memcpy() for CSSSelector in CSSSelectorList constructor
<a href="https://bugs.webkit.org/show_bug.cgi?id=305025">https://bugs.webkit.org/show_bug.cgi?id=305025</a>

Reviewed by Darin Adler.

Use move constructor instead of memcpy() for CSSSelector in the
CSSSelectorList constructor.

This tested as performance neutral on Speedometer.

It also reduces help get rid of one use of `WTF_ALLOW_UNSAFE_BUFFER_USAGE`.

* Source/WebCore/css/CSSSelector.h:
(WebCore::CSSSelector::CSSSelector):
Introduce move constructor.

(WebCore::CSSSelector::operator=):
Introduce corresponding move assignment operator for completeness but it
is not required at the moment.

(WebCore::CSSSelector::~CSSSelector):
Drop some unnecessary data member resetting in the destructor. The object
is being destroyed anyway.

* Source/WebCore/css/CSSSelectorList.cpp:
(WebCore::CSSSelectorList::CSSSelectorList):
Rely on new move constructor instead of memcpy().

Canonical link: <a href="https://commits.webkit.org/305269@main">https://commits.webkit.org/305269@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/110badedc0d389d85372c195183faf9298ae692b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137949 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10313 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49311 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146016 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90924 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/849c468d-9c5b-46d4-9b11-7fcd52578cab) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139822 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11015 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10456 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105493 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d8aa355d-0ebb-4ee9-933b-9487019fc200) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140894 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8213 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123665 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86346 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ffe80650-31a8-44a3-9a07-602a05cd3a0e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7827 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5574 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6302 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117227 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41835 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148729 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9996 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42394 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113897 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10013 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8431 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114227 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29022 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7763 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119921 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64720 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10042 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37916 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9773 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73610 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9983 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9834 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->