### PR TITLE
Adjust container query units for page zoom

### DIFF
--- a/LayoutTests/fast/css/container-query-units-page-zoom-expected.html
+++ b/LayoutTests/fast/css/container-query-units-page-zoom-expected.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Container query units with page zoom - expected</title>
+    <style>
+        body {
+            margin: 0;
+        }
+        .container {
+            /* 200px * 2x zoom = 400px */
+            width: 400px;
+            /* 100px * 2x zoom = 200px */
+            height: 200px;
+            background-color: red;
+            overflow: hidden;
+            position: relative;
+        }
+        .inner {
+            width: 400px;
+            height: 200px;
+            background-color: green;
+        }
+        .caption {
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            /* 100cqw = 200px CSS * 2x zoom = 400px */
+            width: 400px;
+            text-align: center;
+            /* 5cqmin = 5% of min(400,200) = 10px CSS, 2x zoom = 20px */
+            font-size: 20px;
+            line-height: 1.2;
+            color: white;
+            background: black;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="inner"></div>
+        <div class="caption">Caption Text</div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/fast/css/container-query-units-page-zoom.html
+++ b/LayoutTests/fast/css/container-query-units-page-zoom.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Container query units with page zoom</title>
+    <meta name="assert" content="Container query units should be adjusted for page zoom for sizing properties">
+    <style>
+        body {
+            margin: 0;
+        }
+        .container {
+            width: 200px;
+            height: 100px;
+            background-color: red;
+            container-type: size;
+            overflow: hidden;
+            position: relative;
+        }
+        .inner {
+            width: 100cqw;
+            height: 100cqh;
+            background-color: green;
+        }
+        .caption {
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            width: 100cqw;
+            text-align: center;
+            font-size: 5cqmin;
+            line-height: 1.2;
+            color: white;
+            background: black;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="inner"></div>
+        <div class="caption">Caption Text</div>
+    </div>
+</body>
+<script>
+    if (window.internals)
+        window.internals.setPageZoomFactor(2);
+</script>
+</html>

--- a/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
+++ b/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
@@ -254,7 +254,12 @@ double computeNonCalcLengthDouble(double value, CSS::LengthUnit lengthUnit, cons
             auto* containerRenderer = dynamicDowncast<RenderBox>(element->renderer());
             if (containerRenderer && containerRenderer->hasEligibleContainmentForSizeQuery()) {
                 auto widthOrHeight = physicalAxis == CQ::Axis::Width ? containerRenderer->contentBoxWidth() : containerRenderer->contentBoxHeight();
-                return widthOrHeight * value / 100;
+                auto adjustedWidthOrHeight = widthOrHeight.toDouble();
+
+                if (!conversionData.computingFontSize())
+                    adjustedWidthOrHeight = adjustValueForPageZoom(adjustedWidthOrHeight, conversionData);
+
+                return adjustedWidthOrHeight * value / 100;
             }
             // For pseudo-elements the element itself can be the container. Avoid looping forever.
             mode = Style::ContainerQueryEvaluator::SelectionMode::Element;


### PR DESCRIPTION
#### a7f4812384d238f2c1a3200071940e4eb2057a92
<pre>
Adjust container query units for page zoom
<a href="https://rdar.apple.com/167711217">rdar://167711217</a>

Reviewed by Brent Fulgham.

Container query units were not adjusted for page zoom when
evaluation-time zoom is enabled, causing elements to overflow their containers.
Viewport units already had this adjustment via adjustValueForPageZoom.

Apply the same zoom adjustment to container query units, except when computing
font-size so that text still scales with page zoom.

User impact: On marketwatch.com, zoomed-in pages caused video captions to
incorrectly display outside video bounds.

Test: fast/css/container-query-units-page-zoom.html

* LayoutTests/fast/css/container-query-units-page-zoom-expected.html: Added.
* LayoutTests/fast/css/container-query-units-page-zoom.html: Added.
* Source/WebCore/style/values/primitives/StyleLengthResolution.cpp:
(WebCore::Style::computeNonCalcLengthDouble):

Canonical link: <a href="https://commits.webkit.org/305263@main">https://commits.webkit.org/305263@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66b77b8944fd7db5a91a9c51b902d57af1d648d2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137971 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10335 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49340 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146039 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/90946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d562be20-2dab-45df-b299-6d65185dd781) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139844 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11037 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10480 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/105509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/90946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140916 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8231 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/123695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/86361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4668bca7-bd95-4efe-ac43-f44ce7ec4bce) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7845 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5597 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6321 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117241 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41866 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148750 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10018 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42425 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/113911 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10035 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8454 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114242 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29016 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7782 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119952 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64742 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10064 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/37943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9795 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/73632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10005 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9856 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->