### PR TITLE
[Swift in WebKit] Work towards modularizing PAL (part 5)

### DIFF
--- a/Source/WebCore/PAL/pal/cocoa/AVFoundationSoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/AVFoundationSoftLink.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+// FIXME: Remove the `__has_feature(modules)` condition when possible.
+#if !__has_feature(modules)
+
 #include <wtf/Compiler.h>
 #include <wtf/Platform.h>
 
@@ -452,3 +455,5 @@ SPECIALIZE_OBJC_TYPE_TRAITS(AVSampleBufferVideoRenderer, PAL::getAVSampleBufferV
 SPECIALIZE_OBJC_TYPE_TRAITS(AVOutputContext, PAL::getAVOutputContextClassSingleton())
 
 #endif // USE(AVFOUNDATION)
+
+#endif // !__has_feature(modules)

--- a/Source/WebCore/PAL/pal/cocoa/PassKitSoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/PassKitSoftLink.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+// FIXME: (rdar://167375656) Remove the `__has_feature(modules)` condition when possible.
+#if !__has_feature(modules)
+
 #if USE(PASSKIT)
 
 #import <pal/spi/cocoa/PassKitSPI.h>
@@ -164,3 +167,5 @@ SOFT_LINK_FUNCTION_FOR_HEADER(PAL, PassKitCore, PKCanMakePaymentsWithMerchantIde
 #define PKCanMakePaymentsWithMerchantIdentifierDomainAndSourceApplication PAL::softLink_PassKitCore_PKCanMakePaymentsWithMerchantIdentifierDomainAndSourceApplication
 
 #endif // USE(PASSKIT)
+
+#endif // !__has_feature(modules)

--- a/Source/WebCore/PAL/pal/spi/cf/CFNetworkSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cf/CFNetworkSPI.h
@@ -69,6 +69,8 @@ DECLARE_SYSTEM_HEADER
 
 #if defined(__OBJC__)
 
+#include <Foundation/Foundation.h>
+
 @interface _NSHTTPConnectionInfo : NSObject
 - (void)sendPingWithReceiveHandler:(void (^)(NSError * _Nullable error, NSTimeInterval interval))pongHandler;
 @property (readonly) BOOL isValid;

--- a/Source/WebCore/PAL/pal/spi/cf/CoreTextSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cf/CoreTextSPI.h
@@ -33,12 +33,15 @@ DECLARE_SYSTEM_HEADER
 #include <CoreText/CoreText.h>
 #include <pal/spi/cg/CoreGraphicsSPI.h>
 
-// FIXME: (rdar://167351286) Remove the `__has_feature(modules)` condition when possible.
-#if USE(APPLE_INTERNAL_SDK) && !__has_feature(modules)
+#if USE(APPLE_INTERNAL_SDK)
 
 #include <CoreText/CoreTextPriv.h>
 #include <OTSVG/OTSVG.h>
+
+// FIXME: (rdar://167351286) Remove the `__has_feature(modules)` condition when possible.
+#if !__has_feature(modules)
 #include <fparse/FPFontParser.h>
+#endif
 
 #else
 

--- a/Source/WebCore/PAL/pal/spi/cf/VideoToolboxSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cf/VideoToolboxSPI.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
 #include <wtf/Compiler.h>
 #include <wtf/Platform.h>
 

--- a/Source/WebCore/PAL/pal/spi/cocoa/AVAssetWriterSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/AVAssetWriterSPI.h
@@ -33,6 +33,8 @@ DECLARE_SYSTEM_HEADER
 
 #else
 
+#import <AVFoundation/AVAssetWriter.h>
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface AVFragmentedMediaDataReport : NSObject

--- a/Source/WebCore/PAL/pal/spi/cocoa/AVStreamDataParserSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/AVStreamDataParserSPI.h
@@ -38,26 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol AVStreamDataParserOutputHandling;
 @class AVStreamDataParserInternal;
 
-@interface AVStreamDataParser : NSObject {
-@private
-    AVStreamDataParserInternal *_parser;
-}
-
-- (void)setDelegate:(nullable id<AVStreamDataParserOutputHandling>)delegate;
-- (void)appendStreamData:(NSData *)data;
-typedef NS_ENUM(NSUInteger, AVStreamDataParserStreamDataFlags) {
-    AVStreamDataParserStreamDataDiscontinuity = 1 << 0,
-};
-- (void)appendStreamData:(NSData *)data withFlags:(AVStreamDataParserStreamDataFlags)flags;
-- (void)providePendingMediaData;
-- (void)setShouldProvideMediaData:(BOOL)shouldProvideMediaData forTrackID:(CMPersistentTrackID)trackID;
-- (BOOL)shouldProvideMediaDataForTrackID:(CMPersistentTrackID)trackID;
-@end
-
 @protocol AVStreamDataParserOutputHandling <NSObject>
-typedef NS_ENUM(NSUInteger, AVStreamDataParserOutputMediaDataFlags) {
-    AVStreamDataParserOutputMediaDataReserved = 1 << 0
-};
 @optional
 - (void)streamDataParser:(AVStreamDataParser *)streamDataParser didParseStreamDataAsAsset:(AVAsset *)asset withDiscontinuity:(BOOL)withDiscontinuity;
 - (void)streamDataParser:(AVStreamDataParser *)streamDataParser didFailToParseStreamDataWithError:(NSError *)err;

--- a/Source/WebCore/PAL/pal/spi/cocoa/AccessibilitySupportSoftLink.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/AccessibilitySupportSoftLink.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#ifdef __cplusplus
+
 #include <pal/spi/cocoa/AccessibilitySupportSPI.h>
 #include <wtf/SoftLinking.h>
 
@@ -36,3 +38,5 @@ SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(PAL, libAccessibility, _AXSIsolatedTreeMo
 #define _AXSIsolatedTreeModeFunctionIsAvailable PAL::islibAccessibilityLibaryAvailable() && PAL::canLoad_libAccessibility__AXSIsolatedTreeMode
 
 #endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+
+#endif // __cplusplus

--- a/Source/WebCore/PAL/pal/spi/cocoa/CommonCryptoSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/CommonCryptoSPI.h
@@ -69,6 +69,8 @@ typedef struct CCKDFParameters *CCKDFParametersRef;
 
 #endif
 
+#ifdef __cplusplus
+
 typedef struct _CCRSACryptor *CCRSACryptorRef;
 extern "C" CCCryptorStatus CCRSACryptorEncrypt(CCRSACryptorRef publicKey, CCAsymmetricPadding padding, const void *plainText, size_t plainTextLen, void *cipherText, size_t *cipherTextLen, const void *tagData, size_t tagDataLen, CCDigestAlgorithm digestType);
 extern "C" CCCryptorStatus CCRSACryptorDecrypt(CCRSACryptorRef privateKey, CCAsymmetricPadding padding, const void *cipherText, size_t cipherTextLen, void *plainText, size_t *plainTextLen, const void *tagData, size_t tagDataLen, CCDigestAlgorithm digestType);
@@ -126,5 +128,7 @@ extern "C" void CCKDFParametersDestroy(CCKDFParametersRef params);
 extern "C" CCCryptorStatus CCCryptorGCM(CCOperation op, CCAlgorithm alg, const void* key, size_t keyLength, const void* iv, size_t ivLen, const void* aData, size_t aDataLen, const void* dataIn, size_t dataInLength, void* dataOut, void* tag, size_t* tagLength);
 extern "C" CCCryptorStatus CCCryptorGCMOneshotDecrypt(CCAlgorithm alg, const void *key, size_t keyLength, const void  *iv, size_t ivLen, const void  *aData, size_t aDataLen, const void *dataIn, size_t dataInLength, void        *dataOut, const void  *tagIn, size_t tagLength);
 extern "C" CCCryptorStatus CCRSACryptorCreateFromData(CCRSAKeyType keyType, const uint8_t *modulus, size_t modulusLength, const uint8_t *exponent, size_t exponentLength, const uint8_t *p, size_t pLength, const uint8_t *q, size_t qLength, CCRSACryptorRef *ref);
+
+#endif // __cplusplus
 
 #endif // !USE(APPLE_INTERNAL_SDK)

--- a/Source/WebCore/PAL/pal/spi/cocoa/DataDetectorsCoreSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/DataDetectorsCoreSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#import <wtf/Compiler.h>
+#import <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if ENABLE(DATA_DETECTION)
@@ -47,8 +50,6 @@ typedef struct CF_BRIDGED_TYPE(id) __DDResult *DDResultRef;
 #endif // PLATFORM(IOS_FAMILY)
 
 #else // !USE(APPLE_INTERNAL_SDK)
-
-#import <wtf/Compiler.h>
 
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 
@@ -179,10 +180,10 @@ static inline CFIndex _DDScanQueryGetNumberOfFragments(DDScanQueryRef query)
 
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
-#endif
-
 typedef CFIndex DDScannerCopyResultsOptions;
 typedef CFIndex DDScannerOptions;
+
+#endif // !USE(APPLE_INTERNAL_SDK)
 
 enum {
     DDScannerSourceSpotlight = 1<<1,

--- a/Source/WebCore/PAL/pal/spi/cocoa/NSAttributedStringSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/NSAttributedStringSPI.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#ifdef __cplusplus
+
 #include <wtf/Compiler.h>
 #include <wtf/Platform.h>
 
@@ -147,3 +149,5 @@ static NSString *const NSExcludedElementsDocumentAttribute = @"ExcludedElements"
 @end
 
 #endif // PLATFORM(IOS_FAMILY)
+
+#endif // __cplusplus

--- a/Source/WebCore/PAL/pal/spi/cocoa/NSButtonCellSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/NSButtonCellSPI.h
@@ -30,6 +30,8 @@
 
 DECLARE_SYSTEM_HEADER
 
+#if PLATFORM(MAC)
+
 #import <AppKit/NSButtonCell.h>
 
 #if USE(APPLE_INTERNAL_SDK)
@@ -47,3 +49,4 @@ DECLARE_SYSTEM_HEADER
 
 #endif
 
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/PAL/pal/spi/cocoa/PassKitInstallmentsSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/PassKitInstallmentsSPI.h
@@ -30,9 +30,7 @@
 
 DECLARE_SYSTEM_HEADER
 
-#ifndef PAL_PASSKIT_SPI_GUARD_AGAINST_INDIRECT_INCLUSION
-#error "Please #include <pal/spi/cocoa/PassKitSPI.h> instead of this file directly."
-#endif
+#ifdef PAL_PASSKIT_SPI_GUARD_AGAINST_INDIRECT_INCLUSION
 
 #if HAVE(PASSKIT_INSTALLMENTS)
 
@@ -119,3 +117,5 @@ typedef NS_ENUM(NSUInteger, PKPaymentRequestType) {
 #endif // !USE(APPLE_INTERNAL_SDK)
 
 #endif // HAVE(PASSKIT_INSTALLMENTS)
+
+#endif // PAL_PASSKIT_SPI_GUARD_AGAINST_INDIRECT_INCLUSION

--- a/Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+// FIXME: Remove the `__has_feature(modules)` condition when possible.
+#if !__has_feature(modules)
+
 #include <wtf/Compiler.h>
 #include <wtf/Platform.h>
 
@@ -403,3 +406,5 @@ NS_ASSUME_NONNULL_END
 @property (nonatomic, assign) BOOL isDelegatedRequest;
 @end
 #endif // HAVE(PASSKIT_DELEGATED_REQUEST)
+
+#endif // !__has_feature(modules)

--- a/Source/WebCore/PAL/pal/spi/cocoa/RevealSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/RevealSPI.h
@@ -36,7 +36,6 @@ DECLARE_SYSTEM_HEADER
 #if PLATFORM(MAC)
 #import <pal/spi/mac/NSImmediateActionGestureRecognizerSPI.h>
 #endif // PLATFORM(MAC)
-#import <wtf/SoftLinking.h>
 
 #if ENABLE(REVEAL)
 

--- a/Source/WebCore/PAL/pal/spi/cocoa/WebPrivacySPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/WebPrivacySPI.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#ifdef __cplusplus
+
 #include <wtf/Compiler.h>
 #include <wtf/Platform.h>
 
@@ -234,3 +236,5 @@ extern NSNotificationName const WPResourceDataChangedNotificationName;
 WTF_EXTERN_C_END
 
 #endif // ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
+
+#endif // __cplusplus

--- a/Source/WebCore/PAL/pal/spi/ios/BarcodeSupportSPI.h
+++ b/Source/WebCore/PAL/pal/spi/ios/BarcodeSupportSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+// FIXME: Remove the `__has_feature(modules)` condition when possible.
+#if !__has_feature(modules)
+
 DECLARE_SYSTEM_HEADER
 
 #if PLATFORM(IOS) || PLATFORM(VISION)
@@ -50,3 +53,5 @@ DECLARE_SYSTEM_HEADER
 #endif // USE(APPLE_INTERNAL_SDK)
 
 #endif // PLATFORM(IOS) || PLATFORM(VISION)
+
+#endif // !__has_feature(modules)

--- a/Source/WebCore/PAL/pal/spi/ios/CelestialSPI.h
+++ b/Source/WebCore/PAL/pal/spi/ios/CelestialSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+// FIXME: Remove the `__has_feature(modules)` condition when possible.
+#if !__has_feature(modules)
+
 DECLARE_SYSTEM_HEADER
 
 #if HAVE(MEDIAEXPERIENCE_AVSYSTEMCONTROLLER)
@@ -52,3 +55,5 @@ DECLARE_SYSTEM_HEADER
 #endif
 
 #endif // HAVE(MEDIAEXPERIENCE_AVSYSTEMCONTROLLER)
+
+#endif // !__has_feature(modules)

--- a/Source/WebCore/PAL/pal/spi/ios/DataDetectorsUISoftLink.h
+++ b/Source/WebCore/PAL/pal/spi/ios/DataDetectorsUISoftLink.h
@@ -23,6 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef __cplusplus
+
+#import <wtf/Platform.h>
+
 #if PLATFORM(IOS_FAMILY) && ENABLE(DATA_DETECTION)
 
 #import <pal/spi/ios/DataDetectorsUISPI.h>
@@ -42,3 +46,5 @@ SOFT_LINK_CONSTANT_FOR_HEADER(PAL, DataDetectorsUI, kDataDetectorsTrailingText, 
 SOFT_LINK_CONSTANT_FOR_HEADER(PAL, DataDetectorsUI, kDDContextMenuWantsPreviewKey, const NSString *)
 
 #endif
+
+#endif // __cplusplus

--- a/Source/WebCore/PAL/pal/spi/ios/ManagedConfigurationSPI.h
+++ b/Source/WebCore/PAL/pal/spi/ios/ManagedConfigurationSPI.h
@@ -25,6 +25,12 @@
 
 #pragma once
 
+// FIXME: Remove the `__has_feature(modules)` condition when possible.
+#if !__has_feature(modules)
+
+#import <wtf/Compiler.h>
+#import <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if PLATFORM(IOS_FAMILY) && !PLATFORM(MACCATALYST)
@@ -77,3 +83,5 @@ typedef enum MCRestrictedBoolType {
 #endif
 
 #endif // PLATFORM(IOS_FAMILY) && !PLATFORM(MACCATALYST)
+
+#endif // !__has_feature(modules)

--- a/Source/WebCore/PAL/pal/spi/ios/MediaPlayerSPI.h
+++ b/Source/WebCore/PAL/pal/spi/ios/MediaPlayerSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+// FIXME: (rdar://165540771) Remove the `__has_feature(modules)` condition when possible.
+#if !__has_feature(modules)
+
 DECLARE_SYSTEM_HEADER
 
 #import <wtf/Platform.h>
@@ -35,8 +38,6 @@ DECLARE_SYSTEM_HEADER
 #import <UIKit/UIKit.h>
 
 #if USE(APPLE_INTERNAL_SDK)
-
-// FIXME: (rdar://165540771) This file is invalid in a module because MediaPlayer has incorrect extern_c attributes in its dependencies.
 
 #import <MediaPlayer/MPAVRoutingController.h>
 
@@ -78,3 +79,5 @@ NS_ASSUME_NONNULL_END
 #endif
 
 #endif // PLATFORM(IOS_FAMILY)
+
+#endif // !__has_feature(modules)

--- a/Source/WebCore/PAL/pal/spi/ios/SBSStatusBarSPI.h
+++ b/Source/WebCore/PAL/pal/spi/ios/SBSStatusBarSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+// FIXME: Remove the `__has_feature(modules)` condition when possible.
+#if !__has_feature(modules)
+
 DECLARE_SYSTEM_HEADER
 
 #import <wtf/Platform.h>
@@ -79,3 +82,5 @@ typedef void (^SBSStatusBarStyleOverridesAssertionAcquisitionHandler)(BOOL acqui
 #endif // USE(APPLE_INTERNAL_SDK)
 
 #endif // PLATFORM(IOS_FAMILY)
+
+#endif // !__has_feature(modules)

--- a/Source/WebCore/PAL/pal/spi/ios/SystemPreviewSPI.h
+++ b/Source/WebCore/PAL/pal/spi/ios/SystemPreviewSPI.h
@@ -25,6 +25,11 @@
 
 #pragma once
 
+#import <wtf/Compiler.h>
+#import <wtf/Platform.h>
+
+#if PLATFORM(IOS_FAMILY)
+
 DECLARE_SYSTEM_HEADER
 
 #if USE(APPLE_INTERNAL_SDK)
@@ -150,3 +155,5 @@ NS_ASSUME_NONNULL_END
 #endif
 
 #endif
+
+#endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/PAL/pal/spi/ios/UIKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/ios/UIKitSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+// FIXME: Remove the `__has_feature(modules)` condition when possible.
+#if !__has_feature(modules)
+
 DECLARE_SYSTEM_HEADER
 
 #if PLATFORM(IOS_FAMILY)
@@ -316,3 +319,5 @@ typedef NS_ENUM(NSUInteger, NSTextTabType) {
 @end
 
 #endif // PLATFORM(IOS_FAMILY)
+
+#endif // !__has_feature(modules)

--- a/Source/WebCore/PAL/pal/spi/mac/DataDetectorsSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/DataDetectorsSPI.h
@@ -34,7 +34,6 @@ DECLARE_SYSTEM_HEADER
 #if ENABLE(DATA_DETECTION)
 
 #import <pal/spi/cocoa/DataDetectorsCoreSPI.h>
-#import <wtf/SoftLinking.h>
 
 #if PLATFORM(MAC)
 

--- a/Source/WebCore/PAL/pal/spi/mac/HIServicesSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/HIServicesSPI.h
@@ -30,6 +30,8 @@
 
 DECLARE_SYSTEM_HEADER
 
+#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
+
 #include <pal/spi/cg/CoreGraphicsSPI.h>
 #include <span>
 #include <wtf/StdLibExtras.h>
@@ -179,3 +181,5 @@ typedef Boolean (*AXAuditTokenIsAuthenticatedCallback)(audit_token_t);
 WTF_EXTERN_C_END
 
 #define kAXClientTypeWebKitTesting 999999
+
+#endif // PLATFORM(MAC) || PLATFORM(MACCATALYST)

--- a/Source/WebCore/PAL/pal/spi/mac/HIToolboxSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/HIToolboxSPI.h
@@ -30,6 +30,8 @@
 
 DECLARE_SYSTEM_HEADER
 
+#if PLATFORM(MAC)
+
 #if USE(APPLE_INTERNAL_SDK)
 
 #include <Carbon/CarbonPriv.h>
@@ -56,3 +58,5 @@ CFTypeRef TSMGetInputSourceProperty(TSMInputSourceRef, TSMInputSourcePropertyTag
 OSStatus GetEventParameter(EventRef, EventParamName inName, EventParamType inDesiredType, EventParamType* outActualType, ByteCount inBufferSize, ByteCount* outActualSize, void* outData);
 
 WTF_EXTERN_C_END
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/PAL/pal/spi/mac/NSColorSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSColorSPI.h
@@ -30,9 +30,11 @@
 
 DECLARE_SYSTEM_HEADER
 
+#if PLATFORM(MAC)
+
 #import <AppKit/NSColor.h>
 
-#if PLATFORM(MAC) && USE(APPLE_INTERNAL_SDK)
+#if USE(APPLE_INTERNAL_SDK)
 
 #import <AppKit/NSColor_Private.h>
 #import <AppKit/NSColor_UserAccent.h>
@@ -79,3 +81,5 @@ extern "C" void NSColorSetUserAccentColor(NSUserAccentColor key, BOOL sendNotifi
 @property (class, strong, readonly) NSColor *tertiarySystemFillColor;
 @end
 #endif
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/PAL/pal/spi/mac/QuickLookMacSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/QuickLookMacSPI.h
@@ -30,6 +30,8 @@
 
 DECLARE_SYSTEM_HEADER
 
+#if PLATFORM(MAC)
+
 #import <Quartz/Quartz.h>
 
 // FIXME: (rdar://167376152) Remove the `__has_feature(modules)` condition when possible.
@@ -99,3 +101,5 @@ typedef NS_ENUM(NSInteger, QLPreviewActivity) {
 @end
 
 #endif // HAVE(QUICKLOOK_ITEM_PREVIEW_OPTIONS)
+
+#endif // PLATFORM(MAC)


### PR DESCRIPTION
#### 3046a6cb9f089f7423b61ecfb17674e01b8e6db9
<pre>
[Swift in WebKit] Work towards modularizing PAL (part 5)
<a href="https://bugs.webkit.org/show_bug.cgi?id=305074">https://bugs.webkit.org/show_bug.cgi?id=305074</a>
<a href="https://rdar.apple.com/167721363">rdar://167721363</a>

Reviewed by Mike Wyrzykowski.

Add some missing headers and missing compilation guards.

* Source/WebCore/PAL/pal/cocoa/AVFoundationSoftLink.h:
* Source/WebCore/PAL/pal/cocoa/PassKitSoftLink.h:
* Source/WebCore/PAL/pal/spi/cf/CFNetworkSPI.h:
* Source/WebCore/PAL/pal/spi/cf/CoreTextSPI.h:
* Source/WebCore/PAL/pal/spi/cf/VideoToolboxSPI.h:
* Source/WebCore/PAL/pal/spi/cocoa/AVAssetWriterSPI.h:
* Source/WebCore/PAL/pal/spi/cocoa/AVKitSPI.h:
* Source/WebCore/PAL/pal/spi/cocoa/AVStreamDataParserSPI.h:
* Source/WebCore/PAL/pal/spi/cocoa/AccessibilitySupportSoftLink.h:
* Source/WebCore/PAL/pal/spi/cocoa/CommonCryptoSPI.h:
* Source/WebCore/PAL/pal/spi/cocoa/DataDetectorsCoreSPI.h:
* Source/WebCore/PAL/pal/spi/cocoa/NSAttributedStringSPI.h:
* Source/WebCore/PAL/pal/spi/cocoa/NSButtonCellSPI.h:
* Source/WebCore/PAL/pal/spi/cocoa/PassKitInstallmentsSPI.h:
* Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h:
* Source/WebCore/PAL/pal/spi/cocoa/RevealSPI.h:
* Source/WebCore/PAL/pal/spi/cocoa/WebPrivacySPI.h:
* Source/WebCore/PAL/pal/spi/ios/BarcodeSupportSPI.h:
* Source/WebCore/PAL/pal/spi/ios/CelestialSPI.h:
* Source/WebCore/PAL/pal/spi/ios/DataDetectorsUISoftLink.h:
* Source/WebCore/PAL/pal/spi/ios/ManagedConfigurationSPI.h:
* Source/WebCore/PAL/pal/spi/ios/MediaPlayerSPI.h:
* Source/WebCore/PAL/pal/spi/ios/SBSStatusBarSPI.h:
* Source/WebCore/PAL/pal/spi/ios/SystemPreviewSPI.h:
* Source/WebCore/PAL/pal/spi/ios/UIKitSPI.h:
* Source/WebCore/PAL/pal/spi/mac/DataDetectorsSPI.h:
* Source/WebCore/PAL/pal/spi/mac/HIServicesSPI.h:
* Source/WebCore/PAL/pal/spi/mac/HIToolboxSPI.h:
* Source/WebCore/PAL/pal/spi/mac/NSColorSPI.h:
* Source/WebCore/PAL/pal/spi/mac/QuickLookMacSPI.h:

Canonical link: <a href="https://commits.webkit.org/305253@main">https://commits.webkit.org/305253@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bcabdef75ef1b394333016b3b6c2cb14eaa24764

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137950 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10314 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49312 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/146017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/90925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3ea63881-1e6d-4ea1-bad0-e94e51947ec4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139823 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11016 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10457 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/146017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/90925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/86a82971-e2f8-4bb9-8c8a-6d4521ef6f7d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140895 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8210 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123664 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/146017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f377d2b8-0dfc-4ea0-9404-73d5830bb9f0) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/7824 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/5577 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe-cairo-libwebrtc~~](https://ews-build.webkit.org/#/builders/166/builds/6299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117219 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41834 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148727 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9997 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42393 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/113891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10014 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8434 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/114221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29006 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7765 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119920 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64721 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10043 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/37915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9774 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/73611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9984 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9835 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->