### PR TITLE
Fix several safer C++ warnings in Frame and FrameTree

### DIFF
--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -216,7 +216,7 @@ std::optional<uint64_t> Frame::indexInFrameTreeSiblings() const
         return std::nullopt;
 
     for (uint64_t i = 0; i < tree().parent()->tree().childCount(); i++) {
-        if (auto child = tree().parent()->tree().child(i); child->frameID() == this->frameID())
+        if (RefPtr child = tree().parent()->tree().child(i); child->frameID() == this->frameID())
             return i;
     }
 

--- a/Source/WebCore/page/FrameTree.cpp
+++ b/Source/WebCore/page/FrameTree.cpp
@@ -416,29 +416,29 @@ Frame* FrameTree::nextAncestorSibling(const Frame* stayWithin) const
     return nullptr;
 }
 
-Frame* FrameTree::firstRenderedChild() const
+RefPtr<Frame> FrameTree::firstRenderedChild() const
 {
-    auto* child = firstChild();
+    RefPtr child = firstChild();
     if (!child)
         return nullptr;
 
-    if (auto* localChild = dynamicDowncast<LocalFrame>(child); localChild && localChild->ownerRenderer())
+    if (RefPtr localChild = dynamicDowncast<LocalFrame>(child); localChild && localChild->ownerRenderer())
         return child;
 
     while ((child = child->tree().nextSibling())) {
-        if (auto* localChild = dynamicDowncast<LocalFrame>(child); localChild && localChild->ownerRenderer())
+        if (RefPtr localChild = dynamicDowncast<LocalFrame>(child); localChild && localChild->ownerRenderer())
             return child;
     }
 
     return nullptr;
 }
 
-Frame* FrameTree::nextRenderedSibling() const
+RefPtr<Frame> FrameTree::nextRenderedSibling() const
 {
-    auto* sibling = m_thisFrame.ptr();
+    RefPtr sibling = m_thisFrame.ptr();
 
     while ((sibling = sibling->tree().nextSibling())) {
-        if (auto* localSibling = dynamicDowncast<LocalFrame>(sibling); localSibling && localSibling->ownerRenderer())
+        if (RefPtr localSibling = dynamicDowncast<LocalFrame>(sibling); localSibling && localSibling->ownerRenderer())
             return sibling;
     }
     
@@ -463,9 +463,9 @@ LocalFrame* FrameTree::nextLocalSibling() const
     return nullptr;
 }
 
