### PR TITLE
[JSC] Add `@@matchAll` to `regExpPrimordialPropertiesWatchpointSet`

### DIFF
--- a/JSTests/stress/regexp-prototype-matchall-watchpoint.js
+++ b/JSTests/stress/regexp-prototype-matchall-watchpoint.js
@@ -1,0 +1,116 @@
+// This test verifies that modifications to RegExp.prototype[Symbol.match]
+// properly invalidate the fast path optimization for matchAll.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${expected} but got ${actual}`);
+}
+
+const RegExp_prototype_match = RegExp.prototype[Symbol.match];
+
+// Test 1: Verify that Symbol.match getter is called the expected number of times.
+// When String.prototype.matchAll is called:
+// - IsRegExp() accesses @@match once
+// - RegExp constructor (via species constructor) accesses @@match once via isRegExp()
+// Total: 2 calls
+{
+    let regexp = /a+/g;
+    let callCount = 0;
+
+    Object.defineProperty(RegExp.prototype, Symbol.match, {
+        get() {
+            callCount++;
+            return RegExp_prototype_match;
+        },
+        configurable: true
+    });
+
+    let iterator = "aabbaa".matchAll(regexp);
+    shouldBe(callCount, 2);
+
+    // Restore
+    Object.defineProperty(RegExp.prototype, Symbol.match, {
+        value: RegExp_prototype_match,
+        writable: true,
+        enumerable: false,
+        configurable: true
+    });
+}
+
+// Test 2: Verify matchAll still works correctly after Symbol.match modification
+{
+    let results = [...("aabbaa".matchAll(/a+/g))];
+    shouldBe(results.length, 2);
+    shouldBe(results[0][0], "aa");
+    shouldBe(results[1][0], "aa");
+}
+
+// Test 3: Stress test - repeatedly modify and restore Symbol.match
+{
+    for (let i = 0; i < 1000; i++) {
+        let callCount = 0;
+        let regexp = /test/g;
+
+        Object.defineProperty(RegExp.prototype, Symbol.match, {
+            get() {
+                callCount++;
+                return RegExp_prototype_match;
+            },
+            configurable: true
+        });
+
+        let iterator = "test1test2".matchAll(regexp);
+        shouldBe(callCount, 2);
+
+        // Consume the iterator
+        let results = [...iterator];
+        shouldBe(results.length, 2);
+
+        // Restore for next iteration
+        Object.defineProperty(RegExp.prototype, Symbol.match, {
+            value: RegExp_prototype_match,
+            writable: true,
+            enumerable: false,
+            configurable: true
+        });
+    }
+}
+
+// Test 4: Verify fast path works when Symbol.match is not modified
+{
+    for (let i = 0; i < 10000; i++) {
+        let results = [...("hello world".matchAll(/o/g))];
+        shouldBe(results.length, 2);
+        shouldBe(results[0][0], "o");
+        shouldBe(results[1][0], "o");
+    }
+}
+
+// Test 5: Symbol.match set to a different value
+{
+    let callCount = 0;
+    let customMatch = function(string) {
+        callCount++;
+        return RegExp_prototype_match.call(this, string);
+    };
+
+    Object.defineProperty(RegExp.prototype, Symbol.match, {
+        value: customMatch,
+        writable: true,
+        configurable: true
+    });
+
+    // matchAll should use the slow path now
+    let regexp = /a/g;
+    let iterator = "aaa".matchAll(regexp);
+    let results = [...iterator];
+    shouldBe(results.length, 3);
+
+    // Restore
+    Object.defineProperty(RegExp.prototype, Symbol.match, {
+        value: RegExp_prototype_match,
+        writable: true,
+        enumerable: false,
+        configurable: true
+    });
+}

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -2187,6 +2187,7 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     installObjectPropertyChangeAdaptiveWatchpoint(setupAdaptiveWatchpoint(this, m_regExpPrototype.get(), vm.propertyNames->unicode), m_regExpPrimordialPropertiesWatchpointSet);
     installObjectPropertyChangeAdaptiveWatchpoint(setupAdaptiveWatchpoint(this, m_regExpPrototype.get(), vm.propertyNames->unicodeSets), m_regExpPrimordialPropertiesWatchpointSet);
     installObjectPropertyChangeAdaptiveWatchpoint(setupAdaptiveWatchpoint(this, m_regExpPrototype.get(), vm.propertyNames->replaceSymbol), m_regExpPrimordialPropertiesWatchpointSet);
+    installObjectPropertyChangeAdaptiveWatchpoint(setupAdaptiveWatchpoint(this, m_regExpPrototype.get(), vm.propertyNames->matchSymbol), m_regExpPrimordialPropertiesWatchpointSet);
     installObjectPropertyChangeAdaptiveWatchpoint(setupAdaptiveWatchpoint(this, jsSetPrototype(), vm.propertyNames->has), m_setPrimordialPropertiesWatchpointSet);
     installObjectPropertyChangeAdaptiveWatchpoint(setupAdaptiveWatchpoint(this, jsSetPrototype(), vm.propertyNames->keys), m_setPrimordialPropertiesWatchpointSet);
 


### PR DESCRIPTION
#### bb7bc6a96e8c5f742d0cf57bb8b93ee131c70f88
<pre>
[JSC] Add `@@matchAll` to `regExpPrimordialPropertiesWatchpointSet`
<a href="https://bugs.webkit.org/show_bug.cgi?id=305163">https://bugs.webkit.org/show_bug.cgi?id=305163</a>

Reviewed by Yusuke Suzuki.

This patch adds `Symbol.matchAll` to `regExpPrimordialPropertiesWatchpointSet` to fix
test262 failure.

* JSTests/stress/regexp-prototype-matchall-watchpoint.js: Added.
(shouldBe):
(let.customMatch):
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):

Canonical link: <a href="https://commits.webkit.org/305326@main">https://commits.webkit.org/305326@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ea2ff7b18c2b6278b649ed4358dd555ea58af75

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138117 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10482 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49527 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146192 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/91092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11185 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10635 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105633 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/91092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141063 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8353 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123827 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86486 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/7960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5722 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6474 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/130081 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117362 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42025 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148902 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/136674 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10164 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42581 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114044 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10181 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8584 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114376 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29060 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7898 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120112 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/64888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10211 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/38056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/169389 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9941 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/73778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44171 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10151 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10002 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->