### PR TITLE
[JSC] Remove dominator and loop computation from IonGraph generation

### DIFF
--- a/Source/JavaScriptCore/b3/B3Procedure.cpp
+++ b/Source/JavaScriptCore/b3/B3Procedure.cpp
@@ -524,9 +524,6 @@ void Procedure::appendIonGraphPass(ASCIILiteral passName)
         auto ionBlocks = JSON::Array::create();
         ionGraph->setArray("blocks"_s, ionBlocks);
 
-        Dominators dominators(*this);
-        NaturalLoops naturalLoops(*this, dominators);
-
         for (auto* block : *this) {
             if (!block)
                 continue;
@@ -587,25 +584,6 @@ void Procedure::appendIonGraphPass(ASCIILiteral passName)
                 instructions->pushObject(WTF::move(instruction));
             }
 
-            unsigned loopDepth = 0;
-            auto computeWithNaturalLoops = [&](auto& naturalLoops, auto& dominators) {
-                auto isBackEdge = [&](auto* block) -> bool {
-                    for (auto successor : block->successors()) {
-                        if (dominators.dominates(successor.block(), block))
-                            return true;
-                    }
-                    return false;
-                };
-
-                loopDepth = naturalLoops.loopDepth(block);
-                if (isBackEdge(block))
-                    attributes->pushString("backedge"_s);
-                if (auto* loop = naturalLoops.headerOf(block))
-                    attributes->pushString("loopheader"_s);
-            };
-
-            computeWithNaturalLoops(naturalLoops, dominators);
-
             for (auto predecessor : block->predecessors())
                 predecessors->pushInteger(predecessor->index());
 
@@ -614,8 +592,8 @@ void Procedure::appendIonGraphPass(ASCIILiteral passName)
 
             ionBlock->setInteger("ptr"_s, block->index() + 1);
             ionBlock->setInteger("id"_s, block->index());
-            ionBlock->setInteger("loopDepth"_s, loopDepth);
-            ionBlock->setArray("attributes"_s, WTF::move(attributes));
+            ionBlock->setInteger("loopDepth"_s, 0);
+            ionBlock->setArray("attributes"_s, JSON::Array::create());
             ionBlock->setArray("predecessors"_s, WTF::move(predecessors));
             ionBlock->setArray("successors"_s, WTF::move(successors));
             ionBlock->setArray("instructions"_s, WTF::move(instructions));


### PR DESCRIPTION
#### 07baf1347eec9b3f8837bc798eeab82e2616f73d
<pre>
[JSC] Remove dominator and loop computation from IonGraph generation
<a href="https://bugs.webkit.org/show_bug.cgi?id=305157">https://bugs.webkit.org/show_bug.cgi?id=305157</a>
<a href="https://rdar.apple.com/167803703">rdar://167803703</a>

Reviewed by Dan Hecht.

IonGraph viewer is relying on these attributes to layout, so this was
mandatory to compute them. However, dominator computation etc. does not
work well for irreducible graph, and some phases have irreducible graph
(some case does not). Instead, our IonGraph viewer fork is supporting
irreducible graph and not using these attributes (and loopDepth)
information anymore. So let&apos;s remove computation of them. Also support
LoadStore form of DFG too as we do not need to compute dominators
anymore.

* Source/JavaScriptCore/b3/B3Procedure.cpp:
(JSC::B3::Procedure::appendIonGraphPass):
* Source/JavaScriptCore/b3/air/AirCode.cpp:
(JSC::B3::Air::Code::appendIonGraphPass):
* Source/JavaScriptCore/dfg/DFGGraph.cpp:
(JSC::DFG::Graph::appendIonGraphPass):

Canonical link: <a href="https://commits.webkit.org/305323@main">https://commits.webkit.org/305323@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc17f255ec4900224437c69c119503f4b9937a57

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138125 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/10490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/49535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/146200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/91100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/11193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/10644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/146200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/91100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141071 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/11193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/49535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/146200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/11193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/138/builds/49535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo-libwebrtc~~](https://ews-build.webkit.org/#/builders/166/builds/6482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/130089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/11193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/49535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/148910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/136682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/10172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/49535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/148910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/10189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/10644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/148910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/49535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/64896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21258 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/10219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/49535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/169397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/9949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/73786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/169397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/10159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/10010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->