### PR TITLE
Remove more opportunities for media tracks to be null

### DIFF
--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -835,6 +835,8 @@ public:
     void removeAt(size_t position);
     void removeAt(size_t position, size_t length);
     bool removeFirst(const auto&);
+    template<SmartPtr U = T, typename V> requires std::same_as<U, T> && std::derived_from<V, typename GetPtrHelper<U>::UnderlyingType>
+    bool removeFirst(V*);
     bool removeFirstMatching(NOESCAPE const Invocable<bool(T&)> auto&, size_t startIndex = 0);
     bool removeLast(const auto&);
     bool removeLastMatching(NOESCAPE const Invocable<bool(T&)> auto&);
@@ -1136,6 +1138,15 @@ template<SmartPtr U, typename V> requires std::same_as<U, T> && std::derived_fro
 size_t Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::reverseFind(V* ptr) const
 {
     return reverseFindIf([&](auto& item) {
+        return GetPtrHelper<U>::getPtr(item) == ptr;
+    });
+}
+
+template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
+template<SmartPtr U, typename V> requires std::same_as<U, T> && std::derived_from<V, typename GetPtrHelper<U>::UnderlyingType>
+bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::removeFirst(V* ptr)
+{
+    return removeFirstMatching([&](auto& item) {
         return GetPtrHelper<U>::getPtr(item) == ptr;
     });
 }

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.h
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.h
@@ -85,8 +85,8 @@ public:
     double brightness() const { return 1; }
     void setBrightness(double) { }
 
-    Vector<RefPtr<TextTrack>> sortedTrackListForMenu(TextTrackList&);
-    Vector<RefPtr<AudioTrack>> sortedTrackListForMenu(AudioTrackList&);
+    Vector<Ref<TextTrack>> sortedTrackListForMenu(TextTrackList&);
+    Vector<Ref<AudioTrack>> sortedTrackListForMenu(AudioTrackList&);
 
     using TextOrAudioTrack = Variant<RefPtr<TextTrack>, RefPtr<AudioTrack>>;
     String displayNameForTrack(const std::optional<TextOrAudioTrack>&);
@@ -180,9 +180,9 @@ private:
 #if ENABLE(VIDEO_PRESENTATION_MODE)
         PictureInPictureTag,
 #endif
-        RefPtr<AudioTrack>,
-        RefPtr<TextTrack>,
-        RefPtr<VTTCue>,
+        Ref<AudioTrack>,
+        Ref<TextTrack>,
+        Ref<VTTCue>,
         PlaybackSpeed,
         ShowMediaStatsTag
     >;

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -1361,7 +1361,7 @@ private:
     const RefPtr<AudioTrackList> m_audioTracks;
     const RefPtr<TextTrackList> m_textTracks;
     const RefPtr<VideoTrackList> m_videoTracks;
-    Vector<RefPtr<TextTrack>> m_textTracksWhenResourceSelectionBegan;
+    Vector<Ref<TextTrack>> m_textTracksWhenResourceSelectionBegan;
 
     struct CueData;
     std::unique_ptr<CueData> m_cueData;

--- a/Source/WebCore/page/CaptionUserPreferences.cpp
+++ b/Source/WebCore/page/CaptionUserPreferences.cpp
@@ -211,37 +211,37 @@ Vector<String> CaptionUserPreferences::preferredAudioCharacteristics() const
     return characteristics;
 }
 
