### PR TITLE
[libpas] Add stat counter for pas_page_malloc

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_stats.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_stats.h
@@ -278,6 +278,13 @@ typedef struct {
     uint64_t count_by_size[PAS_STATS_MALLOC_INFO_BUCKET_COUNT_PER_STAT];
 } pas_stats_malloc_info_data;
 
+typedef struct {
+    pas_stats_stat_base base;
+    uint64_t total_bytes_mapped;
+    uint64_t bytes_mapped_mte_tagged;
+    uint64_t bytes_mapped_may_contain_small_or_medium;
+} pas_stats_page_alloc_counts_data;
+
 #define PAS_STATS_UINT64_MAX_STRING_LEN 20
 
 #if PAS_ENABLE_STATS
@@ -285,15 +292,21 @@ typedef struct {
 PAS_API char* pas_stats_malloc_info_dump_to_json(void* stat_v);
 PAS_API void pas_stats_malloc_info_record(pas_stats_malloc_info_data* data, pas_stats_heap_type heap_type, size_t size, size_t count);
 
+PAS_API char* pas_stats_page_alloc_counts_dump_to_json(void* stat_v);
+PAS_API void pas_stats_page_alloc_counts_record(pas_stats_page_alloc_counts_data* data, size_t size, bool may_contain_small_or_medium, bool mapped_with_mte);
+
 // Arguments:
 //   - stat-name
 //   - struct used to store stat data
 //   - function used to dump that struct to json
 #define PAS_STATS_FOR_EACH_COUNTER(OP) \
+    OP(page_alloc_counts, pas_stats_page_alloc_counts_data, pas_stats_page_alloc_counts_dump_to_json) \
     OP(malloc_info_bytes, pas_stats_malloc_info_data, pas_stats_malloc_info_dump_to_json) \
     OP(malloc_info_allocations, pas_stats_malloc_info_data, pas_stats_malloc_info_dump_to_json)
 
 // FIXME: in principle it should be possible to automatically generate this via PAS_STATS_FOR_EACH_COUNTER, somehow
+#define PAS_RECORD_STAT_page_alloc_counts(data, size, may_contain_small_or_medium, mapped_with_mte) \
+    pas_stats_page_alloc_counts_record(data, size, may_contain_small_or_medium, mapped_with_mte)
 #define PAS_RECORD_STAT_malloc_info_bytes(data, heap_type, size) \
     pas_stats_malloc_info_record(data, heap_type, size, size)
 #define PAS_RECORD_STAT_malloc_info_allocations(data, heap_type, size) \


### PR DESCRIPTION
#### 60b468c78c7d8471aa5aa10228ed896b9d3dbde1
<pre>
[libpas] Add stat counter for pas_page_malloc
<a href="https://bugs.webkit.org/show_bug.cgi?id=305081">https://bugs.webkit.org/show_bug.cgi?id=305081</a>
<a href="https://rdar.apple.com/167727200">rdar://167727200</a>

Reviewed by Keith Miller.

This new counter tracks:
  1. the number of bytes mapped
  2. the number of those bytes which were mapped with backing MTE memory
  3. the number of those bytes which were used for small or medium pages
Notably, this does not include mmap calls used e.g. for zeroing pages,
or by clients of libpas who map their own memory before passing it in
(e.g. the JIT heap).

Canonical link: <a href="https://commits.webkit.org/305303@main">https://commits.webkit.org/305303@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4fb87f76b12e654ed0f2dc30a1ee65a6c95a166c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138044 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10409 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49445 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146116 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/91019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11111 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10560 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105569 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/91019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5976d4ba-ce94-4513-bea4-8d020957d8d9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140990 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8296 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123766 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86418 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/832516a6-896e-4aa2-82f2-8aff007c7e62) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7909 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/5666 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6397 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/130008 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/117307 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41956 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148825 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/136599 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10091 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42514 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113972 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10108 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8523 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114305 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29045 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7844 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120043 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64815 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10137 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/38003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/169316 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9868 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44154 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10078 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9929 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->