### PR TITLE
[libpas] Add stat counter for MTE tag writes

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_stats.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_stats.c
@@ -430,6 +430,7 @@ static const char* pas_stats_heap_type_to_string(pas_stats_heap_type heap_type)
         return "bitfit";
     case pas_stats_heap_type_large:
         return "large";
+    case pas_stats_heap_type_unknown:
     default:
         return "unknown";
     }
@@ -446,6 +447,7 @@ char* pas_stats_malloc_info_dump_to_json(void* stat_v)
      *     "segregated": <NUM>,
      *     "bitfit": <NUM>,
      *     "large": <NUM>,
+     *     "unknown": <NUM>,
      *   },
      *   "count_by_size": {
      *     "0": <NUM>,

--- a/Source/bmalloc/libpas/src/libpas/pas_stats.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_stats.h
@@ -206,6 +206,7 @@ typedef enum {
     pas_stats_heap_type_segregated = 0,
     pas_stats_heap_type_bitfit = 1,
     pas_stats_heap_type_large = 2,
+    pas_stats_heap_type_unknown = 3,
 
     pas_stats_heap_type_count
 } pas_stats_heap_type;
@@ -302,7 +303,9 @@ PAS_API void pas_stats_page_alloc_counts_record(pas_stats_page_alloc_counts_data
 #define PAS_STATS_FOR_EACH_COUNTER(OP) \
     OP(page_alloc_counts, pas_stats_page_alloc_counts_data, pas_stats_page_alloc_counts_dump_to_json) \
     OP(malloc_info_bytes, pas_stats_malloc_info_data, pas_stats_malloc_info_dump_to_json) \
-    OP(malloc_info_allocations, pas_stats_malloc_info_data, pas_stats_malloc_info_dump_to_json)
+    OP(malloc_info_allocations, pas_stats_malloc_info_data, pas_stats_malloc_info_dump_to_json) \
+    OP(malloc_info_mte_tagged_bytes, pas_stats_malloc_info_data, pas_stats_malloc_info_dump_to_json)
+
 
 // FIXME: in principle it should be possible to automatically generate this via PAS_STATS_FOR_EACH_COUNTER, somehow
 #define PAS_RECORD_STAT_page_alloc_counts(data, size, may_contain_small_or_medium, mapped_with_mte) \
@@ -311,6 +314,8 @@ PAS_API void pas_stats_page_alloc_counts_record(pas_stats_page_alloc_counts_data
     pas_stats_malloc_info_record(data, heap_type, size, size)
 #define PAS_RECORD_STAT_malloc_info_allocations(data, heap_type, size) \
     pas_stats_malloc_info_record(data, heap_type, size, 1)
+#define PAS_RECORD_STAT_malloc_info_mte_tagged_bytes(data, heap_type, size) \
+    pas_stats_malloc_info_record(data, heap_type, size, size)
 
 #endif /* PAS_ENABLE_STATS */
 


### PR DESCRIPTION
#### 2524255c3ed20f4397266b08c06d37d496b59c6e
<pre>
[libpas] Add stat counter for MTE tag writes
<a href="https://bugs.webkit.org/show_bug.cgi?id=305070">https://bugs.webkit.org/show_bug.cgi?id=305070</a>
<a href="https://rdar.apple.com/167718427">rdar://167718427</a>

Reviewed by Dan Hecht.

This is helpful for considering the effect of different tagging
policies on how much memory we tag, both for performance and
(to a lesser extent) security.

This also demacroifies the tag-setting code while I&apos;m touching it
anyways, as the actual code-change there is only one line and thus
should be easy to distinguish from the rest.

Canonical link: <a href="https://commits.webkit.org/305426@main">https://commits.webkit.org/305426@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/493dd341a84f95d7f9aa79aa12e1b534f5c3757f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137884 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10248 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49239 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145950 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90859 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e2eb360f-19c4-4703-a94c-f8cfb8c6da67) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10950 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10388 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105461 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/76953 "Exiting early after 60 failures. 21467 tests run. 60 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d460d5cd-2215-4ea4-8209-25cc26d39726) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140829 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8164 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123624 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86312 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/20cfd7e5-a2cf-496d-ba93-a9befa068df4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7785 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5531 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6232 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/129848 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117179 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41788 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148661 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/136425 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9931 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42347 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113864 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9948 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8388 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114195 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29104 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7728 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119874 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64655 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9977 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37881 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/169156 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9707 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44113 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9918 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9769 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->