### PR TITLE
[libpas] Refactor libpas runtime configuration code

### DIFF
--- a/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
@@ -436,8 +436,10 @@ static ALWAYS_INLINE JITReservation initializeJITPageReservation()
 
 #if !USE(SYSTEM_MALLOC)
         static_assert(WebConfig::reservedSlotsForExecutableAllocator >= 2);
-        WebConfig::g_config[0] = std::bit_cast<uintptr_t>(reservation.base);
-        WebConfig::g_config[1] = std::bit_cast<uintptr_t>(reservationEnd);
+        constexpr size_t startSlot = offsetof(WebConfig::ReservedGlobalConfigSlots, reservationForExecutableAllocator) / sizeof(WebConfig::Slot);
+
+        WebConfig::g_config[startSlot] = std::bit_cast<uintptr_t>(reservation.base);
+        WebConfig::g_config[startSlot + 1] = std::bit_cast<uintptr_t>(reservationEnd);
 #endif
 
 #if HAVE(KDEBUG_H)

--- a/Source/WTF/wtf/WTFConfig.cpp
+++ b/Source/WTF/wtf/WTFConfig.cpp
@@ -96,10 +96,6 @@ alignas(WTF::ConfigAlignment) WTF_CONFIG_SECTION Slot g_config[WTF::ConfigSizeTo
 
 } // namespace WebConfig
 
-#if !USE(SYSTEM_MALLOC)
-static_assert(Gigacage::startSlotOfGigacageConfig == WebConfig::NumberOfReservedConfigBytes);
-#endif
-
 namespace WTF {
 
 // Works together with permanentlyFreezePages().
@@ -195,27 +191,6 @@ void Config::initialize()
 #if USE(LIBPAS) && defined(PAS_MTE_INITIALIZE_IN_WTF_CONFIG)
     PAS_MTE_INITIALIZE_IN_WTF_CONFIG;
 #endif // USE(LIBPAS)
-    const char* useAllocationProfilingRaw = getenv("JSC_useAllocationProfiling");
-    if (useAllocationProfilingRaw) {
-        auto useAllocationProfiling = unsafeSpan(useAllocationProfilingRaw);
-        if (equalLettersIgnoringASCIICase(useAllocationProfiling, "true"_s)
-            || equalLettersIgnoringASCIICase(useAllocationProfiling, "yes"_s)
-            || equal(useAllocationProfiling, "1"_s))
-            reservedConfigBytes[WebConfig::ReservedByteForAllocationProfiling] = 1;
-        else if (equalLettersIgnoringASCIICase(useAllocationProfiling, "false"_s)
-            || equalLettersIgnoringASCIICase(useAllocationProfiling, "no"_s)
-            || equal(useAllocationProfiling, "0"_s))
-            reservedConfigBytes[WebConfig::ReservedByteForAllocationProfiling] = 0;
-
-        const char* useAllocationProfilingModeRaw = getenv("JSC_allocationProfilingMode");
-        if (useAllocationProfilingModeRaw && reservedConfigBytes[WebConfig::ReservedByteForAllocationProfiling] == 1) {
-            unsigned value { 0 };
-            if (sscanf(useAllocationProfilingModeRaw, "%u", &value) == 1) {
-                RELEASE_ASSERT(value <= 0xFF);
-                reservedConfigBytes[WebConfig::ReservedByteForAllocationProfilingMode] = static_cast<uint8_t>(value & 0xFF);
-            }
-        }
-    }
 }
 
 void Config::finalize()

