### PR TITLE
Web Inspector: Show each individual requests when there are redirects

### DIFF
--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -1722,6 +1722,8 @@ localizedStrings["Subscript @ Font Details Sidebar Property Value"] = "Subscript
 localizedStrings["Subtree Modified @ DOM Breakpoint"] = "Subtree Modified";
 localizedStrings["Suggest property names based on usage"] = "Suggest property names based on usage";
 localizedStrings["Summary"] = "Summary";
+/* Section header for network redirect details. */
+localizedStrings["Summary @ Network Redirect Headers"] = "Summary";
 /* Property value for `font-variant-position: super`. */
 localizedStrings["Superscript @ Font Details Sidebar Property Value"] = "Superscript";
 localizedStrings["Symbol"] = "Symbol";
@@ -1923,6 +1925,8 @@ localizedStrings["Video Details @ Media Sidebar"] = "Video Details";
 localizedStrings["Video Format @ Media Sidebar"] = "Video Format";
 /* Value string for Video Range color in the Media Sidebar */
 localizedStrings["Video range @ Media Sidebar"] = "Video range";
+localizedStrings["View Redirect"] = "View Redirect";
+localizedStrings["View Response"] = "View Response";
 localizedStrings["View Image"] = "View Image";
 localizedStrings["View Recording"] = "View Recording";
 localizedStrings["View Shader"] = "View Shader";

--- a/Source/WebInspectorUI/UserInterface/Base/Main.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Main.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -2814,7 +2814,7 @@ WI.linkifyElement = function(linkElement, sourceCodeLocation, options = {}) {
     linkElement.addEventListener("click", showSourceCodeLocation);
     linkElement.addEventListener("contextmenu", (event) => {
         let contextMenu = WI.ContextMenu.createFromEvent(event);
-        WI.appendContextMenuItemsForSourceCode(contextMenu, sourceCodeLocation);
+        WI.appendContextMenuItemsForNetworkResource(contextMenu, sourceCodeLocation);
     });
 };
 

--- a/Source/WebInspectorUI/UserInterface/Main.html
+++ b/Source/WebInspectorUI/UserInterface/Main.html
@@ -392,6 +392,7 @@
     <script src="Models/TimelineRecord.js"></script>
 
     <script src="Models/Resource.js"></script>
+    <script src="Models/ResourceUtilities.js"></script>
     <script src="Models/Script.js"></script>
     <script src="Models/LocalScript.js"></script>
 
@@ -800,6 +801,8 @@
     <script src="Views/MultiSidebar.js"></script>
     <script src="Views/NavigationBar.js"></script>
     <script src="Views/NetworkDOMNodeDetailView.js"></script>
+    <script src="Views/NetworkRedirectDetailView.js"></script>
+    <script src="Views/NetworkRedirectHeadersContentView.js"></script>
     <script src="Views/NetworkResourceDetailView.js"></script>
     <script src="Views/NetworkTableContentView.js"></script>
     <script src="Views/NetworkTimelineOverviewGraph.js"></script>

--- a/Source/WebInspectorUI/UserInterface/Models/Redirect.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Redirect.js
@@ -35,6 +35,11 @@ WI.Redirect = class Redirect
         console.assert(typeof responseHeaders === "object");
         console.assert(!isNaN(timestamp));
 
+        // FIXME: <https://webkit.org/b/190214> Redirect model only stores basic information.
+        // Missing from backend: detailed timing breakdown (ResourceTiming), size metrics (Metrics),
+        // and security information (Security.Security). Protocol supports these fields in
+        // Network.Response but they're not populated for redirectResponse.
+
         this._url = url;
         this._urlComponents = null;
         this._requestMethod = requestMethod;
@@ -60,5 +65,25 @@ WI.Redirect = class Redirect
         if (!this._urlComponents)
             this._urlComponents = parseURL(this._url);
         return this._urlComponents;
+    }
+
+    generateFetchCode()
+    {
+        return WI.ResourceUtilities.generateFetchCode(this);
+    }
+
+    generateCURLCommand()
+    {
+        return WI.ResourceUtilities.generateCURLCommand(this);
+    }
+
+    stringifyHTTPRequestHeaders()
+    {
+        return WI.ResourceUtilities.stringifyHTTPRequestHeaders(this);
+    }
+
+    stringifyHTTPResponseHeaders()
+    {
+        return WI.ResourceUtilities.stringifyHTTPResponseHeaders(this);
     }
 };

