### PR TITLE
Fix rendering for SVG images without intrinsic dimensions and with object-fit

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/object-fit-dimensionless-svg-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/object-fit-dimensionless-svg-001-expected.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CSS Reference: dimensionless SVG should fill content box</title>
+  <style>
+    img {
+      width: 300px;
+      height: 300px;
+      border: 5px solid purple;
+    }
+  </style>
+</head>
+<body>
+  <img src="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'><rect width='100' height='100' fill='green'/></svg>">
+
+  <img src="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'><rect width='100' height='100' fill='green'/></svg>">
+
+  <img src="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'><rect width='100' height='100' fill='green'/></svg>">
+
+  <img src="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'><rect width='100' height='100' fill='green'/></svg>">
+
+  <img src="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'><rect width='100' height='100' fill='green'/></svg>">
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/object-fit-dimensionless-svg-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/object-fit-dimensionless-svg-001-ref.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CSS Reference: dimensionless SVG should fill content box</title>
+  <style>
+    img {
+      width: 300px;
+      height: 300px;
+      border: 5px solid purple;
+    }
+  </style>
+</head>
+<body>
+  <img src="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'><rect width='100' height='100' fill='green'/></svg>">
+
+  <img src="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'><rect width='100' height='100' fill='green'/></svg>">
+
+  <img src="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'><rect width='100' height='100' fill='green'/></svg>">
+
+  <img src="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'><rect width='100' height='100' fill='green'/></svg>">
+
+  <img src="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'><rect width='100' height='100' fill='green'/></svg>">
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/object-fit-dimensionless-svg-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/object-fit-dimensionless-svg-001.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CSS Test: object-fit on img with dimensionless SVG (no width/height/viewBox)</title>
+  <link rel="help" href="https://drafts.csswg.org/css-images-3/#the-object-fit">
+  <link rel="help" href="https://drafts.csswg.org/css-images-3/#default-sizing">
+  <link rel="match" href="object-fit-dimensionless-svg-001-ref.html">
+  <meta name="assert" content="Dimensionless SVGs (no width/height/viewBox) should fill the content box without object-fit offset, preventing content from being clipped out">
+  <style>
+    img {
+      width: 300px;
+      height: 300px;
+      border: 5px solid purple;
+    }
+  </style>
+</head>
+<body>
+  <img src="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'><rect width='100' height='100' fill='green'/></svg>">
+
+  <img style="object-fit: contain" src="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'><rect width='100' height='100' fill='green'/></svg>">
+
+  <img style="object-fit: cover" src="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'><rect width='100' height='100' fill='green'/></svg>">
+
+  <img style="object-fit: none" src="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'><rect width='100' height='100' fill='green'/></svg>">
+
+  <img style="object-fit: scale-down" src="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'><rect width='100' height='100' fill='green'/></svg>">
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderImage.h
+++ b/Source/WebCore/rendering/RenderImage.h
@@ -136,6 +136,8 @@ private:
 
     void paintAreaElementFocusRing(PaintInfo&, const LayoutPoint& paintOffset);
 
+    bool isDimensionlessSVG() const;
+
     bool hasShadowContent() const { return m_hasShadowControls || m_hasImageOverlay; }
 
     LayoutUnit computeReplacedLogicalWidth(ShouldComputePreferred = ShouldComputePreferred::ComputeActual) const override;

--- a/Source/WebCore/svg/SVGSVGElement.cpp
+++ b/Source/WebCore/svg/SVGSVGElement.cpp
@@ -655,6 +655,13 @@ float SVGSVGElement::intrinsicHeight() const
     return height().value(lengthContext);
 }
 
+bool SVGSVGElement::hasIntrinsicDimensions() const
+{
+    if (hasIntrinsicWidth() && hasIntrinsicHeight())
+        return true;
+    return !currentViewBoxRect().isEmpty();
+}
+
 AffineTransform SVGSVGElement::viewBoxToViewTransform(float viewWidth, float viewHeight) const
 {
     if (!m_useCurrentView || !m_viewSpec) {

--- a/Source/WebCore/svg/SVGSVGElement.h
+++ b/Source/WebCore/svg/SVGSVGElement.h
@@ -105,6 +105,8 @@ public:
     float intrinsicWidth() const;
     float intrinsicHeight() const;
 
+    bool hasIntrinsicDimensions() const;
+
     FloatSize currentViewportSizeExcludingZoom() const;
     FloatRect currentViewBoxRect() const;
 


### PR DESCRIPTION
#### cba51e3392efbcf4fdfa14806e8079cd4d155dd4
<pre>
Fix rendering for SVG images without intrinsic dimensions and with object-fit
<a href="https://bugs.webkit.org/show_bug.cgi?id=305207">https://bugs.webkit.org/show_bug.cgi?id=305207</a>
<a href="https://rdar.apple.com/167848972">rdar://167848972</a>

Reviewed by Simon Fraser.

For SVGs without width, height, or viewBox attributes, object-fit was
causing rects to be clipped out due to the default 300x150 intrinsic size.

We bypass object-fit calculations for dimensionless SVGs by using
contentBoxRect for both container and paint rect. This results
in a correct display.

* LayoutTests/imported/w3c/web-platform-tests/css/css-images/object-fit-dimensionless-svg-001-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/object-fit-dimensionless-svg-001-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/object-fit-dimensionless-svg-001.html: Added.
* Source/WebCore/rendering/RenderImage.cpp:
(WebCore::RenderImage::updateInnerContentRect):
(WebCore::RenderImage::isDimensionlessSVG const):
(WebCore::RenderImage::paintReplaced):
* Source/WebCore/rendering/RenderImage.h:
* Source/WebCore/svg/SVGSVGElement.cpp:
(WebCore::SVGSVGElement::hasIntrinsicDimensions const):
* Source/WebCore/svg/SVGSVGElement.h:

Canonical link: <a href="https://commits.webkit.org/305490@main">https://commits.webkit.org/305490@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74004089b5e8399bbd91aeda7ab82a1ec7af772b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138506 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10871 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49916 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146613 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/91481 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b5953d78-bddf-407d-9fc8-d44fa9eb9e12) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140380 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11575 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11026 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/106000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/91481 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f6d16dae-400d-40af-9253-a529006f4f57) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141453 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8702 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124163 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86863 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c393c520-81f7-4eb5-8c37-59076a63b271) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8288 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6055 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6896 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117709 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42364 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149357 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10553 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42921 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/114380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10570 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8922 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114715 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29153 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8429 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120451 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/65442 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10602 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38382 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10336 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74233 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10540 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10391 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->