--- a/Source/WTF/wtf/WTFConfig.h
+++ b/Source/WTF/wtf/WTFConfig.h
@@ -41,24 +41,33 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 namespace WebConfig {
 
 using Slot = uint64_t;
+// Used primarily as storage for WTFConfig.
+// However, other components also use it to stow their own configurations:
+// - the storage for allocator configs is located at the start of the
+//   region, and is laid out a la ReservedGlobalConfigSlots below.
+// - JSC::Config is located after the body of the WTFConfig,
+//   at the address `spaceForExtensions`
 extern "C" WTF_EXPORT_PRIVATE Slot g_config[];
 
+constexpr size_t reservedSlotsForLibpasConfiguration = 2;
 constexpr size_t reservedSlotsForExecutableAllocator = 2;
-constexpr size_t reservedSlotsForMTEConfiguration = 2;
-constexpr size_t reservedSlotsForAllocationProfiling = 2;
-
-enum ReservedConfigByteOffset {
-    ReservedByteForExecutableAllocator0 = 0,
-    ReservedByteForExecutableAllocator1,
-    // The MTE offsets must be kept in sync with pas_mte_config.h
-    ReservedByteForMTEEnablement,
-    ReservedByteForMTEExtendedConfiguration,
-    ReservedByteForAllocationProfiling,
-    ReservedByteForAllocationProfilingMode,
-    NumberOfReservedConfigBytes
+struct ReservedGlobalConfigSlots {
+    // Unlike with the other two allocator configuration regions,
+    // Libpas does NOT reference these definitions to see how much space it has /
+    // what offset it starts at, as it doesn't depend on WTF and can't include
+    // cpp headers.
+    // Instead, it assumes
+    //   A) it gets at least two slots of storage,
+    //   B) that that storage starts at byte 0 of g_config (i.e. no offset)
+    Slot reservationForLibpas[reservedSlotsForLibpasConfiguration];
+    Slot reservationForExecutableAllocator[reservedSlotsForExecutableAllocator];
+    Slot reservationForGigacage[Gigacage::reservedSlotsForGigacageConfig];
+    // Storage for the WTF config proper begins here
 };
 
-static_assert(NumberOfReservedConfigBytes <= sizeof(Slot) * (reservedSlotsForExecutableAllocator + reservedSlotsForMTEConfiguration + reservedSlotsForAllocationProfiling));
+#if !USE(SYSTEM_MALLOC)
+static_assert(Gigacage::startOffsetOfGigacageConfig == offsetof(ReservedGlobalConfigSlots, reservationForGigacage));
+#endif
 
 } // namespace WebConfig
 
@@ -103,15 +112,15 @@ struct Config {
     uint64_t spaceForExtensions[1];
 };
 
-constexpr size_t startSlotOfWTFConfig = Gigacage::reservedSlotsForGigacageConfig;
-constexpr size_t startOffsetOfWTFConfig = startSlotOfWTFConfig * sizeof(WebConfig::Slot);
+constexpr size_t startOffsetOfWTFConfig = sizeof(WebConfig::ReservedGlobalConfigSlots);
+constexpr size_t startSlotOfWTFConfig = startOffsetOfWTFConfig / sizeof(WebConfig::Slot);
 
 constexpr size_t offsetOfWTFConfigExtension = startOffsetOfWTFConfig + offsetof(WTF::Config, spaceForExtensions);
 
 constexpr size_t alignmentOfWTFConfig = std::alignment_of<WTF::Config>::value;
 
-static_assert(Gigacage::reservedBytesForGigacageConfig + sizeof(WTF::Config) <= ConfigSizeToProtect);
 static_assert(roundUpToMultipleOf<alignmentOfWTFConfig>(startOffsetOfWTFConfig) == startOffsetOfWTFConfig);
+static_assert(startOffsetOfWTFConfig + sizeof(WTF::Config) <= ConfigSizeToProtect);
 
 WTF_EXPORT_PRIVATE void setPermissionsOfConfigPage();
 

--- a/Source/bmalloc/CMakeLists.txt
+++ b/Source/bmalloc/CMakeLists.txt
@@ -162,6 +162,7 @@ set(bmalloc_C_SOURCES
     libpas/src/libpas/pas_report_crash.c
     libpas/src/libpas/pas_reserved_memory_provider.c
     libpas/src/libpas/pas_root.c
+    libpas/src/libpas/pas_runtime_config.c
     libpas/src/libpas/pas_scavenger.c
     libpas/src/libpas/pas_segregated_directory.c
     libpas/src/libpas/pas_segregated_exclusive_view.c
@@ -527,6 +528,7 @@ set(bmalloc_PUBLIC_HEADERS
     libpas/src/libpas/pas_report_crash_pgm_report.h
     libpas/src/libpas/pas_reserved_memory_provider.h
     libpas/src/libpas/pas_root.h
+    libpas/src/libpas/pas_runtime_config.h
     libpas/src/libpas/pas_scavenger.h
     libpas/src/libpas/pas_segmented_vector.h
     libpas/src/libpas/pas_segregated_deallocation_logging_mode.h

--- a/Source/bmalloc/bmalloc.xcodeproj/project.pbxproj
+++ b/Source/bmalloc/bmalloc.xcodeproj/project.pbxproj
@@ -22,9 +22,11 @@
 
 /* Begin PBXBuildFile section */
 		0100000C37BABA0A0A993999 /* pas_mte_config.c in Sources */ = {isa = PBXBuildFile; fileRef = 0100000A37BABA0A0A993999 /* pas_mte_config.c */; };
+		0100000C37BABA0A0A993999 /* pas_runtime_config.c in Sources */ = {isa = PBXBuildFile; fileRef = 0100000A47BABA0A0A993999 /* pas_runtime_config.c */; };
 		0100000C37BABA0A0A999999 /* pas_mte.c in Sources */ = {isa = PBXBuildFile; fileRef = 0100000A37BABA0A0A999999 /* pas_mte.c */; };
 		0100000D37BABA0A0A991999 /* pas_zero_memory.h in Headers */ = {isa = PBXBuildFile; fileRef = 0100000B37BABA0A0A991999 /* pas_zero_memory.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0100000D37BABA0A0A993999 /* pas_mte_config.h in Headers */ = {isa = PBXBuildFile; fileRef = 0100000B37BABA0A0A993999 /* pas_mte_config.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		0100000D47BABA0A0A993999 /* pas_runtime_config.h in Headers */ = {isa = PBXBuildFile; fileRef = 0100000B47BABA0A0A993999 /* pas_runtime_config.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0100000D37BABA0A0A999999 /* pas_mte.h in Headers */ = {isa = PBXBuildFile; fileRef = 0100000B37BABA0A0A999999 /* pas_mte.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		07FB5E3D2EA4B31B00603B46 /* bmalloc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07FB5E3C2EA4B31B00603B46 /* bmalloc.swift */; };
 		0F5167741FAD685C008236A8 /* bmalloc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F5167731FAD6852008236A8 /* bmalloc.cpp */; };
@@ -659,10 +661,12 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		0100000A37BABA0A0A993999 /* pas_mte_config.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pas_mte_config.c; path = libpas/src/libpas/pas_mte_config.c; sourceTree = "<group>"; };
+		0100000A47BABA0A0A993999 /* pas_mte_config.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pas_mte_config.c; path = libpas/src/libpas/pas_mte_config.c; sourceTree = "<group>"; };
+		0100000A37BABA0A0A993999 /* pas_runtime_config.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pas_runtime_config.c; path = libpas/src/libpas/pas_runtime_config.c; sourceTree = "<group>"; };
 		0100000A37BABA0A0A999999 /* pas_mte.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pas_mte.c; path = libpas/src/libpas/pas_mte.c; sourceTree = "<group>"; };
 		0100000B37BABA0A0A991999 /* pas_zero_memory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_zero_memory.h; path = libpas/src/libpas/pas_zero_memory.h; sourceTree = "<group>"; };
 		0100000B37BABA0A0A993999 /* pas_mte_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_mte_config.h; path = libpas/src/libpas/pas_mte_config.h; sourceTree = "<group>"; };
+		0100000B47BABA0A0A993999 /* pas_runtime_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_runtime_config.h; path = libpas/src/libpas/pas_runtime_config.h; sourceTree = "<group>"; };
 		0100000B37BABA0A0A999999 /* pas_mte.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_mte.h; path = libpas/src/libpas/pas_mte.h; sourceTree = "<group>"; };
 		07FB5E3C2EA4B31B00603B46 /* bmalloc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = bmalloc.swift; sourceTree = "<group>"; };
 		0F18F83C25C3467700721C2A /* pas_segregated_exclusive_view_inlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_segregated_exclusive_view_inlines.h; path = libpas/src/libpas/pas_segregated_exclusive_view_inlines.h; sourceTree = "<group>"; };
@@ -1726,6 +1730,8 @@
 				0FC40AE32451499200876DA0 /* pas_reserved_memory_provider.h */,
 				0F87005325AF8A1A000E1ABF /* pas_root.c */,
 				0F87005925AF8A1A000E1ABF /* pas_root.h */,
+				0100000A47BABA0A0A993999 /* pas_runtime_config.c */,
+				0100000B47BABA0A0A993999 /* pas_runtime_config.h */,
 				0FC40A6D2451498A00876DA0 /* pas_scavenger.c */,
 				0FC40A572451498800876DA0 /* pas_scavenger.h */,
 				0FC40A702451498A00876DA0 /* pas_segmented_vector.h */,
@@ -2326,6 +2332,7 @@
 				2B6EB7A029EE102E00F10400 /* pas_report_crash_pgm_report.h in Headers */,
 				DD4BEC6529CBA49700398E35 /* pas_reserved_memory_provider.h in Headers */,
 				DD4BEC8529CBA49700398E35 /* pas_root.h in Headers */,
+				0100000D47BABA0A0A993999 /* pas_runtime_config.h in Headers */,
 				DD4BED4829CBA49700398E35 /* pas_scavenger.h in Headers */,
 				DD4BEDD029CBA49700398E35 /* pas_segmented_vector.h in Headers */,
 				DD4BECF529CBA49700398E35 /* pas_segregated_deallocation_logging_mode.h in Headers */,
@@ -2721,6 +2728,7 @@
 				2BDF4F4C29E8B8BA0056BF50 /* pas_report_crash.c in Sources */,
 				DD4BECB829CBA49700398E35 /* pas_reserved_memory_provider.c in Sources */,
 				DD4BEC2C29CBA49700398E35 /* pas_root.c in Sources */,
+				0100000C47BABA0A0A993999 /* pas_runtime_config.c in Sources */,
 				DD4BEC3329CBA49700398E35 /* pas_scavenger.c in Sources */,
 				DD4BED5029CBA49700398E35 /* pas_segregated_directory.c in Sources */,
 				DD4BECF829CBA49700398E35 /* pas_segregated_exclusive_view.c in Sources */,

--- a/Source/bmalloc/bmalloc/GigacageConfig.h
+++ b/Source/bmalloc/bmalloc/GigacageConfig.h
@@ -102,17 +102,15 @@ struct Config {
     size_t allocSizes[static_cast<size_t>(NumberOfKinds)];
 };
 
-// The first 6 slots are reserved for use by system allocators
-constexpr size_t startSlotOfGigacageConfig = 6;
+// Should be kept in sync with the layout of
+// WTFConfig.h:ReservedGlobalConfigSlots
+constexpr size_t startSlotOfGigacageConfig = 4;
 constexpr size_t startOffsetOfGigacageConfig = startSlotOfGigacageConfig * sizeof(WebConfig::Slot);
-
-constexpr size_t reservedSlotsForGigacageConfig = 16;
-constexpr size_t reservedBytesForGigacageConfig = reservedSlotsForGigacageConfig * sizeof(WebConfig::Slot);
-
-constexpr size_t alignmentOfGigacageConfig = std::alignment_of<Gigacage::Config>::value;
-
-static_assert(sizeof(Gigacage::Config) + startOffsetOfGigacageConfig <= reservedBytesForGigacageConfig);
+constexpr size_t alignmentOfGigacageConfig = std::alignment_of_v<Gigacage::Config>;
 static_assert(bmalloc::roundUpToMultipleOf<alignmentOfGigacageConfig>(startOffsetOfGigacageConfig) == startOffsetOfGigacageConfig);
+
+constexpr size_t reservedBytesForGigacageConfig = sizeof(Config);
+constexpr size_t reservedSlotsForGigacageConfig = bmalloc::roundUpToMultipleOf<sizeof(WebConfig::Slot)>(reservedBytesForGigacageConfig);
 
 #define g_gigacageConfig (*std::bit_cast<Gigacage::Config*>(&WebConfig::g_config[Gigacage::startSlotOfGigacageConfig]))
 

--- a/Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj
+++ b/Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj
@@ -364,6 +364,8 @@
 		0F99999D26AAAA0000212121 /* pas_mte.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F99999B26AAAA0000212121 /* pas_mte.h */; };
 		0F99999C26AAAA0000213121 /* pas_mte_config.c in Sources */ = {isa = PBXBuildFile; fileRef = 0F99999A26AAAA0000213121 /* pas_mte_config.c */; };
 		0F99999D26AAAA0000213121 /* pas_mte_config.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F99999B26AAAA0000213121 /* pas_mte_config.h */; };
+		0F99999C36AAAA0000213121 /* pas_runtime_config.c in Sources */ = {isa = PBXBuildFile; fileRef = 0F99999A36AAAA0000213121 /* pas_runtime_config.c */; };
+		0F99999D36AAAA0000213121 /* pas_runtime_config.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F99999B36AAAA0000213121 /* pas_runtime_config.h */; };
 		0F99999D26AAAA0000111111 /* pas_mte.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F99999B26AAAA0000111111 /* pas_zero_memory.h */; };
 		0F99999C26AAAA0000999999 /* pas_stats.c in Sources */ = {isa = PBXBuildFile; fileRef = 0F99999A26AAAA0000999999 /* pas_stats.c */; };
 		0F99999D26AAAA0000999999 /* pas_stats.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F99999B26AAAA0000999999 /* pas_stats.h */; };
