### PR TITLE
DOMPromise::whenSettled should provide an easy way to get the promise result

### DIFF
--- a/Source/WebCore/Modules/streams/StreamTeeUtilities.cpp
+++ b/Source/WebCore/Modules/streams/StreamTeeUtilities.cpp
@@ -247,9 +247,9 @@ ExceptionOr<Vector<Ref<ReadableStream>>> byteStreamTee(JSDOMGlobalObject& global
             JSC::JSValue reason = JSC::constructArray(&globalObject, static_cast<JSC::ArrayAllocationProfile*>(nullptr), list);
 
             Ref promise = state->stream().cancel(globalObject, reason);
-            promise->whenSettled([state, promise] {
-                if (promise->status() == DOMPromise::Status::Rejected) {
-                    state->rejectCancelPromise(promise->result());
+            promise->whenSettledWithResult([state](auto*, bool isFulfilled, auto result) {
+                if (!isFulfilled) {
+                    state->rejectCancelPromise(result);
                     return;
                 }
                 state->resolveCancelPromise();
@@ -272,9 +272,9 @@ ExceptionOr<Vector<Ref<ReadableStream>>> byteStreamTee(JSDOMGlobalObject& global
             JSC::JSValue reason = JSC::constructArray(&globalObject, static_cast<JSC::ArrayAllocationProfile*>(nullptr), list);
 
             Ref promise = state->stream().cancel(globalObject, reason);
-            promise->whenSettled([state, promise] {
-                if (promise->status() == DOMPromise::Status::Rejected) {
-                    state->rejectCancelPromise(promise->result());
+            promise->whenSettledWithResult([state](auto*, bool isFulfilled, auto result) {
+                if (!isFulfilled) {
+                    state->rejectCancelPromise(result);
                     return;
                 }
                 state->resolveCancelPromise();

--- a/Source/WebCore/Modules/web-locks/WebLockManager.cpp
+++ b/Source/WebCore/Modules/web-locks/WebLockManager.cpp
@@ -270,7 +270,7 @@ void WebLockManager::didCompleteLockRequest(WebLockIdentifier lockIdentifier, bo
                 return;
             }
 
-            DOMPromise::whenPromiseIsSettled(waitingPromise->globalObject(), waitingPromise->promise(), [weakThis = WeakPtr { manager }, lockIdentifier = *request.lockIdentifier, name = request.name, waitingPromise] {
+            waitingPromise->whenSettled([weakThis = WeakPtr { manager }, lockIdentifier = *request.lockIdentifier, name = request.name, waitingPromise] {
                 RefPtr protectedThis = weakThis.get();
                 if (!protectedThis)
                     return;

--- a/Source/WebCore/bindings/js/InternalReadableStreamDefaultReader.cpp
+++ b/Source/WebCore/bindings/js/InternalReadableStreamDefaultReader.cpp
@@ -159,10 +159,10 @@ void InternalReadableStreamDefaultReader::onClosedPromiseRejection(Function<void
         return;
 
     Ref domPromise = DOMPromise::create(*globalObject, *promise);
-    domPromise->whenSettled([domPromise, callback = WTF::move(callback)] {
-        if (domPromise->status() != DOMPromise::Status::Rejected || !domPromise->globalObject())
+    domPromise->whenSettledWithResult([callback = WTF::move(callback)](auto* globalObject, bool isFulfilled, auto result) {
+        if (isFulfilled || !globalObject)
             return;
-        callback(*domPromise->globalObject(), domPromise->result());
+        callback(*globalObject, result);
     });
 }
 
@@ -189,8 +189,8 @@ void InternalReadableStreamDefaultReader::onClosedPromiseResolution(Function<voi
         return;
 
     Ref domPromise = DOMPromise::create(*globalObject, *promise);
-    domPromise->whenSettled([domPromise, callback = WTF::move(callback)] {
-        if (domPromise->status() == DOMPromise::Status::Fulfilled)
+    domPromise->whenSettledWithResult([callback = WTF::move(callback)](auto*, bool isFulfilled, auto) {
+        if (isFulfilled)
             callback();
     });
 }

--- a/Source/WebCore/bindings/js/InternalWritableStreamWriter.cpp
+++ b/Source/WebCore/bindings/js/InternalWritableStreamWriter.cpp
@@ -168,10 +168,10 @@ void InternalWritableStreamWriter::onClosedPromiseRejection(Function<void(JSDOMG
         return;
 
     Ref domPromise = DOMPromise::create(*globalObject, *promise);
-    domPromise->whenSettled([domPromise, callback = WTF::move(callback)]() mutable {
-        if (domPromise->status() != DOMPromise::Status::Rejected || !domPromise->globalObject())
+    domPromise->whenSettledWithResult([callback = WTF::move(callback)](auto* globalObject, bool isFulfilled, auto result) mutable {
+        if (isFulfilled || !globalObject)
             return;
-        callback(*domPromise->globalObject(), domPromise->result());
+        callback(*globalObject, result);
     });
 }
 
@@ -196,8 +196,8 @@ void InternalWritableStreamWriter::onClosedPromiseResolution(Function<void()>&& 
         return;
 
     Ref domPromise = DOMPromise::create(*globalObject, *promise);
-    domPromise->whenSettled([domPromise, callback = WTF::move(callback)]() mutable {
-        if (domPromise->status() != DOMPromise::Status::Fulfilled)
+    domPromise->whenSettledWithResult([callback = WTF::move(callback)](auto*, bool isFulfilled, auto) mutable {
+        if (!isFulfilled)
             return;
         callback();
     });
@@ -224,8 +224,8 @@ void InternalWritableStreamWriter::whenReady(Function<void (bool)>&& callback)
         return;
 
     Ref domPromise = DOMPromise::create(*globalObject, *promise);
-    domPromise->whenSettled([domPromise, callback = WTF::move(callback)]() mutable {
-        callback(domPromise->status() == DOMPromise::Status::Fulfilled);
+    domPromise->whenSettledWithResult([callback = WTF::move(callback)](auto*, bool isFulfilled, auto) mutable {
+        callback(isFulfilled);
     });
 }
 

--- a/Source/WebCore/bindings/js/JSDOMPromise.h
+++ b/Source/WebCore/bindings/js/JSDOMPromise.h
@@ -45,7 +45,13 @@ public:
     }
 
     enum class IsCallbackRegistered : bool { No, Yes };
-    WEBCORE_EXPORT IsCallbackRegistered whenSettled(Function<void()>&&);
+    IsCallbackRegistered whenSettled(Function<void()>&& callback)
+    {
+        return whenSettledWithResult([callback = WTF::move(callback)](JSDOMGlobalObject*, bool, JSC::JSValue) {
+            callback();
+        });
+    }
+    WEBCORE_EXPORT IsCallbackRegistered whenSettledWithResult(Function<void(JSDOMGlobalObject*, bool, JSC::JSValue)>&&);
     JSC::JSValue result() const;
 
     void markAsHandled();
@@ -53,7 +59,7 @@ public:
     enum class Status { Pending, Fulfilled, Rejected };
     Status status() const;
 
-    static IsCallbackRegistered whenPromiseIsSettled(JSDOMGlobalObject*, JSC::JSPromise*, Function<void()>&&);
+    static IsCallbackRegistered whenPromiseIsSettled(JSDOMGlobalObject*, JSC::JSPromise*, Function<void(JSDOMGlobalObject*, bool, JSC::JSValue)>&&);
 
 private:
     DOMPromise(JSDOMGlobalObject& globalObject, JSC::JSPromise& promise)

--- a/Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp
+++ b/Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp
@@ -110,14 +110,14 @@ void DeferredPromise::callFunction(JSGlobalObject& lexicalGlobalObject, ResolveM
         clear();
 }
 
-void DeferredPromise::whenSettled(Function<void()>&& callback)
+void DeferredPromise::whenSettledWithResult(Function<void(JSDOMGlobalObject*, bool, JSC::JSValue)>&& callback)
 {
     if (shouldIgnoreRequestToFulfill())
         return;
 
     if (activeDOMObjectsAreSuspended()) {
         scriptExecutionContext()->eventLoop().queueTask(TaskSource::Networking, [this, protectedThis = Ref { *this }, callback = WTF::move(callback)]() mutable {
-            whenSettled(WTF::move(callback));
+            whenSettledWithResult(WTF::move(callback));
         });
         return;
     }

--- a/Source/WebCore/bindings/js/JSDOMPromiseDeferred.h
+++ b/Source/WebCore/bindings/js/JSDOMPromiseDeferred.h
@@ -200,7 +200,14 @@ public:
 
     JSC::JSValue promise() const;
 
-    void whenSettled(Function<void()>&&);
+    void whenSettled(Function<void()>&& callback)
+    {
+        return whenSettledWithResult([callback = WTF::move(callback)](JSDOMGlobalObject*, bool, JSC::JSValue) {
+            callback();
+        });
+    }
+    void whenSettledWithResult(Function<void(JSDOMGlobalObject*, bool, JSC::JSValue)>&&);
+
     bool needsAbort() const { return m_needsAbort; }
 
     void markAsHandled() const


### PR DESCRIPTION
#### be82aa543fa57b2b4b772a437cf39dad54bfff04
<pre>
DOMPromise::whenSettled should provide an easy way to get the promise result
<a href="https://rdar.apple.com/167837259">rdar://167837259</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=305191">https://bugs.webkit.org/show_bug.cgi?id=305191</a>

Reviewed by Chris Dumez.

We introduce DOMPromise::whenSettledWithResult which provides as callback parameters the fulfillment decision and result.
This allows to remove the need to capture the DOMPromise object when calling DOMPromise::whenSettled which can create a ref cycle that gets broken only when context goes away.
We introduce AllPromise in StreamPipeToUtilities to remove the need to capture one promise from the other promise&apos;s callback.

Covered by existing tests.

Canonical link: <a href="https://commits.webkit.org/305443@main">https://commits.webkit.org/305443@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a99b7ea67b29129948783291a263f69b0fb5b1a8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138204 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10569 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49614 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146282 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91179 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1ae9b76d-5d36-4792-a99f-e12c217d8c1c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140078 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11273 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10723 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105718 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77116 "8 flakes 7 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0c9d063a-612e-4d0f-88d1-63f02420e7f0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141150 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8437 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123905 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86565 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/01f15a2a-7924-4f0a-8334-76278a82956e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8031 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5793 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6565 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117442 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42102 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/148992 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10251 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42659 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114123 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10268 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8659 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114462 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29114 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/7989 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120189 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/64988 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10298 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38128 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10029 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73865 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10238 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10089 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->