### PR TITLE
Use more Ref instead of RefPtr in Web Audio

### DIFF
--- a/Source/WebCore/Modules/webaudio/AudioNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioNode.h
@@ -299,6 +299,12 @@ template<typename T> struct AudioNodeConnectionRefDerefTraits {
         return ptr;
     }
 
+    static ALWAYS_INLINE T& ref(T& ref)
+    {
+        ref.incrementConnectionCount();
+        return ref;
+    }
+
     static ALWAYS_INLINE void derefIfNotNull(T* ptr)
     {
         if (ptr) [[likely]]
@@ -308,6 +314,9 @@ template<typename T> struct AudioNodeConnectionRefDerefTraits {
 
 template<typename T>
 using AudioConnectionRefPtr = RefPtr<T, RawPtrTraits<T>, AudioNodeConnectionRefDerefTraits<T>>;
+
+template<typename T>
+using AudioConnectionRef = Ref<T, RawPtrTraits<T>, AudioNodeConnectionRefDerefTraits<T>>;
 
 String convertEnumerationToString(AudioNode::NodeType);
 

--- a/Source/WebCore/Modules/webaudio/AudioNodeOutput.h
+++ b/Source/WebCore/Modules/webaudio/AudioNodeOutput.h
@@ -156,7 +156,6 @@ private:
     unsigned m_renderingParamFanOutCount { 0 };
 
     HashSet<Ref<AudioParam>> m_params;
-    typedef HashSet<RefPtr<AudioParam>>::iterator ParamsIterator;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.cpp
@@ -138,7 +138,7 @@ ExceptionOr<void> AudioWorkletGlobalScope::registerProcessor(String&& name, Ref<
 
 RefPtr<AudioWorkletProcessor> AudioWorkletGlobalScope::createProcessor(const String& name, TransferredMessagePort port, Ref<SerializedScriptValue>&& options)
 {
-    auto constructor = m_processorConstructorMap.get(name);
+    RefPtr constructor = m_processorConstructorMap.get(name);
     ASSERT(constructor);
     if (!constructor)
         return nullptr;

--- a/Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.h
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.h
@@ -83,7 +83,7 @@ private:
 
     size_t m_currentFrame { 0 };
     const float m_sampleRate;
-    MemoryCompactRobinHoodHashMap<String, RefPtr<JSAudioWorkletProcessorConstructor>> m_processorConstructorMap;
+    MemoryCompactRobinHoodHashMap<String, Ref<JSAudioWorkletProcessorConstructor>> m_processorConstructorMap;
     ThreadSafeWeakHashSet<AudioWorkletProcessor> m_processors;
     std::unique_ptr<AudioWorkletProcessorConstructionData> m_pendingProcessorConstructionData;
     std::optional<JSC::VM::DrainMicrotaskDelayScope> m_delayMicrotaskDrainingDuringRendering;

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
@@ -972,7 +972,7 @@ void BaseAudioContext::sourceNodeWillBeginPlayback(AudioNode& node)
 
     ASSERT(!m_referencedSourceNodes.contains(&node));
     // Reference source node to keep it alive and playing even if its JS wrapper gets garbage collected.
-    m_referencedSourceNodes.append(&node);
+    m_referencedSourceNodes.append(node);
 }
 
 void BaseAudioContext::sourceNodeDidFinishPlayback(AudioNode& node)

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.h
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.h
@@ -267,7 +267,7 @@ protected:
 
 protected:
     // Only accessed when the graph lock is held.
-    const Vector<AudioConnectionRefPtr<AudioNode>>& referencedSourceNodes() const { return m_referencedSourceNodes; }
+    const Vector<AudioConnectionRef<AudioNode>>& referencedSourceNodes() const { return m_referencedSourceNodes; }
 
 private:
     void scheduleNodeDeletion();
@@ -311,7 +311,7 @@ private:
     const Ref<AudioWorklet> m_worklet;
 
     // Either accessed when the graph lock is held, or on the main thread when the audio thread has finished.
-    Vector<AudioConnectionRefPtr<AudioNode>> m_referencedSourceNodes;
+    Vector<AudioConnectionRef<AudioNode>> m_referencedSourceNodes;
 
     // Accumulate nodes which need to be deleted here.
     // This is copied to m_nodesToDelete at the end of a render cycle in handlePostRenderTasks(), where we're assured of a stable graph

--- a/Source/WebCore/Modules/webaudio/OfflineAudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/OfflineAudioContext.cpp
@@ -97,7 +97,7 @@ void OfflineAudioContext::increaseNoiseMultiplierIfNeeded()
     if (!target)
         return;
 
-    Vector<AudioConnectionRefPtr<AudioNode>, 1> remainingNodes;
+    Vector<AudioConnectionRef<AudioNode>, 1> remainingNodes;
     for (auto& node : referencedSourceNodes())
         remainingNodes.append(node.copyRef());
 
@@ -110,7 +110,7 @@ void OfflineAudioContext::increaseNoiseMultiplierIfNeeded()
                 continue;
 
             output->forEachInputNode([&](auto& inputNode) {
-                remainingNodes.append(&inputNode);
+                remainingNodes.append(inputNode);
             });
         }
     }
@@ -184,7 +184,7 @@ void OfflineAudioContext::suspendRendering(double suspendTime, Ref<DeferredPromi
     }
 
     Locker locker { graphLock() };
-    auto addResult = m_suspendRequests.add(frame, promise.ptr());
+    auto addResult = m_suspendRequests.add(frame, promise);
     if (!addResult.isNewEntry) {
         promise->reject(Exception { ExceptionCode::InvalidStateError, "There is already a pending suspend request at this frame"_s });
         return;

--- a/Source/WebCore/Modules/webaudio/OfflineAudioContext.h
+++ b/Source/WebCore/Modules/webaudio/OfflineAudioContext.h
@@ -72,7 +72,7 @@ private:
 
     const UniqueRef<OfflineAudioDestinationNode> m_destinationNode;
     RefPtr<DeferredPromise> m_pendingRenderingPromise;
-    HashMap<unsigned /* frame */, RefPtr<DeferredPromise>, IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> m_suspendRequests;
+    HashMap<unsigned /* frame */, Ref<DeferredPromise>, IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> m_suspendRequests;
     unsigned m_length;
     bool m_didStartRendering { false };
 };


### PR DESCRIPTION
#### ae39f9678268e95b7fd3c1d9709f7accb87decd2
<pre>
Use more Ref instead of RefPtr in Web Audio
<a href="https://bugs.webkit.org/show_bug.cgi?id=305182">https://bugs.webkit.org/show_bug.cgi?id=305182</a>

Reviewed by Darin Adler.

Claude AI helped draft this. Improves clarity.

Canonical link: <a href="https://commits.webkit.org/305424@main">https://commits.webkit.org/305424@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f1c8997048c0a789b77ab9abf590ac3651baeab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138388 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10753 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49798 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146471 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91363 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a3bd8bc9-525e-406e-915f-75740f04fa0b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140262 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11457 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10907 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105886 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77234 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/25a3e8a4-e8c7-42f4-b679-1dd65fe058fe) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141335 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8599 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124058 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86728 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c844781b-7eed-4501-8447-818cc434a2e6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8186 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5951 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6758 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117605 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42258 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149185 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10435 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42815 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114283 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10452 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8821 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114626 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8177 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120345 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65281 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21312 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10482 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38278 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10216 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74067 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10422 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10273 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->