### PR TITLE
[Testing] Fix various test failures when Enhanced Security flag is enabled by default 

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2761,17 +2761,20 @@ EncryptedMediaAPIEnabled:
 
 EnhancedSecurityHeuristicsEnabled:
   type: bool
-  status: testable
+  status: stable
   category: security
   defaultsOverridable: true
   humanReadableName: "Enable EnhancedSecurity Heuristics"
   humanReadableDescription: "Triggers EnhancedSecurity when insecure HTTP loads occur"
   defaultValue:
     WebKitLegacy:
+      "PLATFORM(COCOA)": true
       default: false
     WebKit:
+      "PLATFORM(COCOA)": true
       default: false
     WebCore:
+      "PLATFORM(COCOA)": true
       default: false
 
 EnterKeyHintEnabled:

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -181,12 +181,12 @@ DocumentLoader* DocumentLoader::fromScriptExecutionContextIdentifier(ScriptExecu
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(DocumentLoader);
 
-DocumentLoader::DocumentLoader(ResourceRequest&& request, SubstituteData&& substituteData)
+DocumentLoader::DocumentLoader(ResourceRequest&& request, SubstituteData&& substituteData, std::optional<ResourceRequest>&& originalRequest)
     : FrameDestructionObserver(nullptr)
     , m_cachedResourceLoader(CachedResourceLoader::create(this))
-    , m_originalRequest(request)
+    , m_originalRequest(originalRequest.has_value() ? originalRequest.value() : request)
     , m_substituteData(WTF::move(substituteData))
-    , m_originalRequestCopy(request)
+    , m_originalRequestCopy(originalRequest.has_value() ? *std::exchange(originalRequest, std::nullopt) : request)
     , m_request(WTF::move(request))
     , m_substituteResourceDeliveryTimer(*this, &DocumentLoader::substituteResourceDeliveryTimerFired)
     , m_originalSubstituteDataWasValid(substituteData.isValid())

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -519,6 +519,9 @@ public:
     bool isContinuingLoadAfterProvisionalLoadStarted() const { return m_isContinuingLoadAfterProvisionalLoadStarted; }
     void setIsContinuingLoadAfterProvisionalLoadStarted(bool isContinuingLoadAfterProvisionalLoadStarted) { m_isContinuingLoadAfterProvisionalLoadStarted = isContinuingLoadAfterProvisionalLoadStarted; }
 
+    bool isContinuingLoadAfterNavigationPolicyDecision() const { return m_isContinuingLoadAfterNavigationPolicyDecision; }
+    void setIsContinuingLoadAfterNavigationPolicyDecision(bool isContinuingLoadAfterNavigationPolicyDecision) { m_isContinuingLoadAfterNavigationPolicyDecision = isContinuingLoadAfterNavigationPolicyDecision; }
+
     bool isRequestFromClientOrUserInput() const { return m_isRequestFromClientOrUserInput; }
     void setIsRequestFromClientOrUserInput(bool isRequestFromClientOrUserInput) { m_isRequestFromClientOrUserInput = isRequestFromClientOrUserInput; }
 
@@ -797,6 +800,7 @@ private:
     bool m_isClientRedirect { false };
     bool m_isLoadingMultipartContent { false };
     bool m_isContinuingLoadAfterProvisionalLoadStarted { false };
+    bool m_isContinuingLoadAfterNavigationPolicyDecision { false };
     bool m_isInFinishedLoadingOfEmptyDocument { false };
     bool m_isInitialAboutBlank { false };
 

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -187,9 +187,9 @@ class DocumentLoader
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(DocumentLoader, DocumentLoader);
     friend class ContentFilter;
 public:
-    static Ref<DocumentLoader> create(ResourceRequest&& request, SubstituteData&& data)
+    static Ref<DocumentLoader> create(ResourceRequest&& request, SubstituteData&& data, std::optional<ResourceRequest>&& originalRequest = std::nullopt)
     {
-        return adoptRef(*new DocumentLoader(WTF::move(request), WTF::move(data)));
+        return adoptRef(*new DocumentLoader(WTF::move(request), WTF::move(data), WTF::move(originalRequest)));
     }
 
     USING_CAN_MAKE_WEAKPTR(CachedRawResourceClient);
@@ -548,7 +548,7 @@ public:
     void setCrossSiteRequester(NavigationRequester&& crossSiteRequester) { m_crossSiteRequester = WTF::move(crossSiteRequester); }
 
 protected:
-    WEBCORE_EXPORT DocumentLoader(ResourceRequest&&, SubstituteData&&);
+    WEBCORE_EXPORT DocumentLoader(ResourceRequest&&, SubstituteData&&, std::optional<ResourceRequest>&&);
 
     WEBCORE_EXPORT virtual void attachToFrame();
 

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -697,9 +697,9 @@ void EmptyFrameLoaderClient::dispatchWillSubmitForm(FormState&, URL&&, String&&,
     completionHandler();
 }
 
-Ref<DocumentLoader> EmptyFrameLoaderClient::createDocumentLoader(ResourceRequest&& request, SubstituteData&& substituteData)
+Ref<DocumentLoader> EmptyFrameLoaderClient::createDocumentLoader(ResourceRequest&& request, SubstituteData&& substituteData, std::optional<ResourceRequest>&& originalRequest)
 {
-    return DocumentLoader::create(WTF::move(request), WTF::move(substituteData));
+    return DocumentLoader::create(WTF::move(request), WTF::move(substituteData), WTF::move(originalRequest));
 }
 
 RefPtr<LocalFrame> EmptyFrameLoaderClient::createFrame(const AtomString&, HTMLFrameOwnerElement&)

--- a/Source/WebCore/loader/EmptyFrameLoaderClient.h
+++ b/Source/WebCore/loader/EmptyFrameLoaderClient.h
@@ -37,7 +37,7 @@ public:
     { }
 
 private:
-    Ref<DocumentLoader> createDocumentLoader(ResourceRequest&&, SubstituteData&&) override;
+    Ref<DocumentLoader> createDocumentLoader(ResourceRequest&&, SubstituteData&&, std::optional<ResourceRequest>&& = std::nullopt) override;
 
     bool hasWebView() const final;
 

--- a/Source/WebCore/loader/FrameLoadRequest.h
+++ b/Source/WebCore/loader/FrameLoadRequest.h
@@ -75,6 +75,9 @@ public:
     bool isContentRuleListRedirect() const { return m_isContentRuleListRedirect; }
     void setIsContentRuleListRedirect(bool isContentRuleListRedirect) { m_isContentRuleListRedirect = isContentRuleListRedirect; }
 
+    bool isCrossOriginContentRuleListRedirect() const { return m_isCrossOriginContentRuleListRedirect; }
+    void setIsCrossOriginContentRuleListRedirect(bool isCrossOriginContentRuleListRedirect) { m_isCrossOriginContentRuleListRedirect = isCrossOriginContentRuleListRedirect; }
+
     bool isFromNavigationAPI() const { return m_isFromNavigationAPI; }
     void setIsFromNavigationAPI(bool isFromNavigationAPI) { m_isFromNavigationAPI = isFromNavigationAPI; }
 
@@ -102,6 +105,7 @@ private:
     bool m_isInitialFrameSrcLoad { false };
     bool m_isContentRuleListRedirect { false };
     bool m_isFromNavigationAPI { false };
+    bool m_isCrossOriginContentRuleListRedirect { false };
 };
 
 class FrameLoadRequest : public FrameLoadRequestBase {

--- a/Source/WebCore/loader/FrameLoadRequest.h
+++ b/Source/WebCore/loader/FrameLoadRequest.h
@@ -131,6 +131,10 @@ public:
     const ResourceRequest& resourceRequest() const { return m_resourceRequest; }
     ResourceRequest takeResourceRequest() { return std::exchange(m_resourceRequest, { }); }
 
+    void setOriginalResourceRequest(ResourceRequest originalResourceRequest) { m_originalResourceRequest = originalResourceRequest; }
+    bool hasOriginalResourceRequest() { return !!m_originalResourceRequest; }
+    std::optional<ResourceRequest> takeOriginalResourceRequest() { return std::exchange(m_originalResourceRequest, { }); }
+
     const AtomString& frameName() const { return m_frameName; }
     void setFrameName(const AtomString& frameName) { m_frameName = frameName; }
 
@@ -181,6 +185,7 @@ private:
     AtomString m_frameName;
     SubstituteData m_substituteData;
     String m_clientRedirectSourceForHistory;
+    std::optional<ResourceRequest> m_originalResourceRequest;
 
     bool m_shouldCheckNewWindowPolicy { false };
     ShouldTreatAsContinuingLoad m_shouldTreatAsContinuingLoad { ShouldTreatAsContinuingLoad::No };

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1751,7 +1751,7 @@ void FrameLoader::load(FrameLoadRequest&& request, std::optional<NavigationReque
     if (!request.hasSubstituteData())
         request.setSubstituteData(defaultSubstituteDataForURL(request.resourceRequest().url()));
 
-    Ref loader = m_client->createDocumentLoader(request.takeResourceRequest(), request.takeSubstituteData());
+    Ref loader = m_client->createDocumentLoader(request.takeResourceRequest(), request.takeSubstituteData(), request.takeOriginalResourceRequest());
     loader->setIsContentRuleListRedirect(request.isContentRuleListRedirect());
     loader->setIsRequestFromClientOrUserInput(request.isRequestFromClientOrUserInput());
     loader->setIsContinuingLoadAfterProvisionalLoadStarted(request.shouldTreatAsContinuingLoad() == ShouldTreatAsContinuingLoad::YesAfterProvisionalLoadStarted);

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1755,6 +1755,7 @@ void FrameLoader::load(FrameLoadRequest&& request, std::optional<NavigationReque
     loader->setIsContentRuleListRedirect(request.isContentRuleListRedirect());
     loader->setIsRequestFromClientOrUserInput(request.isRequestFromClientOrUserInput());
     loader->setIsContinuingLoadAfterProvisionalLoadStarted(request.shouldTreatAsContinuingLoad() == ShouldTreatAsContinuingLoad::YesAfterProvisionalLoadStarted);
+    loader->setIsContinuingLoadAfterNavigationPolicyDecision(request.shouldTreatAsContinuingLoad() == ShouldTreatAsContinuingLoad::YesAfterNavigationPolicyDecision);
     if (crossSiteRequester)
         loader->setCrossSiteRequester(WTF::move(*crossSiteRequester));
 

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1773,6 +1773,7 @@ void FrameLoader::load(FrameLoadRequest&& request, std::optional<NavigationReque
     }
 
     SetForScope continuingLoadGuard(m_currentLoadContinuingState, request.shouldTreatAsContinuingLoad() != ShouldTreatAsContinuingLoad::No ? LoadContinuingState::ContinuingWithRequest : LoadContinuingState::NotContinuing);
+    SetForScope crossOriginContentRuleListCancellationGuard(m_needsCancellationForContentRuleListCrossOriginRedirect, request.isCrossOriginContentRuleListRedirect());
     load(loader.get(), request.protectedRequesterSecurityOrigin().ptr());
 }
 
@@ -2940,6 +2941,12 @@ void FrameLoader::checkLoadCompleteForThisFrame(LoadWillContinueInAnotherProcess
 
             if (loadWillContinueInAnotherProcess == LoadWillContinueInAnotherProcess::No) {
                 auto willInternallyHandleFailure = (error.errorRecoveryMethod() == ResourceError::ErrorRecoveryMethod::NoRecovery || (error.errorRecoveryMethod() == ResourceError::ErrorRecoveryMethod::HTTPFallback && (!isHTTPSFirstApplicable || isHTTPFallbackInProgress()))) ? WillInternallyHandleFailure::No : WillInternallyHandleFailure::Yes;
+
+                if (error.isCancellation() && m_needsCancellationForContentRuleListCrossOriginRedirect) {
+                    willInternallyHandleFailure = WillInternallyHandleFailure::Yes;
+                    m_needsCancellationForContentRuleListCrossOriginRedirect = false;
+                }
+
                 dispatchDidFailProvisionalLoad(*provisionalDocumentLoader, error, willInternallyHandleFailure);
             }
 

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -562,6 +562,8 @@ private:
     const Ref<DocumentPrefetcher> m_documentPrefetcher;
 
     Function<bool()> m_pendingDispatchNavigateEvent;
+
+    bool m_needsCancellationForContentRuleListCrossOriginRedirect { false };
 };
 
 // This function is called by createWindow() in JSDOMWindowBase.cpp, for example, for

--- a/Source/WebCore/loader/LocalFrameLoaderClient.h
+++ b/Source/WebCore/loader/LocalFrameLoaderClient.h
@@ -36,6 +36,7 @@
 #include <WebCore/LoaderMalloc.h>
 #include <WebCore/RegistrableDomain.h>
 #include <WebCore/ResourceLoaderIdentifier.h>
+#include <WebCore/ResourceRequest.h>
 #include <wtf/Expected.h>
 #include <wtf/Forward.h>
 #include <wtf/Platform.h>
@@ -246,7 +247,7 @@ public:
     virtual void didFinishLoad() = 0;
     virtual void prepareForDataSourceReplacement() = 0;
 
-    virtual Ref<DocumentLoader> createDocumentLoader(ResourceRequest&&, SubstituteData&&) = 0;
+    virtual Ref<DocumentLoader> createDocumentLoader(ResourceRequest&&, SubstituteData&&, std::optional<ResourceRequest>&& = std::nullopt) = 0;
     virtual void updateCachedDocumentLoader(DocumentLoader&) = 0;
     virtual void setTitle(const StringWithDirection&, const URL&) = 0;
 

--- a/Source/WebCore/loader/SubresourceLoader.cpp
+++ b/Source/WebCore/loader/SubresourceLoader.cpp
@@ -298,7 +298,7 @@ void SubresourceLoader::willSendRequestInternal(ResourceRequest&& newRequest, co
         Ref cachedResourceLoader = documentLoader->cachedResourceLoader();
         m_site = CachedResourceLoader::computeFetchMetadataSiteAfterRedirection(newRequest, m_resource->type(), options().mode, originalOrigin.get(), m_site, frame && frame->isMainFrame() && documentLoader->isRequestFromClientOrUserInput());
 
-        if (!cachedResourceLoader->updateRequestAfterRedirection(resource->type(), newRequest, options(), m_site, originalRequest().url())) {
+        if (!cachedResourceLoader->updateRequestAfterRedirection(resource->type(), newRequest, options(), m_site, originalRequest().url(), redirectResponse.url())) {
             SUBRESOURCELOADER_RELEASE_LOG(SUBRESOURCELOADER_WILLSENDREQUESTINTERNAL_RESOURCE_LOAD_CANCELLED_CANNOT_REQUEST_AFTER_REDIRECTION);
             cancel(ResourceError { String(), 0, request().url(), "Redirect was not allowed"_s, ResourceError::Type::AccessControl });
             return completionHandler(WTF::move(newRequest));

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -771,7 +771,7 @@ static bool shouldPerformHTTPSUpgrade(const URL& originalURL, const URL& newURL,
         && !frame.loader().isHTTPFallbackInProgress();
 }
 
-bool CachedResourceLoader::updateRequestAfterRedirection(CachedResource::Type type, ResourceRequest& request, const ResourceLoaderOptions& options, FetchMetadataSite site, const URL& preRedirectURL)
+bool CachedResourceLoader::updateRequestAfterRedirection(CachedResource::Type type, ResourceRequest& request, const ResourceLoaderOptions& options, FetchMetadataSite site, const URL& preRedirectURL, const URL& lastRedirectURL)
 {
     ASSERT(m_documentLoader);
     if (!m_documentLoader)
@@ -786,7 +786,7 @@ bool CachedResourceLoader::updateRequestAfterRedirection(CachedResource::Type ty
     if (frame) {
         RefPtr page = frame->page();
         bool isHTTPSByDefaultEnabled = page ? page->settings().httpsByDefault() : false;
-        if (shouldPerformHTTPSUpgrade(preRedirectURL, request.url(), *frame, type, isHTTPSByDefaultEnabled, m_documentLoader->advancedPrivacyProtections(), m_documentLoader->httpsByDefaultMode())) {
+        if (shouldPerformHTTPSUpgrade(lastRedirectURL, request.url(), *frame, type, isHTTPSByDefaultEnabled, m_documentLoader->advancedPrivacyProtections(), m_documentLoader->httpsByDefaultMode())) {
             auto portsForUpgradingInsecureScheme = page ? std::optional { page->portsForUpgradingInsecureSchemeForTesting() } : std::nullopt;
             auto upgradePort = (portsForUpgradingInsecureScheme && request.url().port() == portsForUpgradingInsecureScheme->first) ? std::optional { portsForUpgradingInsecureScheme->second } : std::nullopt;
             request.upgradeInsecureRequestIfNeeded(ShouldUpgradeLocalhostAndIPAddress::No, upgradePort);

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -1165,6 +1165,7 @@ ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::requ
             if (type == CachedResource::Type::MainResource && RegistrableDomain { resourceRequest.url() } != originalDomain) {
                 FrameLoadRequest frameLoadRequest(frame, ResourceRequest(URL { resourceRequest.url() }));
                 frameLoadRequest.setIsContentRuleListRedirect(true);
+                frameLoadRequest.setIsCrossOriginContentRuleListRedirect(true);
                 frame->loader().load(WTF::move(frameLoadRequest));
                 return makeUnexpected(ResourceError { errorDomainWebKitInternal, 0, url, "Loading in a new process"_s, ResourceError::Type::Cancellation });
             }

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -1144,7 +1144,8 @@ ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::requ
         RefPtr userContentProvider = frame->userContentProvider();
         if (request.options().shouldEnableContentExtensionsCheck == ShouldEnableContentExtensionsCheck::Yes && userContentProvider) {
             RegistrableDomain originalDomain { resourceRequest.url() };
-            auto results = userContentProvider->processContentRuleListsForLoad(page, resourceRequest.url(), ContentExtensions::toResourceType(type, request.resourceRequest().requester(), frame->isMainFrame()), *documentLoader);
+            auto redirectFromURL = (documentLoader->isContinuingLoadAfterNavigationPolicyDecision() && documentLoader->originalRequest().url() != resourceRequest.url()) ? documentLoader->originalRequest().url() : URL { };
+            auto results = userContentProvider->processContentRuleListsForLoad(page, resourceRequest.url(), ContentExtensions::toResourceType(type, request.resourceRequest().requester(), frame->isMainFrame()), *documentLoader, redirectFromURL);
             madeHTTPS = results.summary.madeHTTPS;
             request.applyResults(WTF::move(results), page.ptr());
             if (results.shouldBlock()) {

--- a/Source/WebCore/loader/cache/CachedResourceLoader.h
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.h
@@ -166,7 +166,7 @@ public:
     void warnUnusedPreloads();
     void stopUnusedPreloadsTimer();
 
-    bool updateRequestAfterRedirection(CachedResource::Type, ResourceRequest&, const ResourceLoaderOptions&, FetchMetadataSite, const URL& preRedirectURL);
+    bool updateRequestAfterRedirection(CachedResource::Type, ResourceRequest&, const ResourceLoaderOptions&, FetchMetadataSite, const URL& preRedirectURL, const URL& lastRedirectURL);
     bool allowedByContentSecurityPolicy(CachedResource::Type, const URL&, const ResourceLoaderOptions&, ContentSecurityPolicy::RedirectResponseReceived, const URL& preRedirectURL = URL(), bool shouldReportViolationAsConsoleMessage = true) const;
 
     static const ResourceLoaderOptions& defaultCachedResourceOptions();

--- a/Source/WebCore/platform/network/FormData.h
+++ b/Source/WebCore/platform/network/FormData.h
@@ -19,7 +19,6 @@
 
 #pragma once
 
-#include <WebCore/BlobData.h>
 #include <optional>
 #include <wtf/ArgumentCoder.h>
 #include <wtf/Forward.h>

--- a/Source/WebCore/platform/network/ResourceRequestBase.h
+++ b/Source/WebCore/platform/network/ResourceRequestBase.h
@@ -30,6 +30,7 @@
 #include <WebCore/FormData.h>
 #include <WebCore/FrameLoaderTypes.h>
 #include <WebCore/HTTPHeaderMap.h>
+#include <WebCore/IPAddressSpace.h>
 #include <WebCore/IntRect.h>
 #include <WebCore/ResourceLoadPriority.h>
 #include <optional>
@@ -40,8 +41,6 @@
 #include <wtf/WallTime.h>
 
 namespace WebCore {
-
-enum class IPAddressSpace : bool;
 
 enum class ResourceRequestCachePolicy : uint8_t {
     UseProtocolCachePolicy, // normal load, equivalent to fetch "default" cache mode.

--- a/Source/WebCore/platform/network/cocoa/CookieStorageObserver.h
+++ b/Source/WebCore/platform/network/cocoa/CookieStorageObserver.h
@@ -55,6 +55,8 @@ public:
 
     void cookiesDidChange();
 
+    void registerInternalsForNotifications(bool isReregistering);
+
 private:
     RetainPtr<NSHTTPCookieStorage> m_cookieStorage;
     bool m_hasRegisteredInternalsForNotifications { false };

--- a/Source/WebCore/platform/network/cocoa/CookieStorageObserver.mm
+++ b/Source/WebCore/platform/network/cocoa/CookieStorageObserver.mm
@@ -110,15 +110,26 @@ void CookieStorageObserver::startObserving(WTF::Function<void()>&& callback)
     m_observerAdapter = adoptNS([[WebCookieObserverAdapter alloc] initWithObserver:*this]);
 
     if (!m_hasRegisteredInternalsForNotifications) {
-        if (m_cookieStorage.get() != [NSHTTPCookieStorage sharedHTTPCookieStorage]) {
-            RetainPtr internalObject = (static_cast<WebNSHTTPCookieStorageDummyForInternalAccess *>(m_cookieStorage.get()))->_internal;
-            [internalObject registerForPostingNotificationsWithContext:m_cookieStorage.get()];
-        }
-
+        registerInternalsForNotifications(false);
         m_hasRegisteredInternalsForNotifications = true;
     }
 
     [[NSNotificationCenter defaultCenter] addObserver:m_observerAdapter.get() selector:@selector(cookiesChangedNotificationHandler:) name:NSHTTPCookieManagerCookiesChangedNotification object:m_cookieStorage.get()];
+}
+
+void CookieStorageObserver::registerInternalsForNotifications(bool isReregistering)
+{
+    // This will not be required once rdar://56248709 is fixed.
+    ASSERT(isMainThread());
+    ASSERT(hasProcessPrivilege(ProcessPrivilege::CanAccessRawCookies));
+
+    if (isReregistering && !m_hasRegisteredInternalsForNotifications)
+        return;
+
+    if (m_cookieStorage.get() != [NSHTTPCookieStorage sharedHTTPCookieStorage]) {
+        RetainPtr internalObject = (static_cast<WebNSHTTPCookieStorageDummyForInternalAccess *>(m_cookieStorage.get()))->_internal;
+        [internalObject registerForPostingNotificationsWithContext:m_cookieStorage.get()];
+    }
 }
 
 void CookieStorageObserver::stopObserving()

--- a/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
@@ -134,15 +134,22 @@ Vector<Cookie> NetworkStorageSession::getCookies(const URL& url)
 void NetworkStorageSession::hasCookies(const RegistrableDomain& domain, CompletionHandler<void(bool)>&& completionHandler) const
 {
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanAccessRawCookies));
+
+    bool hasCookieForDomain = false;
     
     for (NSHTTPCookie *nsCookie in [nsCookieStorage() cookies]) {
         if (RegistrableDomain::uncheckedCreateFromHost(nsCookie.domain) == domain) {
-            completionHandler(true);
-            return;
+            hasCookieForDomain = true;
+            break;
         }
     }
 
-    completionHandler(false);
+    // Workaround until rdar://56248709 is fixed.
+    if (m_cookieStorageObserver && cookieStorage().get()) {
+        cookieStorageObserver().registerInternalsForNotifications(true);
+    }
+
+    completionHandler(hasCookieForDomain);
 }
 
 void NetworkStorageSession::setAllCookiesToSameSiteStrict(const RegistrableDomain& domain, CompletionHandler<void()>&& completionHandler)

--- a/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
@@ -145,9 +145,8 @@ void NetworkStorageSession::hasCookies(const RegistrableDomain& domain, Completi
     }
 
     // Workaround until rdar://56248709 is fixed.
-    if (m_cookieStorageObserver && cookieStorage().get()) {
+    if (m_cookieStorageObserver && cookieStorage().get())
         cookieStorageObserver().registerInternalsForNotifications(true);
-    }
 
     completionHandler(hasCookieForDomain);
 }

--- a/Source/WebKit/Shared/LoadParameters.h
+++ b/Source/WebKit/Shared/LoadParameters.h
@@ -96,6 +96,7 @@ struct LoadParameters {
     std::optional<OptionSet<WebCore::AdvancedPrivacyProtections>> advancedPrivacyProtections;
     uint64_t requiredCookiesVersion { 0 };
     std::optional<WebCore::NavigationRequester> requester;
+    std::optional<WebCore::ResourceRequest> originalRequest;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/LoadParameters.serialization.in
+++ b/Source/WebKit/Shared/LoadParameters.serialization.in
@@ -63,4 +63,5 @@ enum class WebCore::NavigationUpgradeToHTTPSBehavior : bool;
     std::optional<OptionSet<WebCore::AdvancedPrivacyProtections>> advancedPrivacyProtections;
     uint64_t requiredCookiesVersion;
     std::optional<WebCore::NavigationRequester> requester;
+    std::optional<WebCore::ResourceRequest> originalRequest;
 };

--- a/Source/WebKit/UIProcess/API/APINavigation.cpp
+++ b/Source/WebKit/UIProcess/API/APINavigation.cpp
@@ -212,7 +212,9 @@ WTF::String Navigation::loggingString() const
 
 void Navigation::setHasStorageForCurrentSite(const WTF::URL& url, bool hasStorageForCurrentSite)
 {
-    ASSERT_UNUSED(url, url == m_currentRequest.url());
+    if (url != m_currentRequest.url())
+        return;
+
     m_hasStorageForCurrentSite = hasStorageForCurrentSite;
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -86,6 +86,13 @@
 #import "RemoteProgressBasedTimeline.h"
 #endif
 
+#if __has_include(<libproc.h>)
+#define HAS_LIBPROC 1
+#import <libproc.h>
+#else
+#define HAS_LIBPROC 0
+#endif // __has_include(<libproc.h>)
+
 #if ENABLE(MEDIA_SESSION_COORDINATOR)
 @interface WKMediaSessionCoordinatorHelper : NSObject <_WKMediaSessionCoordinatorDelegate>
 - (id)initWithCoordinator:(WebCore::MediaSessionCoordinatorClient*)coordinator;
@@ -1141,7 +1148,6 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 
 - (NSString *)_webContentProcessVariantForFrame:(_WKFrameHandle *)frameHandle
 {
-#if USE(APPLE_INTERNAL_SDK)
     if (!_page)
         return @"standard";
 
@@ -1164,6 +1170,27 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
         return @"standard";
 
     Ref connection = process->connection();
+
+#if HAS_LIBPROC
+    // This approach should work on macOS outside of Apple Internal builds.
+    if (auto pid = connection->remoteProcessID()) {
+        char path[PROC_PIDPATHINFO_MAXSIZE] = "\0";
+        int length = proc_pidpath(pid, path, sizeof(path));
+        if (length > 0) {
+            NSString *processPath = [NSString stringWithUTF8String:path];
+            if ([processPath.lastPathComponent hasPrefix:@"com.apple.WebKit.WebContent.EnhancedSecurity"])
+                return @"security";
+
+            if ([processPath.lastPathComponent hasPrefix:@"com.apple.WebKit.WebContent.CaptivePortal"])
+                return @"lockdown";
+
+            if ([processPath.lastPathComponent hasPrefix:@"com.apple.WebKit.WebContent"])
+                return @"standard";
+        }
+    }
+#endif // HAS_LIBPROC
+
+#if USE(APPLE_INTERNAL_SDK)
 
 #if !PLATFORM(IOS_FAMILY)
     bool hasAllowJIT = hasEntitlement(connection->xpcConnection(), "com.apple.security.cs.allow-jit"_s);

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
@@ -51,7 +51,7 @@ void BrowsingContextGroup::sharedProcessForSite(WebsiteDataStore& websiteDataSto
 {
     if (!preferences.siteIsolationEnabled() || !preferences.siteIsolationSharedProcessEnabled())
         return completionHandler(nullptr);
-    if (site.isEmpty() || m_processMap.contains(site))
+    if (site.isEmpty() || m_processMap.contains(std::make_pair(site, enhancedSecurity)))
         return completionHandler(nullptr);
     if (!m_sharedProcessSites.contains(site)) {
         if (isMainFrame == IsMainFrame::Yes)
@@ -99,7 +99,7 @@ Ref<FrameProcess> BrowsingContextGroup::ensureProcessForSite(const Site& site, c
             ASSERT(&m_sharedProcess->process() == &process);
             return *m_sharedProcess;
         }
-        if (RefPtr existingProcess = processForSite(site)) {
+        if (RefPtr existingProcess = processForSite(site, process.enhancedSecurity())) {
             if (existingProcess->process().coreProcessIdentifier() == process.coreProcessIdentifier())
                 return existingProcess.releaseNonNull();
         }
@@ -108,11 +108,11 @@ Ref<FrameProcess> BrowsingContextGroup::ensureProcessForSite(const Site& site, c
     return FrameProcess::create(process, *this, site, mainFrameSite, preferences, loadedWebArchive, injectBrowsingContextIntoProcess);
 }
 
-RefPtr<FrameProcess> BrowsingContextGroup::processForSite(const Site& site)
+RefPtr<FrameProcess> BrowsingContextGroup::processForSite(const Site& site, EnhancedSecurity enhancedSecurity)
 {
     if (m_sharedProcessSites.contains(site))
         return m_sharedProcess.get();
-    RefPtr process = m_processMap.get(site);
+    RefPtr process = m_processMap.get(std::make_pair(site, enhancedSecurity));
     if (!process)
         return nullptr;
     if (process->process().state() == WebProcessProxy::State::Terminated)
@@ -164,10 +164,11 @@ void BrowsingContextGroup::addFrameProcessAndInjectPageContextIf(FrameProcess& p
         return;
     }
     auto& site = *process.site();
-    if (m_processMap.get(site) == &process)
+    auto key = std::make_pair(site, processProxy->enhancedSecurity());
+    if (m_processMap.get(key) == &process)
         return;
-    ASSERT(!m_processMap.get(site) || m_processMap.get(site)->process().state() == WebProcessProxy::State::Terminated);
-    m_processMap.set(site, process);
+    ASSERT(!m_processMap.get(key) || m_processMap.get(key)->process().state() == WebProcessProxy::State::Terminated);
+    m_processMap.set(key, process);
     for (Ref page : m_pages) {
         if (site == Site(URL(page->currentURL())))
             continue;
@@ -182,8 +183,9 @@ void BrowsingContextGroup::removeFrameProcess(FrameProcess& process)
         m_sharedProcessSites.clear();
     } else {
         auto& site = *process.site();
-        ASSERT(site.isEmpty() || m_processMap.get(site) == &process || process.process().state() == WebProcessProxy::State::Terminated);
-        m_processMap.remove(site);
+        auto key = std::make_pair(site, process.process().enhancedSecurity());
+        ASSERT(site.isEmpty() || m_processMap.get(key) == &process || process.process().state() == WebProcessProxy::State::Terminated);
+        m_processMap.remove(key);
     }
     m_remotePages.removeIf([&] (auto& pair) {
         auto& set = pair.value;
@@ -205,7 +207,7 @@ void BrowsingContextGroup::addPage(WebPageProxy& page)
         return HashSet<Ref<RemotePageProxy>> { };
     }).iterator->value;
     m_processMap.removeIf([&] (auto& pair) {
-        auto& site = pair.key;
+        auto& site = pair.key.first;
         auto& process = pair.value;
         if (!process) {
             ASSERT_NOT_REACHED_WITH_MESSAGE("FrameProcess should remove itself in the destructor so we should never find a null WeakPtr");

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.h
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.h
@@ -63,7 +63,7 @@ public:
 
     void sharedProcessForSite(WebsiteDataStore&, API::WebsitePolicies*, const WebPreferences&, const WebCore::Site&, const WebCore::Site& mainFrameSite, WebProcessProxy::LockdownMode, EnhancedSecurity, API::PageConfiguration&, IsMainFrame, CompletionHandler<void(FrameProcess*)>&&);
     Ref<FrameProcess> ensureProcessForSite(const WebCore::Site&, const WebCore::Site& mainFrameSite, WebProcessProxy&, const WebPreferences&, LoadedWebArchive = LoadedWebArchive::No, InjectBrowsingContextIntoProcess = InjectBrowsingContextIntoProcess::Yes);
-    RefPtr<FrameProcess> processForSite(const WebCore::Site&);
+    RefPtr<FrameProcess> processForSite(const WebCore::Site&, EnhancedSecurity);
     void addFrameProcess(FrameProcess&);
     void addFrameProcessAndInjectPageContextIf(FrameProcess&, Function<bool(WebPageProxy&)>);
     void removeFrameProcess(FrameProcess&);
@@ -90,7 +90,7 @@ private:
     HashSet<WebCore::Site> m_sharedProcessSites;
     WeakHashSet<WebPageProxy> m_pagesInSharedProcess;
 
-    HashMap<WebCore::Site, WeakPtr<FrameProcess>> m_processMap;
+    HashMap<std::pair<WebCore::Site, EnhancedSecurity>, WeakPtr<FrameProcess>> m_processMap;
     WeakListHashSet<WebPageProxy> m_pages;
     WeakHashMap<WebPageProxy, HashSet<Ref<RemotePageProxy>>> m_remotePages;
 };

--- a/Source/WebKit/UIProcess/EnhancedSecurityTracking.cpp
+++ b/Source/WebKit/UIProcess/EnhancedSecurityTracking.cpp
@@ -190,6 +190,8 @@ void EnhancedSecurityTracking::handleBackForwardNavigation(const API::Navigation
 void EnhancedSecurityTracking::trackNavigation(const API::Navigation& navigation)
 {
     auto lastNavigationAction = navigation.lastNavigationAction();
+    if (lastNavigationAction->hasOpener)
+        return;
 
     bool isBackForward = lastNavigationAction && lastNavigationAction->navigationType == NavigationType::BackForward;
     bool isReload = lastNavigationAction && lastNavigationAction->navigationType == NavigationType::Reload;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2231,6 +2231,8 @@ void WebPageProxy::loadRequestWithNavigationShared(Ref<WebProcessProxy>&& proces
     loadParameters.originatingFrame = navigation.lastNavigationAction() ? std::optional(navigation.lastNavigationAction()->originatingFrameInfoData) : std::nullopt;
     if (auto& action = navigation.lastNavigationAction())
         loadParameters.requester = action->requester;
+    if (shouldTreatAsContinuingLoad == ShouldTreatAsContinuingLoad::YesAfterNavigationPolicyDecision)
+        loadParameters.originalRequest = navigation.originalRequest();
 
 #if ENABLE(CONTENT_EXTENSIONS)
     if (protectedPreferences()->iFrameResourceMonitoringEnabled())

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1394,7 +1394,7 @@ void WebPageProxy::launchProcess(const Site& site, ProcessLaunchReason reason)
     Ref processPool = m_configuration->processPool();
     RefPtr relatedPage = m_configuration->relatedPage();
 
-    if (RefPtr frameProcess = protectedBrowsingContextGroup()->processForSite(site)) {
+    if (RefPtr frameProcess = protectedBrowsingContextGroup()->processForSite(site, currentEnhancedSecurityState())) {
         ASSERT(protectedPreferences()->siteIsolationEnabled());
         m_legacyMainFrameProcess = frameProcess->process();
     } else if (relatedPage && !relatedPage->isClosed() && reason == ProcessLaunchReason::InitialProcess && hasSameGPUAndNetworkProcessPreferencesAs(*relatedPage)) {
@@ -16618,9 +16618,9 @@ void WebPageProxy::generateTestReport(const String& message, const String& group
     send(Messages::WebPage::GenerateTestReport(message, group));
 }
 
-WebProcessProxy* WebPageProxy::processForSite(const Site& site)
+WebProcessProxy* WebPageProxy::processForSite(const Site& site, EnhancedSecurity enhancedSecurity)
 {
-    if (RefPtr process = protectedBrowsingContextGroup()->processForSite(site))
+    if (RefPtr process = protectedBrowsingContextGroup()->processForSite(site, enhancedSecurity))
         return &process->process();
 
     return nullptr;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2544,7 +2544,7 @@ public:
     WKQuickLookPreviewController *quickLookPreviewController() const { return m_quickLookPreviewController.get(); }
 #endif
 
-    WebProcessProxy* processForSite(const WebCore::Site&);
+    WebProcessProxy* processForSite(const WebCore::Site&, EnhancedSecurity);
 
     void observeAndCreateRemoteSubframesInOtherProcesses(WebFrameProxy&, const String& frameName);
     void broadcastDocumentSyncData(IPC::Connection&, const WebCore::DocumentSyncSerializationData&);

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -2164,7 +2164,7 @@ void WebProcessPool::processForNavigation(WebPageProxy& page, WebFrameProxy& fra
                 return completionHandler(mainFrameProcess.copyRef(), nullptr, "Found process for the same site as main frame"_s);
         }
         RefPtr<WebProcessProxy> process;
-        if (RefPtr frameProcess = browsingContextGroup.processForSite(site))
+        if (RefPtr frameProcess = browsingContextGroup.processForSite(site, enhancedSecurity))
             process = &frameProcess->process();
         if (process && process->websiteDataStore() == dataStore.ptr() && process->websiteDataStore() == &page.websiteDataStore() && !process->isInProcessCache() && process->lockdownMode() == lockdownMode && enhancedSecurityStatesAreConsistent(process->enhancedSecurity(), enhancedSecurity)) {
             dataStore->protectedNetworkProcess()->addAllowedFirstPartyForCookies(*process, mainFrameSite.domain(), LoadedWebArchive::No, [completionHandler = WTF::move(completionHandler), process] () mutable {

--- a/Source/WebKit/WebProcess/Storage/RemoteWorkerFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/Storage/RemoteWorkerFrameLoaderClient.cpp
@@ -39,9 +39,9 @@ RemoteWorkerFrameLoaderClient::RemoteWorkerFrameLoaderClient(WebCore::FrameLoade
     RELEASE_LOG(Worker, "RemoteWorkerFrameLoaderClient::RemoteWorkerFrameLoaderClient webPageProxyID %" PRIu64 ", pageID %" PRIu64, webPageProxyID.toUInt64(), pageID.toUInt64());
 }
 
-Ref<WebCore::DocumentLoader> RemoteWorkerFrameLoaderClient::createDocumentLoader(WebCore::ResourceRequest&& request, WebCore::SubstituteData&& substituteData)
+Ref<WebCore::DocumentLoader> RemoteWorkerFrameLoaderClient::createDocumentLoader(WebCore::ResourceRequest&& request, WebCore::SubstituteData&& substituteData, std::optional<WebCore::ResourceRequest>&& originalRequest)
 {
-    return WebCore::DocumentLoader::create(WTF::move(request), WTF::move(substituteData));
+    return WebCore::DocumentLoader::create(WTF::move(request), WTF::move(substituteData), WTF::move(originalRequest));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Storage/RemoteWorkerFrameLoaderClient.h
+++ b/Source/WebKit/WebProcess/Storage/RemoteWorkerFrameLoaderClient.h
@@ -48,7 +48,7 @@ public:
     std::optional<WebCore::ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier() const { return m_serviceWorkerPageIdentifier; }
 
 private:
-    Ref<WebCore::DocumentLoader> createDocumentLoader(WebCore::ResourceRequest&&, WebCore::SubstituteData&&) final;
+    Ref<WebCore::DocumentLoader> createDocumentLoader(WebCore::ResourceRequest&&, WebCore::SubstituteData&&, std::optional<WebCore::ResourceRequest>&& = std::nullopt) final;
 
     bool shouldUseCredentialStorage(WebCore::DocumentLoader*, WebCore::ResourceLoaderIdentifier) final { return true; }
     bool isRemoteWorkerFrameLoaderClient() const final { return true; }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -1480,9 +1480,9 @@ void WebLocalFrameLoaderClient::prepareForDataSourceReplacement()
     notImplemented();
 }
 
-Ref<DocumentLoader> WebLocalFrameLoaderClient::createDocumentLoader(ResourceRequest&& request, SubstituteData&& substituteData)
+Ref<DocumentLoader> WebLocalFrameLoaderClient::createDocumentLoader(ResourceRequest&& request, SubstituteData&& substituteData, std::optional<ResourceRequest>&& originalRequest)
 {
-    return m_frame->protectedPage()->createDocumentLoader(protectedLocalFrame(), WTF::move(request), WTF::move(substituteData));
+    return m_frame->protectedPage()->createDocumentLoader(protectedLocalFrame(), WTF::move(request), WTF::move(substituteData), WTF::move(originalRequest));
 }
 
 void WebLocalFrameLoaderClient::updateCachedDocumentLoader(WebCore::DocumentLoader& loader)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
@@ -190,8 +190,8 @@ private:
     void provisionalLoadStarted() final;
     void didFinishLoad() final;
     void prepareForDataSourceReplacement() final;
-    
-    Ref<WebCore::DocumentLoader> createDocumentLoader(WebCore::ResourceRequest&&, WebCore::SubstituteData&&) final;
+
+    Ref<WebCore::DocumentLoader> createDocumentLoader(WebCore::ResourceRequest&&, WebCore::SubstituteData&&, std::optional<WebCore::ResourceRequest>&& = std::nullopt) final;
     void updateCachedDocumentLoader(WebCore::DocumentLoader&) final;
 
     void setTitle(const WebCore::StringWithDirection&, const URL&) final;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2211,6 +2211,8 @@ void WebPage::loadRequest(LoadParameters&& loadParameters)
         frameLoadRequest.setIsRequestFromClientOrUserInput();
     if (loadParameters.advancedPrivacyProtections)
         frameLoadRequest.setAdvancedPrivacyProtections(*loadParameters.advancedPrivacyProtections);
+    if (loadParameters.originalRequest)
+        frameLoadRequest.setOriginalResourceRequest(*loadParameters.originalRequest);
 
     if (loadParameters.effectiveSandboxFlags)
         localFrame->updateSandboxFlags(loadParameters.effectiveSandboxFlags, Frame::NotifyUIProcess::No);
@@ -8002,9 +8004,9 @@ void WebPage::setScrollbarOverlayStyle(std::optional<WebCore::ScrollbarOverlaySt
         localMainFrame->protectedView()->recalculateScrollbarOverlayStyle();
 }
 
-Ref<DocumentLoader> WebPage::createDocumentLoader(LocalFrame& frame, ResourceRequest&& request, SubstituteData&& substituteData)
+Ref<DocumentLoader> WebPage::createDocumentLoader(LocalFrame& frame, ResourceRequest&& request, SubstituteData&& substituteData, std::optional<ResourceRequest>&& originalRequest)
 {
-    auto documentLoader = DocumentLoader::create(WTF::move(request), WTF::move(substituteData));
+    auto documentLoader = DocumentLoader::create(WTF::move(request), WTF::move(substituteData), WTF::move(originalRequest));
 
     documentLoader->setLastNavigationWasAppInitiated(m_lastNavigationWasAppInitiated);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -56,6 +56,7 @@
 #include <WebCore/PointerID.h>
 #include <WebCore/RectEdges.h>
 #include <WebCore/RegistrableDomain.h>
+#include <WebCore/ResourceRequest.h>
 #include <WebCore/SecurityPolicyViolationEvent.h>
 #include <WebCore/ShareData.h>
 #include <WebCore/ShareableBitmap.h>
@@ -212,7 +213,6 @@ class RegistrableDomain;
 class RemoteFrameGeometryTransformer;
 class RenderImage;
 class Report;
-class ResourceRequest;
 class ResourceResponse;
 class ScrollingCoordinator;
 class SelectionData;
@@ -1577,7 +1577,7 @@ public:
     std::optional<WebCore::ScrollbarOverlayStyle> scrollbarOverlayStyle() { return m_scrollbarOverlayStyle; }
     void setScrollbarOverlayStyle(std::optional<WebCore::ScrollbarOverlayStyle> scrollbarStyle);
 
-    Ref<WebCore::DocumentLoader> createDocumentLoader(WebCore::LocalFrame&, WebCore::ResourceRequest&&, WebCore::SubstituteData&&);
+    Ref<WebCore::DocumentLoader> createDocumentLoader(WebCore::LocalFrame&, WebCore::ResourceRequest&&, WebCore::SubstituteData&&, std::optional<WebCore::ResourceRequest>&& = std::nullopt);
     void updateCachedDocumentLoader(WebCore::DocumentLoader&, WebCore::LocalFrame&);
 
     void getBytecodeProfile(CompletionHandler<void(const String&)>&&);

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.h
@@ -190,7 +190,7 @@ private:
     void provisionalLoadStarted() final;
     void didFinishLoad() final;
     void prepareForDataSourceReplacement() final;
-    Ref<WebCore::DocumentLoader> createDocumentLoader(WebCore::ResourceRequest&&, WebCore::SubstituteData&&) final;
+    Ref<WebCore::DocumentLoader> createDocumentLoader(WebCore::ResourceRequest&&, WebCore::SubstituteData&&, std::optional<WebCore::ResourceRequest>&& = std::nullopt) final;
     void updateCachedDocumentLoader(WebCore::DocumentLoader&) final { }
 
     void setTitle(const WebCore::StringWithDirection&, const URL&) final;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
@@ -1269,9 +1269,9 @@ void WebFrameLoaderClient::prepareForDataSourceReplacement()
 #endif
 }
 
-Ref<WebCore::DocumentLoader> WebFrameLoaderClient::createDocumentLoader(WebCore::ResourceRequest&& request, WebCore::SubstituteData&& substituteData)
+Ref<WebCore::DocumentLoader> WebFrameLoaderClient::createDocumentLoader(WebCore::ResourceRequest&& request, WebCore::SubstituteData&& substituteData, std::optional<WebCore::ResourceRequest>&& originalRequest)
 {
-    auto loader = WebDocumentLoaderMac::create(WTF::move(request), WTF::move(substituteData));
+    auto loader = WebDocumentLoaderMac::create(WTF::move(request), WTF::move(substituteData), WTF::move(originalRequest));
 
     auto dataSource = adoptNS([[WebDataSource alloc] _initWithDocumentLoader:loader.copyRef()]);
     loader->setDataSource(dataSource.get(), getWebView(m_webFrame.get()));

--- a/Source/WebKitLegacy/mac/WebView/WebDocumentLoaderMac.h
+++ b/Source/WebKitLegacy/mac/WebView/WebDocumentLoaderMac.h
@@ -40,9 +40,9 @@ class ResourceRequest;
 
 class WebDocumentLoaderMac : public WebCore::DocumentLoader {
 public:
-    static Ref<WebDocumentLoaderMac> create(WebCore::ResourceRequest&& request, WebCore::SubstituteData&& data)
+    static Ref<WebDocumentLoaderMac> create(WebCore::ResourceRequest&& request, WebCore::SubstituteData&& data, std::optional<WebCore::ResourceRequest>&& originalRequest = std::nullopt)
     {
-        return adoptRef(*new WebDocumentLoaderMac(WTF::move(request), WTF::move(data)));
+        return adoptRef(*new WebDocumentLoaderMac(WTF::move(request), WTF::move(data), WTF::move(originalRequest)));
     }
 
     void setDataSource(WebDataSource *, WebView*);
@@ -53,7 +53,7 @@ public:
     void decreaseLoadCount(WebCore::ResourceLoaderIdentifier);
 
 private:
-    WebDocumentLoaderMac(WebCore::ResourceRequest&&, WebCore::SubstituteData&&);
+    WebDocumentLoaderMac(WebCore::ResourceRequest&&, WebCore::SubstituteData&&, std::optional<WebCore::ResourceRequest>&&);
 
     virtual void attachToFrame();
     virtual void detachFromFrame(WebCore::LoadWillContinueInAnotherProcess);

--- a/Source/WebKitLegacy/mac/WebView/WebDocumentLoaderMac.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebDocumentLoaderMac.mm
@@ -34,8 +34,8 @@
 
 using namespace WebCore;
 
-WebDocumentLoaderMac::WebDocumentLoaderMac(ResourceRequest&& request, SubstituteData&& substituteData)
-    : DocumentLoader(WTF::move(request), WTF::move(substituteData))
+WebDocumentLoaderMac::WebDocumentLoaderMac(ResourceRequest&& request, SubstituteData&& substituteData, std::optional<ResourceRequest>&& originalRequest)
+    : DocumentLoader(WTF::move(request), WTF::move(substituteData), WTF::move(originalRequest))
     , m_dataSource(nil)
     , m_isDataSourceRetained(false)
 {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurity.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurity.mm
@@ -76,11 +76,8 @@ TEST(EnhancedSecurity, EnhancedSecurityEnablesTrue)
     [webView loadRequest:[NSURLRequest requestWithURL:url]];
     [webView _test_waitForDidFinishNavigation];
     EXPECT_EQ(true, isEnhancedSecurityEnabled(webView.get()));
-// _webContentProcessVariantForFrame relies on private entitlements not available on public builds
-#if USE(APPLE_INTERNAL_SDK)
     NSString *processVariant = [webView _webContentProcessVariantForFrame:nil];
     EXPECT_STREQ("security", processVariant.UTF8String);
-#endif
 }
 
 TEST(EnhancedSecurity, EnhancedSecurityEnableFalse)
@@ -92,11 +89,8 @@ TEST(EnhancedSecurity, EnhancedSecurityEnableFalse)
     [webView loadRequest:[NSURLRequest requestWithURL:url]];
     [webView _test_waitForDidFinishNavigation];
     EXPECT_EQ(false, isEnhancedSecurityEnabled(webView.get()));
-// _webContentProcessVariantForFrame relies on private entitlements not available on public builds
-#if USE(APPLE_INTERNAL_SDK)
     NSString *processVariant = [webView _webContentProcessVariantForFrame:nil];
     EXPECT_STREQ("standard", processVariant.UTF8String);
-#endif
 }
 
 TEST(EnhancedSecurity, EnhancedSecurityDisablesJIT)
@@ -153,10 +147,7 @@ TEST(EnhancedSecurity, PSONToEnhancedSecurity)
     [webView loadRequest:[NSURLRequest requestWithURL:url]];
     TestWebKitAPI::Util::run(&finishedNavigation);
     EXPECT_EQ(false, isEnhancedSecurityEnabled(webView.get()));
-// _webContentProcessVariantForFrame relies on private entitlements not available on public builds
-#if USE(APPLE_INTERNAL_SDK)
     EXPECT_STREQ("standard", [webView _webContentProcessVariantForFrame:nil].UTF8String);
-#endif
     pid_t pid1 = [webView _webProcessIdentifier];
     EXPECT_NE(pid1, 0);
 
@@ -173,10 +164,7 @@ TEST(EnhancedSecurity, PSONToEnhancedSecurity)
     TestWebKitAPI::Util::run(&finishedNavigation);
 
     EXPECT_EQ(true, isEnhancedSecurityEnabled(webView.get()));
-// _webContentProcessVariantForFrame relies on private entitlements not available on public builds
-#if USE(APPLE_INTERNAL_SDK)
     EXPECT_STREQ("security", [webView _webContentProcessVariantForFrame:nil].UTF8String);
-#endif
     EXPECT_NE(pid1, [webView _webProcessIdentifier]);
 }
 
@@ -197,10 +185,7 @@ TEST(EnhancedSecurity, PSONToEnhancedSecuritySamePage)
     [webView loadRequest:[NSURLRequest requestWithURL:url]];
     TestWebKitAPI::Util::run(&finishedNavigation);
     EXPECT_EQ(false, isEnhancedSecurityEnabled(webView.get()));
-// _webContentProcessVariantForFrame relies on private entitlements not available on public builds
-#if USE(APPLE_INTERNAL_SDK)
     EXPECT_STREQ("standard", [webView _webContentProcessVariantForFrame:nil].UTF8String);
-#endif
     pid_t pid1 = [webView _webProcessIdentifier];
     EXPECT_NE(pid1, 0);
 
@@ -217,10 +202,7 @@ TEST(EnhancedSecurity, PSONToEnhancedSecuritySamePage)
     TestWebKitAPI::Util::run(&finishedNavigation);
 
     EXPECT_EQ(true, isEnhancedSecurityEnabled(webView.get()));
-// _webContentProcessVariantForFrame relies on private entitlements not available on public builds
-#if USE(APPLE_INTERNAL_SDK)
     EXPECT_STREQ("security", [webView _webContentProcessVariantForFrame:nil].UTF8String);
-#endif
     EXPECT_NE(pid1, [webView _webProcessIdentifier]);
 }
 
@@ -257,10 +239,7 @@ TEST(EnhancedSecurity, PSONToEnhancedSecuritySharedProcessPool)
     [webView loadRequest:[NSURLRequest requestWithURL:url]];
     TestWebKitAPI::Util::run(&finishedNavigation);
     EXPECT_EQ(false, isEnhancedSecurityEnabled(webView.get()));
-// _webContentProcessVariantForFrame relies on private entitlements not available on public builds
-#if USE(APPLE_INTERNAL_SDK)
     EXPECT_STREQ("standard", [webView _webContentProcessVariantForFrame:nil].UTF8String);
-#endif
     pid_t pid1 = [webView _webProcessIdentifier];
     EXPECT_NE(pid1, 0);
 
@@ -279,10 +258,7 @@ TEST(EnhancedSecurity, PSONToEnhancedSecuritySharedProcessPool)
     TestWebKitAPI::Util::run(&finishedNavigation);
 
     EXPECT_EQ(true, isEnhancedSecurityEnabled(webView2.get()));
-// _webContentProcessVariantForFrame relies on private entitlements not available on public builds
-#if USE(APPLE_INTERNAL_SDK)
     EXPECT_STREQ("security", [webView2 _webContentProcessVariantForFrame:nil].UTF8String);
-#endif
     EXPECT_NE(pid1, [webView2 _webProcessIdentifier]);
 }
 
@@ -309,10 +285,7 @@ TEST(EnhancedSecurity, PSONToEnhancedSecuritySharedProcessPoolReverse)
     [webView loadRequest:[NSURLRequest requestWithURL:url]];
     TestWebKitAPI::Util::run(&finishedNavigation);
     EXPECT_EQ(true, isEnhancedSecurityEnabled(webView.get()));
-// _webContentProcessVariantForFrame relies on private entitlements not available on public builds
-#if USE(APPLE_INTERNAL_SDK)
     EXPECT_STREQ("security", [webView _webContentProcessVariantForFrame:nil].UTF8String);
-#endif
     pid_t pid1 = [webView _webProcessIdentifier];
     EXPECT_NE(pid1, 0);
 
@@ -331,14 +304,10 @@ TEST(EnhancedSecurity, PSONToEnhancedSecuritySharedProcessPoolReverse)
     TestWebKitAPI::Util::run(&finishedNavigation);
 
     EXPECT_EQ(false, isEnhancedSecurityEnabled(webView2.get()));
-// _webContentProcessVariantForFrame relies on private entitlements not available on public builds
-#if USE(APPLE_INTERNAL_SDK)
     EXPECT_STREQ("standard", [webView2 _webContentProcessVariantForFrame:nil].UTF8String);
-#endif
     EXPECT_NE(pid1, [webView2 _webProcessIdentifier]);
 }
 
-#if USE(APPLE_INTERNAL_SDK)
 TEST(EnhancedSecurity, ProcessVariantMatchesConfiguration)
 {
     auto webViewConfiguration1 = adoptNS([WKWebViewConfiguration new]);
@@ -361,7 +330,6 @@ TEST(EnhancedSecurity, ProcessVariantMatchesConfiguration)
     EXPECT_EQ(false, isEnhancedSecurityEnabled(webView2.get()));
     EXPECT_STREQ("standard", [webView2 _webContentProcessVariantForFrame:nil].UTF8String);
 }
-#endif
 
 TEST(EnhancedSecurity, ProcessCanLaunch)
 {
@@ -473,11 +441,8 @@ TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysEnabledAfterSubFrameNaviga
     EXPECT_WK_STREQ([webView _test_waitForAlert], "done");
 
     EXPECT_EQ(true, isEnhancedSecurityEnabled(webView.get()));
-// _webContentProcessVariantForFrame relies on private entitlements not available on public builds
-#if USE(APPLE_INTERNAL_SDK)
     EXPECT_STREQ("security", [webView _webContentProcessVariantForFrame:nil].UTF8String);
     EXPECT_STREQ("security", [webView _webContentProcessVariantForFrame:[webView firstChildFrame]._handle].UTF8String);
-#endif
 
 }
 
@@ -522,11 +487,8 @@ TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysEnabledAfterSubFrameNaviga
     EXPECT_WK_STREQ([webView _test_waitForAlert], "done");
 
     EXPECT_EQ(true, isEnhancedSecurityEnabled(webView.get()));
-// _webContentProcessVariantForFrame relies on private entitlements not available on public builds
-#if USE(APPLE_INTERNAL_SDK)
     EXPECT_STREQ("security", [webView _webContentProcessVariantForFrame:nil].UTF8String);
     EXPECT_STREQ("security", [webView _webContentProcessVariantForFrame:[webView firstChildFrame]._handle].UTF8String);
-#endif
 
 }
 
@@ -571,11 +533,8 @@ TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysDisabledAfterSubFrameNavig
     EXPECT_WK_STREQ([webView _test_waitForAlert], "done");
 
     EXPECT_EQ(false, isEnhancedSecurityEnabled(webView.get()));
-// _webContentProcessVariantForFrame relies on private entitlements not available on public builds
-#if USE(APPLE_INTERNAL_SDK)
     EXPECT_STREQ("standard", [webView _webContentProcessVariantForFrame:nil].UTF8String);
     EXPECT_STREQ("standard", [webView _webContentProcessVariantForFrame:[webView firstChildFrame]._handle].UTF8String);
-#endif
 
 }
 
@@ -620,11 +579,8 @@ TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysDisabledAfterSubFrameNavig
     EXPECT_WK_STREQ([webView _test_waitForAlert], "done");
 
     EXPECT_EQ(false, isEnhancedSecurityEnabled(webView.get()));
-// _webContentProcessVariantForFrame relies on private entitlements not available on public builds
-#if USE(APPLE_INTERNAL_SDK)
     EXPECT_STREQ("standard", [webView _webContentProcessVariantForFrame:nil].UTF8String);
     EXPECT_STREQ("standard", [webView _webContentProcessVariantForFrame:[webView firstChildFrame]._handle].UTF8String);
-#endif
 }
 
 TEST(EnhancedSecurity, WindowOpenWithNoopenerFromEnhancedSecurityPage)
@@ -661,10 +617,7 @@ TEST(EnhancedSecurity, WindowOpenWithNoopenerFromEnhancedSecurityPage)
         TestWebKitAPI::Util::spinRunLoop();
 
     EXPECT_EQ(true, isEnhancedSecurityEnabled(openedWebView.get()));
-// _webContentProcessVariantForFrame relies on private entitlements not available on public builds
-#if USE(APPLE_INTERNAL_SDK)
     EXPECT_STREQ("security", [openedWebView _webContentProcessVariantForFrame:nil].UTF8String);
-#endif
 
     bool hasOpener = [[openedWebView objectByEvaluatingJavaScript:@"!!window.opener"] boolValue];
     EXPECT_FALSE(hasOpener);
@@ -704,11 +657,8 @@ TEST(EnhancedSecurity, WindowOpenWithOpenerFromEnhancedSecurityPage)
         TestWebKitAPI::Util::spinRunLoop();
 
     EXPECT_EQ(true, isEnhancedSecurityEnabled(openedWebView.get()));
-// _webContentProcessVariantForFrame relies on private entitlements not available on public builds
-#if USE(APPLE_INTERNAL_SDK)
     EXPECT_STREQ("security", [openedWebView _webContentProcessVariantForFrame:nil].UTF8String);
     EXPECT_EQ([openerWebView _webProcessIdentifier], [openedWebView _webProcessIdentifier]);
-#endif
 }
 
 TEST(EnhancedSecurity, WindowOpenNoopenerFromEnhancedSecurityInheritsEnhancedSecurity)
@@ -735,10 +685,7 @@ TEST(EnhancedSecurity, WindowOpenNoopenerFromEnhancedSecurityInheritsEnhancedSec
     [standardDelegate waitForDidFinishNavigation];
 
     EXPECT_EQ(false, isEnhancedSecurityEnabled(standardWebView.get()));
-// _webContentProcessVariantForFrame relies on private entitlements not available on public builds
-#if USE(APPLE_INTERNAL_SDK)
     EXPECT_STREQ("standard", [standardWebView _webContentProcessVariantForFrame:nil].UTF8String);
-#endif
     pid_t standardPid = [standardWebView _webProcessIdentifier];
     EXPECT_NE(standardPid, 0);
 
@@ -771,11 +718,8 @@ TEST(EnhancedSecurity, WindowOpenNoopenerFromEnhancedSecurityInheritsEnhancedSec
         TestWebKitAPI::Util::spinRunLoop();
 
     EXPECT_EQ(true, isEnhancedSecurityEnabled(openedWebView.get()));
-// _webContentProcessVariantForFrame relies on private entitlements not available on public builds
-#if USE(APPLE_INTERNAL_SDK)
     EXPECT_STREQ("security", [openedWebView _webContentProcessVariantForFrame:nil].UTF8String);
     EXPECT_NE(standardPid, [openedWebView _webProcessIdentifier]);
-#endif
 
     bool hasOpener = [[openedWebView objectByEvaluatingJavaScript:@"!!window.opener"] boolValue];
     EXPECT_FALSE(hasOpener);
@@ -833,8 +777,6 @@ TEST(EnhancedSecurity, WindowOpenNoopenerFromStandardWithEnhancedSecurityViaDele
     EXPECT_EQ(false, isEnhancedSecurityEnabled(openerWebView.get()));
     EXPECT_EQ(true, isEnhancedSecurityEnabled(openedWebView.get()));
 
-// _webContentProcessVariantForFrame relies on private entitlements not available on public builds
-#if USE(APPLE_INTERNAL_SDK)
     pid_t openerPID = [openerWebView _webProcessIdentifier];
     pid_t openedPID = [openedWebView _webProcessIdentifier];
     bool isEnhanced = isEnhancedSecurityEnabled(openedWebView.get());
@@ -844,7 +786,6 @@ TEST(EnhancedSecurity, WindowOpenNoopenerFromStandardWithEnhancedSecurityViaDele
         EXPECT_NE(openerPID, openedPID);
     } else
         EXPECT_STREQ("standard", [openedWebView _webContentProcessVariantForFrame:nil].UTF8String);
-#endif
 
     bool hasOpener = [[openedWebView objectByEvaluatingJavaScript:@"!!window.opener"] boolValue];
     EXPECT_FALSE(hasOpener);
@@ -902,12 +843,9 @@ TEST(EnhancedSecurity, WindowOpenNoopenerFromEnhancedSecurityWithStandardViaDele
     EXPECT_EQ(true, isEnhancedSecurityEnabled(openerWebView.get()));
     EXPECT_EQ(false, isEnhancedSecurityEnabled(openedWebView.get()));
 
-// _webContentProcessVariantForFrame relies on private entitlements not available on public builds
-#if USE(APPLE_INTERNAL_SDK)
     pid_t openerPID = [openerWebView _webProcessIdentifier];
     EXPECT_STREQ("standard", [openedWebView _webContentProcessVariantForFrame:nil].UTF8String);
     EXPECT_NE(openerPID, [openedWebView _webProcessIdentifier]);
-#endif
 
     bool hasOpener = [[openedWebView objectByEvaluatingJavaScript:@"!!window.opener"] boolValue];
     EXPECT_FALSE(hasOpener);
@@ -926,10 +864,7 @@ TEST(EnhancedSecurity, LockdownModeTakesPrecedenceOverEnhancedSecurity)
 
     EXPECT_EQ(false, isJITEnabled(webView.get()));
     EXPECT_EQ(false, isEnhancedSecurityEnabled(webView.get()));
-// _webContentProcessVariantForFrame relies on private entitlements not available on public builds
-#if USE(APPLE_INTERNAL_SDK)
     EXPECT_STREQ("lockdown", [webView _webContentProcessVariantForFrame:nil].UTF8String);
-#endif
 }
 
 TEST(EnhancedSecurity, EnhancedSecurityRequestedWhenLockdownModeActive)
@@ -966,10 +901,7 @@ TEST(EnhancedSecurity, EnhancedSecurityRequestedWhenLockdownModeActive)
     EXPECT_EQ(false, isJITEnabled(webView.get()));
     EXPECT_EQ(false, isEnhancedSecurityEnabled(webView.get()));
     EXPECT_EQ(true, webViewConfiguration.get().defaultWebpagePreferences.isLockdownModeEnabled);
-// _webContentProcessVariantForFrame relies on private entitlements not available on public builds
-#if USE(APPLE_INTERNAL_SDK)
     EXPECT_STREQ("lockdown", [webView _webContentProcessVariantForFrame:nil].UTF8String);
-#endif
 }
 
 #if HAVE(ENHANCED_SECURITY_WEB_CONTENT_PROCESS)
@@ -988,10 +920,8 @@ TEST(EnhancedSecurity, SystemLockdownModeEnablesEnhancedSecurityWhenAPIOptsOut)
 
     EXPECT_EQ(false, isJITEnabled(webView.get()));
 
-#if USE(APPLE_INTERNAL_SDK)
     NSString *processVariant = [webView _webContentProcessVariantForFrame:nil];
     EXPECT_STREQ("security", processVariant.UTF8String);
-#endif
 
     [WKProcessPool _clearCaptivePortalModeEnabledGloballyForTesting];
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm
@@ -73,14 +73,7 @@ using namespace TestWebKitAPI;
 
     self.runJavaScriptAlertPanelWithMessage = ^(WKWebView *webView, NSString *message, WKFrameInfo *frameInfo, void (^completionHandler)(void)) {
         alertMessage = message;
-
-        // FIXME: rdar://164477631 (Fix Enhanced Security tests to work on non Apple Internal builds)
-#if USE(APPLE_INTERNAL_SDK)
         childFrameVariant = [webView _webContentProcessVariantForFrame:frameInfo._handle];
-#else
-        childFrameVariant = @"unknown";
-#endif
-
         finished = true;
         completionHandler();
     };
@@ -120,11 +113,7 @@ static void testAlertWithEnhancedSecurity(RetainPtr<TestUIDelegate> uiDelegate, 
     NSArray *result = [uiDelegate waitForAlertWithEnhancedSecurity];
 
     EXPECT_WK_STREQ(result[0], message);
-
-    // FIXME: rdar://164477631 (Fix Enhanced Security tests to work on non Apple Internal builds)
-#if USE(APPLE_INTERNAL_SDK)
     EXPECT_EQ([result[1] boolValue], enhancedSecurityEnabled);
-#endif
 }
 
 static RetainPtr<TestWKWebView> enhancedSecurityTestConfiguration(

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm
@@ -551,9 +551,7 @@ static void runMultiHopThenBack(bool useSiteIsolation)
         { "tainted-https-site"_s, ExpectedEnhancedSecurity::Enabled }
     });
 }
-
-// FIXME: rdar://164474301 (Fix SiteIsolation compatibility with EnhancedSecurity feature)
-TEST_WITHOUT_SITE_ISOLATION(MultiHopThenBack)
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(MultiHopThenBack)
 
 static void runMultiHopThenBackJavascript(bool useSiteIsolation)
 {
@@ -582,9 +580,7 @@ static void runMultiHopThenBackJavascript(bool useSiteIsolation)
         { "tainted-https-site"_s, ExpectedEnhancedSecurity::Enabled }
     });
 }
-
-// FIXME: rdar://164474301 (Fix SiteIsolation compatibility with EnhancedSecurity feature)
-TEST_WITHOUT_SITE_ISOLATION(MultiHopThenBackJavascript)
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(MultiHopThenBackJavascript)
 
 static void runMultiHopThenBackToSecure(bool useSiteIsolation)
 {
@@ -843,8 +839,7 @@ static void runHttpRedirectsHttpsWithExplicitNavigationToMeaningfulSite(bool use
         { "location-redirected-site"_s, ExpectedEnhancedSecurity::Disabled }
     });
 }
-// FIXME: rdar://164474301 (Fix SiteIsolation compatibility with EnhancedSecurity feature)
-TEST_WITHOUT_SITE_ISOLATION(HttpRedirectsHttpsWithExplicitNavigationToMeaningfulSite)
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(HttpRedirectsHttpsWithExplicitNavigationToMeaningfulSite)
 
 static void runWindowOpenThenNavigateToMeaningfulSite(bool useSiteIsolation)
 {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm
@@ -2636,13 +2636,14 @@ TEST(WKNavigation, HTTPSFirstWithHTTPRedirect)
     didFailNavigation = false;
     loadCount = 0;
 
-    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://site.example/secure2"]]];
+    // Encourage a process swap to ensure consistency of the test with and without Enhanced Security enabled
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://different.example/secure2"]]];
     TestWebKitAPI::Util::run(&finishedSuccessfully);
 
     EXPECT_EQ(errorCode, 0);
     EXPECT_FALSE(didFailNavigation);
-    EXPECT_EQ(loadCount, 23);
-    EXPECT_WK_STREQ(@"http://site2.example/secure3", [webView URL].absoluteString);
+    EXPECT_EQ(loadCount, 22);
+    EXPECT_WK_STREQ(@"http://site2.example/secure2", [webView URL].absoluteString);
 }
 
 TEST(WKNavigation, DISABLED_PreferredHTTPSPolicyAutomaticHTTPFallbackRedirectNo3SecondTimeout)
@@ -3698,13 +3699,14 @@ TEST(WKNavigation, PreferredHTTPSPolicyAutomaticHTTPFallbackWithHTTPRedirect)
     didFailNavigation = false;
     loadCount = 0;
 
-    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://site.example/secure2"]]];
+    // Encourage a process swap to ensure consistency of the test with and without Enhanced Security enabled
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://different.example/secure2"]]];
     TestWebKitAPI::Util::run(&finishedSuccessfully);
 
     EXPECT_EQ(errorCode, 0);
     EXPECT_FALSE(didFailNavigation);
-    EXPECT_EQ(loadCount, 23);
-    EXPECT_WK_STREQ(@"http://site2.example/secure3", [webView URL].absoluteString);
+    EXPECT_EQ(loadCount, 22);
+    EXPECT_WK_STREQ(@"http://site2.example/secure2", [webView URL].absoluteString);
 }
 
 TEST(WKNavigation, PreferredHTTPSPolicyNoFallbackRedirectNoHTTPDowngradeRedirect)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm
@@ -2532,7 +2532,10 @@ TEST(WKNavigation, HTTPSOnlyWithHTTPRedirect)
     finishedSuccessfully = false;
     didFailNavigation = false;
     loadCount = 0;
-    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://site.example/secure2"]]];
+
+    // Use a different domain to the above to ensure a process swap happens, this ensures testing of an edge
+    // case in the HTTPS upgrade / same-site HTTP logic.
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://different.example/secure2"]]];
     TestWebKitAPI::Util::run(&finishedSuccessfully);
 
     EXPECT_EQ(errorCode, 0);
@@ -2546,7 +2549,7 @@ TEST(WKNavigation, HTTPSOnlyWithHTTPRedirect)
     finishedSuccessfully = false;
     didFailNavigation = false;
     loadCount = 0;
-    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://site.example/secure2"]]];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://different.example/secure2"]]];
 
     EXPECT_NULL([webView _safeBrowsingWarning]);
     while (![webView _safeBrowsingWarning])
@@ -2558,7 +2561,7 @@ TEST(WKNavigation, HTTPSOnlyWithHTTPRedirect)
 
     EXPECT_EQ(errorCode, 0);
     EXPECT_FALSE(didFailNavigation);
-    EXPECT_EQ(loadCount, 23);
+    EXPECT_EQ(loadCount, 22);
 
     [webView evaluateJavaScript:@"location = \"http://site2.example/secure3\";" completionHandler:nil];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
@@ -3987,7 +3987,7 @@ TEST(SiteIsolation, MainFrameRedirectBetweenExistingProcesses)
     EXPECT_EQ([[webView objectByEvaluatingJavaScript:@"window.length"] intValue], 1);
     auto pidBefore = [webView _webProcessIdentifier];
 
-    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"http://webkit.org/webkit_redirect"]]];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://webkit.org/webkit_redirect"]]];
     [navigationDelegate waitForDidFinishNavigation];
     EXPECT_EQ([[webView objectByEvaluatingJavaScript:@"window.length"] intValue], 0);
     EXPECT_EQ([webView _webProcessIdentifier], pidBefore);


### PR DESCRIPTION
#### b7d5852609eedabd8f12b9c05af019b673106750
<pre>
Allow Enhanced Security tests to run outside internal
<a href="https://rdar.apple.com/164477631">rdar://164477631</a>
Need the bug URL (OOPS!).

Reviewed by NOBODY (OOPS!).

Enhanced Security tests have been gated only to Apple Internal builds due
to the requirement of a private entitlement check to function. Specifically,
_webContentProcessVariantForFrame required testing for these private
entitlements.

This addresses this issue by using the proc_pidpath syscall to check the
WebContent process path and use this to distinguish which variant is running.

Tests: Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurity.mm
       Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _webContentProcessVariantForFrame:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurity.mm:
(TestWebKitAPI::TEST(EnhancedSecurity, EnhancedSecurityEnablesTrue)):
(TestWebKitAPI::TEST(EnhancedSecurity, EnhancedSecurityEnableFalse)):
(TestWebKitAPI::TEST(EnhancedSecurity, PSONToEnhancedSecurity)):
(TestWebKitAPI::TEST(EnhancedSecurity, PSONToEnhancedSecuritySamePage)):
(TestWebKitAPI::TEST(EnhancedSecurity, PSONToEnhancedSecuritySharedProcessPool)):
(TestWebKitAPI::TEST(EnhancedSecurity, PSONToEnhancedSecuritySharedProcessPoolReverse)):
(TestWebKitAPI::TEST(EnhancedSecurity, ProcessVariantMatchesConfiguration)):
(TestWebKitAPI::TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysEnabledAfterSubFrameNavigationRequestDisables)):
(TestWebKitAPI::TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysEnabledAfterSubFrameNavigationRequestDisablesCrossOrigin)):
(TestWebKitAPI::TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysDisabledAfterSubFrameNavigationRequestEnabled)):
(TestWebKitAPI::TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysDisabledAfterSubFrameNavigationRequestEnabledCrossOrigin)):
(TestWebKitAPI::TEST(EnhancedSecurity, WindowOpenWithNoopenerFromEnhancedSecurityPage)):
(TestWebKitAPI::TEST(EnhancedSecurity, WindowOpenWithOpenerFromEnhancedSecurityPage)):
(TestWebKitAPI::TEST(EnhancedSecurity, WindowOpenNoopenerFromEnhancedSecurityInheritsEnhancedSecurity)):
(TestWebKitAPI::TEST(EnhancedSecurity, WindowOpenNoopenerFromStandardWithEnhancedSecurityViaDelegate)):
(TestWebKitAPI::TEST(EnhancedSecurity, WindowOpenNoopenerFromEnhancedSecurityWithStandardViaDelegate)):
(TestWebKitAPI::TEST(EnhancedSecurity, LockdownModeTakesPrecedenceOverEnhancedSecurity)):
(TestWebKitAPI::TEST(EnhancedSecurity, EnhancedSecurityRequestedWhenLockdownModeActive)):
(TestWebKitAPI::TEST(EnhancedSecurity, SystemLockdownModeEnablesEnhancedSecurityWhenAPIOptsOut)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm:
(-[TestUIDelegate waitForAlertWithEnhancedSecurity]):
(testAlertWithEnhancedSecurity):
</pre>
----------------------------------------------------------------------
#### 31a5f2341a3194f196d260f555f406d6580c5bf1
<pre>
Fix WKBackForwardList test failures with Enhanced Security heuristics
Need the bug URL (OOPS!).

Reviewed by NOBODY (OOPS!).

The following test fails when the Enhanced Security heuristics flag
is enabled by default:

  * WKBackForwardList.BackForwardNavigationSkipsItemsWithoutUserGestureFragment

This appears to relate to our cookie check callback, which occurs in the
background for a navigation when the heuristics flag is enabled. This checks
if the site being navigated to has cookies or local storage set.

If the callback is delayed, it looks like we can hit our assertion that
the URL being checked does not match the current navigation URL. Instead, we
should ignore the callback in this case as it is too late to be useful.

No new tests (OOPS!).

* Source/WebKit/UIProcess/API/APINavigation.cpp:
(API::Navigation::setHasStorageForCurrentSite):
</pre>
----------------------------------------------------------------------
#### ab46dd177fe2e7602125e630cd688b417ab23fcf
<pre>
Fix for Linux build failures by refactoring headers.

Reviewed by NOBODY (OOPS!).

The earlier change to LocalFrameLoaderClient required including ResourceRequest.h
due to the use of std::optional and std::nullopt. This, however, ended up
eventually including gstreamer related headers and causing an issue on Linux builds.

Instead, this refactors the headers such that BlobData.h is no longer required in
FormData.h, which prevents these gstreamer headers from being included.

* Source/WebCore/platform/network/FormData.h:
* Source/WebCore/platform/network/ResourceRequestBase.h:
</pre>
----------------------------------------------------------------------
#### 268aef4e15ed99b176b81d4db83e0fe1709100cf
<pre>
Fix Site Isolation compatibility with Enhanced Security
<a href="https://rdar.apple.com/164474301">rdar://164474301</a>
Need the bug URL (OOPS!).

Reviewed by NOBODY (OOPS!).

With the introduction of Enhanced Security, it is now possible for a
BrowsingContextGroup to contain multiple processes for a given site if their
Enhanced Security requirement differs. This triggered an assertion when site
isolation was enabled as it expects the process map in a BrowsingContextGroup
to only contain a single process for any given site.

Instead, we now need to track the required Enhanced Security state of the
process when inspecting / modifying the process map.

This also adjusts the MainFrameRedirectBetweenExistingProcesses test to
use HTTPS instead of HTTP, as using HTTP affects the test behaviour when
the Enhanced Security heuristics flag is enabled as it performs more
process swapping.

Tests: Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm
       Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm

* Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm:
(WebCore::NetworkStorageSession::hasCookies const):
* Source/WebKit/UIProcess/BrowsingContextGroup.cpp:
(WebKit::BrowsingContextGroup::sharedProcessForSite):
(WebKit::BrowsingContextGroup::ensureProcessForSite):
(WebKit::BrowsingContextGroup::processForSite):
(WebKit::BrowsingContextGroup::addFrameProcessAndInjectPageContextIf):
(WebKit::BrowsingContextGroup::removeFrameProcess):
(WebKit::BrowsingContextGroup::addPage):
* Source/WebKit/UIProcess/BrowsingContextGroup.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::launchProcess):
(WebKit::WebPageProxy::processForSite):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::processForNavigation):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, MainFrameRedirectBetweenExistingProcesses)):
</pre>
----------------------------------------------------------------------
#### a5231c63a1bdaae4f9802a069d86ac57034eec44
<pre>
Workaround for failing CookieObserver test due to CFNetwork issue.
Need the bug URL (OOPS!).

Reviewed by NOBODY (OOPS!).

When enabling the Enhanced Security heuristics flag by default, we saw
a test failure in:

  * WKHTTPCookieStore.ObserveCookiesReceivedFromHTTP

On investigation, this is due to an underlying issue in CFNetwork which
causes us to lose cookie notifications. This only arises when using
non-persistent data stores.

This change works around this issue for the Enhanced Security case by
re-registering for the cookie notification after our call to
nsCookieStorage() in hasCookies. This is more of an issue when the flag
is enabled by default because we perform a hasCookies check in the background
as part of loading a request.

No new tests (OOPS!).

* Source/WebCore/platform/network/cocoa/CookieStorageObserver.h:
* Source/WebCore/platform/network/cocoa/CookieStorageObserver.mm:
(WebCore::CookieStorageObserver::startObserving):
(WebCore::CookieStorageObserver::registerInternalsForNotifications):
* Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm:
(WebCore::NetworkStorageSession::hasCookies const):
</pre>
----------------------------------------------------------------------
#### 299eff8c3f0a8797f1b9b4c45e00b10513486fb6
<pre>
Fix ContentRuleList HTTPS upgrade test failure with Enhanced Security
Need the bug URL (OOPS!).

Reviewed by NOBODY (OOPS!).

When the Enhanced Security heuristics flag is enabled by default, a test
failure occurred in:

  * WebKit.RedirectToPlaintextHTTPSUpgrade

This test ensures that a HTTPS site performing a same-site redirect to
plaintext HTTP does not get upgraded by the ContentRuleList rules, as this
is an explicit HTTP redirect.

When the Enhanced Security heuristics flag is enabled, the redirect to the HTTP
site causes us to process swap and load this in an Enhanced Security process. In
doing so, we change the load path and lost information that this explicit redirect
had occurred.

To address this, this change explicitly checks for us having continued the load
due to a navigation policy change, and uses the original request URL, if different,
when processing the ContentRuleList for this load.

No new tests (OOPS!).

* Source/WebCore/loader/DocumentLoader.h:
(WebCore::DocumentLoader::isContinuingLoadAfterNavigationPolicyDecision const):
(WebCore::DocumentLoader::setIsContinuingLoadAfterNavigationPolicyDecision):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::load):
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::requestResource):
</pre>
----------------------------------------------------------------------
#### 1d2f526455835dd0c94bbb36003c6001cf718ed2
<pre>
Fix an edge-case in HTTP/HTTPS upgrade logic and WKNavigation test.
Need the bug URL (OOPS!).

Reviewed by NOBODY (OOPS!).

The WKNavigation.HTTPSOnlyWithHTTPRedirect failed when enabling
the Enhanced Security heuristics flag by default.

Investigating this uncovered a slight issue in the HTTPS upgrade /
same-site HTTP upgrade prevention logic. This can be tested by the
attached change to the HTTPSOnlyWithHTTPRedirect test, which ensures
we do a process swap for the initial load, rather than on the first
redirect. Without this, we do a proces swap on the redirect, and the
original request site that is used in upgradeRequestAfterRedirection
is the newly redirected site - at which point we decide not to attempt
a HTTPS upgrade because this is a same site HTTPS -&gt; HTTP redirect.

By making this change, we reveal a bug where the original URL used in
updateRequestAfterRedirection always remains as the initial load site -
this prevents our HTTPS -&gt; HTTP same-site logic from stopping the HTTPS
upgrade, which results in a continuous loop of this request until it
caps out at the max redirects count.

The fix appears to be to use the last redirect response as the
pre-redirect URL when calling updateRequestAfterRedirection.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm

* Source/WebCore/loader/SubresourceLoader.cpp:
(WebCore::SubresourceLoader::willSendRequestInternal):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm:
(TEST(WKNavigation, HTTPSOnlyWithHTTPRedirect)):
</pre>
----------------------------------------------------------------------
#### daa2f6cecc42ddc52c0343b624604dedd395c468
<pre>
Fix WKNavigation tests when Enhanced Security is enabled
Need the bug URL (OOPS!).

Reviewed by NOBODY (OOPS!).

The following two tests in WKNavigation:

  * HTTPSFirstWithHTTPRedirect
  * PreferredHTTSPolicyAutomaticHTTPFallbackWithHTTPRedirect

Have specific results which expect a particular load count and final URL. However,
these have an underlying reliance on a PSON occurring because we previously have loaded a separate
site, and, as such, we get an extra +1 to the loadCount in the test. Removing the
initial load to site.example showcases this by hitting the same assertion failure.

With Enhanced Security heuristics enabled, we&apos;ll perform a process swap earlier and
so hit this same failure case.

To make these consistent, this test fix simply ensures the second browse is to a
different site than the initial browser, standardising the process swapping behaviour
with and without the Enhanced Security flag being enabled.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm:
(TEST(WKNavigation, HTTPSFirstWithHTTPRedirect)):
(TEST(WKNavigation, PreferredHTTPSPolicyAutomaticHTTPFallbackWithHTTPRedirect)):
</pre>
----------------------------------------------------------------------
#### 67dc50465fe4c3a8d00715f380c8115a94397527
<pre>
Fix HistoryDelegate test failures with ESWV.
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Addresses the following test failures when Enhanced Security Heuristics
are enabled:

    * HistoryDelegate.PersistentDataStoreSendsHistoryEvents
    * HistoryDelegate.NonpersistentDataStoreSendsHistoryEventsWhenAllowingPrivacySensitiveOperations

The issue here relates to having begun to load a request in the regular
WebContent process, before navigation policy decisions decide to switch
to an Enhanced Security process.

When this occurs, we do a new loadRequest call on the ProvisionalPageProxy
via continueNavigationInNewProcess. This, however, uses the ResourceRequest
from the Navigation object that was passed todecidePolicyForNavigationAction,
which has already been mutated by the original WebContent process. When
this is then passed to the new EnhancedSecurity process, this is treated
as the original ResourceRequest and used for reporting history events,
leading to the failing test.

Instead, we now pass through the original ResourceRequest if we are doing
a continuing load from such a policy decision, and use this as the original
request when creating the DocumentLoader in the new Enhanced Security
process.

* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::DocumentLoader):
* Source/WebCore/loader/DocumentLoader.h:
(WebCore::DocumentLoader::create):
* Source/WebCore/loader/EmptyClients.cpp:
(WebCore::EmptyFrameLoaderClient::createDocumentLoader):
* Source/WebCore/loader/EmptyFrameLoaderClient.h:
* Source/WebCore/loader/FrameLoadRequest.h:
(WebCore::FrameLoadRequest::setOriginalResourceRequest):
(WebCore::FrameLoadRequest::hasOriginalResourceRequest):
(WebCore::FrameLoadRequest::takeOriginalResourceRequest):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::load):
* Source/WebCore/loader/LocalFrameLoaderClient.h:
* Source/WebKit/Shared/LoadParameters.h:
* Source/WebKit/Shared/LoadParameters.serialization.in:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::loadRequestWithNavigationShared):
* Source/WebKit/WebProcess/Storage/RemoteWorkerFrameLoaderClient.cpp:
(WebKit::RemoteWorkerFrameLoaderClient::createDocumentLoader):
* Source/WebKit/WebProcess/Storage/RemoteWorkerFrameLoaderClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::createDocumentLoader):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::loadRequest):
(WebKit::WebPage::createDocumentLoader):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm:
(WebFrameLoaderClient::createDocumentLoader):
* Source/WebKitLegacy/mac/WebView/WebDocumentLoaderMac.h:
(WebDocumentLoaderMac::create):
* Source/WebKitLegacy/mac/WebView/WebDocumentLoaderMac.mm:
(WebDocumentLoaderMac::WebDocumentLoaderMac):
</pre>
----------------------------------------------------------------------
#### 00f67dd1b03c120b26896f00f8f58eec9571c809
<pre>
Fix opener relationship behaviour with Enhanced Security
Need the bug URL (OOPS!).

