### PR TITLE
Use FixedVector instead of Vector in SelectorQuery For SelectorData objects

### DIFF
--- a/Source/WebCore/css/CSSSelectorList.cpp
+++ b/Source/WebCore/css/CSSSelectorList.cpp
@@ -152,7 +152,7 @@ CSSSelectorList CSSSelectorList::makeJoining(const Vector<const CSSSelectorList*
     return CSSSelectorList { WTF::move(selectorArray) };
 }
 
-unsigned CSSSelectorList::listSize() const
+unsigned CSSSelectorList::size() const
 {
     return std::ranges::count_if(m_selectorArray, [](auto& selector) { return selector.isFirstInComplexSelector(); });
 }

--- a/Source/WebCore/css/CSSSelectorList.h
+++ b/Source/WebCore/css/CSSSelectorList.h
@@ -112,7 +112,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     void buildSelectorsText(StringBuilder&) const;
 
     unsigned componentCount() const { return m_selectorArray.size(); }
-    unsigned listSize() const;
+    unsigned size() const;
 
     CSSSelectorList& operator=(CSSSelectorList&&) = default;
 

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -253,7 +253,7 @@ bool SelectorChecker::matchHostPseudoClass(const CSSSelector& selector, const El
         return false;
 
     if (auto* selectorList = selector.selectorList()) {
-        ASSERT(selectorList->listSize() == 1);
+        ASSERT(selectorList->size() == 1);
         LocalContext context(selectorList->first(), element, VisitedMatchType::Enabled, std::nullopt);
         context.inFunctionalPseudoClass = true;
         context.pseudoElementEffective = false;

--- a/Source/WebCore/css/SelectorFilter.cpp
+++ b/Source/WebCore/css/SelectorFilter.cpp
@@ -169,7 +169,7 @@ void SelectorFilter::collectSimpleSelectorHash(CollectedSelectorHashes& collecte
         case CSSSelector::PseudoClass::Where:
             // We can use the filter in the trivial case of single argument :is()/:where().
             // Supporting the multiargument case would require more than one hash.
-            if (selector.selectorList()->listSize() == 1)
+            if (selector.selectorList()->size() == 1)
                 collectSelectorHashes(collectedHashes, selector.selectorList()->first(), IncludeRightmost::Yes);
             break;
         default:

--- a/Source/WebCore/css/StyleRule.h
+++ b/Source/WebCore/css/StyleRule.h
@@ -513,10 +513,10 @@ inline void StyleRule::adoptSelectorList(CSSSelectorList&& selectors)
 
 inline CompiledSelector& StyleRule::compiledSelectorForListIndex(unsigned index) const
 {
-    ASSERT(index < m_selectorList.listSize());
+    ASSERT(index < m_selectorList.size());
 
     if (m_compiledSelectors.isEmpty())
-        m_compiledSelectors = FixedVector<CompiledSelector>(m_selectorList.listSize());
+        m_compiledSelectors = FixedVector<CompiledSelector>(m_selectorList.size());
     return m_compiledSelectors[index];
 }
 

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -1315,7 +1315,7 @@ CSSSelectorList CSSSelectorParser::resolveNestingParent(const CSSSelectorList& n
             return simpleSelector.lastInCompound()->match() == CSSSelector::Match::Tag;
         };
 
-        if (list.listSize() != 1) {
+        if (list.size() != 1) {
             // .foo, .bar { & .baz {...} } -> :is(.foo, .bar) .baz {...}
             return false;
         }

--- a/Source/WebCore/dom/SelectorQuery.cpp
+++ b/Source/WebCore/dom/SelectorQuery.cpp
@@ -124,13 +124,11 @@ static bool canOptimizeSingleAttributeExactMatch(const CSSSelector& selector)
 
 SelectorDataList::SelectorDataList(const CSSSelectorList& selectorList)
 {
-    unsigned selectorCount = std::ranges::distance(selectorList);
+    m_selectors = FixedVector<SelectorData>::map(selectorList, [](auto& selector) {
+        return SelectorData { &selector };
+    });
 
-    m_selectors.reserveInitialCapacity(selectorCount);
-    for (auto& selector : selectorList)
-        m_selectors.append({ &selector });
-
-    if (selectorCount == 1) {
+    if (m_selectors.size() == 1) {
         const CSSSelector& selector = *m_selectors.first().selector;
         if (selector.isFirstInComplexSelector()) {
             switch (selector.match()) {

--- a/Source/WebCore/dom/SelectorQuery.h
+++ b/Source/WebCore/dom/SelectorQuery.h
@@ -82,7 +82,7 @@ private:
     static bool compileSelector(const SelectorData&);
 #endif // ENABLE(CSS_SELECTOR_JIT)
 
-    Vector<SelectorData> m_selectors;
+    FixedVector<SelectorData> m_selectors;
     mutable enum MatchType {
         CompilableSingle,
         CompilableSingleWithRootFilter,

--- a/Source/WebCore/html/track/WebVTTParser.cpp
+++ b/Source/WebCore/html/track/WebVTTParser.cpp
@@ -399,7 +399,7 @@ bool WebVTTParser::checkAndStoreStyleSheet(StringView line)
             return true;
 
         const auto& selectorList = styleRule->selectorList();
-        if (selectorList.listSize() != 1)
+        if (selectorList.size() != 1)
             return true;
         auto selector = selectorList.selectorAt(0);
         auto selectorText = selector->selectorText();


### PR DESCRIPTION
#### fa091dcc95457b382d308130f8bc6757559229f6
<pre>
Use FixedVector instead of Vector in SelectorQuery For SelectorData objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=305095">https://bugs.webkit.org/show_bug.cgi?id=305095</a>

Reviewed by Ryosuke Niwa.

Use FixedVector instead of Vector in SelectorQuery For SelectorData objects.
We don&apos;t need the modify the Vector here. Also use FixedVector::map() to
simplify the code a bit (This required me to rename CSSSelectorList::listSize()
to CSSSelectorList::size() so that it would work with std::size()).

This tested as performance neutral on Speedometer.

* Source/WebCore/css/CSSSelectorList.cpp:
(WebCore::CSSSelectorList::size const):
(WebCore::CSSSelectorList::listSize const): Deleted.
* Source/WebCore/css/CSSSelectorList.h:
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::matchHostPseudoClass const):
* Source/WebCore/css/SelectorFilter.cpp:
(WebCore::SelectorFilter::collectSimpleSelectorHash):
* Source/WebCore/css/StyleRule.h:
(WebCore::StyleRule::compiledSelectorForListIndex const):
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::resolveNestingParent):
* Source/WebCore/dom/SelectorQuery.cpp:
(WebCore::SelectorDataList::SelectorDataList):
* Source/WebCore/dom/SelectorQuery.h:
* Source/WebCore/html/track/WebVTTParser.cpp:
(WebCore::WebVTTParser::checkAndStoreStyleSheet):

Canonical link: <a href="https://commits.webkit.org/305258@main">https://commits.webkit.org/305258@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f51bcae3f3535bf59906d406c555993be8b0be8d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137952 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10316 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49314 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146019 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90927 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139825 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11018 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10459 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/105491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/76987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3054525a-8148-44c1-8f02-1820b9937a4e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140897 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8212 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123666 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86345 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7826 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5578 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6301 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117221 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41836 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148730 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/9999 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42395 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/113894 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10016 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8435 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114224 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29012 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7769 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119922 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64723 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10045 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37917 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9776 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73613 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/9986 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9837 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->