### PR TITLE
Replace RefPtr with Ref in EventListenerVector

### DIFF
--- a/Source/WebCore/dom/EventListenerMap.h
+++ b/Source/WebCore/dom/EventListenerMap.h
@@ -55,7 +55,7 @@ namespace WebCore {
 
 class EventTarget;
 
-using EventListenerVector = Vector<RefPtr<RegisteredEventListener>, 1, CrashOnOverflow, 2>;
+using EventListenerVector = Vector<Ref<RegisteredEventListener>, 1, CrashOnOverflow, 2>;
 
 class EventListenerMap {
 public:

--- a/Source/WebCore/dom/EventTarget.cpp
+++ b/Source/WebCore/dom/EventTarget.cpp
@@ -226,7 +226,7 @@ bool EventTarget::setAttributeEventListener(const AtomString& eventType, RefPtr<
 
 RefPtr<JSEventListener> EventTarget::attributeEventListener(const AtomString& eventType, DOMWrapperWorld& isolatedWorld)
 {
-    for (RefPtr eventListener : eventListeners(eventType)) {
+    for (Ref eventListener : eventListeners(eventType)) {
         RefPtr jsListener = dynamicDowncast<JSEventListener>(eventListener->callback());
         if (jsListener && jsListener->isAttribute() && jsListener->isolatedWorld() == &isolatedWorld)
             return jsListener;
@@ -393,9 +393,9 @@ void EventTarget::innerInvokeEventListeners(Event& event, EventListenerVector li
         callback->checkValidityForEventTarget(*this);
 #endif
 
-        InspectorInstrumentation::willHandleEvent(context, event, *registeredListener);
+        InspectorInstrumentation::willHandleEvent(context, event, registeredListener);
         callback->handleEvent(context, event);
-        InspectorInstrumentation::didHandleEvent(context, event, *registeredListener);
+        InspectorInstrumentation::didHandleEvent(context, event, registeredListener);
 
         if (registeredListener->isPassive())
             event.setInPassiveListener(false);

--- a/Source/WebCore/inspector/InspectorAuditDOMObject.cpp
+++ b/Source/WebCore/inspector/InspectorAuditDOMObject.cpp
@@ -61,7 +61,7 @@ ExceptionOr<bool> InspectorAuditDOMObject::hasEventListeners(Node& node, const S
             eventTypes.append(type);
 
         for (AtomString& type : eventTypes) {
-            for (const RefPtr<RegisteredEventListener>& listener : node.eventListeners(type)) {
+            for (auto& listener : node.eventListeners(type)) {
                 if (listener->callback().type() == EventListener::JSEventListenerType)
                     return true;
             }

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -1097,7 +1097,7 @@ Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::E
 
     auto listeners = JSON::ArrayOf<Inspector::Protocol::DOM::EventListener>::create();
 
-    auto addListener = [&] (RegisteredEventListener& listener, const EventListenerInfo& info) {
+    auto addListener = [&](RegisteredEventListener& listener, const EventListenerInfo& info) {
         Inspector::Protocol::DOM::EventListenerId identifier = 0;
         bool disabled = false;
         RefPtr<JSC::Breakpoint> breakpoint;
@@ -1129,7 +1129,7 @@ Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::E
     for (auto& info : eventInformation) {
         for (auto& listener : info.eventListeners) {
             if (listener->useCapture())
-                addListener(*listener, info);
+                addListener(listener, info);
         }
     }
 
@@ -1138,7 +1138,7 @@ Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::DOM::E
         const EventListenerInfo& info = eventInformation[i - 1];
         for (auto& listener : info.eventListeners) {
             if (!listener->useCapture())
-                addListener(*listener, info);
+                addListener(listener, info);
         }
     }
 

--- a/Source/WebCore/inspector/agents/WebDebuggerAgent.cpp
+++ b/Source/WebCore/inspector/agents/WebDebuggerAgent.cpp
@@ -79,7 +79,7 @@ void WebDebuggerAgent::didAddEventListener(EventTarget& target, const AtomString
         return;
 
     auto& registeredListener = eventListeners.at(position);
-    if (m_registeredEventListeners.contains(registeredListener.get()))
+    if (m_registeredEventListeners.contains(registeredListener.ptr()))
         return;
 
     auto* globalObject = target.protectedScriptExecutionContext()->globalObject();
@@ -87,7 +87,7 @@ void WebDebuggerAgent::didAddEventListener(EventTarget& target, const AtomString
         return;
 
     int identifier = m_nextEventListenerIdentifier++;
-    m_registeredEventListeners.set(registeredListener.get(), identifier);
+    m_registeredEventListeners.set(registeredListener.ptr(), identifier);
 
     didScheduleAsyncCall(globalObject, InspectorDebuggerAgent::AsyncCallType::EventListener, identifier, registeredListener->isOnce());
 }
@@ -102,7 +102,7 @@ void WebDebuggerAgent::willRemoveEventListener(EventTarget& target, const AtomSt
     if (listenerIndex == notFound)
         return;
 
-    int identifier = m_registeredEventListeners.take(eventListeners[listenerIndex].get());
+    int identifier = m_registeredEventListeners.take(eventListeners[listenerIndex].ptr());
     didCancelAsyncCall(InspectorDebuggerAgent::AsyncCallType::EventListener, identifier);
 }
 


### PR DESCRIPTION
#### 0ae205eb646fde92b798af983e937fdfa18539c7
<pre>
Replace RefPtr with Ref in EventListenerVector
<a href="https://bugs.webkit.org/show_bug.cgi?id=305104">https://bugs.webkit.org/show_bug.cgi?id=305104</a>

Reviewed by Chris Dumez.

No need for null pointers here.

Canonical link: <a href="https://commits.webkit.org/305275@main">https://commits.webkit.org/305275@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8eac39b9a489bfd3752aece2d62a78b0c963f442

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/137980 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10344 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49353 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146048 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90955 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f43fad76-94c3-4417-9ca6-741024cee584) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139853 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11046 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10490 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105522 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/77005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/823146dd-982e-4bc5-a6e2-9a2c9d30daa9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140925 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8242 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123702 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86373 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/68a7ab02-8ae4-4efb-bdfb-4808811654f8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7856 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5608 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6331 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117252 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41875 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148759 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10027 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42434 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113924 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10044 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8465 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114254 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7796 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/119961 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64751 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21237 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10073 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37949 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9804 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73641 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10014 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9865 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->