### PR TITLE
[Cocoa] Implement service worker rule regexp matching

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/static-router-main-resource.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/static-router-main-resource.https-expected.txt
@@ -1,11 +1,11 @@
 
-FAIL Main resource load matched with the condition assert_equals: expected 0 but got 1
+PASS Main resource load matched with the condition
 FAIL Main resource load matched with the ignore case condition assert_equals: expected 0 but got 1
 PASS Main resource load matched without the ignore case condition
 PASS Main resource load not matched with the condition
-FAIL Main resource load matched with the cache source assert_equals: expected 0 but got 1
+PASS Main resource load matched with the cache source
 PASS Main resource fallback to the network when there is no cache entry
-FAIL Main resource load matched with the cache source, with specifying the cache name assert_equals: expected 0 but got 1
-FAIL Main resource load should not match the condition with not assert_equals: expected 1 but got 0
+PASS Main resource load matched with the cache source, with specifying the cache name
+PASS Main resource load should not match the condition with not
 PASS Main resource load should match the condition without not
 

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/static-router-multiple-router-registrations.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/static-router-multiple-router-registrations.https-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Main reosurce load matched with the service worker having multiple rules assert_equals: expected "Network\n" but got ""
-FAIL Resource load matched with the rule registered in the imported service worker assert_equals: expected "Network\n" but got ""
+PASS Main reosurce load matched with the service worker having multiple rules
+PASS Resource load matched with the rule registered in the imported service worker
 

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/static-router-no-fetch-handler.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/static-router-no-fetch-handler.https-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL The router rule is evaluated without fetch handlers in service worker assert_equals: expected "From cache" but got "{\"error\": {\"code\": 404, \"message\": \"404\"}}"
+PASS The router rule is evaluated without fetch handlers in service worker
 PASS addRoutes should raise if the fetch-event source is used without onfetch
 PASS addRoutes should raise if the race-network-and-fetch-handler source is used without onfetch
 

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/static-router-race-network-and-fetch-handler.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/static-router-race-network-and-fetch-handler.https-expected.txt
@@ -1,10 +1,10 @@
 
 PASS Main resource load matched the rule with race-network-and-fetch-handler source, and the fetch handler response is faster than the server response
-FAIL Main resource load matched the rule with race-network-and-fetch-handler source, and the server reseponse is faster than the fetch handler assert_equals: expected "Network with GET request" but got "szkps"
+PASS Main resource load matched the rule with race-network-and-fetch-handler source, and the server reseponse is faster than the fetch handler
 PASS Main resource load matched the rule with race-network-and-fetch-handler source, and the fetch handler response is faster than the server response while fetch() is triggered inside the fetch handler
-FAIL Main resource load matched the rule with race-network-and-fetch-handler source, and the server reseponse is faster than the fetch handler while fetch() is triggered inside the fetch handler assert_equals: expected "Network with GET request" but got "idomx"
+PASS Main resource load matched the rule with race-network-and-fetch-handler source, and the server reseponse is faster than the fetch handler while fetch() is triggered inside the fetch handler
 PASS Subresource load matched the rule with race-network-and-fetch-handler source, and the fetch handler response is faster than the server response
-FAIL Subresource load matched the rule with race-network-and-fetch-handler source, and the server reseponse is faster than the fetch handler assert_equals: expected "Network with GET request" but got "drtvj"
-FAIL Subresource load matched the rule with race-network-and-fetch-handler source, and the server reseponse with 204 response is faster than the fetch handler assert_equals: expected 204 but got 200
+PASS Subresource load matched the rule with race-network-and-fetch-handler source, and the server reseponse is faster than the fetch handler
+PASS Subresource load matched the rule with race-network-and-fetch-handler source, and the server reseponse with 204 response is faster than the fetch handler
 PASS Subresource load matched the rule with race-network-and-fetch-handler source, and the server reseponse is faster than the fetch handler, but not found
 

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/static-router-subresource.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/static-router-subresource.https-expected.txt
@@ -1,20 +1,20 @@
 
 PASS Subresource load not matched with URLPattern condition
-FAIL Subresource load matched with URLPattern condition assert_equals: expected "Network\n" but got "arfcy"
-FAIL Subresource cross origin load matched with URLPattern condition via constructed object assert_equals: expected 0 but got 2
-FAIL Subresource load matched with ignoreCase URLPattern condition assert_equals: expected "Network\n" but got "ncqdg"
+PASS Subresource load matched with URLPattern condition
+PASS Subresource cross origin load matched with URLPattern condition via constructed object
+FAIL Subresource load matched with ignoreCase URLPattern condition assert_equals: expected "Network\n" but got "tvlbp"
 PASS Subresource load matched without ignoreCase URLPattern condition
