### PR TITLE
AX: LiveRegionSearchKey should work with the new live region mechanism

### DIFF
--- a/LayoutTests/accessibility/mac/live-regions/live-region-search-expected.txt
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-search-expected.txt
@@ -1,0 +1,17 @@
+This test ensures that live region searches work correctly after dynamic page changes.
+
+PASS: webArea.uiElementCountForSearchPredicate(null, true, 'AXLiveRegionSearchKey', '', false, false) === 0
+PASS: webArea.uiElementCountForSearchPredicate(null, true, 'AXLiveRegionSearchKey', '', false, false) === 1
+PASS: webArea.uiElementCountForSearchPredicate(null, true, 'AXLiveRegionSearchKey', '', false, false) === 0
+PASS: webArea.uiElementCountForSearchPredicate(null, true, 'AXLiveRegionSearchKey', '', false, false) === 1
+PASS: webArea.uiElementCountForSearchPredicate(null, true, 'AXLiveRegionSearchKey', '', false, false) === 0
+PASS: webArea.uiElementCountForSearchPredicate(null, true, 'AXLiveRegionSearchKey', '', false, false) === 1
+PASS: webArea.uiElementCountForSearchPredicate(null, true, 'AXLiveRegionSearchKey', '', false, false) === 2
+PASS: webArea.uiElementCountForSearchPredicate(null, true, 'AXLiveRegionSearchKey', '', false, false) === 3
+PASS: webArea.uiElementCountForSearchPredicate(null, true, 'AXLiveRegionSearchKey', '', false, false) === 2
+PASS: webArea.uiElementCountForSearchPredicate(null, true, 'AXLiveRegionSearchKey', '', false, false) === 1
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Hello

--- a/LayoutTests/accessibility/mac/live-regions/live-region-search.html
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-search.html
@@ -1,0 +1,60 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ IsAriaLiveRegionManagementEnabled=true ] -->
+<!-- This is a copy of a test that runs with IsAriaLiveRegionManagementEnabled OFF (accessibility/mac/live-region-search.html) -->
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="container">
+</div>
+
+<script>
+var output = "This test ensures that live region searches work correctly after dynamic page changes.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var container = document.getElementById("container");
+    var webArea = accessibilityController.rootElement.childAtIndex(0);
+    output += expect("webArea.uiElementCountForSearchPredicate(null, true, 'AXLiveRegionSearchKey', '', false, false)", "0");
+
+    var dynamicStatus = document.createElement("div");
+    dynamicStatus.id = "dynamic-status";
+    dynamicStatus.role = "status";
+    dynamicStatus.innerText = "Hello";
+
+    var dynamicStatus2 = document.createElement("div");
+    dynamicStatus2.id = "dynamic-status2";
+    dynamicStatus2.role = "status";
+    dynamicStatus2.innerText = "Hello2";
+
+    container.appendChild(dynamicStatus);
+    setTimeout(async function() {
+        output += await expectAsync("webArea.uiElementCountForSearchPredicate(null, true, 'AXLiveRegionSearchKey', '', false, false)", "1");
+        dynamicStatus = document.getElementById("container").removeChild(dynamicStatus);
+        output += await expectAsync("webArea.uiElementCountForSearchPredicate(null, true, 'AXLiveRegionSearchKey', '', false, false)", "0");
+        container.appendChild(dynamicStatus);
+        output += await expectAsync("webArea.uiElementCountForSearchPredicate(null, true, 'AXLiveRegionSearchKey', '', false, false)", "1");
+        dynamicStatus.role = "group";
+        output += await expectAsync("webArea.uiElementCountForSearchPredicate(null, true, 'AXLiveRegionSearchKey', '', false, false)", "0");
+        dynamicStatus.setAttribute("aria-live", "polite");
+        output += await expectAsync("webArea.uiElementCountForSearchPredicate(null, true, 'AXLiveRegionSearchKey', '', false, false)", "1");
+        container.setAttribute("aria-live", "polite");
+        output += await expectAsync("webArea.uiElementCountForSearchPredicate(null, true, 'AXLiveRegionSearchKey', '', false, false)", "2");
+        container.appendChild(dynamicStatus2);
+        output += await expectAsync("webArea.uiElementCountForSearchPredicate(null, true, 'AXLiveRegionSearchKey', '', false, false)", "3");
+        container.removeAttribute("aria-live");
+        output += await expectAsync("webArea.uiElementCountForSearchPredicate(null, true, 'AXLiveRegionSearchKey', '', false, false)", "2");
+        dynamicStatus2.remove();
+        output += await expectAsync("webArea.uiElementCountForSearchPredicate(null, true, 'AXLiveRegionSearchKey', '', false, false)", "1");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -1497,7 +1497,6 @@ void AXObjectCache::handleLiveRegionCreated(Element& element)
 #if PLATFORM(COCOA)
         if (m_liveRegionManager) {
             m_liveRegionManager->registerLiveRegion(*axObject, true);
-            return;
         }
 #endif
 


### PR DESCRIPTION
#### b3430e45aaa7815acba70da4356d3b1026b5c62f
<pre>
AX: LiveRegionSearchKey should work with the new live region mechanism
<a href="https://bugs.webkit.org/show_bug.cgi?id=305068">https://bugs.webkit.org/show_bug.cgi?id=305068</a>
<a href="https://rdar.apple.com/167717949">rdar://167717949</a>

Reviewed by Tyler Wilcock.

Even with the new AXLiveRegionManager, we should still be using the deferred sorted live
region list to serve the AXLiveRegionSearchKey. Since it is a deferred mechanism, enabling
this doesn&apos;t have any adverse performance effects, until an AT decides to make a search
request for this key.

This PR unblocks the paths that build this list that were previously blocked when the
live region manager was active.

Test: accessibility/mac/live-regions/live-region-search.html

* LayoutTests/accessibility/mac/live-regions/live-region-search-expected.txt: Added.
* LayoutTests/accessibility/mac/live-regions/live-region-search.html: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::handleLiveRegionCreated):
* Source/WebCore/accessibility/mac/AXObjectCacheMac.mm:
(WebCore::AXObjectCache::deferSortForNewLiveRegion):
(WebCore::AXObjectCache::sortedLiveRegions):
(WebCore::AXObjectCache::removeLiveRegion):
(WebCore::AXObjectCache::initializeSortedIDLists):

Canonical link: <a href="https://commits.webkit.org/305282@main">https://commits.webkit.org/305282@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c05670ace43a7afd3586be9b9278d58a7a6f3f3b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137900 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10264 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49256 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145967 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90875 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/061daa15-a325-4370-b5d2-cb88de7bc743) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139772 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10966 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10404 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105464 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140845 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8168 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123622 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86315 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b0b87043-a9a2-4897-bb2a-37675dfd8305) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7789 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5539 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6248 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117183 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41784 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148677 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9947 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42344 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113863 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9964 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8396 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114194 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29033 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7727 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119872 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64671 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9993 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37879 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9723 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73561 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9934 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9785 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->