### PR TITLE
[AutoFill Debugging] Add a nodeIdentifierInclusion mode to include UIDs for all elements

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-all-container-uids-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-all-container-uids-expected.txt
@@ -1,0 +1,21 @@
+root
+    'Welcome to Test Page'
+    navigation,uid=…
+        list,uid=…
+            list-item,uid=…
+                link,uid=…,'Section 1'
+            list-item,uid=…
+                link,uid=…,'Section 2'
+    section,uid=…
+        button,uid=…,'Click Me'
+        'This button does nothing'
+        input,'text',uid=…,placeholder='Enter text here'
+        'Clickable Div'
+    section,uid=…
+        'Name Field\n\n        \nDescription'
+        input,'text',uid=…,placeholder='Your name'
+        'This region is labeled by another element.'
+        input,'text',uid=…,placeholder='Full name'
+        'User Profile\n\n        \n\n            Username:'
+        input,'text',uid=…,label='Username:'
+version=2

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-all-container-uids.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-all-container-uids.html
@@ -1,0 +1,96 @@
+<!-- webkit-test-runner [ useFlexibleViewport=true textExtractionEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<head>
+<style>
+body {
+    white-space: pre-wrap;
+}
+
+.clickable {
+    background-color: lightblue;
+    padding: 10px;
+    margin: 5px;
+    cursor: pointer;
+}
+
+.focusable {
+    border: 2px solid green;
+    padding: 5px;
+    margin: 3px;
+}
+
+.interactive {
+    background-color: lightyellow;
+    padding: 8px;
+}
+
+canvas {
+    width: 200px;
+    height: 200px;
+}
+
+.canvas-container {
+    border: 1px dashed gray;
+    padding: 1em;
+}
+
+#error-text {
+    display: none;
+}
+</style>
+<script src="../../resources/ui-helper.js"></script>
+</head>
+<body>
+<div role="banner">
+    <h1 id="main-title" aria-label="Main Page Title">Welcome to Test Page</h1>
+</div>
+<nav role="navigation" aria-label="Main navigation">
+    <ul>
+        <li><a href="mailto:wenson_hsieh@apple.com" onclick="return false;">Section 1</a></li>
+        <li><a href="https://example.com/" onclick="return false;">Section 2</a></li>
+    </ul>
+</nav>
+<main role="main">
+    <section id="section1" aria-label="Interactive Elements">
+        <button class="clickable" onclick="console.log('clicked')" aria-label="Test button" aria-describedby="btn-help">Click Me</button>
+        <div id="btn-help" aria-hidden="true">This button does nothing</div>
+        <input type="text" class="focusable" placeholder="Enter text here" onfocus="this.style.backgroundColor='yellow'" onblur="this.style.backgroundColor=''" aria-required="true" aria-invalid="false" />
+        <div class="interactive" tabindex="0"  role="button" onclick="this.textContent = 'Clicked!'" onkeydown="if(event.key==='Enter') this.click()" aria-pressed="false">Clickable Div</div>
+    </section>
+    <section id="section2" aria-label="ARIA Labeling Examples">
+        <div id="label1">Name Field</div>
+        <div id="label2">Description</div>
+        <input type="text" aria-labelledby="label1" placeholder="Your name" />
+        <div aria-labelledby="label2" role="region">
+            <p>This region is labeled by another element.</p>
+        </div>
+        <div id="error-text">Name not found.</div>
+        <input type="text" aria-labelledby="label1" aria-describedby="error-text" placeholder="Full name" />
+        <div id="title-label">User Profile</div>
+        <div role="group" aria-labelledby="title-label">
+            <label for="username">Username:</label>
+            <input type="text" id="username" />
+        </div>
+    </section>
+</main>
+<script>
+addEventListener("load", async () => {
+    if (!window.testRunner)
+        return;
+
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+
+    document.body.textContent = await UIHelper.requestDebugText({
+        normalize: true,
+        nodeIdentifierInclusion: "allContainers",
+    });
+
+    testRunner.notifyDone();
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -614,8 +614,14 @@ static inline Variant<SkipExtraction, ItemData, URL, Editable> extractItemData(N
 static inline bool shouldIncludeNodeIdentifier(NodeIdentifierInclusion inclusion, OptionSet<EventListenerCategory> eventListeners, AccessibilityRole role, const ItemData& data)
 {
     using enum NodeIdentifierInclusion;
-    if (inclusion == None)
+    switch (inclusion) {
+    case None:
         return false;
+    case AllContainers:
+        return !std::holds_alternative<TextItemData>(data);
+    default:
+        break;
+    }
 
     return WTF::switchOn(data,
         [inclusion, eventListeners, role](ContainerType type) {

--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -83,6 +83,7 @@ enum class NodeIdentifierInclusion : uint8_t {
     None,
     EditableOnly,
     Interactive,
+    AllContainers,
 };
 
 struct Request {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6785,6 +6785,7 @@ header: <WebCore/TextExtractionTypes.h>
     None,
     EditableOnly,
     Interactive,
+    AllContainers,
 };
 
 header: <WebCore/TextExtractionTypes.h>

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -7161,6 +7161,8 @@ static HashMap<String, HashMap<WebCore::JSHandleIdentifier, String>> extractClie
             return WebCore::TextExtraction::NodeIdentifierInclusion::EditableOnly;
         case _WKTextExtractionNodeIdentifierInclusionInteractive:
             return WebCore::TextExtraction::NodeIdentifierInclusion::Interactive;
+        case _WKTextExtractionNodeIdentifierInclusionAllContainers:
+            return WebCore::TextExtraction::NodeIdentifierInclusion::AllContainers;
         }
         return WebCore::TextExtraction::NodeIdentifierInclusion::None;
     }();

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
@@ -43,7 +43,8 @@ typedef NS_OPTIONS(NSUInteger, _WKTextExtractionFilterOptions) {
 typedef NS_ENUM(NSInteger, _WKTextExtractionNodeIdentifierInclusion) {
     _WKTextExtractionNodeIdentifierInclusionNone = 0,
     _WKTextExtractionNodeIdentifierInclusionEditableOnly,
-    _WKTextExtractionNodeIdentifierInclusionInteractive
+    _WKTextExtractionNodeIdentifierInclusionInteractive,
+    _WKTextExtractionNodeIdentifierInclusionAllContainers,
 } WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 typedef NS_ENUM(NSInteger, _WKTextExtractionOutputFormat) {
@@ -89,6 +90,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
  `.none`          	Prevents collection of any identifiers.
  `.editableOnly`    Limits collection of identifiers to editable elements and form controls.
  `.interactive`     Collects identifiers for all buttons, links, and other interactive elements.
+ `.allContainers`   All containers (excludes text items).
  The default value is `.interactive`.
  */
 @property (nonatomic) _WKTextExtractionNodeIdentifierInclusion nodeIdentifierInclusion;

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
@@ -359,6 +359,9 @@ RetainPtr<_WKTextExtractionConfiguration> createTextExtractionConfiguration(WKWe
         if (equalLettersIgnoringASCIICase(inclusion, "interactive"_s))
             return _WKTextExtractionNodeIdentifierInclusionInteractive;
 
+        if (equalLettersIgnoringASCIICase(inclusion, "allcontainers"_s))
+            return _WKTextExtractionNodeIdentifierInclusionAllContainers;
+
         if (equalLettersIgnoringASCIICase(inclusion, "editableonly"_s))
             return _WKTextExtractionNodeIdentifierInclusionEditableOnly;
 


### PR DESCRIPTION
#### 6c4ba0741319f37f37d0b0e3a0e86694a6c4d332
<pre>
[AutoFill Debugging] Add a nodeIdentifierInclusion mode to include UIDs for all elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=305027">https://bugs.webkit.org/show_bug.cgi?id=305027</a>
<a href="https://rdar.apple.com/167666319">rdar://167666319</a>

Reviewed by Abrar Rahman Protyasha.

Add `_WKTextExtractionNodeIdentifierInclusionAllContainers`, which tells text extraction to include
UIDs on all elements (excluding text nodes).

Test: fast/text-extraction/debug-text-extraction-all-container-uids.html

* LayoutTests/fast/text-extraction/debug-text-extraction-all-container-uids-expected.txt: Added.
* LayoutTests/fast/text-extraction/debug-text-extraction-all-container-uids.html: Added.
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::shouldIncludeNodeIdentifier):

Exit early with `true`, as long as the item doesn&apos;t just represent text.

* Source/WebCore/page/text-extraction/TextExtractionTypes.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _requestTextExtractionInternal:completion:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h:
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm:
(WTR::createTextExtractionConfiguration):

Canonical link: <a href="https://commits.webkit.org/305204@main">https://commits.webkit.org/305204@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9fa4c907518359ee84c8b44627b0c70161a4ef87

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137790 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10151 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49084 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145623 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90763 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2db0c221-b9a7-45e6-a540-a62ef67ad412) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139662 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10854 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10284 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105400 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/36c70f43-c90e-47a1-9959-3d351b97e18b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140735 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8079 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123495 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86259 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a3ac4ea4-b529-4928-b559-6e5cca67f4a0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7700 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5431 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6134 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117092 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41658 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148326 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9834 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42204 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113782 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9851 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8288 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114121 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28977 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7638 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119733 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64533 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9882 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37773 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9613 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73447 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9822 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9674 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->