### PR TITLE
AX: When stitched text is enabled, hit testing should return the stitch-group representative object

### DIFF
--- a/LayoutTests/accessibility/hit-test-on-stitched-text-expected.txt
+++ b/LayoutTests/accessibility/hit-test-on-stitched-text-expected.txt
@@ -1,0 +1,8 @@
+This test ensures that when we hit test onto text stitched into other text, that we return the sitch-group owner object.
+
+PASS: platformStaticTextValue(hitTestResult) === 'AXValue: Hello world! How are you doing on this fine day?'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Hello world! How are you doing on this fine day?

--- a/LayoutTests/accessibility/hit-test-on-stitched-text.html
+++ b/LayoutTests/accessibility/hit-test-on-stitched-text.html
@@ -1,0 +1,32 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ runSingly=true AccessibilityTextStitchingEnabled=true ] -->
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+<style>
+* { font-size: 68px; }
+</style>
+</head>
+<body>
+
+<div>
+    <span>Hello</span> <span>world!</span>
+    <i>How</i> 
+    <b>are</b>
+    <span id="target-span">you doing</span> on<b> this fine day</b>?
+</div>
+
+<script>
+var output = "This test ensures that when we hit test onto text stitched into other text, that we return the sitch-group owner object.\n\n";
+
+if (window.accessibilityController) {
+    var targetRect = document.getElementById("target-span").getBoundingClientRect();
+    var hitTestResult = accessibilityController.elementAtPoint(targetRect.x + targetRect.width / 2, targetRect.y + targetRect.height / 2);
+    output += expect("platformStaticTextValue(hitTestResult)", "'AXValue: Hello world! How are you doing on this fine day?'");
+
+    debug(output);
+}
+</script>
+</body>
+</html>
+

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -831,6 +831,7 @@ accessibility/password-notifications-timing.html [ Skip ]
 # AccessibilityTextStitchingEnabled feature is not implemented.
 accessibility/aria-owns-text-stitching.html [ Skip ]
 accessibility/dynamic-text-stitching.html [ Skip ]
+accessibility/hit-test-on-stitched-text.html [ Skip ]
 accessibility/list-marker-text-stitching.html [ Skip ]
 accessibility/text-stitching-inside-links.html [ Skip ]
 

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -2370,6 +2370,11 @@ AccessibilityObject* AccessibilityRenderObject::accessibilityHitTest(const IntPo
 
         result = result->parentObjectUnignored();
     }
+
+    if (std::optional stitchedIntoID = result ? result->stitchedIntoID() : std::nullopt) {
+        if (RefPtr stitchRepresentative = cache->objectForID(*stitchedIntoID))
+            return stitchRepresentative.unsafeGet();
+    }
     return result.unsafeGet();
 }
 


### PR DESCRIPTION
#### 99b3fcf42362f39402552442f299f7d5d8feb091
<pre>
AX: When stitched text is enabled, hit testing should return the stitch-group representative object
<a href="https://bugs.webkit.org/show_bug.cgi?id=305057">https://bugs.webkit.org/show_bug.cgi?id=305057</a>
<a href="https://rdar.apple.com/167700651">rdar://167700651</a>

Reviewed by Joshua Hoffman.

When a hit test would return an object that is stitched into another object, return that other object
(the stitch-group representative) instead.

Test: accessibility/hit-test-on-stitched-text.html

* LayoutTests/accessibility/hit-test-on-stitched-text-expected.txt: Added.
* LayoutTests/accessibility/hit-test-on-stitched-text.html: Added.
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::accessibilityHitTest const):

Canonical link: <a href="https://commits.webkit.org/305291@main">https://commits.webkit.org/305291@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6fb6a768d86f382ce6f623beb71d416ab2a94fe3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137893 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10257 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49249 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145960 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90868 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cf64c822-94ea-434e-a78f-e1efac1e5bb8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139765 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10959 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10397 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105460 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/76956 "Exiting early after 60 failures. 21476 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/26d8008a-d3d5-48ff-a4e1-be1177e804be) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140838 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8161 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123623 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86311 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4616edf9-63da-4196-98f1-2bb4b27f46eb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7782 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5533 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6241 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117176 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41786 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148670 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9940 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42345 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113859 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9957 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8390 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114190 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29038 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7721 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119873 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64664 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9986 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37880 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9716 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73554 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9927 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9778 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->