### PR TITLE
Use a Vector of Ref instead of RefPtr for PendingScript

### DIFF
--- a/Source/WebCore/dom/ScriptRunner.cpp
+++ b/Source/WebCore/dom/ScriptRunner.cpp
@@ -123,7 +123,7 @@ void ScriptRunner::timerFired()
 {
     Ref document = m_document.get();
 
-    Vector<RefPtr<PendingScript>> scripts;
+    Vector<Ref<PendingScript>> scripts;
 
     if (document->shouldDeferAsynchronousScriptsUntilParsingFinishes()) {
         // Scripts not added by the parser are executed asynchronously and yet do not have the 'async' attribute set.
@@ -140,14 +140,9 @@ void ScriptRunner::timerFired()
     while (!m_scriptsToExecuteInOrder.isEmpty() && Ref { m_scriptsToExecuteInOrder.first() }->isLoaded())
         scripts.append(m_scriptsToExecuteInOrder.takeFirst());
 
-    for (auto& currentScript : scripts) {
-        RefPtr script = WTF::move(currentScript);
-        ASSERT(script);
-        // Paper over https://bugs.webkit.org/show_bug.cgi?id=144050
-        if (!script)
-            continue;
+    for (Ref script : scripts) {
         ASSERT(script->needsLoading());
-        script->element().executePendingScript(*script);
+        script->element().executePendingScript(script);
         document->decrementLoadEventDelayCount();
     }
 }

--- a/Source/WebCore/dom/ScriptRunner.h
+++ b/Source/WebCore/dom/ScriptRunner.h
@@ -81,7 +81,7 @@ private:
 
     WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
     Deque<Ref<PendingScript>> m_scriptsToExecuteInOrder;
-    Vector<RefPtr<PendingScript>> m_scriptsToExecuteSoon; // http://www.whatwg.org/specs/web-apps/current-work/#set-of-scripts-that-will-execute-as-soon-as-possible
+    Vector<Ref<PendingScript>> m_scriptsToExecuteSoon; // https://html.spec.whatwg.org/#set-of-scripts-that-will-execute-as-soon-as-possible
     HashSet<Ref<PendingScript>> m_pendingAsyncScripts;
     Timer m_timer;
 };


### PR DESCRIPTION
#### bd480258f2973bb2e493ea09f135ed5386c61071
<pre>
Use a Vector of Ref instead of RefPtr for PendingScript
<a href="https://bugs.webkit.org/show_bug.cgi?id=305119">https://bugs.webkit.org/show_bug.cgi?id=305119</a>

Reviewed by Chris Dumez.

Improve clarity by removing unneeded null checks.

Note that bug 144050 could already not be reproduced back in the day
and these days the code is quite a bit different, but somehow the
comment stuck around.

Canonical link: <a href="https://commits.webkit.org/305345@main">https://commits.webkit.org/305345@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2301115cab01664ed6bf4ba0ba6186a13490d584

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138155 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10520 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49565 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146231 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/91130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/423b73eb-5e11-4181-9c95-2b80d63c257a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140029 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11223 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10674 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105667 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/91130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/072cadf2-0a01-48ac-afbf-a44a75bac20e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141101 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8389 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123859 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86519 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c36bd9dc-3710-4caf-b9d7-b3f7c8fb6151) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7987 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5749 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6512 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/117396 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42056 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148940 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10202 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42612 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114076 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10219 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/8614 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114410 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7926 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120143 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64926 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21270 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10249 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38083 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9979 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/73816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10189 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10040 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->