-static String trackDisplayName(TextTrack* track)
+static String trackDisplayName(const TextTrack& track)
 {
-    if (track == &TextTrack::captionMenuOffItemSingleton())
+    if (&track == &TextTrack::captionMenuOffItemSingleton())
         return textTrackOffMenuItemText();
-    if (track == &TextTrack::captionMenuOnItemSingleton())
+    if (&track == &TextTrack::captionMenuOnItemSingleton())
         return textTrackOnMenuItemText();
-    if (track == &TextTrack::captionMenuAutomaticItemSingleton())
+    if (&track == &TextTrack::captionMenuAutomaticItemSingleton())
         return textTrackAutomaticMenuItemText();
 
-    if (auto label = track->label().string().trim(isASCIIWhitespace); !label.isEmpty())
-        return track->label();
-    if (auto languageIdentifier = track->validBCP47Language(); !languageIdentifier.isEmpty())
+    if (auto label = track.label().string().trim(isASCIIWhitespace); !label.isEmpty())
+        return track.label();
+    if (auto languageIdentifier = track.validBCP47Language(); !languageIdentifier.isEmpty())
         return languageIdentifier;
     return trackNoLabelText();
 }
 
-String CaptionUserPreferences::displayNameForTrack(TextTrack* track) const
+String CaptionUserPreferences::displayNameForTrack(const TextTrack& track) const
 {
     return trackDisplayName(track);
 }
 
