### PR TITLE
[MSE] Fix sample DTS to prevent deletion of preexisting samples when PTS doesn't conflict

### DIFF
--- a/LayoutTests/media/media-source/media-source-samples-out-of-order-erase-last-previous-frames-expected.txt
+++ b/LayoutTests/media/media-source/media-source-samples-out-of-order-erase-last-previous-frames-expected.txt
@@ -1,0 +1,23 @@
+
+RUN(video.src = URL.createObjectURL(source))
+EVENT(sourceopen)
+RUN(sourceBuffer = source.addSourceBuffer("video/mock; codecs=mock"))
+First segment has normal, monotonically increasing samples with decode timestamp equal to presentation timestamp.
+RUN(sourceBuffer.appendBuffer(mediaSegment))
+EVENT(updateend)
+EXPECTED (bufferedSamples.length == '4') OK
+{PTS({0/10 = 0.000000}), DTS({0/10 = 0.000000}), duration({10/10 = 1.000000}), flags(1), generation(0)}
+{PTS({10/10 = 1.000000}), DTS({10/10 = 1.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({20/10 = 2.000000}), DTS({20/10 = 2.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({30/10 = 3.000000}), DTS({30/10 = 3.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+Second, segment with overlap in decoding order but no overlap in presentation order shouldn't cause any deletion if decoding order is corrected to avoid conflicts.
+RUN(sourceBuffer.appendBuffer(mediaSegment))
+EVENT(updateend)
+EXPECTED (bufferedSamples.length == '5') OK
+{PTS({0/10 = 0.000000}), DTS({0/10 = 0.000000}), duration({10/10 = 1.000000}), flags(1), generation(0)}
+{PTS({10/10 = 1.000000}), DTS({10/10 = 1.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({20/10 = 2.000000}), DTS({20/10 = 2.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({30/10 = 3.000000}), DTS({30/10 = 3.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({40/10 = 4.000000}), DTS({3000000001/1000000000 = 3.000000}), duration({10/10 = 1.000000}), flags(1), generation(1)}
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-samples-out-of-order-erase-last-previous-frames.html
+++ b/LayoutTests/media/media-source/media-source-samples-out-of-order-erase-last-previous-frames.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-samples-out-of-order-erase-last-previous-frames</title>
+    <script src="mock-media-source.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    var source;
+    var sourceBuffer;
+    var initSegment;
+    var mediaSegment;
+
+    if (window.internals)
+        internals.initializeMockMediaSource();
+
+    window.addEventListener('load', async event => {
+        findMediaElement();
+
+        source = new MediaSource();
+        run('video.src = URL.createObjectURL(source)');
+        await waitFor(source, 'sourceopen');
+
+        run('sourceBuffer = source.addSourceBuffer("video/mock; codecs=mock")');
+        consoleWrite('First segment has normal, monotonically increasing samples with decode timestamp equal to presentation timestamp.');
+        //makeASample(presentationTime, decodeTime, duration, timeScale, trackID, flags, generation)
+        mediaSegment = concatenateSamples([
+            makeAInit(4, [makeATrack(0, 'mock', TRACK_KIND.VIDEO)]),
+            makeASample( 0,  0, 10, 10, 0, SAMPLE_FLAG.SYNC, 0),
+            makeASample(10, 10, 10, 10, 0, SAMPLE_FLAG.NONE, 0),
+            makeASample(20, 20, 10, 10, 0, SAMPLE_FLAG.NONE, 0),
+            makeASample(30, 30, 10, 10, 0, SAMPLE_FLAG.NONE, 0),
+        ]);
+        run('sourceBuffer.appendBuffer(mediaSegment)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        bufferedSamples = await internals.bufferedSamplesForTrackId(sourceBuffer, 0);
+        testExpected("bufferedSamples.length", 4);
+        bufferedSamples.forEach(consoleWrite);
+
+        consoleWrite("Second, segment with overlap in decoding order but no overlap in presentation order shouldn't cause any deletion if decoding order is corrected to avoid conflicts.");
+        mediaSegment = concatenateSamples([
+            makeAInit(1, [makeATrack(0, 'mock', TRACK_KIND.VIDEO)]),
+            makeASample(40, 9, 10, 10, 0, SAMPLE_FLAG.SYNC, 1),
+        ]);
+        run('sourceBuffer.appendBuffer(mediaSegment)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        bufferedSamples = await internals.bufferedSamplesForTrackId(sourceBuffer, 0);
+        testExpected("bufferedSamples.length", 5);
+        bufferedSamples.forEach(consoleWrite);
+
+        endTest();
+    });
+    </script>
+</head>
+<body>
+    <video></video>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -1325,7 +1325,29 @@ bool SourceBufferPrivate::processMediaSample(SourceBufferPrivateClient& client, 
             while (nextSyncSample != trackBuffer.samples().decodeOrder().end() && Ref { nextSyncSample->second }->presentationTime() <= sample->presentationTime())
                 nextSyncSample = trackBuffer.samples().decodeOrder().findSyncSampleAfterDecodeIterator(nextSyncSample);
 
-            INFO_LOG(LOGIDENTIFIER, "Discovered out-of-order frames, from: ", nextSampleInDecodeOrder->second.get(), " to: ", (nextSyncSample == trackBuffer.samples().decodeOrder().end() ? "[end]"_s : toString(nextSyncSample->second.get())));
+
+            // Try to fix the out-of-ordering by placing the decoding timestamp of sample after the decoding timestamp
+            // of the last pre-existing sample, but only if that means that the new decoding timestamp won't be beyond
+            // the decoding timestamp of the next sample (estimated as sample decoding timestamp + sample duration
+            // - 2 * contiguousFrameTolerance).
+            auto lastSampleToErase = (nextSyncSample == trackBuffer.samples().decodeOrder().end())
+                ? trackBuffer.samples().decodeOrder().rbegin()++
+                : trackBuffer.samples().decodeOrder().reverseFindSampleWithDecodeKey(nextSyncSample->first)++;
+            if (lastSampleToErase != trackBuffer.samples().decodeOrder().rend()) {
+                const MediaTime epsilon = MediaTime(1, 1000000000);
+                auto safeDecodeTime = lastSampleToErase->second->decodeTime() + epsilon;
+
+                if (safeDecodeTime > sample->decodeTime()) {
+                    INFO_LOG(LOGIDENTIFIER, "Discovered out-of-order frames, from: ", nextSampleInDecodeOrder->second.get(), " to: ", (nextSyncSample == trackBuffer.samples().decodeOrder().end() ? "[end]"_s : toString(nextSyncSample->second.get())),
+                    ", but fixed the ordering by changing sample DTS from ", sample->decodeTime(), " to ", safeDecodeTime);
+                    sample->setTimestamps(sample->presentationTime(), safeDecodeTime);
+                    break;
+                }
+            }
+
+            INFO_LOG(LOGIDENTIFIER, "Discovered out-of-order frames, from: ", nextSampleInDecodeOrder->second.get(),
+                " to: ", (nextSyncSample == trackBuffer.samples().decodeOrder().end() ? "[end]"_s : toString(nextSyncSample->second.get())),
+                "erasing them");
             erasedSamples.addRange(nextSampleInDecodeOrder, nextSyncSample);
         } while (false);
 


### PR DESCRIPTION
#### 52d9299455a3bc8ad61035abe8771fc1b2399854
<pre>
[MSE] Fix sample DTS to prevent deletion of preexisting samples when PTS doesn&apos;t conflict
<a href="https://bugs.webkit.org/show_bug.cgi?id=305208">https://bugs.webkit.org/show_bug.cgi?id=305208</a>

Reviewed by NOBODY (OOPS!).

Let&apos;s consider a preexisting samples A, B, C, and a new sample N with the
following timestamps:

       Decoding time  Presentation time
       -------------  -----------------
Sample A: 827.826164000  827.826164000
Sample B: 827.826164100  827.826164100
Sample C: 827.826164200  827.826164200
Sample N: 827.826125000  827.909542000

These disparities in DTS vs. PTS offsets between samples A and B exist
because both samples come from completely different videos (eg: because
of ad insertion).

In a timeline:

DTS ···NABC·······
PTS ····ABC···N···

Judging by PTS, the samples A, B, C should remain and theoretically don&apos;t
need to be erased. However, considering DTS, the samples A, B, C have to
be erased, because the sample N would reach the video decoder earlier (by
decoding ordering) and change the state of the decoder, making it
unsuitable for samples A, B, C.

This commit tries to fix the situation by changing sample N (the new
sample) DTS to a value slightly higher than sample C DTS (that is, DTS plus
epsilon, a small value), like this:

       Decoding time  Presentation time
       -------------  -----------------
Sample A:  827.826164000  827.826164000
Sample B:  827.826164100  827.826164100
Sample C:  827.826164200  827.826164200
Sample N: *827.826164201* 827.909542000

DTS ····ABCN······
PTS ····ABC···N···

This fix avoids the deletion of samples A, B, C and the potential
problems associated with that.

A layout test has been added to show the problem and prove that the fix
solves it.

* LayoutTests/media/media-source/media-source-samples-out-of-order-erase-last-previous-frames-expected.txt: Added.
* LayoutTests/media/media-source/media-source-samples-out-of-order-erase-last-previous-frames.html: Added.
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::processMediaSample): If a new sync sample is being added and there are next samples in decode order with PTS lower than the one of the new sample, fix the DTS of the new sample by assigning it to have a safeDecodeTime (the DTS of the highest (by DTS order) preexisting sample, plus epsilon), but only if that DTS wouldn&apos;t be higher than the DTS of the next sample that should come after the new sample being added (estimated as sample.decodeTime() + 2*duration, and keeping a safety margin).
</pre>