### PR TITLE
Fix RTL grid scrollable area to account for grid and scrollbars correctly

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflow-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflow-001-expected.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>Grid Expands Scrollable Area</title>
+
+<style>
+  .grid {
+    float: left;
+    margin: 1em;
+    border: solid;
+    border-width: 1px 2px 4px 6px;
+    width: 120px;
+    height: 120px;
+    overflow: scroll;
+    position: relative;
+  }
+  .container {
+    position: absolute;
+    inline-size: 140px;
+    block-size: 120px;
+    padding: 10px;
+    z-index: -1;
+  }
+
+  .container > div {
+    border: solid orange;
+    inline-size: 120px;
+    block-size: 110px;
+    box-sizing: border-box;
+  }
+
+  .abspos {
+    border: solid aqua;
+    width: 100%;
+    height: 100%;
+    box-sizing: border-box;
+  }
+</style>
+
+<div class="grid" dir=ltr>
+  <div class="container"><div></div></div>
+  <div class="abspos"></div>
+</div>
+
+<div class="grid" dir=rtl reverse-x>
+  <div class="container"><div></div></div>
+  <div class="abspos"></div>
+</div>
+
+<div class="grid" dir=ltr style="writing-mode: vertical-rl" reverse-x>
+  <div class="container"><div></div></div>
+  <div class="abspos"></div>
+</div>
+
+<div class="grid" dir=rtl style="writing-mode: vertical-rl" reverse-x reverse-y>
+  <div class="container"><div></div></div>
+  <div class="abspos"></div>
+</div>
+
+<div class="grid" dir=ltr style="writing-mode: vertical-lr">
+  <div class="container"><div></div></div>
+  <div class="abspos"></div>
+</div>
+
+<div class="grid" dir=rtl style="writing-mode: vertical-lr" reverse-y>
+  <div class="container"><div></div></div>
+  <div class="abspos"></div>
+</div>
+
+<div class="grid" dir=ltr style="writing-mode: sideways-rl" reverse-x>
+  <div class="container"><div></div></div>
+  <div class="abspos"></div>
+</div>
+
+<div class="grid" dir=rtl style="writing-mode: sideways-rl" reverse-x reverse-y>
+  <div class="container"><div></div></div>
+  <div class="abspos"></div>
+</div>
+
+<div class="grid" dir=ltr style="writing-mode: sideways-lr" reverse-y>
+  <div class="container"><div></div></div>
+  <div class="abspos"></div>
+</div>
+
+<div class="grid" dir=rtl style="writing-mode: sideways-lr">
+  <div class="container"><div></div></div>
+  <div class="abspos"></div>
+</div>
+
+<script>
+  var testElements = document.querySelectorAll('.grid');
+  for (const test of testElements) {
+    var invertX = (test.getAttribute('reverse-x') === null) ? 1 : -1;
+    var invertY = (test.getAttribute('reverse-y') === null) ? 1 : -1;
+    test.scrollBy(100 * invertX, 100 * invertY);
+  }
+  document.documentElement.removeAttribute('class');
+</script>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflow-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflow-001-ref.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>Grid Expands Scrollable Area</title>
+
+<style>
+  .grid {
+    float: left;
+    margin: 1em;
+    border: solid;
+    border-width: 1px 2px 4px 6px;
+    width: 120px;
+    height: 120px;
+    overflow: scroll;
+    position: relative;
+  }
+  .container {
+    position: absolute;
+    inline-size: 140px;
+    block-size: 120px;
+    padding: 10px;
+    z-index: -1;
+  }
+
+  .container > div {
+    border: solid orange;
+    inline-size: 120px;
+    block-size: 110px;
+    box-sizing: border-box;
+  }
+
+  .abspos {
+    border: solid aqua;
+    width: 100%;
+    height: 100%;
+    box-sizing: border-box;
+  }
+</style>
+
+<div class="grid" dir=ltr>
+  <div class="container"><div></div></div>
+  <div class="abspos"></div>
+</div>
+
+<div class="grid" dir=rtl reverse-x>
+  <div class="container"><div></div></div>
+  <div class="abspos"></div>
+</div>
+
+<div class="grid" dir=ltr style="writing-mode: vertical-rl" reverse-x>
+  <div class="container"><div></div></div>
+  <div class="abspos"></div>
+</div>
+
+<div class="grid" dir=rtl style="writing-mode: vertical-rl" reverse-x reverse-y>
+  <div class="container"><div></div></div>
+  <div class="abspos"></div>
+</div>
+
+<div class="grid" dir=ltr style="writing-mode: vertical-lr">
+  <div class="container"><div></div></div>
+  <div class="abspos"></div>
+</div>
+
+<div class="grid" dir=rtl style="writing-mode: vertical-lr" reverse-y>
+  <div class="container"><div></div></div>
+  <div class="abspos"></div>
+</div>
+
+<div class="grid" dir=ltr style="writing-mode: sideways-rl" reverse-x>
+  <div class="container"><div></div></div>
+  <div class="abspos"></div>
+</div>
+
+<div class="grid" dir=rtl style="writing-mode: sideways-rl" reverse-x reverse-y>
+  <div class="container"><div></div></div>
+  <div class="abspos"></div>
+</div>
+
+<div class="grid" dir=ltr style="writing-mode: sideways-lr" reverse-y>
+  <div class="container"><div></div></div>
+  <div class="abspos"></div>
+</div>
+
+<div class="grid" dir=rtl style="writing-mode: sideways-lr">
+  <div class="container"><div></div></div>
+  <div class="abspos"></div>
+</div>
+
+<script>
+  var testElements = document.querySelectorAll('.grid');
+  for (const test of testElements) {
+    var invertX = (test.getAttribute('reverse-x') === null) ? 1 : -1;
+    var invertY = (test.getAttribute('reverse-y') === null) ? 1 : -1;
+    test.scrollBy(100 * invertX, 100 * invertY);
+  }
+  document.documentElement.removeAttribute('class');
+</script>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflow-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflow-001.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>Grid Expands Scrollable Area</title>
+<link rel="help" href="https://www.w3.org/TR/css-grid-2/#overflow">
+<link rel="author" href="http://fantasai.inkedblade.net/contact" title="Elika J. Etemad">
+
+<link rel="match" href="grid-overflow-001-ref.html">
+
+<style>
+  .grid {
+    float: left;
+    margin: 1em;
+    border: solid;
+    border-width: 1px 2px 4px 6px;
+    width: 100px;
+    height: 100px;
+    overflow: scroll;
+    display: grid;
+    position: relative;
+
+    grid-template-columns: 120px 20px;
+    grid-template-rows: 110px 10px;
+    padding: 10px;
+  }
+
+  .grid > div:first-child {
+    border: solid aqua;
+    position: absolute;
+    inset: 0;
+  }
+
+  .grid > div {
+    border: solid orange;
+  }
+
+</style>
+
+<div class="grid" dir=ltr>
+  <div></div>
+  <div></div>
+</div>
+
+<div class="grid" dir=rtl reverse-x>
+  <div></div>
+  <div></div>
+</div>
+
+<div class="grid" dir=ltr style="writing-mode: vertical-rl" reverse-x>
+  <div></div>
+  <div></div>
+</div>
+
+<div class="grid" dir=rtl style="writing-mode: vertical-rl" reverse-x reverse-y>
+  <div></div>
+  <div></div>
+</div>
+
+<div class="grid" dir=ltr style="writing-mode: vertical-lr">
+  <div></div>
+  <div></div>
+</div>
+
+<div class="grid" dir=rtl style="writing-mode: vertical-lr" reverse-y>
+  <div></div>
+  <div></div>
+</div>
+
+<div class="grid" dir=ltr style="writing-mode: sideways-rl" reverse-x>
+  <div></div>
+  <div></div>
+</div>
+
+<div class="grid" dir=rtl style="writing-mode: sideways-rl" reverse-x reverse-y>
+  <div></div>
+  <div></div>
+</div>
+
+<div class="grid" dir=ltr style="writing-mode: sideways-lr" reverse-y>
+  <div></div>
+  <div></div>
+</div>
+
+<div class="grid" dir=rtl style="writing-mode: sideways-lr">
+  <div></div>
+  <div></div>
+</div>
+
+<script>
+  var testElements = document.querySelectorAll('.grid');
+  for (const test of testElements) {
+    var invertX = (test.getAttribute('reverse-x') === null) ? 1 : -1;
+    var invertY = (test.getAttribute('reverse-y') === null) ? 1 : -1;
+    test.scrollBy(100 * invertX, 100 * invertY);
+  }
+  document.documentElement.removeAttribute('class');
+</script>
+

