### PR TITLE
Affects teads.tv: about:blank nested twice inside other about:blank frames doesn’t load

### DIFF
--- a/LayoutTests/fast/frames/nested-about-blanks-expected.html
+++ b/LayoutTests/fast/frames/nested-about-blanks-expected.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div>frame 0</div>
+<div>frame 1</div>
+<div>frame 2</div>
+<div>frame 3</div>
+</body>
+</html>

--- a/LayoutTests/fast/frames/nested-about-blanks.html
+++ b/LayoutTests/fast/frames/nested-about-blanks.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+let doc = document;
+for (let i = 0; i < 4; i++) {
+    const iframe = doc.createElement("iframe");
+    iframe.style.border = 'none';
+    doc.body.appendChild(iframe);
+    doc = iframe.contentDocument;
+    doc.head.innerHTML = '<style>html, body { margin: 0px; padding: 0px; overflow: hidden; } </style>'
+
+    const div = doc.createElement("div");
+    div.textContent = `frame ${i}`;
+    doc.body.appendChild(div);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/HTMLFrameOwnerElement.cpp
+++ b/Source/WebCore/html/HTMLFrameOwnerElement.cpp
@@ -146,6 +146,8 @@ void HTMLFrameOwnerElement::scheduleInvalidateStyleAndLayerComposition()
 
 bool HTMLFrameOwnerElement::isProhibitedSelfReference(const URL& completeURL) const
 {
+    if (completeURL.isAboutBlank())
+        return false;
     // We allow one level of self-reference because some websites depend on that, but we don't allow more than one.
     bool foundOneSelfReference = false;
     for (RefPtr<Frame> frame = document().frame(); frame; frame = frame->tree().parent()) {


### PR DESCRIPTION
#### d49e3f1c1997e5b0d5d841336baf7c7e9bfd3d72
<pre>
Affects teads.tv: about:blank nested twice inside other about:blank frames doesn’t load
<a href="https://bugs.webkit.org/show_bug.cgi?id=251595">https://bugs.webkit.org/show_bug.cgi?id=251595</a>
<a href="https://rdar.apple.com/148373033">rdar://148373033</a>

Reviewed by Simon Fraser.

The issue was caused by isProhibitedSelfReference incorrectly determining about:blank inside
another about:blank as self referencing, which is not the case.

Test: fast/frames/nested-about-blanks.html

* LayoutTests/fast/frames/nested-about-blanks-expected.html: Added.
* LayoutTests/fast/frames/nested-about-blanks.html: Added.
* Source/WebCore/html/HTMLFrameOwnerElement.cpp:
(WebCore::HTMLFrameOwnerElement::isProhibitedSelfReference const):

Canonical link: <a href="https://commits.webkit.org/305404@main">https://commits.webkit.org/305404@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0b863034f87de0f0c9cd370328f6d98857fefe3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138133 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10498 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49543 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146208 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91108 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140006 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11201 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10652 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105647 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77073 "7 flakes 12 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141079 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8367 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123841 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86499 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/84c08a5c-0e8f-45ba-9fa8-c57c1651305c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7969 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5733 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6490 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117374 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42039 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148918 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10180 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42595 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114057 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10197 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8596 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114390 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7904 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120126 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64904 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21300 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10227 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38068 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9957 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73794 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10167 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10018 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->