### PR TITLE
[Site Isolation] [intersection-observer] Compute rootViewToContents in Site Isolation mode

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-003-cross-origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-003-cross-origin-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS Target is not visible as it's rotated perpendicularly to viewport
+PASS Scroll down a bit, target is still not visible
+

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-003-cross-origin.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-003-cross-origin.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+
+<title>Intersection Observer: implicit root observer in iframe works when the iframe is transformed</title>
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
+<script src="/common/get-host-info.sub.js"></script>
+<script src="/common/rendering-utils.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  #iframe {
+    width: 300px;
+    height: 300px;
+    display: block;
+
+    transform: rotateY(-45deg) rotateX(90deg) rotateZ(20deg);
+  }
+
+  .spacer {
+    height: 2000px;
+  }
+</style>
+
+<iframe id="iframe"></iframe>
+<div class="spacer"></div>
+
+<script>
+  isIntersecting = null;
+  window.addEventListener("message", event => {
+    isIntersecting = event.data.isIntersecting;
+  });
+
+  function loadFrame() {
+    return new Promise(resolve => {
+      iframe.addEventListener("load", resolve, { once: true });
+      iframe.src = `${get_host_info().HTTP_NOTSAMESITE_ORIGIN}/intersection-observer/resources/transformed-iframe-subframe.html`;
+    });
+  }
+
+  promise_test(async (t) => {
+    await loadFrame();
+    window.scrollTo(0, 0);
+
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+
+    assert_false(isIntersecting);
+  }, "Target is not visible as it's rotated perpendicularly to viewport");
+
+  promise_test(async (t) => {
+    window.scrollTo(0, 250);
+
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+
+    assert_false(isIntersecting);
+  }, "Scroll down a bit, target is still not visible");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-003-same-origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-003-same-origin-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS Target is not visible as it's rotated perpendicularly to viewport
+PASS Scroll down a bit, target is still not visible
+

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-003-same-origin.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-003-same-origin.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+
+<title>Intersection Observer: implicit root observer in iframe works when the iframe is transformed</title>
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
+<script src="/common/rendering-utils.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  #iframe {
+    width: 300px;
+    height: 300px;
+    display: block;
+
+    transform: rotateY(-45deg) rotateX(90deg) rotateZ(20deg);
+  }
+
+  .spacer {
+    height: 2000px;
+  }
+</style>
+
+<iframe id="iframe"></iframe>
+<div class="spacer"></div>
+
+<script>
+  isIntersecting = null;
+  window.addEventListener("message", event => {
+    isIntersecting = event.data.isIntersecting;
+  });
+
+  function loadFrame() {
+    return new Promise(resolve => {
+      iframe.addEventListener("load", resolve, { once: true });
+      iframe.src = "resources/transformed-iframe-subframe.html";
+    });
+  }
+
+  promise_test(async (t) => {
+    await loadFrame();
+    window.scrollTo(0, 0);
+
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+
+    assert_false(isIntersecting);
+  }, "Target is not visible as it's rotated perpendicularly to viewport");
+
+  promise_test(async (t) => {
+    window.scrollTo(0, 250);
+
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+
+    assert_false(isIntersecting);
+  }, "Scroll down a bit, target is still not visible");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-004-cross-origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-004-cross-origin-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS Target is not visible as it's rotated perpendicularly to viewport
+PASS Scroll down a bit, target is still not visible
+

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-004-cross-origin.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-004-cross-origin.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+
+<title>Intersection Observer: implicit root observer in iframe works when the iframe is transformed</title>
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
+<script src="/common/get-host-info.sub.js"></script>
+<script src="/common/rendering-utils.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  #iframe {
+    width: 300px;
+    height: 300px;
+    display: block;
+
+    transform: rotateX(90deg);
+  }
+
+  .spacer {
+    height: 2000px;
+  }
+</style>
+
+<iframe id="iframe"></iframe>
+<div class="spacer"></div>
+
+<script>
+  isIntersecting = null;
+  window.addEventListener("message", event => {
+    isIntersecting = event.data.isIntersecting;
+  });
+
+  function loadFrame() {
+    return new Promise(resolve => {
+      iframe.addEventListener("load", resolve, { once: true });
+      iframe.src = `${get_host_info().HTTP_NOTSAMESITE_ORIGIN}/intersection-observer/resources/transformed-iframe-subframe.html`;
+    });
+  }
+
+  promise_test(async (t) => {
+    await loadFrame();
+    window.scrollTo(0, 0);
+
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+
+    assert_false(isIntersecting);
+  }, "Target is not visible as it's rotated perpendicularly to viewport");
+
+  promise_test(async (t) => {
+    window.scrollTo(0, 250);
+
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+
+    assert_false(isIntersecting);
+  }, "Scroll down a bit, target is still not visible");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-004-same-origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-004-same-origin-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS Target is not visible as it's rotated perpendicularly to viewport
+PASS Scroll down a bit, target is still not visible
+

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-004-same-origin.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-004-same-origin.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+
+<title>Intersection Observer: implicit root observer in iframe works when the iframe is transformed</title>
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
+<script src="/common/rendering-utils.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  #iframe {
+    width: 300px;
+    height: 300px;
+    display: block;
+
+    transform: rotateX(90deg);
+  }
+
+  .spacer {
+    height: 2000px;
+  }
+</style>
+
+<iframe id="iframe"></iframe>
+<div class="spacer"></div>
+
+<script>
+  isIntersecting = null;
+  window.addEventListener("message", event => {
+    isIntersecting = event.data.isIntersecting;
+  });
+
+  function loadFrame() {
+    return new Promise(resolve => {
+      iframe.addEventListener("load", resolve, { once: true });
+      iframe.src = "resources/transformed-iframe-subframe.html";
+    });
+  }
+
+  promise_test(async (t) => {
+    await loadFrame();
+    window.scrollTo(0, 0);
+
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+
+    assert_false(isIntersecting);
+  }, "Target is not visible as it's rotated perpendicularly to viewport");
+
+  promise_test(async (t) => {
+    window.scrollTo(0, 250);
+
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+
+    assert_false(isIntersecting);
+  }, "Scroll down a bit, target is still not visible");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-non-invertible-iframe-cross-origin-crash.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-non-invertible-iframe-cross-origin-crash.sub.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+
+<html class="reftest-wait">
+
+<title>Don't crash if a cross-origin iframe uses intersection observer and is transformed with a non-invertible transformation</title>
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
+<script src="/common/reftest-wait.js"></script>
+
+<style>
+  iframe {
+    transform: matrix3d(
+        0, 0, 0, 0,
+        0, 0, 0, 0,
+        0, 0, 0, 0,
+        0, 0, 0, 0
+    );
+  }
+</style>
+
+<p>This test passes if it does not crash. You should not see anything besides this text.</p>
+<iframe src="http://{{hosts[alt][]}}:{{ports[http][0]}}/intersection-observer/resources/transformed-iframe-subframe.html"></iframe>
+
+<script>
+  window.addEventListener("message", (e) => {
+    if (Object.hasOwn(e.data, "isIntersecting"))
+        takeScreenshot();
+  });
+</script>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-non-invertible-iframe-same-origin-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-non-invertible-iframe-same-origin-crash.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+
+<html class="reftest-wait">
+
+<title>Don't crash if a same-origin iframe uses intersection observer and is transformed with a non-invertible transformation</title>
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
+<script src="/common/reftest-wait.js"></script>
+
+<style>
+  iframe {
+    transform: matrix3d(
+        0, 0, 0, 0,
+        0, 0, 0, 0,
+        0, 0, 0, 0,
+        0, 0, 0, 0
+    );
+  }
+</style>
+
+<p>This test passes if it does not crash. You should not see anything besides this text.</p>
+<iframe src="resources/transformed-iframe-subframe.html"></iframe>
+
+<script>
+  window.addEventListener("message", (e) => {
+    if (Object.hasOwn(e.data, "isIntersecting"))
+        takeScreenshot();
+  });
+</script>
+
+</html>

