### PR TITLE
AX: expose live region "removals" using new attribute

### DIFF
--- a/LayoutTests/accessibility/ios-simulator/live-regions/live-region-removal-expected.txt
+++ b/LayoutTests/accessibility/ios-simulator/live-regions/live-region-removal-expected.txt
@@ -1,0 +1,13 @@
+This test verifies that live region notification contains the removal attribute with aria-relevant='removals'.
+
+Announcement received, notification: AXAnnouncementRequested, attributed string: world{
+    UIAccessibilitySpeechAttributeAnnouncementPriority = UIAccessibilityPriorityLow;
+    UIAccessibilitySpeechAttributeLanguage = en;
+    UIAccessibilityTokenIsLiveRegionRemoval = 1;
+    UIAccessibilityTokenLiveRegionAnnouncement = 1;
+}
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Hello

--- a/LayoutTests/accessibility/ios-simulator/live-regions/live-region-removal.html
+++ b/LayoutTests/accessibility/ios-simulator/live-regions/live-region-removal.html
@@ -1,0 +1,43 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAriaLiveRegionManagementEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/accessibility-helper.js"></script>
+<meta http-equiv="content-language" content="en">
+</head>
+<body>
+
+<div id="polite-region" aria-live="polite" aria-relevant="removals">
+    Hello 
+    <p id="text">world</p>
+</div>
+
+<script>
+var output = "This test verifies that live region notification contains the removal attribute with aria-relevant='removals'.\n\n";
+var testFinished = false;
+
+function notificationCallback(object, notification, userInfo) {
+    if (notification == "AXAnnouncementRequested") {
+        output += `Announcement received, notification: ${notification}, attributed string: ${userInfo["AXAnnouncementRequested"]}\n`;
+
+        testFinished = true;
+    }
+}
+
+if (accessibilityController) {
+    window.jsTestIsAsync = true;
+    accessibilityController.addNotificationListener(notificationCallback);
+    accessibilityController.accessibleElementById("polite-region");
+
+    document.getElementById('text').remove();
+ 
+    setTimeout(async function() {
+        await waitFor(() => testFinished);
+        accessibilityController.removeNotificationListener();
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/live-regions/live-region-removals-expected.txt
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-removals-expected.txt
@@ -1,8 +1,8 @@
 This tests that the notifications for aria-relevant=removals are correct.
 
 Received announcement request:
-AnnouncementKey: removed{
-} Mariners{
+AnnouncementKey: Mariners{
+    AXIsLiveRegionRemoval = 1;
     AXLanguage = en;
 }
 AXPriorityKey: 10

--- a/Source/WebCore/platform/LocalizedStrings.cpp
+++ b/Source/WebCore/platform/LocalizedStrings.cpp
@@ -710,11 +710,6 @@ String AXAttachmentRoleText()
     return WEB_UI_STRING("attachment", "accessibility role description for an attachment element");
 }
 
-String AXRemovedText()
-{
-    return WEB_UI_STRING("removed", "prefix for announcing removed content in live regions");
-}
-
 String AXSearchFieldCancelButtonText()
 {
     return WEB_UI_STRING("cancel", "accessibility description for a search field cancel button");

--- a/Source/WebCore/platform/LocalizedStrings.h
+++ b/Source/WebCore/platform/LocalizedStrings.h
@@ -231,7 +231,6 @@ namespace WebCore {
     String AXOutputText();
     String AXSearchFieldCancelButtonText();
     String AXAttachmentRoleText();
-    String AXRemovedText();
     String AXDetailsText();
     String AXSummaryText();
     String AXFeedText();


### PR DESCRIPTION
#### 3eabf14c578214563ad10ede0248a00fa851aa1a
<pre>
AX: expose live region &quot;removals&quot; using new attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=305151">https://bugs.webkit.org/show_bug.cgi?id=305151</a>
<a href="https://rdar.apple.com/167662802">rdar://167662802</a>

Reviewed by Tyler Wilcock.

Before this change, for IsLiveRegionManagementEnabled=On, WebKit would prepend &quot;removed&quot; to
the announcement string for live regions. For various reasons, it makes more sense for ATs
to decide how they wants to handle removals (pitch change, braille labels, etc.). So instead
of adding this string in webkit, expose a new attribute on iOS and macOS that can be
consumed by ATs.

Test: accessibility/ios-simulator/live-regions/live-region-removal.html

* LayoutTests/accessibility/ios-simulator/live-regions/live-region-removal-expected.txt: Added.
* LayoutTests/accessibility/ios-simulator/live-regions/live-region-removal.html: Added.
* LayoutTests/accessibility/mac/live-regions/live-region-removals-expected.txt:
* Source/WebCore/accessibility/AXLiveRegionManager.cpp:
(WebCore::AXLiveRegionManager::computeAnnouncement const):
* Source/WebCore/platform/LocalizedStrings.cpp:
(WebCore::AXRemovedText): Deleted.
* Source/WebCore/platform/LocalizedStrings.h:

Canonical link: <a href="https://commits.webkit.org/305363@main">https://commits.webkit.org/305363@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e7ec8f4bd2047a1de2db156577c962b192d6c17

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138160 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10525 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49570 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146236 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91135 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140034 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11228 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10679 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105672 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/77087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/78fed319-803b-49f1-a8ee-fb16aaa0736a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141106 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8393 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123860 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86524 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7990 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5753 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6517 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117399 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42057 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148945 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10207 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42613 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114082 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10224 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8619 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114416 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29074 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7933 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120144 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64931 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10254 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38084 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9984 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73821 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10194 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10045 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->