@@ -1090,6 +1092,8 @@
 		0F99999B26AAAA0000212121 /* pas_mte.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_mte.h; sourceTree = "<group>"; };
 		0F99999A26AAAA0000213121 /* pas_mte_config.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pas_mte_config.c; sourceTree = "<group>"; };
 		0F99999B26AAAA0000213121 /* pas_mte_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_mte_config.h; sourceTree = "<group>"; };
+		0F99999A36AAAA0000213121 /* pas_runtime_config.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pas_runtime_config.c; sourceTree = "<group>"; };
+		0F99999B36AAAA0000213121 /* pas_runtime_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_runtime_config.h; sourceTree = "<group>"; };
 		0F99999B26AAAA0000111111 /* pas_zero_memory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_zero_memory.h; sourceTree = "<group>"; };
 		0F99999A26AAAA0000999999 /* pas_stats.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pas_stats.c; sourceTree = "<group>"; };
 		0F99999B26AAAA0000999999 /* pas_stats.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_stats.h; sourceTree = "<group>"; };
@@ -1889,6 +1893,8 @@
 				0F5B6090235E88EE00CAE629 /* pas_reserved_memory_provider.h */,
 				0F4F60F825979BC7008B4A82 /* pas_root.c */,
 				0F4F60F925979BC8008B4A82 /* pas_root.h */,
