### PR TITLE
[WPE] Set the associated page on WebKitContextMenuItems

### DIFF
--- a/Source/WebKit/Shared/API/glib/WebKitContextMenu.cpp
+++ b/Source/WebKit/Shared/API/glib/WebKitContextMenu.cpp
@@ -22,6 +22,7 @@
 
 #include "APIArray.h"
 #include "WebContextMenuItem.h"
+#include "WebKitContextMenuGAction.h"
 #include "WebKitContextMenuItem.h"
 #include "WebKitContextMenuItemPrivate.h"
 #include "WebKitContextMenuPrivate.h"
@@ -99,6 +100,21 @@ void webkitContextMenuPopulate(WebKitContextMenu* menu, Vector<WebContextMenuIte
     for (GList* item = menu->priv->items; item; item = g_list_next(item)) {
         WebKitContextMenuItem* menuItem = WEBKIT_CONTEXT_MENU_ITEM(item->data);
         contextMenuItems.append(webkitContextMenuItemToWebContextMenuItemGlib(menuItem));
+    }
+}
+
+void webkitContextMenuSetPage(WebKitContextMenu* menu, WebPageProxy* page)
+{
+    for (auto* item = menu->priv->items; item; item = g_list_next(item)) {
+        auto* menuItem = WEBKIT_CONTEXT_MENU_ITEM(item->data);
+        if (auto* subMenu = webkit_context_menu_item_get_submenu(menuItem)) {
+            webkitContextMenuSetPage(subMenu, page);
+            continue;
+        }
+
+        auto* action = webkit_context_menu_item_get_gaction(menuItem);
+        if (WEBKIT_IS_CONTEXT_MENU_GACTION(action))
+            webkitContextMenuGActionSetPage(WEBKIT_CONTEXT_MENU_GACTION(action), page);
     }
 }
 

--- a/Source/WebKit/Shared/API/glib/WebKitContextMenuPrivate.h
+++ b/Source/WebKit/Shared/API/glib/WebKitContextMenuPrivate.h
@@ -22,6 +22,7 @@
 #if ENABLE(CONTEXT_MENUS)
 #include "WebContextMenuItemGlib.h"
 #include "WebKitContextMenu.h"
+#include "WebPageProxy.h"
 #include <WebCore/IntPoint.h>
 
 #if PLATFORM(GTK)
@@ -32,6 +33,7 @@
 WebKitContextMenu* webkitContextMenuCreate(const Vector<WebKit::WebContextMenuItemData>&);
 void webkitContextMenuPopulate(WebKitContextMenu*, Vector<WebKit::WebContextMenuItemGlib>&);
 void webkitContextMenuPopulate(WebKitContextMenu*, Vector<WebKit::WebContextMenuItemData>&);
+void webkitContextMenuSetPage(WebKitContextMenu*, WebKit::WebPageProxy*);
 void webkitContextMenuSetParentItem(WebKitContextMenu*, WebKitContextMenuItem*);
 WebKitContextMenuItem* webkitContextMenuGetParentItem(WebKitContextMenu*);
 void webkitContextMenuSetPosition(WebKitContextMenu*, const WebCore::IntPoint&);

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -3057,6 +3057,13 @@ void webkitWebViewPopulateContextMenu(WebKitWebView* webView, const Vector<WebCo
         nullptr,
 #endif
         hitTestResult.get(), &returnValue);
+    if (!returnValue)
+        return;
+
+    webkitContextMenuSetPage(contextMenu.get(), &getPage(webView));
+
+    // Clear the menu to make sure it's useless after signal emission.
+    webkit_context_menu_remove_all(contextMenu.get());
 }
 #endif
 #endif // ENABLE(CONTEXT_MENUS)


### PR DESCRIPTION
#### a2a7c1bf6505c2eac8f7be5918eebed0c2cbcfa7
<pre>
[WPE] Set the associated page on WebKitContextMenuItems
<a href="https://bugs.webkit.org/show_bug.cgi?id=305183">https://bugs.webkit.org/show_bug.cgi?id=305183</a>

Reviewed by Nikolas Zimmermann.

This makes the context menu item to be automatically selected when the
GAction is activated.

* Source/WebKit/Shared/API/glib/WebKitContextMenu.cpp:
(webkitContextMenuSetPage):
* Source/WebKit/Shared/API/glib/WebKitContextMenuPrivate.h:
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(webkitWebViewPopulateContextMenu):

Canonical link: <a href="https://commits.webkit.org/305504@main">https://commits.webkit.org/305504@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/088d5d100297583abd00fa6bf13f4c8336013e7b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138602 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10967 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/83 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146715 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/91577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11671 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11123 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/106048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/91577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141549 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8795 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/124233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86919 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/8383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/6134 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7006 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/117800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149467 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10649 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/68 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/114432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10666 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/9012 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114773 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8575 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120529 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65543 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21344 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10698 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/71 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10433 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/74330 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10636 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10487 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->