### PR TITLE
Fix twitch keyboard scrolling

### DIFF
--- a/LayoutTests/fast/scrolling/ios/keyboard-scroll-expected.txt
+++ b/LayoutTests/fast/scrolling/ios/keyboard-scroll-expected.txt
@@ -1,0 +1,10 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
+PASS expect keyboard to scroll list
+target text to select
+target text to select
+target text to select
+target text to select
+target text to select
+target text to select

--- a/LayoutTests/fast/scrolling/ios/keyboard-scroll.html
+++ b/LayoutTests/fast/scrolling/ios/keyboard-scroll.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useHardwareKeyboardMode=true useFlexibleViewport=true AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ScrollAnimatorEnabled=true ] -->
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<meta charset="utf-8">
+<meta name="viewport" content="initial-scale=1.5, user-scalable=no">
+
+<script>
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+    }
+
+    async function pressKey(keyName) {
+        await UIHelper.rawKeyDown(keyName);
+        await UIHelper.renderingUpdate();
+        await UIHelper.rawKeyUp(keyName);
+    }
+
+    async function scrollWithKeyboard() {
+        await UIHelper.activateElement(list);
+        await UIHelper.activateElement(list);
+        await UIHelper.activateElement(list);
+        await pressKey("downArrow");
+
+        await UIHelper.waitForZoomingOrScrollingToEnd();
+    }
+
+    async function runTest() {
+        if (!window.testRunner || !testRunner.runUIScript)
+            return;
+
+        const originalScrollTop = list.scrollTop;
+        await scrollWithKeyboard();
+
+        expectTrue(list.scrollTop > originalScrollTop, "expect keyboard to scroll list");
+
+        testRunner.notifyDone();
+    }
+
+</script>
+
+<html lang="en">
+  <body onload="runTest()">
+    <ul id="list">
+      <li style="height: 100%; background-color: red">target text to select</li>
+      <li style="height: 100%; background-color: blue">
+        target text to select
+      </li>
+      <li style="height: 100%; background-color: red">target text to select</li>
+      <li style="height: 100%; background-color: blue">
+        target text to select
+      </li>
+      <li style="height: 100%; background-color: red">target text to select</li>
+      <li style="height: 100%; background-color: blue">
+        target text to select
+      </li>
+    </ul>
+  </body>
+</html>
+
+<style>
+  body {
+    height: 100%;
+    display: flex;
+    overflow: hidden;
+  }
+
+  #list {
+    overflow-y: auto;
+    overflow-x: hidden;
+  }
+</style>
+

--- a/Source/WebKit/UIProcess/ios/WKBaseScrollView.mm
+++ b/Source/WebKit/UIProcess/ios/WKBaseScrollView.mm
@@ -133,6 +133,12 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 ALLOW_DEPRECATED_DECLARATIONS_END
 #endif
 
+#if HAVE(UISCROLLVIEW_ALLOWS_KEYBOARD_SCROLLING)
+    // In iOS 17, the default value of `-[UIScrollView allowsKeyboardScrolling]` is `NO`.
+    // To maintain existing behavior of WKBaseScrollView, this property must be initially set to `YES`.
+    self.allowsKeyboardScrolling = YES;
+#endif
+
     _axesToPreventMomentumScrolling = UIAxisNeither;
     [self.panGestureRecognizer addTarget:self action:@selector(_updatePanGestureToPreventScrolling)];
     return self;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -7837,11 +7837,12 @@ static UITextAutocapitalizationType toUITextAutocapitalize(WebCore::Autocapitali
     if (_focusedElementInformation.elementType == WebKit::InputType::Select)
         return NO;
 
-    if (!self.webView.scrollView.scrollEnabled)
+    UIScrollView *scrollView = animator.scrollView ?: self.webView.scrollView;
+    if (!scrollView.scrollEnabled)
         return NO;
 
 #if HAVE(UISCROLLVIEW_ALLOWS_KEYBOARD_SCROLLING)
-    if (!self.webView.scrollView.allowsKeyboardScrolling)
+    if (!scrollView.allowsKeyboardScrolling)
         return NO;
 #endif
 


### PR DESCRIPTION
#### 9161fa0164ff0627c6e95ce2e0abbe9b3a7d702a
<pre>
Fix twitch keyboard scrolling
<a href="https://bugs.webkit.org/show_bug.cgi?id=305165">https://bugs.webkit.org/show_bug.cgi?id=305165</a>
<a href="https://rdar.apple.com/149250203">rdar://149250203</a>

Reviewed by Wenson Hsieh.

The issue was that WKContetView was checking if the webView&apos;s scroll view
had scroll enable, instead of the animator in question&apos;s scroll view had
scrolling enabled.

* LayoutTests/fast/scrolling/ios/keyboard-scroll-expected.txt: Added.
* LayoutTests/fast/scrolling/ios/keyboard-scroll.html: Added.
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
* Source/WebKit/UIProcess/ios/WKBaseScrollView.mm:
(-[WKBaseScrollView initWithFrame:]):
My change broke scrolling in subscrollable elements on iPhone. This changes
the default scroll view to allow keyboard scrolling, which is consistent with
iPad.
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView isScrollableForKeyboardScrollViewAnimator:]):

Canonical link: <a href="https://commits.webkit.org/305945@main">https://commits.webkit.org/305945@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1870ba43d95eea732bbc767eaf0ea92fcce118d8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139795 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12172 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1300 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147934 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92865 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/702c7c66-35d9-4b92-93ca-fec0cbc586cb) 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12880 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12323 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107047 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77920 "2 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0d3c06cc-208b-471a-acca-e26e48667f48) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142742 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9911 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125199 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87917 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c58f54b4-861c-47ae-a163-34175243ccfe) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9582 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7085 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8222 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118799 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1197 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; Running layout-tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150716 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11856 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1259 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115460 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11874 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10162 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115798 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29433 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10549 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121677 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66867 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11900 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1160 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11643 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75592 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11840 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11687 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->