### PR TITLE
[MiniBrowser] Add option to show WebContent process ID in tab title

### DIFF
--- a/Tools/MiniBrowser/mac/SettingsController.h
+++ b/Tools/MiniBrowser/mac/SettingsController.h
@@ -47,6 +47,7 @@ typedef NS_ENUM(NSInteger, AttachmentElementEnabledState) {
 @property (nonatomic, readonly) BOOL tiledScrollingIndicatorVisible;
 @property (nonatomic, readonly, getter=isSpaceReservedForBanners) BOOL spaceReservedForBanners;
 @property (nonatomic, readonly) BOOL resourceUsageOverlayVisible;
+@property (nonatomic, readonly) BOOL showWebProcessIdentifierInTitle;
 @property (nonatomic, readonly) BOOL nonFastScrollableRegionOverlayVisible;
 @property (nonatomic, readonly) BOOL wheelEventHandlerRegionOverlayVisible;
 @property (nonatomic, readonly) BOOL interactionRegionOverlayVisible;

--- a/Tools/MiniBrowser/mac/SettingsController.m
+++ b/Tools/MiniBrowser/mac/SettingsController.m
@@ -47,6 +47,7 @@ static NSString * const ReserveSpaceForBannersPreferenceKey = @"ReserveSpaceForB
 static NSString * const WebViewFillsWindowKey = @"WebViewFillsWindow";
 
 static NSString * const ResourceUsageOverlayVisiblePreferenceKey = @"ResourceUsageOverlayVisible";
+static NSString * const ShowWebProcessIdentifierInTitlePreferenceKey = @"ShowWebProcessIdentifierInTitle";
 static NSString * const LoadsAllSiteIconsKey = @"LoadsAllSiteIcons";
 static NSString * const UsesGameControllerFrameworkKey = @"UsesGameControllerFramework";
 static NSString * const IncrementalRenderingSuppressedPreferenceKey = @"IncrementalRenderingSuppressed";
@@ -229,6 +230,7 @@ static NSMenu *addSubmenuToMenu(NSMenu *menu, NSString *title)
     addItemToMenu(debugOverlaysMenu, @"Interaction Region", @selector(toggleDebugOverlay:), NO, InteractionRegionOverlayTag);
     addItemToMenu(debugOverlaysMenu, @"Enhanced Security", @selector(toggleDebugOverlay:), NO, EnhancedSecurityOverlayTag);
     addItemToMenu(debugOverlaysMenu, @"Resource Usage", @selector(toggleShowResourceUsageOverlay:), NO, 0);
+    addItemToMenu(debugOverlaysMenu, @"Show Web Process ID in Window Title", @selector(toggleShowWebProcessIdentifierInTitle:), NO, 0);
 
     NSMenu *experimentalFeaturesMenu = addSubmenu(@"Experimental Features");
     for (_WKExperimentalFeature *feature in WKPreferences._experimentalFeatures) {
@@ -425,6 +427,8 @@ static NSMenu *addSubmenuToMenu(NSMenu *menu, NSString *title)
         [menuItem setState:[self tiledScrollingIndicatorVisible] ? NSControlStateValueOn : NSControlStateValueOff];
     else if (action == @selector(toggleShowResourceUsageOverlay:))
         [menuItem setState:[self resourceUsageOverlayVisible] ? NSControlStateValueOn : NSControlStateValueOff];
+    else if (action == @selector(toggleShowWebProcessIdentifierInTitle:))
+        [menuItem setState:[self showWebProcessIdentifierInTitle] ? NSControlStateValueOn : NSControlStateValueOff];
     else if (action == @selector(toggleLoadsAllSiteIcons:))
         [menuItem setState:[self loadsAllSiteIcons] ? NSControlStateValueOn : NSControlStateValueOff];
     else if (action == @selector(toggleUsesGameControllerFramework:))
@@ -616,6 +620,12 @@ static NSMenu *addSubmenuToMenu(NSMenu *menu, NSString *title)
     [self _toggleBooleanDefault:ResourceUsageOverlayVisiblePreferenceKey];
 }
 
+- (void)toggleShowWebProcessIdentifierInTitle:(id)sender
+{
+    [[NSUserDefaults standardUserDefaults] setBool:![self showWebProcessIdentifierInTitle] forKey:ShowWebProcessIdentifierInTitlePreferenceKey];
+    [[[NSApplication sharedApplication] browserAppDelegate] didChangeSettings];
+}
+
 - (BOOL)loadsAllSiteIcons
 {
     return [[NSUserDefaults standardUserDefaults] boolForKey:LoadsAllSiteIconsKey];
@@ -669,6 +679,13 @@ static NSMenu *addSubmenuToMenu(NSMenu *menu, NSString *title)
 - (BOOL)resourceUsageOverlayVisible
 {
     return [[NSUserDefaults standardUserDefaults] boolForKey:ResourceUsageOverlayVisiblePreferenceKey];
+}
+
+- (BOOL)showWebProcessIdentifierInTitle
+{
+    if (![[NSUserDefaults standardUserDefaults] objectForKey:ShowWebProcessIdentifierInTitlePreferenceKey])
+        return YES;
+    return [[NSUserDefaults standardUserDefaults] boolForKey:ShowWebProcessIdentifierInTitlePreferenceKey];
 }
 
 - (void)toggleResourceLoadStatisticsEnabled:(id)sender

--- a/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
+++ b/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
@@ -628,6 +628,8 @@ static BOOL areEssentiallyEqual(double a, double b)
         [footerBannerLayer setBackgroundColor:[NSColor colorWithSRGBRed:116. / 255. green:187. / 255. blue:251. / 255. alpha:1].CGColor];
         [_webView _setFooterBannerLayer:footerBannerLayer];
     }
+
+    [self updateTitle:_webView.title];
 }
 
 - (void)updateTitleForBadgeChange
