### PR TITLE
[AutoFill Debugging] Add a way for clients to map node identifiers and/or search text to _WKJSHandle

### DIFF
--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -1880,6 +1880,19 @@ InteractionDescription interactionDescription(const Interaction& interaction, Lo
     return { description.toString(), WTF::move(stringsToValidate) };
 }
 
+RefPtr<Element> elementForExtractedText(const LocalFrame& frame, ExtractedText&& extractedText)
+{
+    auto range = rangeForExtractedText(frame, WTF::move(extractedText));
+    if (!range)
+        return { };
+
+    RefPtr node = commonInclusiveAncestor<ComposedTree>(*range);
+    if (!node)
+        return { };
+
+    return dynamicDowncast<Element>(node) ?: node->parentElementInComposedTree();
+}
+
 std::optional<SimpleRange> rangeForExtractedText(const LocalFrame& frame, ExtractedText&& extractedText)
 {
     auto [text, nodeIdentifier] = extractedText;

--- a/Source/WebCore/page/text-extraction/TextExtraction.h
+++ b/Source/WebCore/page/text-extraction/TextExtraction.h
@@ -47,6 +47,7 @@ WEBCORE_EXPORT void handleInteraction(Interaction&&, LocalFrame&, CompletionHand
 WEBCORE_EXPORT InteractionDescription interactionDescription(const Interaction&, LocalFrame&);
 
 WEBCORE_EXPORT std::optional<SimpleRange> rangeForExtractedText(const LocalFrame&, ExtractedText&&);
+WEBCORE_EXPORT RefPtr<Element> elementForExtractedText(const LocalFrame&, ExtractedText&&);
 
 WEBCORE_EXPORT Vector<FilterRule> extractRules(Vector<FilterRuleData>&&);
 WEBCORE_EXPORT void applyRules(const String&, std::optional<NodeIdentifier>&& containerNodeID, const Vector<FilterRule>&, Page&, CompletionHandler<void(const String&)>&&);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -647,6 +647,16 @@ struct PerWebProcessState {
 
 @end
 
+@interface WKWebView (WKTextExtraction)
+
+- (void)_requestTextExtractionInternal:(_WKTextExtractionConfiguration *)configuration completion:(CompletionHandler<void(std::optional<WebCore::TextExtraction::Item>&&)>&&)completion;
+- (void)_requestJSHandleForNodeIdentifier:(NSString *)nodeIdentifier searchText:(NSString *)searchText completionHandler:(void (^)(_WKJSHandle *))completionHandler;
+#if ENABLE(TEXT_EXTRACTION_FILTER)
+- (void)_validateText:(const String&)text inNode:(std::optional<WebCore::NodeIdentifier>&&)nodeIdentifier completionHandler:(CompletionHandler<void(const String&)>&&)completionHandler;
+#endif
+
+@end
+
 RetainPtr<NSError> nsErrorFromExceptionDetails(const std::optional<WebCore::ExceptionDetails>&);
 
 #if ENABLE(FULLSCREEN_API) && PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
@@ -176,6 +176,15 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
  */
 @property (nonatomic, readonly) NSDictionary<NSString *, NSURL *> *shortenedURLs;
 
+/*!
+ Asynchronously map a node identifier string (corresponding to a `uid` in
+ text extraction output) to a corresponding JS handle to the node.
+ @param nodeIdentifier  The ID of the node to extract, or the ID of the node to search if `searchText` is additionally specified.
+ @param searchText      Rendered text to search inside the document or node corresponding to `nodeIdentifier`. The resulting element will fully contain this text.
+ At least one of `nodeIdentifier` or `searchText` must be specified.
+ */
+- (void)requestJSHandleForNodeIdentifier:(nullable NSString *)nodeIdentifier searchText:(nullable NSString *)searchText completionHandler:(void (^)(_WKJSHandle * _Nullable))completionHandler;
+
 @end
 
 typedef NS_ENUM(NSInteger, _WKTextExtractionAction) {

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
@@ -182,14 +182,16 @@
 @implementation _WKTextExtractionResult {
     RetainPtr<NSString> _textContent;
     RetainPtr<NSDictionary<NSString *, NSURL *>> _shortenedURLs;
+    __weak WKWebView *_webView;
 }
 
-- (instancetype)initWithTextContent:(NSString *)textContent filteredOutAnyText:(BOOL)filteredOutAnyText shortenedURLs:(NSDictionary<NSString *, NSURL *> *)shortenedURLs
+- (instancetype)initWithWebView:(WKWebView *)webView textContent:(NSString *)textContent filteredOutAnyText:(BOOL)filteredOutAnyText shortenedURLs:(NSDictionary<NSString *, NSURL *> *)shortenedURLs
 {
     if (self = [super init]) {
         _textContent = textContent;
         _filteredOutAnyText = filteredOutAnyText;
         _shortenedURLs = shortenedURLs;
+        _webView = webView;
     }
     return self;
 }
@@ -202,6 +204,15 @@
 - (NSDictionary<NSString *, NSURL *> *)shortenedURLs
 {
     return _shortenedURLs.get();
+}
+
+- (void)requestJSHandleForNodeIdentifier:(NSString *)nodeIdentifier searchText:(NSString *)searchText completionHandler:(void (^)(_WKJSHandle *))completionHandler
+{
+    RetainPtr webView = _webView;
+    if (!webView)
+        return completionHandler(nil);
+
+    [webView _requestJSHandleForNodeIdentifier:nodeIdentifier searchText:searchText completionHandler:completionHandler];
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h
@@ -62,7 +62,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface _WKTextExtractionResult ()
 
-- (instancetype)initWithTextContent:(NSString *)textContent filteredOutAnyText:(BOOL)filteredOutAnyText shortenedURLs:(NSDictionary<NSString *, NSURL *> *)shortenedURLs;
+- (instancetype)initWithWebView:(nullable WKWebView *)webView textContent:(NSString *)textContent filteredOutAnyText:(BOOL)filteredOutAnyText shortenedURLs:(NSDictionary<NSString *, NSURL *> *)shortenedURLs;
 
 @end
 

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -35,6 +35,7 @@
 #include "FrameProcess.h"
 #include "FrameTreeCreationParameters.h"
 #include "FrameTreeNodeData.h"
+#include "JSHandleInfo.h"
 #include "LoadedWebArchive.h"
 #include "MessageSenderInlines.h"
 #include "NetworkProcessMessages.h"
@@ -912,6 +913,14 @@ void WebFrameProxy::describeTextExtractionInteraction(TextExtraction::Interactio
     }
 
     sendWithAsyncReply(Messages::WebFrame::DescribeTextExtractionInteraction(WTF::move(interaction)), WTF::move(completion));
+}
+
+void WebFrameProxy::requestJSHandleForExtractedText(TextExtraction::ExtractedText&& extractedText, CompletionHandler<void(std::optional<JSHandleInfo>&&)>&& completion)
+{
+    if (RefPtr page = m_page.get(); !page || !page->hasRunningProcess())
+        return completion({ });
+
+    sendWithAsyncReply(Messages::WebFrame::RequestJSHandleForExtractedText(WTF::move(extractedText)), WTF::move(completion));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -120,6 +120,7 @@ enum class WasNavigationIntercepted : bool;
 struct FrameInfoData;
 struct FrameTreeCreationParameters;
 struct FrameTreeNodeData;
+struct JSHandleInfo;
 struct SharedPreferencesForWebProcess;
 struct WebsitePoliciesData;
 
@@ -293,6 +294,7 @@ public:
     void handleTextExtractionInteraction(WebCore::TextExtraction::Interaction&&, CompletionHandler<void(bool, String&&)>&&);
     void describeTextExtractionInteraction(WebCore::TextExtraction::Interaction&&, CompletionHandler<void(WebCore::TextExtraction::InteractionDescription&&)>&&);
     void takeSnapshotOfExtractedText(WebCore::TextExtraction::ExtractedText&&, CompletionHandler<void(RefPtr<WebCore::TextIndicator>&&)>&&);
+    void requestJSHandleForExtractedText(WebCore::TextExtraction::ExtractedText&&, CompletionHandler<void(std::optional<JSHandleInfo>&&)>&&);
 
 private:
     WebFrameProxy(WebPageProxy&, FrameProcess&, WebCore::FrameIdentifier, WebCore::SandboxFlags, WebCore::ReferrerPolicy, WebCore::ScrollbarMode, WebFrameProxy*, IsMainFrame);

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -67,6 +67,7 @@ class LocalFrame;
 class PlatformMouseEvent;
 class RemoteFrame;
 class TextIndicator;
+class WebKitJSHandle;
 
 namespace TextExtraction {
 struct ExtractedText;
@@ -103,6 +104,7 @@ class WebRemoteFrameClient;
 
 struct FrameInfoData;
 struct FrameTreeNodeData;
+struct JSHandleInfo;
 struct ProvisionalFrameCreationParameters;
 struct WebsitePoliciesData;
 
@@ -270,6 +272,8 @@ public:
 
     String frameTextForTesting(bool);
 
+    std::pair<Ref<WebCore::WebKitJSHandle>, JSHandleInfo> createAndPrepareToSendJSHandle(WebCore::Node&) const;
+
     void markAsRemovedInAnotherProcess() { m_wasRemovedInAnotherProcess = true; }
     bool wasRemovedInAnotherProcess() const { return m_wasRemovedInAnotherProcess; }
 
@@ -290,6 +294,7 @@ public:
     void handleTextExtractionInteraction(WebCore::TextExtraction::Interaction&&, CompletionHandler<void(bool, String&&)>&&);
     void describeTextExtractionInteraction(WebCore::TextExtraction::Interaction&&, CompletionHandler<void(WebCore::TextExtraction::InteractionDescription&&)>&&);
     void takeSnapshotOfExtractedText(WebCore::TextExtraction::ExtractedText&&, CompletionHandler<void(RefPtr<WebCore::TextIndicator>&&)>&&);
+    void requestJSHandleForExtractedText(WebCore::TextExtraction::ExtractedText&&, CompletionHandler<void(std::optional<JSHandleInfo>&&)>&&);
 
 private:
     WebFrame(WebPage&, WebCore::FrameIdentifier);

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.messages.in
@@ -41,4 +41,5 @@ messages -> WebFrame {
     HandleTextExtractionInteraction(struct WebCore::TextExtraction::Interaction interaction) -> (bool succeeded, String description)
     DescribeTextExtractionInteraction(struct WebCore::TextExtraction::Interaction interaction) -> (struct WebCore::TextExtraction::InteractionDescription description)
     TakeSnapshotOfExtractedText(struct WebCore::TextExtraction::ExtractedText text) -> (RefPtr<WebCore::TextIndicator> textIndicator)
+    RequestJSHandleForExtractedText(struct WebCore::TextExtraction::ExtractedText text) -> (struct std::optional<WebKit::JSHandleInfo> handle)
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -9869,16 +9869,8 @@ void WebPage::hitTestAtPoint(WebCore::FrameIdentifier frameID, WebCore::FloatPoi
     if (!nodeWebFrame)
         return completionHandler({ });
 
-    Ref nodeHandle = [node] {
-        Ref document = node->document();
-        auto* lexicalGlobalObject = document->globalObject();
-        RELEASE_ASSERT(lexicalGlobalObject->template inherits<WebCore::JSDOMGlobalObject>());
-        auto* domGlobalObject = jsCast<WebCore::JSDOMGlobalObject*>(lexicalGlobalObject);
-        JSLockHolder locker(lexicalGlobalObject);
-        return WebCore::WebKitJSHandle::create(WebCore::toJS(lexicalGlobalObject, domGlobalObject, *node).toObject(lexicalGlobalObject));
-    }();
-    WebCore::WebKitJSHandle::jsHandleSentToAnotherProcess(nodeHandle->identifier());
-    completionHandler({ JSHandleInfo { nodeHandle->identifier(), pageContentWorldIdentifier(), nodeWebFrame->info(), nodeHandle->windowFrameIdentifier() } });
+    auto [handle, info] = nodeWebFrame->createAndPrepareToSendJSHandle(*node);
+    completionHandler({ WTF::move(info) });
 }
 
 void WebPage::adjustVisibilityForTargetedElements(Vector<TargetedElementAdjustment>&& adjustments, CompletionHandler<void(bool)>&& completion)


### PR DESCRIPTION
#### 192824c3316352ff5c7dce4c7852ef44c97e582b
<pre>
[AutoFill Debugging] Add a way for clients to map node identifiers and/or search text to _WKJSHandle
<a href="https://bugs.webkit.org/show_bug.cgi?id=305058">https://bugs.webkit.org/show_bug.cgi?id=305058</a>
<a href="https://rdar.apple.com/167703893">rdar://167703893</a>

Reviewed by Tim Horton and Abrar Rahman Protyasha.

Add support for `-[_WKTextExtractionResult requestJSHandleForNodeIdentifier:searchText:completionHandler:]`,
which asynchronously returns a JS handle pointing to the DOM element represented by the node ID and
search text. See below for more details.

Test: TextExtractionTests.RequestJSHandleForNodeIdentifier

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::elementForExtractedText):
* Source/WebCore/page/text-extraction/TextExtraction.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(createEmptyTextExtractionResult):

Add a weak reference to `WKWebView` to `_WKTextExtractionResult`, so that the result can call back
to its `WKWebView` to convert node ID / text to a JS handle.

(-[WKWebView _extractDebugTextWithConfigurationWithoutUpdatingFilterRules:assertionScope:completionHandler:]):
(-[WKWebView _requestJSHandleForNodeIdentifier:searchText:completionHandler:]):

Add an internal helper method to handle the conversion by sending async IPC. This currently only
supports main frame content, but we&apos;ll adjust this to message the appropriate frame once node ID
strings support `subframe ID` + `nodeID` format.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm:
(-[_WKTextExtractionResult initWithWebView:textContent:filteredOutAnyText:shortenedURLs:]):
(-[_WKTextExtractionResult requestJSHandleForNodeIdentifier:searchText:completionHandler:]):
(-[_WKTextExtractionResult initWithTextContent:filteredOutAnyText:shortenedURLs:]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h:
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::requestJSHandleForExtractedText):
* Source/WebKit/UIProcess/WebFrameProxy.h:
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::createAndPrepareToSendJSHandle const):

Pull this logic to create a node `JSHandle` out into a common helper method, so that we can use it
in `WebFrame` too.

(WebKit::WebFrame::requestJSHandleForExtractedText):
* Source/WebKit/WebProcess/WebPage/WebFrame.h:
* Source/WebKit/WebProcess/WebPage/WebFrame.messages.in:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::hitTestAtPoint):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm:
(-[_WKTextExtractionResult jsHandleForNodeIdentifier:searchText:]):
(TestWebKitAPI::TEST(TextExtractionTests, RequestJSHandleForNodeIdentifier)):

Add an API test to exercise the change, by mapping node ID string to a `_WKJSHandle`, and then
passing that handle to the `targetNode` property to re-extract text underneath the subject heading.

Canonical link: <a href="https://commits.webkit.org/305247@main">https://commits.webkit.org/305247@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4febe185f52f5f6699a656f65b353f7ace616698

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137870 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10234 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49224 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/145936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90845 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/eedec880-07f6-444d-8b5c-d2ad34e91c03) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139742 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10936 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10373 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/145936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140815 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8150 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123602 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/145936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/59bb1ce6-9ea8-4ac7-a633-cc045ca31dda) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7770 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5515 "Passed tests") | [  ~~🛠 wpe-cairo-libwebrtc~~](https://ews-build.webkit.org/#/builders/166/builds/6218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117165 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41764 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/148647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9917 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42324 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/148647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9934 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8372 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/148647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29002 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7708 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119852 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64639 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9963 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37863 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9693 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73531 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9904 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9755 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->