### PR TITLE
Fix WebKit-only failures in streams/piping/abort.any.html

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/streams/piping/abort.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/piping/abort.any-expected.txt
@@ -17,9 +17,9 @@ PASS (reason: 'error1: error1') abort should prevent further reads
 PASS (reason: 'null') all pending writes should complete on abort
 PASS (reason: 'undefined') all pending writes should complete on abort
 PASS (reason: 'error1: error1') all pending writes should complete on abort
-FAIL (reason: 'null') underlyingSource.cancel() should called when abort, even with pending pull assert_equals: cancel should have been called expected 2 but got 0
-FAIL (reason: 'undefined') underlyingSource.cancel() should called when abort, even with pending pull assert_equals: cancel should have been called expected 2 but got 0
-FAIL (reason: 'error1: error1') underlyingSource.cancel() should called when abort, even with pending pull assert_equals: cancel should have been called expected 2 but got 0
+PASS (reason: 'null') underlyingSource.cancel() should called when abort, even with pending pull
+PASS (reason: 'undefined') underlyingSource.cancel() should called when abort, even with pending pull
+PASS (reason: 'error1: error1') underlyingSource.cancel() should called when abort, even with pending pull
 PASS a rejection from underlyingSource.cancel() should be returned by pipeTo()
 PASS a rejection from underlyingSink.abort() should be returned by pipeTo()
 FAIL a rejection from underlyingSink.abort() should be preferred to one from underlyingSource.cancel() promise_rejects_exactly: pipeTo should reject function "function() { throw e; }" threw object "error1: error1" but we expected it to throw object "error2: error2"

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/piping/abort.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/piping/abort.any.serviceworker-expected.txt
@@ -17,9 +17,9 @@ PASS (reason: 'error1: error1') abort should prevent further reads
 PASS (reason: 'null') all pending writes should complete on abort
 PASS (reason: 'undefined') all pending writes should complete on abort
 PASS (reason: 'error1: error1') all pending writes should complete on abort
-FAIL (reason: 'null') underlyingSource.cancel() should called when abort, even with pending pull assert_equals: cancel should have been called expected 2 but got 0
-FAIL (reason: 'undefined') underlyingSource.cancel() should called when abort, even with pending pull assert_equals: cancel should have been called expected 2 but got 0
-FAIL (reason: 'error1: error1') underlyingSource.cancel() should called when abort, even with pending pull assert_equals: cancel should have been called expected 2 but got 0
+PASS (reason: 'null') underlyingSource.cancel() should called when abort, even with pending pull
+PASS (reason: 'undefined') underlyingSource.cancel() should called when abort, even with pending pull
+PASS (reason: 'error1: error1') underlyingSource.cancel() should called when abort, even with pending pull
 PASS a rejection from underlyingSource.cancel() should be returned by pipeTo()
 PASS a rejection from underlyingSink.abort() should be returned by pipeTo()
 FAIL a rejection from underlyingSink.abort() should be preferred to one from underlyingSource.cancel() promise_rejects_exactly: pipeTo should reject function "function() { throw e; }" threw object "error1: error1" but we expected it to throw object "error2: error2"

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/piping/abort.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/piping/abort.any.sharedworker-expected.txt
@@ -17,9 +17,9 @@ PASS (reason: 'error1: error1') abort should prevent further reads
 PASS (reason: 'null') all pending writes should complete on abort
 PASS (reason: 'undefined') all pending writes should complete on abort
 PASS (reason: 'error1: error1') all pending writes should complete on abort