-MediaSelectionOption CaptionUserPreferences::mediaSelectionOptionForTrack(TextTrack* track) const
+MediaSelectionOption CaptionUserPreferences::mediaSelectionOptionForTrack(const TextTrack& track) const
 {
     auto legibleType = MediaSelectionOption::LegibleType::Regular;
-    if (track == &TextTrack::captionMenuOffItemSingleton())
+    if (&track == &TextTrack::captionMenuOffItemSingleton())
         legibleType = MediaSelectionOption::LegibleType::LegibleOff;
-    else if (track == &TextTrack::captionMenuAutomaticItemSingleton())
+    else if (&track == &TextTrack::captionMenuAutomaticItemSingleton())
         legibleType = MediaSelectionOption::LegibleType::LegibleAuto;
 
     auto mediaType = MediaSelectionOption::MediaType::Unknown;
-    switch (track->kind()) {
+    switch (track.kind()) {
     case TextTrack::Kind::Forced:
     case TextTrack::Kind::Descriptions:
     case TextTrack::Kind::Subtitles:
@@ -261,14 +261,14 @@ MediaSelectionOption CaptionUserPreferences::mediaSelectionOptionForTrack(TextTr
     return { mediaType, displayNameForTrack(track), legibleType };
 }
     
-Vector<RefPtr<TextTrack>> CaptionUserPreferences::sortedTrackListForMenu(TextTrackList* trackList, HashSet<TextTrack::Kind> kinds)
+Vector<Ref<TextTrack>> CaptionUserPreferences::sortedTrackListForMenu(TextTrackList* trackList, HashSet<TextTrack::Kind> kinds)
 {
     ASSERT(trackList);
 
-    Vector<RefPtr<TextTrack>> tracksForMenu;
+    Vector<Ref<TextTrack>> tracksForMenu;
 
     for (unsigned i = 0, length = trackList->length(); i < length; ++i) {
-        RefPtr track = trackList->item(i);
+        Ref track = *trackList->item(i);
         if (kinds.contains(track->kind()))
             tracksForMenu.append(WTF::move(track));
     }
@@ -287,33 +287,33 @@ Vector<RefPtr<TextTrack>> CaptionUserPreferences::sortedTrackListForMenu(TextTra
     return tracksForMenu;
 }
 
-static String trackDisplayName(AudioTrack* track)
+static String trackDisplayName(const AudioTrack& track)
 {
-    if (auto label = track->label().string().trim(isASCIIWhitespace); !label.isEmpty())
-        return track->label();
-    if (auto languageIdentifier = track->validBCP47Language(); !languageIdentifier.isEmpty())
+    if (auto label = track.label().string().trim(isASCIIWhitespace); !label.isEmpty())
+        return track.label();
+    if (auto languageIdentifier = track.validBCP47Language(); !languageIdentifier.isEmpty())
         return languageIdentifier;
     return trackNoLabelText();
 }
 
-String CaptionUserPreferences::displayNameForTrack(AudioTrack* track) const
+String CaptionUserPreferences::displayNameForTrack(const AudioTrack& track) const
 {
     return trackDisplayName(track);
 }
 
-MediaSelectionOption CaptionUserPreferences::mediaSelectionOptionForTrack(AudioTrack* track) const
+MediaSelectionOption CaptionUserPreferences::mediaSelectionOptionForTrack(const AudioTrack& track) const
 {
     return { MediaSelectionOption::MediaType::Audio, displayNameForTrack(track), MediaSelectionOption::LegibleType::Regular };
 }
 
-Vector<RefPtr<AudioTrack>> CaptionUserPreferences::sortedTrackListForMenu(AudioTrackList* trackList)
+Vector<Ref<AudioTrack>> CaptionUserPreferences::sortedTrackListForMenu(AudioTrackList* trackList)
 {
     ASSERT(trackList);
 
-    Vector<RefPtr<AudioTrack>> tracksForMenu;
+    Vector<Ref<AudioTrack>> tracksForMenu;
 
     for (unsigned i = 0, length = trackList->length(); i < length; ++i)
-        tracksForMenu.append(trackList->item(i));
+        tracksForMenu.append(Ref { *trackList->item(i) });
 
     Collator collator;
 

--- a/Source/WebCore/page/CaptionUserPreferences.h
+++ b/Source/WebCore/page/CaptionUserPreferences.h
@@ -94,13 +94,13 @@ public:
     virtual void setPreferredAudioCharacteristic(const String&);
     virtual Vector<String> preferredAudioCharacteristics() const;
 
-    virtual String displayNameForTrack(TextTrack*) const;
-    MediaSelectionOption mediaSelectionOptionForTrack(TextTrack*) const;
-    virtual Vector<RefPtr<TextTrack>> sortedTrackListForMenu(TextTrackList*, HashSet<TextTrack::Kind>);
+    virtual String displayNameForTrack(const TextTrack&) const;
+    MediaSelectionOption mediaSelectionOptionForTrack(const TextTrack&) const;
+    virtual Vector<Ref<TextTrack>> sortedTrackListForMenu(TextTrackList*, HashSet<TextTrack::Kind>);
 
-    virtual String displayNameForTrack(AudioTrack*) const;
-    MediaSelectionOption mediaSelectionOptionForTrack(AudioTrack*) const;
-    virtual Vector<RefPtr<AudioTrack>> sortedTrackListForMenu(AudioTrackList*);
+    virtual String displayNameForTrack(const AudioTrack&) const;
+    MediaSelectionOption mediaSelectionOptionForTrack(const AudioTrack&) const;
+    virtual Vector<Ref<AudioTrack>> sortedTrackListForMenu(AudioTrackList*);
 
     void setPrimaryAudioTrackLanguageOverride(const String& language) { m_primaryAudioTrackLanguageOverride = language;  }
     String primaryAudioTrackLanguageOverride() const;

--- a/Source/WebCore/page/CaptionUserPreferencesMediaAF.h
+++ b/Source/WebCore/page/CaptionUserPreferencesMediaAF.h
@@ -95,10 +95,10 @@ public:
 #endif
 
     WEBCORE_EXPORT String captionsStyleSheetOverride() const override;
-    Vector<RefPtr<AudioTrack>> sortedTrackListForMenu(AudioTrackList*) override;
-    Vector<RefPtr<TextTrack>> sortedTrackListForMenu(TextTrackList*, HashSet<TextTrack::Kind>) override;
-    String displayNameForTrack(AudioTrack*) const override;
-    String displayNameForTrack(TextTrack*) const override;
+    Vector<Ref<AudioTrack>> sortedTrackListForMenu(AudioTrackList*) override;
+    Vector<Ref<TextTrack>> sortedTrackListForMenu(TextTrackList*, HashSet<TextTrack::Kind>) override;
+    String displayNameForTrack(const AudioTrack&) const override;
+    String displayNameForTrack(const TextTrack&) const override;
     String captionPreviewTitle() const override;
 
 #if HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK)

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
@@ -164,8 +164,8 @@ private:
     RefPtr<HTMLMediaElement> m_mediaElement;
     bool m_isListening { false };
     HashSet<CheckedPtr<PlaybackSessionModelClient>> m_clients;
-    Vector<RefPtr<TextTrack>> m_legibleTracksForMenu;
-    Vector<RefPtr<AudioTrack>> m_audioTracksForMenu;
+    Vector<Ref<TextTrack>> m_legibleTracksForMenu;
+    Vector<Ref<AudioTrack>> m_audioTracksForMenu;
     AudioSessionSoundStageSize m_soundStageSize;
     std::optional<ImmersiveVideoMetadata> m_immersiveVideoMetadata;
 

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
@@ -370,13 +370,13 @@ void PlaybackSessionModelMediaElement::selectLegibleMediaOption(uint64_t index)
     if (!mediaElement)
         return;
 
-    TextTrack* textTrack;
+    RefPtr<TextTrack> textTrack;
     if (index < m_legibleTracksForMenu.size())
-        textTrack = m_legibleTracksForMenu[static_cast<size_t>(index)].get();
+        textTrack = m_legibleTracksForMenu[static_cast<size_t>(index)].copyRef();
     else
-        textTrack = &TextTrack::captionMenuOffItemSingleton();
+        textTrack = TextTrack::captionMenuOffItemSingleton();
 
-    mediaElement->setSelectedTextTrack(textTrack);
+    mediaElement->setSelectedTextTrack(textTrack.get());
 }
 
 void PlaybackSessionModelMediaElement::togglePictureInPicture()
@@ -755,11 +755,11 @@ uint64_t PlaybackSessionModelMediaElement::legibleMediaSelectedIndex() const
     for (size_t index = 0; index < m_legibleTracksForMenu.size(); index++) {
         auto& track = m_legibleTracksForMenu[index];
 
-        if (track == &TextTrack::captionMenuOffItemSingleton())
+        if (track.ptr() == &TextTrack::captionMenuOffItemSingleton())
             offIndex = index;
 
         if (displayMode == MediaControlsHost::automaticKeyword()) {
-            if (track == &TextTrack::captionMenuAutomaticItemSingleton())
+            if (track.ptr() == &TextTrack::captionMenuAutomaticItemSingleton())
                 selectedIndex = index;
         } else {
             if (track->mode() == TextTrack::Mode::Showing)

--- a/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.h
+++ b/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.h
@@ -149,8 +149,6 @@ private:
     bool m_isChildOfElementFullscreen { false };
     FloatSize m_videoDimensions;
     FloatRect m_videoFrame;
-    Vector<RefPtr<TextTrack>> m_legibleTracksForMenu;
-    Vector<RefPtr<AudioTrack>> m_audioTracksForMenu;
     std::optional<MediaPlayerIdentifier> m_playerIdentifier;
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
 #if !RELEASE_LOG_DISABLED


### PR DESCRIPTION
#### b0d58a2a3229e1fa1dbc91cbba2c9826c49be9f6
<pre>
Remove more opportunities for media tracks to be null
<a href="https://bugs.webkit.org/show_bug.cgi?id=305049">https://bugs.webkit.org/show_bug.cgi?id=305049</a>

Reviewed by Chris Dumez.

Claude AI helped with writing this. In particular the change to Vector.

Canonical link: <a href="https://commits.webkit.org/305268@main">https://commits.webkit.org/305268@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da639f341591de90934381fd5a6dda0bb3f8840c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137964 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10328 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49331 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146032 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90939 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/50ac85dc-9561-436f-b74f-8fd3064f4fa4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139837 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11030 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10472 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105505 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/834abe1a-66c5-4041-b98f-146a135e5a9b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140909 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8225 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123682 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86357 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3e0823ad-be39-4729-9dee-48088a93e53a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7839 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5592 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6314 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/129928 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117235 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41852 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148743 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/136514 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10011 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42411 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113907 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10028 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8449 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114238 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7778 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119938 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64735 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21234 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10057 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37931 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/169236 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9788 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73625 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44142 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9998 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9849 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->