### PR TITLE
Unreviewed, rebaseline test

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/web_platform/copyToTexture/video-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/web_platform/copyToTexture/video-expected.txt
@@ -14,7 +14,6 @@ FAIL :copy_from_video:videoName="four-colors-vp8-bt601.webm";sourceType="VideoEl
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:105:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 FAIL :copy_from_video:videoName="four-colors-vp8-bt601.webm";sourceType="VideoElement";srcDoFlipYDuringCopy=true;dstColorSpace="srgb" assert_unreached:
   - EXPECTATION FAILED: Texture level had unexpected contents:
@@ -31,7 +30,6 @@ FAIL :copy_from_video:videoName="four-colors-vp8-bt601.webm";sourceType="VideoEl
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:105:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 FAIL :copy_from_video:videoName="four-colors-vp8-bt601.webm";sourceType="VideoElement";srcDoFlipYDuringCopy=false;dstColorSpace="display-p3" assert_unreached:
   - EXPECTATION FAILED: Texture level had unexpected contents:
@@ -48,7 +46,6 @@ FAIL :copy_from_video:videoName="four-colors-vp8-bt601.webm";sourceType="VideoEl
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:128:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 FAIL :copy_from_video:videoName="four-colors-vp8-bt601.webm";sourceType="VideoElement";srcDoFlipYDuringCopy=false;dstColorSpace="srgb" assert_unreached:
   - EXPECTATION FAILED: Texture level had unexpected contents:
@@ -65,7 +62,6 @@ FAIL :copy_from_video:videoName="four-colors-vp8-bt601.webm";sourceType="VideoEl
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:128:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 PASS :copy_from_video:videoName="four-colors-vp8-bt601.webm";sourceType="VideoFrame";srcDoFlipYDuringCopy=true;dstColorSpace="display-p3"
 PASS :copy_from_video:videoName="four-colors-vp8-bt601.webm";sourceType="VideoFrame";srcDoFlipYDuringCopy=true;dstColorSpace="srgb"
@@ -86,7 +82,6 @@ FAIL :copy_from_video:videoName="four-colors-h264-bt601.mp4";sourceType="VideoEl
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:105:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 FAIL :copy_from_video:videoName="four-colors-h264-bt601.mp4";sourceType="VideoElement";srcDoFlipYDuringCopy=true;dstColorSpace="srgb" assert_unreached:
   - EXPECTATION FAILED: Texture level had unexpected contents:
@@ -103,7 +98,6 @@ FAIL :copy_from_video:videoName="four-colors-h264-bt601.mp4";sourceType="VideoEl
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:105:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 FAIL :copy_from_video:videoName="four-colors-h264-bt601.mp4";sourceType="VideoElement";srcDoFlipYDuringCopy=false;dstColorSpace="display-p3" assert_unreached:
   - EXPECTATION FAILED: Texture level had unexpected contents:
@@ -120,7 +114,6 @@ FAIL :copy_from_video:videoName="four-colors-h264-bt601.mp4";sourceType="VideoEl
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:128:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 FAIL :copy_from_video:videoName="four-colors-h264-bt601.mp4";sourceType="VideoElement";srcDoFlipYDuringCopy=false;dstColorSpace="srgb" assert_unreached:
   - EXPECTATION FAILED: Texture level had unexpected contents:
@@ -137,7 +130,6 @@ FAIL :copy_from_video:videoName="four-colors-h264-bt601.mp4";sourceType="VideoEl
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:128:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 PASS :copy_from_video:videoName="four-colors-h264-bt601.mp4";sourceType="VideoFrame";srcDoFlipYDuringCopy=true;dstColorSpace="display-p3"
 PASS :copy_from_video:videoName="four-colors-h264-bt601.mp4";sourceType="VideoFrame";srcDoFlipYDuringCopy=true;dstColorSpace="srgb"
