### PR TITLE
[JSC] Enable large-value test case in `Math.hypot` using shouldBeCloseEnough

### DIFF
--- a/JSTests/stress/math-hypot.js
+++ b/JSTests/stress/math-hypot.js
@@ -98,9 +98,7 @@ for (var i = 0; i < testLoopCount; i++) {
         1.5819637896591838e308
     );
     shouldBeCloseEnough(Math.hypot(-2.534858246857893e115, 8.988465674311579e307, 8.98846567431158e307), 1.2711610061536462e308);
-    // FIXME: This test result differs from Chrome and Firefox,
-    // although it matches the behavior of Swift, C++, Rust, and Python. Commenting out this test case for now.
-    // shouldBeCloseEnough(Math.hypot(1.3588124894186193e308, 1.4803986201152006e223, 6.741349255733684e307), 1.5168484694516577e308);
+    shouldBeCloseEnough(Math.hypot(1.3588124894186193e308, 1.4803986201152006e223, 6.741349255733684e307), 1.5168484694516577e308);
     shouldBeCloseEnough(Math.hypot(6.741349255733684e307, 1.7976931348623155e308, -7.388327292663961e41), Infinity);
     shouldBeCloseEnough(Math.hypot(-1.9807040628566093e28, 1.7976931348623157e308, 9.9792015476736e291), 1.7976931348623157e308);
     shouldBeCloseEnough(


### PR DESCRIPTION
#### b44cdf4404155c79637436c4509b67ed1ac12ea1
<pre>
[JSC] Enable large-value test case in `Math.hypot` using shouldBeCloseEnough
<a href="https://bugs.webkit.org/show_bug.cgi?id=305121">https://bugs.webkit.org/show_bug.cgi?id=305121</a>

Reviewed by Yusuke Suzuki.

<a href="https://commits.webkit.org/805ad6b">https://commits.webkit.org/805ad6b</a> introduced `shouldBeCloseEnough`,
so that this patch enables large-value test case in `Math.hypot`.

* JSTests/stress/math-hypot.js:

Canonical link: <a href="https://commits.webkit.org/305695@main">https://commits.webkit.org/305695@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9681130f08636372ac198f6b9d064056cb70bf10

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138020 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10385 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49413 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146091 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/90995 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11086 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10535 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105549 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77022 "3 flakes 9 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/140966 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8274 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123743 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86398 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7888 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5646 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6372 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/129984 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117285 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148801 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/136582 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10067 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42484 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113951 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10084 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8503 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114284 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29281 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7825 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120014 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/64791 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10113 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/37982 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/169292 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9844 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44149 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10054 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9905 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->