### PR TITLE
Update capture related Dispatched(From|To)s

### DIFF
--- a/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.messages.in
+++ b/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.messages.in
@@ -23,10 +23,9 @@
 
 #if ENABLE(MEDIA_STREAM)
 
-// rdar://140690546 - Can currently be dispatchedTo UI & GPU
 [
     DispatchedFrom=WebContent,
-    ExceptionForDispatchedTo,
+    DispatchedTo=GPU,
     ExceptionForEnabledBy
 ]
 messages -> UserMediaCaptureManagerProxy {

--- a/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.messages.in
+++ b/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.messages.in
@@ -23,9 +23,8 @@
 
 #if ENABLE(MEDIA_STREAM)
 
-// rdar://140690546 - Can currently be dispatchedFrom UI & GPU
 [
-    ExceptionForDispatchedFrom,
+    DispatchedFrom=GPU,
     DispatchedTo=WebContent
 ]
 messages -> RemoteCaptureSampleManager {

--- a/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.messages.in
+++ b/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.messages.in
@@ -23,9 +23,8 @@
 
 #if ENABLE(MEDIA_STREAM)
 
-// rdar://140690546 - Can currently be dispatchedFrom UI & GPU
 [
-    ExceptionForDispatchedFrom,
+    DispatchedFrom=GPU,
     DispatchedTo=WebContent
 ]
 messages -> UserMediaCaptureManager {


### PR DESCRIPTION
#### 367de4fd8bd34c3132e10347f5f09b2d6d3859ec
<pre>
Update capture related Dispatched(From|To)s
<a href="https://bugs.webkit.org/show_bug.cgi?id=305047">https://bugs.webkit.org/show_bug.cgi?id=305047</a>
<a href="https://rdar.apple.com/167687068">rdar://167687068</a>

Reviewed by Youenn Fablet.

Update UserMediaCaptureManagerProxy and RemoteCaptureSampleManager related
Dispatched(From|To)s now that the subsystems only runs in GPUP.

* Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.messages.in:
* Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.messages.in:
* Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.messages.in:

Canonical link: <a href="https://commits.webkit.org/305225@main">https://commits.webkit.org/305225@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6789d25831672c2fa0c98bea1174f0bbb7d94fe6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137829 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10190 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49154 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145893 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90802 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f0da5544-a216-4ce2-a44f-5a8212772a9a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10893 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10329 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105434 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a34e2aef-52f5-43a3-b7a8-c19de59f326f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140774 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8113 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123551 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86289 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fe1966e3-e55c-42d8-b975-3de8a3df6159) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7734 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5471 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6174 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117127 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148603 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9873 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42269 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113813 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9890 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8328 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114151 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28991 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7672 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119799 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64587 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9921 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37821 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9652 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73486 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9861 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9713 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->