### PR TITLE
[Testing] Fix provisional load related issue with Enhanced Security

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2761,17 +2761,20 @@ EncryptedMediaAPIEnabled:
 
 EnhancedSecurityHeuristicsEnabled:
   type: bool
-  status: testable
+  status: stable
   category: security
   defaultsOverridable: true
   humanReadableName: "Enable EnhancedSecurity Heuristics"
   humanReadableDescription: "Triggers EnhancedSecurity when insecure HTTP loads occur"
   defaultValue:
     WebKitLegacy:
+      "PLATFORM(COCOA)": true
       default: false
     WebKit:
+      "PLATFORM(COCOA)": true
       default: false
     WebCore:
+      "PLATFORM(COCOA)": true
       default: false
 
 EnterKeyHintEnabled:

--- a/Source/WebCore/loader/FrameLoadRequest.h
+++ b/Source/WebCore/loader/FrameLoadRequest.h
@@ -75,6 +75,9 @@ public:
     bool isContentRuleListRedirect() const { return m_isContentRuleListRedirect; }
     void setIsContentRuleListRedirect(bool isContentRuleListRedirect) { m_isContentRuleListRedirect = isContentRuleListRedirect; }
 
+    bool isCrossOriginContentRuleListRedirect() const { return m_isCrossOriginContentRuleListRedirect; }
+    void setIsCrossOriginContentRuleListRedirect(bool isCrossOriginContentRuleListRedirect) { m_isCrossOriginContentRuleListRedirect = isCrossOriginContentRuleListRedirect; }
+
     bool isFromNavigationAPI() const { return m_isFromNavigationAPI; }
     void setIsFromNavigationAPI(bool isFromNavigationAPI) { m_isFromNavigationAPI = isFromNavigationAPI; }
 
@@ -102,6 +105,7 @@ private:
     bool m_isInitialFrameSrcLoad { false };
     bool m_isContentRuleListRedirect { false };
     bool m_isFromNavigationAPI { false };
+    bool m_isCrossOriginContentRuleListRedirect { false };
 };
 
 class FrameLoadRequest : public FrameLoadRequestBase {

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1773,6 +1773,7 @@ void FrameLoader::load(FrameLoadRequest&& request, std::optional<NavigationReque
     }
 
     SetForScope continuingLoadGuard(m_currentLoadContinuingState, request.shouldTreatAsContinuingLoad() != ShouldTreatAsContinuingLoad::No ? LoadContinuingState::ContinuingWithRequest : LoadContinuingState::NotContinuing);
+    SetForScope crossOriginContentRuleListCancellationGuard(m_needsCancellationForContentRuleListCrossOriginRedirect, request.isCrossOriginContentRuleListRedirect());
     load(loader.get(), request.protectedRequesterSecurityOrigin().ptr());
 }
 
@@ -2940,6 +2941,12 @@ void FrameLoader::checkLoadCompleteForThisFrame(LoadWillContinueInAnotherProcess
 
             if (loadWillContinueInAnotherProcess == LoadWillContinueInAnotherProcess::No) {
                 auto willInternallyHandleFailure = (error.errorRecoveryMethod() == ResourceError::ErrorRecoveryMethod::NoRecovery || (error.errorRecoveryMethod() == ResourceError::ErrorRecoveryMethod::HTTPFallback && (!isHTTPSFirstApplicable || isHTTPFallbackInProgress()))) ? WillInternallyHandleFailure::No : WillInternallyHandleFailure::Yes;
+
+                if (error.isCancellation() && m_needsCancellationForContentRuleListCrossOriginRedirect) {
+                    willInternallyHandleFailure = WillInternallyHandleFailure::Yes;
+                    m_needsCancellationForContentRuleListCrossOriginRedirect = false;
+                }
+
                 dispatchDidFailProvisionalLoad(*provisionalDocumentLoader, error, willInternallyHandleFailure);
             }
 

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -562,6 +562,8 @@ private:
     const Ref<DocumentPrefetcher> m_documentPrefetcher;
 
     Function<bool()> m_pendingDispatchNavigateEvent;
+
+    bool m_needsCancellationForContentRuleListCrossOriginRedirect { false };
 };
 
 // This function is called by createWindow() in JSDOMWindowBase.cpp, for example, for

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -1165,6 +1165,7 @@ ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::requ
             if (type == CachedResource::Type::MainResource && RegistrableDomain { resourceRequest.url() } != originalDomain) {
                 FrameLoadRequest frameLoadRequest(frame, ResourceRequest(URL { resourceRequest.url() }));
                 frameLoadRequest.setIsContentRuleListRedirect(true);
+                frameLoadRequest.setIsCrossOriginContentRuleListRedirect(true);
                 frame->loader().load(WTF::move(frameLoadRequest));
                 return makeUnexpected(ResourceError { errorDomainWebKitInternal, 0, url, "Loading in a new process"_s, ResourceError::Type::Cancellation });
             }


