### PR TITLE
[GLib] Add webkit_context_menu_get_position API

### DIFF
--- a/Source/WebKit/Shared/API/glib/WebKitContextMenu.cpp
+++ b/Source/WebKit/Shared/API/glib/WebKitContextMenu.cpp
@@ -25,6 +25,7 @@
 #include "WebKitContextMenuItem.h"
 #include "WebKitContextMenuItemPrivate.h"
 #include "WebKitContextMenuPrivate.h"
+#include <WebCore/IntPoint.h>
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/glib/WTFGType.h>
 
@@ -67,6 +68,7 @@ struct _WebKitContextMenuPrivate {
     GUniquePtr<GdkEvent> event;
 #endif
 #endif
+    std::optional<WebCore::IntPoint> position;
 };
 
 WEBKIT_DEFINE_FINAL_TYPE(WebKitContextMenu, webkit_context_menu, G_TYPE_OBJECT, GObject)
@@ -129,6 +131,11 @@ void webkitContextMenuSetParentItem(WebKitContextMenu* menu, WebKitContextMenuIt
 WebKitContextMenuItem* webkitContextMenuGetParentItem(WebKitContextMenu* menu)
 {
     return menu->priv->parentItem;
+}
+
+void webkitContextMenuSetPosition(WebKitContextMenu* menu, const WebCore::IntPoint& position)
+{
+    menu->priv->position = position;
 }
 #endif // ENABLE(CONTEXT_MENUS)
 
@@ -434,3 +441,33 @@ GdkEvent* webkit_context_menu_get_event(WebKitContextMenu* menu)
     return menu->priv->event.get();
 }
 #endif
+
+/**
+ * webkit_context_menu_get_position:
+ * @menu: a #WebKitContextMenu
+ * @x: (out) (optional): return location for the x coordinate
+ * @y: (out) (optional): return location for the y coordinate
+ *
+ * Gets the position in view coordinates where the context menu was triggered.
+ *
+ * This function only returns valid coordinates when called for a #WebKitContextMenu
+ * passed to #WebKitWebView::context-menu signal.
+ *
+ * Returns: %TRUE if valid position coordinates are available, %FALSE otherwise
+ *
+ * Since: 2.52
+ */
+gboolean webkit_context_menu_get_position(WebKitContextMenu* menu, gint* x, gint* y)
+{
+    g_return_val_if_fail(WEBKIT_IS_CONTEXT_MENU(menu), FALSE);
+
+    if (!menu->priv->position)
+        return FALSE;
+
+    if (x)
+        *x = menu->priv->position->x();
+    if (y)
+        *y = menu->priv->position->y();
+
+    return TRUE;
+}

--- a/Source/WebKit/Shared/API/glib/WebKitContextMenuPrivate.h
+++ b/Source/WebKit/Shared/API/glib/WebKitContextMenuPrivate.h
@@ -22,6 +22,7 @@
 #if ENABLE(CONTEXT_MENUS)
 #include "WebContextMenuItemGlib.h"
 #include "WebKitContextMenu.h"
+#include <WebCore/IntPoint.h>
 
 #if PLATFORM(GTK)
 #include "GRefPtrGtk.h"
