### PR TITLE
Implement IPC message name logging on receive

### DIFF
--- a/Source/WebKit/Platform/IPC/Connection.cpp
+++ b/Source/WebKit/Platform/IPC/Connection.cpp
@@ -30,6 +30,7 @@
 #include "GeneratedSerializers.h"
 #include "Logging.h"
 #include "MessageFlags.h"
+#include "MessageLog.h"
 #include "MessageReceiveQueues.h"
 #include "WorkQueueMessageReceiver.h"
 #include <memory>
@@ -437,6 +438,8 @@ void Connection::dispatchMessageReceiverMessage(MessageReceiverType& messageRece
 #if ASSERT_ENABLED
     ++m_inDispatchMessageCount;
 #endif
+
+    messageLog().add(decoder->messageName());
 
     if (decoder->isSyncMessage()) {
         auto replyEncoder = makeUniqueRef<Encoder>(MessageName::SyncMessageReply, decoder->syncRequestID().toUInt64());
@@ -1461,6 +1464,8 @@ void Connection::dispatchMessage(UniqueRef<Decoder> message)
 
     bool oldDidReceiveInvalidMessage = m_didReceiveInvalidMessage;
     m_didReceiveInvalidMessage = false;
+
+    messageLog().add(message->messageName());
 
     if (message->isSyncMessage())
         dispatchSyncMessage(message.get());

--- a/Source/WebKit/Platform/IPC/MessageLog.cpp
+++ b/Source/WebKit/Platform/IPC/MessageLog.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,43 +23,29 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include "config.h"
+#include "MessageLog.h"
 
-#include <wtf/spi/darwin/XPCSPI.h>
-
-#ifdef __cplusplus
-
-#if !defined(__swift__)
-// IPC::MessageLog accessor functions for TAPI verification
 namespace IPC {
-template<size_t> class MessageLog;
-struct MessageLogMetadata;
-MessageLog<256>& messageLog();
-const MessageLogMetadata& messageLogMetadata();
+
+constinit MessageLog<messageLogCapacity> gMessageLog;
+
+const MessageLogMetadata gMessageLogMetadata = {
+    .version = 0,
+    .capacity = std::tuple_size_v<std::remove_reference_t<decltype(gMessageLog.bufferForTesting())>>,
+    .elementSize = sizeof(std::remove_reference_t<decltype(gMessageLog.bufferForTesting())>::value_type),
+    .size = sizeof(std::remove_reference_t<decltype(gMessageLog.bufferForTesting())>),
+    .initialValue = MessageName::Invalid
+};
+
+MessageLog<messageLogCapacity>& messageLog()
+{
+    return gMessageLog;
 }
-#endif
 
-extern "C" {
-#endif
-
-// FIXME: Remove these after <rdar://problem/30772033> is fixed.
-void NetworkServiceInitializer();
-void WebContentServiceInitializer();
-void GPUServiceInitializer();
-void ModelServiceInitializer();
-
-void ExtensionEventHandler(xpc_connection_t);
-
-#if USE(EXTENSIONKIT)
-// Declared in WKProcessExtension.h for use in extension targets. Must be declared in project
-//  headers because the extension targets cannot import the entire WebKit module (rdar://119162443).
-@interface WKGrant : NSObject
-@end
-
-@interface WKProcessExtension : NSObject
-@end
-#endif
-
-#ifdef __cplusplus
+const MessageLogMetadata& messageLogMetadata()
+{
+    return gMessageLogMetadata;
 }
-#endif
+
+} // namespace IPC

--- a/Source/WebKit/Platform/IPC/MessageLog.h
+++ b/Source/WebKit/Platform/IPC/MessageLog.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "MessageNames.h"
+#include <WebKit/WKDeclarationSpecifiers.h>
+#include <array>
+#include <atomic>
+#include <wtf/ExportMacros.h>
+#include <wtf/MathExtras.h>
+#include <wtf/Noncopyable.h>
+
+namespace IPC {
+
+inline constexpr size_t messageLogCapacity = 256;
+
+template<size_t Capacity>
+class MessageLog {
+    WTF_MAKE_NONCOPYABLE(MessageLog);
+    static_assert(hasOneBitSet(Capacity), "Capacity must be a power of two to handle size_t overflow correctly");
+public:
+    constexpr MessageLog()
+    {
+        m_buffer.fill(MessageName::Invalid);
+    }
+
+    void add(MessageName messageName)
+    {
+        size_t index = m_index.fetch_add(1, std::memory_order_relaxed);
+        m_buffer[index % Capacity] = messageName;
+    }
+
+    size_t indexForTesting() const { return m_index.load(std::memory_order_relaxed); }
+    const std::array<MessageName, Capacity>& bufferForTesting() const { return m_buffer; }
+
+private:
+    std::atomic<size_t> m_index { 0 };
+    std::array<MessageName, Capacity> m_buffer;
+};
+
+// Exported information to help a debugger read the data
+struct MessageLogMetadata {
+    size_t version;
+    size_t capacity;
+    size_t elementSize;
+    size_t size;
+    MessageName initialValue;
+};
+
+WK_EXPORT MessageLog<messageLogCapacity>& messageLog();
+WK_EXPORT const MessageLogMetadata& messageLogMetadata();
+
+} // namespace IPC

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.cpp
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.cpp
@@ -27,6 +27,7 @@
 #include "StreamServerConnection.h"
 
 #include "Connection.h"
+#include "MessageLog.h"
 #include "StreamConnectionWorkQueue.h"
 #include <mutex>
 #include <wtf/NeverDestroyed.h>
@@ -269,6 +270,7 @@ bool StreamServerConnection::dispatchStreamMessage(Decoder& message, StreamMessa
 #if ASSERT_ENABLED
     m_isDispatchingMessage = true;
 #endif
+    IPC::messageLog().add(message.messageName());
     receiver.didReceiveStreamMessage(*this, message);
 #if ASSERT_ENABLED
     m_isDispatchingMessage = false;

--- a/Source/WebKit/Platform/IPC/TransferString.cpp
+++ b/Source/WebKit/Platform/IPC/TransferString.cpp
@@ -104,7 +104,7 @@ std::optional<String> TransferString::release(size_t maxCopySizeInBytes) && // N
         },
 #endif
         [maxCopySizeInBytes](SharedSpan8 handle) -> std::optional<String> {
-            RefPtr<SharedMemory> memory = WebCore::SharedMemory::map(WTF::move(handle.dataHandle), WebCore::SharedMemoryProtection::ReadOnly);
+            RefPtr memory = WebCore::SharedMemory::map(WTF::move(handle.dataHandle), WebCore::SharedMemoryProtection::ReadOnly);
             if (!memory)
                 return std::nullopt;
             if (memory->size() > maxCopySizeInBytes) {
@@ -114,7 +114,7 @@ std::optional<String> TransferString::release(size_t maxCopySizeInBytes) && // N
             return std::optional<String> { std::in_place, String { byteCast<Latin1Character>(memory->span()) } };
         },
         [maxCopySizeInBytes](SharedSpan16 handle) -> std::optional<String> {
-            RefPtr<SharedMemory> memory = WebCore::SharedMemory::map(WTF::move(handle.dataHandle), WebCore::SharedMemoryProtection::ReadOnly);
+            RefPtr memory = WebCore::SharedMemory::map(WTF::move(handle.dataHandle), WebCore::SharedMemoryProtection::ReadOnly);
             if (!memory || (memory->size() % sizeof(char16_t)))
                 return std::nullopt;
             if (memory->size() > maxCopySizeInBytes) {

--- a/Source/WebKit/Platform/Sources.txt
+++ b/Source/WebKit/Platform/Sources.txt
@@ -12,6 +12,7 @@ Platform/IPC/Decoder.cpp
 Platform/IPC/Encoder.cpp
 Platform/IPC/IPCUtilities.cpp
 Platform/IPC/JSIPCBinding.cpp
+Platform/IPC/MessageLog.cpp
 Platform/IPC/MessageReceiveQueueMap.cpp
 Platform/IPC/MessageReceiverMap.cpp
 Platform/IPC/MessageSender.cpp

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -9147,6 +9147,7 @@
 		FAFFC3572E2AB10000CCC89C /* _WKSerializedNode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKSerializedNode.h; sourceTree = "<group>"; };
 		FAFFC35A2E2AB12400CCC89C /* APISerializedNode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = APISerializedNode.h; sourceTree = "<group>"; };
 		FAFFC35B2E2AB12400CCC89C /* APISerializedNode.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = APISerializedNode.cpp; sourceTree = "<group>"; };
+		FC1BA3BB2EF45E4C00EC7312 /* MessageLog.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MessageLog.h; sourceTree = "<group>"; };
 		FC7104512E0ED22A00CC0B24 /* WebInspectorBackendProxy.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebInspectorBackendProxy.messages.in; sourceTree = "<group>"; };
 		FC7104532E0ED23800CC0B24 /* WebInspectorBackendProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebInspectorBackendProxy.h; sourceTree = "<group>"; };
 		FC7104552E0ED24400CC0B24 /* WebInspectorUIProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebInspectorUIProxy.h; sourceTree = "<group>"; };
@@ -10829,6 +10830,7 @@
 				9B47908C25314D8300EC11AB /* MessageArgumentDescriptions.h */,
 				1AC4C82816B876A90069DCCD /* MessageFlags.h */,
 				2DAF90242B553FD20081E921 /* MessageFlags.serialization.in */,
+				FC1BA3BB2EF45E4C00EC7312 /* MessageLog.h */,
 				7BDD9DDA28D205C6004CDF48 /* MessageObserver.h */,
 				7B483F1C25CDDA9B00120486 /* MessageReceiveQueue.h */,
 				7B483F1D25CDDA9B00120486 /* MessageReceiveQueueMap.cpp */,

--- a/Tools/Scripts/dump-message-log
+++ b/Tools/Scripts/dump-message-log
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""
+LLDB script to dump the contents of WebKit's IPC message log for testing.
+
+Usage in LLDB:
+    (lldb) command script import Tools/Scripts/dump-message-log
+    (lldb) dump_message_log
+
+The script dumps messages in reverse chronological order (most recent first),
+starting from the last written position and stopping when it encounters either:
+- An Invalid message name (indicating unwritten slots)
+- A full traversal of the buffer (wrapping back to start)
+"""
+
+import lldb
+import re
+
+def dump_message_log(debugger, command, result, internal_dict):
+    """Dumps the contents of IPC::gMessageLog in reverse chronological order"""
+
+    target = debugger.GetSelectedTarget()
+    if not target or not target.IsValid():
+        print("Error: No valid target selected", file=result)
+        return
+
+    process = target.GetProcess()
+    if not process or not process.IsValid():
+        print("Error: No valid process attached", file=result)
+        return
+
+    # Find the global message log
+    buffer_var = target.FindFirstGlobalVariable("IPC::gMessageLog")
+    if not buffer_var or not buffer_var.IsValid():
+        print("Error: Could not find IPC::gMessageLog", file=result)
+        print("Make sure the process is using a build with the message log compiled in.", file=result)
+        return
+
+    # Get capacity from the type name (e.g., MessageLog<256>)
+    buffer_type = buffer_var.GetType()
+    type_name = buffer_type.GetName()
+    match = re.search(r'MessageLog<(\d+)>', type_name)
+    if not match:
+        print(f"Error: Could not parse capacity from type name: {type_name}", file=result)
+        return
+
+    capacity = int(match.group(1))
+
+    # Get m_index (std::atomic<size_t>)
+    # Note: m_index is a private member, but LLDB can access it for debugging
+    m_index_var = buffer_var.GetChildMemberWithName("m_index")
+    if not m_index_var or not m_index_var.IsValid():
+        print("Error: Could not access m_index member", file=result)
+        return
+
+    # Extract the actual value from std::atomic
+    # Try different member names used by different standard library implementations
+    index_value = None
+    for atomic_member in ["_M_i", "__a_", "_Value", "Value", "__a"]:
+        atomic_storage = m_index_var.GetChildMemberWithName(atomic_member)
+        if atomic_storage and atomic_storage.IsValid():
+            index_value = atomic_storage.GetValueAsUnsigned()
+            break
+
+    if index_value is None:
+        # Fallback: try to get value directly
+        index_value = m_index_var.GetValueAsUnsigned()
+        if index_value == 0xFFFFFFFFFFFFFFFF:  # Likely failed
+            print("Error: Could not read m_index value", file=result)
+            return
+
+    # Get m_buffer (std::array)
+    # Note: m_buffer is a private member, but LLDB can access it for debugging
+    m_buffer_var = buffer_var.GetChildMemberWithName("m_buffer")
+    if not m_buffer_var or not m_buffer_var.IsValid():
+        print("Error: Could not access m_buffer member", file=result)
+        return
+
+    # std::array may wrap the actual array in an __elems_ or similar member
+    # Try to access it, otherwise use m_buffer_var directly
+    elems_var = m_buffer_var.GetChildMemberWithName("__elems_")
+    if elems_var and elems_var.IsValid():
+        m_buffer_var = elems_var
+
+    # Try to find IPC::MessageName::Invalid
+    message_name_type = target.FindFirstType("IPC::MessageName")
+    message_name_invalid = None
+    if message_name_type and message_name_type.IsValid():
+        enum_members = message_name_type.GetEnumMembers()
+        for i in range(enum_members.GetSize()):
+            member = enum_members.GetTypeEnumMemberAtIndex(i)
+            if member.GetName() == "Invalid":
+                message_name_invalid = member.GetValueAsUnsigned()
+                break
+
+    # Print header
+    print("\n" + "=" * 80, file=result)
+    print(f"WebKit IPC Message Log Dump (Capacity: {capacity})", file=result)
+    print("=" * 80, file=result)
+    print("\nMessages (most recent first):\n", file=result)
+
+    # Calculate the last written index
+    # m_index points to the NEXT position to write, so last written is (m_index - 1) % capacity
+    if index_value == 0:
+        last_written = capacity - 1
+    else:
+        last_written = (index_value - 1) % capacity
+
+    current_index = last_written
+    messages_found = 0
+
+    for i in range(capacity):
+        # Get array element at current_index
+        element = m_buffer_var.GetChildAtIndex(current_index)
+        if not element or not element.IsValid():
+            print(f"Warning: Could not read buffer[{current_index}]", file=result)
+            break
+
+        message_value = element.GetValueAsUnsigned()
+
+        # Stop if we encounter Invalid
+        if message_name_invalid is not None and message_value == message_name_invalid:
+            print(f"\n[Stopped at Invalid message after {messages_found} messages (at buffer[{current_index}])]", file=result)
+            break
+
+        # Try to get the symbolic name
+        message_name_str = element.GetValue()
+        if message_name_str:
+            # Clean up the format (e.g., "IPCTester_EmptyMessage" instead of full enum path)
+            message_name_str = message_name_str.replace("IPC::MessageName::", "")
+            # Display "Invalid" instead of "Count" since they're semantically invalid messages
+            if message_name_str == "Count":
+                message_name_str = "Invalid"
+        else:
+            message_name_str = f"<value={message_value}>"
+
+        print(f"{messages_found}. {message_name_str}", file=result)
+
+        messages_found += 1
+
+        # Move to previous index (wrap around)
+        if current_index == 0:
+            current_index = capacity - 1
+        else:
+            current_index -= 1
+
+    print("\n" + "=" * 80 + "\n", file=result)
+
+def __lldb_init_module(debugger, internal_dict):
+    """Register the command when the script is loaded"""
+    debugger.HandleCommand(
+        'command script add -f dump_message_log.dump_message_log dump_message_log'
+    )
+    print('The "dump_message_log" command has been installed.')
+
+if __name__ == "__main__":
+    print("This script is intended to be used within LLDB, not run directly.")
+    print("\nUsage in LLDB:")
+    print("    (lldb) command script import Tools/Scripts/dump-message-log")
+    print("    (lldb) dump_message_log")

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1512,6 +1512,8 @@
 		F6B7BE9517469212008A3445 /* DidAssociateFormControls_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F6B7BE92174691EF008A3445 /* DidAssociateFormControls_Bundle.cpp */; };
 		F6D67D3826F90206006E0349 /* Int128.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F6D67D3626F90206006E0349 /* Int128.cpp */; };
 		F6F49C6B15545CA70007F39D /* DOMWindowExtensionNoCache_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F6F49C6615545C8D0007F39D /* DOMWindowExtensionNoCache_Bundle.cpp */; };
+		FC0A4AEE2F0E76EE0053173D /* MessageLogTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC0A4AED2F0E76EE0053173D /* MessageLogTests.cpp */; };
+		FC0A4AEF2F0E76EE0053173D /* MessageLogEndToEndTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC0A4AF02F0E76EE0053173D /* MessageLogEndToEndTests.cpp */; };
 		FAC1FE462F19C3EB0030C30E /* open-in-new-tab.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = FAC1FE452F19C3EB0030C30E /* open-in-new-tab.html */; };
 		FAC1FE572F21AD890030C30E /* JSHandlePlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = FAC1FE4F2F2152270030C30E /* JSHandlePlugIn.mm */; };
 		FE2BCDC72470FDA300DEC33B /* StdLibExtrasTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE2BCDC62470FC7000DEC33B /* StdLibExtrasTests.cpp */; };
@@ -4484,6 +4486,8 @@
 		FAC1FE4F2F2152270030C30E /* JSHandlePlugIn.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = JSHandlePlugIn.mm; sourceTree = "<group>"; };
 		FAC1FE582F21B1820030C30E /* JSHandlePlugInProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSHandlePlugInProtocol.h; sourceTree = "<group>"; };
 		FAD420BF2E4AB7AA00069B2E /* SerializedNode.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SerializedNode.mm; sourceTree = "<group>"; };
+		FC0A4AED2F0E76EE0053173D /* MessageLogTests.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MessageLogTests.cpp; sourceTree = "<group>"; };
+		FC0A4AF02F0E76EE0053173D /* MessageLogEndToEndTests.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MessageLogEndToEndTests.cpp; sourceTree = "<group>"; };
 		FE2BCDC62470FC7000DEC33B /* StdLibExtrasTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StdLibExtrasTests.cpp; sourceTree = "<group>"; };
 		FE2D9473245EB2DF00E48135 /* BitSet.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BitSet.cpp; sourceTree = "<group>"; };
 		FEB6F74E1B2BA44E009E4922 /* NakedPtr.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NakedPtr.cpp; sourceTree = "<group>"; };
@@ -5580,6 +5584,8 @@
 				51FA14302AF5BAE00003ACD1 /* IPCSerialization.mm */,
 				7B7392EB28F84BD2007297FC /* IPCTestUtilities.cpp */,
 				7B7392EA28F849F3007297FC /* IPCTestUtilities.h */,
+				FC0A4AF02F0E76EE0053173D /* MessageLogEndToEndTests.cpp */,
+				FC0A4AED2F0E76EE0053173D /* MessageLogTests.cpp */,
 				7B7392E128F849EC007297FC /* MessageSenderTests.cpp */,
 				7B9FC58328A26792007570E7 /* StreamConnectionBufferTests.cpp */,
 				7B2950DA2972AFDD008CC225 /* StreamConnectionEncoderTests.cpp */,
@@ -7619,6 +7625,8 @@
 				7B7392EC28F84BD3007297FC /* IPCTestUtilities.cpp in Sources */,
 				7B9FC39F28A26137007570E7 /* mainIOS.mm in Sources */,
 				7B9FC3A028A26137007570E7 /* mainMac.mm in Sources */,
+				FC0A4AEF2F0E76EE0053173D /* MessageLogEndToEndTests.cpp in Sources */,
+				FC0A4AEE2F0E76EE0053173D /* MessageLogTests.cpp in Sources */,
 				7B7392E928F849EC007297FC /* MessageSenderTests.cpp in Sources */,
 				7B9FC58428A26792007570E7 /* StreamConnectionBufferTests.cpp in Sources */,
 				7B2950E22972AFDE008CC225 /* StreamConnectionEncoderTests.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/IPC/MessageLogEndToEndTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/MessageLogEndToEndTests.cpp
@@ -1,0 +1,615 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "IPCTestUtilities.h"
+#include "MessageLog.h"
+#include "StreamClientConnection.h"
+#include "StreamConnectionWorkQueue.h"
+#include "StreamServerConnection.h"
+#include <thread>
+#include <wtf/Vector.h>
+#include <wtf/threads/BinarySemaphore.h>
+
+namespace TestWebKitAPI {
+
+static constexpr Seconds kDefaultWaitForTimeout = 1_s;
+
+// Mock message types for testing different message names in the log
+struct MockTestMessage2 {
+    static constexpr bool isSync = false;
+    static constexpr bool canDispatchOutOfOrder = false;
+    static constexpr bool replyCanDispatchOutOfOrder = false;
+    static constexpr IPC::MessageName name() { return IPC::MessageName::IPCTester_EmptyMessageWithReply; }
+    template<typename Encoder> void encode(Encoder&) { }
+};
+
+struct MockTestMessage3 {
+    static constexpr bool isSync = false;
+    static constexpr bool canDispatchOutOfOrder = false;
+    static constexpr bool replyCanDispatchOutOfOrder = false;
+    static constexpr IPC::MessageName name() { return IPC::MessageName::IPCTester_SendAsyncMessageToReceiver; }
+    template<typename Encoder> void encode(Encoder& encoder)
+    {
+        encoder << static_cast<uint32_t>(0);
+    }
+};
+
+struct MockTestMessage4 {
+    static constexpr bool isSync = false;
+    static constexpr bool canDispatchOutOfOrder = false;
+    static constexpr bool replyCanDispatchOutOfOrder = false;
+    static constexpr IPC::MessageName name() { return IPC::MessageName::IPCTester_AsyncPing; }
+    template<typename Encoder> void encode(Encoder&) { }
+};
+
+struct MockTestSyncMessage {
+    static constexpr bool isSync = true;
+    static constexpr bool canDispatchOutOfOrder = false;
+    static constexpr bool replyCanDispatchOutOfOrder = false;
+    static constexpr IPC::MessageName name() { return IPC::MessageName::IPCTester_SyncPing; }
+    using ReplyArguments = std::tuple<>;
+    template<typename Encoder> void encode(Encoder&) { }
+};
+
+class MessageLogEndToEndTest : public testing::Test, protected ConnectionTestBase {
+public:
+    void SetUp() override
+    {
+        setupBase();
+        // Record the initial index to isolate this test from others
+        m_initialLogIndex = IPC::messageLog().indexForTesting();
+    }
+
+    void TearDown() override
+    {
+        teardownBase();
+    }
+
+protected:
+    size_t messagesLoggedSinceSetup() const
+    {
+        return IPC::messageLog().indexForTesting() - m_initialLogIndex;
+    }
+
+    bool messageLogContains(IPC::MessageName messageName, size_t startIndex = 0) const
+    {
+        const auto& buffer = IPC::messageLog().bufferForTesting();
+        size_t currentIndex = IPC::messageLog().indexForTesting();
+        size_t capacity = buffer.size();
+
+        // Search from startIndex to currentIndex
+        for (size_t i = startIndex; i < currentIndex; ++i) {
+            if (buffer[i % capacity] == messageName)
+                return true;
+        }
+        return false;
+    }
+
+    size_t countMessagesInLog(IPC::MessageName messageName) const
+    {
+        const auto& buffer = IPC::messageLog().bufferForTesting();
+        size_t capacity = buffer.size();
+        size_t count = 0;
+
+        // Count in the entire buffer (for wrap-around tests)
+        for (size_t i = 0; i < capacity; ++i) {
+            if (buffer[i] == messageName)
+                count++;
+        }
+        return count;
+    }
+
+    size_t m_initialLogIndex { 0 };
+};
+
+// Test that receiving a single message through IPC logs it
+TEST_F(MessageLogEndToEndTest, SingleMessageLogged)
+{
+    ASSERT_TRUE(openA());
+    ASSERT_TRUE(openB());
+
+    size_t indexBeforeSend = IPC::messageLog().indexForTesting();
+
+    // Send a message from A to B
+    a()->send(MockTestMessage1 { }, 0);
+
+    // Wait for B to receive the message
+    auto message = bClient().waitForMessage(kDefaultWaitForTimeout);
+    EXPECT_EQ(message.messageName, MockTestMessage1::name());
+
+    // Verify the message was logged
+    size_t indexAfterReceive = IPC::messageLog().indexForTesting();
+    EXPECT_GT(indexAfterReceive, indexBeforeSend);
+
+    // The logged message should match what we sent
+    EXPECT_TRUE(messageLogContains(MockTestMessage1::name(), indexBeforeSend));
+}
+
+// Test that receiving multiple messages logs them all
+TEST_F(MessageLogEndToEndTest, MultipleMessagesLogged)
+{
+    ASSERT_TRUE(openA());
+    ASSERT_TRUE(openB());
+
+    size_t indexBeforeSend = IPC::messageLog().indexForTesting();
+
+    constexpr size_t messageCount = 10;
+
+    // Send multiple messages with different types
+    for (size_t i = 0; i < messageCount; ++i) {
+        if (!(i % 3))
+            a()->send(MockTestMessage1 { }, i);
+        else if (i % 3 == 1)
+            a()->send(MockTestMessage2 { }, i);
+        else
+            a()->send(MockTestMessage3 { }, i);
+    }
+
+    // Wait for all messages to be received
+    for (size_t i = 0; i < messageCount; ++i) {
+        auto message = bClient().waitForMessage(kDefaultWaitForTimeout);
+        EXPECT_EQ(message.destinationID, i);
+    }
+
+    // Verify all messages were logged
+    size_t indexAfterReceive = IPC::messageLog().indexForTesting();
+    EXPECT_GE(indexAfterReceive - indexBeforeSend, messageCount);
+
+    // Verify different message types are in the log
+    EXPECT_TRUE(messageLogContains(MockTestMessage1::name(), indexBeforeSend));
+    EXPECT_TRUE(messageLogContains(MockTestMessage2::name(), indexBeforeSend));
+    EXPECT_TRUE(messageLogContains(MockTestMessage3::name(), indexBeforeSend));
+}
+
+// Test that bidirectional messaging logs messages on both sides
+TEST_F(MessageLogEndToEndTest, BidirectionalMessagesLogged)
+{
+    ASSERT_TRUE(openA());
+    ASSERT_TRUE(openB());
+
+    size_t indexBeforeSend = IPC::messageLog().indexForTesting();
+
+    // Send messages in both directions
+    a()->send(MockTestMessage1 { }, 1);
+    b()->send(MockTestMessage2 { }, 2);
+
+    // Wait for A to receive B's message
+    auto messageAtA = aClient().waitForMessage(kDefaultWaitForTimeout);
+    EXPECT_EQ(messageAtA.messageName, MockTestMessage2::name());
+
+    // Wait for B to receive A's message
+    auto messageAtB = bClient().waitForMessage(kDefaultWaitForTimeout);
+    EXPECT_EQ(messageAtB.messageName, MockTestMessage1::name());
+
+    // Both messages should be logged (since this is a single-process test,
+    // all receives go to the same global log)
+    size_t indexAfterReceive = IPC::messageLog().indexForTesting();
+    EXPECT_GE(indexAfterReceive - indexBeforeSend, 2u);
+
+    EXPECT_TRUE(messageLogContains(MockTestMessage1::name(), indexBeforeSend));
+    EXPECT_TRUE(messageLogContains(MockTestMessage2::name(), indexBeforeSend));
+}
+
+// Test that a high volume of messages properly wraps around the log buffer
+TEST_F(MessageLogEndToEndTest, HighVolumeWrapsBuffer)
+{
+    ASSERT_TRUE(openA());
+    ASSERT_TRUE(openB());
+
+    // Send more messages than the buffer can hold to test wrap-around
+    constexpr size_t messageCount = IPC::messageLogCapacity + 50;
+
+    for (size_t i = 0; i < messageCount; ++i)
+        a()->send(MockTestMessage1 { }, i);
+
+    // Wait for all messages to be received
+    for (size_t i = 0; i < messageCount; ++i) {
+        auto message = bClient().waitForMessage(kDefaultWaitForTimeout);
+        EXPECT_EQ(message.destinationID, i);
+    }
+
+    // The index should have advanced by at least messageCount
+    EXPECT_GE(messagesLoggedSinceSetup(), messageCount);
+
+    // After wrap-around, the buffer should contain mostly our test messages
+    // (though earlier ones will have been overwritten)
+    size_t testMessageCount = countMessagesInLog(MockTestMessage1::name());
+    EXPECT_GT(testMessageCount, 0u);
+}
+
+// Test that messages from multiple sending threads are all logged
+TEST_F(MessageLogEndToEndTest, ConcurrentSendersLogged)
+{
+    ASSERT_TRUE(openA());
+    ASSERT_TRUE(openB());
+
+    size_t indexBeforeSend = IPC::messageLog().indexForTesting();
+
+    constexpr size_t messagesPerThread = 20;
+    std::atomic<size_t> messagesReceived { 0 };
+
+    // Set up handler to count received messages
+    bClient().setAsyncMessageHandler([&messagesReceived](IPC::Connection&, IPC::Decoder&) -> bool {
+        messagesReceived++;
+        return true; // Message handled, don't queue it
+    });
+
+    // Create threads that send messages concurrently
+    std::thread thread1([this]() {
+        for (size_t i = 0; i < messagesPerThread; ++i)
+            a()->send(MockTestMessage1 { }, i);
+    });
+
+    std::thread thread2([this]() {
+        for (size_t i = 0; i < messagesPerThread; ++i)
+            a()->send(MockTestMessage2 { }, i + 100);
+    });
+
+    thread1.join();
+    thread2.join();
+
+    // Wait for all messages to be received
+    while (messagesReceived < messagesPerThread * 2)
+        Util::spinRunLoop();
+
+    // Give a bit more time for any pending message processing
+    Util::spinRunLoop(10);
+
+    // Verify messages were logged
+    size_t indexAfterReceive = IPC::messageLog().indexForTesting();
+    EXPECT_GE(indexAfterReceive - indexBeforeSend, messagesPerThread * 2);
+
+    // Both message types should be in the log
+    EXPECT_TRUE(messageLogContains(MockTestMessage1::name(), indexBeforeSend));
+    EXPECT_TRUE(messageLogContains(MockTestMessage2::name(), indexBeforeSend));
+}
+
+// Test message logging with different message types interleaved
+TEST_F(MessageLogEndToEndTest, InterleavedMessageTypes)
+{
+    ASSERT_TRUE(openA());
+    ASSERT_TRUE(openB());
+
+    size_t indexBeforeSend = IPC::messageLog().indexForTesting();
+
+    // Send interleaved message types
+    a()->send(MockTestMessage1 { }, 0);
+    a()->send(MockTestMessage2 { }, 1);
+    a()->send(MockTestMessage3 { }, 2);
+    a()->send(MockTestMessage4 { }, 3);
+    a()->send(MockTestMessage1 { }, 4);
+    a()->send(MockTestMessage2 { }, 5);
+
+    // Wait for all messages
+    for (size_t i = 0; i < 6; ++i) {
+        auto message = bClient().waitForMessage(kDefaultWaitForTimeout);
+        EXPECT_EQ(message.destinationID, i);
+    }
+
+    size_t indexAfterReceive = IPC::messageLog().indexForTesting();
+    EXPECT_GE(indexAfterReceive - indexBeforeSend, 6u);
+
+    // All message types should be logged
+    EXPECT_TRUE(messageLogContains(MockTestMessage1::name(), indexBeforeSend));
+    EXPECT_TRUE(messageLogContains(MockTestMessage2::name(), indexBeforeSend));
+    EXPECT_TRUE(messageLogContains(MockTestMessage3::name(), indexBeforeSend));
+    EXPECT_TRUE(messageLogContains(MockTestMessage4::name(), indexBeforeSend));
+}
+
+// Test that message logging works with async replies
+TEST_F(MessageLogEndToEndTest, AsyncReplyMessagesLogged)
+{
+    ASSERT_TRUE(openA());
+    ASSERT_TRUE(openB());
+
+    size_t indexBeforeSend = IPC::messageLog().indexForTesting();
+
+    // Set up A to respond to async reply messages
+    aClient().setAsyncMessageHandler([this](IPC::Connection&, IPC::Decoder& decoder) -> bool {
+        auto listenerID = decoder.decode<uint64_t>();
+        auto encoder = makeUniqueRef<IPC::Encoder>(MockTestMessageWithAsyncReply1::asyncMessageReplyName(), *listenerID);
+        encoder.get() << decoder.destinationID();
+        a()->sendSyncReply(WTF::move(encoder));
+        return true;
+    });
+
+    bool gotReply = false;
+    uint64_t replyValue = 0;
+
+    b()->sendWithAsyncReply(MockTestMessageWithAsyncReply1 { }, [&gotReply, &replyValue](uint64_t value) {
+        replyValue = value;
+        gotReply = true;
+    }, 42);
+
+    // Wait for reply
+    Util::runFor(&gotReply, kDefaultWaitForTimeout);
+    EXPECT_TRUE(gotReply);
+    EXPECT_EQ(replyValue, 42u);
+
+    // The async message should have been logged when received by A
+    size_t indexAfterReceive = IPC::messageLog().indexForTesting();
+    EXPECT_GT(indexAfterReceive, indexBeforeSend);
+    EXPECT_TRUE(messageLogContains(MockTestMessageWithAsyncReply1::name(), indexBeforeSend));
+}
+
+// Test that sync messages are logged on receive
+TEST_F(MessageLogEndToEndTest, SyncMessageLogged)
+{
+    ASSERT_TRUE(openA());
+    ASSERT_TRUE(openB());
+
+    size_t indexBeforeSend = IPC::messageLog().indexForTesting();
+
+    // Set up B to handle sync messages
+    bClient().setSyncMessageHandler([](IPC::Connection& connection, IPC::Decoder&, UniqueRef<IPC::Encoder>& encoder) -> bool {
+        connection.sendSyncReply(WTF::move(encoder));
+        return true;
+    });
+
+    auto result = a()->sendSync(MockTestSyncMessage { }, 0, kDefaultWaitForTimeout);
+    EXPECT_TRUE(result.succeeded());
+
+    // The sync message should have been logged when received by B
+    size_t indexAfterReceive = IPC::messageLog().indexForTesting();
+    EXPECT_GT(indexAfterReceive, indexBeforeSend);
+    EXPECT_TRUE(messageLogContains(MockTestSyncMessage::name(), indexBeforeSend));
+}
+
+// Test message logging across run loops
+class MessageLogRunLoopTest : public MessageLogEndToEndTest {
+public:
+    void TearDown() override
+    {
+        // By convention the b() connection is the one that gets opened on various runloops.
+        ASSERT(!b() || !b()->client());
+        MessageLogEndToEndTest::TearDown();
+        EXPECT_EQ(m_runLoops.size(), 0u);
+    }
+
+    Ref<RunLoop> createRunLoop(ASCIILiteral name)
+    {
+        auto runLoop = RunLoop::create(name, ThreadType::Unknown);
+        m_runLoops.append(runLoop);
+        return runLoop;
+    }
+
+    void localReferenceBarrier()
+    {
+        Vector<Ref<Thread>> threadsToWait;
+        for (auto& runLoop : std::exchange(m_runLoops, { })) {
+            BinarySemaphore semaphore;
+            runLoop->dispatch([&semaphore, &threadsToWait] {
+                threadsToWait.append(Thread::currentSingleton());
+                RunLoop::currentSingleton().stop();
+                semaphore.signal();
+            });
+            semaphore.wait();
+        }
+        while (true) {
+            sleep(0.1_s);
+            bool allExited = true;
+            for (auto& thread : threadsToWait) {
+                if (Thread::allThreads().contains(thread.get())) {
+                    allExited = false;
+                    break;
+                }
+            }
+            if (allExited)
+                break;
+        }
+    }
+
+protected:
+    Vector<Ref<RunLoop>> m_runLoops;
+};
+
+#define LOCAL_STRINGIFY(x) #x
+#define RUN_LOOP_NAME "MessageLogRunLoopTest at MessageLogEndToEndTests.cpp:" LOCAL_STRINGIFY(__LINE__) ""_s
+
+TEST_F(MessageLogRunLoopTest, MessagesLoggedAcrossRunLoops)
+{
+    ASSERT_TRUE(openA());
+
+    size_t indexBeforeSend = IPC::messageLog().indexForTesting();
+
+    auto runLoop = createRunLoop(RUN_LOOP_NAME);
+    BinarySemaphore receivedSemaphore;
+
+    runLoop->dispatch([this, &receivedSemaphore] {
+        ASSERT_TRUE(openB());
+
+        // Wait for messages on this run loop
+        for (size_t i = 0; i < 5; ++i) {
+            auto message = bClient().waitForMessage(kDefaultWaitForTimeout);
+            EXPECT_EQ(message.destinationID, i);
+        }
+        receivedSemaphore.signal();
+    });
+
+    // Give B time to open
+    sleep(0.1_s);
+
+    // Send messages from main thread
+    for (size_t i = 0; i < 5; ++i)
+        a()->send(MockTestMessage1 { }, i);
+
+    receivedSemaphore.wait();
+
+    // Verify messages were logged
+    size_t indexAfterReceive = IPC::messageLog().indexForTesting();
+    EXPECT_GE(indexAfterReceive - indexBeforeSend, 5u);
+    EXPECT_TRUE(messageLogContains(MockTestMessage1::name(), indexBeforeSend));
+
+    runLoop->dispatch([this] {
+        b()->invalidate();
+    });
+    localReferenceBarrier();
+}
+
+#undef RUN_LOOP_NAME
+#undef LOCAL_STRINGIFY
+
+// --- StreamServerConnection message log tests ---
+
+namespace {
+
+enum MessageLogTestObjectIdentifierTag { };
+using MessageLogTestObjectIdentifier = ObjectIdentifier<MessageLogTestObjectIdentifierTag>;
+
+struct MockStreamMessage {
+    static constexpr bool isSync = false;
+    static constexpr bool isStreamEncodable = true;
+    static constexpr bool isStreamBatched = false;
+    static constexpr IPC::MessageName name() { return IPC::MessageName::IPCStreamTester_EmptyMessage; }
+    template<typename Encoder> void encode(Encoder&) { }
+};
+
+class MockStreamServerReceiver final : public IPC::StreamServerConnection::Client, public WaitForMessageMixin {
+    WTF_MAKE_TZONE_ALLOCATED(MockStreamServerReceiver);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MockStreamServerReceiver);
+
+public:
+    static Ref<MockStreamServerReceiver> create() { return adoptRef(*new MockStreamServerReceiver()); }
+
+private:
+    MockStreamServerReceiver() = default;
+
+    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder& decoder) final
+    {
+        addMessage(decoder);
+    }
+
+    void didReceiveInvalidMessage(IPC::StreamServerConnection&, IPC::MessageName messageName, const Vector<uint32_t>& failIndices) final
+    {
+        addInvalidMessage(messageName, failIndices);
+    }
+};
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(MockStreamServerReceiver);
+
+} // anonymous namespace
+
+class MessageLogStreamTest : public testing::Test {
+public:
+    void SetUp() override
+    {
+        WTF::initializeMainThread();
+        m_serverQueue = IPC::StreamConnectionWorkQueue::create("MessageLogStreamTest work queue"_s);
+
+        auto connectionPair = IPC::StreamClientConnection::create(defaultBufferSizeLog2, defaultTimeout);
+        ASSERT_TRUE(!!connectionPair);
+        auto [clientConnection, serverConnectionHandle] = WTF::move(*connectionPair);
+        auto serverConnection = IPC::StreamServerConnection::tryCreate(WTF::move(serverConnectionHandle), { }).releaseNonNull();
+
+        m_clientConnection = WTF::move(clientConnection);
+        m_clientConnection->setSemaphores(copyViaEncoder(m_serverQueue->wakeUpSemaphore()).value(), copyViaEncoder(serverConnection->clientWaitSemaphore()).value());
+
+        m_clientConnection->open(m_mockClientReceiver);
+
+        m_mockServerReceiver = MockStreamServerReceiver::create();
+        m_serverQueue->dispatch([this, serverConnection = WTF::move(serverConnection)]() mutable {
+            m_serverConnection = WTF::move(serverConnection);
+            m_serverConnection->open(*m_mockServerReceiver, *m_serverQueue);
+            m_serverConnection->startReceivingMessages(*m_mockServerReceiver, IPC::receiverName(MockStreamMessage::name()), defaultDestinationID().toUInt64());
+        });
+        {
+            BinarySemaphore semaphore;
+            m_serverQueue->dispatch([&semaphore] {
+                semaphore.signal();
+            });
+            semaphore.wait();
+        }
+
+        m_initialLogIndex = IPC::messageLog().indexForTesting();
+    }
+
+    void TearDown() override
+    {
+        m_clientConnection->invalidate();
+        {
+            m_serverQueue->dispatch([this] {
+                m_serverConnection->stopReceivingMessages(IPC::receiverName(MockStreamMessage::name()), defaultDestinationID().toUInt64());
+                m_serverConnection->invalidate();
+            });
+            BinarySemaphore semaphore;
+            m_serverQueue->dispatch([&semaphore] {
+                semaphore.signal();
+            });
+            semaphore.wait();
+        }
+        m_serverQueue->stopAndWaitForCompletion();
+    }
+
+protected:
+    static MessageLogTestObjectIdentifier defaultDestinationID()
+    {
+        return ObjectIdentifier<MessageLogTestObjectIdentifierTag>(77);
+    }
+
+    bool messageLogContains(IPC::MessageName messageName) const
+    {
+        const auto& buffer = IPC::messageLog().bufferForTesting();
+        size_t currentIndex = IPC::messageLog().indexForTesting();
+        size_t capacity = buffer.size();
+        for (size_t i = m_initialLogIndex; i < currentIndex; ++i) {
+            if (buffer[i % capacity] == messageName)
+                return true;
+        }
+        return false;
+    }
+
+    static constexpr Seconds defaultTimeout = 100_s;
+    static constexpr unsigned defaultBufferSizeLog2 = 8;
+
+    RefPtr<IPC::StreamConnectionWorkQueue> m_serverQueue;
+    RefPtr<IPC::StreamClientConnection> m_clientConnection;
+    RefPtr<IPC::StreamServerConnection> m_serverConnection;
+    Ref<MockConnectionClient> m_mockClientReceiver { MockConnectionClient::create() };
+    RefPtr<MockStreamServerReceiver> m_mockServerReceiver;
+    size_t m_initialLogIndex { 0 };
+};
+
+TEST_F(MessageLogStreamTest, StreamMessageLogged)
+{
+    constexpr size_t messageCount = 5;
+
+    for (size_t i = 0; i < messageCount; ++i) {
+        auto result = m_clientConnection->send(MockStreamMessage { }, defaultDestinationID());
+        EXPECT_EQ(result, IPC::Error::NoError);
+    }
+
+    // Wait for all messages to be received on the server side
+    for (size_t i = 0; i < messageCount; ++i) {
+        auto message = m_mockServerReceiver->waitForMessage(defaultTimeout);
+        EXPECT_EQ(message.messageName, MockStreamMessage::name());
+    }
+
+    // The stream messages should have been logged via StreamServerConnection::dispatchStreamMessage
+    EXPECT_TRUE(messageLogContains(MockStreamMessage::name()));
+}
+
+} // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/IPC/MessageLogTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/MessageLogTests.cpp
@@ -1,0 +1,261 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "MessageLog.h"
+#include "Test.h"
+#include <thread>
+#include <wtf/Vector.h>
+
+namespace TestWebKitAPI {
+
+TEST(MessageLogTests, InitialState)
+{
+    IPC::MessageLog<8> buffer;
+
+    // Verify buffer is initialized with Invalid message names
+    EXPECT_EQ(buffer.indexForTesting(), 0u);
+    for (size_t i = 0; i < 8; ++i)
+        EXPECT_EQ(buffer.bufferForTesting()[i], IPC::MessageName::Invalid);
+}
+
+TEST(MessageLogTests, AddSingleMessage)
+{
+    IPC::MessageLog<8> buffer;
+
+    buffer.add(IPC::MessageName::IPCTester_EmptyMessage);
+
+    EXPECT_EQ(buffer.indexForTesting(), 1u);
+    EXPECT_EQ(buffer.bufferForTesting()[0], IPC::MessageName::IPCTester_EmptyMessage);
+
+    // Rest should still be Invalid
+    for (size_t i = 1; i < 8; ++i)
+        EXPECT_EQ(buffer.bufferForTesting()[i], IPC::MessageName::Invalid);
+}
+
+TEST(MessageLogTests, AddMultipleMessages)
+{
+    IPC::MessageLog<8> buffer;
+
+    buffer.add(IPC::MessageName::IPCTester_EmptyMessage);
+    buffer.add(IPC::MessageName::IPCStreamTester_AsyncPing);
+    buffer.add(IPC::MessageName::IPCTester_AsyncPing);
+
+    EXPECT_EQ(buffer.indexForTesting(), 3u);
+    EXPECT_EQ(buffer.bufferForTesting()[0], IPC::MessageName::IPCTester_EmptyMessage);
+    EXPECT_EQ(buffer.bufferForTesting()[1], IPC::MessageName::IPCStreamTester_AsyncPing);
+    EXPECT_EQ(buffer.bufferForTesting()[2], IPC::MessageName::IPCTester_AsyncPing);
+}
+
+TEST(MessageLogTests, WrapAroundAtCapacity)
+{
+    IPC::MessageLog<4> buffer;
+
+    // Fill the buffer
+    buffer.add(IPC::MessageName::IPCTester_EmptyMessage);
+    buffer.add(IPC::MessageName::IPCStreamTester_AsyncPing);
+    buffer.add(IPC::MessageName::IPCTester_AsyncPing);
+    buffer.add(IPC::MessageName::IPCStreamTester_EmptyMessage);
+
+    EXPECT_EQ(buffer.indexForTesting(), 4u); // Free-running index
+    EXPECT_EQ(buffer.bufferForTesting()[0], IPC::MessageName::IPCTester_EmptyMessage);
+    EXPECT_EQ(buffer.bufferForTesting()[1], IPC::MessageName::IPCStreamTester_AsyncPing);
+    EXPECT_EQ(buffer.bufferForTesting()[2], IPC::MessageName::IPCTester_AsyncPing);
+    EXPECT_EQ(buffer.bufferForTesting()[3], IPC::MessageName::IPCStreamTester_EmptyMessage);
+
+    // Add one more, should overwrite index 0
+    buffer.add(IPC::MessageName::IPCTester_CreateStreamTester);
+
+    EXPECT_EQ(buffer.indexForTesting(), 5u); // Free-running index
+    EXPECT_EQ(buffer.bufferForTesting()[0], IPC::MessageName::IPCTester_CreateStreamTester);
+    EXPECT_EQ(buffer.bufferForTesting()[1], IPC::MessageName::IPCStreamTester_AsyncPing);
+}
+
+TEST(MessageLogTests, MultipleWraps)
+{
+    IPC::MessageLog<4> buffer;
+
+    // Add 10 messages to a buffer of size 4
+    for (size_t i = 0; i < 10; ++i)
+        buffer.add(IPC::MessageName::IPCTester_EmptyMessage);
+
+    // Free-running index should be 10
+    EXPECT_EQ(buffer.indexForTesting(), 10u);
+
+    // All entries should have the test message
+    for (size_t i = 0; i < 4; ++i)
+        EXPECT_EQ(buffer.bufferForTesting()[i], IPC::MessageName::IPCTester_EmptyMessage);
+}
+
+TEST(MessageLogTests, ConcurrentAddFromTwoThreads)
+{
+    constexpr size_t bufferSize = 256; // Power of two
+    constexpr size_t messagesPerThread = bufferSize / 2;
+
+    IPC::MessageLog<bufferSize> buffer;
+
+    auto thread1Message = IPC::MessageName::IPCTester_EmptyMessage;
+    auto thread2Message = IPC::MessageName::IPCStreamTester_AsyncPing;
+
+    std::thread thread1([&buffer, thread1Message]() {
+        for (size_t i = 0; i < messagesPerThread; ++i)
+            buffer.add(thread1Message);
+    });
+
+    std::thread thread2([&buffer, thread2Message]() {
+        for (size_t i = 0; i < messagesPerThread; ++i)
+            buffer.add(thread2Message);
+    });
+
+    thread1.join();
+    thread2.join();
+
+    // Total messages added: 256
+    // Buffer size: 256, so no wrapping
+    // Expected final index: 256 (free-running)
+    EXPECT_EQ(buffer.indexForTesting(), bufferSize);
+
+    // Count occurrences of each message type in the buffer
+    size_t thread1Count = 0;
+    size_t thread2Count = 0;
+
+    for (size_t i = 0; i < bufferSize; ++i) {
+        if (buffer.bufferForTesting()[i] == thread1Message)
+            thread1Count++;
+        else if (buffer.bufferForTesting()[i] == thread2Message)
+            thread2Count++;
+        else
+            FAIL() << "Unexpected message name at index " << i << ": expected either thread1 or thread2 message";
+    }
+
+    // Each thread should have written exactly messagesPerThread entries
+    EXPECT_EQ(thread1Count, messagesPerThread);
+    EXPECT_EQ(thread2Count, messagesPerThread);
+
+    // Total should equal buffer size
+    EXPECT_EQ(thread1Count + thread2Count, bufferSize);
+}
+
+TEST(MessageLogTests, ConcurrentAddFromMultipleThreads)
+{
+    constexpr size_t bufferSize = 512; // Power of two
+    constexpr size_t numThreads = 8;
+    constexpr size_t messagesPerThread = bufferSize / numThreads;
+
+    IPC::MessageLog<bufferSize> buffer;
+
+    Vector<std::thread> threads;
+    Vector<IPC::MessageName> messageNames = {
+        IPC::MessageName::IPCTester_EmptyMessage,
+        IPC::MessageName::IPCStreamTester_AsyncPing,
+        IPC::MessageName::IPCTester_AsyncPing,
+        IPC::MessageName::IPCStreamTester_EmptyMessage,
+        IPC::MessageName::IPCTester_CreateStreamTester,
+        IPC::MessageName::IPCTester_CreateConnectionTester,
+        IPC::MessageName::IPCTester_StartMessageTesting,
+        IPC::MessageName::IPCTester_CheckTestParameter
+    };
+
+    for (size_t t = 0; t < numThreads; ++t) {
+        threads.append(std::thread([&buffer, messageName = messageNames[t]]() {
+            for (size_t i = 0; i < messagesPerThread; ++i)
+                buffer.add(messageName);
+        }));
+    }
+
+    for (auto& thread : threads)
+        thread.join();
+
+    // Total messages: 8 * 64 = 512
+    // Buffer size: 512, no wrapping
+    // Expected index: 512 (free-running)
+    EXPECT_EQ(buffer.indexForTesting(), bufferSize);
+
+    // Count messages from each thread
+    Vector<size_t> messageCounts(numThreads, 0);
+
+    for (size_t i = 0; i < bufferSize; ++i) {
+        bool found = false;
+        for (size_t t = 0; t < numThreads; ++t) {
+            if (buffer.bufferForTesting()[i] == messageNames[t]) {
+                messageCounts[t]++;
+                found = true;
+                break;
+            }
+        }
+        EXPECT_TRUE(found) << "Unexpected message at index " << i;
+    }
+
+    // Each thread should have written exactly messagesPerThread entries
+    for (size_t t = 0; t < numThreads; ++t) {
+        EXPECT_EQ(messageCounts[t], messagesPerThread)
+            << "Thread " << t << " wrote " << messageCounts[t]
+            << " messages, expected " << messagesPerThread;
+    }
+}
+
+TEST(MessageLogTests, ConcurrentAddWithWrapping)
+{
+    constexpr size_t bufferSize = 64;
+    constexpr size_t numThreads = 4;
+    constexpr size_t messagesPerThread = 100; // Total = 400, wraps multiple times
+
+    IPC::MessageLog<bufferSize> buffer;
+
+    Vector<std::thread> threads;
+    Vector<IPC::MessageName> messageNames;
+
+    // Each thread uses a unique message name
+    for (size_t t = 0; t < numThreads; ++t)
+        messageNames.append(static_cast<IPC::MessageName>(static_cast<uint16_t>(IPC::MessageName::IPCTester_EmptyMessage) + t));
+
+    for (size_t t = 0; t < numThreads; ++t) {
+        threads.append(std::thread([&buffer, messageName = messageNames[t]]() {
+            for (size_t i = 0; i < messagesPerThread; ++i)
+                buffer.add(messageName);
+        }));
+    }
+
+    for (auto& thread : threads)
+        thread.join();
+
+    // Free-running index should reflect all messages
+    EXPECT_EQ(buffer.indexForTesting(), numThreads * messagesPerThread);
+
+    // Every slot should contain one of the valid message names (no corruption from concurrent wrapping)
+    for (size_t i = 0; i < bufferSize; ++i) {
+        bool found = false;
+        for (size_t t = 0; t < numThreads; ++t) {
+            if (buffer.bufferForTesting()[i] == messageNames[t]) {
+                found = true;
+                break;
+            }
+        }
+        EXPECT_TRUE(found) << "Unexpected message at index " << i;
+    }
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### 69b3a29056049827e6225bd94ca0fb8dccdd3229
<pre>
Implement IPC message name logging on receive
<a href="https://rdar.apple.com/167685378">rdar://167685378</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=305043">https://bugs.webkit.org/show_bug.cgi?id=305043</a>

Reviewed by Kimmo Kinnunen.

This patch implements logging for IPC message names in a process-wide,
append-only ring buffer on message receive.

The contents of this buffer can be read from a crashed process to
understand the flow of messages that might have caused this crash.

Tests: Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
       Tools/TestWebKitAPI/Tests/IPC/MessageLogEndToEndTests.cpp
       Tools/TestWebKitAPI/Tests/IPC/MessageLogTests.cpp

* Source/WebKit/Platform/ExtraPrivateSymbolsForTAPI.h:
* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::dispatchMessageReceiverMessage):
(IPC::Connection::dispatchMessage):
* Source/WebKit/Platform/IPC/MessageLog.cpp: Copied from Source/WebKit/Platform/ExtraPrivateSymbolsForTAPI.h.
(IPC::messageLog):
(IPC::messageLogMetadata):
* Source/WebKit/Platform/IPC/MessageLog.h: Added.
(IPC::MessageLog::MessageLog):
(IPC::MessageLog::add):
(IPC::MessageLog::indexForTesting const):
(IPC::MessageLog::bufferForTesting const):
* Source/WebKit/Platform/IPC/StreamServerConnection.cpp:
(IPC::StreamServerConnection::dispatchStreamMessage):
* Source/WebKit/Platform/IPC/TransferString.cpp:
(IPC::TransferString::release):
* Source/WebKit/Platform/Sources.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/Scripts/dump-message-log: Added.
(dump_message_log):
(__lldb_init_module):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/IPC/MessageLogEndToEndTests.cpp: Added.
(TestWebKitAPI::MockTestMessage2::name):
(TestWebKitAPI::MockTestMessage2::encode):
(TestWebKitAPI::MockTestMessage3::name):
(TestWebKitAPI::MockTestMessage3::encode):
(TestWebKitAPI::MockTestMessage4::name):
(TestWebKitAPI::MockTestMessage4::encode):
(TestWebKitAPI::MockTestSyncMessage::name):
(TestWebKitAPI::MockTestSyncMessage::encode):
(TestWebKitAPI::MessageLogEndToEndTest::messagesLoggedSinceSetup const):
(TestWebKitAPI::MessageLogEndToEndTest::messageLogContains const):
(TestWebKitAPI::MessageLogEndToEndTest::countMessagesInLog const):
(TestWebKitAPI::TEST_F(MessageLogEndToEndTest, SingleMessageLogged)):
(TestWebKitAPI::TEST_F(MessageLogEndToEndTest, MultipleMessagesLogged)):
(TestWebKitAPI::TEST_F(MessageLogEndToEndTest, BidirectionalMessagesLogged)):
(TestWebKitAPI::TEST_F(MessageLogEndToEndTest, HighVolumeWrapsBuffer)):
(TestWebKitAPI::TEST_F(MessageLogEndToEndTest, ConcurrentSendersLogged)):
(TestWebKitAPI::TEST_F(MessageLogEndToEndTest, InterleavedMessageTypes)):
(TestWebKitAPI::TEST_F(MessageLogEndToEndTest, AsyncReplyMessagesLogged)):
(TestWebKitAPI::TEST_F(MessageLogEndToEndTest, SyncMessageLogged)):
(TestWebKitAPI::MessageLogRunLoopTest::createRunLoop):
(TestWebKitAPI::MessageLogRunLoopTest::localReferenceBarrier):
(TestWebKitAPI::TEST_F(MessageLogRunLoopTest, MessagesLoggedAcrossRunLoops)):
(TestWebKitAPI::MessageLogStreamTest::defaultDestinationID):
(TestWebKitAPI::MessageLogStreamTest::messageLogContains const):
(TestWebKitAPI::TEST_F(MessageLogStreamTest, StreamMessageLogged)):
* Tools/TestWebKitAPI/Tests/IPC/MessageLogTests.cpp: Added.
(TestWebKitAPI::TEST(MessageLogTests, InitialState)):
(TestWebKitAPI::TEST(MessageLogTests, AddSingleMessage)):
(TestWebKitAPI::TEST(MessageLogTests, AddMultipleMessages)):
(TestWebKitAPI::TEST(MessageLogTests, WrapAroundAtCapacity)):
(TestWebKitAPI::TEST(MessageLogTests, MultipleWraps)):
(TestWebKitAPI::TEST(MessageLogTests, ConcurrentAddFromTwoThreads)):
(TestWebKitAPI::TEST(MessageLogTests, ConcurrentAddFromMultipleThreads)):
(TestWebKitAPI::TEST(MessageLogTests, ConcurrentAddWithWrapping)):

Canonical link: <a href="https://commits.webkit.org/307569@main">https://commits.webkit.org/307569@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa8a23b1e6a134f3064f2b26a10f270663446766

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144506 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17185 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8745 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153176 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98141 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146381 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17667 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17079 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111117 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79744 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147469 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13503 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129764 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92029 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12890 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10647 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/622 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122396 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6452 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155489 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17037 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7508 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119118 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17075 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14260 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119475 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15297 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127665 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72578 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22340 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16659 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6073 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16395 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80438 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16604 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16459 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->