### PR TITLE
REGRESSION(302499@main): Hitting asserts in http/tests/security/contentSecurityPolicy* on WebKitLegacy

### DIFF
--- a/Source/WebKitLegacy/Storage/StorageAreaSync.h
+++ b/Source/WebKitLegacy/Storage/StorageAreaSync.h
@@ -30,6 +30,7 @@
 #include <wtf/Condition.h>
 #include <wtf/HashMap.h>
 #include <wtf/Lock.h>
+#include <wtf/UniqueRef.h>
 #include <wtf/text/StringHash.h>
 
 namespace WebCore {
@@ -67,7 +68,7 @@ private:
     RefPtr<WebCore::StorageSyncManager> m_syncManager;
 
     // The database handle will only ever be opened and used on the background thread.
-    WebCore::SQLiteDatabase m_database;
+    UniqueRef<WebCore::SQLiteDatabase> m_database;
 
     // The following members are subject to thread synchronization issues.
 public:


### PR DESCRIPTION
#### 682d2e4ee552fc4dcd2038b17fc99ba7f7d17561
<pre>
REGRESSION(302499@main): Hitting asserts in http/tests/security/contentSecurityPolicy* on WebKitLegacy
<a href="https://bugs.webkit.org/show_bug.cgi?id=305150">https://bugs.webkit.org/show_bug.cgi?id=305150</a>
<a href="https://rdar.apple.com/167797804">rdar://167797804</a>

Reviewed by Geoffrey Garen.

Always heap allocate SQLiteDatabase on its own in StorageAreaSync.

No new tests since existing tests caught this issue.

* Source/WebKitLegacy/Storage/StorageAreaSync.cpp:
(WebKit::StorageAreaSync::StorageAreaSync):
(WebKit::StorageAreaSync::scheduleCloseDatabase):
(WebKit::StorageAreaSync::openDatabase):
(WebKit::StorageAreaSync::migrateItemTableIfNeeded):
(WebKit::StorageAreaSync::performImport):
(WebKit::StorageAreaSync::sync):
(WebKit::StorageAreaSync::deleteEmptyDatabase):
* Source/WebKitLegacy/Storage/StorageAreaSync.h:

Canonical link: <a href="https://commits.webkit.org/305322@main">https://commits.webkit.org/305322@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f194ac7085de1d434dc063723f6f729ebbc8a1e6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138086 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10451 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49494 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146160 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/91061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e1c82419-cf93-4e4f-8026-1ebea2e63f93) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11153 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10604 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105606 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/91061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/40f1f6e9-484a-4a5a-95c3-a8b4113b1536) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141032 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8329 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123806 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Running apply-patch; Checked out pull request; 1 api test failed or timed out; re-run-api-tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86457 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d38ea2cb-b4fc-4427-9765-d728824b0e84) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7940 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5704 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6443 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117340 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42002 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148869 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10133 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42558 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114018 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10150 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8562 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114350 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7875 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120089 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/64857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21257 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10179 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/38037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9910 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/73747 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10120 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9971 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->