--- a/Source/WebCore/rendering/PositionedLayoutConstraints.cpp
+++ b/Source/WebCore/rendering/PositionedLayoutConstraints.cpp
@@ -191,6 +191,17 @@ void PositionedLayoutConstraints::captureGridArea()
             ? gridContainer->width() : gridContainer->height();
         m_containingRange.moveTo(containerSize - m_containingRange.max());
     }
+
+    // FIXME: Get PositionedLayoutConstraints to work in pre-corrected coordinates instead of assuming it's wrong and doing "fixup" afterwards, so we don't have to "unfixup" here.
+    if (LogicalBoxAxis::Inline == m_containingAxis) {
+        if (BoxAxis::Horizontal == m_physicalAxis) {
+            if (gridContainer->shouldPlaceVerticalScrollbarOnLeft())
+                m_containingRange.moveBy(-gridContainer->verticalScrollbarWidth());
+        } else {
+            if (!m_containingWritingMode.isInlineTopToBottom())
+                m_containingRange.moveBy(-gridContainer->horizontalScrollbarHeight());
+        }
+    }
 }
 
 LayoutRange PositionedLayoutConstraints::extractRange(LayoutRect anchorRect)


### PR DESCRIPTION
#### b327a3a846c4820f299c686eae6e3176ad935018
<pre>
Fix RTL grid scrollable area to account for grid and scrollbars correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=305145">https://bugs.webkit.org/show_bug.cgi?id=305145</a>
<a href="https://rdar.apple.com/167792896">rdar://167792896</a>

