### PR TITLE
[AutoFill Debugging] Add a way for clients to extract and resolve DOM selector paths from _WKJSHandle

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2133,6 +2133,7 @@ page/DisabledAdaptations.cpp
 page/DragController.cpp
 page/EditorClient.cpp
 page/ElementTargetingController.cpp
+page/ElementTargetingTypes.cpp
 page/EventCounts.cpp
 page/EventHandler.cpp
 page/EventSource.cpp

--- a/Source/WebCore/page/ElementTargetingController.h
+++ b/Source/WebCore/page/ElementTargetingController.h
@@ -69,6 +69,9 @@ public:
 
     WEBCORE_EXPORT RefPtr<Image> snapshotIgnoringVisibilityAdjustment(NodeIdentifier, ScriptExecutionContextIdentifier);
 
+    WEBCORE_EXPORT static RefPtr<Element> elementFromSelectors(Document&, const TargetedElementSelectors&);
+    WEBCORE_EXPORT static TargetedElementSelectors selectorsForElement(Element&);
+
 private:
     void cleanUpAdjustmentClientRects();
 
@@ -79,6 +82,7 @@ private:
         String lastSelectorIncludingPseudo;
     };
     FindElementFromSelectorsResult findElementFromSelectors(const TargetedElementSelectors&);
+    static FindElementFromSelectorsResult findElementFromSelectors(Document&, const TargetedElementSelectors&);
 
     RefPtr<Document> mainDocument() const;
 

--- a/Source/WebCore/page/ElementTargetingTypes.cpp
+++ b/Source/WebCore/page/ElementTargetingTypes.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ElementTargetingTypes.h"
+
+#include "SharedBuffer.h"
+#include <wtf/persistence/PersistentCoders.h>
+
+namespace WebCore {
+
+Ref<SharedBuffer> serializeTargetedElementSelectors(const TargetedElementSelectors& selectors)
+{
+    static constexpr unsigned currentVersion = 1;
+
+    WTF::Persistence::Encoder encoder;
+
+    encoder << currentVersion;
+    encoder << selectors;
+    return SharedBuffer::create(encoder.span());
+}
+
+std::optional<TargetedElementSelectors> deserializeTargetedElementSelectors(std::span<const uint8_t> data)
+{
+    static constexpr unsigned maxAllowedVersion = 1;
+
+    WTF::Persistence::Decoder decoder { data };
+
+    std::optional<unsigned> version;
+    decoder >> version;
+    if (!version || *version > maxAllowedVersion)
+        return { };
+
+    std::optional<TargetedElementSelectors> result;
+    decoder >> result;
+    return result;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/page/ElementTargetingTypes.h
+++ b/Source/WebCore/page/ElementTargetingTypes.h
@@ -32,11 +32,14 @@
 #include <WebCore/RectEdges.h>
 #include <WebCore/RenderStyleConstants.h>
 #include <WebCore/ScriptExecutionContextIdentifier.h>
+#include <wtf/RefCounted.h>
 #include <wtf/URLHash.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
+
+class SharedBuffer;
 
 using TargetedElementSelectors = Vector<HashSet<String>>;
 using TargetedElementIdentifiers = std::pair<NodeIdentifier, ScriptExecutionContextIdentifier>;
@@ -72,5 +75,8 @@ struct TargetedElementInfo {
     bool hasLargeReplacedDescendant { false };
     bool hasAudibleMedia { false };
 };
+
+WEBCORE_EXPORT Ref<SharedBuffer> serializeTargetedElementSelectors(const TargetedElementSelectors&);
+WEBCORE_EXPORT std::optional<TargetedElementSelectors> deserializeTargetedElementSelectors(std::span<const uint8_t>);
 
 } // namespace WebCore

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -32,6 +32,7 @@
 #include "AXObjectCache.h"
 #include "AutoscrollController.h"
 #include "BackForwardController.h"
+#include "BoundaryPointInlines.h"
 #include "CachedImage.h"
 #include "Chrome.h"
 #include "ChromeClient.h"

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -657,6 +657,9 @@ typedef NS_OPTIONS(NSUInteger, _WKWebViewDataType) {
 - (void)_takeSnapshotOfNode:(_WKJSHandle *)node completionHandler:(WK_SWIFT_UI_ACTOR void (^)(NSImage *, NSError *))completionHandler WK_SWIFT_ASYNC_NAME(_takeSnapshotOfNode(_:)) WK_API_AVAILABLE(macos(WK_MAC_TBA));
 #endif
 
+- (void)_getSelectorPathDataForNode:(_WKJSHandle *)node completionHandler:(WK_SWIFT_UI_ACTOR void (^)(NSData *))completionHandler WK_SWIFT_ASYNC_NAME(_getSelectorPathDataForNode(_:)) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (void)_getNodeForSelectorPathData:(NSData *)data completionHandler:(WK_SWIFT_UI_ACTOR void (^)(_WKJSHandle *))completionHandler WK_SWIFT_ASYNC_NAME(_getNodeForSelectorPathData(_:)) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
 - (void)_debugTextWithConfiguration:(_WKTextExtractionConfiguration *)configuration completionHandler:(WK_SWIFT_UI_ACTOR void(^)(NSString *))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) NS_SWIFT_NAME(_debugText(with:completionHandler:));
 - (void)_extractDebugTextWithConfiguration:(_WKTextExtractionConfiguration *)configuration completionHandler:(WK_SWIFT_UI_ACTOR void(^)(_WKTextExtractionResult *))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) NS_SWIFT_NAME(_extractDebugText(with:completionHandler:));
 - (void)_performInteraction:(_WKTextExtractionInteraction *)interaction completionHandler:(WK_SWIFT_UI_ACTOR void(^)(_WKTextExtractionInteractionResult *))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) NS_SWIFT_NAME(_performInteraction(_:completionHandler:));

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -923,6 +923,22 @@ void WebFrameProxy::requestJSHandleForExtractedText(TextExtraction::ExtractedTex
     sendWithAsyncReply(Messages::WebFrame::RequestJSHandleForExtractedText(WTF::move(extractedText)), WTF::move(completion));
 }
 
