### PR TITLE
[Win] Fix WebGL regression after 304611@main

### DIFF
--- a/Source/ThirdParty/ANGLE/src/libANGLE/formatutils.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/formatutils.cpp
@@ -1762,7 +1762,7 @@ bool InternalFormat::computeRowDepthSkipBytes(GLenum formatType,
                                               GLuint *skipBytesOut) const
 {
     GLuint rowPitch = 0;
-    if (!computeRowPitch(type, area.width, unpack.alignment, unpack.rowLength, &rowPitch))
+    if (!computeRowPitch(formatType, area.width, unpack.alignment, unpack.rowLength, &rowPitch))
     {
         return false;
     }
@@ -1776,7 +1776,7 @@ bool InternalFormat::computeRowDepthSkipBytes(GLenum formatType,
     const GLuint skipRows   = static_cast<GLuint>(unpack.skipRows);
     const GLuint skipPixels = static_cast<GLuint>(unpack.skipPixels);
     const GLuint skipImages = is3D ? static_cast<GLuint>(unpack.skipImages) : 0u;
-    if (!computeSkipBytes(type, rowPitch, depthPitch, skipRows, skipPixels, skipImages, &skipBytes))
+    if (!computeSkipBytes(formatType, rowPitch, depthPitch, skipRows, skipPixels, skipImages, &skipBytes))
     {
         return false;
     }
@@ -1793,7 +1793,7 @@ bool InternalFormat::computeRowSkipBytes(GLenum formatType,
                                          GLuint *skipBytesOut) const
 {
     GLuint rowPitch = 0;
-    if (!computeRowPitch(type, width, pack.alignment, pack.rowLength, &rowPitch))
+    if (!computeRowPitch(formatType, width, pack.alignment, pack.rowLength, &rowPitch))
     {
         return false;
     }
@@ -1802,7 +1802,7 @@ bool InternalFormat::computeRowSkipBytes(GLenum formatType,
     const GLuint skipRows   = static_cast<GLuint>(pack.skipRows);
     const GLuint skipPixels = static_cast<GLuint>(pack.skipPixels);
     const GLuint skipImages = 0u;
-    if (!computeSkipBytes(type, rowPitch, depthPitch, skipRows, skipPixels, skipImages, &skipBytes))
+    if (!computeSkipBytes(formatType, rowPitch, depthPitch, skipRows, skipPixels, skipImages, &skipBytes))
     {
         return false;
     }


### PR DESCRIPTION
#### d5114b38ca89d9cbdfdddb71937a71a15e80ff08
<pre>
[Win] Fix WebGL regression after 304611@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=305073">https://bugs.webkit.org/show_bug.cgi?id=305073</a>

Reviewed by Yusuke Suzuki.

Incorrectly using `type` from the InternalFormat struct, instead of the
passed parameter `formatType`.

Canonical link: <a href="https://commits.webkit.org/305288@main">https://commits.webkit.org/305288@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38699de6fe3d398a67d4b0e0b01fb904476c6db0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137890 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10254 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49245 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145957 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90865 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10956 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10394 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105468 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/76955 "11 flakes 9 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140835 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8160 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123617 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86319 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7781 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5530 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6238 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117175 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41779 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148667 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9937 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42339 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113868 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9954 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8387 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114189 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29037 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7720 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119867 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64661 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/9983 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37875 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9713 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9924 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9775 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->