### PR TITLE
Move from RefPtr to Ref in IndexedDB

### DIFF
--- a/Source/WebCore/Modules/indexeddb/IDBKey.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBKey.cpp
@@ -37,7 +37,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(IDBKey);
 
-using IDBKeyVector = Vector<RefPtr<IDBKey>>;
+using IDBKeyVector = Vector<Ref<IDBKey>>;
 
 Ref<IDBKey> IDBKey::createBinary(const ThreadSafeDataBuffer& buffer)
 {
@@ -76,9 +76,9 @@ IDBKey::IDBKey(const String& value)
 {
 }
 
-IDBKey::IDBKey(const IDBKeyVector& keyArray, size_t arraySize)
+IDBKey::IDBKey(Vector<Ref<IDBKey>>&& keyArray, size_t arraySize)
     : m_type(IndexedDB::KeyType::Array)
-    , m_value(keyArray)
+    , m_value(WTF::move(keyArray))
     , m_sizeEstimate(OverheadSize + arraySize)
 {
 }
@@ -117,7 +117,7 @@ std::weak_ordering IDBKey::compare(const IDBKey& other) const
         auto& array = std::get<IDBKeyVector>(m_value);
         auto& otherArray = std::get<IDBKeyVector>(other.m_value);
         for (size_t i = 0; i < array.size() && i < otherArray.size(); ++i) {
-            if (auto result = Ref { *array[i] }->compare(Ref { *otherArray[i] }); is_neq(result))
+            if (auto result = Ref { array[i] }->compare(Ref { otherArray[i] }); is_neq(result))
                 return result;
         }
         return array.size() <=> otherArray.size();

--- a/Source/WebCore/Modules/indexeddb/IDBKey.h
+++ b/Source/WebCore/Modules/indexeddb/IDBKey.h
@@ -63,39 +63,13 @@ public:
         return adoptRef(*new IDBKey(IndexedDB::KeyType::Date, date));
     }
 
-    static Ref<IDBKey> createMultiEntryArray(const Vector<RefPtr<IDBKey>>& array)
-    {
-        Vector<RefPtr<IDBKey>> result;
-
-        size_t sizeEstimate = 0;
-        for (auto& key : array) {
-            if (!key->isValid())
-                continue;
-
-            bool skip = false;
-            for (auto& resultKey : result) {
-                if (key->isEqual(*resultKey)) {
-                    skip = true;
-                    break;
-                }
-            }
-            if (!skip) {
-                result.append(key);
-                sizeEstimate += key->m_sizeEstimate;
-            }
-        }
-        auto idbKey = adoptRef(*new IDBKey(result, sizeEstimate));
-        ASSERT(idbKey->isValid());
-        return idbKey;
-    }
-
-    static Ref<IDBKey> createArray(const Vector<RefPtr<IDBKey>>& array)
+    static Ref<IDBKey> createArray(Vector<Ref<IDBKey>>&& array)
     {
         size_t sizeEstimate = 0;
         for (auto& key : array)
             sizeEstimate += key->m_sizeEstimate;
 
-        return adoptRef(*new IDBKey(array, sizeEstimate));
+        return adoptRef(*new IDBKey(WTF::move(array), sizeEstimate));
     }
 
     static Ref<IDBKey> createBinary(const ThreadSafeDataBuffer&);
@@ -107,10 +81,10 @@ public:
     IndexedDB::KeyType type() const { return m_type; }
     WEBCORE_EXPORT bool isValid() const;
 
-    const Vector<RefPtr<IDBKey>>& array() const
+    const Vector<Ref<IDBKey>>& array() const
     {
         ASSERT(m_type == IndexedDB::KeyType::Array);
-        return std::get<Vector<RefPtr<IDBKey>>>(m_value);
+        return std::get<Vector<Ref<IDBKey>>>(m_value);
     }
 
     const String& string() const
@@ -156,11 +130,11 @@ private:
 
     IDBKey(IndexedDB::KeyType, double number);
     explicit IDBKey(const String& value);
-    IDBKey(const Vector<RefPtr<IDBKey>>& keyArray, size_t arraySize);
+    IDBKey(Vector<Ref<IDBKey>>&& keyArray, size_t arraySize);
     explicit IDBKey(const ThreadSafeDataBuffer&);
 
     const IndexedDB::KeyType m_type;
-    Variant<Vector<RefPtr<IDBKey>>, String, double, ThreadSafeDataBuffer> m_value;
+    Variant<Vector<Ref<IDBKey>>, String, double, ThreadSafeDataBuffer> m_value;
 
     const size_t m_sizeEstimate;
 

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.h
@@ -257,11 +257,11 @@ private:
     RefPtr<IDBOpenDBRequest> m_openDBRequest;
     WeakHashSet<IDBRequest, WeakPtrImplWithEventTargetData> m_cursorRequests;
 