Reviewed by Alan Baradlay.

Recent fixes for anchor positioning / scrollable areas got RTL coordinates
backwards for calculating the grid&apos;s contribution to the scrollable area.

This patch corrects this error, and also fixes some left-side scrollbars errors
found while investigating.

Tests: imported/w3c/web-platform-tests/css/css-grid/grid-overflow-001-ref.html
       imported/w3c/web-platform-tests/css/css-grid/grid-overflow-001.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflow-001-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflow-001-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflow-001.html: Added.

Add more test coverage.

* Source/WebCore/rendering/PositionedLayoutConstraints.cpp:
(WebCore::PositionedLayoutConstraints::captureGridArea):

Handle left-side scrollbars consistently between grid and non-grid CBs.

* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::gridAreaRangeForOutOfFlow const):

Account for right-side RTL scrollbars.

(WebCore::RenderGrid::contentOverflowRect const):

Fix backwards coordinates in RTL grid overflow calculation.

(WebCore::RenderGrid::translateRTLCoordinate const):

Call into shouldPlaceVerticalScrollbarOnLeft() instead of making assumptions.

(WebCore::RenderGrid::logicalOffsetForGridItem const):

Account for left-side LTR scrollbars.

Canonical link: <a href="https://commits.webkit.org/305614@main">https://commits.webkit.org/305614@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3bedc0a4a9e77907c3972a3ae394111a0b14ad4d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138283 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10648 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49693 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146363 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91258 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a10875f3-a84d-4f3e-a079-6cc1cf21f820) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140157 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11352 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10802 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105794 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77162 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141230 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8505 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123965 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86637 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/13bbec1f-f872-478b-84a3-3d0c255541a2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8094 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5858 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6646 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117508 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42166 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149074 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10330 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42723 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114192 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10347 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8730 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114535 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29238 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8067 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120253 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65153 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10377 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38186 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10108 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73944 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10317 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10168 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->