### PR TITLE
[GFC][Cleanup] Move some logic that checks eligibility to some helper functions

### DIFF
--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
@@ -100,6 +100,86 @@ enum class GridAvoidanceReason : uint8_t {
     }
 #endif
 
+static std::optional<GridAvoidanceReason> hasValidGridTemplateColumnsList(const Style::GridTemplateList& gridTemplateColumns)
+{
+    auto& gridTemplateColumnsTrackList = gridTemplateColumns.list;
+    if (gridTemplateColumnsTrackList.isEmpty())
+        return GridAvoidanceReason::GridHasUnsupportedGridTemplateColumns;
+
+    for (auto& columnsTrackListEntry : gridTemplateColumnsTrackList) {
+        auto avoidanceReason = WTF::switchOn(columnsTrackListEntry,
+            [&](const Style::GridTrackSize& trackSize) -> std::optional<GridAvoidanceReason> {
+                // Since a GridTrackSize type of Breadth sets the MinTrackBreadth and
+                // MaxTrackBreadth to the same value we only need to check one.
+                if (!trackSize.isBreadth() || !trackSize.minTrackBreadth().isLength())
+                    return GridAvoidanceReason::GridHasUnsupportedGridTemplateColumns;
+
+                auto& gridTrackBreadthLength = trackSize.minTrackBreadth().length();
+                if (!gridTrackBreadthLength.isFixed())
+                    return GridAvoidanceReason::GridHasUnsupportedGridTemplateColumns;
+                return std::nullopt;
+            },
+            [&](const Vector<String>& names) -> std::optional<GridAvoidanceReason> {
+                if (!names.isEmpty())
+                    return GridAvoidanceReason::GridHasUnsupportedGridTemplateColumns;
+                return std::nullopt;
+            },
+            [&](const Style::GridTrackEntryRepeat&) {
+                return std::make_optional(GridAvoidanceReason::GridHasUnsupportedGridTemplateColumns);
+            },
+            [&](const Style::GridTrackEntryAutoRepeat&) {
+                return std::make_optional(GridAvoidanceReason::GridHasUnsupportedGridTemplateColumns);
+            },
+            [&](const Style::GridTrackEntrySubgrid&) {
+                return std::make_optional(GridAvoidanceReason::GridHasUnsupportedGridTemplateColumns);
+            }
+        );
+        if (avoidanceReason)
+            return avoidanceReason;
+    }
+    return { };
+}
+
+static std::optional<GridAvoidanceReason> hasValidGridTemplateRowsList(const Style::GridTemplateList& gridTemplateRows)
+{
+    auto& gridTemplateRowsTrackList = gridTemplateRows.list;
+    if (gridTemplateRowsTrackList.isEmpty())
+        return GridAvoidanceReason::GridHasUnsupportedGridTemplateRows;
+
+    for (auto& rowsTrackListEntry : gridTemplateRowsTrackList) {
+        auto avoidanceReason = WTF::switchOn(rowsTrackListEntry,
+            [&](const Style::GridTrackSize& trackSize) -> std::optional<GridAvoidanceReason> {
+                // Since a GridTrackSize type of Breadth sets the MinTrackBreadth and
+                // MaxTrackBreadth to the same value we only need to check one.
+                if (!trackSize.isBreadth() || !trackSize.minTrackBreadth().isLength())
+                    return GridAvoidanceReason::GridHasUnsupportedGridTemplateRows;
+
+                auto& gridTrackBreadthLength = trackSize.minTrackBreadth().length();
+                if (!gridTrackBreadthLength.isFixed())
+                    return GridAvoidanceReason::GridHasUnsupportedGridTemplateRows;
+                return std::nullopt;
+            },
+            [&](const Vector<String>& names) -> std::optional<GridAvoidanceReason> {
+                if (!names.isEmpty())
+                    return GridAvoidanceReason::GridHasUnsupportedGridTemplateRows;
+                return std::nullopt;
+            },
+            [&](const Style::GridTrackEntryRepeat&) {
+                return std::make_optional(GridAvoidanceReason::GridHasUnsupportedGridTemplateRows);
+            },
+            [&](const Style::GridTrackEntryAutoRepeat&) {
+                return std::make_optional(GridAvoidanceReason::GridHasUnsupportedGridTemplateRows);
+            },
+            [&](const Style::GridTrackEntrySubgrid&) {
+                return std::make_optional(GridAvoidanceReason::GridHasUnsupportedGridTemplateRows);
+            }
+        );
+
+        if (avoidanceReason)
+            return avoidanceReason;
+    }
+    return { };
+}
 
 static std::optional<GridAvoidanceReason> hasValidColumnEnd(const Style::GridPositionExplicit&, const Style::GridPosition columnEnd, size_t linesFromGridTemplateColumnsCount)
 {
@@ -121,6 +201,26 @@ static std::optional<GridAvoidanceReason> hasValidColumnEnd(const Style::GridPos
     );
 }
 
