### PR TITLE
[audit-spi] SDKDB cache contains multiples of each API declaration when switching between Xcodes

### DIFF
--- a/Source/WTF/Scripts/audit-spi-if-needed.sh
+++ b/Source/WTF/Scripts/audit-spi-if-needed.sh
@@ -29,10 +29,14 @@ if [[ "${WK_AUDIT_SPI}" == YES && -f "${program}" ]]; then
         fi
     done
 
+    # Use a different cache file for different SDKs (either different
+    # platforms, or reusing the same build directory between different Xcodes).
+    sdk_name_unique="${SDK_NAME}_$(printf %s ${SDKROOT} | shasum | cut -wf1)"
+
     for arch in ${ARCHS}; do
         (set -x && "${program}" \
          --sdkdb-dir "${versioned_sdkdb_dir}" \
-         --sdkdb-cache "${OBJROOT}/WebKitSDKDBs/${SDK_NAME}.sqlite3" \
+         --sdkdb-cache "${OBJROOT}/WebKitSDKDBs/${sdk_name_unique}.sqlite3" \
          --sdk-dir "${SDKROOT}" --arch-name "${arch}" \
          --depfile "${depfile}" \
          -F "${BUILT_PRODUCTS_DIR}" \

--- a/Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb.py
+++ b/Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb.py
@@ -421,7 +421,7 @@ class SDKDB:
                     'SELECT i.arch, i.kind, i.input_file, i.name, '
                     '       a.kind, group_concat(aw.input_file), a.name, '
                     '           min(a.allow_unused), '
-                    '       ew.input_file, '
+                    '       group_concat(ew.input_file), '
                     '       sum(e.name IS NOT NULL AND '
                     '           ew.input_file IS NOT NULL) as export_found, '
                     '       sum(a.name IS NOT NULL AND '
@@ -453,7 +453,7 @@ class SDKDB:
                     'ORDER BY i.input_file, i.kind, a.kind, i.name, a.name')
         for (arch, import_kind, input_path, import_name,
              allowed_kind, allowlist_paths, allowed_name, allow_unused,
-             export_path, export_found, allow_found) in cur.fetchall():
+             export_paths, export_found, allow_found) in cur.fetchall():
             if import_name and not export_found and not allow_found:
                 # Imported but neither exported nor allowed => possible SPI.
                 yield MissingName(name=import_name, file=Path(input_path),
@@ -470,6 +470,10 @@ class SDKDB:
                 # Allowed but also exported => unnecessary allowlist entry to
                 # remove.
                 for path in sorted(set(allowlist_paths.split(','))):
+                    # Normally, a declaration would only be exported from one
+                    # library in the SDK. If the cache sees multiple sources,
+                    # just pick one.
+                    export_path = min(export_paths.split(','))
                     yield UnnecessaryAllowedName(name=allowed_name,
                                                  file=Path(path),
                                                  kind=allowed_kind,


### PR DESCRIPTION
#### 46d3869ef51b0802a88106e99f509f55c9ca1091
<pre>
[audit-spi] SDKDB cache contains multiples of each API declaration when switching between Xcodes
<a href="https://bugs.webkit.org/show_bug.cgi?id=304224">https://bugs.webkit.org/show_bug.cgi?id=304224</a>
<a href="https://rdar.apple.com/166578115">rdar://166578115</a>

Unreviewed, reland of 305233@main with scripting fix for older OS
versions.

We cache the SDKDB at a path like
`WebKitBuild/WebKitSDKDBs/iphoneos26.0.sqlite3`. When switching between
different Xcode bundles with the same SDK, the cache will be updated
with API declarations from each SDK, for libraries that we treat
as implicitly API and load from the SDK.

This wastes space and reveals a bug in the main query: when diagnosing
an UnnecessaryAllowedName, it may be exported from multiple entries in
the SDKDB cache; one for the loaded SDK, and others for the other copies
of the SDK seeded in the cache. The query assumes that the `input_file`
of the declaration will always be nonnull, because any matched
declaration comes from a file in the window. But because the field was
not aggregated, its value could come from one of the un-loaded entries
and be NULL.

Fix this, and change how Xcode invokes audit-spi to isolate different
copies of the same SDK.

* Source/WTF/Scripts/audit-spi-if-needed.sh:
* Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb.py:
(SDKDB.audit):
* Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb_unittest.py:
(TestSDKDB.add_library):
(TestSDKDB.test_audit_unnecessary_allow_unqualified_methods_same_name):
(TestSDKDB):
(TestSDKDB.test_exported_in_nonnull):

Canonical link: <a href="https://commits.webkit.org/305300@main">https://commits.webkit.org/305300@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b59719d4d9dd71c3b8a9eb69ad87306242d3e972

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137930 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10294 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49289 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/145997 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90905 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/29e1815c-cf1e-4664-bd37-230c4e2f4bce) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139802 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/10996 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10435 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105482 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/53e27ac6-2078-4ee8-abe1-89d07b2d4f02) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140875 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8195 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123647 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86333 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/26fbed35-209c-4ad8-985e-f80e61345851) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/137278 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7812 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5562 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6279 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/129894 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117206 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41814 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148707 "Built successfully") | | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/136476 "Found unexpected failure with change (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9977 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42373 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113882 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/9994 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8419 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114212 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7747 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119900 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64701 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21245 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10023 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37902 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/169202 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9753 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73591 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44121 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9964 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9815 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->