### PR TITLE
Update CSSSelectorList::selectorAt() to return a C++ reference

### DIFF
--- a/Source/WTF/wtf/FixedVector.h
+++ b/Source/WTF/wtf/FixedVector.h
@@ -207,6 +207,13 @@ public:
     size_t reverseFind(const auto&) const;
     size_t reverseFindIf(NOESCAPE const Invocable<bool(const T&)> auto&) const;
 
+    size_t offsetFromStart(const T* value) const
+    {
+        ASSERT(value >= std::to_address(begin()));
+        ASSERT(value < std::to_address(end()));
+        return value - std::to_address(begin());
+    }
+
     void swap(Self& other)
     {
         using std::swap;

--- a/Source/WebCore/css/CSSSelectorList.h
+++ b/Source/WebCore/css/CSSSelectorList.h
@@ -52,19 +52,8 @@ public:
 
     bool isEmpty() const { return m_selectorArray.isEmpty(); }
     const CSSSelector& first() const LIFETIME_BOUND { return m_selectorArray[0]; }
-    const CSSSelector* selectorAt(size_t index) const LIFETIME_BOUND
-    {
-        return &m_selectorArray[index];
-    }
-
-    size_t indexOfNextSelectorAfter(size_t index) const
-    {
-        const_iterator current = selectorAt(index);
-        ++current;
-        if (current == end())
-            return notFound;
-        return &*current - m_selectorArray.begin();
-    }
+    const CSSSelector& selectorAt(size_t index) const LIFETIME_BOUND { return m_selectorArray[index]; }
+    size_t indexOfSelector(const CSSSelector& selector) const { return m_selectorArray.offsetFromStart(&selector); }
 
     struct const_iterator {
         friend class CSSSelectorList;

--- a/Source/WebCore/html/track/WebVTTParser.cpp
+++ b/Source/WebCore/html/track/WebVTTParser.cpp
@@ -401,8 +401,8 @@ bool WebVTTParser::checkAndStoreStyleSheet(StringView line)
         const auto& selectorList = styleRule->selectorList();
         if (selectorList.size() != 1)
             return true;
-        auto selector = selectorList.selectorAt(0);
-        auto selectorText = selector->selectorText();
+        auto& selector = selectorList.selectorAt(0);
+        auto selectorText = selector.selectorText();
         
         bool isCue = selectorText == "::cue"_s || selectorText.startsWith("::cue("_s);
         if (!isCue)

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -525,7 +525,7 @@ inline bool ElementRuleCollector::ruleMatches(const RuleData& ruleData, unsigned
 
     if (compilerEnabled) {
         if (compiledSelector.status == SelectorCompilationStatus::NotCompiled)
-            SelectorCompiler::compileSelector(compiledSelector, ruleData.selector(), SelectorCompiler::SelectorContext::RuleCollector);
+            SelectorCompiler::compileSelector(compiledSelector, &ruleData.selector(), SelectorCompiler::SelectorContext::RuleCollector);
 
         if (compiledSelector.status == SelectorCompilationStatus::SimpleSelectorChecker) {
             compiledSelector.wasUsed();
@@ -564,12 +564,12 @@ inline bool ElementRuleCollector::ruleMatches(const RuleData& ruleData, unsigned
     } else
 #endif // ENABLE(CSS_SELECTOR_JIT)
     {
-        auto* selector = ruleData.selector();
+        auto& selector = ruleData.selector();
         // Slow path.
         SelectorChecker selectorChecker(element().document());
-        selectorMatches = selectorChecker.match(*selector, element(), context);
+        selectorMatches = selectorChecker.match(selector, element(), context);
         if (selectorMatches)
-            specificity = selector->computeSpecificity();
+            specificity = selector.computeSpecificity();
     }
 
     m_matchedPseudoElements.add(context.publicPseudoElements);
@@ -636,7 +636,7 @@ bool ElementRuleCollector::containerQueriesMatch(const RuleData& ruleData, const
     auto selectionMode = [&] {
         if (matchRequest.matchingPartPseudoElementRules)
             return ContainerQueryEvaluator::SelectionMode::PartPseudoElement;
-        if (ruleData.canMatchPseudoElement() && !complexSelectorMatchesElementBackedPseudoElement(*ruleData.selector()))
+        if (ruleData.canMatchPseudoElement() && !complexSelectorMatchesElementBackedPseudoElement(ruleData.selector()))
             return ContainerQueryEvaluator::SelectionMode::PseudoElement;
         return ContainerQueryEvaluator::SelectionMode::Element;
     }();

--- a/Source/WebCore/style/RuleData.cpp
+++ b/Source/WebCore/style/RuleData.cpp
@@ -85,9 +85,9 @@ static inline MatchBasedOnRuleHash computeMatchBasedOnRuleHash(const CSSSelector
     return MatchBasedOnRuleHash::None;
 }
 
-static inline PropertyAllowlist determinePropertyAllowlist(const CSSSelector* selector)
+static inline PropertyAllowlist determinePropertyAllowlist(const CSSSelector& selector)
 {
-    for (const CSSSelector* component = selector; component; component = component->precedingInComplexSelector()) {
+    for (const CSSSelector* component = &selector; component; component = component->precedingInComplexSelector()) {
 #if ENABLE(VIDEO)
         // Property allow-list for `::cue`:
         if (component->match() == CSSSelector::Match::PseudoElement && component->pseudoElement() == CSSSelector::PseudoElement::UserAgentPart && component->value() == UserAgentParts::cue())
@@ -102,9 +102,9 @@ static inline PropertyAllowlist determinePropertyAllowlist(const CSSSelector* se
         if (component->match() == CSSSelector::Match::PseudoElement && component->pseudoElement() == CSSSelector::PseudoElement::Marker)
             return propertyAllowlistForPseudoElement(PseudoElementType::Marker);
 
-        if (const auto* selectorList = selector->selectorList()) {
+        if (const auto* selectorList = selector.selectorList()) {
             for (auto& subSelector : *selectorList) {
-                auto allowlistType = determinePropertyAllowlist(&subSelector);
+                auto allowlistType = determinePropertyAllowlist(subSelector);
                 if (allowlistType != PropertyAllowlist::None)
                     return allowlistType;
             }
@@ -116,13 +116,13 @@ static inline PropertyAllowlist determinePropertyAllowlist(const CSSSelector* se
 RuleData::RuleData(const StyleRule& styleRule, unsigned selectorIndex, unsigned selectorListIndex, unsigned position, OptionSet<UsedRuleType> usedRuleTypes)
     : m_styleRuleWithSelectorIndex(&styleRule, static_cast<uint16_t>(selectorIndex))
     , m_selectorListIndex(selectorListIndex)
-    , m_matchBasedOnRuleHash(enumToUnderlyingType(computeMatchBasedOnRuleHash(*selector())))
-    , m_canMatchPseudoElement(complexSelectorCanMatchPseudoElement(*selector()))
+    , m_matchBasedOnRuleHash(enumToUnderlyingType(computeMatchBasedOnRuleHash(selector())))
+    , m_canMatchPseudoElement(complexSelectorCanMatchPseudoElement(selector()))
     , m_propertyAllowlist(enumToUnderlyingType(determinePropertyAllowlist(selector())))
     , m_usedRuleTypes(usedRuleTypes.toRaw())
     , m_isEnabled(true)
     , m_position(position)
-    , m_descendantSelectorIdentifierHashes(SelectorFilter::collectHashes(*selector()))
+    , m_descendantSelectorIdentifierHashes(SelectorFilter::collectHashes(selector()))
 {
     ASSERT(m_position == position);
     ASSERT(this->selectorIndex() == selectorIndex);

--- a/Source/WebCore/style/RuleData.h
+++ b/Source/WebCore/style/RuleData.h
@@ -52,7 +52,7 @@ public:
 
     const StyleRule& styleRule() const { return *m_styleRuleWithSelectorIndex.pointer(); }
 
-    const CSSSelector* selector() const
+    const CSSSelector& selector() const
     { 
         return styleRule().selectorList().selectorAt(selectorIndex());
     }

--- a/Source/WebCore/style/RuleFeature.cpp
+++ b/Source/WebCore/style/RuleFeature.cpp
@@ -129,7 +129,7 @@ RuleAndSelector::RuleAndSelector(const RuleData& ruleData)
 
 const CSSSelector& RuleAndSelector::selector() const
 {
-    return *styleRule->selectorList().selectorAt(selectorIndex);
+    return styleRule->selectorList().selectorAt(selectorIndex);
 }
 
 RuleFeature::RuleFeature(const RuleData& ruleData, MatchElement matchElement, IsNegation isNegation)
@@ -444,9 +444,10 @@ void RuleFeatureSet::collectFeatures(CollectionContext& collectionContext, const
 {
     SelectorFeatures selectorFeatures;
 
-    bool firstSeen = collectionContext.selectorDeduplicationSet.add({ *ruleData.selector() }).isNewEntry;
+    auto& selector = ruleData.selector();
+    bool firstSeen = collectionContext.selectorDeduplicationSet.add({ selector }).isNewEntry;
     if (firstSeen)
-        recursivelyCollectFeaturesFromSelector(selectorFeatures, *ruleData.selector());
+        recursivelyCollectFeaturesFromSelector(selectorFeatures, selector);
 
     if (ruleData.canMatchPseudoElement())
         collectPseudoElementFeatures(ruleData);
@@ -560,7 +561,7 @@ void RuleFeatureSet::collectPseudoElementFeatures(const RuleData& ruleData)
 {
     ASSERT(ruleData.canMatchPseudoElement());
 
-    auto& selector = *ruleData.selector();
+    auto& selector = ruleData.selector();
     for (auto* simpleSelector = &selector; simpleSelector; simpleSelector = simpleSelector->precedingInCompound()) {
         if (simpleSelector->match() != CSSSelector::Match::PseudoElement)
             continue;

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -162,13 +162,13 @@ void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerId
     const auto& scopeRules = scopeRulesFor(ruleData);
 
     auto computeLinkMatchType = [&] {
-        ASSERT(ruleData.selector());
+        auto& selector = ruleData.selector();
         // General case: no @scope rule or current rule selector is not :scope.
-        if (scopeRules.isEmpty() || !ruleData.selector()->hasScope())
-            return SelectorChecker::determineLinkMatchType(*ruleData.selector());
+        if (scopeRules.isEmpty() || !selector.hasScope())
+            return SelectorChecker::determineLinkMatchType(selector);
         // When current rule is :scope, we need to take into account the @scope selectors to determine the link match type.
         Ref scopeRule = scopeRules.last();
-        return SelectorChecker::determineLinkMatchType(*ruleData.selector(), scopeRule.ptr());
+        return SelectorChecker::determineLinkMatchType(selector, scopeRule.ptr());
     };
     ruleData.setLinkMatchType(computeLinkMatchType());
 
@@ -192,7 +192,7 @@ void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerId
 #if ENABLE(VIDEO)
     const CSSSelector* cuePseudoElementSelector = nullptr;
 #endif
-    const CSSSelector* selector = ruleData.selector();
+    const CSSSelector* selector = &ruleData.selector();
     do {
         switch (selector->match()) {
         case CSSSelector::Match::Id:
@@ -297,7 +297,7 @@ void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerId
     } while (selector);
 
     if (!m_hasHostPseudoClassRulesMatchingInShadowTree)
-        m_hasHostPseudoClassRulesMatchingInShadowTree = isHostSelectorMatchingInShadowTree(*ruleData.selector());
+        m_hasHostPseudoClassRulesMatchingInShadowTree = isHostSelectorMatchingInShadowTree(ruleData.selector());
 
 #if ENABLE(VIDEO)
     if (cuePseudoElementSelector) {
@@ -617,7 +617,7 @@ String RuleSet::selectorsForDebugging() const
     ts << "RuleSet size " << ruleCount();
     ts.nextLine();
     traverseRuleDatas([&](auto& ruleData) {
-        ts << ruleData.selector()->selectorText();
+        ts << ruleData.selector().selectorText();
         ts.nextLine();
     });
     return ts.release();

--- a/Source/WebCore/style/RuleSetBuilder.cpp
+++ b/Source/WebCore/style/RuleSetBuilder.cpp
@@ -324,11 +324,10 @@ void RuleSetBuilder::addStyleRuleWithSelectorList(const CSSSelectorList& selecto
     // It should not happen here.
     ASSERT(!selectorList.isEmpty());
     unsigned selectorListIndex = 0;
-    for (size_t selectorIndex = 0; selectorIndex != notFound; selectorIndex = selectorList.indexOfNextSelectorAfter(selectorIndex)) {
-        RuleData ruleData(rule, selectorIndex, selectorListIndex, m_ruleSet->ruleCount(), m_usedRuleTypes);
+    for (auto& selector : selectorList) {
+        RuleData ruleData(rule, selectorList.indexOfSelector(selector), selectorListIndex++, m_ruleSet->ruleCount(), m_usedRuleTypes);
         m_mediaQueryCollector.addRuleIfNeeded(ruleData);
         m_ruleSet->addRule(WTF::move(ruleData), m_currentCascadeLayerIdentifier, m_currentContainerQueryIdentifier, m_currentScopeIdentifier, &m_featureCollectionContext);
-        ++selectorListIndex;
     }
 }
 


### PR DESCRIPTION
#### 53d2448abd70c781f7a99e96fd24cbf5001fd271
<pre>
Update CSSSelectorList::selectorAt() to return a C++ reference
<a href="https://bugs.webkit.org/show_bug.cgi?id=305180">https://bugs.webkit.org/show_bug.cgi?id=305180</a>

Reviewed by Darin Adler and Sam Weinig.

Update CSSSelectorList::selectorAt() to return a C++ reference instead
of a raw pointer.

* Source/WTF/wtf/FixedVector.h:
(WTF::FixedVector::offsetFromStart const):
* Source/WebCore/css/CSSSelectorList.h:
(WebCore::CSSSelectorList::indexOfSelector const):
(WebCore::CSSSelectorList::indexOfNextSelectorAfter const): Deleted.
* Source/WebCore/html/track/WebVTTParser.cpp:
(WebCore::WebVTTParser::checkAndStoreStyleSheet):
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::ruleMatches):
(WebCore::Style::ElementRuleCollector::containerQueriesMatch):
* Source/WebCore/style/RuleData.cpp:
(WebCore::Style::determinePropertyAllowlist):
(WebCore::Style::RuleData::RuleData):
* Source/WebCore/style/RuleData.h:
(WebCore::Style::RuleData::selector const):
* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::RuleAndSelector::selector const):
(WebCore::Style::RuleFeatureSet::collectFeatures):
(WebCore::Style::RuleFeatureSet::collectPseudoElementFeatures):
* Source/WebCore/style/RuleSet.cpp:
(WebCore::Style::RuleSet::addRule):
(WebCore::Style::RuleSet::selectorsForDebugging const):
* Source/WebCore/style/RuleSetBuilder.cpp:
(WebCore::Style::RuleSetBuilder::addStyleRuleWithSelectorList):

Canonical link: <a href="https://commits.webkit.org/305435@main">https://commits.webkit.org/305435@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/efc7b6e403834fe7b4595d8c7f2b65fcbd78db44

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138426 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10791 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49836 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146510 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91401 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d42ae818-bb8b-4ec6-bf36-80125a804492) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140300 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11495 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10945 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105915 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/77264 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dc3d303b-0c90-4b81-9610-e40c7c3c0b39) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141373 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8628 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124094 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86763 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a007f23c-a2a1-4dc6-9bb2-109edc0467d0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8215 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5988 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6801 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/130390 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117635 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42293 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149231 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/137012 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10473 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42850 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/114316 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10490 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8856 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114658 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29108 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8288 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120380 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65351 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10521 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38313 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/169699 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10255 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74117 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44235 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10460 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10311 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->