### PR TITLE
Improve clip-path duplicate ID removal test timing

### DIFF
--- a/LayoutTests/svg/clip-path-duplicate-id-removal.html
+++ b/LayoutTests/svg/clip-path-duplicate-id-removal.html
@@ -35,15 +35,21 @@
     if (window.testRunner)
         testRunner.waitUntilDone();
 
-    document.querySelector('svg').remove();
-
-    // Force repaint. A direct script removal doesn't force the repaint
-    // needed to re-resolve the clip-path reference and expose the bug.
-    document.body.style.background = 'white';
-
+    // Wait for initial paint so the clip-path is applied and cached,
+    // then remove the first SVG (which is NOT the registered resource
+    // since the last duplicate wins) and force a repaint.
     requestAnimationFrame(() => {
-        if (window.testRunner)
-            testRunner.notifyDone();
+        setTimeout(() => {
+            document.querySelector('svg').remove();
+
+            // Force repaint to re-resolve the clip-path reference.
+            document.body.style.background = 'white';
+
+            requestAnimationFrame(() => {
+                if (window.testRunner)
+                    testRunner.notifyDone();
+            });
+        }, 0);
     });
 </script>
 </body>


### PR DESCRIPTION
#### e61410c543d4108f77eecd91d08ff117030f75a2
<pre>
Improve clip-path duplicate ID removal test timing
<a href="https://bugs.webkit.org/show_bug.cgi?id=305079">https://bugs.webkit.org/show_bug.cgi?id=305079</a>
<a href="https://rdar.apple.com/problem/167726176">rdar://problem/167726176</a>

Reviewed by Simon Fraser.

Follow up to 305197@main

Wait for the initial paint to complete before removing the SVG element.
This allows the test to properly expose the bug on unpatched builds.

* LayoutTests/svg/clip-path-duplicate-id-removal.html:

Canonical link: <a href="https://commits.webkit.org/305261@main">https://commits.webkit.org/305261@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/028697bb478c9b456bf50ca177d653fa17d316ac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137911 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10275 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49268 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145978 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90886 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8f2e2584-d513-4402-941c-4f2674dfaeca) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10977 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10416 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105471 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/88c9c8e9-8d66-41bb-8165-ac37a19d6308) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140856 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8181 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123633 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86322 "Found 1 new API test failure: TestWebKit:WebKit.PageLoadState (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/75d96eee-cea4-49f6-a568-96d198e79402) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7799 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5547 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6259 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117193 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41798 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148688 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9958 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42357 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113870 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9975 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8404 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114200 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29015 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7735 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119884 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64682 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10004 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37889 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9734 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9945 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9796 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->