+void WebFrameProxy::getSelectorPathsForNode(JSHandleInfo&& handle, CompletionHandler<void(Vector<HashSet<String>>&&)>&& completion)
+{
+    if (RefPtr page = m_page.get(); !page || !page->hasRunningProcess())
+        return completion({ });
+
+    sendWithAsyncReply(Messages::WebFrame::GetSelectorPathsForNode(WTF::move(handle)), WTF::move(completion));
+}
+
+void WebFrameProxy::getNodeForSelectorPaths(Vector<HashSet<String>>&& selectors, CompletionHandler<void(std::optional<JSHandleInfo>&&)>&& completion)
+{
+    if (RefPtr page = m_page.get(); !page || !page->hasRunningProcess())
+        return completion({ });
+
+    sendWithAsyncReply(Messages::WebFrame::GetNodeForSelectorPaths(WTF::move(selectors)), WTF::move(completion));
+}
+
 } // namespace WebKit
 
 #undef MESSAGE_CHECK

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -296,6 +296,9 @@ public:
     void takeSnapshotOfExtractedText(WebCore::TextExtraction::ExtractedText&&, CompletionHandler<void(RefPtr<WebCore::TextIndicator>&&)>&&);
     void requestJSHandleForExtractedText(WebCore::TextExtraction::ExtractedText&&, CompletionHandler<void(std::optional<JSHandleInfo>&&)>&&);
 
+    void getSelectorPathsForNode(JSHandleInfo&&, CompletionHandler<void(Vector<HashSet<String>>&&)>&&);
+    void getNodeForSelectorPaths(Vector<HashSet<String>>&&, CompletionHandler<void(std::optional<JSHandleInfo>&&)>&&);
+
 private:
     WebFrameProxy(WebPageProxy&, FrameProcess&, WebCore::FrameIdentifier, WebCore::SandboxFlags, WebCore::ReferrerPolicy, WebCore::ScrollbarMode, WebFrameProxy*, IsMainFrame);
 

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -296,6 +296,9 @@ public:
     void takeSnapshotOfExtractedText(WebCore::TextExtraction::ExtractedText&&, CompletionHandler<void(RefPtr<WebCore::TextIndicator>&&)>&&);
     void requestJSHandleForExtractedText(WebCore::TextExtraction::ExtractedText&&, CompletionHandler<void(std::optional<JSHandleInfo>&&)>&&);
 
