### PR TITLE
Web Inspector: Break ref-cycle between WebInspectorUIProxy and WebInspectorBackendProxy

### DIFF
--- a/Source/WebKit/UIProcess/Inspector/WebInspectorBackendProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorBackendProxy.cpp
@@ -31,44 +31,44 @@ namespace WebKit {
 
 void WebInspectorBackendProxy::requestOpenLocalInspectorFrontend()
 {
-    m_proxy->requestOpenLocalInspectorFrontend();
+    protectedProxy()->requestOpenLocalInspectorFrontend();
 }
 
 void WebInspectorBackendProxy::didClose()
 {
-    m_proxy->didClose();
+    protectedProxy()->didClose();
 }
 
 void WebInspectorBackendProxy::bringToFront()
 {
-    m_proxy->bringToFront();
+    protectedProxy()->bringToFront();
 }
 
 void WebInspectorBackendProxy::elementSelectionChanged(bool active)
 {
-    m_proxy->elementSelectionChanged(active);
+    protectedProxy()->elementSelectionChanged(active);
 }
 
 void WebInspectorBackendProxy::timelineRecordingChanged(bool active)
 {
-    m_proxy->timelineRecordingChanged(active);
+    protectedProxy()->timelineRecordingChanged(active);
 }
 
 void WebInspectorBackendProxy::setDeveloperPreferenceOverride(WebCore::InspectorBackendClient::DeveloperPreference developerPreference, std::optional<bool> overrideValue)
 {
-    m_proxy->setDeveloperPreferenceOverride(developerPreference, overrideValue);
+    protectedProxy()->setDeveloperPreferenceOverride(developerPreference, overrideValue);
 }
 
 #if ENABLE(INSPECTOR_NETWORK_THROTTLING)
 void WebInspectorBackendProxy::setEmulatedConditions(std::optional<int64_t> bytesPerSecondLimit)
 {
-    m_proxy->setEmulatedConditions(bytesPerSecondLimit);
+    protectedProxy()->setEmulatedConditions(bytesPerSecondLimit);
 }
 #endif
 
 void WebInspectorBackendProxy::attachAvailabilityChanged(bool available)
 {
-    m_proxy->attachAvailabilityChanged(available);
+    protectedProxy()->attachAvailabilityChanged(available);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorBackendProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorBackendProxy.h
@@ -29,6 +29,7 @@
 #include "WebInspectorUIProxy.h"
 #include <WebCore/InspectorBackendClient.h>
 #include <wtf/RefCounted.h>
+#include <wtf/WeakRef.h>
 
 namespace WebKit {
 
@@ -38,7 +39,7 @@ class WebInspectorBackendProxy
 : public RefCounted<WebInspectorBackendProxy>
 , public IPC::MessageReceiver {
 public:
-    explicit WebInspectorBackendProxy(Ref<WebInspectorUIProxy> proxy)
+    explicit WebInspectorBackendProxy(WebInspectorUIProxy& proxy)
     : m_proxy(proxy) { }
 
     // RefCounted
@@ -63,7 +64,9 @@ public:
     void attachAvailabilityChanged(bool);
 
 private:
-    const Ref<WebInspectorUIProxy> m_proxy;
+    Ref<WebInspectorUIProxy> protectedProxy() const { return m_proxy.get(); }
+
+    const WeakRef<WebInspectorUIProxy> m_proxy;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp
@@ -73,7 +73,7 @@ const unsigned WebInspectorUIProxy::initialWindowWidth = 1000;
 const unsigned WebInspectorUIProxy::initialWindowHeight = 650;
 
 WebInspectorUIProxy::WebInspectorUIProxy(WebPageProxy& inspectedPage)
-    : m_backend(adoptRef(new WebInspectorBackendProxy(*this)))
+    : m_backend(adoptRef(*new WebInspectorBackendProxy(*this)))
     , m_inspectedPage(inspectedPage)
     , m_inspectorClient(makeUnique<API::InspectorClient>())
     , m_inspectedPageIdentifier(inspectedPage.identifier())
@@ -81,7 +81,7 @@ WebInspectorUIProxy::WebInspectorUIProxy(WebPageProxy& inspectedPage)
     , m_closeFrontendAfterInactivityTimer(RunLoop::mainSingleton(), "WebInspectorUIProxy::CloseFrontendAfterInactivityTimer"_s, this, &WebInspectorUIProxy::closeFrontendAfterInactivityTimerFired)
 #endif
 {
-    protectedInspectedPage()->protectedLegacyMainFrameProcess()->addMessageReceiver(Messages::WebInspectorBackendProxy::messageReceiverName(), m_inspectedPage->webPageIDInMainFrameProcess(), *m_backend);
+    protectedInspectedPage()->protectedLegacyMainFrameProcess()->addMessageReceiver(Messages::WebInspectorBackendProxy::messageReceiverName(), m_inspectedPage->webPageIDInMainFrameProcess(), m_backend.get());
 }
 
 WebInspectorUIProxy::~WebInspectorUIProxy()
@@ -252,7 +252,7 @@ void WebInspectorUIProxy::updateForNewPageProcess(WebPageProxy& inspectedPage)
     m_inspectedPage = inspectedPage;
     m_inspectedPageIdentifier = inspectedPage.identifier();
 
-    protectedInspectedPage()->protectedLegacyMainFrameProcess()->addMessageReceiver(Messages::WebInspectorBackendProxy::messageReceiverName(), m_inspectedPage->webPageIDInMainFrameProcess(), *m_backend);
+    protectedInspectedPage()->protectedLegacyMainFrameProcess()->addMessageReceiver(Messages::WebInspectorBackendProxy::messageReceiverName(), m_inspectedPage->webPageIDInMainFrameProcess(), m_backend.get());
 
     if (RefPtr inspectorPage = m_inspectorPage.get())
         inspectorPage->protectedLegacyMainFrameProcess()->send(Messages::WebInspectorUI::UpdateConnection(), m_inspectorPage->webPageIDInMainFrameProcess());

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
@@ -225,7 +225,7 @@ public:
     void evaluateInFrontendForTesting(const String&);
 
 private:
-    const RefPtr<WebInspectorBackendProxy> m_backend;
+    const Ref<WebInspectorBackendProxy> m_backend;
 
     void createFrontendPage();
     void closeFrontendPageAndWindow();


### PR DESCRIPTION
#### 5c7bdc5d1f25eebabd8f7079279232e02d629df9
<pre>
Web Inspector: Break ref-cycle between WebInspectorUIProxy and WebInspectorBackendProxy
<a href="https://rdar.apple.com/167106238">rdar://167106238</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=305138">https://bugs.webkit.org/show_bug.cgi?id=305138</a>

Reviewed by BJ Burg.

WebInspectorUIProxy and WebInspectorBackendProxy must not hold strong
refs to each other. Given the backend proxy is created by the UI, make
its m_proxy a weak ref. This is safe despite the backend proxy is
ref-counted because its other user AuxiliaryProcess only stores weak
refs to message receivers, meaning WebInspectorBackendProxy cannot
outlive its owner WebInspectorUIProxy.

No new tests: no change in observable behavior. Tested manually that
inspector opens and closes OK, and element selection works fine.

* Source/WebKit/UIProcess/Inspector/WebInspectorBackendProxy.h:
* Source/WebKit/UIProcess/Inspector/WebInspectorBackendProxy.cpp:
(WebKit::WebInspectorBackendProxy::requestOpenLocalInspectorFrontend):
(WebKit::WebInspectorBackendProxy::didClose):
(WebKit::WebInspectorBackendProxy::bringToFront):
(WebKit::WebInspectorBackendProxy::elementSelectionChanged):
(WebKit::WebInspectorBackendProxy::timelineRecordingChanged):
(WebKit::WebInspectorBackendProxy::setDeveloperPreferenceOverride):
(WebKit::WebInspectorBackendProxy::setEmulatedConditions):
(WebKit::WebInspectorBackendProxy::attachAvailabilityChanged):
(WebKit::WebInspectorBackendProxy::WebInspectorBackendProxy):
(WebKit::WebInspectorBackendProxy::protectedProxy const):
   Use WeakRef to break the ref cycle.

* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h:
* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp:
(WebKit::WebInspectorUIProxy::WebInspectorUIProxy):
(WebKit::WebInspectorUIProxy::updateForNewPageProcess):
   Using a const Ref should be cleaner given m_backend can&apos;t be null.

Canonical link: <a href="https://commits.webkit.org/305482@main">https://commits.webkit.org/305482@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d29fab429739e150a8151548486e5fc959f4deba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138249 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10614 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49659 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146328 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91224 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/052d17b2-b563-4a17-ad52-aa7ca55a9c0b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11318 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10768 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105754 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77141 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3e5832a1-e82b-43b1-a79f-a192fcf65d12) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141196 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8473 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123940 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86601 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d0b0e99e-e93a-4d4c-aebf-b066024c384f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8065 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5875 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6610 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117477 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149037 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10296 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42696 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114162 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10313 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8698 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114502 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8035 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120226 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65119 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21333 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10343 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38162 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10074 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73910 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10283 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10134 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->