+				0F99999A36AAAA0000213121 /* pas_runtime_config.c */,
+				0F99999B36AAAA0000213121 /* pas_runtime_config.h */,
 				0F19326B22F73E8400FBA713 /* pas_scavenger.c */,
 				0F19326A22F73E8400FBA713 /* pas_scavenger.h */,
 				0F68127122BD4BF40036A02B /* pas_segmented_vector.h */,
@@ -2390,6 +2396,7 @@
 				2BDF4F4529E8B36F0056BF50 /* pas_report_crash.h in Headers */,
 				0F5B6092235E88EF00CAE629 /* pas_reserved_memory_provider.h in Headers */,
 				0F4F60FB25979BC8008B4A82 /* pas_root.h in Headers */,
+				0F99999D36AAAA0000213121 /* pas_runtime_config.h in Headers */,
 				0F19326C22F73E8500FBA713 /* pas_scavenger.h in Headers */,
 				0F68127222BD4BF40036A02B /* pas_segmented_vector.h in Headers */,
 				2C34FFFC27571D2F005565CB /* pas_segregated_deallocation_logging_mode.h in Headers */,
@@ -2894,6 +2901,7 @@
 				0FA5E4592492D5BA00CE962A /* pas_redundant_local_allocator_node.c in Sources */,
 				0F5B6091235E88EF00CAE629 /* pas_reserved_memory_provider.c in Sources */,
 				0F4F60FA25979BC8008B4A82 /* pas_root.c in Sources */,
+				0F99999C36AAAA0000213121 /* pas_runtime_config.c in Sources */,
 				0F19326D22F73E8500FBA713 /* pas_scavenger.c in Sources */,
 				0FD48B5923A9ABB30026C46D /* pas_segregated_directory.c in Sources */,
 				0FD48B5323A9ABB30026C46D /* pas_segregated_exclusive_view.c in Sources */,

--- a/Source/bmalloc/libpas/src/libpas/pas_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_config.h
@@ -86,11 +86,7 @@
 #define PAS_ARM __PAS_ARM
 
 #ifndef PAS_ENABLE_MTE
-#if defined(PAS_BMALLOC)
 #define PAS_ENABLE_MTE (PAS_USE_APPLE_INTERNAL_SDK && __PAS_ARM64E)
-#else /* !defined(PAS_BMALLOC) */
-#define PAS_ENABLE_MTE 0
-#endif /* defined(PAS_BMALLOC) */
 #endif /* PAS_ENABLE_MTE */
 
 #define PAS_RISCV __PAS_RISCV