@@ -33,6 +34,7 @@ void webkitContextMenuPopulate(WebKitContextMenu*, Vector<WebKit::WebContextMenu
 void webkitContextMenuPopulate(WebKitContextMenu*, Vector<WebKit::WebContextMenuItemData>&);
 void webkitContextMenuSetParentItem(WebKitContextMenu*, WebKitContextMenuItem*);
 WebKitContextMenuItem* webkitContextMenuGetParentItem(WebKitContextMenu*);
+void webkitContextMenuSetPosition(WebKitContextMenu*, const WebCore::IntPoint&);
 #if PLATFORM(GTK)
 #if USE(GTK4)
 void webkitContextMenuSetEvent(WebKitContextMenu*, GRefPtr<GdkEvent>&&);

--- a/Source/WebKit/UIProcess/API/glib/WebKitContextMenu.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitContextMenu.h.in
@@ -111,6 +111,11 @@ WEBKIT_API GdkEvent *
 webkit_context_menu_get_event            (WebKitContextMenu     *menu);
 #endif
 
+WEBKIT_API gboolean
+webkit_context_menu_get_position         (WebKitContextMenu     *menu,
+                                          gint                  *x,
+                                          gint                  *y);
+
 G_END_DECLS
 
 #endif

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -111,6 +111,7 @@
 #include "WPEUtilities.h"
 #include "WPEWebViewLegacy.h"
 #include "WPEWebViewPlatform.h"
+#include "WebContextMenuProxy.h"
 #include "WebKitOptionMenuPrivate.h"
 #include "WebKitWebViewBackendPrivate.h"
 #include "WebKitWebViewClient.h"
@@ -3017,6 +3018,7 @@ void webkitWebViewPopulateContextMenu(WebKitWebView* webView, const Vector<WebCo
     if (userData)
         webkit_context_menu_set_user_data(WEBKIT_CONTEXT_MENU(contextMenu.get()), userData);
     webkitContextMenuSetEvent(contextMenu.get(), webkitWebViewBaseTakeContextMenuEvent(webViewBase));
+    webkitContextMenuSetPosition(contextMenu.get(), contextMenuProxy->menuLocation());
 
     GRefPtr<WebKitHitTestResult> hitTestResult = adoptGRef(webkitHitTestResultCreate(hitTestResultData));
     gboolean returnValue;
@@ -3045,6 +3047,9 @@ void webkitWebViewPopulateContextMenu(WebKitWebView* webView, const Vector<WebCo
     GRefPtr<WebKitContextMenu> contextMenu = adoptGRef(webkitContextMenuCreate(proposedMenu));
     if (userData)
         webkit_context_menu_set_user_data(WEBKIT_CONTEXT_MENU(contextMenu.get()), userData);
+    if (auto* contextMenuProxy = getPage(webView).activeContextMenu())
+        webkitContextMenuSetPosition(contextMenu.get(), contextMenuProxy->menuLocation());
+
     GRefPtr<WebKitHitTestResult> hitTestResult = adoptGRef(webkitHitTestResultCreate(hitTestResultData));
     gboolean returnValue;
     g_signal_emit(webView, signals[CONTEXT_MENU], 0, contextMenu.get(),

--- a/Source/WebKit/UIProcess/WebContextMenuProxy.h
+++ b/Source/WebKit/UIProcess/WebContextMenuProxy.h
@@ -55,6 +55,7 @@ public:
     WebPageProxy* page() const { return m_page.get(); }
     RefPtr<WebPageProxy> protectedPage() const;
     const FrameInfoData& frameInfo() const { return m_frameInfo; }
+    const WebCore::IntPoint& menuLocation() const { return m_context.menuLocation(); }
 
 #if PLATFORM(COCOA)
     virtual NSMenu *platformMenu() const = 0;

--- a/Tools/TestWebKitAPI/Tests/WebKitGtk/TestContextMenu.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGtk/TestContextMenu.cpp
@@ -61,12 +61,22 @@ public:
 #endif
     }
 
+    void checkContextMenuPosition(WebKitContextMenu* contextMenu)
+    {
+        gint x, y;
+        gboolean hasPosition = webkit_context_menu_get_position(contextMenu, &x, &y);
+        g_assert_true(hasPosition);
+        g_assert_cmpint(x, ==, static_cast<gint>(m_menuPositionX));
+        g_assert_cmpint(y, ==, static_cast<gint>(m_menuPositionY));
+    }
+
     static gboolean contextMenuCallback(WebKitWebView* webView, WebKitContextMenu* contextMenu, GdkEvent* event, WebKitHitTestResult* hitTestResult, ContextMenuTest* test)
     {
         g_assert_true(WEBKIT_IS_CONTEXT_MENU(contextMenu));
         test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(contextMenu));
         g_assert_true(webkit_context_menu_get_event(contextMenu) == event);
         test->checkContextMenuEvent(event);
+        test->checkContextMenuPosition(contextMenu);
         g_assert_true(WEBKIT_IS_HIT_TEST_RESULT(hitTestResult));
         test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(hitTestResult));
 


### PR DESCRIPTION
#### d585739018e693a01ff8972b8adcf693fdd9be38
<pre>
[GLib] Add webkit_context_menu_get_position API
<a href="https://bugs.webkit.org/show_bug.cgi?id=305137">https://bugs.webkit.org/show_bug.cgi?id=305137</a>

Reviewed by Carlos Garcia Campos.

Added webkit_context_menu_get_position() to retrieve the click coordinates
(x, y) in view coordinates when a context menu is triggered. This allows
applications to know the exact position where the user right-clicked.

* Source/WebKit/Shared/API/glib/WebKitContextMenu.cpp:
* Source/WebKit/Shared/API/glib/WebKitContextMenuPrivate.h:
* Source/WebKit/UIProcess/API/glib/WebKitContextMenu.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
* Source/WebKit/UIProcess/WebContextMenuProxy.h:
* Tools/TestWebKitAPI/Tests/WebKitGtk/TestContextMenu.cpp:&quot;

Canonical link: <a href="https://commits.webkit.org/305444@main">https://commits.webkit.org/305444@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d4a97217940f5c1192e9cfc5d8d5dc2f722ec6b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138466 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10831 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49876 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146550 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/91441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140340 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11535 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10986 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/105951 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/91441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141413 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8662 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/124129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86798 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8249 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/6020 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6842 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117669 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/42328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149270 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10513 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42885 "Build is in progress. Recent messages:") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/114350 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10530 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8887 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114689 "Passed tests") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/8358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/120415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/65399 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21321 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10561 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/38348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10296 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/74168 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10500 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/10351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->