### PR TITLE
[Cocoa] Only update NowPlaying when playback state changes

### DIFF
--- a/Source/WebCore/Modules/webaudio/AudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioContext.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2010 Google Inc. All rights reserved.
- * Copyright (C) 2016-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -45,6 +45,7 @@
 #include "Performance.h"
 #include "PlatformMediaSessionManager.h"
 #include "Settings.h"
+#include <wtf/CryptographicallyRandomNumber.h>
 #include <wtf/MediaTime.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -595,8 +596,9 @@ std::optional<NowPlayingInfo> AudioContext::nowPlayingInfo() const
             { },
             { }
         },
-        MediaPlayer::invalidTime(),
-        MediaPlayer::invalidTime(),
+        cryptographicallyRandomNumber<uint64_t>(),
+        std::numeric_limits<double>::quiet_NaN(),
+        std::numeric_limits<double>::quiet_NaN(),
         1.0,
         false,
         m_currentIdentifier,

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2007-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2014-2016 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -5877,6 +5877,9 @@ void HTMLMediaElement::mediaPlayerTimeChanged()
 
     // When the current playback position reaches the end of the media resource then the user agent must follow these steps:
     if ((dur || (!dur && !now)) && dur.isValid() && !dur.isPositiveInfinite() && !dur.isNegativeInfinite()) {
+
+        protectedMediaSession()->clientCharacteristicsChanged(true);
+
         // If the media element has a loop attribute specified and does not have a current media controller,
         if (loop() && !m_mediaController && playbackRate > 0) {
             m_sentEndEvent = false;

--- a/Source/WebCore/platform/audio/MediaSessionManagerInterface.h
+++ b/Source/WebCore/platform/audio/MediaSessionManagerInterface.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2025-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -77,6 +77,8 @@ public:
     virtual bool shouldDeactivateAudioSession() { return m_shouldDeactivateAudioSession; };
 
     virtual void updateNowPlayingInfoIfNecessary();
+    virtual void updateNowPlayingInfo() { updateNowPlayingInfoIfNecessary(); }
+    virtual void setNowPlayingUpdateInterval(double) { };
     virtual void updateAudioSessionCategoryIfNecessary();
 
     virtual std::optional<NowPlayingInfo> nowPlayingInfo() const { return { }; }

--- a/Source/WebCore/platform/audio/NowPlayingInfo.h
+++ b/Source/WebCore/platform/audio/NowPlayingInfo.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -56,6 +56,7 @@ struct NowPlayingMetadata {
 
 struct NowPlayingInfo {
     NowPlayingMetadata metadata;
+    uint64_t updateTime { 0 };
     double duration { 0 };
     double currentTime { 0 };
     double rate { 1.0 };

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -78,8 +78,10 @@ protected:
     std::optional<NowPlayingInfo> nowPlayingInfo() const final { return m_nowPlayingInfo; }
 
     void scheduleSessionStatusUpdate() final;
-    void updateNowPlayingInfo();
+    void updateNowPlayingInfo() final;
+    void setNowPlayingUpdateInterval(double) final;
     void updateActiveNowPlayingSession(RefPtr<PlatformMediaSessionInterface>);
+    bool shouldUpdateNowPlaying(const NowPlayingInfo&);
 
     void removeSession(PlatformMediaSessionInterface&) override;
     void addSession(PlatformMediaSessionInterface&) override;
@@ -132,9 +134,12 @@ private:
     double m_lastUpdatedNowPlayingDuration { NAN };
     double m_lastUpdatedNowPlayingElapsedTime { NAN };
     Markable<MediaUniqueIdentifier> m_lastUpdatedNowPlayingInfoUniqueIdentifier;
-    std::optional<NowPlayingInfo> m_nowPlayingInfo;
 
+    std::optional<NowPlayingInfo> m_nowPlayingInfo;
     const std::unique_ptr<NowPlayingManager> m_nowPlayingManager;
+    RunLoop::Timer m_nowPlayingUpdateTimer;
+    Seconds m_nowPlayingUpdateInterval { 5_s };
+
     RefPtr<AudioHardwareListener> m_audioHardwareListener;
 
     AudioHardwareListener::BufferSizeRange m_supportedAudioHardwareBufferSizes;

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2023-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -265,6 +265,9 @@ MediaPlayer::ReadyState MediaSourcePrivate::mediaPlayerReadyState() const
 
 void MediaSourcePrivate::setMediaPlayerReadyState(MediaPlayer::ReadyState readyState)
 {
+    if (m_mediaPlayerReadyState == readyState)
+        return;
+
     m_mediaPlayerReadyState = readyState;
     ensureOnMainThread([weakThis = ThreadSafeWeakPtr { *this }] {
         RefPtr protectedThis = weakThis.get();

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -687,14 +687,15 @@ void MediaPlayerPrivateAVFoundation::seekCompleted(bool finished)
     }
 }
 
-void MediaPlayerPrivateAVFoundation::didEnd()
+void MediaPlayerPrivateAVFoundation::didEnd(double now)
 {
     // Hang onto the current time and use it as duration from now on since we are definitely at
     // the end of the movie. Do this because the initial duration is sometimes an estimate.
-    MediaTime now = currentTime();
     ALWAYS_LOG(LOGIDENTIFIER, "currentTime: ", now, ", seeking: ", m_seeking);
-    if (now > MediaTime::zeroTime() && !m_seeking)
-        m_cachedDuration = now;
+    if (now > 0 && !m_seeking) {
+        ALWAYS_LOG(LOGIDENTIFIER, "Updating cached duration to ", now);
+        m_cachedDuration = MediaTime::createWithDouble(now);
+    }
 
     updateStates();
     if (RefPtr player = m_player.get())

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -66,7 +66,7 @@ public:
     virtual void seekableTimeRangesChanged();
     virtual void timeChanged(const MediaTime&);
     virtual void seekCompleted(bool);
-    virtual void didEnd();
+    virtual void didEnd(double);
     virtual void contentsNeedsDisplay() { }
     virtual void configureInbandTracks();
     virtual void setCurrentTextTrack(InbandTextTrackPrivateAVF*) { }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -86,7 +86,7 @@ public:
     static void registerMediaEngine(MediaEngineRegistrar);
 
     void setAsset(RetainPtr<id>&&);
-    void didEnd() final;
+    void didEnd(double) final;
     void metadataLoaded() final;
 
     void processCue(NSArray *, NSArray *, const MediaTime&);

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012 Google Inc. All rights reserved.
- * Copyright (C) 2013-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -5444,6 +5444,13 @@ ExceptionOr<Internals::NowPlayingState> Internals::nowPlayingState() const
     return Exception { ExceptionCode::InvalidAccessError };
 #endif
 }
+
+void Internals::setNowPlayingUpdateInterval(double interval)
+{
+    if (RefPtr manager = sessionManager())
+        manager->setNowPlayingUpdateInterval(interval);
+}
+
 
 #if ENABLE(VIDEO)
 RefPtr<HTMLMediaElement> Internals::bestMediaElementForRemoteControls(Internals::PlaybackControlsPurpose purpose)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012 Google Inc. All rights reserved.
- * Copyright (C) 2013-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -1206,6 +1206,7 @@ public:
         bool haveEverRegisteredAsNowPlayingApplication;
     };
     ExceptionOr<NowPlayingState> nowPlayingState() const;
+    void setNowPlayingUpdateInterval(double);
 
     struct MediaUsageState {
         String mediaURL;

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012 Google Inc. All rights reserved.
- * Copyright (C) 2013-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -1304,6 +1304,7 @@ enum ContentsFormat {
     [Conditional=VIDEO] readonly attribute NowPlayingMetadata? nowPlayingMetadata;
     [Conditional=VIDEO] readonly attribute NowPlayingState nowPlayingState;
     [Conditional=VIDEO] boolean elementIsActiveNowPlayingSession(HTMLMediaElement element);
+    undefined setNowPlayingUpdateInterval(double interval);
 
     [Conditional=VIDEO] HTMLMediaElement bestMediaElementForRemoteControls(PlaybackControlsPurpose purpose);
     [Conditional=VIDEO] MediaSessionState mediaSessionState(HTMLMediaElement element);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2025 Apple Inc. All rights reserved.
+# Copyright (C) 2022-2026 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -7564,6 +7564,7 @@ header: <WebCore/NowPlayingInfo.h>
 
 struct WebCore::NowPlayingInfo {
     WebCore::NowPlayingMetadata metadata;
+    uint64_t updateTime;
     double duration;
     double currentTime;
     double rate;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -69,7 +69,7 @@ struct WKAppPrivacyReportTestingData {
 - (void)_setGrammarCheckingEnabledForTesting:(BOOL)enabled;
 - (NSDictionary *)_contentsOfUserInterfaceItem:(NSString *)userInterfaceItem;
 
-- (void)_requestActiveNowPlayingSessionInfo:(void(^)(BOOL, BOOL, NSString*, double, double, NSInteger))callback;
+- (void)_requestActiveNowPlayingSessionInfo:(void(^)(BOOL, BOOL, NSString*, double, double, NSInteger, NSUInteger))callback;
 - (void)_setNowPlayingMetadataObserver:(void(^)(_WKNowPlayingMetadata *))observer;
 
 - (void)_doAfterNextPresentationUpdateWithoutWaitingForAnimatedResizeForTesting:(void (^)(void))updateBlock;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -289,15 +289,15 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 #endif
 }
 
-- (void)_requestActiveNowPlayingSessionInfo:(void(^)(BOOL, BOOL, NSString*, double, double, NSInteger))callback
+- (void)_requestActiveNowPlayingSessionInfo:(void(^)(BOOL, BOOL, NSString*, double, double, NSInteger, NSUInteger))callback
 {
     if (!_page) {
-        callback(NO, NO, @"", std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN(), 0);
+        callback(NO, NO, @"", std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN(), 0, 0);
         return;
     }
 
     _page->requestActiveNowPlayingSessionInfo([handler = makeBlockPtr(callback)] (bool registeredAsNowPlayingApplication, WebCore::NowPlayingInfo&& nowPlayingInfo) {
-        handler(nowPlayingInfo.allowsNowPlayingControlsVisibility, registeredAsNowPlayingApplication, nowPlayingInfo.metadata.title.createNSString().get(), nowPlayingInfo.duration, nowPlayingInfo.currentTime, nowPlayingInfo.uniqueIdentifier ? nowPlayingInfo.uniqueIdentifier->toUInt64() : 0);
+        handler(nowPlayingInfo.allowsNowPlayingControlsVisibility, registeredAsNowPlayingApplication, nowPlayingInfo.metadata.title.createNSString().get(), nowPlayingInfo.duration, nowPlayingInfo.currentTime, nowPlayingInfo.uniqueIdentifier ? nowPlayingInfo.uniqueIdentifier->toUInt64() : 0, nowPlayingInfo.updateTime);
     });
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/large-video-test-now-playing.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/large-video-test-now-playing.html
@@ -28,6 +28,24 @@
             }, 0);
         }
 
+        function seeked() {
+            setTimeout(function() {
+                try {
+                    window.webkit.messageHandlers.testHandler.postMessage("seeked");
+                } catch(e) {
+                    console.debug(`error: ${e}`);
+                }
+            }, 0);
+        }
+
+        function seekTo(time) {
+            document.querySelector("video").currentTime = time;
+        }
+
+        function setLoop(loop) {
+            document.querySelector("video").loop = loop;
+        }
+
         function mousedown() {
             document.querySelector("video").muted = true;
         }
@@ -37,18 +55,32 @@
             return document.querySelector("video");
         }
 
+        function play() {
+            document.querySelector("video").play();
+        }
+
         function pause() {
             document.querySelector("video").pause();
         }
 
         function stopped() {
             setTimeout(function() {
-               try {
+                try {
                     window.webkit.messageHandlers.testHandler.postMessage("paused");
-               } catch(e) {
-                   console.debug(`error: ${e}`);
-               }
-           }, 0);
+                } catch(e) {
+                    console.debug(`error: ${e}`);
+                }
+            }, 0);
+        }
+
+        function handleEnded() {
+            setTimeout(function() {
+                try {
+                    window.webkit.messageHandlers.testHandler.postMessage("ended");
+                } catch(e) {
+                    console.debug(`error: ${e}`);
+                }
+            }, 0);
         }
 
         function setMediaSessionMetadata() {
@@ -76,7 +108,7 @@
     </script>
 </head>
 <body>
-    <video autoplay title="foo" onmousedown=mousedown() onplaying=playing() onpause=stopped()><source src="large-video-with-audio.mp4"></video>
+    <video autoplay title="foo" onmousedown=mousedown() onplaying=playing() onpause=stopped() onseeked=seeked() onended=handleEnded()><source src="large-video-with-audio.mp4"></video>
     <button onclick="console.log(removeVideoElement())">Stop!</button>
 </body>
 <html>


### PR DESCRIPTION
#### 3a747bee7ac465555eeb2a943b44e51ee717e777
<pre>
[Cocoa] Only update NowPlaying when playback state changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=305170">https://bugs.webkit.org/show_bug.cgi?id=305170</a>
<a href="https://rdar.apple.com/166578429">rdar://166578429</a>

Reviewed by Jean Yves Avenard.

Updating NowPlaying is a relatively expensive operation, so only do it when a property
it uses other than current time has changed since the last time it was called. Because it
is important to update NowPlaying with the current time periodically so it&apos;s interpolated
time doesn&apos;t drift from the actual playback time, update it even if only current time
has changed every five seconds.

Add a new API test to verify the changes.

Tests: Tools/TestWebKitAPI/Tests/WebKitCocoa/NowPlayingControlsTests.mm
       Tools/TestWebKitAPI/Tests/WebKitCocoa/large-video-test-now-playing.html

* Source/WebCore/Modules/webaudio/AudioContext.cpp:
(WebCore::AudioContext::nowPlayingInfo const): Initialize NowPlayingInfo.updateTime.

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::mediaPlayerTimeChanged): Call MediaSessionManager::clientCharacteristicsChanged
when the current playback position reaches the end so we update NowPlaying with the
state change.

* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::MediaElementSession::computeNowPlayingInfo const):  Initialize NowPlayingInfo.updateTime.
Drive-by fix: use the actual playback rate, not just 1.0
(WebCore::MediaElementSession::clientCharacteristicsChanged): Update NowPlaying if the
playback position has changed.
* Source/WebCore/platform/audio/MediaSessionManagerInterface.h:

* Source/WebCore/platform/audio/NowPlayingInfo.h: Add `updateTime` to the struct for testing.

* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h:
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::MediaSessionManagerCocoa::MediaSessionManagerCocoa): Initialize the timer we
use to ensure NowPlaying is updated at least every five seconds.
(WebCore::MediaSessionManagerCocoa::setNowPlayingInfo): Some parts of the code used
-1 for an NowPlayingInfo.duration, and some used NaN. Use NaN everywhere.
(WebCore::MediaSessionManagerCocoa::shouldUpdateNowPlaying):
(WebCore::MediaSessionManagerCocoa::setNowPlayingUpdateInterval): New, setter for the
minimum NowPlaying interval so we can shorten it for testings.
(WebCore::MediaSessionManagerCocoa::updateNowPlayingInfo): Return early when `shouldUpdateNowPlaying`
says nothing interesting has changed.

