### PR TITLE
Avoid heap-allocating CSSSelector in MutableCSSSelector

### DIFF
--- a/Source/WebCore/css/CSSSelectorList.cpp
+++ b/Source/WebCore/css/CSSSelectorList.cpp
@@ -58,7 +58,7 @@ CSSSelectorList::CSSSelectorList(MutableCSSSelectorList&& selectorVector)
         auto* last = selectorVector[i].get();
         auto* current = last;
         while (current) {
-            new (NotNull, &m_selectorArray[arrayIndex]) CSSSelector(WTF::move(*current->releaseSelector()));
+            new (NotNull, &m_selectorArray[arrayIndex]) CSSSelector(current->releaseSelector());
             if (current != last)
                 m_selectorArray[arrayIndex].m_isLastInComplexSelector = false;
             current = current->precedingInComplexSelector();

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -268,10 +268,7 @@ bool CSSSelectorParser::supportsComplexSelector(CSSParserTokenRange range, const
     if (parser.m_failedParsing || !range.atEnd() || !mutableSelector)
         return false;
 
-    auto complexSelector = mutableSelector->releaseSelector();
-    ASSERT(complexSelector);
-
-    return !containsUnknownWebKitPseudoElements(*complexSelector);
+    return !containsUnknownWebKitPseudoElements(mutableSelector->selector());
 }
 
 MutableCSSSelectorList CSSSelectorParser::consumeCompoundSelectorList(CSSParserTokenRange& range)

--- a/Source/WebCore/css/parser/MutableCSSSelector.h
+++ b/Source/WebCore/css/parser/MutableCSSSelector.h
@@ -51,40 +51,40 @@ public:
 
     ~MutableCSSSelector();
 
-    std::unique_ptr<CSSSelector> releaseSelector() { return WTF::move(m_selector); }
-    const CSSSelector* selector() const { return m_selector.get(); };
-    CSSSelector* selector() { return m_selector.get(); }
+    CSSSelector releaseSelector() { return WTF::move(m_selector); }
+    const CSSSelector& selector() const { return m_selector; };
+    CSSSelector& selector() { return m_selector; }
 
-    void setValue(const AtomString& value, bool matchLowerCase = false) { m_selector->setValue(value, matchLowerCase); }
-    const AtomString& value() const { return m_selector->value(); }
+    void setValue(const AtomString& value, bool matchLowerCase = false) { m_selector.setValue(value, matchLowerCase); }
+    const AtomString& value() const { return m_selector.value(); }
 
-    void setAttribute(const QualifiedName& value, CSSSelector::AttributeMatchType type) { m_selector->setAttribute(value, type); }
+    void setAttribute(const QualifiedName& value, CSSSelector::AttributeMatchType type) { m_selector.setAttribute(value, type); }
 
-    void setArgument(const AtomString& value) { m_selector->setArgument(value); }
-    void setNth(int a, int b) { m_selector->setNth(a, b); }
-    void setMatch(CSSSelector::Match value) { m_selector->setMatch(value); }
-    void setRelation(CSSSelector::Relation value) { m_selector->setRelation(value); }
-    void setForPage() { m_selector->setForPage(); }
+    void setArgument(const AtomString& value) { m_selector.setArgument(value); }
+    void setNth(int a, int b) { m_selector.setNth(a, b); }
+    void setMatch(CSSSelector::Match value) { m_selector.setMatch(value); }
+    void setRelation(CSSSelector::Relation value) { m_selector.setRelation(value); }
+    void setForPage() { m_selector.setForPage(); }
 
-    CSSSelector::Match match() const { return m_selector->match(); }
-    CSSSelector::PseudoElement pseudoElement() const { return m_selector->pseudoElement(); }
-    const CSSSelectorList* selectorList() const { return m_selector->selectorList(); }
+    CSSSelector::Match match() const { return m_selector.match(); }
+    CSSSelector::PseudoElement pseudoElement() const { return m_selector.pseudoElement(); }
+    const CSSSelectorList* selectorList() const { return m_selector.selectorList(); }
 
-    void setPseudoElement(CSSSelector::PseudoElement type) { m_selector->setPseudoElement(type); }
-    void setPseudoClass(CSSSelector::PseudoClass type) { m_selector->setPseudoClass(type); }
+    void setPseudoElement(CSSSelector::PseudoElement type) { m_selector.setPseudoElement(type); }
+    void setPseudoClass(CSSSelector::PseudoClass type) { m_selector.setPseudoClass(type); }
 
     void adoptSelectorVector(MutableCSSSelectorList&&);
     void setArgumentList(FixedVector<AtomString>);
     void setLangList(FixedVector<PossiblyQuotedIdentifier>);
     void setSelectorList(std::unique_ptr<CSSSelectorList>);
 
-    void setImplicit() { m_selector->setImplicit(); }
+    void setImplicit() { m_selector.setImplicit(); }
 
-    CSSSelector::PseudoClass pseudoClass() const { return m_selector->pseudoClass(); }
+    CSSSelector::PseudoClass pseudoClass() const { return m_selector.pseudoClass(); }
 
     bool matchesPseudoElement() const;
 
-    bool isHostPseudoClass() const { return m_selector->isHostPseudoClass(); }
+    bool isHostPseudoClass() const { return m_selector.isHostPseudoClass(); }
 
     bool hasExplicitNestingParent() const;
     bool hasExplicitPseudoClassScope() const;
@@ -106,7 +106,7 @@ public:
     std::unique_ptr<MutableCSSSelector> releaseFromComplexSelector();
 
 private:
-    std::unique_ptr<CSSSelector> m_selector;
+    CSSSelector m_selector;
     std::unique_ptr<MutableCSSSelector> m_precedingInComplexSelector;
 };
 


