### PR TITLE
Fix sandbox extension file access failures on MacCatalyst caused by multiple entitlement lookups

### DIFF
--- a/Source/WebKit/Scripts/compile-sandbox.sh
+++ b/Source/WebKit/Scripts/compile-sandbox.sh
@@ -40,7 +40,7 @@ if [[ $SDK_NAME =~ "mac" ]]; then
         # Use the IMPORT_DIR of the build host.
         # That's acceptable for syntax check purposes, but will prevent adoption of
         # new rules in imports, e.g. when the build host runs an older macOS version.
-        xcrun --sdk $SDK_NAME sbutil compile -D IMPORT_DIR=/System/Library/Sandbox/Profiles -D ENABLE_SANDBOX_MESSAGE_FILTER=YES -D WEBKIT2_FRAMEWORK_DIR=dir -D HOME_DIR=dir -D HOME_LIBRARY_PREFERENCES_DIR=dir -D DARWIN_USER_CACHE_DIR=dir -D DARWIN_USER_TEMP_DIR=dir $SANDBOX_PATH > /dev/null;
+        xcrun --sdk $SDK_NAME sbutil compile -D IMPORT_DIR=/System/Library/Sandbox/Profiles -D ENABLE_SANDBOX_MESSAGE_FILTER=YES -D WEBKIT2_FRAMEWORK_DIR=dir -D HOME_DIR=dir -D HOME_LIBRARY_PREFERENCES_DIR=dir -D DARWIN_USER_CACHE_DIR=dir -D DARWIN_USER_TEMP_DIR=dir -D WEBCONTENT_IS_LOCKDOWN_MODE=NO -D WEBCONTENT_IS_ENHANCED_SECURITY=NO $SANDBOX_PATH > /dev/null;
         if [[ $? != 0 ]]; then
             exit 1;
         fi

--- a/Source/WebKit/Scripts/process-entitlements.sh
+++ b/Source/WebKit/Scripts/process-entitlements.sh
@@ -82,7 +82,6 @@ function mac_process_webcontent_enhancedsecurity_entitlements()
 
     if [[ "${WK_USE_RESTRICTED_ENTITLEMENTS}" == YES ]]
     then
-        plistbuddy Add :com.apple.private.webkit.enhanced-security bool YES
         plistbuddy Add :com.apple.private.webkit.use-xpc-endpoint bool YES
         plistbuddy Add :com.apple.rootless.storage.WebKitWebContentSandbox bool YES
         plistbuddy Add :com.apple.QuartzCore.webkit-end-points bool YES
@@ -443,7 +442,6 @@ function maccatalyst_process_webcontent_enhancedsecurity_entitlements()
 
     if [[ "${WK_USE_RESTRICTED_ENTITLEMENTS}" == YES ]]
     then
-        plistbuddy Add :com.apple.private.webkit.enhanced-security bool YES
         plistbuddy Add :com.apple.security.cs.jit-write-allowlist bool YES
     fi
 

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -1031,6 +1031,11 @@ void WebProcess::initializeSandbox(const AuxiliaryProcessInitializationParameter
     registerVorbisDecoderIfNeeded();
 #endif
 
+    if (parameters.extraInitializationData.get<HashTranslatorASCIILiteral>("enable-lockdown-mode"_s) == "1"_s)
+        sandboxParameters.addParameter("WEBCONTENT_IS_LOCKDOWN_MODE"_s, "YES"_span);
+    else if (parameters.extraInitializationData.get<HashTranslatorASCIILiteral>("enable-enhanced-security"_s) == "1"_s)
+        sandboxParameters.addParameter("WEBCONTENT_IS_ENHANCED_SECURITY"_s, "YES"_span);
+
     auto webKitBundle = [NSBundle bundleForClass:NSClassFromString(@"WKWebView")];
 
     sandboxParameters.setOverrideSandboxProfilePath(makeString(String([webKitBundle resourcePath]), "/com.apple.WebProcess.sb"_s));

--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -26,18 +26,10 @@
 
 
 (define (enhanced-security)
-    (require-any
-        (require-all
-            (require-not (require-entitlement "com.apple.security.cs.allow-jit"))
-            (require-not (require-entitlement "com.apple.private.verified-jit"))
-            (require-not (require-entitlement "com.apple.security.cs.single-jit"))))
-        (require-entitlement "com.apple.private.webkit.enhanced-security")
-    )
+    (equal? (param "WEBCONTENT_IS_ENHANCED_SECURITY") "YES"))
 
 (define (lockdown-mode)
-    (require-all
-        (require-not (require-entitlement "com.apple.security.cs.allow-jit"))
-        (require-not (enhanced-security))))
+    (equal? (param "WEBCONTENT_IS_LOCKDOWN_MODE") "YES"))
 
 #define FALSE #f
 
@@ -51,9 +43,9 @@
 
 #if USE(SANDBOX_VERSION_3)
 (allow dynamic-code-generation)
