### PR TITLE
Go from RefPtr to Ref in mediastream Module

### DIFF
--- a/Source/WebCore/Modules/mediastream/MediaDeviceInfo.h
+++ b/Source/WebCore/Modules/mediastream/MediaDeviceInfo.h
@@ -61,8 +61,6 @@ private:
 
 MediaDeviceInfo::Kind toMediaDeviceInfoKind(CaptureDevice::DeviceType);
 
-typedef Vector<RefPtr<MediaDeviceInfo>> MediaDeviceInfoVector;
-
-}
+} // namespace WebCore
 
 #endif

--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
@@ -410,7 +410,7 @@ void PeerConnectionBackend::setLocalDescriptionSucceeded(std::optional<Descripti
                 RefPtr<RTCRtpTransceiver> transceiver;
                 for (auto& item : peerConnection.currentTransceivers()) {
                     if (item->mid() == transceiverState.mid) {
-                        transceiver = item;
+                        transceiver = item.ptr();
                         break;
                     }
                 }
@@ -516,7 +516,7 @@ void PeerConnectionBackend::setRemoteDescriptionSucceeded(std::optional<Descript
                 RefPtr<RTCRtpTransceiver> transceiver;
                 for (auto& item : peerConnection.currentTransceivers()) {
                     if (item->mid() == transceiverState.mid) {
-                        transceiver = item;
+                        transceiver = item.ptr();
                         break;
                     }
                 }

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
@@ -172,7 +172,7 @@ ExceptionOr<void> RTCPeerConnection::removeTrack(RTCRtpSender& sender)
     RTCRtpTransceiver* senderTransceiver = nullptr;
     for (auto& transceiver : m_transceiverSet.list()) {
         if (&sender == &transceiver->sender()) {
-            senderTransceiver = transceiver.get();
+            senderTransceiver = transceiver.ptr();
             shouldAbort = sender.isStopped() || !sender.track();
             break;
         }
@@ -861,7 +861,7 @@ RTCPeerConnectionState RTCPeerConnection::computeConnectionState()
         if (m_sctpTransport && &m_sctpTransport->transport().iceTransport() == iceTransport.ptr())
             return false;
         return std::ranges::all_of(m_transceiverSet.list(), [&iceTransport](auto& transceiver) {
-            return !isIceTransportUsedByTransceiver(iceTransport.get(), *transceiver);
+            return !isIceTransportUsedByTransceiver(iceTransport.get(), transceiver);
         });
     });
 
@@ -915,7 +915,7 @@ RTCIceConnectionState RTCPeerConnection::computeIceConnectionStateFromIceTranspo
         if (m_sctpTransport && &m_sctpTransport->transport().iceTransport() == iceTransport.ptr())
             return false;
         return std::ranges::all_of(m_transceiverSet.list(), [&iceTransport](auto& transceiver) {
-            return !isIceTransportUsedByTransceiver(iceTransport.get(), *transceiver);
+            return !isIceTransportUsedByTransceiver(iceTransport.get(), transceiver);
         });
     });
 
@@ -1083,7 +1083,7 @@ Vector<std::reference_wrapper<RTCRtpReceiver>> RTCPeerConnection::getReceivers()
     return m_transceiverSet.receivers();
 }
 
-const Vector<RefPtr<RTCRtpTransceiver>>& RTCPeerConnection::getTransceivers() const
+const Vector<Ref<RTCRtpTransceiver>>& RTCPeerConnection::getTransceivers() const
 {
     return m_transceiverSet.list();
 }

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
@@ -150,9 +150,9 @@ public:
     // 5.1 RTCPeerConnection extensions
     Vector<std::reference_wrapper<RTCRtpSender>> getSenders() const;
     Vector<std::reference_wrapper<RTCRtpReceiver>> getReceivers() const;
