### PR TITLE
Fix double-zoom issue with video poster images

### DIFF
--- a/LayoutTests/fast/css/video-poster-zoom-expected.txt
+++ b/LayoutTests/fast/css/video-poster-zoom-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Video poster size with zoom:1
+PASS Video poster size with zoom:1.5
+PASS Video poster size with zoom:2 and non-square dimensions
+

--- a/LayoutTests/fast/css/video-poster-zoom.html
+++ b/LayoutTests/fast/css/video-poster-zoom.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Video poster image should respect CSS zoom</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<style>
+  video {
+    /* Ensure no default styling interferes. */
+    border: none;
+    padding: 0;
+    margin: 0;
+  }
+</style>
+</head>
+<body>
+<script>
+// Helper to create a data URL image of specific size.
+function createImageDataURL(width, height) {
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext('2d');
+  // Fill with a color so it's visible.
+  ctx.fillStyle = 'blue';
+  ctx.fillRect(0, 0, width, height);
+  return canvas.toDataURL();
+}
+
+promise_test(async t => {
+  const video = document.createElement('video');
+  video.poster = createImageDataURL(10, 10);
+  video.style.zoom = '1';
+  document.body.appendChild(video);
+  
+  // Wait for poster to load.
+  await new Promise(resolve => {
+    const img = new Image();
+    img.onload = resolve;
+    img.src = video.poster;
+  });
+  
+  // Force layout.
+  video.getBoundingClientRect();
+  
+  const rect = video.getBoundingClientRect();
+  assert_equals(rect.width, 10, 'Video width should match poster width with zoom:1');
+  assert_equals(rect.height, 10, 'Video height should match poster height with zoom:1');
+  
+  video.remove();
+}, 'Video poster size with zoom:1');
+
+promise_test(async t => {
+  const video = document.createElement('video');
+  video.poster = createImageDataURL(10, 10);
+  video.style.zoom = '1.5';
+  document.body.appendChild(video);
+  
+  // Wait for poster to load.
+  await new Promise(resolve => {
+    const img = new Image();
+    img.onload = resolve;
+    img.src = video.poster;
+  });
+  
+  // Force layout.
+  video.getBoundingClientRect();
+  
+  const rect = video.getBoundingClientRect();
+  assert_equals(rect.width, 15, 'Video width should be scaled by zoom:1.5');
+  assert_equals(rect.height, 15, 'Video height should be scaled by zoom:1.5');
+  
+  video.remove();
+}, 'Video poster size with zoom:1.5');
+
+promise_test(async t => {
+  const video = document.createElement('video');
+  video.poster = createImageDataURL(20, 10);
+  video.style.zoom = '2';
+  document.body.appendChild(video);
+  
+  // Wait for poster to load.
+  await new Promise(resolve => {
+    const img = new Image();
+    img.onload = resolve;
+    img.src = video.poster;
+  });
+  
+  // Force layout.
+  video.getBoundingClientRect();
+  
+  const rect = video.getBoundingClientRect();
+  assert_equals(rect.width, 40, 'Video width should be scaled by zoom:2');
+  assert_equals(rect.height, 20, 'Video height should be scaled by zoom:2');
+  
+  video.remove();
+}, 'Video poster size with zoom:2 and non-square dimensions');
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### b0f444c6149c18fcbfa7f435f6c224ce394b13a6
<pre>
Fix double-zoom issue with video poster images
<a href="https://bugs.webkit.org/show_bug.cgi?id=292415">https://bugs.webkit.org/show_bug.cgi?id=292415</a>
<a href="https://rdar.apple.com/150976146">rdar://150976146</a>

Reviewed by Brent Fulgham.

Inspired by: <a href="https://chromium.googlesource.com/chromium/src/+/75dc85b2a87137b90854ff8b3a16ed6da5081ac8">https://chromium.googlesource.com/chromium/src/+/75dc85b2a87137b90854ff8b3a16ed6da5081ac8</a>

m_cachedImageSize already contains zoom-scaled dimensions when cached in
imageChanged(). Applying zoom again in calculateIntrinsicSize() caused
poster images to be incorrectly double-scaled.

Move poster size handling to calculateIntrinsicSize() to return the
cached size directly without additional scaling. Only apply zoom to
unscaled sizes from calculateIntrinsicSizeInternal().

* Source/WebCore/rendering/RenderVideo.cpp:
(WebCore::RenderVideo::calculateIntrinsicSizeInternal):
(WebCore::RenderVideo::calculateIntrinsicSize):
* LayoutTests/fast/css/video-poster-zoom-expected.txt: Added.
* LayoutTests/fast/css/video-poster-zoom.html: Added.

Canonical link: <a href="https://commits.webkit.org/305347@main">https://commits.webkit.org/305347@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/645eb865f2f825df6161c0386ffe8c61e1962961

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138135 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10500 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49545 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146210 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91110 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9ba9a9b5-ab09-4781-ad25-dcf3e50ba9ac) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140008 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11203 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10654 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105649 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/77076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9909af60-0194-40d3-a2aa-68676e6cc16a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141081 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8373 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123839 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86501 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/5c00e567-e83d-4d4d-9547-64eb1d4caa95) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7973 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5735 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6492 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117379 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42037 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148920 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10182 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42593 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114059 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10199 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8598 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114392 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29070 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7906 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120124 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64906 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10229 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38066 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9959 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73796 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10169 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10020 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->