### PR TITLE
Update CSSSelectorList::first() to return a reference

### DIFF
--- a/Source/WebCore/css/CSSPageRule.cpp
+++ b/Source/WebCore/css/CSSPageRule.cpp
@@ -56,11 +56,9 @@ CSSPageDescriptors& CSSPageRule::style()
 
 String CSSPageRule::selectorText() const
 {
-    if (auto* selector = m_pageRule->selector()) {
-        if (!selector->selectorText().isEmpty())
-            return selector->selectorText();
-    }
-    return ""_s;
+    if (auto& selector = m_pageRule->selector(); !selector.selectorText().isEmpty())
+        return selector.selectorText();
+    return emptyString();
 }
 
 void CSSPageRule::setSelectorText(const String& selectorText)

--- a/Source/WebCore/css/CSSSelectorList.cpp
+++ b/Source/WebCore/css/CSSSelectorList.cpp
@@ -213,16 +213,13 @@ bool CSSSelectorList::hasOnlyNestingSelector() const
     if (componentCount() != 1)
         return false;
 
-    auto singleSelector = first();
-
-    if (!singleSelector)
-        return false;
+    auto& singleSelector = first();
     
     // Selector should be a single selector
-    if (singleSelector->precedingInComplexSelector())
+    if (singleSelector.precedingInComplexSelector())
         return false;
 
-    return singleSelector->match() == CSSSelector::Match::NestingParent;
+    return singleSelector.match() == CSSSelector::Match::NestingParent;
 }
 
 bool CSSSelectorList::operator==(const CSSSelectorList& other) const

--- a/Source/WebCore/css/CSSSelectorList.h
+++ b/Source/WebCore/css/CSSSelectorList.h
@@ -51,7 +51,7 @@ public:
     static CSSSelectorList makeJoining(const Vector<const CSSSelectorList*>&);
 
     bool isEmpty() const { return m_selectorArray.isEmpty(); }