-FAIL (reason: 'null') underlyingSource.cancel() should called when abort, even with pending pull assert_equals: cancel should have been called expected 2 but got 0
-FAIL (reason: 'undefined') underlyingSource.cancel() should called when abort, even with pending pull assert_equals: cancel should have been called expected 2 but got 0
-FAIL (reason: 'error1: error1') underlyingSource.cancel() should called when abort, even with pending pull assert_equals: cancel should have been called expected 2 but got 0
+PASS (reason: 'null') underlyingSource.cancel() should called when abort, even with pending pull
+PASS (reason: 'undefined') underlyingSource.cancel() should called when abort, even with pending pull
+PASS (reason: 'error1: error1') underlyingSource.cancel() should called when abort, even with pending pull
 PASS a rejection from underlyingSource.cancel() should be returned by pipeTo()
 PASS a rejection from underlyingSink.abort() should be returned by pipeTo()
 FAIL a rejection from underlyingSink.abort() should be preferred to one from underlyingSource.cancel() promise_rejects_exactly: pipeTo should reject function "function() { throw e; }" threw object "error1: error1" but we expected it to throw object "error2: error2"

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/piping/abort.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/piping/abort.any.worker-expected.txt
@@ -17,9 +17,9 @@ PASS (reason: 'error1: error1') abort should prevent further reads
 PASS (reason: 'null') all pending writes should complete on abort
 PASS (reason: 'undefined') all pending writes should complete on abort
 PASS (reason: 'error1: error1') all pending writes should complete on abort
-FAIL (reason: 'null') underlyingSource.cancel() should called when abort, even with pending pull assert_equals: cancel should have been called expected 2 but got 0
-FAIL (reason: 'undefined') underlyingSource.cancel() should called when abort, even with pending pull assert_equals: cancel should have been called expected 2 but got 0
-FAIL (reason: 'error1: error1') underlyingSource.cancel() should called when abort, even with pending pull assert_equals: cancel should have been called expected 2 but got 0
+PASS (reason: 'null') underlyingSource.cancel() should called when abort, even with pending pull
+PASS (reason: 'undefined') underlyingSource.cancel() should called when abort, even with pending pull
+PASS (reason: 'error1: error1') underlyingSource.cancel() should called when abort, even with pending pull
 PASS a rejection from underlyingSource.cancel() should be returned by pipeTo()
 PASS a rejection from underlyingSink.abort() should be returned by pipeTo()
 FAIL a rejection from underlyingSink.abort() should be preferred to one from underlyingSource.cancel() promise_rejects_exactly: pipeTo should reject function "function() { throw e; }" threw object "error1: error1" but we expected it to throw object "error2: error2"


### PR DESCRIPTION
#### fc9ae5401e788cdbd02054cdc80a11bf91c67f59
<pre>
Fix WebKit-only failures in streams/piping/abort.any.html
<a href="https://rdar.apple.com/167841090">rdar://167841090</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=305196">https://bugs.webkit.org/show_bug.cgi?id=305196</a>

Reviewed by Chris Dumez.

The readable stream built-in implementation is relying on an older version of the spec where read requests were only promises.
The spec is now using read requests which is useful for the pipeTo algorithm.

This creates a mismatch between the pipeTo algorithm and the built-in readable stream implementation.
In particular, pipeTo algorithm may know that a readable gets closed before it knows that the last read request is fulfilled.
This is due to the pipeTo read requests being called once a promise resolves, while it should be synchronous.

To work-around that issue until we rework the readable stream implementation, StreamPipeToState will keep in memory that pipeTo is shutting down due to readable being closed.
In that case, we wait for the pending read request (which is actually fulfilled) before proceeding with the finalization of pipeTo.

Covered by rebased tests.

Canonical link: <a href="https://commits.webkit.org/305455@main">https://commits.webkit.org/305455@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60025f9f91d89b8298b30ff57d1654a79aff7c05

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138203 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10568 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49613 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146281 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91178 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/522d44b2-ecb2-42f9-82ef-4e95e0bd0a88) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140077 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11272 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10722 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105719 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77115 "2 flakes 8 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a1ca27e6-53d3-4f18-87af-5e858742b002) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141149 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8435 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123903 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86566 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4a3ecdba-b72b-4f02-993a-0fc67822fa9e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8029 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5792 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6564 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117440 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42100 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148991 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10250 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42657 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114122 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10267 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8658 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114461 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29123 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7991 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120187 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64987 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10297 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38126 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10028 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73864 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10237 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10088 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->