-    const Vector<RefPtr<RTCRtpTransceiver>>& getTransceivers() const;
+    const Vector<Ref<RTCRtpTransceiver>>& getTransceivers() const;
 
-    const Vector<RefPtr<RTCRtpTransceiver>>& currentTransceivers() const { return m_transceiverSet.list(); }
+    const Vector<Ref<RTCRtpTransceiver>>& currentTransceivers() const { return m_transceiverSet.list(); }
 
     ExceptionOr<Ref<RTCRtpSender>> addTrack(Ref<MediaStreamTrack>&&, const FixedVector<std::reference_wrapper<MediaStream>>&);
     ExceptionOr<void> removeTrack(RTCRtpSender&);
@@ -218,7 +218,7 @@ public:
     void clearTransports();
 
 private:
-    RTCPeerConnection(Document&);
+    explicit RTCPeerConnection(Document&);
 
     ExceptionOr<void> initializeWithConfiguration(RTCConfiguration&&);
 
@@ -280,7 +280,6 @@ private:
 
     RTCConfiguration m_configuration;
     WeakPtr<RTCController> m_controller;
-    Vector<RefPtr<RTCCertificate>> m_certificates;
     Vector<RTCDataChannelIdentifier> m_channels;
     bool m_shouldDelayTasks { false };
     Deque<std::pair<Ref<DeferredPromise>, Function<void(Ref<DeferredPromise>&&)>>> m_operations;

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformErrorEvent.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformErrorEvent.h
@@ -36,7 +36,7 @@ class RTCRtpSFrameTransformErrorEvent final : public Event {
 public:
     virtual ~RTCRtpSFrameTransformErrorEvent();
 
-    enum Type { Authentication, KeyID, Syntax };
+    enum class Type : uint8_t { Authentication, KeyID, Syntax };
 
     struct Init : EventInit {
         Type errorType;

--- a/Source/WebCore/Modules/mediastream/RTCRtpSender.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSender.cpp
@@ -217,7 +217,7 @@ std::optional<RTCRtpTransceiverDirection> RTCRtpSender::currentTransceiverDirect
     RTCRtpTransceiver* senderTransceiver = nullptr;
     for (auto& transceiver : m_connection->currentTransceivers()) {
         if (&transceiver->sender() == this) {
-            senderTransceiver = transceiver.get();
+            senderTransceiver = transceiver.ptr();
             break;
         }
     }

--- a/Source/WebCore/Modules/mediastream/RTCRtpTransceiver.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpTransceiver.h
@@ -92,14 +92,14 @@ private:
 
 class RtpTransceiverSet {
 public:
-    const Vector<RefPtr<RTCRtpTransceiver>>& list() const { return m_transceivers; }
+    const Vector<Ref<RTCRtpTransceiver>>& list() const { return m_transceivers; }
     void append(Ref<RTCRtpTransceiver>&&);
 
     Vector<std::reference_wrapper<RTCRtpSender>> senders() const;
     Vector<std::reference_wrapper<RTCRtpReceiver>> receivers() const;
 
 private:
-    Vector<RefPtr<RTCRtpTransceiver>> m_transceivers;
+    Vector<Ref<RTCRtpTransceiver>> m_transceivers;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/RTCStatsReport.h
+++ b/Source/WebCore/Modules/mediastream/RTCStatsReport.h
@@ -407,7 +407,7 @@ public:
     };
     static_assert(!std::is_default_constructible_v<CodecStats>);
 
-    enum DtlsRole {
+    enum class DtlsRole : uint8_t {
         Client,
         Server,
         Unknown

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
@@ -328,7 +328,7 @@ ExceptionOr<Ref<RTCRtpSender>> GStreamerPeerConnectionBackend::addTrack(MediaStr
         RefPtr<RTCRtpTransceiver> transceiver;
         for (const auto& currentTransceiver : protectedPeerConnection()->currentTransceivers()) {
             if (&currentTransceiver->sender() == sender.get()) {
-                transceiver = currentTransceiver;
+                transceiver = currentTransceiver.ptr();
                 break;
             }
         }
@@ -411,8 +411,8 @@ static inline GStreamerRtpTransceiverBackend& backendFromRTPTransceiver(RTCRtpTr
 RefPtr<RTCRtpTransceiver> GStreamerPeerConnectionBackend::existingTransceiver(WTF::Function<bool(GStreamerRtpTransceiverBackend&)>&& matchingFunction)
 {
     for (auto& transceiver : protectedPeerConnection()->currentTransceivers()) {
-        if (matchingFunction(backendFromRTPTransceiver(*transceiver)))
-            return transceiver;
+        if (matchingFunction(backendFromRTPTransceiver(transceiver)))
+            return transceiver.ptr();
     }
     return nullptr;
 }
@@ -489,7 +489,7 @@ void GStreamerPeerConnectionBackend::tearDown()
         if (auto receiverBackend = receiver.backend())
             static_cast<GStreamerRtpReceiverBackend*>(receiverBackend)->tearDown();
 
-        auto& backend = backendFromRTPTransceiver(*transceiver);
+        auto& backend = backendFromRTPTransceiver(transceiver);
         backend.tearDown();
     }
     connection().clearTransports();

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
@@ -308,7 +308,7 @@ std::unique_ptr<RTCDataChannelHandler> LibWebRTCPeerConnectionBackend::createDat
     return m_endpoint->createDataChannel(label, options);
 }
 
-static inline RefPtr<RTCRtpSender> findExistingSender(const Vector<RefPtr<RTCRtpTransceiver>>& transceivers, LibWebRTCRtpSenderBackend& senderBackend)
+static inline RefPtr<RTCRtpSender> findExistingSender(const Vector<Ref<RTCRtpTransceiver>>& transceivers, LibWebRTCRtpSenderBackend& senderBackend)
 {
     ASSERT(senderBackend.rtcSender());
     for (auto& transceiver : transceivers) {
@@ -382,8 +382,8 @@ static inline LibWebRTCRtpTransceiverBackend& backendFromRTPTransceiver(RTCRtpTr
 RefPtr<RTCRtpTransceiver> LibWebRTCPeerConnectionBackend::existingTransceiver(Function<bool(LibWebRTCRtpTransceiverBackend&)>&& matchingFunction)
 {
     for (auto& transceiver : protectedPeerConnection()->currentTransceivers()) {
-        if (matchingFunction(backendFromRTPTransceiver(*transceiver)))
-            return transceiver;
+        if (matchingFunction(backendFromRTPTransceiver(transceiver)))
+            return transceiver.ptr();
     }
     return nullptr;
 }


### PR DESCRIPTION
#### bcee4c1300ed678ffcdad9c0cd2725e0f4c2555b
<pre>
Go from RefPtr to Ref in mediastream Module
<a href="https://bugs.webkit.org/show_bug.cgi?id=305200">https://bugs.webkit.org/show_bug.cgi?id=305200</a>

Reviewed by Charlie Wolfe.

Improves clarity. Also convert some enums to class enums and remove
dead code.

Canonical link: <a href="https://commits.webkit.org/305401@main">https://commits.webkit.org/305401@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f767b690ffbe67d5b6ffaf0071828e81f2d3db6a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138226 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10591 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49636 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146304 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91201 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0857552c-fd0b-4b72-8c15-da0ad42dba12) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140100 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11295 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10745 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105732 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77127 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cee8afe8-9482-4196-953f-ec65a21eea61) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141173 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8453 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123922 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86579 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c41f0a14-ab6e-4c6e-a2e9-5f15ee2f55cc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8047 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5808 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6587 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117458 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42119 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149014 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10273 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42676 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114139 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10290 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8674 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114476 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8010 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120206 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65105 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21299 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10320 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38144 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10051 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73887 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10260 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10111 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->