### PR TITLE
[CI Filters] Implement the FEComposite `arithmetic` operator in Core Image

### DIFF
--- a/Source/WebCore/platform/graphics/coreimage/FECompositeCoreImageApplier.h
+++ b/Source/WebCore/platform/graphics/coreimage/FECompositeCoreImageApplier.h
@@ -44,7 +44,10 @@ public:
     static bool supportsCoreImageRendering(const FEComposite&);
 
 private:
-    bool apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const final;
+    bool apply(const Filter&, std::span<const Ref<FilterImage>>, FilterImage&) const final;
+
+    RetainPtr<CIImage> applyBuiltIn(RetainPtr<CIImage>&&, RetainPtr<CIImage>&&, const FloatRect& extent) const;
+    RetainPtr<CIImage> applyArithmetic(RetainPtr<CIImage>&&, RetainPtr<CIImage>&&, const FloatRect& extent) const;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 7642fa7ea36b193acd6e638887c28847558e21f8
<pre>
[CI Filters] Implement the FEComposite `arithmetic` operator in Core Image
<a href="https://bugs.webkit.org/show_bug.cgi?id=305090">https://bugs.webkit.org/show_bug.cgi?id=305090</a>
<a href="https://rdar.apple.com/167732902">rdar://167732902</a>

Reviewed by Mike Wyrzykowski.

Implement a CI kernel to handle the &quot;arithmetic&quot; FECompositor operator,
which takes 4 factors; we pass those in using a CIVector.

* Source/WebCore/platform/graphics/coreimage/FECompositeCoreImageApplier.h:
* Source/WebCore/platform/graphics/coreimage/FECompositeCoreImageApplier.mm:
(WebCore::compositeArithmeticKernel):
(WebCore::FECompositeCoreImageApplier::FECompositeCoreImageApplier): Deleted.
(WebCore::FECompositeCoreImageApplier::supportsCoreImageRendering): Deleted.
(WebCore::FECompositeCoreImageApplier::apply const): Deleted.

Canonical link: <a href="https://commits.webkit.org/305309@main">https://commits.webkit.org/305309@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70b1c3ecb3d02475bd04d7ff1cf5a91256082807

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137939 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10303 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49298 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146006 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90914 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a7aa6a64-d166-400c-b1c1-b20473cd1432) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139811 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11005 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10445 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105485 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/76982 "Exiting early after 60 failures. 21505 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/dea2e944-0bff-4e3c-851a-f69c281eaf22) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140884 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8199 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123654 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86336 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7816 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5567 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6288 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117210 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41821 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148716 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9986 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42380 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113884 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10003 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8424 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114214 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29053 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7752 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119907 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64710 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10032 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37908 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9762 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73600 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9973 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9824 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->