### PR TITLE
MouseEvent offsetX and offsetY should be relative to padding edge

### DIFF
--- a/LayoutTests/fast/events/document-elementFromPoint-expected.txt
+++ b/LayoutTests/fast/events/document-elementFromPoint-expected.txt
@@ -6,13 +6,13 @@ Table Content
 In Columns
 Transformed
 In RTL overflow
-PASS: event at (109, 57) hit absolute at offset (29, 32)
-PASS: event at (161, 13) hit relative at offset (31, 28)
-PASS: event at (40, 297) hit table-content at offset (15, 18)
-PASS: event at (122, 407) hit transformed at offset (18, 15)
+PASS: event at (109, 57) hit absolute at offset (19, 22)
+PASS: event at (161, 13) hit relative at offset (21, 18)
+PASS: event at (40, 297) hit table-content at offset (5, 8)
+PASS: event at (122, 407) hit transformed at offset (8, 5)
 PASS: event at (573, 480) hit inside-overflow at offset (2, 9)
 PASS: event at (707, 174) hit in-columns at offset (87, 13)
-PASS: event at (241, 67) hit fixed at offset (41, 17)
-PASS: event at (244, 102) hit fixed at offset (44, 52)
-PASS: event at (388, 88) hit fixed at offset (188, 38)
+PASS: event at (241, 67) hit fixed at offset (31, 7)
+PASS: event at (244, 102) hit fixed at offset (34, 42)
+PASS: event at (388, 88) hit fixed at offset (178, 28)
 

--- a/LayoutTests/fast/events/document-elementFromPoint.html
+++ b/LayoutTests/fast/events/document-elementFromPoint.html
@@ -76,8 +76,8 @@ th { height: 30px; }
     top: 220px;
     left: 500px;
     border: 1px solid black;
-    -webkit-column-count: 3;
-    -webkit-column-fill: auto;
+    column-count: 3;
+    column-fill: auto;
     column-count: 3;
     column-fill: auto;
 }
@@ -93,7 +93,7 @@ th { height: 30px; }
     top: 470px;
     height: 120px;
     width: 200px;
-    -webkit-transform: translate(100px, 50px) rotate(20deg);
+    transform: translate(100px, 50px) rotate(20deg);
 }
 
 #overflow {