### PR DESCRIPTION
#### 294838e45e850ccd6edb70c7ac160bfecd7c58ae
<pre>
Testing a provisional load fix in EWS.

* Source/WebCore/loader/FrameLoadRequest.h:
(WebCore::FrameLoadRequestBase::isCrossOriginContentRuleListRedirect const):
(WebCore::FrameLoadRequestBase::setIsCrossOriginContentRuleListRedirect):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::load):
(WebCore::FrameLoader::checkLoadCompleteForThisFrame):
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::requestResource):
</pre>
----------------------------------------------------------------------
#### 6a49c1b23a6d611773371d59f609206420a834b6
<pre>
Testing results for enabling ES heuristics.
Need the bug URL (OOPS!).

Reviewed by NOBODY (OOPS!).

Toggle this on by default on Apple platforms.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/294838e45e850ccd6edb70c7ac160bfecd7c58ae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137818 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10179 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49128 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145860 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90791 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f1009c11-cf9e-451e-9962-c37e243d78a4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139690 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10882 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10316 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105429 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2c7f4991-5f16-4017-9a72-525d040cfa19) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140763 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8104 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123540 "Found 17 new API test failures: TestWebKitAPI.WebKit.RedirectToPlaintextHTTPSUpgrade, TestWebKitAPI.WKNavigation.HTTPSFirstWithHTTPRedirect, TestWebKitAPI.SOAuthorizationPopUp.SOAuthorizationLoadPolicyAllowAsync, TestWebKitAPI.WKNavigation.PreferredHTTPSPolicyAutomaticHTTPFallbackWithHTTPRedirect, TestWebKitAPI.HistoryDelegate.PersistentDataStoreSendsHistoryEvents, TestWebKitAPI.AdvancedPrivacyProtections.DoNotHideReferrerInPopupWindow, TestWebKitAPI.SOAuthorizationPopUp.InterceptionSucceedNewWindowNavigation, TestWebKitAPI.SiteIsolation.MainFrameRedirectBetweenExistingProcesses, TestWebKitAPI.SOAuthorizationPopUp.InterceptionSucceedCloseByParent, TestWebKitAPI.SOAuthorizationPopUp.InterceptionSucceedSuppressActiveSession ... (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86280 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ec370495-51cf-4cb4-9a64-905e74c3cffd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7725 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5460 "Found 18 new API test failures: TestWebKitAPI.WebKit.RedirectToPlaintextHTTPSUpgrade, TestWebKitAPI.WKNavigation.HTTPSFirstWithHTTPRedirect, TestWebKitAPI.SOAuthorizationPopUp.SOAuthorizationLoadPolicyAllowAsync, TestWebKitAPI.WKNavigation.PreferredHTTPSPolicyAutomaticHTTPFallbackWithHTTPRedirect, TestWebKitAPI.HistoryDelegate.PersistentDataStoreSendsHistoryEvents, TestWebKitAPI.AdvancedPrivacyProtections.DoNotHideReferrerInPopupWindow, TestWebKitAPI.SOAuthorizationPopUp.InterceptionSucceedNewWindowNavigation, TestWebKitAPI.SiteIsolation.MainFrameRedirectBetweenExistingProcesses, TestWebKitAPI.SOAuthorizationPopUp.InterceptionSucceedCloseByParent, TestWebKitAPI.SOAuthorizationPopUp.InterceptionSucceedSuppressActiveSession ... (failure)") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6163 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/129779 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117118 "Found 16 new API test failures: TestWebKitAPI.WebKit.RedirectToPlaintextHTTPSUpgrade, TestWebKitAPI.WKNavigation.HTTPSFirstWithHTTPRedirect, TestWebKitAPI.SOAuthorizationPopUp.SOAuthorizationLoadPolicyAllowAsync, TestWebKitAPI.WKNavigation.PreferredHTTPSPolicyAutomaticHTTPFallbackWithHTTPRedirect, TestWebKitAPI.HistoryDelegate.PersistentDataStoreSendsHistoryEvents, TestWebKitAPI.AdvancedPrivacyProtections.DoNotHideReferrerInPopupWindow, TestWebKitAPI.SOAuthorizationPopUp.InterceptionSucceedNewWindowNavigation, TestWebKitAPI.SiteIsolation.MainFrameRedirectBetweenExistingProcesses, TestWebKitAPI.SOAuthorizationPopUp.InterceptionSucceedCloseByParent, TestWebKitAPI.SOAuthorizationPopUp.InterceptionSucceedSuppressActiveSession ... (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41702 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148595 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/136355 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9862 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42253 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113810 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9879 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8317 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114146 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7663 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119779 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/64572 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9910 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37814 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/169090 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9641 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73475 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44097 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9850 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9702 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->