-FAIL Subresource load matched with URLPattern condition via URLPatternCompatible assert_equals: expected "Network\n" but got "mkjnr"
-FAIL Subresource cross origin load not matched with URLPattern condition via URLPatternCompatible assert_equals: expected 1 but got 2
-FAIL Subresource load matched with URLPattern condition via string assert_equals: expected "Network\n" but got "rfdaj"
-FAIL Subresource cross origin load not matched with URLPattern condition via string assert_equals: expected 1 but got 2
+PASS Subresource load matched with URLPattern condition via URLPatternCompatible
+FAIL Subresource cross origin load not matched with URLPattern condition via URLPatternCompatible promise_test: Unhandled rejection with value: object "TypeError: Load failed"
+PASS Subresource load matched with URLPattern condition via string
+PASS Subresource cross origin load not matched with URLPattern condition via string
 PASS Subresource load matched with RequestMode condition
-FAIL Subresource load matched with the nested `or` condition assert_equals: expected "Network\n" but got "ytihv"
-FAIL Subresource load matched with the next `or` condition assert_equals: expected "Network\n" but got "lzkmm"
+PASS Subresource load matched with the nested `or` condition
+PASS Subresource load matched with the next `or` condition
 PASS Subresource load not matched with `or` condition
-FAIL Subresource load matched with the cache source rule assert_equals: expected "From cache" but got ""
-FAIL Subresource load did not match with the cache and fallback to the network assert_equals: expected "Network\n" but got "wytpc"
-FAIL Subresource load matched with the cache source, with specifying the cache name assert_equals: expected "From cache" but got ""
-FAIL Subresource load should not match with the not condition assert_equals: expected "xirxd" but got "{\"error\": {\"code\": 404, \"message\": \"404\"}}"
+PASS Subresource load matched with the cache source rule
+PASS Subresource load did not match with the cache and fallback to the network
+PASS Subresource load matched with the cache source, with specifying the cache name
+PASS Subresource load should not match with the not condition
 PASS Subresource load should match with a file other than not
 

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/tentative/static-router/static-router-resource-timing.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/tentative/static-router/static-router-resource-timing.https-expected.txt
@@ -1,16 +1,16 @@
 
 FAIL Main resource matched the rule with fetch-event source assert_equals: fetch-event as source on main resource expected (string) "fetch-event" but got (undefined) undefined
-FAIL Main resource load matched with the condition and resource timing assert_equals: expected 0 but got 1
+FAIL Main resource load matched with the condition and resource timing assert_equals: network as source on main resource expected (string) "network" but got (undefined) undefined
 FAIL Main resource load not matched with the condition and resource timing assert_equals: no rule matched on main resource expected (string) "" but got (undefined) undefined
-FAIL Main resource load matched with the cache source and resource timing assert_equals: expected 0 but got 1
-FAIL Main resource fallback to the network when there is no cache entry and resource timing assert_equals: expected 0 but got 1
+FAIL Main resource load matched with the cache source and resource timing assert_equals: cache as source on main resource and cache hit expected 1 but got 0
+FAIL Main resource fallback to the network when there is no cache entry and resource timing assert_equals: cache as source on main resource and cache miss, fallback to network expected (string) "cache" but got (undefined) undefined
 FAIL Subresource load matched the rule fetch-event source assert_equals: fetch-event as source on sub resource expected (string) "fetch-event" but got (undefined) undefined
 FAIL Subresource load not matched with URLPattern condition assert_equals: no source type matched expected (string) "" but got (undefined) undefined
-FAIL Subresource load matched with URLPattern condition assert_equals: expected "Network\n" but got "staue"
-FAIL Subresource load matched with the cache source rule assert_equals: expected "From cache" but got ""
-FAIL Subresource load did not match with the cache and fallback to the network assert_equals: expected "Network\n" but got "fpsvl"
+FAIL Subresource load matched with URLPattern condition assert_equals: network as source on subresource expected (string) "network" but got (undefined) undefined
+FAIL Subresource load matched with the cache source rule assert_equals: cache as source on subresource and cache hits expected (string) "cache" but got (undefined) undefined
+FAIL Subresource load did not match with the cache and fallback to the network assert_equals: cache as source on subresource and cache misses expected (string) "cache" but got (undefined) undefined
 FAIL Main resource load matched the rule with race-network-and-fetch-handler source, and the fetch handler response is faster than the server response assert_equals: race as source on main resource, and fetch-event wins expected (string) "race-network-and-fetch-handler" but got (undefined) undefined
