### PR TITLE
[Filters] Disable CoreGraphics blur and drop-shadow filters

### DIFF
--- a/LayoutTests/fast/filter-image/clipped-filter-expected.html
+++ b/LayoutTests/fast/filter-image/clipped-filter-expected.html
@@ -43,7 +43,7 @@
 <svg>
     <defs>
         <clipPath id="clipPath">
-            <path d="M18,38 v200 h90 a150,150 0 0,1 300,0 h50 v-200 z"
+            <path d="M18,38 v200 h90 a150,150 0 0,1 300,0 h50 v-200 z">
         </clipPath>
     </defs>
 </svg>

--- a/LayoutTests/fast/filter-image/clipped-filter.html
+++ b/LayoutTests/fast/filter-image/clipped-filter.html
@@ -2,7 +2,7 @@
 
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-5; totalPixels=0-5" />
+    <meta name="fuzzy" content="maxDifference=0-75; totalPixels=0-132" />
     <style>
         .circle {
             width: 300px;

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/filters/canvas-filter-shadow-and-properties-blur.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/filters/canvas-filter-shadow-and-properties-blur.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <link rel="match" href="canvas-filter-shadow-and-properties-blur-expected.html"/>
-<meta name="fuzzy" content="maxDifference=0-13; totalPixels=0-25600">
+<meta name="fuzzy" content="maxDifference=0-35; totalPixels=0-25600">
 <body>
   <canvas id="canvas" width="300" height="300"></canvas>
 </body>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2385,8 +2385,6 @@ webkit.org/b/299830 imported/w3c/web-platform-tests/storage-access-api/hasStorag
 
 webkit.org/b/299826 [ Release x86_64 ] media/modern-media-controls/media-controller/media-controller-click-on-video-background-should-pause.html [ Crash ]
 
-webkit.org/b/300864 imported/w3c/web-platform-tests/css/css-viewport/zoom/filters-drop-shadow.html [ Pass ImageOnlyFailure ]
-
 webkit.org/b/301153 [ Debug ] fast/parser/entity-comment-in-textarea.html [ Pass Timeout ]
 
 webkit.org/b/301566 [ Debug ] imported/w3c/web-platform-tests/custom-elements/registries/Element-innerHTML.html [ Skip ]

--- a/Source/WebCore/platform/graphics/filters/FEDropShadow.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEDropShadow.cpp
@@ -147,7 +147,7 @@ OptionSet<FilterRenderingMode> FEDropShadow::supportedFilterRenderingModes(Optio
 #if (USE(CORE_IMAGE)) || (USE(SKIA))
     modes.add(FilterRenderingMode::Accelerated);
 #endif
-#if USE(CG)
+#if USE(CG) && HAVE(FIX_FOR_RADAR_163968203)
     if (m_stdX == m_stdY)
         modes.add(FilterRenderingMode::GraphicsContext);
 #endif

--- a/Source/WebCore/platform/graphics/filters/FEGaussianBlur.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEGaussianBlur.cpp
@@ -168,7 +168,7 @@ OptionSet<FilterRenderingMode> FEGaussianBlur::supportedFilterRenderingModes(Opt
         modes.add(FilterRenderingMode::Accelerated);
 #endif
     // FIXME: Ensure the correctness of the CG GaussianBlur filter (http://webkit.org/b/243816).
-#if HAVE(CGSTYLE_COLORMATRIX_BLUR)
+#if HAVE(CGSTYLE_COLORMATRIX_BLUR) && HAVE(FIX_FOR_RADAR_163968203) && HAVE(FIX_FOR_RADAR_160309842)
     if (m_stdX == m_stdY && preferredFilterRenderingModes.contains(FilterRenderingMode::GraphicsContext))
         modes.add(FilterRenderingMode::GraphicsContext);
 #endif
@@ -195,16 +195,8 @@ std::unique_ptr<FilterEffectApplier> FEGaussianBlur::createSoftwareApplier() con
     return FilterEffectApplier::create<FEGaussianBlurSoftwareApplier>(*this);
 }
 
-std::optional<GraphicsStyle> FEGaussianBlur::createGraphicsStyle(GraphicsContext& context, const Filter& filter) const
+std::optional<GraphicsStyle> FEGaussianBlur::createGraphicsStyle(GraphicsContext&, const Filter& filter) const
 {
-#if PLATFORM(COCOA) && !HAVE(FIX_FOR_RADAR_160309842)
-    if (context.renderingMode() == RenderingMode::Accelerated) {
-        auto radius = calculateKernelSize(filter, { m_stdX, m_stdY });
-        return GraphicsGaussianBlur { radius };
-    }
-#else
-    UNUSED_PARAM(context);
-#endif
     auto radius = calculateUnscaledKernelSize(filter.resolvedSize({ m_stdX, m_stdY }));
     return GraphicsGaussianBlur { radius };
 }


### PR DESCRIPTION
#### 8428c6de6700a24294217812e40ea83d511c6507
<pre>
[Filters] Disable CoreGraphics blur and drop-shadow filters
<a href="https://bugs.webkit.org/show_bug.cgi?id=305034">https://bugs.webkit.org/show_bug.cgi?id=305034</a>
<a href="https://rdar.apple.com/166631624">rdar://166631624</a>

The CoreGraphics filters will be turned off until system frameworks bugs are fixed.
Also the workaround which was added in 299903@main will be reverted.

Reviewed by Simon Fraser.

* LayoutTests/fast/filter-image/clipped-filter-expected.html:
* LayoutTests/fast/filter-image/clipped-filter.html:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/filters/canvas-filter-shadow-and-properties-blur.html:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/platform/graphics/filters/FEDropShadow.cpp:
(WebCore::FEDropShadow::supportedFilterRenderingModes const):
* Source/WebCore/platform/graphics/filters/FEGaussianBlur.cpp:
(WebCore::FEGaussianBlur::supportedFilterRenderingModes const):
(WebCore::FEGaussianBlur::createGraphicsStyle const):

Canonical link: <a href="https://commits.webkit.org/305216@main">https://commits.webkit.org/305216@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a48a161a52e66f9834244f2f5042ae429d53ae5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137811 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10172 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49112 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145841 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90784 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1e168d18-856d-41d3-a5db-dcf5c0405aef) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139683 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10875 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10307 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105422 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140756 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8096 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123519 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86278 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/10409b9e-d717-4092-82a7-d71a251be57f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7717 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5451 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6156 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117110 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41682 "Passed tests") | [💥 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148583 "An unexpected error occured. Recent messages:Printed configuration") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9855 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42230 "Passed tests") | [💥 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/148583 "An unexpected error occured. Recent messages:Printed configuration") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9872 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8308 "Passed tests") | [💥 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/148583 "An unexpected error occured. Recent messages:Printed configuration") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28988 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7656 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119757 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64554 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9903 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37797 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9634 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73468 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9843 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9695 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->