### PR DESCRIPTION
#### 13585ff380c99f95692fb240d7ffd2b833a135f4
<pre>
Avoid heap-allocating CSSSelector in MutableCSSSelector
<a href="https://bugs.webkit.org/show_bug.cgi?id=305153">https://bugs.webkit.org/show_bug.cgi?id=305153</a>

Reviewed by Darin Adler.

Avoid heap-allocating CSSSelector in MutableCSSSelector. This is no
longer needed after 305269@main.

* Source/WebCore/css/CSSSelectorList.cpp:
(WebCore::CSSSelectorList::CSSSelectorList):
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::supportsComplexSelector):
* Source/WebCore/css/parser/MutableCSSSelector.cpp:
(WebCore::MutableCSSSelector::parsePagePseudoSelector):
(WebCore::MutableCSSSelector::parsePseudoElementSelector):
(WebCore::MutableCSSSelector::parsePseudoClassSelector):
(WebCore::MutableCSSSelector::MutableCSSSelector):
(WebCore::MutableCSSSelector::adoptSelectorVector):
(WebCore::MutableCSSSelector::setArgumentList):
(WebCore::MutableCSSSelector::setLangList):
(WebCore::MutableCSSSelector::setSelectorList):
(WebCore::MutableCSSSelector::hasExplicitNestingParent const):
(WebCore::MutableCSSSelector::hasExplicitPseudoClassScope const):
(WebCore::MutableCSSSelector::matchesPseudoElement const):
(WebCore::MutableCSSSelector::prependInComplexSelectorAsRelative):
(WebCore::MutableCSSSelector::appendTagInComplexSelector):
(WebCore::MutableCSSSelector::startsWithExplicitCombinator const):
* Source/WebCore/css/parser/MutableCSSSelector.h:
(WebCore::MutableCSSSelector::releaseSelector):
(WebCore::MutableCSSSelector::selector const):
(WebCore::MutableCSSSelector::selector):
(WebCore::MutableCSSSelector::setValue):
(WebCore::MutableCSSSelector::value const):
(WebCore::MutableCSSSelector::setAttribute):
(WebCore::MutableCSSSelector::setArgument):
(WebCore::MutableCSSSelector::setNth):
(WebCore::MutableCSSSelector::setMatch):
(WebCore::MutableCSSSelector::setRelation):
(WebCore::MutableCSSSelector::setForPage):
(WebCore::MutableCSSSelector::match const):
(WebCore::MutableCSSSelector::pseudoElement const):
(WebCore::MutableCSSSelector::selectorList const):
(WebCore::MutableCSSSelector::setPseudoElement):
(WebCore::MutableCSSSelector::setPseudoClass):
(WebCore::MutableCSSSelector::setImplicit):
(WebCore::MutableCSSSelector::pseudoClass const):
(WebCore::MutableCSSSelector::isHostPseudoClass const):

Canonical link: <a href="https://commits.webkit.org/305339@main">https://commits.webkit.org/305339@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/354e94495037c2970ff3eb92826310f02f458719

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138098 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10463 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49506 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146172 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91073 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/954a41ac-6fba-4130-91ef-4607d1a47202) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/139971 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11165 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10616 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105616 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/77060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/dc904e16-1350-48c9-adb1-20cdc7019370) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141044 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8337 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123814 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86468 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/9c4b8d16-7554-420a-aed1-66cf01ecb0d7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7946 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5711 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6455 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117347 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42010 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148881 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10145 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42566 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114027 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10162 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8572 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114358 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29063 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7886 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120097 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64869 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10191 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38044 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9922 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73759 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10132 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/9983 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->