--- a/Source/bmalloc/libpas/src/libpas/pas_mte_config.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_mte_config.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Apple Inc. All rights reserved.
+ * Copyright (c) 2025-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -108,37 +108,41 @@ static bool get_value_if_available(unsigned* valuePtr, const char* var)
 
 static void pas_mte_do_initialization(void)
 {
-    uint8_t* enabled_byte = &PAS_MTE_CONFIG_BYTE(PAS_MTE_ENABLE_FLAG);
-    uint8_t* mode_byte = &PAS_MTE_CONFIG_BYTE(PAS_MTE_MODE_BITS);
-    uint8_t* medium_byte = &PAS_MTE_CONFIG_BYTE(PAS_MTE_MEDIUM_TAGGING_ENABLE_FLAG);
-    uint8_t* lockdown_mode_byte = &PAS_MTE_CONFIG_BYTE(PAS_MTE_LOCKDOWN_MODE_FLAG);
-    uint8_t* hardened_byte = &PAS_MTE_CONFIG_BYTE(PAS_MTE_HARDENED_FLAG);
+    pas_runtime_config* config = PAS_RUNTIME_CONFIG_PTR;
 
     struct proc_bsdinfo info;
     int rc = proc_pidinfo(getpid(), PROC_PIDTBSDINFO, 0, &info, sizeof(info));
     if (rc == sizeof(info) && info.pbi_flags & PAS_MTE_PROC_FLAG_SEC_ENABLED)
-        *enabled_byte = 1;
+        config->enabled = true;
 
     if (is_env_true("JSC_useAllocationProfiling") || is_env_true("MTE_overrideEnablementForJavaScriptCore")) {
         PAS_ASSERT(!(is_env_false("JSC_useAllocationProfiling") || is_env_false("MTE_overrideEnablementForJavaScriptCore")));
-        *enabled_byte = 1;
+        config->enabled = true;
     }
     if (is_env_false("JSC_useAllocationProfiling") || is_env_false("MTE_overrideEnablementForJavaScriptCore"))
-        *enabled_byte = 0;
+        config->enabled = false;
 
-    if (!*enabled_byte)
+    if (!config->enabled)
         return;
 
     uint64_t ldmState = 0;
     size_t sysCtlLen = sizeof(ldmState);
     if (sysctlbyname("security.mac.lockdown_mode_state", &ldmState, &sysCtlLen, NULL, 0) >= 0 && ldmState == 1)
-        *lockdown_mode_byte = 1;
+        config->is_lockdown_mode = true;
     else
-        *lockdown_mode_byte = 0;
+        config->is_lockdown_mode = false;
 
     unsigned mode = 0;
-    if (get_value_if_available(&mode, "JSC_allocationProfilingMode"))
-        *mode_byte = (uint8_t)(mode & 0xFF);
+    if (get_value_if_available(&mode, "JSC_allocationProfilingMode")) {
+        uint8_t mode_byte = (uint8_t)(mode & 0xFF);
+        config->mode_bits.retag_on_scavenge = (mode_byte >> PAS_MTE_FEATURE_RETAG_ON_SCAVENGE) & 1;
+        config->mode_bits.log_on_tag = (mode_byte >> PAS_MTE_FEATURE_LOG_ON_TAG) & 1;
+        config->mode_bits.log_on_purify = (mode_byte >> PAS_MTE_FEATURE_LOG_ON_PURIFY) & 1;
+        config->mode_bits.log_page_alloc = (mode_byte >> PAS_MTE_FEATURE_LOG_PAGE_ALLOC) & 1;
+        config->mode_bits.zero_tag_all = (mode_byte >> PAS_MTE_FEATURE_ZERO_TAG_ALL) & 1;
+        config->mode_bits.adjacent_tag_exclusion = (mode_byte >> PAS_MTE_FEATURE_ADJACENT_TAG_EXCLUSION) & 1;
+        config->mode_bits.assert_adjacent_tags_are_disjoint = (mode_byte >> PAS_MTE_FEATURE_ASSERT_ADJACENT_TAGS_ARE_DISJOINT) & 1;
+    }
 
     const char* name = getprogname();
     bool isWebContentProcess = !strncmp(name, "com.apple.WebKit.WebContent", 27) || !strncmp(name, "jsc", 3);
@@ -155,7 +159,7 @@ static void pas_mte_do_initialization(void)
     // Debug option to unconditionally override the tagging rate.
     get_value_if_available(&taggingRate, "MTE_taggingRate");
 
-    PAS_MTE_CONFIG_BYTE(PAS_MTE_TAGGING_RATE) = taggingRate;
+    config->tagging_rate = taggingRate;
 
     if (isWebContentProcess) {
         // For a variety of reasons, a full MTE implementation in the WebContent process is not generally practical.
@@ -165,24 +169,24 @@ static void pas_mte_do_initialization(void)
 
         bool wcp_is_hardened = false;
         bool isEnhancedSecurityWebContentProcess = !strncmp(name, "com.apple.WebKit.WebContent.EnhancedSecurity", 44);
-        if (*lockdown_mode_byte || isEnhancedSecurityWebContentProcess)
+        if (config->is_lockdown_mode || isEnhancedSecurityWebContentProcess)
             wcp_is_hardened = true;
 
         if (wcp_is_hardened) {
-            *medium_byte = 1;
-            *enabled_byte = 1;
-            *hardened_byte = 1;
+            config->medium_tagging_enabled = true;
+            config->enabled = true;
+            config->is_hardened = true;
 
             pas_mte_force_nontaggable_user_allocations_into_large_heap();
         } else {
-            *medium_byte = 0;
+            config->medium_tagging_enabled = false;
 #if !PAS_USE_MTE_IN_WEBCONTENT
             // Disable tagging in libpas by default in WebContent process
-            *enabled_byte = 0;
+            config->enabled = false;
 #else
-            *enabled_byte = 1;
+            config->enabled = true;
 #endif
-            *hardened_byte = 0;
+            config->is_hardened = false;
             // FIXME: rdar://159974195
             bmalloc_common_primitive_heap.is_non_compact_heap = false;
         }
@@ -190,54 +194,41 @@ static void pas_mte_do_initialization(void)
 #ifndef NDEBUG
         if (is_env_true("MTE_disableForWebContent")) {
             PAS_ASSERT(!is_env_true("MTE_overrideEnablementForWebContent"));
-            *enabled_byte = 0;
-            *medium_byte = 0;
+            config->enabled = false;
+            config->medium_tagging_enabled = false;
         }
 #endif
         if (is_env_true("MTE_overrideEnablementForWebContent")) {
-            *enabled_byte = 1;
-            *medium_byte = 1;
+            config->enabled = true;
+            config->medium_tagging_enabled = true;
         } else if (is_env_false("MTE_overrideEnablementForWebContent")) {
-            *enabled_byte = 0;
-            *medium_byte = 0;
+            config->enabled = false;
+            config->medium_tagging_enabled = false;
         }
     } else {
-        *medium_byte = 1; // Tag libpas medium objects in privileged processes
-        *hardened_byte = 1;
+        config->medium_tagging_enabled = true; // Tag libpas medium objects in privileged processes
+        config->is_hardened = true;
     }
 }
 
 static bool pas_mte_is_enabled(void)
 {
-    const uint8_t* enabledByte = ((const uint8_t*)(g_config + 2));
+    const pas_runtime_config* config = PAS_RUNTIME_CONFIG_PTR;
     struct proc_bsdinfo info;
     int rc = proc_pidinfo(getpid(), PROC_PIDTBSDINFO, 0, &info, sizeof(info));
-    return (rc == sizeof(info) && (info.pbi_flags & PAS_MTE_PROC_FLAG_SEC_ENABLED) && !!*enabledByte);
-}
-
-static void pas_mte_get_config_bytes(uint8_t (*bytes_out)[6])
-{
-    (*bytes_out)[0] = PAS_MTE_CONFIG_BYTE(PAS_MTE_ENABLE_FLAG);
-    (*bytes_out)[1] = PAS_MTE_CONFIG_BYTE(PAS_MTE_MODE_BITS);
-    (*bytes_out)[2] = PAS_MTE_CONFIG_BYTE(PAS_MTE_TAGGING_RATE);
-    (*bytes_out)[3] = PAS_MTE_CONFIG_BYTE(PAS_MTE_MEDIUM_TAGGING_ENABLE_FLAG);
-    (*bytes_out)[4] = PAS_MTE_CONFIG_BYTE(PAS_MTE_LOCKDOWN_MODE_FLAG);
-    (*bytes_out)[5] = PAS_MTE_CONFIG_BYTE(PAS_MTE_HARDENED_FLAG);
+    return (rc == sizeof(info) && (info.pbi_flags & PAS_MTE_PROC_FLAG_SEC_ENABLED) && config->enabled);
 }
 
 #else // !PAS_ENABLE_MTE
 