-    Deque<RefPtr<IDBClient::TransactionOperation>> m_pendingTransactionOperationQueue;
-    Deque<RefPtr<IDBClient::TransactionOperation>> m_transactionOperationsInProgressQueue;
-    Deque<RefPtr<IDBClient::TransactionOperation>> m_abortQueue;
-    HashMap<RefPtr<IDBClient::TransactionOperation>, IDBResultData> m_transactionOperationResultMap;
-    HashMap<IDBResourceIdentifier, RefPtr<IDBClient::TransactionOperation>> m_transactionOperationMap;
+    Deque<Ref<IDBClient::TransactionOperation>> m_pendingTransactionOperationQueue;
+    Deque<Ref<IDBClient::TransactionOperation>> m_transactionOperationsInProgressQueue;
+    Deque<Ref<IDBClient::TransactionOperation>> m_abortQueue;
+    HashMap<Ref<IDBClient::TransactionOperation>, IDBResultData> m_transactionOperationResultMap;
+    HashMap<IDBResourceIdentifier, Ref<IDBClient::TransactionOperation>> m_transactionOperationMap;
 
     mutable Lock m_referencedObjectStoreLock;
     HashMap<String, std::unique_ptr<IDBObjectStore>> m_referencedObjectStores WTF_GUARDED_BY_LOCK(m_referencedObjectStoreLock);

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.cpp
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.cpp
@@ -581,7 +581,7 @@ void IDBConnectionProxy::unregisterDatabaseConnection(IDBDatabase& database)
     m_databaseConnectionMap.remove(database.databaseConnectionIdentifier());
 }
 
-void IDBConnectionProxy::forgetActiveOperations(const Vector<RefPtr<TransactionOperation>>& operations)
+void IDBConnectionProxy::forgetActiveOperations(const Vector<Ref<TransactionOperation>>& operations)
 {
     Locker locker { m_transactionOperationLock };
 

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.h
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.h
@@ -129,7 +129,7 @@ public:
     void registerDatabaseConnection(IDBDatabase&, ScriptExecutionContextIdentifier);
     void unregisterDatabaseConnection(IDBDatabase&);
 
-    void forgetActiveOperations(const Vector<RefPtr<TransactionOperation>>&);
+    void forgetActiveOperations(const Vector<Ref<TransactionOperation>>&);
     void forgetTransaction(IDBTransaction&);
     void abortActivitiesForCurrentThread();
     void setContextSuspended(ScriptExecutionContext& currentContext, bool isContextSuspended);

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h
@@ -181,7 +181,7 @@ private:
     std::unique_ptr<IDBDatabaseInfo> m_databaseInfo;
     std::unique_ptr<IDBDatabaseInfo> m_mostRecentDeletedDatabaseInfo;
 
-    Deque<RefPtr<UniqueIDBDatabaseTransaction>> m_pendingTransactions;
+    Deque<Ref<UniqueIDBDatabaseTransaction>> m_pendingTransactions;
     HashMap<IDBResourceIdentifier, RefPtr<UniqueIDBDatabaseTransaction>> m_inProgressTransactions;
 
     // The keys into these sets are the object store ID.

--- a/Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp
@@ -293,14 +293,14 @@ static RefPtr<IDBKey> idbKeyFromInspectorObject(Ref<JSON::Object>&& key)
         if (!array)
             return nullptr;
 
-        Vector<RefPtr<IDBKey>> keyArray;
+        Vector<Ref<IDBKey>> keyArray;
         for (size_t i = 0; i < array->length(); ++i) {
             auto object = array->get(i)->asObject();
             if (!object)
                 return nullptr;
-            keyArray.append(idbKeyFromInspectorObject(object.releaseNonNull()));
+            keyArray.append(idbKeyFromInspectorObject(object.releaseNonNull()).releaseNonNull());
         }
-        return IDBKey::createArray(keyArray);
+        return IDBKey::createArray(WTF::move(keyArray));
     }
     }
 


### PR DESCRIPTION
#### 99e644fcbdeeebeb54ec7506505cd33d57d105f2
<pre>
Move from RefPtr to Ref in IndexedDB
<a href="https://bugs.webkit.org/show_bug.cgi?id=305129">https://bugs.webkit.org/show_bug.cgi?id=305129</a>

Reviewed by Chris Dumez.

Note that both InspectorIndexedDBAgent and IDBKeyData were handing
IDBKey::createArray potentially null objects that were then
dereferenced. They now consistently call releaseNonNull().

We also change IDBKey::createArray to take an r-value reference so the
Vector can be moved in and does not require a copy.

Canonical link: <a href="https://commits.webkit.org/305355@main">https://commits.webkit.org/305355@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1623f844d3212e986d43f95e1881161c0c3ad55

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138189 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10554 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49599 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146266 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91164 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0c3df2d5-d8a1-45e5-82b5-3d04898db246) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140063 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11258 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10708 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105700 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/77107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e1bb300b-7256-4630-b55d-d08b07702342) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141135 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8424 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123891 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86550 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8018 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5781 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6547 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117429 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42088 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148977 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10236 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42645 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114111 "35 flakes 35 failures") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10253 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8647 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114445 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7970 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120175 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64967 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21276 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10283 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38114 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10013 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73850 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10223 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10074 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->