### PR TITLE
Fix clipping when <use> element in <clipPath> has visibility:hidden but references visible content

### DIFF
--- a/LayoutTests/svg/clip-path/visible-clip-path-as-hidden-use-element-expected.html
+++ b/LayoutTests/svg/clip-path/visible-clip-path-as-hidden-use-element-expected.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<div style="width: 100px; height: 100px; background-color: green"></div>

--- a/LayoutTests/svg/clip-path/visible-clip-path-as-hidden-use-element.html
+++ b/LayoutTests/svg/clip-path/visible-clip-path-as-hidden-use-element.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<svg>
+  <defs>
+    <rect id="rect" width="100" height="100" visibility="visible"></rect>
+    <clipPath id="clip" visibility="hidden">
+      <use xlink:href="#rect"/>
+    </clipPath>
+  </defs>
+  <rect width="400" height="400" fill="green" clip-path="url(#clip)"></rect>
+</svg>

--- a/LayoutTests/svg/clip-path/visible-nested-clip-path-as-hidden-use-element-expected.html
+++ b/LayoutTests/svg/clip-path/visible-nested-clip-path-as-hidden-use-element-expected.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<div style="width: 100px; height: 100px; background-color: green"></div>

--- a/LayoutTests/svg/clip-path/visible-nested-clip-path-as-hidden-use-element.html
+++ b/LayoutTests/svg/clip-path/visible-nested-clip-path-as-hidden-use-element.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<svg>
+    <defs>
+        <rect id="rect" width="100" height="100" visibility="visible"/>
+        <clipPath id="clipClip">
+            <rect width="100" height="100"/>
+        </clipPath>
+        <clipPath id="clip" clip-path="url(#clipClip)">
+            <use visibility="hidden" xlink:href="#rect"/>
+        </clipPath>
+    </defs>
+    <rect height="400" width="400" fill="green" clip-path="url(#clip)"/>
+</svg>

--- a/Source/WebCore/svg/SVGUseElement.h
+++ b/Source/WebCore/svg/SVGUseElement.h
@@ -49,6 +49,8 @@ public:
     RefPtr<SVGElement> clipChild() const;
     RenderElement* rendererClipChild() const;
 
+    SVGGraphicsElement* visibleTargetGraphicsElement() const;
+
     const SVGLengthValue& x() const { return m_x->currentValue(); }
     const SVGLengthValue& y() const { return m_y->currentValue(); }
     const SVGLengthValue& width() const { return m_width->currentValue(); }


### PR DESCRIPTION
#### ccba346ddcc57b22c5a34f3cb45215b934e34c41
<pre>
Fix clipping when &lt;use&gt; element in &lt;clipPath&gt; has visibility:hidden but references visible content
<a href="https://bugs.webkit.org/show_bug.cgi?id=304896">https://bugs.webkit.org/show_bug.cgi?id=304896</a>
<a href="https://rdar.apple.com/167491519">rdar://167491519</a>

Reviewed by Nikolas Zimmermann and Brent Fulgham.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium. Additionally,
it fixes the bug in both LegacySVG and Layer Based SVG engine (LBSE).

Merge: <a href="https://chromium.googlesource.com/chromium/src/+/53cbed151cea16f4d27cc887a272d9e672c41b75">https://chromium.googlesource.com/chromium/src/+/53cbed151cea16f4d27cc887a272d9e672c41b75</a>

When a &lt;use&gt; element inside a &lt;clipPath&gt; has visibility:hidden, but the element
it references has visibility:visible, the clipping should still be applied based
on the referenced element&apos;s visibility, not the &lt;use&gt; element&apos;s visibility.

Previously, WebKit incorrectly checked the &lt;use&gt; element&apos;s own visibility state,
causing valid clips to be ignored. Now we correctly look through to the referenced
element to determine if clipping should be applied

And remove reportError() to print error info for &lt;clipPath&gt; usage on SVGUseElement.

* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp:
(WebCore::LegacyRenderSVGResourceClipper::pathOnlyClipping):
(WebCore::LegacyRenderSVGResourceClipper::drawContentIntoMaskImage):
(WebCore::LegacyRenderSVGResourceClipper::calculateClipContentRepaintRect):
* Source/WebCore/svg/SVGClipPathElement.cpp:
(WebCore::SVGClipPathElement::shouldApplyPathClipping const):
(WebCore::SVGClipPathElement::calculateClipContentRepaintRect):
* Source/WebCore/svg/SVGUseElement.cpp:
(WebCore::SVGUseElement::visibleTargetGraphicsElementForClipping const):
(WebCore::SVGUseElement::toClipPath):
* Source/WebCore/svg/SVGUseElement.h:
* LayoutTests/svg/clip-path/visible-clip-path-as-hidden-use-element-expected.html: Added.
* LayoutTests/svg/clip-path/visible-clip-path-as-hidden-use-element.html: Added.
* LayoutTests/svg/clip-path/visible-nested-clip-path-as-hidden-use-element-expected.html: Added.
* LayoutTests/svg/clip-path/visible-nested-clip-path-as-hidden-use-element.html: Added.

Canonical link: <a href="https://commits.webkit.org/305374@main">https://commits.webkit.org/305374@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7062956dd0b8a1b8483ad27b70838fd2478aedce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138175 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10540 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49585 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146252 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91150 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140049 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11244 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10694 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105686 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77095 "8 flakes 9 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141121 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8414 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123877 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86538 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8009 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5768 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6532 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117419 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42075 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148961 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10222 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42632 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114097 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10239 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8634 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114432 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29080 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7953 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120162 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64948 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10269 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38101 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9999 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73836 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10209 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10060 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->