### PR TITLE
IDLParser should remove leading '_' from dictionary members

### DIFF
--- a/LayoutTests/http/wpt/service-workers/service-worker-add-routes-worker.js
+++ b/LayoutTests/http/wpt/service-workers/service-worker-add-routes-worker.js
@@ -14,7 +14,10 @@ onmessage = e => {
     const routes = [];
     for (let i = 0; i < e.data; i++) {
         routes.push({
-            condition: {urlPattern: new URLPattern({pathname: 'direct.txt' + i})},
+            condition: {
+                urlPattern: new URLPattern({pathname: 'direct.txt' + i}),
+                get _or() {  throw "_or should not be used"; }
+            },
             source: 'network'
         });
     }

--- a/Source/WebCore/bindings/scripts/IDLParser.pm
+++ b/Source/WebCore/bindings/scripts/IDLParser.pm
@@ -1359,7 +1359,7 @@ sub parseDictionary
         my $nameToken = $self->getToken();
         $self->assertTokenType($nameToken, IdentifierToken);
 
-        my $name = $nameToken->value();
+        my $name = identifierRemoveNullablePrefix($nameToken->value());
         $dictionary->type(makeSimpleType($name));
 
         $next = $self->nextToken();
@@ -1425,7 +1425,7 @@ sub parseDictionaryMember
 
         my $nameToken = $self->getToken();
         $self->assertTokenType($nameToken, IdentifierToken);
-        $member->name($nameToken->value);
+        $member->name(identifierRemoveNullablePrefix($nameToken->value));
         $member->default($self->parseDefault());
         $self->assertTokenValue($self->getToken(), ";", __LINE__);
         return $member;

--- a/Source/WebCore/bindings/scripts/test/TestObj.idl
+++ b/Source/WebCore/bindings/scripts/test/TestObj.idl
@@ -524,8 +524,8 @@ typedef any AnyTypedef;
 [
     JSGenerateToJSObject,
     JSGenerateToNativeObject
-] dictionary TestDictionary {
-    TestEnumType enumerationValueWithoutDefault;
+] dictionary _TestDictionary {
+    TestEnumType _enumerationValueWithoutDefault;
     TestEnumType enumerationValueWithDefault = "enumValue1";
     TestEnumType enumerationValueWithEmptyStringDefault = "";
     DOMString stringWithDefault = "defaultString";


### PR DESCRIPTION
#### 25fff15efc95a4910ad08f0a87dcfabb36fa486a
<pre>
IDLParser should remove leading &apos;_&apos; from dictionary members
<a href="https://rdar.apple.com/167749736">rdar://167749736</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=305097">https://bugs.webkit.org/show_bug.cgi?id=305097</a>

Reviewed by Anne van Kesteren.

As per WebIDL spec, starting &apos;_&apos; should be removed from identifiers, including for dictionary names and members.
Update IDLParser accordingly, make sure this fixes RouterCondition &apos;_or&apos; member.

Covered by updated binding and layout test.

Canonical link: <a href="https://commits.webkit.org/305265@main">https://commits.webkit.org/305265@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/51d6086b14a7eca31766a818315f31be773f2360

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137969 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10333 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49338 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146037 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/90944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/09352a73-9419-4023-b0c1-8a55da4a6047) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139842 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11035 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10478 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/105508 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/90944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/208bb906-8403-4c59-89cd-8ec61d28a18f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140914 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8228 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123692 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86360 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/19c493db-cb0e-4aef-9de9-c0e6f6859afb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7842 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5596 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6319 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117238 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41863 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148748 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10016 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42422 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/113908 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10033 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8453 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114239 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29020 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7785 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119949 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64740 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10062 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/37940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9793 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/73630 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10003 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9854 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->