Reviewed by NOBODY (OOPS!).

We cannot make an EnhancedSecurity state change when we have an opener
relationship, as we do not have the ability to maintain the opener
relationship across process boundaries until site isolation is present.

Therefore, we should not change EnhancedSecurity state when a navigation
requires an opener relationship, as otherwise a process swap will have to
occur to accommodate the change in state.

This change applies this, which fixes the following tests when the
Enhanced Security heuristics flag is enabled by default:

  * AdvancedPrivacyProtections.DoNotHideReferrerInPopupWindow
  * SOAuthorizationPopUp.InterceptionSucceedCloseByItself
  * SOAuthorizationPopUp.InterceptionSucceedCloseByParent
  * SOAuthorizationPopUp.InterceptionSucceedCloseByWebKit
  * SOAuthorizationPopUp.InterceptionSucceedNewWindowNavigation
  * SOAuthorizationPopUp.InterceptionSucceedSuppressActiveSession
  * SOAuthorizationPopUp.InterceptionSucceedTwice
  * SOAuthorizationPopUp.InterceptionSucceedWithCookie
  * SOAuthorizationPopUp.SOAuthorizationLoadPolicyAllowAsync
  * WKWebExtensionAPIDevTools.PortMessagePassingFromPanelToBackground

* Source/WebKit/UIProcess/EnhancedSecurityTracking.cpp:
(WebKit::EnhancedSecurityTracking::trackNavigation):
</pre>
----------------------------------------------------------------------
#### 294838e45e850ccd6edb70c7ac160bfecd7c58ae
<pre>
Testing a provisional load fix in EWS.

