### PR TITLE
Debug assert fires with cyclic clip-path referencing

### DIFF
--- a/LayoutTests/svg/custom/clip-path-2-step-cycle-expected.txt
+++ b/LayoutTests/svg/custom/clip-path-2-step-cycle-expected.txt
@@ -1,0 +1,1 @@
+Passes if we did not debug assert.

--- a/LayoutTests/svg/custom/clip-path-2-step-cycle.svg
+++ b/LayoutTests/svg/custom/clip-path-2-step-cycle.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <script>
+        if (window.testRunner)
+            testRunner.dumpAsText();
+    </script>
+    <defs>
+        <clipPath id="clip1" clip-path="url(#clip2)">
+            <rect width="100%" height="100%"/>
+        </clipPath>
+        <clipPath id="clip2" clip-path="url(#clip1)">
+            <circle cx="60" cy="60" r="50"/>
+        </clipPath>
+    </defs>
+    <rect width="100%" height="100%" fill="green" clip-path="url(#clip1)"/>
+    <text x="10" y="130">Passes if we did not debug assert.</text>
+</svg>

--- a/Source/WebCore/rendering/ReferencedSVGResources.cpp
+++ b/Source/WebCore/rendering/ReferencedSVGResources.cpp
@@ -99,6 +99,45 @@ ReferencedSVGResources::~ReferencedSVGResources()
         removeClientForTarget(treeScope, targetID);
 }
 
+bool ReferencedSVGResources::resourceContainsCycles(SVGResourceElementClient& client, SingleThreadWeakHashSet<RenderElement>& activeClients, SingleThreadWeakHashSet<RenderElement>& acyclicClients)
+{
+    auto& renderer = client.renderer();
+
+    if (activeClients.contains(renderer))
+        return true;
+
+    if (acyclicClients.contains(renderer))
+        return false;
+
+    RefPtr element = dynamicDowncast<SVGElement>(renderer.element());
+    if (!element)
+        return false;
+
+    activeClients.add(renderer);
+
+    for (auto& client : element->referencingCSSClients()) {
+        if (client && resourceContainsCycles(*client, activeClients, acyclicClients))
+            return true;
+    }
+
+    activeClients.remove(renderer);
+    acyclicClients.add(renderer);
+    return false;
+}
+
+bool ReferencedSVGResources::resourceContainsCycles(SVGElement& targetElement)
+{
+    SingleThreadWeakHashSet<RenderElement> acyclicResources;
+    SingleThreadWeakHashSet<RenderElement> activeResources;
+
+    for (auto& client : targetElement.referencingCSSClients()) {
+        if (client && resourceContainsCycles(*client, activeResources, acyclicResources))
+            return true;
+    }
+
+    return false;
+}
+
 void ReferencedSVGResources::addClientForTarget(SVGElement& targetElement, const AtomString& targetID)
 {
     m_elementClients.ensure(targetID, [&] {
@@ -196,6 +235,12 @@ void ReferencedSVGResources::updateReferencedResources(TreeScope& treeScope, con
             continue;
 
         addClientForTarget(*element, targetID);
+
+        if (resourceContainsCycles(*element)) {
+            oldKeys.add(targetID);
+            continue;
+        }
+
         oldKeys.remove(targetID);
     }
 

--- a/Source/WebCore/rendering/ReferencedSVGResources.h
+++ b/Source/WebCore/rendering/ReferencedSVGResources.h
@@ -84,6 +84,9 @@ private:
     static RefPtr<SVGElement> elementForResourceID(TreeScope&, const AtomString& resourceID, const SVGQualifiedName& tagName);
     static RefPtr<SVGElement> elementForResourceIDs(TreeScope&, const AtomString& resourceID, const SVGQualifiedNames& tagNames);
 
+    bool resourceContainsCycles(SVGResourceElementClient&, SingleThreadWeakHashSet<RenderElement>& activeClients, SingleThreadWeakHashSet<RenderElement>& acyclicClients);
+    bool resourceContainsCycles(SVGElement& targetElement);
+
     void addClientForTarget(SVGElement& targetElement, const AtomString&);
     void removeClientForTarget(TreeScope&, const AtomString&);
 


### PR DESCRIPTION
#### 427dfd240a3b86ddbb0702895f1eb463b1d689f1
<pre>
Debug assert fires with cyclic clip-path referencing
<a href="https://bugs.webkit.org/show_bug.cgi?id=305144">https://bugs.webkit.org/show_bug.cgi?id=305144</a>
<a href="https://rdar.apple.com/167791627">rdar://167791627</a>

Reviewed by NOBODY (OOPS!).

Ensure when adding a referenced resource, it does not cause a cyclic referencing
and if it does, remove it. Use DFS to traverse the referencing graph and return
once a cycle is detected.

Test: svg/custom/clip-path-2-step-cycle.svg

* LayoutTests/svg/custom/clip-path-2-step-cycle-expected.txt: Added.
* LayoutTests/svg/custom/clip-path-2-step-cycle.svg: Added.
* Source/WebCore/rendering/ReferencedSVGResources.cpp:
(WebCore::ReferencedSVGResources::resourceContainsCycles):
(WebCore::ReferencedSVGResources::updateReferencedResources):
* Source/WebCore/rendering/ReferencedSVGResources.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/427dfd240a3b86ddbb0702895f1eb463b1d689f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138071 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10436 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49477 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146143 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91046 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/540a24a0-4b3e-4686-8700-774abd312f93) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139944 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11138 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10588 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105594 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77050 "3 flakes 13 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f4b5c16f-a23e-4084-a7e4-a2e0fa59d454) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141017 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8322 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123788 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86445 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7935 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5692 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6424 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117333 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/41983 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148854 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10118 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42539 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114008 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10135 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8549 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114332 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7864 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120070 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64842 "Hash 427dfd24 for PR 56283 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10164 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38025 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9895 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73732 "Found 1 new failure in rendering/ReferencedSVGResources.cpp") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10105 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9956 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->