@@ -158,7 +150,6 @@ FAIL :copy_from_video:videoName="four-colors-vp9-bt601.webm";sourceType="VideoEl
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:105:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 FAIL :copy_from_video:videoName="four-colors-vp9-bt601.webm";sourceType="VideoElement";srcDoFlipYDuringCopy=true;dstColorSpace="srgb" assert_unreached:
   - EXPECTATION FAILED: Texture level had unexpected contents:
@@ -175,7 +166,6 @@ FAIL :copy_from_video:videoName="four-colors-vp9-bt601.webm";sourceType="VideoEl
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:105:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 FAIL :copy_from_video:videoName="four-colors-vp9-bt601.webm";sourceType="VideoElement";srcDoFlipYDuringCopy=false;dstColorSpace="display-p3" assert_unreached:
   - EXPECTATION FAILED: Texture level had unexpected contents:
@@ -192,7 +182,6 @@ FAIL :copy_from_video:videoName="four-colors-vp9-bt601.webm";sourceType="VideoEl
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:128:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 FAIL :copy_from_video:videoName="four-colors-vp9-bt601.webm";sourceType="VideoElement";srcDoFlipYDuringCopy=false;dstColorSpace="srgb" assert_unreached:
   - EXPECTATION FAILED: Texture level had unexpected contents:
@@ -209,7 +198,6 @@ FAIL :copy_from_video:videoName="four-colors-vp9-bt601.webm";sourceType="VideoEl
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:128:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 PASS :copy_from_video:videoName="four-colors-vp9-bt601.webm";sourceType="VideoFrame";srcDoFlipYDuringCopy=true;dstColorSpace="display-p3"
 PASS :copy_from_video:videoName="four-colors-vp9-bt601.webm";sourceType="VideoFrame";srcDoFlipYDuringCopy=true;dstColorSpace="srgb"
@@ -230,7 +218,6 @@ FAIL :copy_from_video:videoName="four-colors-vp9-bt709.webm";sourceType="VideoEl
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:105:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 FAIL :copy_from_video:videoName="four-colors-vp9-bt709.webm";sourceType="VideoElement";srcDoFlipYDuringCopy=true;dstColorSpace="srgb" assert_unreached:
   - EXPECTATION FAILED: Texture level had unexpected contents:
@@ -247,7 +234,6 @@ FAIL :copy_from_video:videoName="four-colors-vp9-bt709.webm";sourceType="VideoEl
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:105:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 FAIL :copy_from_video:videoName="four-colors-vp9-bt709.webm";sourceType="VideoElement";srcDoFlipYDuringCopy=false;dstColorSpace="display-p3" assert_unreached:
   - EXPECTATION FAILED: Texture level had unexpected contents:
@@ -264,7 +250,6 @@ FAIL :copy_from_video:videoName="four-colors-vp9-bt709.webm";sourceType="VideoEl
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:128:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 FAIL :copy_from_video:videoName="four-colors-vp9-bt709.webm";sourceType="VideoElement";srcDoFlipYDuringCopy=false;dstColorSpace="srgb" assert_unreached:
   - EXPECTATION FAILED: Texture level had unexpected contents:
@@ -281,7 +266,6 @@ FAIL :copy_from_video:videoName="four-colors-vp9-bt709.webm";sourceType="VideoEl
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:128:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 PASS :copy_from_video:videoName="four-colors-vp9-bt709.webm";sourceType="VideoFrame";srcDoFlipYDuringCopy=true;dstColorSpace="display-p3"
 PASS :copy_from_video:videoName="four-colors-vp9-bt709.webm";sourceType="VideoFrame";srcDoFlipYDuringCopy=true;dstColorSpace="srgb"
@@ -302,7 +286,6 @@ FAIL :copy_from_video:videoName="four-colors-h264-bt601-rotate-90.mp4";sourceTyp
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:105:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 FAIL :copy_from_video:videoName="four-colors-h264-bt601-rotate-90.mp4";sourceType="VideoElement";srcDoFlipYDuringCopy=true;dstColorSpace="srgb" assert_unreached:
   - EXPECTATION FAILED: Texture level had unexpected contents:
