### PR TITLE
DOMPromise::whenPromiseIsSettled should deallocate its callback as soon as called

### DIFF
--- a/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.cpp
@@ -338,7 +338,8 @@ void ReadableStreamDefaultReader::onClosedPromiseResolution(Function<void()>&& c
         if (!closedPromise->globalObject() || !protectedThis->m_closedResolutionCallback || closedPromise->status() != DOMPromise::Status::Fulfilled)
             return;
 
-        protectedThis->m_closedResolutionCallback();
+        // We exhange m_closedResolutionCallback to reset it to an empty function, which will deallocate any captured variable of the callback.
+        std::exchange(protectedThis->m_closedResolutionCallback, { })();
     });
 }
 

--- a/Source/WebCore/bindings/js/InternalWritableStreamWriter.cpp
+++ b/Source/WebCore/bindings/js/InternalWritableStreamWriter.cpp
@@ -203,7 +203,7 @@ void InternalWritableStreamWriter::onClosedPromiseResolution(Function<void()>&& 
     });
 }
 
-void InternalWritableStreamWriter::whenReady(Function<void ()>&& callback)
+void InternalWritableStreamWriter::whenReady(Function<void (bool)>&& callback)
 {
     auto* globalObject = this->globalObject();
     if (!globalObject)
@@ -225,9 +225,7 @@ void InternalWritableStreamWriter::whenReady(Function<void ()>&& callback)
 
     Ref domPromise = DOMPromise::create(*globalObject, *promise);
     domPromise->whenSettled([domPromise, callback = WTF::move(callback)]() mutable {
-        if (domPromise->status() != DOMPromise::Status::Fulfilled)
-            return;
-        callback();
+        callback(domPromise->status() == DOMPromise::Status::Fulfilled);
     });
 }
 

--- a/Source/WebCore/bindings/js/InternalWritableStreamWriter.h
+++ b/Source/WebCore/bindings/js/InternalWritableStreamWriter.h
@@ -41,7 +41,7 @@ public:
         return adoptRef(*new InternalWritableStreamWriter(globalObject, writer));
     }
 
-    void whenReady(Function<void()>&&);
+    void whenReady(Function<void(bool)>&&);
     void onClosedPromiseRejection(Function<void(JSDOMGlobalObject&, JSC::JSValue)>&&);
     void onClosedPromiseResolution(Function<void()>&&);
 

--- a/Source/WebCore/bindings/js/JSDOMPromise.cpp
+++ b/Source/WebCore/bindings/js/JSDOMPromise.cpp
@@ -51,7 +51,8 @@ auto DOMPromise::whenPromiseIsSettled(JSDOMGlobalObject* globalObject, JSC::JSPr
     auto& vm = lexicalGlobalObject.vm();
     JSLockHolder lock(vm);
     auto* handler = JSC::JSNativeStdFunction::create(vm, globalObject, 1, String { }, [callback = WTF::move(callback)] (JSGlobalObject*, CallFrame*) mutable {
-        callback();
+        // We exchange callback so that all captured variables are deallocated after the call. This is quicker than waiting for the handler function to be GCed.
+        std::exchange(callback, { })();
         return JSC::JSValue::encode(JSC::jsUndefined());
     });
 


### PR DESCRIPTION
#### 397f9236f48ee41fb71362ef742999fb61b8ef7d
<pre>
DOMPromise::whenPromiseIsSettled should deallocate its callback as soon as called
<a href="https://rdar.apple.com/167782759">rdar://167782759</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=305130">https://bugs.webkit.org/show_bug.cgi?id=305130</a>

Reviewed by Chris Dumez.

DOMPromise::whenPromiseIsSettled callback was previously deallocated when its promise gets deallocated.
This might be late and might also create ref cycle.
To prevent this, we make sure the callback is deallocated right after it is called in DOMPromise::whenPromiseIsSettled.

We also do the same in ReadableStreamDefaultReader::onClosedPromiseResolution to update StreamPipeToState.

This triggers the need to ensure that StreamPipeToState stays allocated until the writer ready promise callbacks are called in case of rejection.
We update InternalWritableStreamWriter::whenReady so that the callback is always called and update StreamPipeToState like we have done for reader closing.

Covered by existing tests.

Canonical link: <a href="https://commits.webkit.org/305353@main">https://commits.webkit.org/305353@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf1cd1ea4b6b9b5905bcb6657c60e5e78b3e1423

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138192 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10557 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49602 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146270 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91167 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/bf3863d1-5612-4233-9e41-f9940aea63cf) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140066 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11261 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10711 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/105706 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/77109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/042a74de-6787-4196-aa89-4e22c03100e2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141138 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8426 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123895 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86557 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fc154993-e267-48e6-80d1-c557d0213692) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8020 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5785 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6552 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117431 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42092 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148980 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10239 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42649 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/114115 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10256 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/8651 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/114454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29072 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/7979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120179 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64975 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10286 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38118 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10017 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/73853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10226 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10077 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->