### PR TITLE
REGRESSION(304666@main) [WPE] Build broken when DEVELOPER_MODE=OFF due to undefined symbols when linking jsc

### DIFF
--- a/Source/JavaScriptCore/shell/PlatformWPE.cmake
+++ b/Source/JavaScriptCore/shell/PlatformWPE.cmake
@@ -9,9 +9,12 @@
 # regardless of whether those objects are already contained in a SHARED
 # library in the list. Including both WebKit and the OBJECT frameworks
 # would cause duplicate symbols and bloated binaries.
-set(jsc_FRAMEWORKS WebKit)
 
+# The goal is to reduce binary size of the built-products. See bug 304213
+# This only works with -DDEVELOPER_MODE=ON because without it a webkitglib-symbols.map
+# filter is passed to the linker that makes the required symbols not visible.
 if (DEVELOPER_MODE)
+    set(jsc_FRAMEWORKS WebKit)
     set(testapi_FRAMEWORKS ${jsc_FRAMEWORKS})
     set(testmasm_FRAMEWORKS ${jsc_FRAMEWORKS})
     set(testRegExp_FRAMEWORKS ${jsc_FRAMEWORKS})

--- a/Tools/TestWebKitAPI/PlatformWPE.cmake
+++ b/Tools/TestWebKitAPI/PlatformWPE.cmake
@@ -103,17 +103,29 @@ set(TestJSC_SOURCES
 set(TestJSC_PRIVATE_INCLUDE_DIRECTORIES
     ${CMAKE_BINARY_DIR}
     ${TESTWEBKITAPI_DIR}
-    "${JavaScriptCoreGLib_FRAMEWORK_HEADERS_DIR}"
-    "${JavaScriptCoreGLib_DERIVED_SOURCES_DIR}"
     "${JavaScriptCoreGLib_DERIVED_SOURCES_DIR}/jsc"
 )
 
-# To reduce binary bloat, link only against the shared libWPEWebKit library
-# without embedding the object files from the OBJECT library frameworks
-# (WTF, bmalloc, JavaScriptCore) that are already bundled into libWPEWebKit.
+# If developer_mode is enabled, to reduce binary bloat, link this binaries
+# against the shared libWPEWebKit library rather than embedding the object
+# files from the frameworks (statically linking).
 # See detailed explanation at Source/JavaScriptCore/shell/PlatformWPE.cmake
-set(TestJSC_FRAMEWORKS WebKit)
-set(TestJavaScriptCore_FRAMEWORKS WebKit)
+if (DEVELOPER_MODE)
+    list(APPEND TestJSC_PRIVATE_INCLUDE_DIRECTORIES
+        "${JavaScriptCoreGLib_FRAMEWORK_HEADERS_DIR}"
+        "${JavaScriptCoreGLib_DERIVED_SOURCES_DIR}"
+    )
+    set(TestJSC_FRAMEWORKS WebKit)
+    set(TestJavaScriptCore_FRAMEWORKS WebKit)
+else ()
+    set(TestJSC_FRAMEWORKS
+        JavaScriptCore
+        WTF
+    )
+    if (NOT USE_SYSTEM_MALLOC)
+        list(APPEND TestJSC_FRAMEWORKS bmalloc)
+    endif ()
+endif ()
 
 set(TestJSC_DEFINITIONS
     WEBKIT_SRC_DIR="${CMAKE_SOURCE_DIR}"


### PR DESCRIPTION
#### 6d81a49969e7a90f37fb4bff6981affea88856de
<pre>
REGRESSION(304666@main) [WPE] Build broken when DEVELOPER_MODE=OFF due to undefined symbols when linking jsc
<a href="https://bugs.webkit.org/show_bug.cgi?id=305186">https://bugs.webkit.org/show_bug.cgi?id=305186</a>

Reviewed by Nikolas Zimmermann.

304666@main introduced an optimization in WPE to link the jsc binary and other test binaries against
libWPEWebKit instead of statically linking (embedding) WTF, JSC and other libraries inside.

However, it happens that when DEVELOPER_MODE is not enabled we pass a linker filter to libWPEWebKit that
makes many of the symbols (JSC::* WTF::*) required to link this binaries not longer visible, and that
causes errors when trying to link this binaries against the filtered libWPEWebKit.

This patch makes the changes done by 304666@main to only apply when DEVELOPER_MODE is enabled.

Co-authored-by: Pablo Saavedra &lt;psaavedra@igalia.com&gt;

* Source/JavaScriptCore/shell/PlatformWPE.cmake:
* Tools/TestWebKitAPI/PlatformWPE.cmake:

Canonical link: <a href="https://commits.webkit.org/305354@main">https://commits.webkit.org/305354@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20a7b8139d2a9aa703865e337f237efb0f799f59

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138183 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10548 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49593 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146267 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91158 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140057 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11252 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10702 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/105711 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/77102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141129 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8418 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123884 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86556 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8012 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5774 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6551 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/130147 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117423 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42082 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148971 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/136741 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10230 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42639 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114108 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10247 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8640 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114438 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7963 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120169 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64956 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21275 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10277 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38108 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/169455 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10007 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73844 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44181 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10217 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10068 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->