+static std::optional<GridAvoidanceReason> hasValidColumnPlacement(const Style::GridPosition& columnStart, const Style::GridPosition& columnEnd, unsigned linesFromGridTemplateColumnsCount)
+{
+    return WTF::switchOn(columnStart,
+        [&](const CSS::Keyword::Auto&) -> std::optional<GridAvoidanceReason> {
+            return GridAvoidanceReason::GridItemHasUnsupportedColumnPlacement;
+        },
+        [&](const Style::GridPositionExplicit& explicitPosition) -> std::optional<GridAvoidanceReason> {
+            if (!columnStart.namedGridLine().isEmpty() || columnStart.explicitPosition() < 0 || columnStart.explicitPosition() > static_cast<int>(linesFromGridTemplateColumnsCount))
+                return GridAvoidanceReason::GridItemHasUnsupportedColumnPlacement;
+            return hasValidColumnEnd(explicitPosition, columnEnd, linesFromGridTemplateColumnsCount);
+        },
+        [&](const Style::GridPositionSpan&) -> std::optional<GridAvoidanceReason> {
+            return GridAvoidanceReason::GridItemHasUnsupportedColumnPlacement;
+        },
+        [&](const CustomIdentifier&) -> std::optional<GridAvoidanceReason> {
+            return GridAvoidanceReason::GridItemHasUnsupportedColumnPlacement;
+        }
+    );
+}
+
 static std::optional<GridAvoidanceReason> hasValidRowEnd(const Style::GridPositionExplicit&, const Style::GridPosition rowEnd, size_t linesFromGridTemplateRowsCount)
 {
     return WTF::switchOn(rowEnd,
@@ -131,6 +231,26 @@ static std::optional<GridAvoidanceReason> hasValidRowEnd(const Style::GridPositi
             if (!rowEnd.namedGridLine().isEmpty() || rowEnd.explicitPosition() < 0 || rowEnd.explicitPosition() > static_cast<int>(linesFromGridTemplateRowsCount))
                 return GridAvoidanceReason::GridItemHasUnsupportedRowPlacement;
             return { };
+        },
+        [&](const Style::GridPositionSpan&) -> std::optional<GridAvoidanceReason> {
+            return GridAvoidanceReason::GridItemHasUnsupportedRowPlacement;
+        },
+        [&](const CustomIdentifier&) -> std::optional<GridAvoidanceReason> {
+            return GridAvoidanceReason::GridItemHasUnsupportedRowPlacement;
+        }
+    );
+}
+
+static std::optional<GridAvoidanceReason> hasValidRowPlacement(const Style::GridPosition& rowStart, const Style::GridPosition& rowEnd, unsigned linesFromGridTemplateRowsCount)
+{
+    return WTF::switchOn(rowStart,
+        [&](const CSS::Keyword::Auto&) -> std::optional<GridAvoidanceReason> {
+            return GridAvoidanceReason::GridItemHasUnsupportedRowPlacement;
+        },
+        [&](const Style::GridPositionExplicit& explicitPosition) -> std::optional<GridAvoidanceReason> {
+            if (!rowStart.namedGridLine().isEmpty() || rowStart.explicitPosition() < 0 || rowStart.explicitPosition() > static_cast<int>(linesFromGridTemplateRowsCount))
+                return GridAvoidanceReason::GridItemHasUnsupportedRowPlacement;
+            return hasValidRowEnd(explicitPosition, rowEnd, linesFromGridTemplateRowsCount);
         },
         [&](const Style::GridPositionSpan&) -> std::optional<GridAvoidanceReason> {
             return GridAvoidanceReason::GridItemHasUnsupportedRowPlacement;
@@ -198,86 +318,15 @@ static EnumSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& 
         ADD_REASON_AND_RETURN_IF_NEEDED(GridHasGridTemplateAreas, reasons, reasonCollectionMode);
 
     auto& gridTemplateColumns = renderGridStyle->gridTemplateColumns();
-    auto& gridTemplateColumnsTrackList = gridTemplateColumns.list;
-    if (gridTemplateColumnsTrackList.isEmpty())
+    if (auto gridTemplateColumnsAvoidanceReason = hasValidGridTemplateColumnsList(gridTemplateColumns)) {
+        ASSERT(gridTemplateColumnsAvoidanceReason == GridAvoidanceReason::GridHasUnsupportedGridTemplateColumns);
         ADD_REASON_AND_RETURN_IF_NEEDED(GridHasUnsupportedGridTemplateColumns, reasons, reasonCollectionMode);
-
-    for (auto& columnsTrackListEntry : gridTemplateColumnsTrackList) {
-
-        auto avoidanceReason = WTF::switchOn(columnsTrackListEntry,
-            [&](const Style::GridTrackSize& trackSize) -> std::optional<GridAvoidanceReason> {
-                // Since a GridTrackSize type of Breadth sets the MinTrackBreadth and
-                // MaxTrackBreadth to the same value we only need to check one.
-                if (!trackSize.isBreadth() || !trackSize.minTrackBreadth().isLength())
-                    return GridAvoidanceReason::GridHasUnsupportedGridTemplateColumns;
-
-                auto& gridTrackBreadthLength = trackSize.minTrackBreadth().length();
-                if (!gridTrackBreadthLength.isFixed())
-                    return GridAvoidanceReason::GridHasUnsupportedGridTemplateColumns;
-                return std::nullopt;
-            },
-            [&](const Vector<String>& names) -> std::optional<GridAvoidanceReason> {
-                if (!names.isEmpty())
-                    return GridAvoidanceReason::GridHasUnsupportedGridTemplateColumns;
-                return std::nullopt;
-            },
-            [&](const Style::GridTrackEntryRepeat&) {
-                return std::make_optional(GridAvoidanceReason::GridHasUnsupportedGridTemplateColumns);
-            },
-            [&](const Style::GridTrackEntryAutoRepeat&) {
-                return std::make_optional(GridAvoidanceReason::GridHasUnsupportedGridTemplateColumns);
-            },
-            [&](const Style::GridTrackEntrySubgrid&) {
-                return std::make_optional(GridAvoidanceReason::GridHasUnsupportedGridTemplateColumns);
-            }
-        );
-
-        if (avoidanceReason) {
-            reasons.add(*avoidanceReason);
-            if (reasonCollectionMode == ReasonCollectionMode::FirstOnly)
-                return reasons;
-        }
     }
 
     auto& gridTemplateRows = renderGridStyle->gridTemplateRows();
-    auto& gridTemplateRowsTrackList = gridTemplateRows.list;
-    if (gridTemplateRowsTrackList.isEmpty())
+    if (auto gridTemplateRowsAvoidanceReason = hasValidGridTemplateRowsList(gridTemplateRows)) {
+        ASSERT(gridTemplateRowsAvoidanceReason == GridAvoidanceReason::GridHasUnsupportedGridTemplateRows);
         ADD_REASON_AND_RETURN_IF_NEEDED(GridHasUnsupportedGridTemplateRows, reasons, reasonCollectionMode);
-
-    for (auto& rowsTrackListEntry : gridTemplateRowsTrackList) {
-        auto avoidanceReason = WTF::switchOn(rowsTrackListEntry,
-            [&](const Style::GridTrackSize& trackSize) -> std::optional<GridAvoidanceReason> {
-                // Since a GridTrackSize type of Breadth sets the MinTrackBreadth and
-                // MaxTrackBreadth to the same value we only need to check one.
-                if (!trackSize.isBreadth() || !trackSize.minTrackBreadth().isLength())
-                    return GridAvoidanceReason::GridHasUnsupportedGridTemplateRows;
-
-                auto& gridTrackBreadthLength = trackSize.minTrackBreadth().length();
-                if (!gridTrackBreadthLength.isFixed())
-                    return GridAvoidanceReason::GridHasUnsupportedGridTemplateRows;
-                return std::nullopt;
-            },
-            [&](const Vector<String>& names) -> std::optional<GridAvoidanceReason> {
-                if (!names.isEmpty())
-                    return GridAvoidanceReason::GridHasUnsupportedGridTemplateRows;
-                return std::nullopt;
-            },
-            [&](const Style::GridTrackEntryRepeat&) {
-                return std::make_optional(GridAvoidanceReason::GridHasUnsupportedGridTemplateRows);
-            },
-            [&](const Style::GridTrackEntryAutoRepeat&) {
-                return std::make_optional(GridAvoidanceReason::GridHasUnsupportedGridTemplateRows);
-            },
-            [&](const Style::GridTrackEntrySubgrid&) {
-                return std::make_optional(GridAvoidanceReason::GridHasUnsupportedGridTemplateRows);
-            }
-        );
-
-        if (avoidanceReason) {
-            reasons.add(*avoidanceReason);
-            if (reasonCollectionMode == ReasonCollectionMode::FirstOnly)
-                return reasons;
-        }
     }
 
     if (renderGridStyle->usedContain().contains(Style::ContainValue::Size))
@@ -337,49 +386,14 @@ static EnumSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& 
             ADD_REASON_AND_RETURN_IF_NEEDED(GridItemHasUnsupportedBlockAxisAlignment, reasons, reasonCollectionMode);
 
         auto linesFromGridTemplateColumnsCount = gridTemplateColumns.sizes.size() + 1;
-        auto linesFromGridTemplateRowsCount = gridTemplateRows.sizes.size() + 1;
-        auto& columnStart = gridItemStyle->gridItemColumnStart();
-        auto columnPositioningAvoidanceReason = WTF::switchOn(columnStart,
-            [&](const CSS::Keyword::Auto&) -> std::optional<GridAvoidanceReason> {
-                return GridAvoidanceReason::GridItemHasUnsupportedColumnPlacement;
-            },
-            [&](const Style::GridPositionExplicit& explicitPosition) -> std::optional<GridAvoidanceReason> {
-                if (!columnStart.namedGridLine().isEmpty() || columnStart.explicitPosition() < 0 || columnStart.explicitPosition() > static_cast<int>(linesFromGridTemplateColumnsCount))
-                    return GridAvoidanceReason::GridItemHasUnsupportedColumnPlacement;
-                return hasValidColumnEnd(explicitPosition, gridItemStyle->gridItemColumnEnd(), linesFromGridTemplateColumnsCount);
-            },
-            [&](const Style::GridPositionSpan&) -> std::optional<GridAvoidanceReason> {
-                return GridAvoidanceReason::GridItemHasUnsupportedColumnPlacement;
-            },
-            [&](const CustomIdentifier&) -> std::optional<GridAvoidanceReason> {
-                return GridAvoidanceReason::GridItemHasUnsupportedColumnPlacement;
-            }
-        );
-
-        if (columnPositioningAvoidanceReason) {
+        if (auto columnPositioningAvoidanceReason = hasValidColumnPlacement(gridItemStyle->gridItemColumnStart(), gridItemStyle->gridItemColumnEnd(), linesFromGridTemplateColumnsCount)) {
             ASSERT(columnPositioningAvoidanceReason == GridAvoidanceReason::GridItemHasUnsupportedColumnPlacement);
             ADD_REASON_AND_RETURN_IF_NEEDED(GridItemHasUnsupportedColumnPlacement, reasons, reasonCollectionMode);
         }
 
-        auto& rowStart = gridItemStyle->gridItemRowStart();
-        auto rowPositioningAvoidanceReason = WTF::switchOn(rowStart,
-            [&](const CSS::Keyword::Auto&) -> std::optional<GridAvoidanceReason> {
-                return GridAvoidanceReason::GridItemHasUnsupportedRowPlacement;
-            },
-            [&](const Style::GridPositionExplicit& explicitPosition) -> std::optional<GridAvoidanceReason> {
-                if (!rowStart.namedGridLine().isEmpty() || rowStart.explicitPosition() < 0 || rowStart.explicitPosition() > static_cast<int>(linesFromGridTemplateRowsCount))
-                    return GridAvoidanceReason::GridItemHasUnsupportedRowPlacement;
-                return hasValidRowEnd(explicitPosition, gridItemStyle->gridItemRowEnd(), linesFromGridTemplateRowsCount);
-            },
-            [&](const Style::GridPositionSpan&) -> std::optional<GridAvoidanceReason> {
-                return GridAvoidanceReason::GridItemHasUnsupportedRowPlacement;
-            },
-            [&](const CustomIdentifier&) -> std::optional<GridAvoidanceReason> {
-                return GridAvoidanceReason::GridItemHasUnsupportedRowPlacement;
-            }
-        );
+        auto linesFromGridTemplateRowsCount = gridTemplateRows.sizes.size() + 1;
 
-        if (rowPositioningAvoidanceReason) {
+        if (auto rowPositioningAvoidanceReason = hasValidRowPlacement(gridItemStyle->gridItemRowStart(), gridItemStyle->gridItemRowEnd(), linesFromGridTemplateRowsCount)) {
             ASSERT(rowPositioningAvoidanceReason == GridAvoidanceReason::GridItemHasUnsupportedRowPlacement);
             ADD_REASON_AND_RETURN_IF_NEEDED(GridItemHasUnsupportedRowPlacement, reasons, reasonCollectionMode);
         }


### PR DESCRIPTION
#### d2b8f8b4b84665ed31350d876f9acec62264e590
<pre>
[GFC][Cleanup] Move some logic that checks eligibility to some helper functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=305080">https://bugs.webkit.org/show_bug.cgi?id=305080</a>
<a href="https://rdar.apple.com/167726683">rdar://167726683</a>

Reviewed by NOBODY (OOPS!).

Right now gridLayoutAvoidanceReason is populated with some verbose
checks that make it a bit difficult to read the high level logic at a
glance. Specifically, the logic to check the grid template lists as well
as a grid item&apos;s placement a lot of extra lines of code that checks the
different combinations. We can improve the readability a bit by moving
each of these pieces into their own dedicated function.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2b8f8b4b84665ed31350d876f9acec62264e590

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138023 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10388 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49419 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146094 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90998 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/6f8a8fa9-6768-4670-a41e-da2d5b818cd8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139896 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11089 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10538 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105551 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77023 "8 flakes 13 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b1998504-dd33-46ca-b1a4-8393cd69eaa9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140969 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8275 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123748 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86400 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/07a1bb83-d8cc-4da3-b46d-68d0c4ce69b0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7889 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5647 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6375 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117286 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41934 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148804 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10070 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42492 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113953 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10087 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8504 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114286 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7829 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120022 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64794 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10116 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37986 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9847 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73684 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10057 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9908 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->