--- a/LayoutTests/platform/ios-site-isolation/TestExpectations
+++ b/LayoutTests/platform/ios-site-isolation/TestExpectations
@@ -232,9 +232,7 @@ imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-in-cross-origin-iframe-002.sub.html [ Failure ]
 imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/details-toggle-source.html [ Failure ]
 imported/w3c/web-platform-tests/html/semantics/popovers/popover-attribute-basic.html [ Failure ]
-imported/w3c/web-platform-tests/intersection-observer/cross-origin-iframe.sub.html [ Failure ]
 imported/w3c/web-platform-tests/intersection-observer/nested-cross-origin-iframe.sub.html [ Failure ]
-imported/w3c/web-platform-tests/intersection-observer/same-origin-grand-child-iframe.sub.html [ Failure ]
 imported/w3c/web-platform-tests/intersection-observer/scroll-margin-propagation.html [ Failure ]
 imported/w3c/web-platform-tests/loading/preloader-template.html [ Failure ]
 imported/w3c/web-platform-tests/navigation-api/navigate-event/defer/tentative/defer-back.html [ Failure ]
@@ -351,12 +349,6 @@ http/tests/security/block-top-level-navigations-by-sandboxed-iframe-with-propaga
 http/tests/security/block-top-level-navigations-by-third-party-iframes.html [ Failure ]
 http/tests/security/block-top-level-navigations-by-third-party-sandboxed-iframe.html [ Failure ]
 http/tests/security/frameNavigation/not-opener.html [ Failure ]