* Source/WebCore/platform/graphics/MediaSourcePrivate.cpp:
(WebCore::MediaSourcePrivate::setMediaPlayerReadyState): Return early if readyState hasn&apos;t
actually changed to avoid churn.

* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp:
(WebCore::MediaPlayerPrivateAVFoundation::didEnd): Drive-by: take current time as a
parameter so we have the time at which playback ended.
* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h:

* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::didEnd): Ditto.
(-[WebCoreAVFMovieObserver didEnd:]): Pass AVPlayerItem.currentTime to `didEnd()` as it won&apos;t
be called immediately.

* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::setNowPlayingUpdateInterval):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _requestActiveNowPlayingSessionInfo:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/NowPlayingControlsTests.mm:
(-[NowPlayingTestWebView requestActiveNowPlayingSessionInfo]):
(TestWebKitAPI::TEST(NowPlayingControlsTests, NowPlayingUpdatesThrottled)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/large-video-test-now-playing.html:

Canonical link: <a href="https://commits.webkit.org/305364@main">https://commits.webkit.org/305364@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4646b3ee0751aa3a52c733b21233694818f44677

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138156 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10521 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49566 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146232 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91131 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fd45112d-a0f1-4ce7-9854-dcf106ec7e5b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140030 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11224 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10675 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105669 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/77086 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/77f7831d-d008-45d0-ab6f-b999b6e3cf52) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141102 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8396 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123862 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86521 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/f8a58cce-f808-42e2-a5e4-23ed5ddec596) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7993 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5750 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6513 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117402 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42059 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148941 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10203 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42615 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114078 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10220 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8615 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114412 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29077 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7928 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120146 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64927 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10250 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38086 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9980 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73817 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10190 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10041 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->