-FAIL Main resource load matched the rule with race-network-and-fetch-handler source, and the server reseponse is faster than the fetch handler assert_equals: expected "Network with GET request" but got "uoflc"
+FAIL Main resource load matched the rule with race-network-and-fetch-handler source, and the server reseponse is faster than the fetch handler assert_equals: race as source on main resource, and network wins expected (string) "race-network-and-fetch-handler" but got (undefined) undefined
 FAIL Subresource load matched the rule with race-network-and-fetch-handler source, and the fetch handler response is faster than the server response assert_equals: race as source on subresource and fetch wins expected (string) "race-network-and-fetch-handler" but got (undefined) undefined
-FAIL Subresource load matched the rule with race-network-and-fetch-handler source, and the server reseponse is faster than the fetch handler assert_equals: expected "Network with GET request" but got "irkga"
+FAIL Subresource load matched the rule with race-network-and-fetch-handler source, and the server reseponse is faster than the fetch handler assert_equals: race as source on subresource and network wins expected (string) "race-network-and-fetch-handler" but got (undefined) undefined
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -798,6 +798,12 @@ imported/w3c/web-platform-tests/css/css-fonts/font-variant-emoji-005.html [ Pass
 
 imported/w3c/web-platform-tests/service-workers/service-worker/fetch-audio-tainting.https.html [ Pass ]
 
+# Need regexp support in networking process for sw rules
+imported/w3c/web-platform-tests/service-workers/service-worker/static-router-main-resource.https.html [ Failure ]
+imported/w3c/web-platform-tests/service-workers/service-worker/static-router-multiple-router-registrations.https.html [ Failure ]
+imported/w3c/web-platform-tests/service-workers/service-worker/static-router-mutiple-conditions.https.html [ Failure ]
+imported/w3c/web-platform-tests/service-workers/service-worker/static-router-no-fetch-handler.https.html [ Failure ]
+
 # Needs rebasing and testing
 imported/w3c/web-platform-tests/service-workers/service-worker/fetch-canvas-tainting-video.https.html [ Failure ]
 imported/w3c/web-platform-tests/service-workers/service-worker/registration-script-module.https.html [ Failure ]

--- a/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
+++ b/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		3CBEEDE928A1861D00221FAE /* BarcodeSupportSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C963637289DC1C600570DD6 /* BarcodeSupportSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		416E995323DAE6BE00E871CB /* AudioToolboxSoftLink.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 416E995123DAE6BD00E871CB /* AudioToolboxSoftLink.cpp */; };
 		4177B3DA296CB8C3009711F0 /* CoreCryptoSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 4177B3D9296CB8C3009711F0 /* CoreCryptoSPI.h */; };
+		41832D362F16454200103096 /* RegexpHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41832D352F16454200103096 /* RegexpHelper.swift */; };
 		41D99CC82C9C45590025844F /* AVFAudioSoftLink.h in Headers */ = {isa = PBXBuildFile; fileRef = 41D99CC22C9C45580025844F /* AVFAudioSoftLink.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		41D99CC92C9C45590025844F /* AVFAudioSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = 41D99CC72C9C45580025844F /* AVFAudioSoftLink.mm */; };
 		41E1F344248A6A000022D5DE /* VideoToolboxSoftLink.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 416E995523DAEFF700E871CB /* VideoToolboxSoftLink.cpp */; };
@@ -620,6 +621,7 @@
 		416E995523DAEFF700E871CB /* VideoToolboxSoftLink.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VideoToolboxSoftLink.cpp; sourceTree = "<group>"; };
 		416E995623DAEFF700E871CB /* VideoToolboxSoftLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VideoToolboxSoftLink.h; sourceTree = "<group>"; };
 		4177B3D9296CB8C3009711F0 /* CoreCryptoSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreCryptoSPI.h; sourceTree = "<group>"; };
+		41832D352F16454200103096 /* RegexpHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegexpHelper.swift; sourceTree = "<group>"; };
 		41B99E4525DD70150007829A /* AVStreamDataParserSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AVStreamDataParserSPI.h; sourceTree = "<group>"; };
 		41D99CC22C9C45580025844F /* AVFAudioSoftLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AVFAudioSoftLink.h; sourceTree = "<group>"; };
 		41D99CC72C9C45580025844F /* AVFAudioSoftLink.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AVFAudioSoftLink.mm; sourceTree = "<group>"; };
@@ -814,6 +816,7 @@
 			isa = PBXGroup;
 			children = (
 				94F4AA012B730D2C006DFFDE /* CryptoKitShim.swift */,
+				41832D352F16454200103096 /* RegexpHelper.swift */,
 				94A41E702BB1E10D00DA715C /* UnsafeOverlays.swift */,
 			);
 			path = PALSwift;