-Frame* FrameTree::traverseNextRendered(const Frame* stayWithin) const
+RefPtr<Frame> FrameTree::traverseNextRendered(const Frame* stayWithin) const
 {
-    auto* child = firstRenderedChild();
+    RefPtr child = firstRenderedChild();
     if (child) {
         ASSERT(!stayWithin || child->tree().isDescendantOf(stayWithin));
         return child;
@@ -474,13 +474,13 @@ Frame* FrameTree::traverseNextRendered(const Frame* stayWithin) const
     if (m_thisFrame.ptr() == stayWithin)
         return nullptr;
 
-    auto* sibling = nextRenderedSibling();
+    RefPtr sibling = nextRenderedSibling();
     if (sibling) {
         ASSERT(!stayWithin || sibling->tree().isDescendantOf(stayWithin));
         return sibling;
     }
 
-    auto* frame = m_thisFrame.ptr();
+    RefPtr frame = m_thisFrame.ptr();
     while (!sibling && (!stayWithin || frame->tree().parent() != stayWithin)) {
         frame = frame->tree().parent();
         if (!frame)

--- a/Source/WebCore/page/FrameTree.h
+++ b/Source/WebCore/page/FrameTree.h
@@ -53,8 +53,8 @@ public:
     Frame* firstChild() const { return m_firstChild.get(); }
     Frame* lastChild() const { return m_lastChild.get(); }
 
-    Frame* firstRenderedChild() const;
-    Frame* nextRenderedSibling() const;
+    RefPtr<Frame> firstRenderedChild() const;
+    RefPtr<Frame> nextRenderedSibling() const;
 
     LocalFrame* firstLocalDescendant() const;
     LocalFrame* nextLocalSibling() const;
@@ -64,7 +64,7 @@ public:
     WEBCORE_EXPORT Frame* traverseNext(const Frame* stayWithin = nullptr) const;
     Frame* traverseNextSkippingChildren(const Frame* stayWithin = nullptr) const;
     // Rendered means being the main frame or having an ownerRenderer. It may not have been parented in the Widget tree yet (see WidgetHierarchyUpdatesSuspensionScope).
-    WEBCORE_EXPORT Frame* traverseNextRendered(const Frame* stayWithin = nullptr) const;
+    WEBCORE_EXPORT RefPtr<Frame> traverseNextRendered(const Frame* stayWithin = nullptr) const;
     WEBCORE_EXPORT Frame* traverseNext(CanWrap, DidWrap* = nullptr) const;
     WEBCORE_EXPORT Frame* traversePrevious(CanWrap, DidWrap* = nullptr) const;
 

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -5777,8 +5777,8 @@ void LocalFrameView::updateLayoutAndStyleIfNeededRecursive(OptionSet<LayoutOptio
             // Append renderered children after processing the parent, in case the processing
             // affects the set of rendered children.
             auto previousView = descendantsDeque.takeFirst();
-            for (auto* frame = previousView->m_frame->tree().firstRenderedChild(); frame; frame = frame->tree().nextRenderedSibling()) {
-                auto* localFrame = dynamicDowncast<LocalFrame>(frame);
+            for (RefPtr frame = previousView->m_frame->tree().firstRenderedChild(); frame; frame = frame->tree().nextRenderedSibling()) {
+                RefPtr localFrame = dynamicDowncast<LocalFrame>(frame);
                 if (!localFrame)
                     continue;
                 if (auto* view = localFrame->view())

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2460,8 +2460,8 @@ void Page::doAfterUpdateRendering()
     if (localMainFrame) {
         ASSERT(!localMainFrame->view() || !localMainFrame->view()->needsLayout());
 #if ASSERT_ENABLED
-        for (auto* child = localMainFrame->tree().firstRenderedChild(); child; child = child->tree().traverseNextRendered()) {
-            auto* localFrame = dynamicDowncast<LocalFrame>(child);
+        for (RefPtr child = localMainFrame->tree().firstRenderedChild(); child; child = child->tree().traverseNextRendered()) {
+            RefPtr localFrame = dynamicDowncast<LocalFrame>(child);
             auto* frameView = localFrame->view();
             ASSERT(!frameView || !frameView->needsLayout());
         }


### PR DESCRIPTION
#### faae635a0b0239551ddcbdf88f7368987d421cd9
<pre>
Fix several safer C++ warnings in Frame and FrameTree
<a href="https://bugs.webkit.org/show_bug.cgi?id=305173">https://bugs.webkit.org/show_bug.cgi?id=305173</a>

Reviewed by Richard Robinson.

Fix several safer C++ warnings ahead of #56282 (Uncounted raw pointer or reference not provably
backed by ref-counted variable):

File            Function                    Line
------------------------------------------------
Frame.cpp       indexInFrameTreeSiblings    219
FrameTree.cpp   firstRenderedChild          421
FrameTree.cpp   firstRenderedChild          425
FrameTree.cpp   firstRenderedChild          429
FrameTree.cpp   nextRenderedSibling         438
FrameTree.cpp   nextRenderedSibling         441
FrameTree.cpp   traverseNextRendered        468
FrameTree.cpp   traverseNextRendered        477
FrameTree.cpp   traverseNextRendered        483
```

* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::indexInFrameTreeSiblings const):
* Source/WebCore/page/FrameTree.cpp:
(WebCore::FrameTree::firstRenderedChild const):
(WebCore::FrameTree::nextRenderedSibling const):
(WebCore::FrameTree::traverseNextRendered const):
* Source/WebCore/page/FrameTree.h:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::updateLayoutAndStyleIfNeededRecursive):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::doAfterUpdateRendering):

Canonical link: <a href="https://commits.webkit.org/305341@main">https://commits.webkit.org/305341@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b25f5f9de55b39aceafdff98659d4d77be3bd748

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138146 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10511 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49556 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146222 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91121 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/31910f49-e06e-4b24-a8a9-f142ca4adc99) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140020 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11214 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10665 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105659 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/77080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ccfeb26b-e6ed-4994-ab53-8cad1ff213ce) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141092 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8381 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123854 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86511 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/539c373f-e73e-49f1-87ea-87fba060d114) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/7979 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5742 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6503 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117387 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42051 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148931 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10193 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42607 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114068 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10210 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8607 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114402 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29067 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7920 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120138 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64917 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10240 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38078 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/9970 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/73807 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10180 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10031 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->