### PR TITLE
REGRESSION (Safari 26.2): Scrollbar drag fails on first attempt after dynamic DOM replacement in overflow container

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -1260,6 +1260,7 @@ scrollbars/scrolling-by-page-accounting-top-fixed-elements-on-keyboard-spacebar.
 scrollbars/scrolling-by-page-accounting-top-fixed-elements-with-negative-top-on-keyboard-spacebar.html [ Skip ]
 scrollbars/scrolling-by-page-ignoring-hidden-fixed-elements-on-keyboard-spacebar.html [ Skip ]
 scrollbars/scrolling-by-page-ignoring-transparent-fixed-elements-on-keyboard-spacebar.html [ Skip ]
+scrollbars/scrollbar-drag-thumb-composited.html [ Skip ]
 storage/domstorage/sessionstorage/set-item-synchronous-keydown.html [ Skip ]
 svg/custom/display-none-a-does-not-stop-focus-navigation.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-scroll-snap/input/keyboard.html [ Skip ]

--- a/LayoutTests/scrollbars/scrollbar-drag-thumb-composited-expected.txt
+++ b/LayoutTests/scrollbars/scrollbar-drag-thumb-composited-expected.txt
@@ -1,0 +1,1 @@
+Scrolled to 361

--- a/LayoutTests/scrollbars/scrollbar-drag-thumb-composited.html
+++ b/LayoutTests/scrollbars/scrollbar-drag-thumb-composited.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <style>
+        .box {
+            width: 100px;
+            height: 100px;
+            background-color: blue;
+        }
+        
+        .scroller {
+            margin-top: 250px;
+            width: 600px;
+            height: 200px;
+            overflow-x: hidden;
+            overflow-y: scroll;
+            border: 1px solid black;
+        }
+        
+        .contents {
+            width: 300%;
+            height: 1200%;
+            background-color: silver;
+        }
+        
+        body.changed .contents {
+            background-color: rgb(212, 212, 212);
+        }        
+    </style>
+    <script src="../resources/ui-helper.js"></script>
+    <script>
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+
+        async function runTest()
+        {
+            await UIHelper.renderingUpdate();
+            document.body.classList.add('changed');
+            
+            const scroller = document.getElementsByClassName("scroller")[0];
+            const scrollerBounds = scroller.getBoundingClientRect();
+
+            if (window.eventSender) {
+                const startX = scrollerBounds.width - 8;
+                const eventY = scrollerBounds.top + 4;
+                eventSender.mouseMoveTo(startX, eventY);
+                eventSender.mouseDown();
+                eventSender.mouseMoveTo(startX, eventY + 10);
+
+                await UIHelper.renderingUpdate();
+                eventSender.mouseMoveTo(startX, eventY + 20);
+
+                await UIHelper.renderingUpdate();
+                eventSender.mouseMoveTo(startX, eventY + 30);
+                eventSender.mouseUp();
+            }
+
+            await UIHelper.ensurePresentationUpdate();
+
+            if (window.testRunner)
+                document.getElementById("result").innerText = `Scrolled to ${scroller.scrollTop}`;
+
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }
+    
+        window.addEventListener('load', runTest, false);
+    </script>
+</head>
+<body>
+    <div class="scroller">
+        <div class="contents"></div>
+    </div>
+    
+    <p id="result">Test did not run.</p>    
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -1328,6 +1328,16 @@ private:
         {
             return !scrollCorner.isEmpty() ? scrollCorner : resizer;
         }
+        IntRect scrollbarRect(ScrollbarOrientation orientation)
+        {
+            switch (orientation) {
+            case ScrollbarOrientation::Horizontal:
+                return horizontalScrollbar;
+            case ScrollbarOrientation::Vertical:
+                return verticalScrollbar;
+            }
+            return { };
+        }
     };
     OverflowControlRects overflowControlsRects() const;
 

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -4248,13 +4248,15 @@ void RenderLayerBacking::paintContents(const GraphicsLayer& graphicsLayer, Graph
         auto* scrollableArea = m_owningLayer.scrollableArea();
         ASSERT(scrollableArea);
 
-        auto cornerRect = scrollableArea->overflowControlsRects().scrollCornerOrResizerRect();
+        auto controlsRects = scrollableArea->overflowControlsRects();
+        auto cornerRect = controlsRects.scrollCornerOrResizerRect();
         GraphicsContextStateSaver stateSaver(context);
         context.translate(-cornerRect.location());
         LayoutRect transformedClip = LayoutRect(clip);
         transformedClip.moveBy(cornerRect.location());
-        scrollableArea->paintScrollCorner(context, IntPoint(), snappedIntRect(transformedClip));
-        scrollableArea->paintResizer(context, IntPoint(), transformedClip);
+
+        scrollableArea->paintScrollCorner(context, IntPoint(), controlsRects.scrollCorner, snappedIntRect(transformedClip));
+        scrollableArea->paintResizer(context, IntPoint(), controlsRects.resizer, transformedClip);
     }
 #ifndef NDEBUG
     renderer().page().setIsPainting(false);

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.h
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.h
@@ -142,8 +142,8 @@ public:
     bool hitTestResizerInFragments(const LayerFragments&, const HitTestLocation&, LayoutPoint& pointInFragment) const;
 
     void paintOverflowControls(GraphicsContext&, OptionSet<PaintBehavior>, const IntPoint&, const IntRect& damageRect, bool paintingOverlayControls = false);