@@ -267,15 +267,15 @@ window.addEventListener('load', function() {
         overflowContent.scrollTop = 60;
         setTimeout(function() {
             // Dispatch events.
-            dispatchEvent(109, 57, 'absolute', 29, 32);
-            dispatchEvent(161, 13, 'relative', 31, 28);
-            dispatchEvent(40, 297, 'table-content', 15, 18);
-            dispatchEvent(122, 407, 'transformed', 18, 15);
+            dispatchEvent(109, 57, 'absolute', 19, 22);
+            dispatchEvent(161, 13, 'relative', 21, 18);
+            dispatchEvent(40, 297, 'table-content', 5, 8);
+            dispatchEvent(122, 407, 'transformed', 8, 5);
             dispatchEvent(573, 480, 'inside-overflow', 2, 9);
             dispatchEvent(707, 174, 'in-columns', hasSubpixelSupport ? 87 : 88, 13);
-            dispatchEvent(241, 67, 'fixed', 41, 17);
-            dispatchEvent(244, 102, 'fixed', 44, 52);
-            dispatchEvent(388, 88, 'fixed', 188, 38);
+            dispatchEvent(241, 67, 'fixed', 31, 7);
+            dispatchEvent(244, 102, 'fixed', 34, 42);
+            dispatchEvent(388, 88, 'fixed', 178, 28);
 
             // End asynchronous test.
             if (window.testRunner)

--- a/LayoutTests/fast/events/offsetX-offsetY-expected.txt
+++ b/LayoutTests/fast/events/offsetX-offsetY-expected.txt
@@ -14,7 +14,7 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
 In RTL overflow
 Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 
-PASS: event hit abs-box at offset (32, 37)
+PASS: event hit abs-box at offset (17, 22)
 PASS: event hit rel-box at offset (22, 24)
 PASS: event hit fixed-box at offset (10, 10)
 PASS: event hit with-bordertopextra at offset (4, 4)

--- a/LayoutTests/fast/events/offsetX-offsetY.html
+++ b/LayoutTests/fast/events/offsetX-offsetY.html
@@ -35,10 +35,11 @@
 
       var offsetX = 32;
       var offsetY = 37;
+      var borderSize = 15;
       var positions = sumPositions(document.getElementById('abs-box'));
       var clientX = positions.offsetLeft - positions.scrollLeft + offsetX;
       var clientY = positions.offsetTop - positions.scrollTop + offsetY;
-      dispatchEvent(clientX, clientY, 'abs-box', offsetX, offsetY);
+      dispatchEvent(clientX, clientY, 'abs-box', offsetX-borderSize, offsetY-borderSize);
 
       offsetX = 22;
       offsetY = 24;

--- a/LayoutTests/fast/forms/option-mouseevents-expected.txt
+++ b/LayoutTests/fast/forms/option-mouseevents-expected.txt
@@ -75,15 +75,15 @@ PASS: event type should be mousedown and is
 PASS: event target should be [object HTMLSelectElement] and is
 PASS: event.pageX should be 22 and is
 PASS: event.pageY should be 448 and is
-PASS: event.offsetX should be 14 and is
-PASS: event.offsetY should be 40 and is
+PASS: event.offsetX should be 13 and is
+PASS: event.offsetY should be 39 and is
 PASS: event.x should be 22 and is
 PASS: event.y should be 448 and is
 PASS: event type should be mousedown and is
 PASS: event target should be [object HTMLSelectElement] and is
 PASS: event.pageX should be 22 and is
 PASS: event.pageY should be 448 and is
-PASS: event.offsetX should be 14 and is
-PASS: event.offsetY should be 40 and is
+PASS: event.offsetX should be 13 and is
+PASS: event.offsetY should be 39 and is
 PASS: event.x should be 22 and is
 PASS: event.y should be 448 and is

--- a/LayoutTests/fast/forms/option-mouseevents.html
+++ b/LayoutTests/fast/forms/option-mouseevents.html
@@ -116,7 +116,7 @@ Bug 3248: Mouse events on OPTION element seem to be ignored<br>
 <option id="o4" ondblclick="mouseeventverify(event, 22, 344, this, 'dblclick')">Two
 </select>
 </form>
-<select style="position:absolute; top: 408;" size="3" onmousedown="mouseeventverify2(event, 22, 448, 14, 40, this, 'mousedown')">
+<select style="position:absolute; top: 408;" size="3" onmousedown="mouseeventverify2(event, 22, 448, 13, 39, this, 'mousedown')">
 <option>One
 <option id="o5" onmousedown="mouseeventverify2(event, 22, 448, 14, 40, this, 'mousedown')">Two
 </select>

--- a/LayoutTests/platform/glib/transforms/3d/point-mapping/3d-point-mapping-2-expected.txt
+++ b/LayoutTests/platform/glib/transforms/3d/point-mapping/3d-point-mapping-2-expected.txt
@@ -16,27 +16,27 @@ layer at (30,500) size 328x108
   RenderBlock (positioned) {DIV} at (30,500) size 329x108
     RenderInline {SPAN} at (0,0) size 313x17 [color=#008000]
       RenderText {#text} at (0,0) size 313x17
-        text run at (0,0) width 313: "PASS: event at (120, 128) hit box4 at offset (2, 2)"
+        text run at (0,0) width 313: "PASS: event at (120, 128) hit box4 at offset (1, 1)"
     RenderBR {BR} at (312,0) size 1x17
     RenderInline {SPAN} at (0,18) size 329x17 [color=#008000]
       RenderText {#text} at (0,18) size 329x17
-        text run at (0,18) width 329: "PASS: event at (184, 160) hit box3 at offset (83, 52)"
+        text run at (0,18) width 329: "PASS: event at (184, 160) hit box3 at offset (82, 51)"
     RenderBR {BR} at (328,18) size 1x17
     RenderInline {SPAN} at (0,36) size 305x17 [color=#008000]
       RenderText {#text} at (0,36) size 305x17
-        text run at (0,36) width 305: "PASS: event at (336, 87) hit box7 at offset (2, 2)"
+        text run at (0,36) width 305: "PASS: event at (336, 87) hit box7 at offset (1, 1)"
     RenderBR {BR} at (304,36) size 1x17
     RenderInline {SPAN} at (0,54) size 305x17 [color=#008000]
       RenderText {#text} at (0,54) size 305x17
-        text run at (0,54) width 305: "PASS: event at (359, 87) hit box8 at offset (2, 2)"
+        text run at (0,54) width 305: "PASS: event at (359, 87) hit box8 at offset (1, 1)"
     RenderBR {BR} at (304,54) size 1x17
     RenderInline {SPAN} at (0,72) size 312x17 [color=#008000]
       RenderText {#text} at (0,72) size 312x17
-        text run at (0,72) width 312: "PASS: event at (582, 87) hit box11 at offset (2, 2)"
+        text run at (0,72) width 312: "PASS: event at (582, 87) hit box11 at offset (1, 1)"
     RenderBR {BR} at (311,72) size 1x17
     RenderInline {SPAN} at (0,90) size 313x17 [color=#008000]
       RenderText {#text} at (0,90) size 313x17
-        text run at (0,90) width 313: "PASS: event at (605, 87) hit box12 at offset (2, 2)"
+        text run at (0,90) width 313: "PASS: event at (605, 87) hit box12 at offset (1, 1)"
     RenderBR {BR} at (312,90) size 1x17
 layer at (42,42) size 140x140
   RenderBlock {DIV} at (21,21) size 140x140 [bgcolor=#DDDDDD] [border: (1px solid #000000)]

--- a/LayoutTests/platform/glib/transforms/3d/point-mapping/3d-point-mapping-deep-expected.txt
+++ b/LayoutTests/platform/glib/transforms/3d/point-mapping/3d-point-mapping-deep-expected.txt
@@ -26,31 +26,31 @@ layer at (30,650) size 344x144
   RenderBlock (positioned) {DIV} at (30,650) size 345x144
     RenderInline {SPAN} at (0,0) size 297x17 [color=#008000]
       RenderText {#text} at (0,0) size 297x17
-        text run at (0,0) width 297: "PASS: event at (45, 45) hit box1 at offset (3, 3)"
+        text run at (0,0) width 297: "PASS: event at (45, 45) hit box1 at offset (2, 2)"
     RenderBR {BR} at (296,0) size 1x17
     RenderInline {SPAN} at (0,18) size 297x17 [color=#008000]
       RenderText {#text} at (0,18) size 297x17
-        text run at (0,18) width 297: "PASS: event at (54, 44) hit box2 at offset (2, 2)"
+        text run at (0,18) width 297: "PASS: event at (54, 44) hit box2 at offset (1, 1)"
     RenderBR {BR} at (296,18) size 1x17
     RenderInline {SPAN} at (0,36) size 305x17 [color=#008000]
       RenderText {#text} at (0,36) size 305x17
-        text run at (0,36) width 305: "PASS: event at (104, 93) hit box3 at offset (2, 2)"
+        text run at (0,36) width 305: "PASS: event at (104, 93) hit box3 at offset (1, 1)"
     RenderBR {BR} at (304,36) size 1x17
     RenderInline {SPAN} at (0,54) size 313x17 [color=#008000]
       RenderText {#text} at (0,54) size 313x17
-        text run at (0,54) width 313: "PASS: event at (175, 137) hit box4 at offset (2, 2)"
+        text run at (0,54) width 313: "PASS: event at (175, 137) hit box4 at offset (1, 1)"
     RenderBR {BR} at (312,54) size 1x17
     RenderInline {SPAN} at (0,72) size 329x17 [color=#008000]
       RenderText {#text} at (0,72) size 329x17
-        text run at (0,72) width 329: "PASS: event at (167, 528) hit box4 at offset (2, 296)"
+        text run at (0,72) width 329: "PASS: event at (167, 528) hit box4 at offset (1, 295)"
     RenderBR {BR} at (328,72) size 1x17
     RenderInline {SPAN} at (0,90) size 313x17 [color=#008000]
       RenderText {#text} at (0,90) size 313x17
-        text run at (0,90) width 313: "PASS: event at (227, 197) hit box5 at offset (2, 2)"
+        text run at (0,90) width 313: "PASS: event at (227, 197) hit box5 at offset (1, 1)"
     RenderBR {BR} at (312,90) size 1x17
     RenderInline {SPAN} at (0,108) size 345x17 [color=#008000]
       RenderText {#text} at (0,108) size 345x17
-        text run at (0,108) width 345: "PASS: event at (539, 569) hit box7 at offset (296, 296)"
+        text run at (0,108) width 345: "PASS: event at (539, 569) hit box7 at offset (295, 295)"
     RenderBR {BR} at (344,108) size 1x17
     RenderInline {SPAN} at (0,126) size 329x17 [color=#008000]
       RenderText {#text} at (0,126) size 329x17

--- a/LayoutTests/platform/glib/transforms/3d/point-mapping/3d-point-mapping-expected.txt
+++ b/LayoutTests/platform/glib/transforms/3d/point-mapping/3d-point-mapping-expected.txt
@@ -7,39 +7,39 @@ layer at (30,500) size 336x162
   RenderBlock (positioned) {DIV} at (30,500) size 337x162
     RenderInline {SPAN} at (0,0) size 297x17 [color=#008000]
       RenderText {#text} at (0,0) size 297x17
-        text run at (0,0) width 297: "PASS: event at (44, 44) hit box1 at offset (2, 2)"
+        text run at (0,0) width 297: "PASS: event at (44, 44) hit box1 at offset (1, 1)"
     RenderBR {BR} at (296,0) size 1x17
     RenderInline {SPAN} at (0,18) size 297x17 [color=#008000]
       RenderText {#text} at (0,18) size 297x17
-        text run at (0,18) width 297: "PASS: event at (69, 55) hit box2 at offset (2, 2)"
+        text run at (0,18) width 297: "PASS: event at (69, 55) hit box2 at offset (1, 1)"
     RenderBR {BR} at (296,18) size 1x17
     RenderInline {SPAN} at (0,36) size 329x17 [color=#008000]
       RenderText {#text} at (0,36) size 329x17
-        text run at (0,36) width 329: "PASS: event at (165, 182) hit box2 at offset (96, 96)"
+        text run at (0,36) width 329: "PASS: event at (165, 182) hit box2 at offset (95, 95)"
     RenderBR {BR} at (328,36) size 1x17
     RenderInline {SPAN} at (0,54) size 305x17 [color=#008000]
       RenderText {#text} at (0,54) size 305x17
-        text run at (0,54) width 305: "PASS: event at (333, 79) hit box7 at offset (2, 2)"
+        text run at (0,54) width 305: "PASS: event at (333, 79) hit box7 at offset (1, 1)"
     RenderBR {BR} at (304,54) size 1x17
     RenderInline {SPAN} at (0,72) size 313x17 [color=#008000]
       RenderText {#text} at (0,72) size 313x17
-        text run at (0,72) width 313: "PASS: event at (87, 325) hit box10 at offset (2, 2)"
+        text run at (0,72) width 313: "PASS: event at (87, 325) hit box10 at offset (1, 1)"
     RenderBR {BR} at (312,72) size 1x17
     RenderInline {SPAN} at (0,90) size 337x17 [color=#008000]
       RenderText {#text} at (0,90) size 337x17
-        text run at (0,90) width 337: "PASS: event at (196, 467) hit box10 at offset (98, 98)"
+        text run at (0,90) width 337: "PASS: event at (196, 467) hit box10 at offset (97, 97)"
     RenderBR {BR} at (336,90) size 1x17
     RenderInline {SPAN} at (0,108) size 321x17 [color=#008000]
       RenderText {#text} at (0,108) size 321x17
-        text run at (0,108) width 321: "PASS: event at (333, 325) hit box13 at offset (2, 2)"
+        text run at (0,108) width 321: "PASS: event at (333, 325) hit box13 at offset (1, 1)"
     RenderBR {BR} at (320,108) size 1x17
     RenderInline {SPAN} at (0,126) size 321x17 [color=#008000]
       RenderText {#text} at (0,126) size 321x17
-        text run at (0,126) width 321: "PASS: event at (353, 352) hit box14 at offset (2, 2)"
+        text run at (0,126) width 321: "PASS: event at (353, 352) hit box14 at offset (1, 1)"
     RenderBR {BR} at (320,126) size 1x17
     RenderInline {SPAN} at (0,144) size 337x17 [color=#008000]
       RenderText {#text} at (0,144) size 337x17
-        text run at (0,144) width 337: "PASS: event at (472, 507) hit box14 at offset (97, 97)"
+        text run at (0,144) width 337: "PASS: event at (472, 507) hit box14 at offset (96, 96)"
     RenderBR {BR} at (336,144) size 1x17
 layer at (21,21) size 202x202
   RenderBlock (positioned) {DIV} at (21,21) size 202x202 [border: (1px solid #000000)]

--- a/LayoutTests/platform/glib/transforms/3d/point-mapping/3d-point-mapping-preserve-3d-expected.txt
+++ b/LayoutTests/platform/glib/transforms/3d/point-mapping/3d-point-mapping-preserve-3d-expected.txt
@@ -7,71 +7,71 @@ layer at (30,500) size 336x306
   RenderBlock (positioned) {DIV} at (30,500) size 337x306
     RenderInline {SPAN} at (0,0) size 297x17 [color=#008000]
       RenderText {#text} at (0,0) size 297x17
-        text run at (0,0) width 297: "PASS: event at (44, 44) hit box1 at offset (2, 2)"
+        text run at (0,0) width 297: "PASS: event at (44, 44) hit box1 at offset (1, 1)"
     RenderBR {BR} at (296,0) size 1x17
     RenderInline {SPAN} at (0,18) size 297x17 [color=#008000]
       RenderText {#text} at (0,18) size 297x17
-        text run at (0,18) width 297: "PASS: event at (74, 68) hit box2 at offset (2, 2)"
+        text run at (0,18) width 297: "PASS: event at (74, 68) hit box2 at offset (1, 1)"
     RenderBR {BR} at (296,18) size 1x17
     RenderInline {SPAN} at (0,36) size 329x17 [color=#008000]
       RenderText {#text} at (0,36) size 329x17
-        text run at (0,36) width 329: "PASS: event at (157, 164) hit box2 at offset (98, 98)"
+        text run at (0,36) width 329: "PASS: event at (157, 164) hit box2 at offset (97, 97)"
     RenderBR {BR} at (328,36) size 1x17
     RenderInline {SPAN} at (0,54) size 305x17 [color=#008000]
       RenderText {#text} at (0,54) size 305x17
-        text run at (0,54) width 305: "PASS: event at (320, 68) hit box4 at offset (2, 2)"
+        text run at (0,54) width 305: "PASS: event at (320, 68) hit box4 at offset (1, 1)"
     RenderBR {BR} at (304,54) size 1x17
     RenderInline {SPAN} at (0,72) size 305x17 [color=#008000]
       RenderText {#text} at (0,72) size 305x17
-        text run at (0,72) width 305: "PASS: event at (336, 87) hit box5 at offset (2, 2)"
+        text run at (0,72) width 305: "PASS: event at (336, 87) hit box5 at offset (1, 1)"
     RenderBR {BR} at (304,72) size 1x17
     RenderInline {SPAN} at (0,90) size 305x17 [color=#008000]
       RenderText {#text} at (0,90) size 305x17
-        text run at (0,90) width 305: "PASS: event at (582, 87) hit box8 at offset (2, 2)"
+        text run at (0,90) width 305: "PASS: event at (582, 87) hit box8 at offset (1, 1)"
     RenderBR {BR} at (304,90) size 1x17
     RenderInline {SPAN} at (0,108) size 329x17 [color=#008000]
       RenderText {#text} at (0,108) size 329x17
-        text run at (0,108) width 329: "PASS: event at (658, 174) hit box8 at offset (86, 86)"
+        text run at (0,108) width 329: "PASS: event at (658, 174) hit box8 at offset (85, 85)"
     RenderBR {BR} at (328,108) size 1x17
     RenderInline {SPAN} at (0,126) size 313x17 [color=#008000]
       RenderText {#text} at (0,126) size 313x17
-        text run at (0,126) width 313: "PASS: event at (74, 314) hit box10 at offset (2, 2)"
+        text run at (0,126) width 313: "PASS: event at (74, 314) hit box10 at offset (1, 1)"
     RenderBR {BR} at (312,126) size 1x17
     RenderInline {SPAN} at (0,144) size 312x17 [color=#008000]
       RenderText {#text} at (0,144) size 312x17
-        text run at (0,144) width 312: "PASS: event at (91, 351) hit box11 at offset (2, 2)"
+        text run at (0,144) width 312: "PASS: event at (91, 351) hit box11 at offset (1, 1)"
     RenderBR {BR} at (311,144) size 1x17
     RenderInline {SPAN} at (0,162) size 321x17 [color=#008000]
       RenderText {#text} at (0,162) size 321x17
-        text run at (0,162) width 321: "PASS: event at (320, 314) hit box13 at offset (2, 2)"
+        text run at (0,162) width 321: "PASS: event at (320, 314) hit box13 at offset (1, 1)"
     RenderBR {BR} at (320,162) size 1x17
     RenderInline {SPAN} at (0,180) size 321x17 [color=#008000]
       RenderText {#text} at (0,180) size 321x17
-        text run at (0,180) width 321: "PASS: event at (343, 351) hit box14 at offset (2, 2)"
+        text run at (0,180) width 321: "PASS: event at (343, 351) hit box14 at offset (1, 1)"
     RenderBR {BR} at (320,180) size 1x17
     RenderInline {SPAN} at (0,198) size 321x17 [color=#008000]
       RenderText {#text} at (0,198) size 321x17
-        text run at (0,198) width 321: "PASS: event at (365, 375) hit box15 at offset (2, 2)"
+        text run at (0,198) width 321: "PASS: event at (365, 375) hit box15 at offset (1, 1)"
     RenderBR {BR} at (320,198) size 1x17
     RenderInline {SPAN} at (0,216) size 321x17 [color=#008000]
       RenderText {#text} at (0,216) size 321x17
-        text run at (0,216) width 321: "PASS: event at (566, 314) hit box17 at offset (2, 2)"
+        text run at (0,216) width 321: "PASS: event at (566, 314) hit box17 at offset (1, 1)"
     RenderBR {BR} at (320,216) size 1x17
     RenderInline {SPAN} at (0,234) size 321x17 [color=#008000]
       RenderText {#text} at (0,234) size 321x17
-        text run at (0,234) width 321: "PASS: event at (587, 352) hit box18 at offset (2, 2)"
+        text run at (0,234) width 321: "PASS: event at (587, 352) hit box18 at offset (1, 1)"
     RenderBR {BR} at (320,234) size 1x17
     RenderInline {SPAN} at (0,252) size 321x17 [color=#008000]
       RenderText {#text} at (0,252) size 321x17
-        text run at (0,252) width 321: "PASS: event at (629, 401) hit box19 at offset (2, 2)"
+        text run at (0,252) width 321: "PASS: event at (629, 401) hit box19 at offset (1, 1)"
     RenderBR {BR} at (320,252) size 1x17
     RenderInline {SPAN} at (0,270) size 321x17 [color=#008000]
       RenderText {#text} at (0,270) size 321x17
-        text run at (0,270) width 321: "PASS: event at (653, 422) hit box20 at offset (2, 2)"
+        text run at (0,270) width 321: "PASS: event at (653, 422) hit box20 at offset (1, 1)"
     RenderBR {BR} at (320,270) size 1x17
     RenderInline {SPAN} at (0,288) size 337x17 [color=#008000]
       RenderText {#text} at (0,288) size 337x17
-        text run at (0,288) width 337: "PASS: event at (745, 505) hit box20 at offset (86, 87)"
+        text run at (0,288) width 337: "PASS: event at (745, 505) hit box20 at offset (85, 86)"
     RenderBR {BR} at (336,288) size 1x17
 layer at (21,21) size 202x202
   RenderBlock (positioned) {DIV} at (21,21) size 202x202 [border: (1px solid #000000)]

--- a/LayoutTests/platform/ios/transforms/3d/point-mapping/3d-point-mapping-2-expected.txt
+++ b/LayoutTests/platform/ios/transforms/3d/point-mapping/3d-point-mapping-2-expected.txt
@@ -16,27 +16,27 @@ layer at (30,500) size 333x120
   RenderBlock (positioned) {DIV} at (30,500) size 334x120
     RenderInline {SPAN} at (0,0) size 318x19 [color=#008000]
       RenderText {#text} at (0,0) size 318x19
-        text run at (0,0) width 318: "PASS: event at (120, 128) hit box4 at offset (2, 2)"
+        text run at (0,0) width 318: "PASS: event at (120, 128) hit box4 at offset (1, 1)"
     RenderBR {BR} at (317,0) size 1x19
     RenderInline {SPAN} at (0,20) size 334x19 [color=#008000]
       RenderText {#text} at (0,20) size 334x19
-        text run at (0,20) width 334: "PASS: event at (184, 160) hit box3 at offset (83, 52)"
+        text run at (0,20) width 334: "PASS: event at (184, 160) hit box3 at offset (82, 51)"
     RenderBR {BR} at (333,20) size 1x19
     RenderInline {SPAN} at (0,40) size 310x19 [color=#008000]
       RenderText {#text} at (0,40) size 310x19
-        text run at (0,40) width 310: "PASS: event at (336, 87) hit box7 at offset (2, 2)"
+        text run at (0,40) width 310: "PASS: event at (336, 87) hit box7 at offset (1, 1)"
     RenderBR {BR} at (309,40) size 1x19
     RenderInline {SPAN} at (0,60) size 310x19 [color=#008000]
       RenderText {#text} at (0,60) size 310x19
-        text run at (0,60) width 310: "PASS: event at (359, 87) hit box8 at offset (2, 2)"
+        text run at (0,60) width 310: "PASS: event at (359, 87) hit box8 at offset (1, 1)"
     RenderBR {BR} at (309,60) size 1x19
     RenderInline {SPAN} at (0,80) size 317x19 [color=#008000]
       RenderText {#text} at (0,80) size 317x19
-        text run at (0,80) width 317: "PASS: event at (582, 87) hit box11 at offset (2, 2)"
+        text run at (0,80) width 317: "PASS: event at (582, 87) hit box11 at offset (1, 1)"
     RenderBR {BR} at (316,80) size 1x19
     RenderInline {SPAN} at (0,100) size 318x19 [color=#008000]
       RenderText {#text} at (0,100) size 318x19
-        text run at (0,100) width 318: "PASS: event at (605, 87) hit box12 at offset (2, 2)"
+        text run at (0,100) width 318: "PASS: event at (605, 87) hit box12 at offset (1, 1)"
     RenderBR {BR} at (317,100) size 1x19
 layer at (42,42) size 140x140
   RenderBlock {DIV} at (21,21) size 140x140 [bgcolor=#DDDDDD] [border: (1px solid #000000)]

--- a/LayoutTests/platform/ios/transforms/3d/point-mapping/3d-point-mapping-deep-expected.txt
+++ b/LayoutTests/platform/ios/transforms/3d/point-mapping/3d-point-mapping-deep-expected.txt
@@ -26,31 +26,31 @@ layer at (30,650) size 349x160
   RenderBlock (positioned) {DIV} at (30,650) size 350x160
     RenderInline {SPAN} at (0,0) size 302x19 [color=#008000]
       RenderText {#text} at (0,0) size 302x19
-        text run at (0,0) width 302: "PASS: event at (45, 45) hit box1 at offset (3, 3)"
+        text run at (0,0) width 302: "PASS: event at (45, 45) hit box1 at offset (2, 2)"
     RenderBR {BR} at (301,0) size 1x19
     RenderInline {SPAN} at (0,20) size 302x19 [color=#008000]
       RenderText {#text} at (0,20) size 302x19
-        text run at (0,20) width 302: "PASS: event at (54, 44) hit box2 at offset (2, 2)"
+        text run at (0,20) width 302: "PASS: event at (54, 44) hit box2 at offset (1, 1)"
     RenderBR {BR} at (301,20) size 1x19
     RenderInline {SPAN} at (0,40) size 310x19 [color=#008000]
       RenderText {#text} at (0,40) size 310x19
-        text run at (0,40) width 310: "PASS: event at (104, 93) hit box3 at offset (2, 2)"
+        text run at (0,40) width 310: "PASS: event at (104, 93) hit box3 at offset (1, 1)"
     RenderBR {BR} at (309,40) size 1x19
     RenderInline {SPAN} at (0,60) size 318x19 [color=#008000]
       RenderText {#text} at (0,60) size 318x19
-        text run at (0,60) width 318: "PASS: event at (175, 137) hit box4 at offset (2, 2)"
+        text run at (0,60) width 318: "PASS: event at (175, 137) hit box4 at offset (1, 1)"
     RenderBR {BR} at (317,60) size 1x19
     RenderInline {SPAN} at (0,80) size 334x19 [color=#008000]
       RenderText {#text} at (0,80) size 334x19
-        text run at (0,80) width 334: "PASS: event at (167, 528) hit box4 at offset (2, 296)"
+        text run at (0,80) width 334: "PASS: event at (167, 528) hit box4 at offset (1, 295)"
     RenderBR {BR} at (333,80) size 1x19
     RenderInline {SPAN} at (0,100) size 318x19 [color=#008000]
       RenderText {#text} at (0,100) size 318x19
-        text run at (0,100) width 318: "PASS: event at (227, 197) hit box5 at offset (2, 2)"
+        text run at (0,100) width 318: "PASS: event at (227, 197) hit box5 at offset (1, 1)"
     RenderBR {BR} at (317,100) size 1x19
     RenderInline {SPAN} at (0,120) size 350x19 [color=#008000]
       RenderText {#text} at (0,120) size 350x19
-        text run at (0,120) width 350: "PASS: event at (539, 569) hit box7 at offset (296, 296)"
+        text run at (0,120) width 350: "PASS: event at (539, 569) hit box7 at offset (295, 295)"
     RenderBR {BR} at (349,120) size 1x19
     RenderInline {SPAN} at (0,140) size 334x19 [color=#008000]
       RenderText {#text} at (0,140) size 334x19

--- a/LayoutTests/platform/ios/transforms/3d/point-mapping/3d-point-mapping-expected.txt
+++ b/LayoutTests/platform/ios/transforms/3d/point-mapping/3d-point-mapping-expected.txt
@@ -7,39 +7,39 @@ layer at (30,500) size 341x180
   RenderBlock (positioned) {DIV} at (30,500) size 342x180
     RenderInline {SPAN} at (0,0) size 302x19 [color=#008000]
       RenderText {#text} at (0,0) size 302x19
-        text run at (0,0) width 302: "PASS: event at (44, 44) hit box1 at offset (2, 2)"
+        text run at (0,0) width 302: "PASS: event at (44, 44) hit box1 at offset (1, 1)"
     RenderBR {BR} at (301,0) size 1x19
     RenderInline {SPAN} at (0,20) size 302x19 [color=#008000]
       RenderText {#text} at (0,20) size 302x19
-        text run at (0,20) width 302: "PASS: event at (69, 55) hit box2 at offset (2, 2)"
+        text run at (0,20) width 302: "PASS: event at (69, 55) hit box2 at offset (1, 1)"
     RenderBR {BR} at (301,20) size 1x19
     RenderInline {SPAN} at (0,40) size 334x19 [color=#008000]
       RenderText {#text} at (0,40) size 334x19
-        text run at (0,40) width 334: "PASS: event at (165, 182) hit box2 at offset (96, 96)"
+        text run at (0,40) width 334: "PASS: event at (165, 182) hit box2 at offset (95, 95)"
     RenderBR {BR} at (333,40) size 1x19
     RenderInline {SPAN} at (0,60) size 310x19 [color=#008000]
       RenderText {#text} at (0,60) size 310x19
-        text run at (0,60) width 310: "PASS: event at (333, 79) hit box7 at offset (2, 2)"
+        text run at (0,60) width 310: "PASS: event at (333, 79) hit box7 at offset (1, 1)"
     RenderBR {BR} at (309,60) size 1x19
     RenderInline {SPAN} at (0,80) size 318x19 [color=#008000]
       RenderText {#text} at (0,80) size 318x19
-        text run at (0,80) width 318: "PASS: event at (87, 325) hit box10 at offset (2, 2)"
+        text run at (0,80) width 318: "PASS: event at (87, 325) hit box10 at offset (1, 1)"
     RenderBR {BR} at (317,80) size 1x19
     RenderInline {SPAN} at (0,100) size 342x19 [color=#008000]
       RenderText {#text} at (0,100) size 342x19
-        text run at (0,100) width 342: "PASS: event at (196, 467) hit box10 at offset (98, 98)"
+        text run at (0,100) width 342: "PASS: event at (196, 467) hit box10 at offset (97, 97)"
     RenderBR {BR} at (341,100) size 1x19
     RenderInline {SPAN} at (0,120) size 326x19 [color=#008000]
       RenderText {#text} at (0,120) size 326x19
-        text run at (0,120) width 326: "PASS: event at (333, 325) hit box13 at offset (2, 2)"
+        text run at (0,120) width 326: "PASS: event at (333, 325) hit box13 at offset (1, 1)"
     RenderBR {BR} at (325,120) size 1x19
     RenderInline {SPAN} at (0,140) size 326x19 [color=#008000]
       RenderText {#text} at (0,140) size 326x19
-        text run at (0,140) width 326: "PASS: event at (353, 352) hit box14 at offset (2, 2)"
+        text run at (0,140) width 326: "PASS: event at (353, 352) hit box14 at offset (1, 1)"
     RenderBR {BR} at (325,140) size 1x19
     RenderInline {SPAN} at (0,160) size 342x19 [color=#008000]
       RenderText {#text} at (0,160) size 342x19
-        text run at (0,160) width 342: "PASS: event at (472, 507) hit box14 at offset (97, 97)"
+        text run at (0,160) width 342: "PASS: event at (472, 507) hit box14 at offset (96, 96)"
     RenderBR {BR} at (341,160) size 1x19
 layer at (21,21) size 202x202
   RenderBlock (positioned) {DIV} at (21,21) size 202x202 [border: (1px solid #000000)]

--- a/LayoutTests/platform/ios/transforms/3d/point-mapping/3d-point-mapping-preserve-3d-expected.txt
+++ b/LayoutTests/platform/ios/transforms/3d/point-mapping/3d-point-mapping-preserve-3d-expected.txt
@@ -7,71 +7,71 @@ layer at (30,500) size 341x340
   RenderBlock (positioned) {DIV} at (30,500) size 342x340
     RenderInline {SPAN} at (0,0) size 302x19 [color=#008000]
       RenderText {#text} at (0,0) size 302x19
-        text run at (0,0) width 302: "PASS: event at (44, 44) hit box1 at offset (2, 2)"
+        text run at (0,0) width 302: "PASS: event at (44, 44) hit box1 at offset (1, 1)"
     RenderBR {BR} at (301,0) size 1x19
     RenderInline {SPAN} at (0,20) size 302x19 [color=#008000]
       RenderText {#text} at (0,20) size 302x19
-        text run at (0,20) width 302: "PASS: event at (74, 68) hit box2 at offset (2, 2)"
+        text run at (0,20) width 302: "PASS: event at (74, 68) hit box2 at offset (1, 1)"
     RenderBR {BR} at (301,20) size 1x19
     RenderInline {SPAN} at (0,40) size 334x19 [color=#008000]
       RenderText {#text} at (0,40) size 334x19
-        text run at (0,40) width 334: "PASS: event at (157, 164) hit box2 at offset (98, 98)"
+        text run at (0,40) width 334: "PASS: event at (157, 164) hit box2 at offset (97, 97)"
     RenderBR {BR} at (333,40) size 1x19
     RenderInline {SPAN} at (0,60) size 310x19 [color=#008000]
       RenderText {#text} at (0,60) size 310x19
-        text run at (0,60) width 310: "PASS: event at (320, 68) hit box4 at offset (2, 2)"
+        text run at (0,60) width 310: "PASS: event at (320, 68) hit box4 at offset (1, 1)"
     RenderBR {BR} at (309,60) size 1x19
     RenderInline {SPAN} at (0,80) size 310x19 [color=#008000]
       RenderText {#text} at (0,80) size 310x19
-        text run at (0,80) width 310: "PASS: event at (336, 87) hit box5 at offset (2, 2)"
+        text run at (0,80) width 310: "PASS: event at (336, 87) hit box5 at offset (1, 1)"
     RenderBR {BR} at (309,80) size 1x19
     RenderInline {SPAN} at (0,100) size 310x19 [color=#008000]
       RenderText {#text} at (0,100) size 310x19
-        text run at (0,100) width 310: "PASS: event at (582, 87) hit box8 at offset (2, 2)"
+        text run at (0,100) width 310: "PASS: event at (582, 87) hit box8 at offset (1, 1)"
     RenderBR {BR} at (309,100) size 1x19
     RenderInline {SPAN} at (0,120) size 334x19 [color=#008000]
       RenderText {#text} at (0,120) size 334x19
-        text run at (0,120) width 334: "PASS: event at (658, 174) hit box8 at offset (86, 86)"
+        text run at (0,120) width 334: "PASS: event at (658, 174) hit box8 at offset (85, 85)"
     RenderBR {BR} at (333,120) size 1x19
     RenderInline {SPAN} at (0,140) size 318x19 [color=#008000]
       RenderText {#text} at (0,140) size 318x19
-        text run at (0,140) width 318: "PASS: event at (74, 314) hit box10 at offset (2, 2)"
+        text run at (0,140) width 318: "PASS: event at (74, 314) hit box10 at offset (1, 1)"
     RenderBR {BR} at (317,140) size 1x19
     RenderInline {SPAN} at (0,160) size 317x19 [color=#008000]
       RenderText {#text} at (0,160) size 317x19
-        text run at (0,160) width 317: "PASS: event at (91, 351) hit box11 at offset (2, 2)"
+        text run at (0,160) width 317: "PASS: event at (91, 351) hit box11 at offset (1, 1)"
     RenderBR {BR} at (316,160) size 1x19
     RenderInline {SPAN} at (0,180) size 326x19 [color=#008000]
       RenderText {#text} at (0,180) size 326x19
-        text run at (0,180) width 326: "PASS: event at (320, 314) hit box13 at offset (2, 2)"
+        text run at (0,180) width 326: "PASS: event at (320, 314) hit box13 at offset (1, 1)"
     RenderBR {BR} at (325,180) size 1x19
     RenderInline {SPAN} at (0,200) size 326x19 [color=#008000]
       RenderText {#text} at (0,200) size 326x19
-        text run at (0,200) width 326: "PASS: event at (343, 351) hit box14 at offset (2, 2)"
+        text run at (0,200) width 326: "PASS: event at (343, 351) hit box14 at offset (1, 1)"
     RenderBR {BR} at (325,200) size 1x19
     RenderInline {SPAN} at (0,220) size 326x19 [color=#008000]
       RenderText {#text} at (0,220) size 326x19
-        text run at (0,220) width 326: "PASS: event at (365, 375) hit box15 at offset (2, 2)"
+        text run at (0,220) width 326: "PASS: event at (365, 375) hit box15 at offset (1, 1)"
     RenderBR {BR} at (325,220) size 1x19
     RenderInline {SPAN} at (0,240) size 326x19 [color=#008000]
       RenderText {#text} at (0,240) size 326x19
-        text run at (0,240) width 326: "PASS: event at (566, 314) hit box17 at offset (2, 2)"
+        text run at (0,240) width 326: "PASS: event at (566, 314) hit box17 at offset (1, 1)"
     RenderBR {BR} at (325,240) size 1x19
     RenderInline {SPAN} at (0,260) size 326x19 [color=#008000]
       RenderText {#text} at (0,260) size 326x19
-        text run at (0,260) width 326: "PASS: event at (587, 352) hit box18 at offset (2, 2)"
+        text run at (0,260) width 326: "PASS: event at (587, 352) hit box18 at offset (1, 1)"
     RenderBR {BR} at (325,260) size 1x19
     RenderInline {SPAN} at (0,280) size 326x19 [color=#008000]
       RenderText {#text} at (0,280) size 326x19
-        text run at (0,280) width 326: "PASS: event at (629, 401) hit box19 at offset (2, 2)"
+        text run at (0,280) width 326: "PASS: event at (629, 401) hit box19 at offset (1, 1)"
     RenderBR {BR} at (325,280) size 1x19
     RenderInline {SPAN} at (0,300) size 326x19 [color=#008000]
       RenderText {#text} at (0,300) size 326x19
-        text run at (0,300) width 326: "PASS: event at (653, 422) hit box20 at offset (2, 2)"
+        text run at (0,300) width 326: "PASS: event at (653, 422) hit box20 at offset (1, 1)"
     RenderBR {BR} at (325,300) size 1x19
     RenderInline {SPAN} at (0,320) size 342x19 [color=#008000]
       RenderText {#text} at (0,320) size 342x19
-        text run at (0,320) width 342: "PASS: event at (745, 505) hit box20 at offset (86, 87)"
+        text run at (0,320) width 342: "PASS: event at (745, 505) hit box20 at offset (85, 86)"
     RenderBR {BR} at (341,320) size 1x19
 layer at (21,21) size 202x202
   RenderBlock (positioned) {DIV} at (21,21) size 202x202 [border: (1px solid #000000)]

--- a/LayoutTests/platform/mac/transforms/3d/point-mapping/3d-point-mapping-2-expected.txt
+++ b/LayoutTests/platform/mac/transforms/3d/point-mapping/3d-point-mapping-2-expected.txt
@@ -16,27 +16,27 @@ layer at (30,500) size 333x108
   RenderBlock (positioned) {DIV} at (30,500) size 334x108
     RenderInline {SPAN} at (0,0) size 318x18 [color=#008000]
       RenderText {#text} at (0,0) size 318x18
-        text run at (0,0) width 318: "PASS: event at (120, 128) hit box4 at offset (2, 2)"
+        text run at (0,0) width 318: "PASS: event at (120, 128) hit box4 at offset (1, 1)"
     RenderBR {BR} at (317,0) size 1x18
     RenderInline {SPAN} at (0,18) size 334x18 [color=#008000]
       RenderText {#text} at (0,18) size 334x18
-        text run at (0,18) width 334: "PASS: event at (184, 160) hit box3 at offset (83, 52)"
+        text run at (0,18) width 334: "PASS: event at (184, 160) hit box3 at offset (82, 51)"
     RenderBR {BR} at (333,18) size 1x18
     RenderInline {SPAN} at (0,36) size 310x18 [color=#008000]
       RenderText {#text} at (0,36) size 310x18
-        text run at (0,36) width 310: "PASS: event at (336, 87) hit box7 at offset (2, 2)"
+        text run at (0,36) width 310: "PASS: event at (336, 87) hit box7 at offset (1, 1)"
     RenderBR {BR} at (309,36) size 1x18
     RenderInline {SPAN} at (0,54) size 310x18 [color=#008000]
       RenderText {#text} at (0,54) size 310x18
-        text run at (0,54) width 310: "PASS: event at (359, 87) hit box8 at offset (2, 2)"
+        text run at (0,54) width 310: "PASS: event at (359, 87) hit box8 at offset (1, 1)"
     RenderBR {BR} at (309,54) size 1x18
     RenderInline {SPAN} at (0,72) size 317x18 [color=#008000]
       RenderText {#text} at (0,72) size 317x18
-        text run at (0,72) width 317: "PASS: event at (582, 87) hit box11 at offset (2, 2)"
+        text run at (0,72) width 317: "PASS: event at (582, 87) hit box11 at offset (1, 1)"
     RenderBR {BR} at (316,72) size 1x18
     RenderInline {SPAN} at (0,90) size 318x18 [color=#008000]
       RenderText {#text} at (0,90) size 318x18
-        text run at (0,90) width 318: "PASS: event at (605, 87) hit box12 at offset (2, 2)"
+        text run at (0,90) width 318: "PASS: event at (605, 87) hit box12 at offset (1, 1)"
     RenderBR {BR} at (317,90) size 1x18
 layer at (42,42) size 140x140
   RenderBlock {DIV} at (21,21) size 140x140 [bgcolor=#DDDDDD] [border: (1px solid #000000)]

--- a/LayoutTests/platform/mac/transforms/3d/point-mapping/3d-point-mapping-deep-expected.txt
+++ b/LayoutTests/platform/mac/transforms/3d/point-mapping/3d-point-mapping-deep-expected.txt
@@ -26,31 +26,31 @@ layer at (30,650) size 349x144
   RenderBlock (positioned) {DIV} at (30,650) size 350x144
     RenderInline {SPAN} at (0,0) size 302x18 [color=#008000]
       RenderText {#text} at (0,0) size 302x18
-        text run at (0,0) width 302: "PASS: event at (45, 45) hit box1 at offset (3, 3)"
+        text run at (0,0) width 302: "PASS: event at (45, 45) hit box1 at offset (2, 2)"
     RenderBR {BR} at (301,0) size 1x18
     RenderInline {SPAN} at (0,18) size 302x18 [color=#008000]
       RenderText {#text} at (0,18) size 302x18
-        text run at (0,18) width 302: "PASS: event at (54, 44) hit box2 at offset (2, 2)"
+        text run at (0,18) width 302: "PASS: event at (54, 44) hit box2 at offset (1, 1)"
     RenderBR {BR} at (301,18) size 1x18
     RenderInline {SPAN} at (0,36) size 310x18 [color=#008000]
       RenderText {#text} at (0,36) size 310x18
-        text run at (0,36) width 310: "PASS: event at (104, 93) hit box3 at offset (2, 2)"
+        text run at (0,36) width 310: "PASS: event at (104, 93) hit box3 at offset (1, 1)"
     RenderBR {BR} at (309,36) size 1x18
     RenderInline {SPAN} at (0,54) size 318x18 [color=#008000]
       RenderText {#text} at (0,54) size 318x18
-        text run at (0,54) width 318: "PASS: event at (175, 137) hit box4 at offset (2, 2)"
+        text run at (0,54) width 318: "PASS: event at (175, 137) hit box4 at offset (1, 1)"
     RenderBR {BR} at (317,54) size 1x18
     RenderInline {SPAN} at (0,72) size 334x18 [color=#008000]
       RenderText {#text} at (0,72) size 334x18
-        text run at (0,72) width 334: "PASS: event at (167, 528) hit box4 at offset (2, 296)"
+        text run at (0,72) width 334: "PASS: event at (167, 528) hit box4 at offset (1, 295)"
     RenderBR {BR} at (333,72) size 1x18
     RenderInline {SPAN} at (0,90) size 318x18 [color=#008000]
       RenderText {#text} at (0,90) size 318x18
-        text run at (0,90) width 318: "PASS: event at (227, 197) hit box5 at offset (2, 2)"
+        text run at (0,90) width 318: "PASS: event at (227, 197) hit box5 at offset (1, 1)"
     RenderBR {BR} at (317,90) size 1x18
     RenderInline {SPAN} at (0,108) size 350x18 [color=#008000]
       RenderText {#text} at (0,108) size 350x18
-        text run at (0,108) width 350: "PASS: event at (539, 569) hit box7 at offset (296, 296)"
+        text run at (0,108) width 350: "PASS: event at (539, 569) hit box7 at offset (295, 295)"
     RenderBR {BR} at (349,108) size 1x18
     RenderInline {SPAN} at (0,126) size 334x18 [color=#008000]
       RenderText {#text} at (0,126) size 334x18

--- a/LayoutTests/platform/mac/transforms/3d/point-mapping/3d-point-mapping-expected.txt
+++ b/LayoutTests/platform/mac/transforms/3d/point-mapping/3d-point-mapping-expected.txt
@@ -7,39 +7,39 @@ layer at (30,500) size 341x162
   RenderBlock (positioned) {DIV} at (30,500) size 342x162
     RenderInline {SPAN} at (0,0) size 302x18 [color=#008000]
       RenderText {#text} at (0,0) size 302x18
-        text run at (0,0) width 302: "PASS: event at (44, 44) hit box1 at offset (2, 2)"
+        text run at (0,0) width 302: "PASS: event at (44, 44) hit box1 at offset (1, 1)"
     RenderBR {BR} at (301,0) size 1x18
     RenderInline {SPAN} at (0,18) size 302x18 [color=#008000]
       RenderText {#text} at (0,18) size 302x18
-        text run at (0,18) width 302: "PASS: event at (69, 55) hit box2 at offset (2, 2)"
+        text run at (0,18) width 302: "PASS: event at (69, 55) hit box2 at offset (1, 1)"
     RenderBR {BR} at (301,18) size 1x18
     RenderInline {SPAN} at (0,36) size 334x18 [color=#008000]
       RenderText {#text} at (0,36) size 334x18
-        text run at (0,36) width 334: "PASS: event at (165, 182) hit box2 at offset (96, 96)"
+        text run at (0,36) width 334: "PASS: event at (165, 182) hit box2 at offset (95, 95)"
     RenderBR {BR} at (333,36) size 1x18
     RenderInline {SPAN} at (0,54) size 310x18 [color=#008000]
       RenderText {#text} at (0,54) size 310x18
-        text run at (0,54) width 310: "PASS: event at (333, 79) hit box7 at offset (2, 2)"
+        text run at (0,54) width 310: "PASS: event at (333, 79) hit box7 at offset (1, 1)"
     RenderBR {BR} at (309,54) size 1x18
     RenderInline {SPAN} at (0,72) size 318x18 [color=#008000]
       RenderText {#text} at (0,72) size 318x18
-        text run at (0,72) width 318: "PASS: event at (87, 325) hit box10 at offset (2, 2)"
+        text run at (0,72) width 318: "PASS: event at (87, 325) hit box10 at offset (1, 1)"
     RenderBR {BR} at (317,72) size 1x18
     RenderInline {SPAN} at (0,90) size 342x18 [color=#008000]
       RenderText {#text} at (0,90) size 342x18
-        text run at (0,90) width 342: "PASS: event at (196, 467) hit box10 at offset (98, 98)"
+        text run at (0,90) width 342: "PASS: event at (196, 467) hit box10 at offset (97, 97)"
     RenderBR {BR} at (341,90) size 1x18
     RenderInline {SPAN} at (0,108) size 326x18 [color=#008000]
       RenderText {#text} at (0,108) size 326x18
-        text run at (0,108) width 326: "PASS: event at (333, 325) hit box13 at offset (2, 2)"
+        text run at (0,108) width 326: "PASS: event at (333, 325) hit box13 at offset (1, 1)"
     RenderBR {BR} at (325,108) size 1x18
     RenderInline {SPAN} at (0,126) size 326x18 [color=#008000]
       RenderText {#text} at (0,126) size 326x18
-        text run at (0,126) width 326: "PASS: event at (353, 352) hit box14 at offset (2, 2)"
+        text run at (0,126) width 326: "PASS: event at (353, 352) hit box14 at offset (1, 1)"
     RenderBR {BR} at (325,126) size 1x18
     RenderInline {SPAN} at (0,144) size 342x18 [color=#008000]
       RenderText {#text} at (0,144) size 342x18
-        text run at (0,144) width 342: "PASS: event at (472, 507) hit box14 at offset (97, 97)"
+        text run at (0,144) width 342: "PASS: event at (472, 507) hit box14 at offset (96, 96)"
     RenderBR {BR} at (341,144) size 1x18
 layer at (21,21) size 202x202
   RenderBlock (positioned) {DIV} at (21,21) size 202x202 [border: (1px solid #000000)]

--- a/LayoutTests/platform/mac/transforms/3d/point-mapping/3d-point-mapping-preserve-3d-expected.txt
+++ b/LayoutTests/platform/mac/transforms/3d/point-mapping/3d-point-mapping-preserve-3d-expected.txt
@@ -7,71 +7,71 @@ layer at (30,500) size 341x306
   RenderBlock (positioned) {DIV} at (30,500) size 342x306
     RenderInline {SPAN} at (0,0) size 302x18 [color=#008000]
       RenderText {#text} at (0,0) size 302x18
-        text run at (0,0) width 302: "PASS: event at (44, 44) hit box1 at offset (2, 2)"
+        text run at (0,0) width 302: "PASS: event at (44, 44) hit box1 at offset (1, 1)"
     RenderBR {BR} at (301,0) size 1x18
     RenderInline {SPAN} at (0,18) size 302x18 [color=#008000]
       RenderText {#text} at (0,18) size 302x18
-        text run at (0,18) width 302: "PASS: event at (74, 68) hit box2 at offset (2, 2)"
+        text run at (0,18) width 302: "PASS: event at (74, 68) hit box2 at offset (1, 1)"
     RenderBR {BR} at (301,18) size 1x18
     RenderInline {SPAN} at (0,36) size 334x18 [color=#008000]
       RenderText {#text} at (0,36) size 334x18
-        text run at (0,36) width 334: "PASS: event at (157, 164) hit box2 at offset (98, 98)"
+        text run at (0,36) width 334: "PASS: event at (157, 164) hit box2 at offset (97, 97)"
     RenderBR {BR} at (333,36) size 1x18
     RenderInline {SPAN} at (0,54) size 310x18 [color=#008000]
       RenderText {#text} at (0,54) size 310x18
-        text run at (0,54) width 310: "PASS: event at (320, 68) hit box4 at offset (2, 2)"
+        text run at (0,54) width 310: "PASS: event at (320, 68) hit box4 at offset (1, 1)"
     RenderBR {BR} at (309,54) size 1x18
     RenderInline {SPAN} at (0,72) size 310x18 [color=#008000]
       RenderText {#text} at (0,72) size 310x18
-        text run at (0,72) width 310: "PASS: event at (336, 87) hit box5 at offset (2, 2)"
+        text run at (0,72) width 310: "PASS: event at (336, 87) hit box5 at offset (1, 1)"
     RenderBR {BR} at (309,72) size 1x18
     RenderInline {SPAN} at (0,90) size 310x18 [color=#008000]
       RenderText {#text} at (0,90) size 310x18
-        text run at (0,90) width 310: "PASS: event at (582, 87) hit box8 at offset (2, 2)"
+        text run at (0,90) width 310: "PASS: event at (582, 87) hit box8 at offset (1, 1)"
     RenderBR {BR} at (309,90) size 1x18
     RenderInline {SPAN} at (0,108) size 334x18 [color=#008000]
       RenderText {#text} at (0,108) size 334x18
-        text run at (0,108) width 334: "PASS: event at (658, 174) hit box8 at offset (86, 86)"
+        text run at (0,108) width 334: "PASS: event at (658, 174) hit box8 at offset (85, 85)"
     RenderBR {BR} at (333,108) size 1x18
     RenderInline {SPAN} at (0,126) size 318x18 [color=#008000]
       RenderText {#text} at (0,126) size 318x18
-        text run at (0,126) width 318: "PASS: event at (74, 314) hit box10 at offset (2, 2)"
+        text run at (0,126) width 318: "PASS: event at (74, 314) hit box10 at offset (1, 1)"
     RenderBR {BR} at (317,126) size 1x18
     RenderInline {SPAN} at (0,144) size 317x18 [color=#008000]
       RenderText {#text} at (0,144) size 317x18
-        text run at (0,144) width 317: "PASS: event at (91, 351) hit box11 at offset (2, 2)"
+        text run at (0,144) width 317: "PASS: event at (91, 351) hit box11 at offset (1, 1)"
     RenderBR {BR} at (316,144) size 1x18
     RenderInline {SPAN} at (0,162) size 326x18 [color=#008000]
       RenderText {#text} at (0,162) size 326x18
-        text run at (0,162) width 326: "PASS: event at (320, 314) hit box13 at offset (2, 2)"
+        text run at (0,162) width 326: "PASS: event at (320, 314) hit box13 at offset (1, 1)"
     RenderBR {BR} at (325,162) size 1x18
     RenderInline {SPAN} at (0,180) size 326x18 [color=#008000]
       RenderText {#text} at (0,180) size 326x18
-        text run at (0,180) width 326: "PASS: event at (343, 351) hit box14 at offset (2, 2)"
+        text run at (0,180) width 326: "PASS: event at (343, 351) hit box14 at offset (1, 1)"
     RenderBR {BR} at (325,180) size 1x18
     RenderInline {SPAN} at (0,198) size 326x18 [color=#008000]
       RenderText {#text} at (0,198) size 326x18
-        text run at (0,198) width 326: "PASS: event at (365, 375) hit box15 at offset (2, 2)"
+        text run at (0,198) width 326: "PASS: event at (365, 375) hit box15 at offset (1, 1)"
     RenderBR {BR} at (325,198) size 1x18
     RenderInline {SPAN} at (0,216) size 326x18 [color=#008000]
       RenderText {#text} at (0,216) size 326x18
-        text run at (0,216) width 326: "PASS: event at (566, 314) hit box17 at offset (2, 2)"
+        text run at (0,216) width 326: "PASS: event at (566, 314) hit box17 at offset (1, 1)"
     RenderBR {BR} at (325,216) size 1x18
     RenderInline {SPAN} at (0,234) size 326x18 [color=#008000]
       RenderText {#text} at (0,234) size 326x18
-        text run at (0,234) width 326: "PASS: event at (587, 352) hit box18 at offset (2, 2)"
+        text run at (0,234) width 326: "PASS: event at (587, 352) hit box18 at offset (1, 1)"
     RenderBR {BR} at (325,234) size 1x18
     RenderInline {SPAN} at (0,252) size 326x18 [color=#008000]
       RenderText {#text} at (0,252) size 326x18
-        text run at (0,252) width 326: "PASS: event at (629, 401) hit box19 at offset (2, 2)"
+        text run at (0,252) width 326: "PASS: event at (629, 401) hit box19 at offset (1, 1)"
     RenderBR {BR} at (325,252) size 1x18
     RenderInline {SPAN} at (0,270) size 326x18 [color=#008000]
       RenderText {#text} at (0,270) size 326x18
-        text run at (0,270) width 326: "PASS: event at (653, 422) hit box20 at offset (2, 2)"
+        text run at (0,270) width 326: "PASS: event at (653, 422) hit box20 at offset (1, 1)"
     RenderBR {BR} at (325,270) size 1x18
     RenderInline {SPAN} at (0,288) size 342x18 [color=#008000]
       RenderText {#text} at (0,288) size 342x18
-        text run at (0,288) width 342: "PASS: event at (745, 505) hit box20 at offset (86, 87)"
+        text run at (0,288) width 342: "PASS: event at (745, 505) hit box20 at offset (85, 86)"
     RenderBR {BR} at (341,288) size 1x18
 layer at (21,21) size 202x202
   RenderBlock (positioned) {DIV} at (21,21) size 202x202 [border: (1px solid #000000)]

--- a/LayoutTests/platform/win/transforms/3d/point-mapping/3d-point-mapping-2-expected.txt
+++ b/LayoutTests/platform/win/transforms/3d/point-mapping/3d-point-mapping-2-expected.txt
@@ -16,27 +16,27 @@ layer at (30,500) size 328x108
   RenderBlock (positioned) {DIV} at (30,500) size 328x108
     RenderInline {SPAN} at (0,0) size 312x17 [color=#008000]
       RenderText {#text} at (0,0) size 312x17
-        text run at (0,0) width 312: "PASS: event at (120, 128) hit box4 at offset (2, 2)"
+        text run at (0,0) width 312: "PASS: event at (120, 128) hit box4 at offset (1, 1)"
     RenderBR {BR} at (312,0) size 0x17
     RenderInline {SPAN} at (0,0) size 328x17 [color=#008000]
       RenderText {#text} at (0,18) size 328x17
-        text run at (0,18) width 328: "PASS: event at (184, 160) hit box3 at offset (83, 52)"
+        text run at (0,18) width 328: "PASS: event at (184, 160) hit box3 at offset (82, 51)"
     RenderBR {BR} at (328,18) size 0x17
     RenderInline {SPAN} at (0,0) size 304x17 [color=#008000]
       RenderText {#text} at (0,36) size 304x17
-        text run at (0,36) width 304: "PASS: event at (336, 87) hit box7 at offset (2, 2)"
+        text run at (0,36) width 304: "PASS: event at (336, 87) hit box7 at offset (1, 1)"
     RenderBR {BR} at (304,36) size 0x17
     RenderInline {SPAN} at (0,0) size 304x17 [color=#008000]
       RenderText {#text} at (0,54) size 304x17
-        text run at (0,54) width 304: "PASS: event at (359, 87) hit box8 at offset (2, 2)"
+        text run at (0,54) width 304: "PASS: event at (359, 87) hit box8 at offset (1, 1)"
     RenderBR {BR} at (304,54) size 0x17
     RenderInline {SPAN} at (0,0) size 311x17 [color=#008000]
       RenderText {#text} at (0,72) size 311x17
-        text run at (0,72) width 311: "PASS: event at (582, 87) hit box11 at offset (2, 2)"
+        text run at (0,72) width 311: "PASS: event at (582, 87) hit box11 at offset (1, 1)"
     RenderBR {BR} at (311,72) size 0x17
     RenderInline {SPAN} at (0,0) size 312x17 [color=#008000]
       RenderText {#text} at (0,90) size 312x17
-        text run at (0,90) width 312: "PASS: event at (605, 87) hit box12 at offset (2, 2)"
+        text run at (0,90) width 312: "PASS: event at (605, 87) hit box12 at offset (1, 1)"
     RenderBR {BR} at (312,90) size 0x17
 layer at (42,42) size 140x140
   RenderBlock {DIV} at (21,21) size 140x140 [bgcolor=#DDDDDD] [border: (1px solid #000000)]

--- a/LayoutTests/platform/win/transforms/3d/point-mapping/3d-point-mapping-deep-expected.txt
+++ b/LayoutTests/platform/win/transforms/3d/point-mapping/3d-point-mapping-deep-expected.txt
@@ -26,7 +26,7 @@ layer at (30,650) size 344x144
   RenderBlock (positioned) {DIV} at (30,650) size 344x144
     RenderInline {SPAN} at (0,0) size 296x17 [color=#008000]
       RenderText {#text} at (0,0) size 296x17
-        text run at (0,0) width 296: "PASS: event at (45, 45) hit box1 at offset (3, 3)"
+        text run at (0,0) width 296: "PASS: event at (45, 45) hit box1 at offset (2, 2)"
     RenderBR {BR} at (296,0) size 0x17
     RenderInline {SPAN} at (0,0) size 296x17 [color=#008000]
       RenderText {#text} at (0,18) size 296x17
@@ -34,23 +34,23 @@ layer at (30,650) size 344x144
     RenderBR {BR} at (296,18) size 0x17
     RenderInline {SPAN} at (0,0) size 304x17 [color=#008000]
       RenderText {#text} at (0,36) size 304x17
-        text run at (0,36) width 304: "PASS: event at (104, 93) hit box3 at offset (2, 2)"
+        text run at (0,36) width 304: "PASS: event at (104, 93) hit box3 at offset (1, 1)"
     RenderBR {BR} at (304,36) size 0x17
     RenderInline {SPAN} at (0,0) size 312x17 [color=#008000]
       RenderText {#text} at (0,54) size 312x17
-        text run at (0,54) width 312: "PASS: event at (175, 137) hit box4 at offset (2, 2)"
+        text run at (0,54) width 312: "PASS: event at (175, 137) hit box4 at offset (1, 1)"
     RenderBR {BR} at (312,54) size 0x17
     RenderInline {SPAN} at (0,0) size 328x17 [color=#008000]
       RenderText {#text} at (0,72) size 328x17
-        text run at (0,72) width 328: "PASS: event at (167, 528) hit box4 at offset (2, 296)"
+        text run at (0,72) width 328: "PASS: event at (167, 528) hit box4 at offset (1, 295)"
     RenderBR {BR} at (328,72) size 0x17
     RenderInline {SPAN} at (0,0) size 312x17 [color=#008000]
       RenderText {#text} at (0,90) size 312x17
-        text run at (0,90) width 312: "PASS: event at (227, 197) hit box5 at offset (2, 2)"
+        text run at (0,90) width 312: "PASS: event at (227, 197) hit box5 at offset (1, 1)"
     RenderBR {BR} at (312,90) size 0x17
     RenderInline {SPAN} at (0,0) size 344x17 [color=#008000]
       RenderText {#text} at (0,108) size 344x17
-        text run at (0,108) width 344: "PASS: event at (539, 569) hit box7 at offset (296, 296)"
+        text run at (0,108) width 344: "PASS: event at (539, 569) hit box7 at offset (295, 295)"
     RenderBR {BR} at (344,108) size 0x17
     RenderInline {SPAN} at (0,0) size 328x17 [color=#008000]
       RenderText {#text} at (0,126) size 328x17

--- a/LayoutTests/platform/win/transforms/3d/point-mapping/3d-point-mapping-expected.txt
+++ b/LayoutTests/platform/win/transforms/3d/point-mapping/3d-point-mapping-expected.txt
@@ -7,39 +7,39 @@ layer at (30,500) size 336x162
   RenderBlock (positioned) {DIV} at (30,500) size 336x162
     RenderInline {SPAN} at (0,0) size 296x17 [color=#008000]
       RenderText {#text} at (0,0) size 296x17
-        text run at (0,0) width 296: "PASS: event at (44, 44) hit box1 at offset (2, 2)"
+        text run at (0,0) width 296: "PASS: event at (44, 44) hit box1 at offset (1, 1)"
     RenderBR {BR} at (296,0) size 0x17
     RenderInline {SPAN} at (0,0) size 296x17 [color=#008000]
       RenderText {#text} at (0,18) size 296x17
-        text run at (0,18) width 296: "PASS: event at (69, 55) hit box2 at offset (2, 2)"
+        text run at (0,18) width 296: "PASS: event at (69, 55) hit box2 at offset (1, 1)"
     RenderBR {BR} at (296,18) size 0x17
     RenderInline {SPAN} at (0,0) size 328x17 [color=#008000]
       RenderText {#text} at (0,36) size 328x17
-        text run at (0,36) width 328: "PASS: event at (165, 182) hit box2 at offset (96, 96)"
+        text run at (0,36) width 328: "PASS: event at (165, 182) hit box2 at offset (95, 95)"
     RenderBR {BR} at (328,36) size 0x17
     RenderInline {SPAN} at (0,0) size 304x17 [color=#008000]
       RenderText {#text} at (0,54) size 304x17
-        text run at (0,54) width 304: "PASS: event at (333, 79) hit box7 at offset (2, 2)"
+        text run at (0,54) width 304: "PASS: event at (333, 79) hit box7 at offset (1, 1)"
     RenderBR {BR} at (304,54) size 0x17
     RenderInline {SPAN} at (0,0) size 312x17 [color=#008000]
       RenderText {#text} at (0,72) size 312x17
-        text run at (0,72) width 312: "PASS: event at (87, 325) hit box10 at offset (2, 2)"
+        text run at (0,72) width 312: "PASS: event at (87, 325) hit box10 at offset (1, 1)"
     RenderBR {BR} at (312,72) size 0x17
     RenderInline {SPAN} at (0,0) size 336x17 [color=#008000]
       RenderText {#text} at (0,90) size 336x17
-        text run at (0,90) width 336: "PASS: event at (196, 467) hit box10 at offset (98, 98)"
+        text run at (0,90) width 336: "PASS: event at (196, 467) hit box10 at offset (97, 97)"
     RenderBR {BR} at (336,90) size 0x17
     RenderInline {SPAN} at (0,0) size 320x17 [color=#008000]
       RenderText {#text} at (0,108) size 320x17
-        text run at (0,108) width 320: "PASS: event at (333, 325) hit box13 at offset (2, 2)"
+        text run at (0,108) width 320: "PASS: event at (333, 325) hit box13 at offset (1, 1)"
     RenderBR {BR} at (320,108) size 0x17
     RenderInline {SPAN} at (0,0) size 320x17 [color=#008000]
       RenderText {#text} at (0,126) size 320x17
-        text run at (0,126) width 320: "PASS: event at (353, 352) hit box14 at offset (2, 2)"
+        text run at (0,126) width 320: "PASS: event at (353, 352) hit box14 at offset (1, 1)"
     RenderBR {BR} at (320,126) size 0x17
     RenderInline {SPAN} at (0,0) size 336x17 [color=#008000]
       RenderText {#text} at (0,144) size 336x17
-        text run at (0,144) width 336: "PASS: event at (472, 507) hit box14 at offset (97, 97)"
+        text run at (0,144) width 336: "PASS: event at (472, 507) hit box14 at offset (96, 96)"
     RenderBR {BR} at (336,144) size 0x17
 layer at (21,21) size 202x202
   RenderBlock (positioned) {DIV} at (21,21) size 202x202 [border: (1px solid #000000)]

--- a/LayoutTests/platform/win/transforms/3d/point-mapping/3d-point-mapping-preserve-3d-expected.txt
+++ b/LayoutTests/platform/win/transforms/3d/point-mapping/3d-point-mapping-preserve-3d-expected.txt
@@ -7,71 +7,71 @@ layer at (30,500) size 336x306
   RenderBlock (positioned) {DIV} at (30,500) size 336x306
     RenderInline {SPAN} at (0,0) size 296x17 [color=#008000]
       RenderText {#text} at (0,0) size 296x17
-        text run at (0,0) width 296: "PASS: event at (44, 44) hit box1 at offset (2, 2)"
+        text run at (0,0) width 296: "PASS: event at (44, 44) hit box1 at offset (1, 1)"
     RenderBR {BR} at (296,0) size 0x17
     RenderInline {SPAN} at (0,0) size 296x17 [color=#008000]
       RenderText {#text} at (0,18) size 296x17
-        text run at (0,18) width 296: "PASS: event at (74, 68) hit box2 at offset (2, 2)"
+        text run at (0,18) width 296: "PASS: event at (74, 68) hit box2 at offset (1, 1)"
     RenderBR {BR} at (296,18) size 0x17
     RenderInline {SPAN} at (0,0) size 328x17 [color=#008000]
       RenderText {#text} at (0,36) size 328x17
-        text run at (0,36) width 328: "PASS: event at (157, 164) hit box2 at offset (98, 98)"
+        text run at (0,36) width 328: "PASS: event at (157, 164) hit box2 at offset (97, 97)"
     RenderBR {BR} at (328,36) size 0x17
     RenderInline {SPAN} at (0,0) size 304x17 [color=#008000]
       RenderText {#text} at (0,54) size 304x17
-        text run at (0,54) width 304: "PASS: event at (320, 68) hit box4 at offset (2, 2)"
+        text run at (0,54) width 304: "PASS: event at (320, 68) hit box4 at offset (1, 1)"
     RenderBR {BR} at (304,54) size 0x17
     RenderInline {SPAN} at (0,0) size 304x17 [color=#008000]
       RenderText {#text} at (0,72) size 304x17
-        text run at (0,72) width 304: "PASS: event at (336, 87) hit box5 at offset (2, 2)"
+        text run at (0,72) width 304: "PASS: event at (336, 87) hit box5 at offset (1, 1)"
     RenderBR {BR} at (304,72) size 0x17
     RenderInline {SPAN} at (0,0) size 304x17 [color=#008000]
       RenderText {#text} at (0,90) size 304x17
-        text run at (0,90) width 304: "PASS: event at (582, 87) hit box8 at offset (2, 2)"
+        text run at (0,90) width 304: "PASS: event at (582, 87) hit box8 at offset (1, 1)"
     RenderBR {BR} at (304,90) size 0x17
     RenderInline {SPAN} at (0,0) size 328x17 [color=#008000]
       RenderText {#text} at (0,108) size 328x17
-        text run at (0,108) width 328: "PASS: event at (658, 174) hit box8 at offset (86, 86)"
+        text run at (0,108) width 328: "PASS: event at (658, 174) hit box8 at offset (85, 85)"
     RenderBR {BR} at (328,108) size 0x17
     RenderInline {SPAN} at (0,0) size 312x17 [color=#008000]
       RenderText {#text} at (0,126) size 312x17
-        text run at (0,126) width 312: "PASS: event at (74, 314) hit box10 at offset (2, 2)"
+        text run at (0,126) width 312: "PASS: event at (74, 314) hit box10 at offset (1, 1)"
     RenderBR {BR} at (312,126) size 0x17
     RenderInline {SPAN} at (0,0) size 311x17 [color=#008000]
       RenderText {#text} at (0,144) size 311x17
-        text run at (0,144) width 311: "PASS: event at (91, 351) hit box11 at offset (2, 2)"
+        text run at (0,144) width 311: "PASS: event at (91, 351) hit box11 at offset (1, 1)"
     RenderBR {BR} at (311,144) size 0x17
     RenderInline {SPAN} at (0,0) size 320x17 [color=#008000]
       RenderText {#text} at (0,162) size 320x17
-        text run at (0,162) width 320: "PASS: event at (320, 314) hit box13 at offset (2, 2)"
+        text run at (0,162) width 320: "PASS: event at (320, 314) hit box13 at offset (1, 1)"
     RenderBR {BR} at (320,162) size 0x17
     RenderInline {SPAN} at (0,0) size 320x17 [color=#008000]
       RenderText {#text} at (0,180) size 320x17
-        text run at (0,180) width 320: "PASS: event at (343, 351) hit box14 at offset (2, 2)"
+        text run at (0,180) width 320: "PASS: event at (343, 351) hit box14 at offset (1, 1)"
     RenderBR {BR} at (320,180) size 0x17
     RenderInline {SPAN} at (0,0) size 320x17 [color=#008000]
       RenderText {#text} at (0,198) size 320x17
-        text run at (0,198) width 320: "PASS: event at (365, 375) hit box15 at offset (2, 2)"
+        text run at (0,198) width 320: "PASS: event at (365, 375) hit box15 at offset (1, 1)"
     RenderBR {BR} at (320,198) size 0x17
     RenderInline {SPAN} at (0,0) size 320x17 [color=#008000]
       RenderText {#text} at (0,216) size 320x17
-        text run at (0,216) width 320: "PASS: event at (566, 314) hit box17 at offset (2, 2)"
+        text run at (0,216) width 320: "PASS: event at (566, 314) hit box17 at offset (1, 1)"
     RenderBR {BR} at (320,216) size 0x17
     RenderInline {SPAN} at (0,0) size 320x17 [color=#008000]
       RenderText {#text} at (0,234) size 320x17
-        text run at (0,234) width 320: "PASS: event at (587, 352) hit box18 at offset (2, 2)"
+        text run at (0,234) width 320: "PASS: event at (587, 352) hit box18 at offset (1, 1)"
     RenderBR {BR} at (320,234) size 0x17
     RenderInline {SPAN} at (0,0) size 320x17 [color=#008000]
       RenderText {#text} at (0,252) size 320x17
-        text run at (0,252) width 320: "PASS: event at (629, 401) hit box19 at offset (2, 2)"
+        text run at (0,252) width 320: "PASS: event at (629, 401) hit box19 at offset (1, 1)"
     RenderBR {BR} at (320,252) size 0x17
     RenderInline {SPAN} at (0,0) size 320x17 [color=#008000]
       RenderText {#text} at (0,270) size 320x17
-        text run at (0,270) width 320: "PASS: event at (653, 422) hit box20 at offset (2, 2)"
+        text run at (0,270) width 320: "PASS: event at (653, 422) hit box20 at offset (1, 1)"
     RenderBR {BR} at (320,270) size 0x17
     RenderInline {SPAN} at (0,0) size 336x17 [color=#008000]
       RenderText {#text} at (0,288) size 336x17
-        text run at (0,288) width 336: "PASS: event at (745, 505) hit box20 at offset (86, 87)"
+        text run at (0,288) width 336: "PASS: event at (745, 505) hit box20 at offset (85, 86)"
     RenderBR {BR} at (336,288) size 0x17
 layer at (21,21) size 202x202
   RenderBlock (positioned) {DIV} at (21,21) size 202x202 [border: (1px solid #000000)]

--- a/LayoutTests/transforms/3d/point-mapping/3d-point-mapping-2.html
+++ b/LayoutTests/transforms/3d/point-mapping/3d-point-mapping-2.html
@@ -16,13 +16,13 @@
       if (!window.testRunner)
         document.body.addEventListener('mousemove', mousemoved, false);
 
-      dispatchEvent(120, 128, 'box4', 2, 2);
-      dispatchEvent(184, 160, 'box3', 83, 52);
-      dispatchEvent(336, 87, 'box7', 2, 2);
-      dispatchEvent(359, 87, 'box8', 2, 2);
+      dispatchEvent(120, 128, 'box4', 1, 1);
+      dispatchEvent(184, 160, 'box3', 82, 51);
+      dispatchEvent(336, 87, 'box7', 1, 1);
+      dispatchEvent(359, 87, 'box8', 1, 1);
 
-      dispatchEvent(582, 87, 'box11', 2, 2);
-      dispatchEvent(605, 87, 'box12', 2, 2);
+      dispatchEvent(582, 87, 'box11', 1, 1);
+      dispatchEvent(605, 87, 'box12', 1, 1);
     }
   </script>
   <style type="text/css" media="screen">

--- a/LayoutTests/transforms/3d/point-mapping/3d-point-mapping-deep.html
+++ b/LayoutTests/transforms/3d/point-mapping/3d-point-mapping-deep.html
@@ -16,16 +16,16 @@
       if (!window.testRunner)
         document.body.addEventListener('mousemove', mousemoved, false);
 
-      dispatchEvent(45, 45, 'box1', 3, 3);
-      dispatchEvent(54, 44, 'box2', 2, 2);
-      dispatchEvent(104, 93, 'box3', 2, 2);
+      dispatchEvent(45, 45, 'box1', 2, 2);
+      dispatchEvent(54, 44, 'box2', 1, 1);
+      dispatchEvent(104, 93, 'box3', 1, 1);
 
-      dispatchEvent(175, 137, 'box4', 2, 2);
-      dispatchEvent(167, 528, 'box4', 2, 296);
+      dispatchEvent(175, 137, 'box4', 1, 1);
+      dispatchEvent(167, 528, 'box4', 1, 295);
 
-      dispatchEvent(227, 197, 'box5', 2, 2);
+      dispatchEvent(227, 197, 'box5', 1, 1);
 
-      dispatchEvent(539, 569, 'box7', 296, 296);
+      dispatchEvent(539, 569, 'box7', 295, 295);
 
       dispatchEvent(431, 441, 'box8', 85, 85);
     }

--- a/LayoutTests/transforms/3d/point-mapping/3d-point-mapping-preserve-3d.html
+++ b/LayoutTests/transforms/3d/point-mapping/3d-point-mapping-preserve-3d.html
@@ -10,28 +10,28 @@
       if (!window.testRunner)
         document.body.addEventListener('mousemove', mousemoved, false);
 
-      dispatchEvent(44, 44, 'box1', 2, 2);
-      dispatchEvent(74, 68, 'box2', 2, 2);
-      dispatchEvent(157, 164, 'box2', 98, 98);
+      dispatchEvent(44, 44, 'box1', 1, 1);
+      dispatchEvent(74, 68, 'box2', 1, 1);
+      dispatchEvent(157, 164, 'box2', 97, 97);
 
-      dispatchEvent(320, 68, 'box4', 2, 2);
-      dispatchEvent(336, 87, 'box5', 2, 2);
+      dispatchEvent(320, 68, 'box4', 1, 1);
+      dispatchEvent(336, 87, 'box5', 1, 1);
 
-      dispatchEvent(582, 87, 'box8', 2, 2);
-      dispatchEvent(658, 174, 'box8', 86, 86);
+      dispatchEvent(582, 87, 'box8', 1, 1);
+      dispatchEvent(658, 174, 'box8', 85, 85);
 
-      dispatchEvent(74, 314, 'box10', 2, 2);
-      dispatchEvent(91, 351, 'box11', 2, 2);
+      dispatchEvent(74, 314, 'box10', 1, 1);
+      dispatchEvent(91, 351, 'box11', 1, 1);
 
-      dispatchEvent(320, 314, 'box13', 2, 2);
-      dispatchEvent(343, 351, 'box14', 2, 2);
-      dispatchEvent(365, 375, 'box15', 2, 2);
+      dispatchEvent(320, 314, 'box13', 1, 1);
+      dispatchEvent(343, 351, 'box14', 1, 1);
+      dispatchEvent(365, 375, 'box15', 1, 1);
 
-      dispatchEvent(566, 314, 'box17', 2, 2);
-      dispatchEvent(587, 352, 'box18', 2, 2);
-      dispatchEvent(629, 401, 'box19', 2, 2);
-      dispatchEvent(653, 422, 'box20', 2, 2);
-      dispatchEvent(745, 505, 'box20', 86, 87);
+      dispatchEvent(566, 314, 'box17', 1, 1);
+      dispatchEvent(587, 352, 'box18', 1, 1);
+      dispatchEvent(629, 401, 'box19', 1, 1);
+      dispatchEvent(653, 422, 'box20', 1, 1);
+      dispatchEvent(745, 505, 'box20', 85, 86);
     }
   </script>
   <style type="text/css" media="screen">

--- a/LayoutTests/transforms/3d/point-mapping/3d-point-mapping.html
+++ b/LayoutTests/transforms/3d/point-mapping/3d-point-mapping.html
@@ -7,15 +7,15 @@
     
     function test()
     {
-      dispatchEvent(44, 44, 'box1', 2, 2);
-      dispatchEvent(69, 55, 'box2', 2, 2);
-      dispatchEvent(165, 182, 'box2', 96, 96);
-      dispatchEvent(333, 79, 'box7', 2, 2);
-      dispatchEvent(87, 325, 'box10', 2, 2);
-      dispatchEvent(196, 467, 'box10', 98, 98);
-      dispatchEvent(333, 325, 'box13', 2, 2);
-      dispatchEvent(353, 352, 'box14', 2, 2);
-      dispatchEvent(472, 507, 'box14', 97, 97);
+      dispatchEvent(44, 44, 'box1', 1, 1);
+      dispatchEvent(69, 55, 'box2', 1, 1);
+      dispatchEvent(165, 182, 'box2', 95, 95);
+      dispatchEvent(333, 79, 'box7', 1, 1);
+      dispatchEvent(87, 325, 'box10', 1, 1);
+      dispatchEvent(196, 467, 'box10', 97, 97);
+      dispatchEvent(333, 325, 'box13', 1, 1);
+      dispatchEvent(353, 352, 'box14', 1, 1);
+      dispatchEvent(472, 507, 'box14', 96, 96);
     }
     
   </script>

--- a/Source/WebCore/dom/MouseRelatedEvent.cpp
+++ b/Source/WebCore/dom/MouseRelatedEvent.cpp
@@ -28,6 +28,7 @@
 #include "LocalDOMWindow.h"
 #include "LocalFrame.h"
 #include "LocalFrameView.h"
+#include "RenderBoxModelObjectInlines.h"
 #include "RenderLayer.h"
 #include "RenderLayerInlines.h"
 #include "RenderObject.h"
@@ -205,9 +206,13 @@ void MouseRelatedEvent::computeRelativePosition()
     // Must have an updated render tree for this math to work correctly.
     targetNode->protectedDocument()->updateLayoutIgnorePendingStylesheets();
 
-    // Adjust offsetLocation to be relative to the target's position.
+    // Adjust offsetLocation to be relative to the target's padding box.
     if (CheckedPtr renderer = targetNode->renderer()) {
         m_offsetLocation = renderer->absoluteToLocal(absoluteLocation(), UseTransforms);
+
+        if (CheckedPtr boxModel = dynamicDowncast<RenderBoxModelObject>(renderer.get()))
+            m_offsetLocation.move(-boxModel->borderLeft(), -boxModel->borderTop());
+
         float scaleFactor = 1 / documentToAbsoluteScaleFactor();
         if (scaleFactor != 1.0f)
             m_offsetLocation.scale(scaleFactor);


### PR DESCRIPTION
#### 2a4ece3e4b025e969143a02a4b3e46c2999bc553
<pre>
MouseEvent offsetX and offsetY should be relative to padding edge
<a href="https://bugs.webkit.org/show_bug.cgi?id=271694">https://bugs.webkit.org/show_bug.cgi?id=271694</a>
<a href="https://rdar.apple.com/125763807">rdar://125763807</a>

Reviewed by Abrar Rahman Protyasha.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/ad76338520534c07a557bb68db876fbf2c34ce49">https://chromium.googlesource.com/chromium/src.git/+/ad76338520534c07a557bb68db876fbf2c34ce49</a>

Currently, we are computing relative to target coordinate while we should
be relative to padding box and this patch subtract borderLeft / borderTop
from offsetX / offsetY to achieve this. This matches us with the web
specification [1] &amp; [2]:

[1] <a href="https://drafts.csswg.org/cssom-view/#dom-mouseevent-offsetx">https://drafts.csswg.org/cssom-view/#dom-mouseevent-offsetx</a>

&quot;...return the x-coordinate of the position where the event occurred relative
to the origin of the padding edge of the target node...&quot;

[2] <a href="https://drafts.csswg.org/cssom-view/#dom-mouseevent-offsety">https://drafts.csswg.org/cssom-view/#dom-mouseevent-offsety</a>

&quot;...return the y-coordinate of the position where the event occurred relative
to the origin of the padding edge of the target node...&quot;

* LayoutTests/fast/events/document-elementFromPoint-expected.txt:
* LayoutTests/fast/events/document-elementFromPoint.html:
* LayoutTests/fast/events/offsetX-offsetY-expected.txt:
* LayoutTests/fast/events/offsetX-offsetY.html:
* LayoutTests/fast/forms/option-mouseevents-expected.txt:
* LayoutTests/fast/forms/option-mouseevents.html:
* LayoutTests/platform/glib/transforms/3d/point-mapping/3d-point-mapping-2-expected.txt:
* LayoutTests/platform/glib/transforms/3d/point-mapping/3d-point-mapping-deep-expected.txt:
* LayoutTests/platform/glib/transforms/3d/point-mapping/3d-point-mapping-expected.txt:
* LayoutTests/platform/glib/transforms/3d/point-mapping/3d-point-mapping-preserve-3d-expected.txt:
* LayoutTests/platform/ios/transforms/3d/point-mapping/3d-point-mapping-2-expected.txt:
* LayoutTests/platform/ios/transforms/3d/point-mapping/3d-point-mapping-deep-expected.txt:
* LayoutTests/platform/ios/transforms/3d/point-mapping/3d-point-mapping-expected.txt:
* LayoutTests/platform/ios/transforms/3d/point-mapping/3d-point-mapping-preserve-3d-expected.txt:
* LayoutTests/platform/mac/transforms/3d/point-mapping/3d-point-mapping-2-expected.txt:
* LayoutTests/platform/mac/transforms/3d/point-mapping/3d-point-mapping-deep-expected.txt:
* LayoutTests/platform/mac/transforms/3d/point-mapping/3d-point-mapping-expected.txt:
* LayoutTests/platform/mac/transforms/3d/point-mapping/3d-point-mapping-preserve-3d-expected.txt:
* LayoutTests/platform/win/transforms/3d/point-mapping/3d-point-mapping-2-expected.txt:
* LayoutTests/platform/win/transforms/3d/point-mapping/3d-point-mapping-deep-expected.txt:
* LayoutTests/platform/win/transforms/3d/point-mapping/3d-point-mapping-expected.txt:
* LayoutTests/platform/win/transforms/3d/point-mapping/3d-point-mapping-preserve-3d-expected.txt:
* LayoutTests/transforms/3d/point-mapping/3d-point-mapping-2.html:
* LayoutTests/transforms/3d/point-mapping/3d-point-mapping-deep.html:
* LayoutTests/transforms/3d/point-mapping/3d-point-mapping-preserve-3d.html:
* LayoutTests/transforms/3d/point-mapping/3d-point-mapping.html:
* Source/WebCore/dom/MouseRelatedEvent.cpp:
(WebCore::MouseRelatedEvent::computeRelativePosition):

Canonical link: <a href="https://commits.webkit.org/305479@main">https://commits.webkit.org/305479@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a7e193ab7adf54021ea232cc2242f1394a769b7b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138131 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10496 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49541 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146206 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91106 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/bb5c78ba-1314-40f6-81c7-8004c464e4d4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140004 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11199 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10650 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105646 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77071 "4 flakes 11 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0be7d889-688e-4210-bca5-66e98b13ffd7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141077 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8366 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123840 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86498 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7968 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5732 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6488 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117372 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42038 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148916 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10178 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42619 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114054 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10195 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8595 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114387 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; run-api-tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29138 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7903 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120125 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64902 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10225 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38067 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9955 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73792 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10165 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10016 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->