### PR TITLE
StreamPipeToState creates a reference cycle when creating a read request

### DIFF
--- a/LayoutTests/streams/pipeTo-gc-expected.txt
+++ b/LayoutTests/streams/pipeTo-gc-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A piped to readable stream should be freed when gced
+

--- a/LayoutTests/streams/pipeTo-gc.html
+++ b/LayoutTests/streams/pipeTo-gc.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="../resources/testharness.js"></script>
+        <script src="../resources/testharnessreport.js"></script>
+        <script src="../resources/gc.js"></script>
+    </head>
+    <body>
+        <script>
+promise_test(async (test) => {
+     const numStreams = 1000;
+     for (let i = 0; i < numStreams; ++i) {
+         const writable = new WritableStream();
+         const readable = new Blob(['x'.repeat(10)]).stream();
+
+         window.internals?.observeReadableStreamLifetime(readable);
+
+         await readable.pipeTo(writable);
+     }
+     gc();
+
+     if (!window.internals)
+         return;
+
+     assert_less_than(internals.observedLiveReadableStreamCount(), numStreams);
+}, "A piped to readable stream should be freed when gced");
+        </script>
+    </body>
+</html>

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -5995,6 +5995,16 @@ bool Internals::isReadableStreamDisturbed(ReadableStream& stream)
     return stream.isDisturbed();
 }
 
+void Internals::observeReadableStreamLifetime(ReadableStream& stream)
+{
+    m_observedLiveReadableStreams.add(stream);
+}
+
+unsigned Internals::observedLiveReadableStreamCount()
+{
+    return m_observedLiveReadableStreams.computeSize();
+}
+
 JSValue Internals::cloneArrayBuffer(JSC::JSGlobalObject& lexicalGlobalObject, JSValue buffer, JSValue srcByteOffset, JSValue srcLength)
 {
     auto& vm = lexicalGlobalObject.vm();

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -967,6 +967,8 @@ public:
     void setTrackingPreventionEnabled(bool);
 
     bool isReadableStreamDisturbed(ReadableStream&);
+    void observeReadableStreamLifetime(ReadableStream&);
+    unsigned observedLiveReadableStreamCount();
     JSC::JSValue cloneArrayBuffer(JSC::JSGlobalObject&, JSC::JSValue, JSC::JSValue, JSC::JSValue);
 
     String composedTreeAsText(Node&);
@@ -1750,6 +1752,7 @@ private:
 #if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
     RefPtr<MockMediaDeviceRouteController> m_mockMediaDeviceRouteController;
 #endif
+    WeakHashSet<ReadableStream> m_observedLiveReadableStreams;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1137,6 +1137,8 @@ enum ContentsFormat {
 
     [CallWith=CurrentGlobalObject] any cloneArrayBuffer(any buffer, any srcByteOffset, any byteLength);
     boolean isReadableStreamDisturbed(ReadableStream stream);
+    undefined observeReadableStreamLifetime(ReadableStream stream);
+    unsigned long observedLiveReadableStreamCount();
 
     DOMString resourceLoadStatisticsForURL(DOMURL url);
     undefined setTrackingPreventionEnabled(boolean enable);


### PR DESCRIPTION
#### 4863df935d2003de4ec5248d7d0ecc4c934485ce
<pre>
StreamPipeToState creates a reference cycle when creating a read request
<a href="https://rdar.apple.com/166710239">rdar://166710239</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=305109">https://bugs.webkit.org/show_bug.cgi?id=305109</a>

Reviewed by Chris Dumez.

We were creating a ref cycle between StreamPipeToState and PipeToDefaultReadRequest which was supposed to be broken at finalize time. But this is not happening.
We are now making StreamPipeToState keeping a WeakPtr to its PipeToDefaultReadRequest and keeping PipeToDefaultReadRequest taking a strong ref to its StreamPipeToState.

This ensures that, until PipeToDefaultReadRequest is fulfilled, StreamPipeToState stays alive.
In case PipeToDefaultReadRequest is being closed/errored, we need to ensure that StreamPipeToState stays alive until the clsoed promise callback is called to forward the closure to the writable stream.
We add readableStreamIsClosing for that purpose.

To further strengthen the appraoch, we are also clearing the pending read and write request in finalize.
We add an internals API to allow testing that the ref cycle is correctly broken.

Covered by added test.

Canonical link: <a href="https://commits.webkit.org/305346@main">https://commits.webkit.org/305346@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3201bb6d13dd3ddfbacff014c68101f26dc9e193

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138057 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10422 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49460 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146129 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91032 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/2b180ec9-969b-4c87-b588-b19ce3960b84) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139930 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11124 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10574 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105582 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77042 "4 flakes 9 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0bf70a66-1185-4eaa-b2e5-1154b3fce8ac) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141003 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8304 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123773 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86431 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f37169ec-128d-418a-9c0f-79573812c98f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7917 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5681 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6410 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117315 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41965 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148840 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10104 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42522 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/113985 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10121 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8538 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114320 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29071 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7852 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120052 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64828 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10150 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38010 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9881 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73718 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10091 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9942 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->