-static PAS_UNUSED void pas_mte_do_initialization(void) { }
+static PAS_UNUSED void pas_mte_do_initialization(void) {
+    pas_runtime_config* config = PAS_RUNTIME_CONFIG_PTR;
+    config->enabled = false;
+}
 
 static PAS_UNUSED bool pas_mte_is_enabled(void)
 {
     return false;
-}
-
-static PAS_UNUSED void pas_mte_get_config_bytes(uint8_t (*bytes_out)[6])
-{
-    for (int i = 0; i < 6; i++)
-        (*bytes_out)[i] = 0;
 }
 
 #endif // PAS_ENABLE_MTE
@@ -258,8 +249,7 @@ static void pas_report_config(void)
     const int pid = getpid();
     const mach_port_t threadno = pthread_mach_thread_np(pthread_self());
 
-    uint8_t mte_conf[6];
-    pas_mte_get_config_bytes(&mte_conf);
+    const pas_runtime_config* config = PAS_RUNTIME_CONFIG_PTR;
 
 #define LOG_FMT_STR_FOR_HEAP_CONFIG(name) "\n\tHeap-Config " #name ":" \
                                    "\n\t\tPage Configs (Enabled/MTE Taggable, Static Max Obj Size):" \
@@ -275,15 +265,15 @@ static void pas_report_config(void)
     cfg.medium_bitfit_config.base.is_enabled, cfg.medium_bitfit_config.base.allow_mte_tagging, max_object_size_for_page_config_sans_heap(&cfg.medium_bitfit_config.base), \
     cfg.marge_bitfit_config.base.is_enabled, cfg.marge_bitfit_config.base.allow_mte_tagging, max_object_size_for_page_config_sans_heap(&cfg.marge_bitfit_config.base)
 #define LOG_FMT_VARS_FOR_HEAP_RUNTIME_CONFIG(rcfg) \
-        rcfg.base.max_segregated_object_size, rcfg.base.max_bitfit_object_size, rcfg.base.directory_size_bound_for_baseline_allocators, rcfg.base.directory_size_bound_for_no_view_cache
+    rcfg.base.max_segregated_object_size, rcfg.base.max_bitfit_object_size, rcfg.base.directory_size_bound_for_baseline_allocators, rcfg.base.directory_size_bound_for_no_view_cache
 
     fprintf(stderr,
         "%s(%d,0x%x) malloc: libpas config:"
         "\n\tDeallocation Log (Max Entries, Max Bytes): %zu, %zuB"
         "\n\tScavenger (Period, Deep-Sleep Timeout, Epoch-Delta): %.2fms, %.2fms, %llu"
-        "\n\tMTE (Enabled/Mode-Bits/Tagging-Rate/Medium-Enabled/Lockdown/Hardened): (%u, %u, %u, %u, %u, %u)"
+        "\n\tMTE (Enabled/Tagging-Rate/Medium-Enabled/Lockdown/Hardened/ATE/RoS/ZTA): (%u, %u, %u, %u, %u, %u, %u, %u)"
 #if PAS_ENABLE_BMALLOC
-        "\n\tUsing System Heap: %u"
+        "\n\tForwarding to System Heap: %u"
         LOG_FMT_STR_FOR_HEAP_CONFIG(bmalloc)
         "\n\t\tRuntime Heap Config Size-Maximums (Segregated, Bitfit, Baseline Dir, No-View-Cache Dir):"
         "\n\t\t\tFlex: %uB, %uB, %uB, %uB"
@@ -306,9 +296,10 @@ static void pas_report_config(void)
         progname, pid, (int)threadno,
         (size_t)PAS_DEALLOCATION_LOG_SIZE, (size_t)PAS_DEALLOCATION_LOG_MAX_BYTES,
         pas_scavenger_period_in_milliseconds, pas_scavenger_deep_sleep_timeout_in_milliseconds, pas_scavenger_max_epoch_delta,
-        mte_conf[0], mte_conf[1], mte_conf[2], mte_conf[3], mte_conf[4], mte_conf[5],
+        config->enabled, config->tagging_rate, config->medium_tagging_enabled, config->is_lockdown_mode, config->is_hardened,
+        config->mode_bits.adjacent_tag_exclusion, config->mode_bits.retag_on_scavenge, config->mode_bits.zero_tag_all,
 #if PAS_ENABLE_BMALLOC
-        pas_system_heap_is_enabled(pas_heap_config_kind_bmalloc),
+        pas_system_heap_should_supplant_bmalloc(pas_heap_config_kind_bmalloc),
         LOG_FMT_VARS_FOR_HEAP_CONFIG(bmalloc_heap_config),
         LOG_FMT_VARS_FOR_HEAP_RUNTIME_CONFIG(bmalloc_flex_runtime_config),
         LOG_FMT_VARS_FOR_HEAP_RUNTIME_CONFIG(bmalloc_intrinsic_runtime_config),

--- a/Source/bmalloc/libpas/src/libpas/pas_mte_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_mte_config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Apple Inc. All rights reserved.
+ * Copyright (c) 2025-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,6 +27,7 @@
 #define PAS_MTE_CONFIG_H
 
 #include "pas_platform.h"
+#include "pas_runtime_config.h"
 #include "pas_config.h"
 #if defined(PAS_BMALLOC)
 #include "BPlatform.h"
@@ -66,36 +67,14 @@
 #if defined(PAS_USE_OPENSOURCE_MTE) && PAS_USE_OPENSOURCE_MTE
 #if PAS_ENABLE_MTE
 
-typedef uint64_t Slot;
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-extern Slot g_config[];
-#ifdef __cplusplus
-}
-#endif
-
-#define PAS_MTE_ENABLE_FLAG 0
-#define PAS_MTE_MODE_BITS 1
-#define PAS_MTE_TAGGING_RATE 2
-#define PAS_MTE_MEDIUM_TAGGING_ENABLE_FLAG 3
-#define PAS_MTE_LOCKDOWN_MODE_FLAG 4
-#define PAS_MTE_HARDENED_FLAG 5
-
-// Must be kept in sync with the offsets in WTFConfig.h:ReservedConfigByteOffset
-#define PAS_MTE_CONFIG_RESERVED_BYTE_OFFSET 2
-#define PAS_MTE_CONFIG_BYTE(byte) (((uint8_t*)(g_config + PAS_MTE_CONFIG_RESERVED_BYTE_OFFSET))[byte])
-
-#define PAS_USE_MTE (PAS_MTE_CONFIG_BYTE(PAS_MTE_ENABLE_FLAG))
+#define PAS_USE_MTE (PAS_RUNTIME_CONFIG_PTR->enabled)
 #ifndef PAS_USE_MTE_IN_WEBCONTENT
 #define PAS_USE_MTE_IN_WEBCONTENT 1
 #endif
 