-(with-filter (lockdown-mode)
+(when (lockdown-mode)
     (deny dynamic-code-generation))
-(with-filter (enhanced-security)
+(when (enhanced-security)
     (deny dynamic-code-generation))
 
 (with-filter (mac-policy-name "Sandbox")
@@ -1117,16 +1109,15 @@
 
 ; Needed for [CAContext remoteContextWithOptions]
 #if HAVE(SANDBOX_STATE_FLAGS) && PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 140000
-(with-filter
-    (require-all
-        (require-not (lockdown-mode))
+(when (not (lockdown-mode))
+    (with-filter
         (require-any
             (require-not (state-flag "UnifiedPDFEnabled"))
-            (require-not (state-flag "BlockIOKitInWebContentSandbox"))))
-    (allow mach-lookup
-        (require-all
-            (extension "com.apple.webkit.extension.mach")
-            (global-name "com.apple.CARenderServer"))))
+            (require-not (state-flag "BlockIOKitInWebContentSandbox")))
+        (allow mach-lookup
+            (require-all
+                (extension "com.apple.webkit.extension.mach")
+                (global-name "com.apple.CARenderServer")))))
 #else
 (allow mach-lookup (global-name "com.apple.CARenderServer"))
 #endif
@@ -1627,8 +1618,9 @@
 #endif
 (with-filter (require-not (state-flag "BlockIOKitInWebContentSandbox"))
     (allow syscall-unix (syscall-unix-downlevels)))
-(with-filter (require-all (require-not (lockdown-mode)) (require-not (state-flag "BlockIOKitInWebContentSandbox")))
-    (allow syscall-unix (syscall-unix-downlevels-blocked-in-lockdown-mode)))
+(when (not (lockdown-mode))
+    (with-filter (require-not (state-flag "BlockIOKitInWebContentSandbox"))
+        (allow syscall-unix (syscall-unix-downlevels-blocked-in-lockdown-mode))))
 #else
 (allow syscall-unix
     (syscall-unix-only-in-use-before-launch)
@@ -1643,11 +1635,11 @@
 
 #if !PLATFORM(MAC) || __MAC_OS_X_VERSION_MIN_REQUIRED <= 140000
 (allow syscall-unix (syscall-unix-downlevels))
-(with-filter (require-not (lockdown-mode))
+(when (not (lockdown-mode))
     (allow syscall-unix (syscall-unix-downlevels-blocked-in-lockdown-mode)))
 #endif
 
-(with-filter (require-not (lockdown-mode))
+(when (not (lockdown-mode))
     (allow syscall-unix (syscall-unix-blocked-in-lockdown-mode))
     (when (equal? (param "CPU") "arm64")
         (allow syscall-unix (syscall-unix-apple-silicon)))
@@ -1666,7 +1658,7 @@
     (allow syscall-unix (syscall-number SYS_quotactl)))
 #endif
 
-(with-filter (lockdown-mode)
+(when (lockdown-mode)
     (deny syscall-unix (with telemetry) (syscall-unix-blocked-in-lockdown-mode))
     (deny syscall-unix (with telemetry) (syscalls-rarely-used-blocked-in-lockdown-mode))
     (when (equal? (param "CPU") "arm64")
@@ -1793,10 +1785,10 @@
 
 (when (defined? 'syscall-mig)
     (deny syscall-mig)
-    (with-filter (require-not (lockdown-mode))
+    (when (not (lockdown-mode))
         (allow-mach-exceptions syscall-mig)
         (allow syscall-mig (kernel-mig-routines-blocked-in-lockdown-mode)))
-    (with-filter (lockdown-mode)
+    (when (lockdown-mode)
         (deny syscall-mig (with telemetry) (kernel-mig-routines-blocked-in-lockdown-mode)))
     (allow syscall-mig (kernel-mig-routines-in-use))
 #if HAVE(MACH_RANGE_CREATE)
@@ -1810,24 +1802,25 @@
         (allow syscall-mig (kernel-mig-routines-iokit-service)))
     (with-filter (state-flag "BlockIOKitInWebContentSandbox")
         (deny syscall-mig (with no-report) (kernel-mig-routines-iokit-service)))
-    (with-filter (require-all (require-not (lockdown-mode)) (require-not (state-flag "BlockIOKitInWebContentSandbox")))
-        (allow syscall-mig (kernel-mig-routines-downlevels-blocked-in-lockdown-mode))))
+    (when (not (lockdown-mode))
+        (with-filter (require-not (state-flag "BlockIOKitInWebContentSandbox"))
+            (allow syscall-mig (kernel-mig-routines-downlevels-blocked-in-lockdown-mode)))))
 
 (if (and (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES") (and (defined? 'mach-kernel-endpoint) (not (defined? 'syscall-mig))))
     (allow mach-kernel-endpoint
         (apply-message-filter
             (deny mach-message-send)
-            (with-filter (require-not (lockdown-mode))
+            (when (not (lockdown-mode))
                 (allow mach-message-send (kernel-mig-routines-blocked-in-lockdown-mode)))
-            (with-filter (lockdown-mode)
+            (when (lockdown-mode)
                 (deny mach-message-send (with telemetry) (kernel-mig-routines-blocked-in-lockdown-mode)))
-            (with-filter (require-not (lockdown-mode))
+            (when (not (lockdown-mode))
                 (allow-mach-exceptions mach-message-send))
 
             (allow mach-message-send (kernel-mig-routines-in-use))
 #if !PLATFORM(MAC) || __MAC_OS_X_VERSION_MIN_REQUIRED <= 140000
             (allow mach-message-send (kernel-mig-routines-downlevels))
-            (with-filter (require-not (lockdown-mode))
+            (when (not (lockdown-mode))
                 (allow mach-message-send (kernel-mig-routines-downlevels-blocked-in-lockdown-mode)))
 #endif
 #if HAVE(SANDBOX_STATE_FLAGS)
@@ -1842,8 +1835,9 @@
             (with-filter (require-not (state-flag "BlockIOKitInWebContentSandbox"))
                 (allow mach-message-send (kernel-mig-routines-downlevels))
                 (allow mach-message-send (kernel-mig-routines-iokit)))
-            (with-filter (require-all (require-not (lockdown-mode)) (require-not (state-flag "BlockIOKitInWebContentSandbox")))
-                (allow mach-message-send (kernel-mig-routines-downlevels-blocked-in-lockdown-mode)))
+            (when (not (lockdown-mode))
+                (with-filter (require-not (state-flag "BlockIOKitInWebContentSandbox"))
+                    (allow mach-message-send (kernel-mig-routines-downlevels-blocked-in-lockdown-mode))))
 #else
             (allow mach-message-send (kernel-mig-routines-iokit))
             (allow mach-message-send (kernel-mig-routines-iokit-service))
@@ -1910,17 +1904,18 @@
 #if HAVE(SANDBOX_STATE_FLAGS)
     (with-filter (require-not (state-flag "BlockIOKitInWebContentSandbox"))
         (allow syscall-mach (syscall-mach-downlevels)))
-    (with-filter (require-all (require-not (lockdown-mode)) (require-not (state-flag "BlockIOKitInWebContentSandbox")))
-        (allow syscall-mach (syscall-mach-downlevels-blocked-in-lockdown-mode)))
+    (when (not (lockdown-mode))
+        (with-filter (require-not (state-flag "BlockIOKitInWebContentSandbox"))
+            (allow syscall-mach (syscall-mach-downlevels-blocked-in-lockdown-mode))))
 #endif
 #if !PLATFORM(MAC) || __MAC_OS_X_VERSION_MIN_REQUIRED <= 140000
     (allow syscall-mach (syscall-mach-downlevels))
-    (with-filter (require-not (lockdown-mode))
+    (when (not (lockdown-mode))
         (allow syscall-mach (syscall-mach-downlevels-blocked-in-lockdown-mode)))
 #endif
-    (with-filter (require-not (lockdown-mode))
+    (when (not (lockdown-mode))
         (allow syscall-mach (syscall-mach-blocked-in-lockdown-mode)))
-    (with-filter (lockdown-mode)
+    (when (lockdown-mode)
         (deny syscall-mach (with telemetry) (syscall-mach-blocked-in-lockdown-mode)))
     (when (defined? 'MSC_mach_msg2_trap)
         (allow syscall-mach (machtrap-number MSC_mach_msg2_trap))))


### PR DESCRIPTION
#### 95dcfb0c569ea1ecfcf6f6cd13c581037ad2965b
<pre>
Fix sandbox extension file access failures on MacCatalyst caused by multiple entitlement lookups
<a href="https://bugs.webkit.org/show_bug.cgi?id=305190">https://bugs.webkit.org/show_bug.cgi?id=305190</a>
<a href="https://rdar.apple.com/166738679">rdar://166738679</a>

Reviewed by Per Arne Vollan.

WebContent processes on MacCatalyst were experiencing sandbox extension file
access failures. Investigation suggests that inferring security mode from
missing entitlements required multiple lookups, contributing to a race
condition.

This patch switches to explicit entitlement-based detection for internal SDK
builds, reducing the number of entitlement lookups required to determine the
security mode.

* Source/WebKit/Scripts/compile-sandbox.sh:
* Source/WebKit/Scripts/process-entitlements.sh:
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::accessibilityFocusedUIElement):
* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/305495@main">https://commits.webkit.org/305495@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ae44d9afc446acebacd840e34fdbcf462b86f4a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138512 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10877 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49922 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146609 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91487 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/44830b8d-c2c9-4185-aac0-3aec8f2cd3cb) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11581 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11032 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/105999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77327 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9e30d39a-1868-44ac-9324-3614d1406752) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141459 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8703 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124166 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86862 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/78a20cdc-698b-4690-b165-513562b6688e) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/137860 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8289 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6077 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6909 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117710 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149365 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10559 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42924 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/114450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10576 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8927 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114716 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29158 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8434 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120454 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65449 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10608 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38385 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10342 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74259 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10546 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10397 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->