+    void getSelectorPathsForNode(JSHandleInfo&&, CompletionHandler<void(Vector<HashSet<String>>&&)>&&);
+    void getNodeForSelectorPaths(Vector<HashSet<String>>&&, CompletionHandler<void(std::optional<JSHandleInfo>&&)>&&);
+
 private:
     WebFrame(WebPage&, WebCore::FrameIdentifier);
 

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.messages.in
@@ -42,4 +42,8 @@ messages -> WebFrame {
     DescribeTextExtractionInteraction(struct WebCore::TextExtraction::Interaction interaction) -> (struct WebCore::TextExtraction::InteractionDescription description)
     TakeSnapshotOfExtractedText(struct WebCore::TextExtraction::ExtractedText text) -> (RefPtr<WebCore::TextIndicator> textIndicator)
     RequestJSHandleForExtractedText(struct WebCore::TextExtraction::ExtractedText text) -> (struct std::optional<WebKit::JSHandleInfo> handle)
+
+    # Element targeting support
+    GetSelectorPathsForNode(struct WebKit::JSHandleInfo handle) -> (Vector<HashSet<String>> selectors)
+    GetNodeForSelectorPaths(Vector<HashSet<String>> selectors) -> (struct std::optional<WebKit::JSHandleInfo> handle)
 }


### PR DESCRIPTION
#### 6208d85450b164ab80406f4964fa6db9a14d21ad
<pre>
[AutoFill Debugging] Add a way for clients to extract and resolve DOM selector paths from _WKJSHandle
<a href="https://bugs.webkit.org/show_bug.cgi?id=305140">https://bugs.webkit.org/show_bug.cgi?id=305140</a>
<a href="https://rdar.apple.com/167717829">rdar://167717829</a>

Reviewed by Abrar Rahman Protyasha.

Add support for two new methods on `WKWebView`:

```
- (void)_getSelectorPathDataForNode:(_WKJSHandle *)node completionHandler:(void (^)(NSData *))completionHandler;
- (void)_getNodeForSelectorPathData:(NSData *)data completionHandler:(void (^)(_WKJSHandle *))completionHandler;
```

...which can be used to convert a `_WKJSHandle` that points to a DOM node into a serialized data
blob representing CSS selector paths that can be used to reidentify the &quot;same&quot; (or similar) DOM node
upon subsequent page loads. See below for more details.

Test: TextExtractionTests.ResolveTargetNodeFromSelectorData

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:

Drive-by fix: remove stale (broken) references to `PaintTimingData.{h|cpp}` in the Xcode project.

* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::ElementTargetingController::elementFromSelectors):
(WebCore::ElementTargetingController::selectorsForElement):
(WebCore::ElementTargetingController::findElementFromSelectors):

Refactor `ElementTargetingController`, such that the abilities to map between elements/selectors are
exposed as public static methods.

* Source/WebCore/page/ElementTargetingController.h:
* Source/WebCore/page/ElementTargetingTypes.cpp: Added.
(WebCore::serializeTargetedElementSelectors):
(WebCore::deserializeTargetedElementSelectors):

Add helper methods to convert selector path sets into opaque data, and vice versa.

* Source/WebCore/page/ElementTargetingTypes.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _getSelectorPathDataForNode:completionHandler:]):
(-[WKWebView _getNodeForSelectorPathData:completionHandler:]):

Add the new SPI entry points.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::getSelectorPathsForNode):
(WebKit::WebFrameProxy::getNodeForSelectorPaths):
* Source/WebKit/UIProcess/WebFrameProxy.h:
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::nodeFromJSHandleIdentifier):

Pull this logic out into a separate static helper function, so that we can invoke it in
`getNodeForSelectorPaths` as well.

(WebKit::WebFrame::takeSnapshotOfNode):
(WebKit::WebFrame::getSelectorPathsForNode):
(WebKit::WebFrame::getNodeForSelectorPaths):
* Source/WebKit/WebProcess/WebPage/WebFrame.h:
* Source/WebKit/WebProcess/WebPage/WebFrame.messages.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm:
(-[WKWebView synchronouslyGetSelectorPathDataForNode:]):
(-[WKWebView synchronouslyGetNodeForSelectorPathData:]):
(TestWebKitAPI::TEST(TextExtractionTests, ResolveTargetNodeFromSelectorData)):

Add a new API test that first obtains selector path data for a given element using text extraction,
and then (in a newly created web view that loads the same page) resolves the selector paths to a
node handle, which is then used to extract text in the new web view.

Canonical link: <a href="https://commits.webkit.org/305344@main">https://commits.webkit.org/305344@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c22c6cca91195a5dc5489f29cfec51b16135aafc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138084 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10449 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49492 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146158 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91059 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139957 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11151 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10602 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105611 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/77056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141030 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8335 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123804 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86462 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/507db190-0788-47d8-9576-4b5ef954acab) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7944 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5702 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6441 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117345 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42000 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148867 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10131 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42556 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114015 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10148 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8560 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114347 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29069 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7880 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120087 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64855 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10177 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38035 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9908 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73745 "Found 9 new failures in page/FrameTree.cpp, page/Frame.cpp") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10118 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9969 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->