-    const CSSSelector* first() const LIFETIME_BOUND { return m_selectorArray.begin(); } // Using begin() instead of &m_selectorArray[0] to avoid assertions when the array is empty.
+    const CSSSelector& first() const LIFETIME_BOUND { return m_selectorArray[0]; }
     const CSSSelector* selectorAt(size_t index) const LIFETIME_BOUND
     {
         return &m_selectorArray[index];

--- a/Source/WebCore/css/SelectorChecker.h
+++ b/Source/WebCore/css/SelectorChecker.h
@@ -130,7 +130,7 @@ public:
     static bool attributeSelectorMatches(const Element&, const QualifiedName&, const AtomString& attributeValue, const CSSSelector&);
 
     enum LinkMatchMask { MatchDefault = 0, MatchLink = 1, MatchVisited = 2, MatchAll = MatchLink | MatchVisited };
-    static unsigned determineLinkMatchType(const CSSSelector*, const StyleRuleScope* = nullptr);
+    static unsigned determineLinkMatchType(const CSSSelector&, const StyleRuleScope* = nullptr);
 
     struct LocalContext;
     

--- a/Source/WebCore/css/SelectorFilter.cpp
+++ b/Source/WebCore/css/SelectorFilter.cpp
@@ -170,7 +170,7 @@ void SelectorFilter::collectSimpleSelectorHash(CollectedSelectorHashes& collecte
             // We can use the filter in the trivial case of single argument :is()/:where().
             // Supporting the multiargument case would require more than one hash.
             if (selector.selectorList()->listSize() == 1)
-                collectSelectorHashes(collectedHashes, *selector.selectorList()->first(), IncludeRightmost::Yes);
+                collectSelectorHashes(collectedHashes, selector.selectorList()->first(), IncludeRightmost::Yes);
             break;
         default:
             break;

--- a/Source/WebCore/css/StyleRule.h
+++ b/Source/WebCore/css/StyleRule.h
@@ -291,7 +291,7 @@ public:
 
     ~StyleRulePage();
 
-    const CSSSelector* selector() const { return m_selectorList.first(); }    
+    const CSSSelector& selector() const { return m_selectorList.first(); }
     const StyleProperties& properties() const { return m_properties; }
     MutableStyleProperties& mutableProperties();
 

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -1319,11 +1319,11 @@ CSSSelectorList CSSSelectorParser::resolveNestingParent(const CSSSelectorList& n
             // .foo, .bar { & .baz {...} } -> :is(.foo, .bar) .baz {...}
             return false;
         }
-        if (complexSelectorCanMatchPseudoElement(*list.first())) {
+        if (complexSelectorCanMatchPseudoElement(list.first())) {
             // .foo::before { & {...} } -> :is(.foo::before) {...} (which matches nothing)
             return false;
         }
-        if (hasTagInCompound(*list.first()) && hasTagInCompound(nestingSelector)) {
+        if (hasTagInCompound(list.first()) && hasTagInCompound(nestingSelector)) {
             // foo { bar& {...} } -> bar:is(foo) {...}
             return false;
         }
@@ -1331,7 +1331,7 @@ CSSSelectorList CSSSelectorParser::resolveNestingParent(const CSSSelectorList& n
             // .foo .bar { & .baz {...} } -> .foo .bar .baz {...}
             return true;
         }
-        bool hasSingleCompound = !list.first()->firstInCompound()->precedingInComplexSelector();
+        bool hasSingleCompound = !list.first().firstInCompound()->precedingInComplexSelector();
         if (hasSingleCompound) {
             // .foo.bar { .baz & {...} } -> .baz .foo.bar {...}
             return true;
@@ -1346,7 +1346,7 @@ CSSSelectorList CSSSelectorParser::resolveNestingParent(const CSSSelectorList& n
         if (parentResolvedSelectorList && !parentRuleIsScope) {
             if (canInline(nestingSelector, *parentResolvedSelectorList)) {
                 // :is() not needed.
-                return makeUnique<MutableCSSSelector>(*parentResolvedSelectorList->first());
+                return makeUnique<MutableCSSSelector>(parentResolvedSelectorList->first());
             }
             // General case where we wrap with :is().
             auto isSelector = makeUnique<MutableCSSSelector>();

--- a/Source/WebCore/style/PageRuleCollector.cpp
+++ b/Source/WebCore/style/PageRuleCollector.cpp
@@ -40,7 +40,7 @@ namespace Style {
 
 static inline bool comparePageRules(const StyleRulePage* r1, const StyleRulePage* r2)
 {
-    return r1->selector()->specificityForPage() < r2->selector()->specificityForPage();
+    return r1->selector().specificityForPage() < r2->selector().specificityForPage();
 }
 
 bool PageRuleCollector::isLeftPage(int pageIndex) const
@@ -91,9 +91,9 @@ void PageRuleCollector::matchPageRules(RuleSet* rules, bool isLeftPage, bool isF
     });
 }
 
-static bool checkPageSelectorComponents(const CSSSelector* selector, bool isLeftPage, bool isFirstPage, const String& pageName)
+static bool checkPageSelectorComponents(const CSSSelector& selector, bool isLeftPage, bool isFirstPage, const String& pageName)
 {
-    for (const CSSSelector* component = selector; component; component = component->precedingInComplexSelector()) {
+    for (const CSSSelector* component = &selector; component; component = component->precedingInComplexSelector()) {
         if (component->match() == CSSSelector::Match::Tag) {
             const AtomString& localName = component->tagQName().localName();
             if (localName != starAtom() && localName != pageName)

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -162,12 +162,13 @@ void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerId
     const auto& scopeRules = scopeRulesFor(ruleData);
 
     auto computeLinkMatchType = [&] {
+        ASSERT(ruleData.selector());
         // General case: no @scope rule or current rule selector is not :scope.
         if (scopeRules.isEmpty() || !ruleData.selector()->hasScope())
-            return SelectorChecker::determineLinkMatchType(ruleData.selector());
+            return SelectorChecker::determineLinkMatchType(*ruleData.selector());
         // When current rule is :scope, we need to take into account the @scope selectors to determine the link match type.
         Ref scopeRule = scopeRules.last();
-        return SelectorChecker::determineLinkMatchType(ruleData.selector(), scopeRule.ptr());
+        return SelectorChecker::determineLinkMatchType(*ruleData.selector(), scopeRule.ptr());
     };
     ruleData.setLinkMatchType(computeLinkMatchType());
 

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -7898,7 +7898,7 @@ Internals::SelectorFilterHashCounts Internals::selectorFilterHashCounts(const St
     if (!selectorList)
         return { };
     
-    auto hashes = SelectorFilter::collectHashesForTesting(*selectorList->first());
+    auto hashes = SelectorFilter::collectHashesForTesting(selectorList->first());
 
     return { hashes.ids.size(), hashes.classes.size(), hashes.tags.size(), hashes.attributes.size() };
 }


### PR DESCRIPTION
#### 266815bc8b19a791ab0a70218af6eb680b9de4f5
<pre>
Update CSSSelectorList::first() to return a reference
<a href="https://bugs.webkit.org/show_bug.cgi?id=305029">https://bugs.webkit.org/show_bug.cgi?id=305029</a>

Reviewed by Darin Adler and Sam Weinig.

Update CSSSelectorList::first() to return a reference instead of a raw
pointer and have it call FixedVector&apos;s `operator[]` for memory safety.

* Source/WebCore/css/CSSPageRule.cpp:
(WebCore::CSSPageRule::selectorText const):
* Source/WebCore/css/CSSSelectorList.cpp:
(WebCore::CSSSelectorList::hasOnlyNestingSelector const):
* Source/WebCore/css/CSSSelectorList.h:
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::matchHostPseudoClass const):
(WebCore::SelectorChecker::checkOne const):
(WebCore::SelectorChecker::determineLinkMatchType):
* Source/WebCore/css/SelectorChecker.h:
* Source/WebCore/css/SelectorFilter.cpp:
(WebCore::SelectorFilter::collectSimpleSelectorHash):
* Source/WebCore/css/StyleRule.h:
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::resolveNestingParent):
* Source/WebCore/style/PageRuleCollector.cpp:
(WebCore::Style::comparePageRules):
(WebCore::Style::checkPageSelectorComponents):
* Source/WebCore/style/RuleSet.cpp:
(WebCore::Style::RuleSet::addRule):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::selectorFilterHashCounts):

Canonical link: <a href="https://commits.webkit.org/305237@main">https://commits.webkit.org/305237@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02a2480f64d7fd02a13a87d19e98e396cdf6334c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137794 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10155 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49088 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145683 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90767 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139666 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10858 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10288 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105406 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e46fc1e6-84f8-4427-ac62-87f267faf6d4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140739 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8081 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123499 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86265 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/89838c1b-5eb7-45ad-922a-2576837504db) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7702 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5435 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6138 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117094 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41662 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148379 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9838 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42224 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113786 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9855 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8292 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114125 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28998 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7642 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119737 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64537 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9886 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37777 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9617 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73451 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9826 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9678 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->