### PR TITLE
ASSERTION FAILED: resolvedMainSize >= 0 in RenderFlexibleBox::computeFlexItemMinMaxSizes.

### DIFF
--- a/LayoutTests/fast/forms/search-selection-insert-crash-expected.txt
+++ b/LayoutTests/fast/forms/search-selection-insert-crash-expected.txt
@@ -1,0 +1,4 @@
+This test passes if it does not crash in debug.
+
+
+

--- a/LayoutTests/fast/forms/search-selection-insert-crash.html
+++ b/LayoutTests/fast/forms/search-selection-insert-crash.html
@@ -1,0 +1,24 @@
+<html>
+<head>
+<style>
+ #quote {
+  zoom: 52%;
+}
+</style>
+<script>
+if (window.testRunner)
+  testRunner.dumpAsText();
+
+function insertSearchInput() {
+  var documentSelection = document.getSelection();
+  documentSelection.setPosition(quote);
+  var inputElementOuterHTML = inputElement.outerHTML;
+  document.execCommand("insertHTML", false, inputElementOuterHTML);
+}
+</script>
+</head>
+<body onload="insertSearchInput()">
+  <p>This test passes if it does not crash in debug.</p>
+  <input id="inputElement" type="search" >
+  <blockquote id="quote" contenteditable="plaintext-only" ></blockquote>
+</body>

--- a/Source/WebCore/rendering/mac/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.mm
@@ -1534,7 +1534,7 @@ std::span<const IntSize, 4> RenderThemeMac::resultsButtonSizes() const
     return sizes;
 }
 
-const int emptyResultsOffset = 9;
+constexpr int emptyResultsOffset = 9;
 void RenderThemeMac::adjustSearchFieldDecorationPartStyle(RenderStyle& style, const Element* element) const
 {
 #if ENABLE(FORM_CONTROL_REFRESH)
@@ -1547,14 +1547,21 @@ void RenderThemeMac::adjustSearchFieldDecorationPartStyle(RenderStyle& style, co
 #endif
 
     IntSize size = sizeForSystemFont(style, resultsButtonSizes());
-    int widthOffset = 0;
-    int heightOffset = 0;
-    if (style.writingMode().isHorizontal())
-        widthOffset = emptyResultsOffset;
-    else
-        heightOffset = emptyResultsOffset;
-    style.setWidth(Style::PreferredSize::Fixed { static_cast<float>(size.width() - widthOffset) });
-    style.setHeight(Style::PreferredSize::Fixed { static_cast<float>(size.height() - heightOffset) });
+    bool isHorizontalWritingMode = style.writingMode().isHorizontal();
+    auto computedWidth = [isHorizontalWritingMode, &size]() -> float {
+        if (isHorizontalWritingMode)
+            return std::max(0, size.width() - emptyResultsOffset);
+        return size.width();
+    };
+
+    auto computedHeight = [isHorizontalWritingMode, &size]() -> float {
+        if (!isHorizontalWritingMode)
+            return std::max(0, size.height() - emptyResultsOffset);
+        return size.height();
+    };
+
+    style.setWidth(Style::PreferredSize::Fixed { computedWidth() });
+    style.setHeight(Style::PreferredSize::Fixed { computedHeight() });
     style.setBoxShadow(CSS::Keyword::None { });
 }
 


### PR DESCRIPTION
#### 67c3e5ec34ea24955a4c9b6a8256b07125fad540
<pre>
ASSERTION FAILED: resolvedMainSize &gt;= 0 in RenderFlexibleBox::computeFlexItemMinMaxSizes.
<a href="https://bugs.webkit.org/show_bug.cgi?id=304266">https://bugs.webkit.org/show_bug.cgi?id=304266</a>
<a href="https://rdar.apple.com/167701366">rdar://167701366</a>

Reviewed by Brent Fulgham.

It seems like it is possible to compute a width/height that is negative
inside of RenderThemeMac::adjustSearchFieldDecorationPartStyle. This
size is determined based off some sizes that we have precomputed for the
results button and the system font size. This value is also scaled by
zoom. After computing this value we subtract out the offset used for
empty results which is what can cause us to compute a negative value and
then set it on the associated RenderStyle.

When this happens, we end up triggering a debug assert inside of
RenderFlexibleBox::computeFlexItemMinMaxSizes that checks to see is the
main size we determined for the flex item is non-negative. In this case,
since the computed main size of the flex item is definite we end up
using it. To fix this, we can just make sure that we clamp to value to
be at least zero.

Note that this only seems like it can happen when Form Control Refresh
flag is not enabled. In the attached testcase this is forced when a new
Document is created within the ReplacementFragment constructor and we
end up performing layout via the call to insertFragmentForTestRendering.

* Source/WebCore/rendering/mac/RenderThemeMac.mm:
(WebCore::RenderThemeMac::adjustSearchFieldDecorationPartStyle const):

Canonical link: <a href="https://commits.webkit.org/305249@main">https://commits.webkit.org/305249@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd801d402e9649cb1bdaf95981f8ef8feb5a9c60

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137873 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10237 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49228 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/145939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90848 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3caab2bc-a31b-49ff-a193-c84294aa7de2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139745 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10939 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10376 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/145939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/052f20e2-c9e1-4828-842b-f27d23b9bd1b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140818 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8154 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123606 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/145939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f2cbb8b3-272c-4ecc-ae2e-4527890e3ff8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7775 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5518 "Passed tests") | [  ~~🛠 wpe-cairo-libwebrtc~~](https://ews-build.webkit.org/#/builders/166/builds/6221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117169 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41768 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148650 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9920 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42328 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/113855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9937 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8375 "Found 1 new test failure: imported/w3c/web-platform-tests/media-source/mediasource-changetype-play-without-codecs-parameter.html (failure)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/114186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29003 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7711 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119856 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64644 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9966 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37866 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9696 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73534 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9907 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9758 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->