@@ -319,7 +302,6 @@ FAIL :copy_from_video:videoName="four-colors-h264-bt601-rotate-90.mp4";sourceTyp
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:105:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 FAIL :copy_from_video:videoName="four-colors-h264-bt601-rotate-90.mp4";sourceType="VideoElement";srcDoFlipYDuringCopy=false;dstColorSpace="display-p3" assert_unreached:
   - EXPECTATION FAILED: Texture level had unexpected contents:
@@ -336,7 +318,6 @@ FAIL :copy_from_video:videoName="four-colors-h264-bt601-rotate-90.mp4";sourceTyp
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:128:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 FAIL :copy_from_video:videoName="four-colors-h264-bt601-rotate-90.mp4";sourceType="VideoElement";srcDoFlipYDuringCopy=false;dstColorSpace="srgb" assert_unreached:
   - EXPECTATION FAILED: Texture level had unexpected contents:
@@ -353,7 +334,6 @@ FAIL :copy_from_video:videoName="four-colors-h264-bt601-rotate-90.mp4";sourceTyp
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:128:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 PASS :copy_from_video:videoName="four-colors-h264-bt601-rotate-90.mp4";sourceType="VideoFrame";srcDoFlipYDuringCopy=true;dstColorSpace="display-p3"
 PASS :copy_from_video:videoName="four-colors-h264-bt601-rotate-90.mp4";sourceType="VideoFrame";srcDoFlipYDuringCopy=true;dstColorSpace="srgb"
@@ -374,7 +354,6 @@ FAIL :copy_from_video:videoName="four-colors-h264-bt601-rotate-180.mp4";sourceTy
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:105:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 FAIL :copy_from_video:videoName="four-colors-h264-bt601-rotate-180.mp4";sourceType="VideoElement";srcDoFlipYDuringCopy=true;dstColorSpace="srgb" assert_unreached:
   - EXPECTATION FAILED: Texture level had unexpected contents:
@@ -391,7 +370,6 @@ FAIL :copy_from_video:videoName="four-colors-h264-bt601-rotate-180.mp4";sourceTy
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:105:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 FAIL :copy_from_video:videoName="four-colors-h264-bt601-rotate-180.mp4";sourceType="VideoElement";srcDoFlipYDuringCopy=false;dstColorSpace="display-p3" assert_unreached:
   - EXPECTATION FAILED: Texture level had unexpected contents:
@@ -408,7 +386,6 @@ FAIL :copy_from_video:videoName="four-colors-h264-bt601-rotate-180.mp4";sourceTy
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:128:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 FAIL :copy_from_video:videoName="four-colors-h264-bt601-rotate-180.mp4";sourceType="VideoElement";srcDoFlipYDuringCopy=false;dstColorSpace="srgb" assert_unreached:
   - EXPECTATION FAILED: Texture level had unexpected contents:
@@ -425,7 +402,6 @@ FAIL :copy_from_video:videoName="four-colors-h264-bt601-rotate-180.mp4";sourceTy
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:128:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 PASS :copy_from_video:videoName="four-colors-h264-bt601-rotate-180.mp4";sourceType="VideoFrame";srcDoFlipYDuringCopy=true;dstColorSpace="display-p3"
 PASS :copy_from_video:videoName="four-colors-h264-bt601-rotate-180.mp4";sourceType="VideoFrame";srcDoFlipYDuringCopy=true;dstColorSpace="srgb"
@@ -446,7 +422,6 @@ FAIL :copy_from_video:videoName="four-colors-h264-bt601-rotate-270.mp4";sourceTy
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:105:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 FAIL :copy_from_video:videoName="four-colors-h264-bt601-rotate-270.mp4";sourceType="VideoElement";srcDoFlipYDuringCopy=true;dstColorSpace="srgb" assert_unreached:
   - EXPECTATION FAILED: Texture level had unexpected contents:
