### PR TITLE
Unreviewed, reverting 305233@main (560b5b740328)

### DIFF
--- a/Source/WTF/Scripts/audit-spi-if-needed.sh
+++ b/Source/WTF/Scripts/audit-spi-if-needed.sh
@@ -29,14 +29,10 @@ if [[ "${WK_AUDIT_SPI}" == YES && -f "${program}" ]]; then
         fi
     done
 
-    # Use a different cache file for different SDKs (either different
-    # platforms, or reusing the same build directory between different Xcodes).
-    sdk_name_unique="${SDK_NAME}_$(printf %s ${SDKROOT} | sha1)"
-
     for arch in ${ARCHS}; do
         (set -x && "${program}" \
          --sdkdb-dir "${versioned_sdkdb_dir}" \
-         --sdkdb-cache "${OBJROOT}/WebKitSDKDBs/${sdk_name_unique}.sqlite3" \
+         --sdkdb-cache "${OBJROOT}/WebKitSDKDBs/${SDK_NAME}.sqlite3" \
          --sdk-dir "${SDKROOT}" --arch-name "${arch}" \
          --depfile "${depfile}" \
          -F "${BUILT_PRODUCTS_DIR}" \

--- a/Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb.py
+++ b/Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb.py
@@ -421,7 +421,7 @@ class SDKDB:
                     'SELECT i.arch, i.kind, i.input_file, i.name, '
                     '       a.kind, group_concat(aw.input_file), a.name, '
                     '           min(a.allow_unused), '
-                    '       group_concat(ew.input_file), '
+                    '       ew.input_file, '
                     '       sum(e.name IS NOT NULL AND '
                     '           ew.input_file IS NOT NULL) as export_found, '
                     '       sum(a.name IS NOT NULL AND '
@@ -453,7 +453,7 @@ class SDKDB:
                     'ORDER BY i.input_file, i.kind, a.kind, i.name, a.name')
         for (arch, import_kind, input_path, import_name,
              allowed_kind, allowlist_paths, allowed_name, allow_unused,
-             export_paths, export_found, allow_found) in cur.fetchall():
+             export_path, export_found, allow_found) in cur.fetchall():
             if import_name and not export_found and not allow_found:
                 # Imported but neither exported nor allowed => possible SPI.
                 yield MissingName(name=import_name, file=Path(input_path),
@@ -470,10 +470,6 @@ class SDKDB:
                 # Allowed but also exported => unnecessary allowlist entry to
                 # remove.
                 for path in sorted(set(allowlist_paths.split(','))):
-                    # Normally, a declaration would only be exported from one
-                    # library in the SDK. If the cache sees multiple sources,
-                    # just pick one.
-                    export_path = min(export_paths.split(','))
                     yield UnnecessaryAllowedName(name=allowed_name,
                                                  file=Path(path),
                                                  kind=allowed_kind,

--- a/Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb_unittest.py
+++ b/Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb_unittest.py
@@ -138,10 +138,10 @@ class TestSDKDB(TestCase):
     def tearDown(self):
         self.sdkdb.con.close()
 
-    def add_library(self, fixture=R, file=F, file_hash=F_Hash):
+    def add_library(self):
         with self.sdkdb:
-            self.sdkdb._cache_hit_preparing_to_insert(file, file_hash)
-            self.sdkdb._add_api_report(fixture, file)
+            self.sdkdb._cache_hit_preparing_to_insert(F, F_Hash)
+            self.sdkdb._add_api_report(R, F)
 
     def add_partial_sdkdb(self):
         with self.sdkdb:
@@ -398,21 +398,3 @@ class TestSDKDB(TestCase):
                                              kind=OBJC_SEL,
                                              exported_in=F_Client),
                       self.audit_with(client))
-
-    def test_exported_in_nonnull(self):
-        # Add the same API declarations twice (i.e. two different SDKs loaded
-        # into the same cache).
-        self.add_library(file=Path('/some/other/sdk/libdoesntexist.dylib'))
-        self.add_library()
-
-        # Reconnect and load only the second source of our symbols.
-        self.reconnect()
-        self.add_library()
-
-        # Cause an UnnecessaryAllowedName. It should have a nonnull
-        # export_path.
-        self.add_allowlist()
-        self.assertIn(UnnecessaryAllowedName(name='initWithData:',
-                                             kind=OBJC_SEL, file=A_File,
-                                             exported_in=F),
-                      self.audit_with(R_Client))


### PR DESCRIPTION
#### 7edb9b43d6a2d096d9729b2c7de3c33c0fa7e8ba
<pre>
Unreviewed, reverting 305233@main (560b5b740328)
<a href="https://rdar.apple.com/167726984">rdar://167726984</a>

Broke the builds.

Reverted change:

    [audit-spi] SDKDB cache contains multiples of each API declaration when switching between Xcodes
    <a href="https://bugs.webkit.org/show_bug.cgi?id=304224">https://bugs.webkit.org/show_bug.cgi?id=304224</a>
    <a href="https://rdar.apple.com/166578115">rdar://166578115</a>
    305233@main (560b5b740328)

Canonical link: <a href="https://commits.webkit.org/305242@main">https://commits.webkit.org/305242@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f9b394c37cc52847514591734c2d8aa5c849780

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137920 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10284 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49278 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/145987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/90895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139792 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10986 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10425 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/145987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/90895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140865 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/8183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/123645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/145987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/137268 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/7801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/5552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo-libwebrtc~~](https://ews-build.webkit.org/#/builders/166/builds/6268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/129884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/117195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/41812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/148697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/136465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9967 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/42371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/148697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/9984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/8409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/148697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/119898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/64691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21227 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10013 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37900 "Build is in progress. Recent messages:") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/169192 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/9743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/73581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/44119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/9954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/9805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->