### PR TITLE
Use Ref instead of RefPtr in WakeLockManager

### DIFF
--- a/Source/WebCore/Modules/screen-wake-lock/WakeLockManager.cpp
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLockManager.cpp
@@ -61,7 +61,7 @@ void WakeLockManager::deref() const
 void WakeLockManager::addWakeLock(Ref<WakeLockSentinel>&& lock, std::optional<PageIdentifier> pageID)
 {
     auto type = lock->type();
-    auto& locks = m_wakeLocks.ensure(type, [] { return Vector<RefPtr<WakeLockSentinel>>(); }).iterator->value;
+    auto& locks = m_wakeLocks.ensure(type, [] { return Vector<Ref<WakeLockSentinel>>(); }).iterator->value;
     ASSERT(!locks.contains(lock.ptr()));
     locks.append(WTF::move(lock));
 
@@ -112,7 +112,7 @@ void WakeLockManager::releaseAllLocks(WakeLockType type)
 
     auto& locks = it->value;
     while (!locks.isEmpty()) {
-        RefPtr lock = *locks.begin();
+        Ref lock = *locks.begin();
         lock->release(*this);
     }
 }

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLockManager.h
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLockManager.h
@@ -57,7 +57,7 @@ private:
     void visibilityStateChanged() final;
 
     const CheckedRef<Document> m_document;
-    HashMap<WakeLockType, Vector<RefPtr<WakeLockSentinel>>, WTF::IntHash<WakeLockType>, WTF::StrongEnumHashTraits<WakeLockType>> m_wakeLocks;
+    HashMap<WakeLockType, Vector<Ref<WakeLockSentinel>>, WTF::IntHash<WakeLockType>, WTF::StrongEnumHashTraits<WakeLockType>> m_wakeLocks;
     std::unique_ptr<SleepDisabler> m_screenLockDisabler;
 };
 


### PR DESCRIPTION
#### af51fe7724379da858626b96115517a0e9bd56f3
<pre>
Use Ref instead of RefPtr in WakeLockManager
<a href="https://bugs.webkit.org/show_bug.cgi?id=305189">https://bugs.webkit.org/show_bug.cgi?id=305189</a>

Reviewed by Chris Dumez.

Improves clarity.

Canonical link: <a href="https://commits.webkit.org/305357@main">https://commits.webkit.org/305357@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/023bad1893bdd305b20c019339cd78b6def51b16

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138190 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10555 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49600 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146268 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91165 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/e7b11951-5020-4526-861c-e37b55cdf1d5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140064 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11259 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10709 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105712 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/77108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/3829e196-5653-4725-b25d-bb9523e5c5b2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141136 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8425 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123893 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86554 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/192ca39e-43fe-4f83-b1f9-8aef6a3d7216) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8019 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5782 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6549 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117430 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42090 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148978 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10237 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42647 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114114 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10254 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8648 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114449 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7972 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120177 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64973 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21278 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10284 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38116 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10015 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73851 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10224 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10075 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->