### PR TITLE
Table layout: Fix min-width distribution for spanning cells across mixed percent/auto columns

### DIFF
--- a/LayoutTests/fast/table/table-colspan-mixed-percent-fixed-auto-expected.txt
+++ b/LayoutTests/fast/table/table-colspan-mixed-percent-fixed-auto-expected.txt
@@ -1,0 +1,10 @@
+P
+A
+F
+F
+A
+P
+Lorem
+
+PASS Table with mixed percent, fixed, and auto columns should respect width attribute
+

--- a/LayoutTests/fast/table/table-colspan-mixed-percent-fixed-auto.html
+++ b/LayoutTests/fast/table/table-colspan-mixed-percent-fixed-auto.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Table layout with mixed percent, fixed, and auto columns with colspan</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<style>
+table {
+    border: 1px solid black;
+    border-collapse: collapse;
+}
+td {
+    border: 1px solid black;
+    padding: 0;
+}
+</style>
+</head>
+<body>
+<table id="testTable" border width="600" cellspacing="0" cellpadding="0">
+    <tr>
+        <td width="50%">
+            <div style="width: 50px; background-color: violet;">P</div>
+        </td>
+        <td>
+            <div style="width: 50px; background-color: orange;">A</div>
+        </td>
+        <td width="50px">
+            <div style="background-color: green;">F</div>
+        </td>
+        <td width="50px">
+            <div style="background-color: green;">F</div>
+        </td>
+        <td>
+            <div style="width: 100px; background-color: orange;">A</div>
+        </td>
+        <td width="50%">
+            <div style="width: 50px; background-color: violet;">P</div>
+        </td>
+    </tr>
+    <tr>
+        <td width="100%" colspan="6">
+            <div style="width: 600px; background-color: lightblue;">Lorem</div>
+        </td>
+    </tr>
+</table>
+
+<script>
+test(function() {
+    var table = document.getElementById('testTable');
+    var tableWidth = table.offsetWidth;
+    assert_equals(tableWidth, 602, 'Table width should be 602px');
+}, 'Table with mixed percent, fixed, and auto columns should respect width attribute');
+</script>
+</body>
+</html>

--- a/Source/WebCore/rendering/AutoTableLayout.cpp
+++ b/Source/WebCore/rendering/AutoTableLayout.cpp
@@ -457,7 +457,7 @@ float AutoTableLayout::calcEffectiveLogicalWidth()
                 ASSERT(allocatedMinLogicalWidth < cellMinLogicalWidth || WTF::areEssentiallyEqual(allocatedMinLogicalWidth, cellMinLogicalWidth));
                 ASSERT(allocatedMaxLogicalWidth < cellMaxLogicalWidth || WTF::areEssentiallyEqual(allocatedMaxLogicalWidth, cellMaxLogicalWidth));
                 cellMaxLogicalWidth -= allocatedMaxLogicalWidth;
-            } else if (!allColsAreFixed && totalPercent > 0 && haveAuto) {
+            } else if (!allColsAreFixed && fixedWidth <= 0 && totalPercent > 0 && haveAuto) {
                 // By this point, the earlier code has converted auto columns to effectiveLogicalWidth percentages,
                 // so we can use the same percentage-based distribution as the allColsArePercent case.
 #if ASSERT_ENABLED


### PR DESCRIPTION
#### 273c6381a3c34fc7fcba99f7873a9f76145d9a2b
<pre>
Table layout: Fix min-width distribution for spanning cells across mixed percent/auto columns
<a href="https://bugs305120@main.webkit.org/show_bug.cgi?id=305042">https://bugs305120@main.webkit.org/show_bug.cgi?id=305042</a>
<a href="https://rdar.apple.com/167684748">rdar://167684748</a>

Reviewed by Alan Baradlay.

This patch undo some renering progressions from 305120@main where we shipped
correct rendering but it broke distribution and caused tables to be wide
in linked test case (in bugzilla - also converted to regression test case).

i.e., table was ~770 pixel instead of 602 but with correct rendering.

This patch will give us same rendering albeit incorrect as of shipping Safari,
although it does not negate our 305120@main fully and we still progress a lot
of test cases - which is right step to do.

When a spanning cell covers columns with a mix of percentages, fixed widths,
and auto widths, the distribution logic needs to account for fixed-width
columns separately. The new code path for distributing min/max widths based
on effective percentages should only apply when there are no fixed-width
columns in the span.

The fix adds a check for fixedWidth &lt;= 0 to ensure the new distribution
logic only runs when the span contains only percent and auto columns, allowing
the existing else block to handle the mixed fixed+percent+auto case correctly.

* Source/WebCore/rendering/AutoTableLayout.cpp:
(WebCore::AutoTableLayout::calcEffectiveLogicalWidth):
* LayoutTests/fast/table/table-colspan-mixed-percent-fixed-auto-expected.txt: Added.
* LayoutTests/fast/table/table-colspan-mixed-percent-fixed-auto.html: Added.

^ So we don&apos;t regress it in future. It checks width (not rendering).

Canonical link: <a href="https://commits.webkit.org/305215@main">https://commits.webkit.org/305215@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9807f30ccf7cb2972797727a9312330dcce0dd9d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137821 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10182 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49133 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145885 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90794 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d486f7c2-52c2-476f-bdcb-f2da80b4d4d7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139693 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10885 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10319 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105428 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/70a407fe-fbe4-4ca4-9cfb-f4d744953c5f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140766 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8106 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123539 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86284 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f3bf7d25-9835-4e94-a324-19ab6fb4142c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7727 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5463 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6166 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117120 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41701 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148594 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9865 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42252 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113808 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9882 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8320 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114144 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28986 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7666 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119778 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64576 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9913 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37813 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9644 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73478 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9853 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9705 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->