--- a/Source/WebInspectorUI/UserInterface/Models/ResourceUtilities.js
+++ b/Source/WebInspectorUI/UserInterface/Models/ResourceUtilities.js
@@ -1,0 +1,194 @@
+/*
+ * Copyright (C) 2024-2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    distribution and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+WI.ResourceUtilities = class ResourceUtilities
+{
+    static generateFetchCode(resource)
+    {
+        console.assert(resource instanceof WI.Resource || resource instanceof WI.Redirect, resource);
+
+        let options = {};
+
+        if (resource.requestData)
+            options.body = resource.requestData;
+
+        options.cache = "default";
+        options.credentials = (resource.requestCookies.length || resource.requestHeaders.valueForCaseInsensitiveKey("Authorization")) ? "include" : "omit";
+
+        // https://fetch.spec.whatwg.org/#forbidden-header-name
+        const forbiddenHeaders = new Set([
+            "accept-charset",
+            "accept-encoding",
+            "access-control-request-headers",
+            "access-control-request-method",
+            "connection",
+            "content-length",
+            "cookie",
+            "cookie2",
+            "date",
+            "dnt",
+            "expect",
+            "host",
+            "keep-alive",
+            "origin",
+            "referer",
+            "te",
+            "trailer",
+            "transfer-encoding",
+            "upgrade",
+            "via",
+        ]);
+        let headers = Object.entries(resource.requestHeaders)
+            .filter((header) => {
+                let key = header[0].toLowerCase();
+                if (forbiddenHeaders.has(key))
+                    return false;
+                if (key.startsWith("proxy-") || key.startsWith("sec-"))
+                    return false;
+                return true;
+            })
+            .sort((a, b) => a[0].extendedLocaleCompare(b[0]))
+            .reduce((accumulator, current) => {
+                accumulator[current[0]] = current[1];
+                return accumulator;
+            }, {});
+        if (!isEmptyObject(headers))
+            options.headers = headers;
+
+        if (resource._integrity)
+            options.integrity = resource._integrity;
+
+        if (resource.requestMethod)
+            options.method = resource.requestMethod;
+
+        options.mode = "cors";
+        options.redirect = "follow";
+
+        let referrer = resource.requestHeaders.valueForCaseInsensitiveKey("Referer");
+        if (referrer)
+            options.referrer = referrer;
+
+        if (resource._referrerPolicy)
+            options.referrerPolicy = resource._referrerPolicy;
+
+        return `fetch(${JSON.stringify(resource.url)}, ${JSON.stringify(options, null, WI.indentString())})`;
+    }
+
+    static generateCURLCommand(resource)
+    {
+        console.assert(resource instanceof WI.Resource || resource instanceof WI.Redirect, "Expected WI.Resource or WI.Redirect", resource);
+
+        function escapeStringPosix(str) {
+            function escapeCharacter(x) {
+                let code = x.charCodeAt(0);
+                let hex = code.toString(16);
+                if (code < 256)
+                    return "\\x" + hex.padStart(2, "0");
+                return "\\u" + hex.padStart(4, "0");
+            }
+
+            if (/[^\x20-\x7E]|'/.test(str)) {
+                // Use ANSI-C quoting syntax.
+                return "$'" + str.replace(/\\/g, "\\\\")
+                                 .replace(/'/g, "\\'")
+                                 .replace(/\n/g, "\\n")
+                                 .replace(/\r/g, "\\r")
+                                 .replace(/!/g, "\\041")
+                                 .replace(/[^\x20-\x7E]/g, escapeCharacter) + "'";
+            }
+
+            // Use single quote syntax.
+            return "'" + str + "'";
+        }
+
+        let command = ["curl " + escapeStringPosix(resource.url).replace(/[[{}\]]/g, "\\$&")];
+        command.push("-X " + escapeStringPosix(resource.requestMethod));
+
+        for (let key in resource.requestHeaders)
+            command.push("-H " + escapeStringPosix(`${key}: ${resource.requestHeaders[key]}`));
+
+        if (resource.requestDataContentType && resource.requestMethod !== WI.HTTPUtilities.RequestMethod.GET && resource.requestData) {
+            if (resource.requestDataContentType.match(/^application\/x-www-form-urlencoded\s*(;.*)?$/i))
+                command.push("--data " + escapeStringPosix(resource.requestData));
+            else
+                command.push("--data-raw " + escapeStringPosix(resource.requestData));
+        }
+
+        return command.join(" \\\n");
+    }
+
+    static stringifyHTTPRequestHeaders(resource)
+    {
+        console.assert(resource instanceof WI.Resource || resource instanceof WI.Redirect, "Expected WI.Resource or WI.Redirect", resource);
+
+        let lines = [];
+
+        let protocol = resource.protocol || "";
+        if (protocol === "h2") {
+            // HTTP/2 Request pseudo headers:
+            // https://tools.ietf.org/html/rfc7540#section-8.1.2.3
+            lines.push(`:method: ${resource.requestMethod}`);
+            lines.push(`:scheme: ${resource.urlComponents.scheme}`);
+            lines.push(`:authority: ${WI.h2Authority(resource.urlComponents)}`);
+            lines.push(`:path: ${WI.h2Path(resource.urlComponents)}`);
+        } else {
+            // HTTP/1.1 request line:
+            // https://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html#sec5.1
+            lines.push(`${resource.requestMethod} ${resource.urlComponents.path}${protocol ? " " + protocol.toUpperCase() : ""}`);
+        }
+
+        for (let key in resource.requestHeaders)
+            lines.push(`${key}: ${resource.requestHeaders[key]}`);
+
+        return lines.join("\n") + "\n";
+    }
+
+    static stringifyHTTPResponseHeaders(resource)
+    {
+        console.assert(resource instanceof WI.Resource || resource instanceof WI.Redirect, "Expected WI.Resource or WI.Redirect", resource);
+
+        let lines = [];
+
+        // Handle property name differences between Resource and Redirect
+        let statusCode = resource.statusCode ?? resource.responseStatusCode;
+        let statusText = resource.statusText ?? resource.responseStatusText;
+
+        let protocol = resource.protocol || "";
+        if (protocol === "h2") {
+            // HTTP/2 Response pseudo headers:
+            // https://tools.ietf.org/html/rfc7540#section-8.1.2.4
+            lines.push(`:status: ${statusCode}`);
+        } else {
+            // HTTP/1.1 response status line:
+            // https://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html#sec6.1
+            lines.push(`${protocol ? protocol.toUpperCase() + " " : ""}${statusCode} ${statusText}`);
+        }
+
+        for (let key in resource.responseHeaders)
+            lines.push(`${key}: ${resource.responseHeaders[key]}`);
+
+        return lines.join("\n") + "\n";
+    }
+};

--- a/Source/WebInspectorUI/UserInterface/Test.html
+++ b/Source/WebInspectorUI/UserInterface/Test.html
@@ -120,6 +120,7 @@
     <script src="Models/TimelineRange.js"></script>
     <script src="Models/TimelineRecord.js"></script>
 
+    <script src="Models/ResourceUtilities.js"></script>
     <script src="Models/Resource.js"></script>
     <script src="Models/Script.js"></script>
     <script src="Models/LocalScript.js"></script>

--- a/Source/WebInspectorUI/UserInterface/Views/CallFrameTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/CallFrameTreeElement.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013, 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -115,7 +115,7 @@ WI.CallFrameTreeElement = class CallFrameTreeElement extends WI.GeneralTreeEleme
     populateContextMenu(contextMenu, event)
     {
         if (this._callFrame.sourceCodeLocation)
-            WI.appendContextMenuItemsForSourceCode(contextMenu, this._callFrame.sourceCodeLocation);
+            WI.appendContextMenuItemsForNetworkResource(contextMenu, this._callFrame.sourceCodeLocation);
 
         super.populateContextMenu(contextMenu, event);
     }

--- a/Source/WebInspectorUI/UserInterface/Views/NetworkRedirectDetailView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/NetworkRedirectDetailView.js
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    distribution and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+WI.NetworkRedirectDetailView = class NetworkRedirectDetailView extends WI.NetworkDetailView
+{
+    constructor(redirect, parentResource, redirectIndex, parentEntry, delegate)
+    {
+        console.assert(redirect instanceof WI.Redirect, redirect);
+        console.assert(parentResource instanceof WI.Resource, parentResource);
+
+        super(redirect, delegate);
+
+        this._redirect = redirect;
+        this._parentResource = parentResource;
+        this._redirectIndex = redirectIndex;
+        this._parentEntry = parentEntry;
+
+        this.element.classList.add("redirect");
+
+        this._headersContentView = null;
+    }
+
+    // Public
+
+    showParentResource()
+    {
+        this._delegate?.networkRedirectDetailViewShowParentResource(this, this._parentResource);
+    }
+
+    // Protected
+
+    initialLayout()
+    {
+        this.createDetailNavigationItem("headers", WI.UIString("Headers"));
+
+        super.initialLayout();
+    }
+
+    // Private
+
+    showContentViewForIdentifier(identifier)
+    {
+        super.showContentViewForIdentifier(identifier);
+
+        switch (identifier) {
+        case "headers":
+            this._headersContentView ||= new WI.NetworkRedirectHeadersContentView(this._redirect, this._parentResource, this._redirectIndex, this._parentEntry, this._delegate);
+            this._contentBrowser.showContentView(this._headersContentView);
+            break;
+        }
+    }
+};

--- a/Source/WebInspectorUI/UserInterface/Views/NetworkRedirectHeadersContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/NetworkRedirectHeadersContentView.js
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+WI.NetworkRedirectHeadersContentView = class NetworkRedirectHeadersContentView extends WI.ContentView
+{
+    constructor(redirect, parentResource, redirectIndex, parentEntry, delegate)
+    {
+        console.assert(redirect instanceof WI.Redirect, redirect);
+        console.assert(parentResource instanceof WI.Resource, parentResource);
+
+        const representedObject = null;
+        super(representedObject);
+
+        this._redirect = redirect;
+        this._parentResource = parentResource;
+        this._redirectIndex = redirectIndex;
+        this._parentEntry = parentEntry;
+        this._delegate = delegate;
+
+        this.element.classList.add("resource-details", "resource-headers");
+        this.element.tabIndex = 0;
+    }
+
+    // Protected
+
+    initialLayout()
+    {
+        super.initialLayout();
+
+        let summarySection = new WI.ResourceDetailsSection(WI.UIString("Summary", "Summary @ Network Redirect Headers", "Section header for network redirect details"), "summary");
+        this.element.appendChild(summarySection.element);
+
+        summarySection.toggleError(this._redirect.responseStatusCode >= 400);
+        summarySection.appendKeyValuePair(WI.UIString("URL"), this._redirect.url.insertWordBreakCharacters(), "url");
+
+        let status = emDash;
+        if (this._redirect.responseStatusCode)
+            status = `${this._redirect.responseStatusCode}${this._redirect.responseStatusText ? " " + this._redirect.responseStatusText : ""}`;
+        summarySection.appendKeyValuePair(WI.UIString("Status"), status);
+
+        summarySection.appendKeyValuePair(WI.UIString("Source"), WI.UIString("Network"));
+
+        let requestSection = new WI.ResourceDetailsSection(WI.UIString("Request"), "redirect");
+        this.element.appendChild(requestSection.element);
+        requestSection.toggleError(this._redirect.responseStatusCode >= 400);
+
+        // FIXME: <https://webkit.org/b/190214> Web Inspector: expose full load metrics for redirect requests
+        requestSection.appendKeyValuePair(`${this._redirect.requestMethod} ${this._redirect.urlComponents.path}`, null, "h1-status");
+
+        for (let [key, value] of this._createSortedArrayForHeaders(this._redirect.requestHeaders))
+            requestSection.appendKeyValuePair(key, value, "header");
+
+        let responseSection = new WI.ResourceDetailsSection(WI.UIString("Redirect Response"), "redirect");
+        this.element.appendChild(responseSection.element);
+        responseSection.toggleError(this._redirect.responseStatusCode >= 400);
+
+        if (this._parentEntry?.redirectEntries) {
+            let nextRedirectEntry = this._parentEntry.redirectEntries[this._redirectIndex + 1];
+
+            let canNavigate = nextRedirectEntry
+                ? typeof this._delegate?.networkRedirectHeadersContentViewShowRedirect === "function"
+                : (typeof this._delegate?.showEntry === "function" || typeof this._delegate?.networkRedirectHeadersContentViewShowParentResource === "function");
+
+            if (canNavigate) {
+                let navLink = WI.createGoToArrowButton();
+                navLink.classList.add("redirect-nav-link");
+
+                if (nextRedirectEntry) {
+                    navLink.title = WI.UIString("View Redirect");
+                    navLink.addEventListener("click", (event) => {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        this._delegate.networkRedirectHeadersContentViewShowRedirect(this, nextRedirectEntry.redirect, this._parentResource, this._parentEntry);
+                    });
+                } else {
+                    navLink.title = WI.UIString("View Response");
+                    navLink.addEventListener("click", (event) => {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        if (this._delegate.showEntry)
+                            this._delegate.showEntry(this._parentEntry);
+                        else
+                            this._delegate.networkRedirectHeadersContentViewShowParentResource(this, this._parentResource);
+                    });
+                }
+
+                responseSection._titleElement.appendChild(navLink);
+            }
+        }
+
+        responseSection.appendKeyValuePair(`${this._redirect.responseStatusCode} ${this._redirect.responseStatusText}`, null, "h1-status");
+
+        for (let [key, value] of this._createSortedArrayForHeaders(this._redirect.responseHeaders))
+            responseSection.appendKeyValuePair(key, value, "header");
+    }
+
+    // Private
+
+    _createSortedArrayForHeaders(headers)
+    {
+        return Object.entries(headers).sort((a, b) => a[0].toLowerCase().extendedLocaleCompare(b[0].toLowerCase()));
+    }
+};

--- a/Source/WebInspectorUI/UserInterface/Views/NetworkResourceDetailView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/NetworkResourceDetailView.js
@@ -25,11 +25,13 @@
 
 WI.NetworkResourceDetailView = class NetworkResourceDetailView extends WI.NetworkDetailView
 {
-    constructor(resource, delegate)
+    constructor(resource, entry, delegate)
     {
-        console.assert(resource instanceof WI.Resource);
+        console.assert(resource instanceof WI.Resource, resource);
 
         super(resource, delegate);
+
+        this._entry = entry;
 
         this.element.classList.add("resource");
 
@@ -72,6 +74,16 @@ WI.NetworkResourceDetailView = class NetworkResourceDetailView extends WI.Networ
         this._contentBrowser.navigationBar.selectedNavigationItem = this.detailNavigationItemForIdentifier("preview");
 
         this._resourceContentView.showRequest();
+    }
+
+    showRedirect(redirect, parentResource, parentEntry)
+    {
+        this._delegate?.showRedirect?.(redirect, parentResource, parentEntry || this._entry);
+    }
+
+    showRepresentedObject(representedObject)
+    {
+        this._delegate?.showRepresentedObject?.(representedObject);
     }
 
     // ResourceSizesContentView delegate
@@ -128,7 +140,7 @@ WI.NetworkResourceDetailView = class NetworkResourceDetailView extends WI.Networ
             break;
         case "headers":
             if (!this._headersContentView)
-                this._headersContentView = new WI.ResourceHeadersContentView(this.representedObject, this);
+                this._headersContentView = new WI.ResourceHeadersContentView(this.representedObject, this._entry, this);
             this._contentBrowser.showContentView(this._headersContentView, this._contentViewCookie);
             break;
         case "cookies":

--- a/Source/WebInspectorUI/UserInterface/Views/NetworkTableContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/NetworkTableContentView.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -146,17 +146,48 @@ body[dir=rtl] .network-table > .table .cell.dom-node.name .disclosure {
     content: url(../Images/DisclosureTriangles.svg#open-selected);
 }
 
-.network-table > .table.grouped .data-container .cell.name {
-    --item-padding-start: 19px;
-    --item-disclosure-width: 11px;
+/* Styling for redirect rows */
+
+.network-table > .table .cell.name .disclosure {
+    width: 13px;
+    height: 13px;
+    vertical-align: -2px;
+    content: url(../Images/DisclosureTriangles.svg#closed-normal);
+    background-size: 13px 13px;
+    background-repeat: no-repeat;
+    margin-inline-end: 4px;
 }
 
-.network-table > .table.grouped .data-container .cell:not(.parent).name {
-    padding-inline-start: var(--item-padding-start);
+body[dir=rtl] .network-table > .table .cell.name .disclosure {
+    transform: scaleX(-1);
 }
 
-.network-table > .table.grouped .data-container .cell.child.name {
-    padding-inline-start: calc(var(--item-padding-start) + var(--item-disclosure-width));
+.network-table:focus > .table li.selected .cell.name .disclosure {
+    content: url(../Images/DisclosureTriangles.svg#closed-selected);
+}
+
+.network-table > .table .cell.name .disclosure.expanded {
+    content: url(../Images/DisclosureTriangles.svg#open-normal);
+}
+
+.network-table:focus > .table li.selected .cell.name .disclosure.expanded {
+    content: url(../Images/DisclosureTriangles.svg#open-selected);
+}
+
+.network-table > .table .cell.name.child {
+    padding-inline-start: 37px;
+}
+
+.table.network-table .data-container .data-list > li.redirect .cell:not(.name) {
+    --table-cell-padding-inline-start: 6px;
+}
+
+.table.network-table.grouped .data-container .cell.name.parent {
+    --table-cell-padding-inline-start: 6px;
+}
+
+.table.network-table.grouped .data-container .cell.name:not(.parent):not(.child) {
+    --table-cell-padding-inline-start: 23px;
 }
 
 .network-table > .table .data-container .cell.name .range {
@@ -169,6 +200,29 @@ body[dir=rtl] .network-table > .table .cell.dom-node.name .disclosure {
 
 .network-table:focus > .table .data-container li.selected .cell.name .range {
     color: hsla(0, 0%, 100%, 0.9);
+}
+
+.network-table > .table .data-container .cell.name .redirect-count {
+    display: inline-block;
+    margin-inline-start: 6px;
+    padding: 0.5px 4px;
+    background-color: var(--background-color-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: 3px;
+    font-size: 9px;
+    line-height: 1;
+    color: var(--text-color-secondary);
+    vertical-align: 1px;
+}
+
+.network-table:focus > .table li.selected .cell.name .redirect-count {
+    color: white;
+    border-color: hsla(0, 0%, 100%, 0.3);
+    background-color: hsla(0, 0%, 100%, 0.1);
+}
+
+.network-table > .table li.selected .cell.name .redirect-count {
+    color: var(--selected-foreground-color);
 }
 
 .network-table > .table li:not(.selected) .cell:is(.cache-type, .multiple) {
@@ -436,6 +490,12 @@ body[dir=rtl] .waterfall.network .block {
     }
 
     .network-table > .table .data-container .cell.name .range {
+        color: var(--text-color-secondary);
+    }
+
+    .network-table > .table .data-container .cell.name .redirect-count {
+        background-color: hsla(0, 0%, 100%, 0.05);
+        border-color: var(--border-color);
         color: var(--text-color-secondary);
     }
 

--- a/Source/WebInspectorUI/UserInterface/Views/ResourceDetailsSection.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ResourceDetailsSection.css
@@ -30,6 +30,19 @@
 .resource-details > section > .title {
     margin-bottom: 10px;
     font-size: 14px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.resource-details > section > .title > .redirect-nav-link {
+    margin-inline-start: -3px;
+    margin-bottom: -1px;
+    align-self: flex-end;
+}
+
+.resource-details > section:not(:hover) > .title > .redirect-nav-link {
+    visibility: hidden;
 }
 
 .resource-details > section > .details {

--- a/Source/WebInspectorUI/UserInterface/Views/ResourceSizesContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ResourceSizesContentView.css
@@ -108,6 +108,15 @@
     margin-inline-start: 3px;
 }
 
+.resource-sizes > .content > section.note-section {
+    text-align: center;
+}
+
+.resource-sizes > .content > section.note-section .note {
+    color: var(--text-color-secondary);
+    font-size: 11px;
+}
+
 @media (prefers-color-scheme: dark) {
     .resource-sizes > .content .label {
         color: var(--text-color-secondary);

--- a/Source/WebInspectorUI/UserInterface/Views/ResourceTimelineDataGridNode.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ResourceTimelineDataGridNode.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013, 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -178,7 +178,7 @@ WI.ResourceTimelineDataGridNode = class ResourceTimelineDataGridNode extends WI.
 
     appendContextMenuItems(contextMenu)
     {
-        WI.appendContextMenuItemsForSourceCode(contextMenu, this.resource);
+        WI.appendContextMenuItemsForNetworkResource(contextMenu, this.resource);
     }
 
     // Protected

--- a/Source/WebInspectorUI/UserInterface/Views/ResourceTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ResourceTreeElement.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -257,7 +257,7 @@ WI.ResourceTreeElement = class ResourceTreeElement extends WI.SourceCodeTreeElem
 
     populateContextMenu(contextMenu, event)
     {
-        WI.appendContextMenuItemsForSourceCode(contextMenu, this._resource);
+        WI.appendContextMenuItemsForNetworkResource(contextMenu, this._resource);
 
         super.populateContextMenu(contextMenu, event);
     }

--- a/Source/WebInspectorUI/UserInterface/Views/Table.css
+++ b/Source/WebInspectorUI/UserInterface/Views/Table.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -136,7 +136,9 @@
 .table .cell {
     position: relative;
     display: inline-block;
-    padding: 0 6px;
+    padding: 0;
+    padding-inline-start: var(--table-cell-padding-inline-start, 6px);
+    padding-inline-end: var(--table-cell-padding-inline-end, 6px);
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;

--- a/Source/WebInspectorUI/UserInterface/Views/WorkerTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/WorkerTreeElement.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -106,7 +106,7 @@ WI.WorkerTreeElement = class WorkerTreeElement extends WI.ScriptTreeElement
     populateContextMenu(contextMenu, event)
     {
         // FIXME: <https://webkit.org/b/164427> Web Inspector: WorkerTarget's mainResource should be a Resource not a Script
-        WI.appendContextMenuItemsForSourceCode(contextMenu, this.script.resource ? this.script.resource : this.script);
+        WI.appendContextMenuItemsForNetworkResource(contextMenu, this.script.resource ? this.script.resource : this.script);
 
         super.populateContextMenu(contextMenu, event);
     }


### PR DESCRIPTION
#### 485d754b0dd5e783973cf9eb29b27e1ccaad4962
<pre>
Web Inspector: Show each individual requests when there are redirects
<a href="https://bugs.webkit.org/show_bug.cgi?id=293708">https://bugs.webkit.org/show_bug.cgi?id=293708</a>
<a href="https://rdar.apple.com/152606018">rdar://152606018</a>

Reviewed by BJ Burg and Devin Rousso.

This change surfaces individual redirect information in the Network tab by allowing users
to click on redirect entries to view detailed information across multiple tabs (Preview,
Headers, Cookies, Sizes, Timing, and Security) as well as the right click context utility menu.

Limitations:
  Due to backend constraints, redirects have incomplete information compared to full resources (see <a href="https://webkit.org/b/190214)">https://webkit.org/b/190214)</a>:
  - Timing: Only a single timestamp is available (no breakdown of DNS, connection, etc.)
  - Security: No certificate or detailed security information
  - Sizes: Only estimated from header lengths (no actual body size data)

* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:
* Source/WebInspectorUI/UserInterface/Base/Main.js:
* Source/WebInspectorUI/UserInterface/Controllers/HARBuilder.js:
(WI.HARBuilder.async buildArchive):
(WI.HARBuilder.entry):
(WI.HARBuilder.requestForRedirect):
(WI.HARBuilder.responseForRedirect):
(WI.HARBuilder.timingsForRedirect):
* Source/WebInspectorUI/UserInterface/Main.html:
* Source/WebInspectorUI/UserInterface/Models/Redirect.js:
(WI.Redirect):
(WI.Redirect.prototype.generateFetchCode):
(WI.Redirect.prototype.generateCURLCommand):
(WI.Redirect.prototype.stringifyHTTPRequestHeaders):
(WI.Redirect.prototype.stringifyHTTPResponseHeaders):
* Source/WebInspectorUI/UserInterface/Models/Resource.js:
(WI.Resource.prototype.updateForRedirectResponse):
(WI.Resource.prototype.generateFetchCode):
(WI.Resource.prototype.generateCURLCommand):
(WI.Resource.prototype.stringifyHTTPRequestHeaders):
(WI.Resource.prototype.stringifyHTTPResponseHeaders):
(WI.Resource.prototype.generateCURLCommand.escapeStringPosix.escapeCharacter): Deleted.
(WI.Resource.prototype.generateCURLCommand.escapeStringPosix): Deleted.
* Source/WebInspectorUI/UserInterface/Models/ResourceUtilities.js: Added.
(WI.ResourceUtilities.generateFetchCode):
(WI.ResourceUtilities.generateCURLCommand.escapeStringPosix.escapeCharacter):
(WI.ResourceUtilities.generateCURLCommand.escapeStringPosix):
(WI.ResourceUtilities.generateCURLCommand):
(WI.ResourceUtilities):
* Source/WebInspectorUI/UserInterface/Test.html:
* Source/WebInspectorUI/UserInterface/Views/CallFrameTreeElement.js:
(WI.CallFrameTreeElement.prototype.populateContextMenu):
* Source/WebInspectorUI/UserInterface/Views/ContextMenuUtilities.js:
(WI.appendContextMenuItemsForNetworkResource):
(WI.appendContextMenuItemsForSourceCode):
* Source/WebInspectorUI/UserInterface/Views/NetworkRedirectDetailView.js: Added.
(WI.NetworkRedirectDetailView):
(WI.NetworkRedirectDetailView.prototype.showParentResource):
(WI.NetworkRedirectDetailView.prototype.initialLayout):
(WI.NetworkRedirectDetailView.prototype.showContentViewForIdentifier):
* Source/WebInspectorUI/UserInterface/Views/NetworkRedirectHeadersContentView.js: Added.
(WI.NetworkRedirectHeadersContentView):
(WI.NetworkRedirectHeadersContentView.prototype.initialLayout):
(WI.NetworkRedirectHeadersContentView.prototype._createSortedArrayForHeaders):
* Source/WebInspectorUI/UserInterface/Views/NetworkResourceDetailView.js:
(WI.NetworkResourceDetailView):
(WI.NetworkResourceDetailView.prototype.showRedirect):
(WI.NetworkResourceDetailView.prototype.showRepresentedObject):
(WI.NetworkResourceDetailView.prototype.showContentViewForIdentifier):
* Source/WebInspectorUI/UserInterface/Views/NetworkTableContentView.css:
(.network-table &gt; .table .cell.name .disclosure):
(body[dir=rtl] .network-table &gt; .table .cell.name .disclosure):
(.network-table:focus &gt; .table li.selected .cell.name .disclosure):
(.network-table &gt; .table .cell.name .disclosure.expanded):
(.network-table:focus &gt; .table li.selected .cell.name .disclosure.expanded):
(.network-table &gt; .table .cell.name.child):
(.table.network-table .data-container .data-list &gt; li.redirect .cell:not(.name)):
(.table.network-table.grouped .data-container .cell.name.parent):
(.table.network-table.grouped .data-container .cell.name:not(.parent):not(.child)):
(.network-table &gt; .table .data-container .cell.name .redirect-count):
(.network-table:focus &gt; .table li.selected .cell.name .redirect-count):
(.network-table &gt; .table li.selected .cell.name .redirect-count):
(@media (prefers-color-scheme: dark) .network-table &gt; .table .data-container .cell.name .redirect-count):
(.network-table &gt; .table.grouped .data-container .cell.name): Deleted.
(.network-table &gt; .table.grouped .data-container .cell:not(.parent).name): Deleted.
(.network-table &gt; .table.grouped .data-container .cell.child.name): Deleted.
* Source/WebInspectorUI/UserInterface/Views/NetworkTableContentView.js:
(WI.NetworkTableContentView):
(WI.NetworkTableContentView.prototype.closed):
(WI.NetworkTableContentView.prototype.showRepresentedObject):
(WI.NetworkTableContentView.prototype.networkRedirectDetailViewShowParentResource):
(WI.NetworkTableContentView.prototype.networkRedirectHeadersContentViewShowRedirect):
(WI.NetworkTableContentView.prototype.networkRedirectHeadersContentViewShowParentResource):
(WI.NetworkTableContentView.prototype.showRedirect):
(WI.NetworkTableContentView.prototype.tableCellContextMenuClicked):
(WI.NetworkTableContentView.prototype.tableSelectionDidChange):
(WI.NetworkTableContentView.prototype.tablePopulateCell):
(WI.NetworkTableContentView.prototype._populateNameCell):
(WI.NetworkTableContentView.prototype._populateInitiatorCell):
(WI.NetworkTableContentView.prototype._processPendingEntries):
(WI.NetworkTableContentView.prototype._rowIndexForRepresentedObject):
(WI.NetworkTableContentView.prototype._updateEntryForResource):
(WI.NetworkTableContentView.prototype._populateRedirectEntriesForResourceEntry):
(WI.NetworkTableContentView.prototype._showDetailView):
(WI.NetworkTableContentView.prototype._resourceRedirectsDidChange):
(WI.NetworkTableContentView.prototype._insertResourceAndReloadTable):
(WI.NetworkTableContentView.prototype._entryForResource):
(WI.NetworkTableContentView.prototype._entryForRedirect):
(WI.NetworkTableContentView.prototype._estimateHeaderSize):
(WI.NetworkTableContentView.prototype._updateFilteredEntries):
(WI.NetworkTableContentView.prototype._reloadTable):
(WI.NetworkTableContentView.prototype._HARResources):
* Source/WebInspectorUI/UserInterface/Views/ResourceCookiesContentView.js:
(WI.ResourceCookiesContentView):
(WI.ResourceCookiesContentView.prototype._refreshRequestCookiesSection):
(WI.ResourceCookiesContentView.prototype._refreshResponseCookiesSection):
* Source/WebInspectorUI/UserInterface/Views/ResourceDetailsSection.css:
(.resource-details &gt; section &gt; .title):
(.resource-details &gt; section &gt; .title &gt; .redirect-nav-link):
(.resource-details &gt; section:not(:hover) &gt; .title &gt; .redirect-nav-link):
* Source/WebInspectorUI/UserInterface/Views/ResourceHeadersContentView.js:
(WI.ResourceHeadersContentView):
(WI.ResourceHeadersContentView.prototype._refreshSummarySection):
(WI.ResourceHeadersContentView.prototype._refreshRedirectHeadersSections):
(WI.ResourceHeadersContentView.prototype._refreshRequestHeadersSection):
(WI.ResourceHeadersContentView.prototype._refreshResponseHeadersSection):
* Source/WebInspectorUI/UserInterface/Views/ResourceSizesContentView.css:
(.resource-sizes &gt; .content &gt; section.note-section):
(.resource-sizes &gt; .content &gt; section.note-section .note):
* Source/WebInspectorUI/UserInterface/Views/ResourceTimelineDataGridNode.js:
(WI.ResourceTimelineDataGridNode.prototype.appendContextMenuItems):
* Source/WebInspectorUI/UserInterface/Views/ResourceTreeElement.js:
(WI.ResourceTreeElement.prototype.populateContextMenu):
* Source/WebInspectorUI/UserInterface/Views/Table.css:
(.table .cell):
* Source/WebInspectorUI/UserInterface/Views/WorkerTreeElement.js:
(WI.WorkerTreeElement.prototype.populateContextMenu):

Canonical link: <a href="https://commits.webkit.org/306537@main">https://commits.webkit.org/306537@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0df97b2f059ba2d42e2eacb3d8823bf1f63fdefc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141463 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13850 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3191 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150039 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94560 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14560 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14007 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108687 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78657 "6 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144415 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11241 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126577 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89593 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10803 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8420 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/111 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120074 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2567 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152432 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13537 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3013 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116794 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13552 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11810 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117124 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29870 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13166 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123243 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/68734 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13580 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2564 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13316 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77293 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13515 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13363 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->