### PR TITLE
[CoordinatedGraphics] LayerTreeHost: inspector/debugger/async-stack-trace-basic.html and inspector/debugger/async-stack-trace-truncate.html are crashing

### DIFF
--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -122,9 +122,6 @@ webkit.org/b/254733 inspector/canvas/recording-offscreen-webgl-memoryLimit.html 
 webkit.org/b/254733 inspector/canvas/shaderProgram-add-remove-webgl2.html [ Failure ]
 webkit.org/b/254733 inspector/canvas/shaderProgram-add-remove-webgl.html [ Failure ]
 
-webkit.org/b/303375 inspector/debugger/async-stack-trace-basic.html [ Crash Timeout Pass ]
-webkit.org/b/303375 inspector/debugger/async-stack-trace-truncate.html [ Crash Timeout ]
-
 # Crash on EWS bot.
 webrtc/vp8-then-h264-gpu-process-crash.html [ Skip ]
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -182,6 +182,8 @@ void LayerTreeHost::invalidateRenderingUpdateRunLoopObserver()
 
 void LayerTreeHost::updateRendering()
 {
+    invalidateRenderingUpdateRunLoopObserver();
+
     RELEASE_ASSERT(!m_isUpdatingRendering);
     if (m_layerTreeStateIsFrozen)
         return;
@@ -233,7 +235,6 @@ void LayerTreeHost::updateRendering()
     m_forceFrameSync = false;
 
     page->didUpdateRendering();
-    invalidateRenderingUpdateRunLoopObserver();
 
     // Eject any backing stores whose only reference is held in the HashMap cache.
     m_imageBackingStores.removeIf([](auto& it) {
@@ -312,7 +313,6 @@ void LayerTreeHost::updateRenderingWithForcedRepaint()
     // not need to cancel pending ones and immediately flush again (re-entrancy!).
     if (m_isUpdatingRendering)
         return;
-    invalidateRenderingUpdateRunLoopObserver();
     updateRendering();
 }
 
@@ -334,10 +334,8 @@ void LayerTreeHost::sizeDidChange()
     m_pendingResize = true;
     if (m_isWaitingForRenderer)
         scheduleRenderingUpdate();
-    else {
-        invalidateRenderingUpdateRunLoopObserver();
+    else
         updateRendering();
-    }
 }
 
 void LayerTreeHost::pauseRendering()


### PR DESCRIPTION
#### 7216ac5e37b8b27719576e9f2062aa95c3bbb366
<pre>
[CoordinatedGraphics] LayerTreeHost: inspector/debugger/async-stack-trace-basic.html and inspector/debugger/async-stack-trace-truncate.html are crashing
<a href="https://bugs.webkit.org/show_bug.cgi?id=303375">https://bugs.webkit.org/show_bug.cgi?id=303375</a>

Reviewed by Carlos Garcia Campos.

inspector/debugger/async-stack-trace-basic.html and
inspector/debugger/async-stack-trace-truncate.html were crashing for GTK port
due to a release assertion failure of reentrant of
LayerTreeHost::updateRendering().

Call invalidateRenderingUpdateRunLoopObserver() first in updateRendering().

* LayoutTests/platform/gtk/TestExpectations:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::updateRendering):
(WebKit::LayerTreeHost::updateRenderingWithForcedRepaint):
(WebKit::LayerTreeHost::sizeDidChange):

Canonical link: <a href="https://commits.webkit.org/305838@main">https://commits.webkit.org/305838@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94480933da49cad64ecb4aa90a4be14290b66bb7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139515 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11891 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1017 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147643 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92583 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12599 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12041 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106814 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77771 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142462 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9642 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Ignored 1 pre-existing failure based on results-db; Uploaded test results") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124960 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87678 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9268 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6880 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7941 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118565 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/948 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150426 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11575 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/964 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115216 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11589 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9894 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115527 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10085 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121393 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66581 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21528 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11620 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/903 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11355 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75298 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11555 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11406 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->