### PR TITLE
Reduce unsafeness in Geolocation

### DIFF
--- a/Source/WebCore/Modules/geolocation/GeoNotifier.h
+++ b/Source/WebCore/Modules/geolocation/GeoNotifier.h
@@ -49,7 +49,7 @@ public:
     }
 
     const PositionOptions& options() const { return m_options; }
-    void setFatalError(RefPtr<GeolocationPositionError>&&);
+    void setFatalError(Ref<GeolocationPositionError>&&);
 
     bool useCachedPosition() const { return m_useCachedPosition; }
     void setUseCachedPosition();
@@ -70,7 +70,7 @@ private:
     const RefPtr<PositionErrorCallback> m_errorCallback;
     PositionOptions m_options;
     Timer m_timer;
-    RefPtr<GeolocationPositionError> m_fatalError;
+    const RefPtr<GeolocationPositionError> m_fatalError;
     bool m_useCachedPosition;
 };
 

--- a/Source/WebCore/Modules/geolocation/Geolocation.h
+++ b/Source/WebCore/Modules/geolocation/Geolocation.h
@@ -74,7 +74,7 @@ public:
     WEBCORE_EXPORT void setIsAllowed(bool, const String& authorizationToken);
     const String& authorizationToken() const { return m_authorizationToken; }
     WEBCORE_EXPORT void resetIsAllowed();
-    bool isAllowed() const { return m_allowGeolocation == Yes; }
+    bool isAllowed() const { return m_allowGeolocation == AllowGeolocation::Yes; }
 
     bool hasBeenRequested() const { return m_hasBeenRequested; }
 
@@ -95,18 +95,18 @@ private:
     void suspend(ReasonForSuspension) override;
     void resume() override;
 
-    bool isDenied() const { return m_allowGeolocation == No; }
+    bool isDenied() const { return m_allowGeolocation == AllowGeolocation::No; }
 
     Page* page() const;
     SecurityOrigin* securityOrigin() const;
     RefPtr<SecurityOrigin> protectedSecurityOrigin() const;
 
-    typedef Vector<RefPtr<GeoNotifier>> GeoNotifierVector;
-    typedef HashSet<RefPtr<GeoNotifier>> GeoNotifierSet;
+    typedef Vector<Ref<GeoNotifier>> GeoNotifierVector;
+    typedef HashSet<Ref<GeoNotifier>> GeoNotifierSet;
 
     class Watchers {
     public:
-        bool add(int id, RefPtr<GeoNotifier>&&);
+        bool add(int id, Ref<GeoNotifier>&&);
         GeoNotifier* find(int id);
         void remove(int id);
         void remove(GeoNotifier*);
@@ -115,8 +115,8 @@ private:
         bool isEmpty() const;
         void getNotifiersVector(GeoNotifierVector&) const;
     private:
-        typedef HashMap<int, RefPtr<GeoNotifier>> IdToNotifierMap;
-        typedef HashMap<RefPtr<GeoNotifier>, int> NotifierToIdMap;
+        typedef HashMap<int, Ref<GeoNotifier>> IdToNotifierMap;
+        typedef HashMap<Ref<GeoNotifier>, int> NotifierToIdMap;
         IdToNotifierMap m_idToNotifierMap;
         NotifierToIdMap m_notifierToIdMap;
     };
@@ -143,20 +143,22 @@ private:
     void requestPermission();
     void revokeAuthorizationTokenIfNecessary();
 
-    bool startUpdating(GeoNotifier*);
+    bool startUpdating(GeoNotifier&);
     void stopUpdating();
 
     void handlePendingPermissionNotifiers();
 
-    void startRequest(GeoNotifier*);
+    void startRequest(GeoNotifier&);
 
-    void fatalErrorOccurred(GeoNotifier*);
-    void requestTimedOut(GeoNotifier*);
-    void requestUsesCachedPosition(GeoNotifier*);
+    void fatalErrorOccurred(GeoNotifier&);
+    void requestTimedOut(GeoNotifier&);
+    void requestUsesCachedPosition(GeoNotifier&);
     bool haveSuitableCachedPosition(const PositionOptions&);
     void makeCachedPositionCallbacks();
 
     void resumeTimerFired();
+
+    enum class AllowGeolocation : uint8_t { Unknown, InProgress, Yes, No };
 
     WeakPtr<Navigator> m_navigator;
     GeoNotifierSet m_oneShots;
@@ -166,7 +168,7 @@ private:
 
     bool m_hasBeenRequested { false };
 
-    enum { Unknown, InProgress, Yes, No } m_allowGeolocation { Unknown };
+    AllowGeolocation m_allowGeolocation { AllowGeolocation::Unknown };
     String m_authorizationToken;
     bool m_isSuspended { false };
     bool m_resetOnResume { false };


### PR DESCRIPTION
#### 92b7782a45213ed02ab8bd6b98ecc36ebc652740
<pre>
Reduce unsafeness in Geolocation
<a href="https://bugs.webkit.org/show_bug.cgi?id=305188">https://bugs.webkit.org/show_bug.cgi?id=305188</a>

Reviewed by Chris Dumez.

Migrate from RefPtr to Ref, pointer to reference, enum to class enum,
and make use of const member variables to avoid additional reffing.

Canonical link: <a href="https://commits.webkit.org/305356@main">https://commits.webkit.org/305356@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b6dda3c867278c24645af54991c29a4e9a7d20a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138185 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10550 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49595 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146262 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91160 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fa2535a2-2cc7-44b3-9acd-d915a964d871) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140059 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11254 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10704 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105702 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/77104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0e56b710-a0a6-4964-b090-0f1b43a6b894) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141131 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8420 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123885 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86546 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/41e65652-cb9b-4804-a742-f61e28917d8f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8014 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5777 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6542 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117425 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42083 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148973 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10232 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42640 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114106 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10249 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8643 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114442 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7973 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120170 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64961 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21277 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10279 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38109 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10009 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73846 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10219 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10070 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->