-    void paintScrollCorner(GraphicsContext&, const IntPoint&, const IntRect& damageRect);
-    void paintResizer(GraphicsContext&, const LayoutPoint&, const LayoutRect& damageRect);
+    void paintScrollCorner(GraphicsContext&, const IntPoint&, const IntRect& scrollCornerRect, const IntRect& damageRect);
+    void paintResizer(GraphicsContext&, const LayoutPoint&, const IntRect& resizerRect, const LayoutRect& damageRect);
     void paintOverlayScrollbars(GraphicsContext&, const LayoutRect& damageRect, OptionSet<PaintBehavior>, RenderObject* subtreePaintRoot = nullptr);
 
     void updateScrollInfoAfterLayout();

--- a/Source/WebCore/rendering/RenderWidget.cpp
+++ b/Source/WebCore/rendering/RenderWidget.cpp
@@ -371,7 +371,8 @@ void RenderWidget::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
 
     if (hasLayer() && layer()->canResize()) {
         ASSERT(layer()->scrollableArea());
-        layer()->scrollableArea()->paintResizer(paintInfo.context(), roundedIntPoint(adjustedPaintOffset), paintInfo.rect);
+        auto controlsRects = layer()->scrollableArea()->overflowControlsRects();
+        layer()->scrollableArea()->paintResizer(paintInfo.context(), roundedIntPoint(adjustedPaintOffset), controlsRects.resizer, paintInfo.rect);
     }
 }
 


### PR DESCRIPTION
#### bc68ba9c807c8876f89480d26161f07e00e26df6
<pre>
REGRESSION (Safari 26.2): Scrollbar drag fails on first attempt after dynamic DOM replacement in overflow container
<a href="https://bugs.webkit.org/show_bug.cgi?id=304726">https://bugs.webkit.org/show_bug.cgi?id=304726</a>
<a href="https://rdar.apple.com/167249048">rdar://167249048</a>

Reviewed by Alan Baradlay.

Dragging the scrollbar thumb would often fail the first time with always-on scrollbars.

Code in `RenderLayerScrollableArea::paintOverflowControls()` called `positionOverflowControls()` using a paint-relative
offset, which is different from the layout-relative offset normally used, and this sets a bad `frameRect` on the
`Scrollbar` until fixed by the next layout. When dragging the thumb, this mutation of the scrollbar&apos;s frame
confused the event coordinate logic.

The call to `positionOverflowControls()` in `RenderLayerScrollableArea::paintOverflowControls()` is necessary
for painted scrollbars (e.g. the mock scrollbars used for testing), which rely on the bad repositioning
of the Scrollbar&apos;s Widget. So fix that so that we can paint scrollbars without mutating their position,
by applying math similar to that in `RenderWidget::paint()` (another place we paint Widgets), which transforms
the GraphicsContext so that the Scrollbar can use its frameRect to paint with. This prompted cleanup of this
overflow control painting code, and some minor optimizing to only call `overflowControlsRects()` once.

Test: scrollbars/scrollbar-drag-thumb-composited.html

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/scrollbars/scrollbar-drag-thumb-composited-expected.txt: Added.
* LayoutTests/scrollbars/scrollbar-drag-thumb-composited.html: Added.
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::paintContents):
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::paintOverflowControls):
(WebCore::RenderLayerScrollableArea::paintScrollCorner):
(WebCore::RenderLayerScrollableArea::paintResizer):
* Source/WebCore/rendering/RenderLayerScrollableArea.h:
* Source/WebCore/rendering/RenderWidget.cpp:
(WebCore::RenderWidget::paint):

Canonical link: <a href="https://commits.webkit.org/305383@main">https://commits.webkit.org/305383@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/722e0e0d82b0a10b724af04d29478cba8657128a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138229 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10594 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49639 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146308 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91204 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ede754a6-0e6c-402a-97ea-862cad294246) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140103 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11298 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10748 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105739 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/77128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2f4ae8e2-9789-4841-bf0f-63c5c24d7c3e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141176 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8454 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123923 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86586 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8d2d4fa9-a3df-4dc5-86ae-854dbf61b7e6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8048 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5812 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6590 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117459 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42120 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149017 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10276 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42677 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114141 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10293 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8678 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114478 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29085 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8017 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120207 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/65070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10323 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38145 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10054 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73890 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10263 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10114 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->