### PR TITLE
[JSC] `RegExp.prototype [ %Symbol.split% ]` Incorrectly Uses Fast Path when `limit` is not a Number

### DIFF
--- a/JSTests/microbenchmarks/regexp-non-numeric-limit.js
+++ b/JSTests/microbenchmarks/regexp-non-numeric-limit.js
@@ -1,0 +1,23 @@
+function test(regexp, string) {
+    var r = regexp[Symbol.split](string, {
+        valueOf() {
+            RegExp.prototype.exec = () => null;
+            return 100;
+        },
+    });
+    return r.length;
+}
+noInline(test);
+
+var regexp = /test/g;
+var string = "abba";
+var result = 0;
+var expected = 1;
+for (let i = 0; i < testLoopCount; i++) {
+    if (test(regexp, string) === expected) {
+        result++;
+    }
+}
+if (result !== testLoopCount) {
+    throw "Error: bad: " + result;
+}

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -746,9 +746,6 @@ test/staging/sm/RegExp/replace-sticky-lastIndex.js:
 test/staging/sm/RegExp/replace-sticky.js:
   default: 'Test262Error: Expected SameValue(«"ABCDEabcdeabcdefghij"», «"abcdeABCDEabcdefghij"») to be true'
   strict mode: 'Test262Error: Expected SameValue(«"ABCDEabcdeabcdefghij"», «"abcdeABCDEabcdefghij"») to be true'
-test/staging/sm/RegExp/split-limit.js:
-  default: 'Test262Error: Expected SameValue(«3», «1») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«3», «1») to be true'
 test/staging/sm/RegExp/unicode-braced.js:
   default: 'SyntaxError: Invalid regular expression: regular expression too large'
   strict mode: 'SyntaxError: Invalid regular expression: regular expression too large'

--- a/Source/JavaScriptCore/builtins/RegExpPrototype.js
+++ b/Source/JavaScriptCore/builtins/RegExpPrototype.js
@@ -238,7 +238,11 @@ function split(string, limit)
     // 4. Let C be ? SpeciesConstructor(rx, %RegExp%).
     var speciesConstructor = @speciesConstructor(regexp, @RegExp);
 
-    if (speciesConstructor === @RegExp && !@hasObservableSideEffectsForRegExpSplit(regexp))
+    // Skip fast path if limit is number or undefined
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=1287525
+    var isLimitNumberOrUndefined = typeof limit === "number" || limit === @undefined;
+
+    if (speciesConstructor === @RegExp && !@hasObservableSideEffectsForRegExpSplit(regexp) && isLimitNumberOrUndefined)
         return @regExpSplitFast.@call(regexp, str, limit);
 
     // 5. Let flags be ? ToString(? Get(rx, "flags")).
@@ -256,7 +260,7 @@ function split(string, limit)
 
     // We need to check again for RegExp subclasses that will fail the speciesConstructor test
     // but can still use the fast path after we invoke the constructor above.
-    if (!@hasObservableSideEffectsForRegExpSplit(splitter))
+    if (!@hasObservableSideEffectsForRegExpSplit(splitter) && isLimitNumberOrUndefined)
         return @regExpSplitFast.@call(splitter, str, limit);
 
     // 11. Let A be ArrayCreate(0).


### PR DESCRIPTION
#### d21256503ee6c71f334de5ae962e89c018ff70b6
<pre>
[JSC] `RegExp.prototype [ %Symbol.split% ]` Incorrectly Uses Fast Path when `limit` is not a Number
<a href="https://bugs.webkit.org/show_bug.cgi?id=305192">https://bugs.webkit.org/show_bug.cgi?id=305192</a>

Reviewed by Yusuke Suzuki.

This patch fixes `RegExp.prototype[%Symbol.split%]`
because incorrectly uses fast path when `limit` is not a number or undefined [1][2].

[1]: <a href="https://github.com/tc39/test262/blob/6251b55fc6e46be41243e88ce73fcd04dd5069f2/test/staging/sm/RegExp/split-limit.js">https://github.com/tc39/test262/blob/6251b55fc6e46be41243e88ce73fcd04dd5069f2/test/staging/sm/RegExp/split-limit.js</a>
[2]: <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1287525">https://bugzilla.mozilla.org/show_bug.cgi?id=1287525</a>

Test: JSTests/microbenchmarks/regexp-non-numeric-limit.js

* JSTests/microbenchmarks/regexp-non-numeric-limit.js: Added.
(test):
(i.test):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/builtins/RegExpPrototype.js:
(overriddenName.string_appeared_here.split):

Canonical link: <a href="https://commits.webkit.org/305879@main">https://commits.webkit.org/305879@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac1c55cb3161b168a431101103f4b1fcf61a8216

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139477 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11853 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/979 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147604 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92545 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12561 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12003 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106782 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77748 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142424 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124927 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87645 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7903 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/131450 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118530 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/907 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150387 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/272 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11537 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/923 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115184 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11551 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9851 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115496 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29382 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10004 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121352 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/66543 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11581 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/860 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/170749 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11316 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75247 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44435 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11517 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11368 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->