-#define PAS_MTE_CONFIG_FIELD(byte, bit) (((PAS_MTE_CONFIG_BYTE(byte)) & (1UL << (bit))) ? 1 : 0)
-#define PAS_MTE_MEDIUM_TAGGING_ENABLED (PAS_MTE_CONFIG_BYTE(PAS_MTE_MEDIUM_TAGGING_ENABLE_FLAG))
-#define PAS_MTE_IS_LOCKDOWN_MODE (PAS_MTE_CONFIG_BYTE(PAS_MTE_LOCKDOWN_MODE_FLAG))
-#define PAS_MTE_IS_HARDENED (PAS_MTE_CONFIG_BYTE(PAS_MTE_HARDENED_FLAG))
+#define PAS_MTE_MEDIUM_TAGGING_ENABLED (PAS_RUNTIME_CONFIG_PTR->medium_tagging_enabled)
+#define PAS_MTE_IS_LOCKDOWN_MODE (PAS_RUNTIME_CONFIG_PTR->is_lockdown_mode)
+#define PAS_MTE_IS_HARDENED (PAS_RUNTIME_CONFIG_PTR->is_hardened)
 #define PAS_MTE_USE_LARGE_OBJECT_DELEGATION (PAS_USE_MTE && PAS_MTE_IS_HARDENED)
 
 #define PAS_VM_MTE 0x2000
@@ -126,6 +105,17 @@ extern Slot g_config[];
 #define PAS_MTE_FEATURE_ADJACENT_TAG_EXCLUSION 5
 #define PAS_MTE_FEATURE_ASSERT_ADJACENT_TAGS_ARE_DISJOINT 6
 
+// Helper to access feature bits by index (for dynamic feature checking)
+#define PAS_MTE_FEATURE_BIT(feature) ( \
+    (feature) == PAS_MTE_FEATURE_RETAG_ON_SCAVENGE ? PAS_RUNTIME_CONFIG_PTR->mode_bits.retag_on_scavenge : \
+    (feature) == PAS_MTE_FEATURE_LOG_ON_TAG ? PAS_RUNTIME_CONFIG_PTR->mode_bits.log_on_tag : \
+    (feature) == PAS_MTE_FEATURE_LOG_ON_PURIFY ? PAS_RUNTIME_CONFIG_PTR->mode_bits.log_on_purify : \
+    (feature) == PAS_MTE_FEATURE_LOG_PAGE_ALLOC ? PAS_RUNTIME_CONFIG_PTR->mode_bits.log_page_alloc : \
+    (feature) == PAS_MTE_FEATURE_ZERO_TAG_ALL ? PAS_RUNTIME_CONFIG_PTR->mode_bits.zero_tag_all : \
+    (feature) == PAS_MTE_FEATURE_ADJACENT_TAG_EXCLUSION ? PAS_RUNTIME_CONFIG_PTR->mode_bits.adjacent_tag_exclusion : \
+    (feature) == PAS_MTE_FEATURE_ASSERT_ADJACENT_TAGS_ARE_DISJOINT ? PAS_RUNTIME_CONFIG_PTR->mode_bits.assert_adjacent_tags_are_disjoint : \
+    0)
+
 #define PAS_MTE_FEATURE_FORCED(feature) (0)
 #define PAS_MTE_FEATURE_HARDENED_FORCED(feature) (feature == PAS_MTE_FEATURE_ADJACENT_TAG_EXCLUSION || feature == PAS_MTE_FEATURE_RETAG_ON_SCAVENGE)
 #define PAS_MTE_FEATURE_DEBUG_FORCED(feature) (feature == PAS_MTE_FEATURE_ASSERT_ADJACENT_TAGS_ARE_DISJOINT)
@@ -137,7 +127,7 @@ extern Slot g_config[];
 #define PAS_MTE_FEATURE_FORCED_IN_DEBUG_BUILD(feature) \
     (PAS_MTE_FEATURE_FORCED_IN_RELEASE_BUILD(feature) || \
      PAS_MTE_FEATURE_DEBUG_FORCED(feature) || \
-     PAS_MTE_CONFIG_FIELD(PAS_MTE_MODE_BITS, feature))
+     PAS_MTE_FEATURE_BIT(feature))
 
 #ifndef NDEBUG
 #define PAS_MTE_FEATURE_ENABLED(feature) (PAS_USE_MTE && PAS_MTE_FEATURE_FORCED_IN_DEBUG_BUILD(feature))

