### PR TITLE
[Gardening]: [macOS] TestWebKitAPI.WebKit.MediaBufferingPolicy tests are flaky timeouts

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/MediaBufferingPolicy.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/MediaBufferingPolicy.mm
@@ -68,7 +68,7 @@ static void setWebViewVisible(TestWKWebView* webView, BOOL isVisible)
     TestWebKitAPI::Util::run(&stateChanged);
 }
 
-#if PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED <= 140000
+#if PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED < 150000
 TEST(WebKit, DISABLED_MediaBufferingPolicy)
 #else
 TEST(WebKit, MediaBufferingPolicy)
@@ -110,7 +110,7 @@ TEST(WebKit, MediaBufferingPolicy)
     waitUntilBufferingPolicyIsEqualTo(webView.get(), "Default");
 }
 
-#if PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED <= 140000
+#if PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED < 150000
 TEST(WebKit, DISABLED_MediaBufferingPolicyWhenSuspendedOrHidden)
 #else
 TEST(WebKit, MediaBufferingPolicyWhenSuspendedOrHidden)


### PR DESCRIPTION
#### 287eb0f15f467c3827371a29b624260cc5c1278a
<pre>
[Gardening]: [macOS] TestWebKitAPI.WebKit.MediaBufferingPolicy tests are flaky timeouts
<a href="https://bugs.webkit.org/show_bug.cgi?id=305008">https://bugs.webkit.org/show_bug.cgi?id=305008</a>
<a href="https://rdar.apple.com/167649319">rdar://167649319</a>

Unreviewed test Gardening

Another attempt to skip the tests in macOS Sonoma.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/MediaBufferingPolicy.mm:

Canonical link: <a href="https://commits.webkit.org/305244@main">https://commits.webkit.org/305244@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b179a94705d2f936b7248c3d580b0c292a491caa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137923 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10287 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49281 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/145990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/90898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1a2e1316-3284-41dd-b47d-1fa19ea5cdbf) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139795 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10989 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10428 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/145990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/90898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d409739e-9162-4944-a9de-61d09c60c49d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140868 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8185 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/123643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/145990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/7803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/5554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo-libwebrtc~~](https://ews-build.webkit.org/#/builders/166/builds/6272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/117197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41810 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/148700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9970 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/42369 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/148700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9987 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8411 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/148700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29000 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7740 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119896 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/64694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10016 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/37898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9746 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9957 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9808 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->