-
-# Intersection Observer x Site Isolation is not fully implemented.
-http/tests/intersection-observer/zoomed-page-iframe-cross-origin.html [ Failure ]
-imported/w3c/web-platform-tests/intersection-observer/cross-origin-tall-iframe.sub.html [ Failure ]
-imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-001-cross-origin.html [ Failure ]
-imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-002-cross-origin.html [ Failure ]
 
 # rdar://178066625
 imported/w3c/web-platform-tests/html/user-activation/propagation-crossorigin.sub.html [ Failure ]

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -76,9 +76,7 @@ imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/t
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-in-cross-origin-iframe-001.sub.html [ Failure ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-in-cross-origin-iframe-002.sub.html [ Failure ]
 imported/w3c/web-platform-tests/html/semantics/forms/customizable-combobox/customizable-combobox-appearance.html [ Skip ] # Flaky Failure
-imported/w3c/web-platform-tests/intersection-observer/cross-origin-iframe.sub.html [ Failure ]
 imported/w3c/web-platform-tests/intersection-observer/nested-cross-origin-iframe.sub.html [ Failure ]
-imported/w3c/web-platform-tests/intersection-observer/same-origin-grand-child-iframe.sub.html [ Failure ]
 imported/w3c/web-platform-tests/mediasession/playbackstate.html [ Failure ]
 imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-origin-iframe-navigation.sub.https.window.html [ Failure ]
 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-analysernode-interface/test-analyser-minimum.html [ Failure ]
@@ -264,10 +262,7 @@ http/tests/security/frameNavigation/not-opener.html [ Failure ]
 inspector/unit-tests/target-manager.html [ Skip ]
 
 # Intersection Observer x Site Isolation is not fully implemented.
-http/tests/intersection-observer/zoomed-page-iframe-cross-origin.html [ Failure ]
-imported/w3c/web-platform-tests/intersection-observer/cross-origin-tall-iframe.sub.html [ Failure ]
-imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-001-cross-origin.html [ Failure ]
-imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-002-cross-origin.html [ Failure ]
+imported/w3c/web-platform-tests/intersection-observer/scroll-margin-propagation.html [ Failure ]
 
 # Inspector protocol commands (e.g. CSS.getMatchedStylesForNode) return
 # "Not yet implemented for frame targets" under site isolation.

--- a/Source/WebCore/page/FrameView.h
+++ b/Source/WebCore/page/FrameView.h
@@ -141,6 +141,11 @@ public:
     // does not correspond to the absolute coordinate of this FrameView, as it doesn't
     // include the page scale transform on the RenderView (if page is scaled).
     virtual TransformationMatrix childFrameOwnerToRootContentTransform(const Frame&) const = 0;
+
+    // Returns the transformation matrix to project from this frame view's absolute coordinate
+    // to a child frame's owner renderer's local coordinate.
+    virtual TransformationMatrix absoluteToChildFrameOwnerLocalTransform(const Frame&) const = 0;
+
 private:
     ScrollableArea* enclosingScrollableArea() const final;
 

--- a/Source/WebCore/page/IntersectionObserver.cpp
+++ b/Source/WebCore/page/IntersectionObserver.cpp
@@ -63,6 +63,7 @@
 #include "StylePrimitiveNumericTypes+Conversions.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
 #include "StylePrimitiveNumericTypes+Logging.h"
+#include "TransformState.h"
 #include "VisibleRectContext.h"
 #include "WebCoreOpaqueRootInlines.h"
 #include <JavaScriptCore/AbstractSlotVisitorInlines.h>
@@ -499,6 +500,53 @@ static std::optional<LayoutRect> computeClippedRectInRootContentsSpace(const Lay
     return computeClippedRectInRootContentsSpace(*absoluteClippedRect, targetSecurityOrigin, enclosingFrame.get(), WTF::move(scrollMargin));
 }
 
+// Equivalent to FrameView::convertFromContainingView.
+static FloatRect convertFromContainingView(const FrameView& frameView, const FrameView& parentView, FloatRect rect)
+{
+    if (is<LocalFrameView>(parentView)) {
+        // If we can compute it the old way, do so.
+        return frameView.convertFromContainingView(rect);
+    }
+
+    rect = parentView.viewToContents(rect);
+
+    auto transform = parentView.absoluteToChildFrameOwnerLocalTransform(frameView.frame());
+    FloatRect transformed = transform.projectQuad(rect).boundingBox();
+    transformed.moveBy(-parentView.childFrameOwnerContentBoxLocation(frameView.frame()));
+
+    return transformed;
+}
+
+// Equivalent to Widget::convertFromRootView.
+static FloatRect convertFromRootView(const FrameView& frameView, FloatRect rect)
+{
+    auto parentView = [&frameView] () -> RefPtr<const FrameView> {
+        if (RefPtr parent = dynamicDowncast<FrameView>(frameView.parent()))
+            return parent;
+
+        // When Site Isolation is enabled, Widget::m_parent is not populated if
+        // frameView is RemoteFrameView. Workaround this by using the frame tree parent.
+        // FIXME: fix the underlying issue instead.
+        if (RefPtr parent = frameView.frame().tree().parent())
+            return parent->virtualView();
+
+        return nullptr;
+    }();
+
+    if (parentView) {
+        FloatRect parentRect = convertFromRootView(*parentView, rect);
+        return convertFromContainingView(frameView, *parentView, parentRect);
+    }
+
+    return rect;
+}
+
+// Equivalent to rootViewToContents.
+static FloatRect mainFrameViewToContents(const FrameView& targetFrameView, FloatRect rect)
+{
+    return targetFrameView.viewToContents(convertFromRootView(targetFrameView, rect));
+}
+
 auto IntersectionObserver::computeIntersectionState(const IntersectionObserverRegistration& registration, FrameView& hostFrameView, Element& target, ApplyRootMargin applyRootMargin) const -> IntersectionObservationState
 {
     bool isFirstObservation = !registration.previousThresholdIndex;
@@ -674,7 +722,7 @@ auto IntersectionObserver::computeIntersectionState(const IntersectionObserverRe
             intersectionState.absoluteIntersectionRect = rootAbsoluteIntersectionRect;
         else {
             auto rootViewIntersectionRect = hostFrameView.contentsToView(rootAbsoluteIntersectionRect);
-            intersectionState.absoluteIntersectionRect = targetRenderer->view().frameView().rootViewToContents(rootViewIntersectionRect);
+            intersectionState.absoluteIntersectionRect = mainFrameViewToContents(targetRenderer->view().frameView(), rootViewIntersectionRect);
         }
 
         intersectionState.isIntersecting = intersectionState.absoluteIntersectionRect->edgeInclusiveIntersect(*intersectionState.absoluteTargetRect);

--- a/Source/WebCore/page/IntersectionObserver.h
+++ b/Source/WebCore/page/IntersectionObserver.h
@@ -134,6 +134,7 @@ private:
 
     struct IntersectionObservationState {
         FloatRect rootBounds;
+        // "Absolute" means in the absolute coordinate system of the target's frame.
         std::optional<FloatRect> absoluteIntersectionRect; // Only computed if intersecting.
         std::optional<FloatRect> absoluteTargetRect; // Only computed if first observation, or intersecting.
         std::optional<FloatRect> absoluteRootBounds; // Only computed if observationChanged.

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -2199,6 +2199,24 @@ TransformationMatrix LocalFrameView::childFrameOwnerToRootContentTransform(const
     return *transformState.releaseTrackedTransform();
 }
 
+TransformationMatrix LocalFrameView::absoluteToChildFrameOwnerLocalTransform(const Frame& child) const
+{
+    CheckedPtr<RenderObject> childOwnerRenderer = child.ownerRenderer();
+    if (!childOwnerRenderer)
+        return { };
+
+    // Ensure |child| is a child of this frame.
+    ASSERT(child.tree().parent()->frameID() == m_frame->frameID());
+    ASSERT(childOwnerRenderer->frame().frameID() == m_frame->frameID());
+
+    // We aren't transforming anything here, we just need the resulting transformation matrix.
+    TransformState transformState(TransformState::UnapplyInverseTransformDirection, FloatPoint { });
+    childOwnerRenderer->mapAbsoluteToLocalPoint({ MapCoordinatesMode::UseTransforms }, transformState);
+
+    auto matrix = transformState.releaseTrackedTransform();
+    return valueOrDefault(matrix->inverse());
+}
+
 LayoutRect LocalFrameView::rectForFixedPositionLayout() const
 {
     if (m_frame->settings().visualViewportEnabled())

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -327,6 +327,7 @@ public:
     OptionSet<FrameOwnerElementAppearance> appearanceOfOwnerElementOfChildFrame(const Frame&) const final;
     LayoutPoint childFrameOwnerContentBoxLocation(const Frame&) const final;
     TransformationMatrix childFrameOwnerToRootContentTransform(const Frame&) const final;
+    TransformationMatrix absoluteToChildFrameOwnerLocalTransform(const Frame&) const final;
 
     static LayoutRect visibleDocumentRect(const FloatRect& visibleContentRect, float headerHeight, float footerHeight, const FloatSize& totalContentsSize, float pageScaleFactor);
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2194,6 +2194,7 @@ void Page::syncLocalFrameInfoToRemote()
             childrenFrameLayoutInfo.add(child->frameID(), RemoteFrameLayoutInfo::create(
                 frameView->visibleRectOfChild(*child.get()),
                 frameView->childFrameOwnerToRootContentTransform(*child),
+                frameView->absoluteToChildFrameOwnerLocalTransform(*child),
                 frame.usedZoomForChild(*child),
                 frameView->childFrameOwnerContentBoxLocation(*child),
                 frameView->appearanceOfOwnerElementOfChildFrame(*child)

--- a/Source/WebCore/page/RemoteFrameLayoutInfo.cpp
+++ b/Source/WebCore/page/RemoteFrameLayoutInfo.cpp
@@ -32,14 +32,15 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteFrameLayoutInfo);
 
-Ref<RemoteFrameLayoutInfo> RemoteFrameLayoutInfo::create(std::optional<LayoutRect> visibleRectInParent, TransformationMatrix childFrameOwnerToRootContentTransform, float usedZoom, LayoutPoint contentBoxLocation, OptionSet<FrameOwnerElementAppearance> ownerElementAppearance)
+Ref<RemoteFrameLayoutInfo> RemoteFrameLayoutInfo::create(std::optional<LayoutRect> visibleRectInParent, TransformationMatrix childFrameOwnerToRootContentTransform, TransformationMatrix absoluteToChildFrameOwnerLocalTransform, float usedZoom, LayoutPoint contentBoxLocation, OptionSet<FrameOwnerElementAppearance> ownerElementAppearance)
 {
-    return adoptRef(*new RemoteFrameLayoutInfo(visibleRectInParent, WTF::move(childFrameOwnerToRootContentTransform), usedZoom, contentBoxLocation, ownerElementAppearance));
+    return adoptRef(*new RemoteFrameLayoutInfo(visibleRectInParent, WTF::move(childFrameOwnerToRootContentTransform), WTF::move(absoluteToChildFrameOwnerLocalTransform), usedZoom, contentBoxLocation, ownerElementAppearance));
 }
 
-RemoteFrameLayoutInfo::RemoteFrameLayoutInfo(std::optional<LayoutRect> visibleRectInParent, TransformationMatrix childFrameOwnerToRootContentTransform, float usedZoom, LayoutPoint contentBoxLocation, OptionSet<FrameOwnerElementAppearance> ownerElementAppearance)
+RemoteFrameLayoutInfo::RemoteFrameLayoutInfo(std::optional<LayoutRect> visibleRectInParent, TransformationMatrix childFrameOwnerToRootContentTransform, TransformationMatrix absoluteToChildFrameOwnerLocalTransform, float usedZoom, LayoutPoint contentBoxLocation, OptionSet<FrameOwnerElementAppearance> ownerElementAppearance)
     : m_visibleRectInParent(visibleRectInParent)
     , m_childFrameOwnerToRootContentTransform(WTF::move(childFrameOwnerToRootContentTransform))
+    , m_absoluteToChildFrameOwnerLocalTransform(WTF::move(absoluteToChildFrameOwnerLocalTransform))
     , m_usedZoom(usedZoom)
     , m_contentBoxLocation(contentBoxLocation)
     , m_ownerElementAppearance(ownerElementAppearance)

--- a/Source/WebCore/page/RemoteFrameLayoutInfo.h
+++ b/Source/WebCore/page/RemoteFrameLayoutInfo.h
@@ -48,16 +48,17 @@ class RemoteFrameLayoutInfo : public RefCounted<RemoteFrameLayoutInfo> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(RemoteFrameLayoutInfo, WEBCORE_EXPORT);
 
 public:
-    WEBCORE_EXPORT static Ref<RemoteFrameLayoutInfo> create(std::optional<LayoutRect>, TransformationMatrix, float, LayoutPoint, OptionSet<FrameOwnerElementAppearance>);
+    WEBCORE_EXPORT static Ref<RemoteFrameLayoutInfo> create(std::optional<LayoutRect>, TransformationMatrix, TransformationMatrix, float, LayoutPoint, OptionSet<FrameOwnerElementAppearance>);
 
     std::optional<LayoutRect> visibleRectInParent() const { return m_visibleRectInParent; }
     const TransformationMatrix& childFrameOwnerToRootContentTransform() const { return m_childFrameOwnerToRootContentTransform; }
+    const TransformationMatrix& absoluteToChildFrameOwnerLocalTransform() const { return m_absoluteToChildFrameOwnerLocalTransform; }
     float usedZoom() const { return m_usedZoom; }
     LayoutPoint contentBoxLocation() const { return m_contentBoxLocation; }
     OptionSet<FrameOwnerElementAppearance> ownerElementAppearance() const { return m_ownerElementAppearance; }
 
 private:
-    RemoteFrameLayoutInfo(std::optional<LayoutRect>, TransformationMatrix, float, LayoutPoint, OptionSet<FrameOwnerElementAppearance>);
+    RemoteFrameLayoutInfo(std::optional<LayoutRect>, TransformationMatrix, TransformationMatrix, float, LayoutPoint, OptionSet<FrameOwnerElementAppearance>);
 
     // Rectangle of the visible portion of the frame in its parent frame,
     // in the coordinate space of the document of the parent frame.
@@ -68,6 +69,10 @@ private:
     // Note: this DOES NOT include the frame scale transform on the
     // RenderView.
     TransformationMatrix m_childFrameOwnerToRootContentTransform;
+
+    // The transformation matrix to project from current frame's
+    // absolute coordinate to the child frame owner's local coordinate.
+    TransformationMatrix m_absoluteToChildFrameOwnerLocalTransform;
 
     // Style::ComputedStyle::usedZoom of the owner renderer of the frame.
     float m_usedZoom;

--- a/Source/WebCore/page/RemoteFrameView.cpp
+++ b/Source/WebCore/page/RemoteFrameView.cpp
@@ -103,6 +103,14 @@ TransformationMatrix RemoteFrameView::childFrameOwnerToRootContentTransform(cons
     return { };
 }
 
+TransformationMatrix RemoteFrameView::absoluteToChildFrameOwnerLocalTransform(const Frame& child) const
+{
+    if (RefPtr info = m_frame->frameTreeSyncData().childrenFrameLayoutInfo.get(child.frameID()))
+        return info->absoluteToChildFrameOwnerLocalTransform();
+
+    return { };
+}
+
 // FIXME: Implement all the stubs below.
 
 bool RemoteFrameView::isScrollableOrRubberbandable()

--- a/Source/WebCore/page/RemoteFrameView.h
+++ b/Source/WebCore/page/RemoteFrameView.h
@@ -55,6 +55,7 @@ public:
     OptionSet<FrameOwnerElementAppearance> appearanceOfOwnerElementOfChildFrame(const Frame&) const final;
     LayoutPoint childFrameOwnerContentBoxLocation(const Frame&) const final;
     TransformationMatrix childFrameOwnerToRootContentTransform(const Frame&) const final;
+    TransformationMatrix absoluteToChildFrameOwnerLocalTransform(const Frame&) const final;
 
 private:
     WEBCORE_EXPORT RemoteFrameView(RemoteFrame&);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1316,6 +1316,7 @@ class WebCore::LayoutRect {
 [RefCounted] class WebCore::RemoteFrameLayoutInfo {
     std::optional<WebCore::LayoutRect> visibleRectInParent();
     WebCore::TransformationMatrix childFrameOwnerToRootContentTransform();
+    WebCore::TransformationMatrix absoluteToChildFrameOwnerLocalTransform();
     float usedZoom();
     WebCore::LayoutPoint contentBoxLocation();
     OptionSet<WebCore::FrameOwnerElementAppearance> ownerElementAppearance();


### PR DESCRIPTION
#### dc0ab49b51f17b5b0995ee1a0207e440907a36ac
<pre>
[Site Isolation] [intersection-observer] Compute rootViewToContents in Site Isolation mode
<a href="https://rdar.apple.com/167805455">rdar://167805455</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=305160">https://bugs.webkit.org/show_bug.cgi?id=305160</a>

Reviewed by Simon Fraser.

In implicit root mode, IntersectionObserver first computes the visible rect in the
root view (main frame) first, then use rootViewToContents to convert it back
to the visible rect in the target&apos;s frame view.

FrameView::rootViewToContents does this by traversing from the main frame to the
target frame in the frame tree. It converts the rect from absolute (current frame)
to local (next frame&apos;s owner element), then repeats this until it reaches the target
frame&apos;s owner element. If Site Isolation is enabled, and any frames are cross-origin
from the target frame, then we don&apos;t have the layout information for the absolute -&gt;
local conversion.

This patch makes rootViewToContents work in Site Isolation by synchronizing the
absolute -&gt; local transformation matrix using RemoteFrameLayoutInfo. This way,
the absolute -&gt; local conversion can be done anywhere by multiplying the absolute
rect with the synchronized transformation matrix.

Instead of changing FrameView::rootViewToContents to make it SI-safe, IntersectionObserver
will use a function that is equivalent to rootViewToContents but with Site Isolation
support. This ensures we don&apos;t accidentally break existing use cases of rootViewToContents.
Once we know this works, we could port back the changes to rootViewToContents.

Tests: imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-003-cross-origin.html
       imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-003-same-origin.html
       imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-004-cross-origin.html
       imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-004-same-origin.html
       imported/w3c/web-platform-tests/intersection-observer/transformed-non-invertible-iframe-cross-origin-crash.sub.html
       imported/w3c/web-platform-tests/intersection-observer/transformed-non-invertible-iframe-same-origin-crash.html

* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-003-cross-origin-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-003-cross-origin.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-003-same-origin-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-003-same-origin.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-004-cross-origin-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-004-cross-origin.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-004-same-origin-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-iframe-004-same-origin.html: Added.
    - Add tests that require the synchronized transformation matrix to be
      original and not flattened/affined before synchronization.

* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-non-invertible-iframe-cross-origin-crash.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/transformed-non-invertible-iframe-same-origin-crash.html: Added.
* LayoutTests/platform/ios-site-isolation/TestExpectations:
* LayoutTests/platform/mac-site-isolation/TestExpectations:
    - Pass more tests.

* Source/WebCore/page/FrameView.h:
* Source/WebCore/page/IntersectionObserver.cpp:
(WebCore::convertFromContainingView):
(WebCore::convertFromRootView):
(WebCore::mainFrameViewToContents):
(WebCore::IntersectionObserver::computeIntersectionState const):
* Source/WebCore/page/IntersectionObserver.h:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::absoluteToChildFrameOwnerLocalTransform const):
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::syncLocalFrameInfoToRemote):
* Source/WebCore/page/RemoteFrameLayoutInfo.cpp:
(WebCore::RemoteFrameLayoutInfo::create):
(WebCore::RemoteFrameLayoutInfo::RemoteFrameLayoutInfo):
* Source/WebCore/page/RemoteFrameLayoutInfo.h:
(WebCore::RemoteFrameLayoutInfo::absoluteToChildFrameOwnerLocalTransform const):
* Source/WebCore/page/RemoteFrameView.cpp:
(WebCore::RemoteFrameView::absoluteToChildFrameOwnerLocalTransform const):
* Source/WebCore/page/RemoteFrameView.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/315227@main">https://commits.webkit.org/315227@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be928ad6c5baddc4fa15829bae14988813385f81

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168308 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41865 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35451 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177636 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126009 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3e51ccd8-6832-497b-bbc5-a68cce659fc2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170174 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42240 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41822 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130983 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92080 "1 flakes 5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/93b4c5ec-79fa-481f-ba13-e65bc85271b9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171267 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33451 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151258 "Found 12 new API test failures: TestWebKitAPI.WKWebExtension.MultipleContentScriptsInjectedWhenMatched, TestWebKitAPI.WKWebExtensionContext.UncaughtScriptErrorInContentScript, TestWebKitAPI.WKWebExtensionContext.LoadNonExistentImage, TestWebKitAPI.WKWebExtensionContext.CallingMissingBrowserAPIInBackground, TestWebKitAPI.WKWebExtensionContext.TopLevelThrowInModuleBackground, TestWebKitAPI.WKWebExtensionContext.UncaughtScriptErrorInMainWorldContentScript, TestWebKitAPI.WKWebExtensionContext.UncaughtScriptErrorInServiceWorkerBackground, TestWebKitAPI.WKWebExtensionContext.UnhandledPromiseRejectionInBackground, TestWebKitAPI.WKWebExtensionContext.ReferenceErrorInBackground, TestWebKitAPI.WebKit.AddUnsupportedAndBogusImageTypesTwice ... (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111495 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a26d7373-3ab7-4005-a91d-d6f78f34811f) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32437 "Found 1 new test failure: imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-getSynchronizationSources.https.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31138 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26332 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142423 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180236 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32960 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30662 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139420 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41877 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35297 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139283 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37532 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42565 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150735 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106047 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34573 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27633 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41069 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114325 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40466 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5717 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40717 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40611 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->