--- a/Source/bmalloc/libpas/src/libpas/pas_runtime_config.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_runtime_config.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#include "pas_config.h"
+
+#if LIBPAS_ENABLED
+#include "pas_runtime_config.h"
+
+// Check whether we're linked as part of bmalloc -- if not, we need to provide
+// our own storage in lieu of the WTF config.
+// PAS_BMALLOC is not the same as PAS_ENABLE_BMALLOC: the latter is a pas-
+// internal macro which just controls whether the bmalloc heap is enabled.
+#if !defined(PAS_BMALLOC)
+#define PAS_G_CONFIG_SLOTS (PAS_RUNTIME_CONFIG_RESERVED_BYTES + sizeof(Slot) - 1) / sizeof(Slot)
+Slot g_config[PAS_G_CONFIG_SLOTS];
+#endif
+
+#endif // LIBPAS_ENABLED

--- a/Source/bmalloc/libpas/src/libpas/pas_runtime_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_runtime_config.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#ifndef PAS_RUNTIME_CONFIG_H
+#define PAS_RUNTIME_CONFIG_H
+
+#include "pas_config.h"
+#include "pas_platform.h"
+#if defined(PAS_BMALLOC)
+#include "BPlatform.h"
+// FIXME: Find a way to declare bmalloc's symbol visibility without having to
+// import a bmalloc header.
+#include "BExport.h"
+#endif
+
+
+#include <stddef.h>
+#include <stdint.h>
+
+typedef uint64_t Slot;
+
+// If libpas is linked as part of bmalloc (i.e. as part of WebKit), then
+// it uses the reserved slots in WTF's WebConfig::g_config to store its
+// configuration data. In this case, libpas' configuration storage will
+// begin at byte 0 of g_config.
+// In all other build configurations, it allocates its own storage.
+#ifdef __cplusplus
+extern "C" {
+#endif
+#if LIBPAS_ENABLED
+#if defined(PAS_BMALLOC)
+BEXPORT extern Slot g_config[];
+#else // !defined(PAS_BMALLOC)
+extern Slot g_config[];
+#endif // defined(PAS_BMALLOC)
+#endif // LIBPAS_ENABLED
+#ifdef __cplusplus
+}
+#endif
+
+// Must be kept in sync with WTFConfig.h:reservedSlotsForLibpasConfiguration
+#define PAS_RUNTIME_CONFIG_RESERVED_SLOTS 2
+#define PAS_RUNTIME_CONFIG_RESERVED_BYTES (PAS_RUNTIME_CONFIG_RESERVED_SLOTS * sizeof(Slot))
+
+typedef struct {
+    uint8_t enabled;
+
+    struct {
+        uint8_t retag_on_scavenge : 1;
+        uint8_t log_on_tag : 1;
+        uint8_t log_on_purify : 1;
+        uint8_t log_page_alloc : 1;
+        uint8_t zero_tag_all : 1;
+        uint8_t adjacent_tag_exclusion : 1;
+        uint8_t assert_adjacent_tags_are_disjoint : 1;
+    } mode_bits;
+
+    uint8_t tagging_rate;
+    bool medium_tagging_enabled;
+    bool is_lockdown_mode;
+    bool is_hardened;
+} pas_runtime_config;
+
+#if PAS_COMPILER(CLANG)
+_Static_assert(sizeof(pas_runtime_config) <= PAS_RUNTIME_CONFIG_RESERVED_BYTES, "Must not exceed storage reserved by WTF");
+#endif
+
+
+#define PAS_RUNTIME_CONFIG_PTR ((pas_runtime_config*)((uint8_t*)(g_config)))
+
+#endif // PAS_RUNTIME_CONFIG_H


### PR DESCRIPTION
#### 807130f624151270fd94d0af0190ed5be8d20298
<pre>
[libpas] Refactor libpas runtime configuration code
<a href="https://bugs.webkit.org/show_bug.cgi?id=305146">https://bugs.webkit.org/show_bug.cgi?id=305146</a>
<a href="https://rdar.apple.com/167796173">rdar://167796173</a>

Reviewed by Dan Hecht and Yusuke Suzuki.

Previously, the PAS_ENABLE_MTE guard macro was only set when
PAS_BMALLOC was defined — i.e. when libpas was being built as part of a
bmalloc build. This means that freestanding builds of libpas could not
leverage MTE — including the test suite.
Fixing this is obviously a pre-requisite for more reliably testing
libpas&apos; MTE tagging policy and the like through test-pas.

In order to do so, I refactored the initialization structure to allow for
it to cleanly manage its own storage when not linked against WTF. The new
pas_runtime_config.h includes the relevant definitions + storage, as
needed.

Further refactors were made to clean up how WTFConfig.h&apos;s g_config
storage is managed, in particular with regards to the slots reserved for
use by allocators. This includes moving libpas&apos; reserved storage to the
beginning of g_config, switching places with the storage previously used
by the ExecutableAllocator.

Beyond those refactors, the only functional change required was to add a
pas-internal replacement for the storage provided by WTF&apos;s g_config in
bmalloc builds.

* Source/bmalloc/libpas/src/libpas/pas_runtime_config.c: Added.
* Source/bmalloc/libpas/src/libpas/pas_runtime_config.h: Added.

Canonical link: <a href="https://commits.webkit.org/306105@main">https://commits.webkit.org/306105@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2f5251b7cf0932f3b327bd1daeb320ce17514e2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140118 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12498 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1628 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148269 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93194 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0422f5e9-2d40-450f-aa3f-3e3622c4ee1e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13210 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12651 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107276 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78051 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0deaceff-2027-4173-a161-bc07bef58197) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143067 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10165 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125461 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88167 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/724f8c07-d203-4c94-abd7-857423b03d1e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9813 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7345 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8549 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/132091 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119038 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1468 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151055 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/914 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12185 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1536 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115717 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12198 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10439 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116027 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29539 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10994 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121943 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67194 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12226 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1419 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/171390 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11968 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75924 "Built successfully") | [⏳ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12163 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12013 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->