@@ -463,7 +438,6 @@ FAIL :copy_from_video:videoName="four-colors-h264-bt601-rotate-270.mp4";sourceTy
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:105:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 FAIL :copy_from_video:videoName="four-colors-h264-bt601-rotate-270.mp4";sourceType="VideoElement";srcDoFlipYDuringCopy=false;dstColorSpace="display-p3" assert_unreached:
   - EXPECTATION FAILED: Texture level had unexpected contents:
@@ -480,7 +454,6 @@ FAIL :copy_from_video:videoName="four-colors-h264-bt601-rotate-270.mp4";sourceTy
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:128:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 FAIL :copy_from_video:videoName="four-colors-h264-bt601-rotate-270.mp4";sourceType="VideoElement";srcDoFlipYDuringCopy=false;dstColorSpace="srgb" assert_unreached:
   - EXPECTATION FAILED: Texture level had unexpected contents:
@@ -497,7 +470,6 @@ FAIL :copy_from_video:videoName="four-colors-h264-bt601-rotate-270.mp4";sourceTy
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:128:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 PASS :copy_from_video:videoName="four-colors-h264-bt601-rotate-270.mp4";sourceType="VideoFrame";srcDoFlipYDuringCopy=true;dstColorSpace="display-p3"
 PASS :copy_from_video:videoName="four-colors-h264-bt601-rotate-270.mp4";sourceType="VideoFrame";srcDoFlipYDuringCopy=true;dstColorSpace="srgb"
@@ -518,7 +490,6 @@ FAIL :copy_from_video:videoName="four-colors-vp9-bt601-rotate-90.mp4";sourceType
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:105:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 FAIL :copy_from_video:videoName="four-colors-vp9-bt601-rotate-90.mp4";sourceType="VideoElement";srcDoFlipYDuringCopy=true;dstColorSpace="srgb" assert_unreached:
   - EXPECTATION FAILED: Texture level had unexpected contents:
@@ -535,7 +506,6 @@ FAIL :copy_from_video:videoName="four-colors-vp9-bt601-rotate-90.mp4";sourceType
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:105:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 FAIL :copy_from_video:videoName="four-colors-vp9-bt601-rotate-90.mp4";sourceType="VideoElement";srcDoFlipYDuringCopy=false;dstColorSpace="display-p3" assert_unreached:
   - EXPECTATION FAILED: Texture level had unexpected contents:
@@ -552,7 +522,6 @@ FAIL :copy_from_video:videoName="four-colors-vp9-bt601-rotate-90.mp4";sourceType
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:128:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 FAIL :copy_from_video:videoName="four-colors-vp9-bt601-rotate-90.mp4";sourceType="VideoElement";srcDoFlipYDuringCopy=false;dstColorSpace="srgb" assert_unreached:
   - EXPECTATION FAILED: Texture level had unexpected contents:
@@ -569,7 +538,6 @@ FAIL :copy_from_video:videoName="four-colors-vp9-bt601-rotate-90.mp4";sourceType
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:128:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 PASS :copy_from_video:videoName="four-colors-vp9-bt601-rotate-90.mp4";sourceType="VideoFrame";srcDoFlipYDuringCopy=true;dstColorSpace="display-p3"
 PASS :copy_from_video:videoName="four-colors-vp9-bt601-rotate-90.mp4";sourceType="VideoFrame";srcDoFlipYDuringCopy=true;dstColorSpace="srgb"
@@ -590,7 +558,6 @@ FAIL :copy_from_video:videoName="four-colors-vp9-bt601-rotate-180.mp4";sourceTyp
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:105:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 FAIL :copy_from_video:videoName="four-colors-vp9-bt601-rotate-180.mp4";sourceType="VideoElement";srcDoFlipYDuringCopy=true;dstColorSpace="srgb" assert_unreached:
   - EXPECTATION FAILED: Texture level had unexpected contents:
@@ -607,7 +574,6 @@ FAIL :copy_from_video:videoName="four-colors-vp9-bt601-rotate-180.mp4";sourceTyp
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:105:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 FAIL :copy_from_video:videoName="four-colors-vp9-bt601-rotate-180.mp4";sourceType="VideoElement";srcDoFlipYDuringCopy=false;dstColorSpace="display-p3" assert_unreached:
   - EXPECTATION FAILED: Texture level had unexpected contents:
@@ -624,7 +590,6 @@ FAIL :copy_from_video:videoName="four-colors-vp9-bt601-rotate-180.mp4";sourceTyp
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:128:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 FAIL :copy_from_video:videoName="four-colors-vp9-bt601-rotate-180.mp4";sourceType="VideoElement";srcDoFlipYDuringCopy=false;dstColorSpace="srgb" assert_unreached:
   - EXPECTATION FAILED: Texture level had unexpected contents:
@@ -641,7 +606,6 @@ FAIL :copy_from_video:videoName="four-colors-vp9-bt601-rotate-180.mp4";sourceTyp
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:128:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 PASS :copy_from_video:videoName="four-colors-vp9-bt601-rotate-180.mp4";sourceType="VideoFrame";srcDoFlipYDuringCopy=true;dstColorSpace="display-p3"
 PASS :copy_from_video:videoName="four-colors-vp9-bt601-rotate-180.mp4";sourceType="VideoFrame";srcDoFlipYDuringCopy=true;dstColorSpace="srgb"
@@ -662,7 +626,6 @@ FAIL :copy_from_video:videoName="four-colors-vp9-bt601-rotate-270.mp4";sourceTyp
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:105:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 FAIL :copy_from_video:videoName="four-colors-vp9-bt601-rotate-270.mp4";sourceType="VideoElement";srcDoFlipYDuringCopy=true;dstColorSpace="srgb" assert_unreached:
   - EXPECTATION FAILED: Texture level had unexpected contents:
@@ -679,7 +642,6 @@ FAIL :copy_from_video:videoName="four-colors-vp9-bt601-rotate-270.mp4";sourceTyp
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:105:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 FAIL :copy_from_video:videoName="four-colors-vp9-bt601-rotate-270.mp4";sourceType="VideoElement";srcDoFlipYDuringCopy=false;dstColorSpace="display-p3" assert_unreached:
   - EXPECTATION FAILED: Texture level had unexpected contents:
@@ -696,7 +658,6 @@ FAIL :copy_from_video:videoName="four-colors-vp9-bt601-rotate-270.mp4";sourceTyp
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:128:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 FAIL :copy_from_video:videoName="four-colors-vp9-bt601-rotate-270.mp4";sourceType="VideoElement";srcDoFlipYDuringCopy=false;dstColorSpace="srgb" assert_unreached:
   - EXPECTATION FAILED: Texture level had unexpected contents:
@@ -713,7 +674,6 @@ FAIL :copy_from_video:videoName="four-colors-vp9-bt601-rotate-270.mp4";sourceTyp
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:128:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 PASS :copy_from_video:videoName="four-colors-vp9-bt601-rotate-270.mp4";sourceType="VideoFrame";srcDoFlipYDuringCopy=true;dstColorSpace="display-p3"
 PASS :copy_from_video:videoName="four-colors-vp9-bt601-rotate-270.mp4";sourceType="VideoFrame";srcDoFlipYDuringCopy=true;dstColorSpace="srgb"
@@ -734,7 +694,6 @@ FAIL :copy_from_video:videoName="four-colors-h264-bt601-hflip.mp4";sourceType="V
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:105:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 FAIL :copy_from_video:videoName="four-colors-h264-bt601-hflip.mp4";sourceType="VideoElement";srcDoFlipYDuringCopy=true;dstColorSpace="srgb" assert_unreached:
   - EXPECTATION FAILED: Texture level had unexpected contents:
@@ -751,7 +710,6 @@ FAIL :copy_from_video:videoName="four-colors-h264-bt601-hflip.mp4";sourceType="V
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:105:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 FAIL :copy_from_video:videoName="four-colors-h264-bt601-hflip.mp4";sourceType="VideoElement";srcDoFlipYDuringCopy=false;dstColorSpace="display-p3" assert_unreached:
   - EXPECTATION FAILED: Texture level had unexpected contents:
@@ -768,7 +726,6 @@ FAIL :copy_from_video:videoName="four-colors-h264-bt601-hflip.mp4";sourceType="V
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:128:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 FAIL :copy_from_video:videoName="four-colors-h264-bt601-hflip.mp4";sourceType="VideoElement";srcDoFlipYDuringCopy=false;dstColorSpace="srgb" assert_unreached:
   - EXPECTATION FAILED: Texture level had unexpected contents:
@@ -785,7 +742,6 @@ FAIL :copy_from_video:videoName="four-colors-h264-bt601-hflip.mp4";sourceType="V
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:128:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 PASS :copy_from_video:videoName="four-colors-h264-bt601-hflip.mp4";sourceType="VideoFrame";srcDoFlipYDuringCopy=true;dstColorSpace="display-p3"
 PASS :copy_from_video:videoName="four-colors-h264-bt601-hflip.mp4";sourceType="VideoFrame";srcDoFlipYDuringCopy=true;dstColorSpace="srgb"
@@ -806,7 +762,6 @@ FAIL :copy_from_video:videoName="four-colors-h264-bt601-vflip.mp4";sourceType="V
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:105:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 FAIL :copy_from_video:videoName="four-colors-h264-bt601-vflip.mp4";sourceType="VideoElement";srcDoFlipYDuringCopy=true;dstColorSpace="srgb" assert_unreached:
   - EXPECTATION FAILED: Texture level had unexpected contents:
@@ -823,7 +778,6 @@ FAIL :copy_from_video:videoName="four-colors-h264-bt601-vflip.mp4";sourceType="V
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:105:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 FAIL :copy_from_video:videoName="four-colors-h264-bt601-vflip.mp4";sourceType="VideoElement";srcDoFlipYDuringCopy=false;dstColorSpace="display-p3" assert_unreached:
   - EXPECTATION FAILED: Texture level had unexpected contents:
@@ -840,7 +794,6 @@ FAIL :copy_from_video:videoName="four-colors-h264-bt601-vflip.mp4";sourceType="V
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:128:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 FAIL :copy_from_video:videoName="four-colors-h264-bt601-vflip.mp4";sourceType="VideoElement";srcDoFlipYDuringCopy=false;dstColorSpace="srgb" assert_unreached:
   - EXPECTATION FAILED: Texture level had unexpected contents:
@@ -857,7 +810,6 @@ FAIL :copy_from_video:videoName="four-colors-h264-bt601-vflip.mp4";sourceType="V
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:128:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 PASS :copy_from_video:videoName="four-colors-h264-bt601-vflip.mp4";sourceType="VideoFrame";srcDoFlipYDuringCopy=true;dstColorSpace="display-p3"
 PASS :copy_from_video:videoName="four-colors-h264-bt601-vflip.mp4";sourceType="VideoFrame";srcDoFlipYDuringCopy=true;dstColorSpace="srgb"
@@ -878,7 +830,6 @@ FAIL :copy_from_video:videoName="four-colors-vp9-bt601-hflip.mp4";sourceType="Vi
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:105:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 FAIL :copy_from_video:videoName="four-colors-vp9-bt601-hflip.mp4";sourceType="VideoElement";srcDoFlipYDuringCopy=true;dstColorSpace="srgb" assert_unreached:
   - EXPECTATION FAILED: Texture level had unexpected contents:
@@ -895,7 +846,6 @@ FAIL :copy_from_video:videoName="four-colors-vp9-bt601-hflip.mp4";sourceType="Vi
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:105:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 FAIL :copy_from_video:videoName="four-colors-vp9-bt601-hflip.mp4";sourceType="VideoElement";srcDoFlipYDuringCopy=false;dstColorSpace="display-p3" assert_unreached:
   - EXPECTATION FAILED: Texture level had unexpected contents:
@@ -912,7 +862,6 @@ FAIL :copy_from_video:videoName="four-colors-vp9-bt601-hflip.mp4";sourceType="Vi
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:128:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 FAIL :copy_from_video:videoName="four-colors-vp9-bt601-hflip.mp4";sourceType="VideoElement";srcDoFlipYDuringCopy=false;dstColorSpace="srgb" assert_unreached:
   - EXPECTATION FAILED: Texture level had unexpected contents:
@@ -929,7 +878,6 @@ FAIL :copy_from_video:videoName="four-colors-vp9-bt601-hflip.mp4";sourceType="Vi
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:128:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 PASS :copy_from_video:videoName="four-colors-vp9-bt601-hflip.mp4";sourceType="VideoFrame";srcDoFlipYDuringCopy=true;dstColorSpace="display-p3"
 PASS :copy_from_video:videoName="four-colors-vp9-bt601-hflip.mp4";sourceType="VideoFrame";srcDoFlipYDuringCopy=true;dstColorSpace="srgb"
@@ -950,7 +898,6 @@ FAIL :copy_from_video:videoName="four-colors-vp9-bt601-vflip.mp4";sourceType="Vi
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:105:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 FAIL :copy_from_video:videoName="four-colors-vp9-bt601-vflip.mp4";sourceType="VideoElement";srcDoFlipYDuringCopy=true;dstColorSpace="srgb" assert_unreached:
   - EXPECTATION FAILED: Texture level had unexpected contents:
@@ -967,7 +914,6 @@ FAIL :copy_from_video:videoName="four-colors-vp9-bt601-vflip.mp4";sourceType="Vi
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:105:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 FAIL :copy_from_video:videoName="four-colors-vp9-bt601-vflip.mp4";sourceType="VideoElement";srcDoFlipYDuringCopy=false;dstColorSpace="display-p3" assert_unreached:
   - EXPECTATION FAILED: Texture level had unexpected contents:
@@ -984,7 +930,6 @@ FAIL :copy_from_video:videoName="four-colors-vp9-bt601-vflip.mp4";sourceType="Vi
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:128:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 FAIL :copy_from_video:videoName="four-colors-vp9-bt601-vflip.mp4";sourceType="VideoElement";srcDoFlipYDuringCopy=false;dstColorSpace="srgb" assert_unreached:
   - EXPECTATION FAILED: Texture level had unexpected contents:
@@ -1001,7 +946,6 @@ FAIL :copy_from_video:videoName="four-colors-vp9-bt601-vflip.mp4";sourceType="Vi
     eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:414:34
     expectSinglePixelComparisonsAreOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/texture_test_utils.js:238:21
     @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:128:53
-    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/video.spec.js:64:60
  Reached unreachable code
 PASS :copy_from_video:videoName="four-colors-vp9-bt601-vflip.mp4";sourceType="VideoFrame";srcDoFlipYDuringCopy=true;dstColorSpace="display-p3"
 PASS :copy_from_video:videoName="four-colors-vp9-bt601-vflip.mp4";sourceType="VideoFrame";srcDoFlipYDuringCopy=true;dstColorSpace="srgb"


### PR DESCRIPTION
#### c17789aa57543f79f59272004351b9e628d3dd57
<pre>
Unreviewed, rebaseline test
<a href="https://bugs.webkit.org/show_bug.cgi?id=305041">https://bugs.webkit.org/show_bug.cgi?id=305041</a>
<a href="https://rdar.apple.com/167652123">rdar://167652123</a>

This is actually progression. Unfortunately this test is not running in EWS at all! Rebaselining.

* LayoutTests/http/tests/webgpu/webgpu/web_platform/copyToTexture/video-expected.txt:

Canonical link: <a href="https://commits.webkit.org/305210@main">https://commits.webkit.org/305210@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/364240113dd8cd13b29dec00fb20e833173f653b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137820 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10181 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49132 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/145883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/90793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10884 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10318 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/145883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/90793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140765 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/8105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/123537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/145883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/7726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/5462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6165 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/117119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/41699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148592 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9864 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/42250 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/113807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9881 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/8319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/114143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/7665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119776 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64575 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21214 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9912 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/37811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9643 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9852 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9704 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->