@@ -1854,6 +1857,7 @@
 				4450FC9F21F5F602004DFA56 /* QuickLookSoftLink.mm in Sources */,
 				F4C85A4E2658551A005B89CC /* QuickLookUISoftLink.mm in Sources */,
 				DD5697F92DC1303C00050321 /* rdar150228472.swift in Sources */,
+				41832D362F16454200103096 /* RegexpHelper.swift in Sources */,
 				071C00372707EDF000D027C7 /* ReplayKitSoftLink.mm in Sources */,
 				F4974EA4265EEA2200B49B8C /* RevealSoftLink.mm in Sources */,
 				07789181273B14FF00E408D1 /* ScreenCaptureKitSoftLink.mm in Sources */,

--- a/Source/WebCore/PAL/pal/PALSwift/RegexpHelper.swift
+++ b/Source/WebCore/PAL/pal/PALSwift/RegexpHelper.swift
@@ -1,0 +1,35 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+import Foundation
+import RegexBuilder
+
+public class RegexHelper {
+    public static func match(pattern: NSString, value: NSString) -> Bool {
+        guard let expression = try? Regex(pattern as String) else {
+            return false
+        }
+        let swiftValue = value as String
+        return swiftValue.contains(expression)
+    }
+}

--- a/Source/WebCore/workers/service/ServiceWorkerRoute.h
+++ b/Source/WebCore/workers/service/ServiceWorkerRoute.h
@@ -83,6 +83,11 @@ struct ServiceWorkerRoute {
 
 std::optional<size_t> countRouterInnerConditions(const ServiceWorkerRouteCondition&, size_t result, size_t depth);
 std::optional<ExceptionData> validateServiceWorkerRoute(ServiceWorkerRoute&);
+
+#if PLATFORM(COCOA)
+bool isRegexpMatching(const String& pattern, StringView value);
+#endif
+
 bool matchRouterCondition(const ServiceWorkerRouteCondition&, const FetchOptions&, const ResourceRequest&, bool isServiceWorkerRunning);
 
 } // namespace WebCore

--- a/Source/WebCore/workers/service/ServiceWorkerRoute.mm
+++ b/Source/WebCore/workers/service/ServiceWorkerRoute.mm
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "ServiceWorkerRoute.h"
+
+#import <pal/PALSwift.h>
+
+#if !defined(CLANG_WEBKIT_BRANCH)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
+#include "PALSwift-Generated.h"
+#pragma clang diagnostic pop
+#endif // !defined(CLANG_WEBKIT_BRANCH)
+
+namespace WebCore {
+
+bool isRegexpMatching(const String& pattern, StringView value)
+{
+#if !defined(CLANG_WEBKIT_BRANCH)
+    return pal::RegexHelper::match(pattern.createNSString().get(), value.createNSString().get());
+#else
+    UNUSED_PARAM(pattern);
+    UNUSED_PARAM(value);
+    return false;
+#endif
+}
+
+}


### PR DESCRIPTION
#### c86e9a1433be7fb300485afeb59787fb00bf2133
<pre>
[Cocoa] Implement service worker rule regexp matching
<a href="https://rdar.apple.com/167750788">rdar://167750788</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=305098">https://bugs.webkit.org/show_bug.cgi?id=305098</a>

Reviewed by Chris Dumez.

We use Swift regexp API in cocoa ports to match regular expression for service worker static routing in networking process.
To do so, we introduce Source/WebCore/workers/service/ServiceWorkerRoute.swift and Source/WebCore/workers/service/ServiceWorkerRoute.mm ObjC wrapper.
To optimize matching, at rule matching time, we replace the URLPattern based strings with their corresponding regexp version using existing URLPattern infrastructure.

Glib does not have regexp support so we mark some WPT related tests as failing.

Covered by existing tests.

Canonical link: <a href="https://commits.webkit.org/305693@main">https://commits.webkit.org/305693@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/32d87d95f05375d0c754390c5b99ac79124bb224

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139036 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11403 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/523 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147161 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92063 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1611d9ae-ec16-4f57-a2b9-0fa52c4f794c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140909 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12112 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11559 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106423 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77557 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3b9741ab-ca39-4ad5-828b-b7a2dc4c40e4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141983 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9145 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124544 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87297 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c3d19c04-1d6c-4b3f-b7b6-49d8ad87ff0f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8700 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6470 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7456 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118146 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/443 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149941 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11088 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/449 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114813 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11106 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9376 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115132 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29278 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9020 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120894 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65991 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11135 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/423 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10871 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74785 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11074 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10922 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->