@@ -647,6 +649,11 @@ static BOOL areEssentiallyEqual(double a, double b)
 
     if (BrowserAppDelegate.currentBadge)
         title = [title stringByAppendingFormat:@" (%@)", BrowserAppDelegate.currentBadge];
+
+    SettingsController *settings = [[NSApp browserAppDelegate] settingsController];
+    pid_t webPID = _webView._webProcessIdentifier;
+    if (settings.showWebProcessIdentifierInTitle && webPID)
+        title = [title stringByAppendingFormat:@" [%d]", webPID];
 
     self.window.title = title;
 


### PR DESCRIPTION
#### a2884e090e5b06b0b872de03b4d23399d02fa7f3
<pre>
[MiniBrowser] Add option to show WebContent process ID in tab title
<a href="https://bugs.webkit.org/show_bug.cgi?id=305135">https://bugs.webkit.org/show_bug.cgi?id=305135</a>
<a href="https://rdar.apple.com/167784433">rdar://167784433</a>

Reviewed by Vitor Roriz, Brent Fulgham, and Brandon Stewart.

Add a &quot;Show Web Process ID in Window Title&quot; toggle to the Debug Overlays
submenu that displays the WebContent PID in the window title (For example &quot;WebKit [1234]&quot;).

This makes the WebContent PID visible in the tab bar when using tabbed windows.

The setting is persisted via NSUserDefaults, and the setting is togglable
through the `Settings menu` → `Debug Overlays` → `&quot;Show Web Process ID in Window Title&quot;` menu item.

* Tools/MiniBrowser/mac/SettingsController.h:
* Tools/MiniBrowser/mac/SettingsController.m:
(-[SettingsController _populateMenu:]):
(-[SettingsController validateMenuItem:]):
(-[SettingsController toggleShowWebProcessIdentifierInTitle:]):
(-[SettingsController showWebProcessIdentifierInTitle]):
* Tools/MiniBrowser/mac/WK2BrowserWindowController.m:
(-[WK2BrowserWindowController didChangeSettings]):
(-[WK2BrowserWindowController updateTitle:]):

Canonical link: <a href="https://commits.webkit.org/305382@main">https://commits.webkit.org/305382@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a134aaf5e57ecbdf56f86d53f3877fcc5ac95fd1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138080 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10445 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49487 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146156 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91055 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/96ee49bd-2365-4847-862e-efbf3a05023c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139953 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11147 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10597 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105604 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77054 "2 flakes 11 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d3a2038f-b5a2-4586-9dec-3d9a1703a339) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141026 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8328 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123801 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86455 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9ae099f6-027b-46fe-ad8b-284d7852557e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7939 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5699 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6433 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117339 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41996 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148863 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10127 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42552 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114012 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10144 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8557 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114344 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29084 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7874 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120083 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64851 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10173 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38033 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9904 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10114 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9965 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->