### PR TITLE
[LOL] Add support for resolve/put_to_scope

### DIFF
--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1017,7 +1017,6 @@
 		530A66C31FA3E78B0026A545 /* UnifiedSource144.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 530A66AD1FA3E7770026A545 /* UnifiedSource144.cpp */; };
 		530A66C41FA3E78B0026A545 /* UnifiedSource145.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 530A66B01FA3E77A0026A545 /* UnifiedSource145.cpp */; };
 		530A66CD1FB1346D0026A545 /* SuperSamplerBytecodeScope.h in Headers */ = {isa = PBXBuildFile; fileRef = 530A66CC1FB1346D0026A545 /* SuperSamplerBytecodeScope.h */; };
-		530E4FAF2E3455E000479AEE /* LOLJIT.h in Headers */ = {isa = PBXBuildFile; fileRef = 530E4FAB2E34554A00479AEE /* LOLJIT.h */; };
 		530F0A982AE0607B00A0EEC0 /* LazyValueProfile.h in Headers */ = {isa = PBXBuildFile; fileRef = 530F0A962AE0606900A0EEC0 /* LazyValueProfile.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		530FB3021E7A0B6E003C19DD /* WasmWorklist.h in Headers */ = {isa = PBXBuildFile; fileRef = 530FB3011E7A0B6E003C19DD /* WasmWorklist.h */; };
 		530FDE7521FAB00600059D65 /* testIncludes.m in Sources */ = {isa = PBXBuildFile; fileRef = 530FDE7321FAAFC600059D65 /* testIncludes.m */; };
@@ -1220,6 +1219,9 @@
 		539BFBB022AD3CDC0023F4C0 /* JSWeakObjectRef.h in Headers */ = {isa = PBXBuildFile; fileRef = 539BFBAF22AD3CDC0023F4C0 /* JSWeakObjectRef.h */; };
 		539DD7F523C1BBB500905F13 /* JSArrayIterator.h in Headers */ = {isa = PBXBuildFile; fileRef = 539DD7F423C1BBA900905F13 /* JSArrayIterator.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		539FB8BA1C99DA7C00940FA1 /* JSArrayInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 539FB8B91C99DA7C00940FA1 /* JSArrayInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		53ADF4772F0D7A7400A05CDD /* LOLJIT.h in Headers */ = {isa = PBXBuildFile; fileRef = 53ADF46F2F0D7A2000A05CDD /* LOLJIT.h */; };
+		53ADF4782F0D7A7B00A05CDD /* LOLJITOperations.h in Headers */ = {isa = PBXBuildFile; fileRef = 53ADF4712F0D7A2000A05CDD /* LOLJITOperations.h */; };
+		53ADF4792F0D7A8000A05CDD /* LOLRegisterAllocator.h in Headers */ = {isa = PBXBuildFile; fileRef = 53ADF4732F0D7A2000A05CDD /* LOLRegisterAllocator.h */; };
 		53B0D0C42E2E834300FC209B /* SimpleRegisterAllocator.h in Headers */ = {isa = PBXBuildFile; fileRef = 53B0D0C32E2E834300FC209B /* SimpleRegisterAllocator.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		53B4BD121F68B32500D2BEA3 /* WasmOps.h in Headers */ = {isa = PBXBuildFile; fileRef = 533B15DE1DC7F463004D500A /* WasmOps.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		53B601EC2034B8C5006BE667 /* JSCast.h in Headers */ = {isa = PBXBuildFile; fileRef = 53B601EB2034B8C5006BE667 /* JSCast.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -4260,8 +4262,6 @@
 		530A66B71FA3E77D0026A545 /* UnifiedSource143.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource143.cpp; path = "DerivedSources/JavaScriptCore/unified-sources/UnifiedSource143.cpp"; sourceTree = BUILT_PRODUCTS_DIR; };
 		530A66B81FA3E77E0026A545 /* UnifiedSource4-nonARC.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = "UnifiedSource4-nonARC.mm"; path = "DerivedSources/JavaScriptCore/unified-sources/UnifiedSource4-nonARC.mm"; sourceTree = BUILT_PRODUCTS_DIR; };
 		530A66CC1FB1346D0026A545 /* SuperSamplerBytecodeScope.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SuperSamplerBytecodeScope.h; sourceTree = "<group>"; };
-		530E4FAB2E34554A00479AEE /* LOLJIT.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = LOLJIT.h; path = lol/LOLJIT.h; sourceTree = "<group>"; };
-		530E4FAC2E34554A00479AEE /* LOLJIT.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LOLJIT.cpp; path = lol/LOLJIT.cpp; sourceTree = "<group>"; };
 		530F0A962AE0606900A0EEC0 /* LazyValueProfile.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LazyValueProfile.h; sourceTree = "<group>"; };
 		530F0A972AE0606900A0EEC0 /* LazyValueProfile.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = LazyValueProfile.cpp; sourceTree = "<group>"; };
 		530FB3011E7A0B6E003C19DD /* WasmWorklist.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WasmWorklist.h; sourceTree = "<group>"; };
@@ -4495,6 +4495,11 @@
 		539DD7F323C1BBA900905F13 /* JSArrayIterator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSArrayIterator.cpp; sourceTree = "<group>"; };
 		539DD7F423C1BBA900905F13 /* JSArrayIterator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSArrayIterator.h; sourceTree = "<group>"; };
 		539FB8B91C99DA7C00940FA1 /* JSArrayInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSArrayInlines.h; sourceTree = "<group>"; };
+		53ADF46F2F0D7A2000A05CDD /* LOLJIT.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LOLJIT.h; sourceTree = "<group>"; };
+		53ADF4702F0D7A2000A05CDD /* LOLJIT.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = LOLJIT.cpp; sourceTree = "<group>"; };
+		53ADF4712F0D7A2000A05CDD /* LOLJITOperations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LOLJITOperations.h; sourceTree = "<group>"; };
+		53ADF4722F0D7A2000A05CDD /* LOLJITOperations.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = LOLJITOperations.cpp; sourceTree = "<group>"; };
+		53ADF4732F0D7A2000A05CDD /* LOLRegisterAllocator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LOLRegisterAllocator.h; sourceTree = "<group>"; };
 		53B0BE331E561AC900A8FC29 /* GetterSetterAccessCase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GetterSetterAccessCase.cpp; sourceTree = "<group>"; };
 		53B0BE351E561B0900A8FC29 /* ProxyableAccessCase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ProxyableAccessCase.cpp; sourceTree = "<group>"; };
 		53B0BE371E561B2400A8FC29 /* IntrinsicGetterAccessCase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IntrinsicGetterAccessCase.cpp; sourceTree = "<group>"; };
@@ -6540,8 +6545,7 @@
 				45E12D8806A49B0F00E9DF84 /* jsc.cpp */,
 				A7C225CC139981F100FF1662 /* KeywordLookupGenerator.py */,
 				79D7B0E121152FD200FE7C64 /* entitlements.plist */,
-				530E4FAB2E34554A00479AEE /* LOLJIT.h */,
-				530E4FAC2E34554A00479AEE /* LOLJIT.cpp */,
+				53ADF4742F0D7A2000A05CDD /* lol */,
 				1432EBD70A34CAD400717B9F /* API */,
 				9688CB120ED12B4E001D649F /* assembler */,
 				0FEC84B21BDACD5E0080FF74 /* b3 */,
@@ -7944,6 +7948,18 @@
 				538F15DF368FBBB600D601C4 /* UnifiedSource165.cpp */,
 			);
 			path = "unified-sources";
+			sourceTree = "<group>";
+		};
+		53ADF4742F0D7A2000A05CDD /* lol */ = {
+			isa = PBXGroup;
+			children = (
+				53ADF4702F0D7A2000A05CDD /* LOLJIT.cpp */,
+				53ADF46F2F0D7A2000A05CDD /* LOLJIT.h */,
+				53ADF4722F0D7A2000A05CDD /* LOLJITOperations.cpp */,
+				53ADF4712F0D7A2000A05CDD /* LOLJITOperations.h */,
+				53ADF4732F0D7A2000A05CDD /* LOLRegisterAllocator.h */,
+			);
+			path = lol;
 			sourceTree = "<group>";
 		};
 		53C3D5E321ECE68E0087FDFC /* testapiScripts */ = {
@@ -11897,7 +11913,9 @@
 				92B4EF902D71C3650068CB55 /* LLVMProfiling.h in Headers */,
 				0F75A061200D26180038E2CF /* LocalAllocator.h in Headers */,
 				0F75A060200D260B0038E2CF /* LocalAllocatorInlines.h in Headers */,
-				530E4FAF2E3455E000479AEE /* LOLJIT.h in Headers */,
+				53ADF4772F0D7A7400A05CDD /* LOLJIT.h in Headers */,
+				53ADF4782F0D7A7B00A05CDD /* LOLJITOperations.h in Headers */,
+				53ADF4792F0D7A8000A05CDD /* LOLRegisterAllocator.h in Headers */,
 				BC18C4370E16F5CD00B34460 /* Lookup.h in Headers */,
 				0F4680CD14BBB17D00BFE272 /* LowLevelInterpreter.h in Headers */,
 				981ED82328234D91BAECCADE /* MachineContext.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -694,6 +694,7 @@ jit/JITTZoneImpls.cpp
 jit/Width.cpp
 
 lol/LOLJIT.cpp
+lol/LOLJITOperations.cpp
 
 llint/InPlaceInterpreter.cpp
 llint/LLIntCLoop.cpp

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.h
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.h
@@ -1835,6 +1835,7 @@ public:
         return branch8(Above, AbsoluteAddress(address), TrustedImm32(blackThreshold));
     }
     
+    // FIXME: We should name this something more obvious like branchIfCellIsRememberedOrEden. barrierBranch could mean many things.
     // Branch taken if the cell does not need a memory fence or store barrier.
     // When reverse is true, branch taken when the memory barrier or store barrier is needed.
     Jump barrierBranch(VM& vm, GPRReg cell, GPRReg scratchGPR, bool reverse = false)

--- a/Source/JavaScriptCore/jit/BaselineJITRegisters.h
+++ b/Source/JavaScriptCore/jit/BaselineJITRegisters.h
@@ -119,7 +119,8 @@ namespace ResolveScope {
     static constexpr GPRReg scopeGPR { GPRInfo::regT0 };
     static constexpr GPRReg bytecodeOffsetGPR { GPRInfo::regT3 };
     static constexpr GPRReg scratch1GPR { GPRInfo::regT5 };
-    static_assert(noOverlap(metadataGPR, scopeGPR, bytecodeOffsetGPR, scratch1GPR), "Required for call to CTI thunk");
+    static constexpr GPRReg scratch2GPR { GPRInfo::regT1 };
+    static_assert(noOverlap(metadataGPR, scopeGPR, bytecodeOffsetGPR, scratch1GPR, scratch2GPR), "Required for call to CTI thunk");
 }
 
 namespace GetFromScope {

--- a/Source/JavaScriptCore/jit/CCallHelpers.h
+++ b/Source/JavaScriptCore/jit/CCallHelpers.h
@@ -671,7 +671,7 @@ private:
         if constexpr (std::same_as<FirstArgumentType, CallFrame*>) {
 #if USE(JSVALUE64)
             // This only really works for 64-bit since jsvalue regs mess things up for 32-bit...
-            static_assert(FunctionTraits<OperationType>::cCallArity() == sizeof...(Args) + 1, "Basic sanity check");
+            static_assert(FunctionTraits<OperationType>::cCallArity() == sizeof...(Args) + 1, "Basic sanity check; Did you explicitly pass callFrameRegister for the first argument?");
 #endif
             setupArgumentsImpl<OperationType>(argSourceRegs, GPRInfo::callFrameRegister, args...);
         } else {

--- a/Source/JavaScriptCore/jit/GPRInfo.h
+++ b/Source/JavaScriptCore/jit/GPRInfo.h
@@ -900,6 +900,7 @@ inline NoResultTag extractResult(NoResultTag) { return NoResult; }
 // We use this hack to get the GPRInfo from the GPRReg type in templates because our code is bad and we should feel bad..
 constexpr GPRInfo toInfoFromReg(GPRReg) { return GPRInfo(); }
 
+// FIXME: We should just use a RegisterSet for this check since RegisterSet is constexpr anyway.
 class NoOverlapImpl {
     static constexpr unsigned noOverlapImplRegMask(GPRReg gpr)
     {

--- a/Source/JavaScriptCore/jit/JIT.h
+++ b/Source/JavaScriptCore/jit/JIT.h
@@ -291,7 +291,8 @@ namespace JSC {
         void compileOpStrictEqCommon(VirtualRegister src1,  VirtualRegister src2);
 #endif
 
-        enum WriteBarrierMode { UnconditionalWriteBarrier, ShouldFilterBase, ShouldFilterValue, ShouldFilterBaseAndValue };
+        enum class WriteBarrierMode { UnconditionalWriteBarrier, ShouldFilterBase, ShouldFilterValue, ShouldFilterBaseAndValue };
+        using enum WriteBarrierMode;
         // value register in write barrier is used before any scratch registers
         // so may safely be the same as either of the scratch registers.
         void emitWriteBarrier(VirtualRegister owner, WriteBarrierMode);

--- a/Source/JavaScriptCore/jit/JITArithmetic.cpp
+++ b/Source/JavaScriptCore/jit/JITArithmetic.cpp
@@ -367,8 +367,8 @@ void JIT::emit_compareAndJumpSlow(const JSInstruction* instruction, DoubleCondit
     emit_compareSlowImpl(op1, op2, instruction->size(), operation, iter, handleReturnValueGPR, emitCompareAndJump);
 }
 
-template<typename SlowOperation, typename HanldeReturnValueGPRFunctor, typename EmitDoubleCompareFunctor>
-void JIT::emit_compareSlowImpl(VirtualRegister op1, VirtualRegister op2, size_t instructionSize, SlowOperation operation, Vector<SlowCaseEntry>::iterator& iter, const HanldeReturnValueGPRFunctor& handleReturnValueGPR, const EmitDoubleCompareFunctor& emitDoubleCompare)
+template<typename SlowOperation, typename HandleReturnValueGPRFunctor, typename EmitDoubleCompareFunctor>
+void JIT::emit_compareSlowImpl(VirtualRegister op1, VirtualRegister op2, size_t instructionSize, SlowOperation operation, Vector<SlowCaseEntry>::iterator& iter, const HandleReturnValueGPRFunctor& handleReturnValueGPR, const EmitDoubleCompareFunctor& emitDoubleCompare)
 {
 
     // We generate inline code for the following cases in the slow path:

--- a/Source/JavaScriptCore/jit/RegisterSet.h
+++ b/Source/JavaScriptCore/jit/RegisterSet.h
@@ -38,6 +38,8 @@
 #include <wtf/BitSet.h>
 #include <wtf/CommaPrinter.h>
 
+#include <ranges>
+
 namespace JSC {
 
 class ScalarRegisterSet;
@@ -61,6 +63,14 @@ public:
     inline constexpr explicit RegisterSetBuilder(Regs... regs)
     {
         setMany(regs...);
+    }
+
+    static RegisterSetBuilder fromIterable(const std::ranges::range auto& regs)
+    {
+        RegisterSetBuilder result;
+        for (auto reg : regs)
+            result.setAny(reg);
+        return result;
     }
 
     inline constexpr RegisterSetBuilder& add(Reg reg, Width width)

--- a/Source/JavaScriptCore/lol/LOLJITOperations.cpp
+++ b/Source/JavaScriptCore/lol/LOLJITOperations.cpp
@@ -1,0 +1,227 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#include "config.h"
+#include "LOLJITOperations.h"
+
+#if ENABLE(JIT) && USE(JSVALUE64)
+
+#include "ArithProfile.h"
+#include "ArrayConstructor.h"
+#include "CacheableIdentifierInlines.h"
+#include "CodeBlockInlines.h"
+#include "CommonSlowPathsInlines.h"
+#include "DFGDriver.h"
+#include "DFGOSREntry.h"
+#include "DFGThunks.h"
+#include "Debugger.h"
+#include "EnsureStillAliveHere.h"
+#include "ExceptionFuzz.h"
+#include "FrameTracers.h"
+#include "GetterSetter.h"
+#include "ICStats.h"
+#include "InlineCacheCompiler.h"
+#include "Interpreter.h"
+#include "JIT.h"
+#include "JITExceptions.h"
+#include "JITThunks.h"
+#include "JITToDFGDeferredCompilationCallback.h"
+#include "JITWorklist.h"
+#include "JSArrayIterator.h"
+#include "JSAsyncFunction.h"
+#include "JSAsyncGenerator.h"
+#include "JSAsyncGeneratorFunction.h"
+#include "JSBoundFunction.h"
+#include "JSCInlines.h"
+#include "JSCPtrTag.h"
+#include "JSGeneratorFunction.h"
+#include "JSGlobalObjectFunctions.h"
+#include "JSInternalPromise.h"
+#include "JSLexicalEnvironment.h"
+#include "JSRemoteFunction.h"
+#include "JSWithScope.h"
+#include "LLIntEntrypoint.h"
+#include "MegamorphicCache.h"
+#include "ObjectConstructor.h"
+#include "PropertyName.h"
+#include "RegExpObject.h"
+#include "RepatchInlines.h"
+#include "ShadowChicken.h"
+#include "StructureStubInfo.h"
+#include "SuperSampler.h"
+#include "ThunkGenerators.h"
+#include "TypeProfilerLog.h"
+
+namespace JSC::LOL {
+
+JSC_DEFINE_JIT_OPERATION(operationResolveScopeForLOL, EncodedJSValue, (CallFrame* callFrame, unsigned bytecodeOffset, JSScope* environment))
+{
+    CodeBlock* codeBlock = callFrame->codeBlock();
+    JSGlobalObject* globalObject = codeBlock->globalObject();
+    VM& vm = globalObject->vm();
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    const JSInstruction* pc = codeBlock->instructionAt(BytecodeIndex(bytecodeOffset));
+    auto bytecode = pc->as<OpResolveScope>();
+    const Identifier& ident = codeBlock->identifier(bytecode.m_var);
+    JSObject* resolvedScope = JSScope::resolve(globalObject, environment, ident);
+    // Proxy can throw an error here, e.g. Proxy in with statement's @unscopables.
+    OPERATION_RETURN_IF_EXCEPTION(scope, encodedJSValue());
+
+    auto& metadata = bytecode.metadata(codeBlock);
+    ResolveType resolveType = metadata.m_resolveType;
+
+    // ModuleVar does not keep the scope register value alive in DFG.
+    ASSERT(resolveType != ModuleVar);
+
+    switch (resolveType) {
+    case GlobalProperty:
+    case GlobalPropertyWithVarInjectionChecks:
+    case UnresolvedProperty:
+    case UnresolvedPropertyWithVarInjectionChecks: {
+        if (resolvedScope->isGlobalObject()) {
+            JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(resolvedScope);
+            bool hasProperty = globalObject->hasProperty(globalObject, ident);
+            OPERATION_RETURN_IF_EXCEPTION(scope, encodedJSValue());
+            if (hasProperty) {
+                ConcurrentJSLocker locker(codeBlock->m_lock);
+                metadata.m_resolveType = needsVarInjectionChecks(resolveType) ? GlobalPropertyWithVarInjectionChecks : GlobalProperty;
+                metadata.m_globalObject.set(vm, codeBlock, globalObject);
+                metadata.m_globalLexicalBindingEpoch = globalObject->globalLexicalBindingEpoch();
+            }
+        } else if (resolvedScope->isGlobalLexicalEnvironment()) {
+            JSGlobalLexicalEnvironment* globalLexicalEnvironment = jsCast<JSGlobalLexicalEnvironment*>(resolvedScope);
+            ConcurrentJSLocker locker(codeBlock->m_lock);
+            metadata.m_resolveType = needsVarInjectionChecks(resolveType) ? GlobalLexicalVarWithVarInjectionChecks : GlobalLexicalVar;
+            metadata.m_globalLexicalEnvironment.set(vm, codeBlock, globalLexicalEnvironment);
+        }
+        break;
+    }
+    default:
+        break;
+    }
+
+    OPERATION_RETURN(scope, JSValue::encode(resolvedScope));
+}
+
+JSC_DEFINE_JIT_OPERATION(operationGetFromScopeForLOL, EncodedJSValue, (CallFrame* callFrame, unsigned bytecodeOffset, JSObject* environment))
+{
+    CodeBlock* codeBlock = callFrame->codeBlock();
+    JSGlobalObject* globalObject = codeBlock->globalObject();
+    VM& vm = globalObject->vm();
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    const JSInstruction* pc = codeBlock->instructionAt(BytecodeIndex(bytecodeOffset));
+    auto bytecode = pc->as<OpGetFromScope>();
+    const Identifier& ident = codeBlock->identifier(bytecode.m_var);
+    GetPutInfo& getPutInfo = bytecode.metadata(codeBlock).m_getPutInfo;
+
+    // ModuleVar is always converted to ClosureVar for get_from_scope.
+    ASSERT(getPutInfo.resolveType() != ModuleVar);
+
+    OPERATION_RETURN(scope, JSValue::encode(environment->getPropertySlot(globalObject, ident, [&] (bool found, PropertySlot& slot) -> JSValue {
+        if (!found) {
+            if (getPutInfo.resolveMode() == ThrowIfNotFound)
+                throwException(globalObject, scope, createUndefinedVariableError(globalObject, ident));
+            return jsUndefined();
+        }
+
+        JSValue result = JSValue();
+        if (environment->isGlobalLexicalEnvironment()) {
+            // When we can't statically prove we need a TDZ check, we must perform the check on the slow path.
+            result = slot.getValue(globalObject, ident);
+            if (result == jsTDZValue()) {
+                throwException(globalObject, scope, createTDZError(globalObject, ident.string()));
+                return jsUndefined();
+            }
+        }
+
+        CommonSlowPaths::tryCacheGetFromScopeGlobal(globalObject, codeBlock, vm, bytecode, environment, slot, ident);
+
+        if (!result)
+            return slot.getValue(globalObject, ident);
+        return result;
+    })));
+}
+
+JSC_DEFINE_JIT_OPERATION(operationPutToScopeForLOL, void, (CallFrame* callFrame, unsigned bytecodeOffset, JSObject* jsScope, JSValue value))
+{
+    CodeBlock* codeBlock = callFrame->codeBlock();
+    JSGlobalObject* globalObject = codeBlock->globalObject();
+    VM& vm = globalObject->vm();
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    const JSInstruction* pc = codeBlock->instructionAt(BytecodeIndex(bytecodeOffset));
+    auto bytecode = pc->as<OpPutToScope>();
+    auto& metadata = bytecode.metadata(codeBlock);
+
+    const Identifier& ident = codeBlock->identifier(bytecode.m_var);
+    GetPutInfo& getPutInfo = metadata.m_getPutInfo;
+
+    // ModuleVar does not keep the scope register value alive in DFG.
+    ASSERT(getPutInfo.resolveType() != ModuleVar);
+
+    if (getPutInfo.resolveType() == ResolvedClosureVar) {
+        JSLexicalEnvironment* environment = jsCast<JSLexicalEnvironment*>(jsScope);
+        environment->variableAt(ScopeOffset(metadata.m_operand)).set(vm, environment, value);
+        if (RefPtr set = metadata.m_watchpointSet)
+            set->touch(vm, "Executed op_put_scope<ResolvedClosureVar>");
+        OPERATION_RETURN(scope);
+    }
+
+    bool hasProperty = jsScope->hasProperty(globalObject, ident);
+    OPERATION_RETURN_IF_EXCEPTION(scope);
+    if (hasProperty
+        && jsScope->isGlobalLexicalEnvironment()
+        && !isInitialization(getPutInfo.initializationMode())) {
+        // When we can't statically prove we need a TDZ check, we must perform the check on the slow path.
+        PropertySlot slot(jsScope, PropertySlot::InternalMethodType::Get);
+        JSGlobalLexicalEnvironment::getOwnPropertySlot(jsScope, globalObject, ident, slot);
+        if (slot.getValue(globalObject, ident) == jsTDZValue()) {
+            throwException(globalObject, scope, createTDZError(globalObject, ident.string()));
+            OPERATION_RETURN(scope);
+        }
+    }
+
+    if (getPutInfo.resolveMode() == ThrowIfNotFound && !hasProperty) {
+        throwException(globalObject, scope, createUndefinedVariableError(globalObject, ident));
+        OPERATION_RETURN(scope);
+    }
+
+    PutPropertySlot slot(jsScope, getPutInfo.ecmaMode().isStrict(), PutPropertySlot::UnknownContext, isInitialization(getPutInfo.initializationMode()));
+    jsScope->methodTable()->put(jsScope, globalObject, ident, value, slot);
+
+    OPERATION_RETURN_IF_EXCEPTION(scope);
+
+    CommonSlowPaths::tryCachePutToScopeGlobal(globalObject, codeBlock, bytecode, jsScope, slot, ident);
+    OPERATION_RETURN(scope);
+}
+
+} // namespace JSC::LOL
+
+#endif // ENABLE(JIT) && USE(JSVALUE64)

--- a/Source/JavaScriptCore/lol/LOLJITOperations.h
+++ b/Source/JavaScriptCore/lol/LOLJITOperations.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#pragma once
+
+#if ENABLE(JIT) && USE(JSVALUE64)
+
+#include "JITOperations.h"
+
+namespace JSC {
+
+namespace LOL {
+
+// These are only valid to use from the LOLJIT since they directly use the bytecode stream.
+JSC_DECLARE_JIT_OPERATION(operationResolveScopeForLOL, EncodedJSValue, (CallFrame*, unsigned bytecodeOffset, JSScope* environment));
+JSC_DECLARE_JIT_OPERATION(operationGetFromScopeForLOL, EncodedJSValue, (CallFrame*, unsigned bytecodeOffset, JSObject* environment));
+JSC_DECLARE_JIT_OPERATION(operationPutToScopeForLOL, void, (CallFrame*, unsigned bytecodeOffset, JSObject* environment, JSValue value));
+
+} } // namespace JSC::LOL
+
+#endif // ENABLE(JIT) && USE(JSVALUE64)

--- a/Source/JavaScriptCore/lol/LOLRegisterAllocator.h
+++ b/Source/JavaScriptCore/lol/LOLRegisterAllocator.h
@@ -228,6 +228,7 @@ using ReplayRegisterAllocator = RegisterAllocator<ReplayBackend>;
     macro(OpToObject, m_operand, 0) \
     macro(OpToNumeric, m_operand, 0) \
     macro(OpBitnot, m_operand, 0) \
+    macro(OpResolveScope, m_scope, 1) \
     macro(OpGetFromScope, m_scope, 1)
 
 #define ALLOCATE_USE_DEFS_FOR_UNARY_OP(Struct, operand, scratchCount) \
@@ -270,6 +271,15 @@ FOR_EACH_BINARY_OP(ALLOCATE_USE_DEFS_FOR_BINARY_OP)
 
 #undef ALLOCATE_USE_DEFS_FOR_BINARY_OP
 #undef FOR_EACH_BINARY_OP
+
+template<typename Backend>
+auto RegisterAllocator<Backend>::allocate(Backend& jit, const OpPutToScope& instruction, BytecodeIndex index)
+{
+    std::array<VirtualRegister, 2> uses = { instruction.m_scope, instruction.m_value };
+    std::array<VirtualRegister, 0> defs = { };
+    return allocateImpl<1>(jit, instruction, index, uses, defs); // 1 scratch for metadata
+}
+
 
 } // namespace JSC
 


### PR DESCRIPTION
#### 9d453e3d623cbed559e7d31195b5c7840b9b679b
<pre>
[LOL] Add support for resolve/put_to_scope
<a href="https://bugs.webkit.org/show_bug.cgi?id=305063">https://bugs.webkit.org/show_bug.cgi?id=305063</a>
<a href="https://rdar.apple.com/167709636">rdar://167709636</a>

Reviewed by Yusuke Suzuki.

This patch is somewhat complicated since the scope resolution/access
bytecodes go through multiple thunks, which makes generating the
correct fast paths tricky.

I also had to make new operations for scope slow paths. The existing
slow paths were reading values from the stack directly which we want to
avoid. Although, after bug 1 below maybe that&apos;s less of an issue since
we&apos;ll essentially have to flush the operands for exceptions anyway.

Additionally there were a number of bugs that were uncovered now that
we support enough bytecodes to trigger some interesting edge cases:

1) We have to silentSpill a def&apos;s GPR when it aliases a use. This is
   because the slow path could throw. This is not normally a problem but
   we could catch that exception in the same frame we threw from. In
   that case the use wouldn&apos;t have been flushed properly and we would
   see a stale value.

2) emitLoadCharacterString was clobbering the source and used regT1
   without taking it as a parameter. I copied it and changed the behavior
   to avoid allocating an extra scratch register in every other case.

3) I had written the comparison operators incorrectly as for some of the
   constant cases they would compare backwards.

4) get_from_scope would end up clobbering the scope before jumping to
   the slow path, which would result in using the globalObject as the
   scope when it should&apos;ve been a different object.

Canonical link: <a href="https://commits.webkit.org/305289@main">https://commits.webkit.org/305289@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07e5b5ba5a5ba2f60f401c38315ab1c295567163

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137953 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10317 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49315 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146020 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90928 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b886f368-7617-4a58-b21b-9d47db1b9a71) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11019 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10460 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105499 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9df75d1b-3cf2-4ad4-9b5c-1840777f4180) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140898 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8214 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123668 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86349 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e57c69f1-6ba4-46cc-9616-5566d30798be) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7828 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5580 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6303 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/129917 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117223 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41838 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148731 "Built successfully") | | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/136502 "Found unexpected failure with change (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10000 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42397 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113896 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10017 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8437 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114226 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7766 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119924 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64724 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21241 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10046 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37918 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/169225 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9777 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73614 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44127 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9987 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9838 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->