* Source/WebCore/loader/FrameLoadRequest.h:
(WebCore::FrameLoadRequestBase::isCrossOriginContentRuleListRedirect const):
(WebCore::FrameLoadRequestBase::setIsCrossOriginContentRuleListRedirect):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::load):
(WebCore::FrameLoader::checkLoadCompleteForThisFrame):
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::requestResource):
</pre>
----------------------------------------------------------------------
#### 6a49c1b23a6d611773371d59f609206420a834b6
<pre>
Testing results for enabling ES heuristics.
Need the bug URL (OOPS!).

Reviewed by NOBODY (OOPS!).

Toggle this on by default on Apple platforms.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7d5852609eedabd8f12b9c05af019b673106750

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138412 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10777 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49822 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146496 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91387 "Hash b7d58526 for PR 56199 does not build (failure)") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fdfb3efc-f7a5-4d4d-aa79-dceb09254a33) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140286 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11481 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10931 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105902 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/91387 "Hash b7d58526 for PR 56199 does not build (failure)") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1b527b37-e1af-48b3-b296-f66cfb524f2f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141359 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8619 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124082 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIDevTools.PortMessagePassingFromPanelToBackground (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86747 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5ac3c2ca-bff5-4312-a86c-fb8f2b4323cf) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8206 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5976 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6786 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/130376 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117626 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42281 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149212 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/136995 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10459 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42838 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114308 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10476 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8844 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114645 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8271 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120368 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/65328 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10507 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38301 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/169685 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10241 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74101 "Found 1 new failure in platform/network/cocoa/NetworkStorageSessionCocoa.mm") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44232 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10446 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10297 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->