### PR TITLE
[EvaluationTimeZoom] Convert `scroll-margin-*` properties to evaluation time zoom

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/scroll-margin-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/scroll-margin-ref.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group { 
+  display: inline-block;
+  border: solid black 1px;
+  padding: 10px;
+}
+
+#container {
+  display: inline-block;
+  width: 200px;
+  height: 100px;
+  overflow-x: hidden;
+  overflow-y: scroll;
+  padding: 40px 0;
+  margin: auto;
+  scroll-snap-type: y mandatory;
+}
+
+.buffer {
+  scroll-snap-align: start;
+  background-color: lightblue;
+  height: 300px;
+  width: 200px;
+}
+
+.target {
+  scroll-snap-align: start;
+  background-color: black;
+  height: 10px;
+  width: 200px;
+}
+.target-zoomed {
+  scroll-snap-align: start;
+  background-color: black;
+  height: 20px;
+  width: 400px;
+}
+</style>
+</head>
+<body>
+<p>The black bars should line up in each group</p> 
+<div class="group">
+  <div id="container">
+    <div class="buffer"></div>
+    <div class="target" style="scroll-margin-top: 20px;"></div>
+    <div class="buffer"></div>
+  </div>
+
+  <div id="container">
+    <div class="buffer"></div>
+    <div class="target" style="scroll-margin-top: 20px;"></div>
+    <div class="buffer"></div>
+  </div>
+</div>
+<div class="group">
+  <div id="container">
+    <div class="buffer"></div>
+    <div class="target-zoomed" style="scroll-margin-top: 40px;"></div>
+    <div class="buffer"></div>
+  </div>
+
+  <div id="container">
+    <div class="buffer"></div>
+    <div class="target-zoomed" style="scroll-margin-top: 40px;"></div>
+    <div class="buffer"></div>
+  </div>
+</div>
+<script>
+  for (match of document.querySelectorAll(".target, .target-zoomed")) {
+    match.scrollIntoView();
+  }
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/scroll-margin-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/scroll-margin-expected.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group { 
+  display: inline-block;
+  border: solid black 1px;
+  padding: 10px;
+}
+
+#container {
+  display: inline-block;
+  width: 200px;
+  height: 100px;
+  overflow-x: hidden;
+  overflow-y: scroll;
+  padding: 40px 0;
+  margin: auto;
+  scroll-snap-type: y mandatory;
+}
+
+.buffer {
+  scroll-snap-align: start;
+  background-color: lightblue;
+  height: 300px;
+  width: 200px;
+}
+
+.target {
+  scroll-snap-align: start;
+  background-color: black;
+  height: 10px;
+  width: 200px;
+}
+.target-zoomed {
+  scroll-snap-align: start;
+  background-color: black;
+  height: 20px;
+  width: 400px;
+}
+</style>
+</head>
+<body>
+<p>The black bars should line up in each group</p> 
+<div class="group">
+  <div id="container">
+    <div class="buffer"></div>
+    <div class="target" style="scroll-margin-top: 20px;"></div>
+    <div class="buffer"></div>
+  </div>
+
+  <div id="container">
+    <div class="buffer"></div>
+    <div class="target" style="scroll-margin-top: 20px;"></div>
+    <div class="buffer"></div>
+  </div>
+</div>
+<div class="group">
+  <div id="container">
+    <div class="buffer"></div>
+    <div class="target-zoomed" style="scroll-margin-top: 40px;"></div>
+    <div class="buffer"></div>
+  </div>
+
+  <div id="container">
+    <div class="buffer"></div>
+    <div class="target-zoomed" style="scroll-margin-top: 40px;"></div>
+    <div class="buffer"></div>
+  </div>
+</div>
+<script>
+  for (match of document.querySelectorAll(".target, .target-zoomed")) {
+    match.scrollIntoView();
+  }
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/scroll-margin.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/scroll-margin.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Zoom applies to scroll-margin</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<link rel="match" href="reference/scroll-margin-ref.html">
+<style>
+.group { 
+  display: inline-block;
+  border: solid black 1px;
+  padding: 10px;
+}
+
+#container {
+  display: inline-block;
+  width: 200px;
+  height: 100px;
+  overflow-x: hidden;
+  overflow-y: scroll;
+  padding: 40px 0;
+  margin: auto;
+  scroll-snap-type: y mandatory;
+}
+
+.buffer {
+  scroll-snap-align: start;
+  background-color: lightblue;
+  height: 300px;
+  width: 200px;
+}
+
+.target {
+  scroll-snap-align: start;
+  background-color: black;
+  height: 10px;
+  width: 200px;
+}
+</style>
+</head>
+<body>
+<p>The black bars should line up in each group</p> 
+<div class="group">
+  <div id="container">
+    <div class="buffer"></div>
+    <div class="target" style="scroll-margin-top: 20px; zoom 1;"></div>
+    <div class="buffer"></div>
+  </div>
+
+  <div id="container" style="scroll-margin-top: 20px;">
+    <div class="buffer"></div>
+    <div class="target" style="scroll-margin-top: inherit; zoom: 1;"></div>
+    <div class="buffer"></div>
+  </div>
+</div>
+<div class="group">
+  <div id="container">
+    <div class="buffer"></div>
+    <div class="target" style="scroll-margin-top: 20px; zoom: 2;"></div>
+    <div class="buffer"></div>
+  </div>
+
+  <div id="container" style="scroll-margin-top: 20px;">
+    <div class="buffer"></div>
+    <div class="target" style="scroll-margin-top: inherit; zoom: 2;"></div>
+    <div class="buffer"></div>
+  </div>
+</div>
+<script>
+  for (match of document.querySelectorAll(".target")) {
+    match.scrollIntoView();
+  }
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-computed-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-computed-style-expected.txt
@@ -49,6 +49,10 @@ PASS Property padding value '20px 40px 60px 80px' no zoom
 PASS Property padding value 'inherit' no zoom
 PASS Property padding value '20px 40px 60px 80px' zoom: 2
 PASS Property padding value 'inherit' zoom: 2
+PASS Property scroll-margin value '20px 40px 60px 80px' no zoom
+PASS Property scroll-margin value 'inherit' no zoom
+PASS Property scroll-margin value '20px 40px 60px 80px' zoom: 2
+PASS Property scroll-margin value 'inherit' zoom: 2
 PASS Property text-decoration-thickness value '4px' no zoom
 PASS Property text-decoration-thickness value 'inherit' no zoom
 PASS Property text-decoration-thickness value '4px' zoom: 2

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-computed-style.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-computed-style.html
@@ -64,6 +64,10 @@
       "value": "10px 20px 30px 40px",
       "otherValues": ["20px 40px 60px 80px"]
     },
+    "scroll-margin" : {
+      "value": "10px 20px 30px 40px",
+      "otherValues": ["20px 40px 60px 80px"]
+    },
     "text-decoration-thickness": {
       "value": "2px",
       "otherValues": ["4px"]

--- a/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp
+++ b/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2014-2022 Apple Inc. All rights reserved.
  * Copyright (C) 2020 Igalia S.L.
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -257,10 +258,10 @@ static LayoutRect computeScrollSnapPortRect(const Style::ScrollPaddingBox& paddi
     return result;
 }
 
-static LayoutRect computeScrollSnapAreaRect(const Style::ScrollMarginBox& margin, const LayoutRect& rect)
+static LayoutRect computeScrollSnapAreaRect(const RenderStyle& style, const LayoutRect& rect)
 {
     auto result = rect;
-    result.expand(Style::extentForRect(margin, rect));
+    result.expand(Style::extentForRect(style.scrollMarginBox(), rect, style.usedZoomForLength()));
     return result;
 }
 
@@ -358,7 +359,7 @@ void updateSnapOffsetsForScrollableArea(ScrollableArea& scrollableArea, const Re
         if (!scrollableArea.isScrollView())
             scrollSnapArea.moveBy(scrollPosition);
 
-        scrollSnapArea = computeScrollSnapAreaRect(child.style().scrollMarginBox(), scrollSnapArea);
+        scrollSnapArea = computeScrollSnapAreaRect(child.style(), scrollSnapArea);
         LOG_WITH_STREAM(ScrollSnap, stream << "    Considering scroll snap target area " << scrollSnapArea << " scroll snap id: " << child.element()->nodeIdentifier() << " element: " << *child.element());
         auto alignment = child.style().scrollSnapAlign();
         auto stop = child.style().scrollSnapStop();

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2005 Allan Sandfeld Jensen (kde@carewolf.com)
- *           (C) 2005, 2006 Samuel Weinig (sam.weinig@gmail.com)
+ * Copyright (C) 2005-2026 Samuel Weinig (sam@webkit.org)
  * Copyright (C) 2005-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2010-2018 Google Inc. All rights reserved.
  *
@@ -2109,7 +2109,7 @@ MarginRect RenderElement::absoluteAnchorRectWithScrollMargin(bool* insideFixed) 
     // box of the transformed border box of the target element.
     // See https://www.w3.org/TR/css-scroll-snap-1/#scroll-margin.
     auto marginRect = anchorRect;
-    marginRect.expand(Style::extentForRect(scrollMarginBox, anchorRect));
+    marginRect.expand(Style::extentForRect(scrollMarginBox, anchorRect, style().usedZoomForLength()));
     return { marginRect, anchorRect };
 }
 

--- a/Source/WebCore/style/values/scroll-snap/StyleScrollMargin.cpp
+++ b/Source/WebCore/style/values/scroll-snap/StyleScrollMargin.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2025-2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,10 +26,8 @@
 #include "StyleScrollMargin.h"
 
 #include "LayoutRect.h"
-#include "StyleBuilderState.h"
 #include "StylePrimitiveNumericTypes+CSSValueConversion.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
-#include <wtf/text/TextStream.h>
 
 namespace WebCore {
 namespace Style {
@@ -38,40 +36,40 @@ namespace Style {
 
 auto CSSValueConversion<ScrollMarginEdge>::operator()(BuilderState& state, const CSSValue& value) -> ScrollMarginEdge
 {
-    return ScrollMarginEdge { toStyleFromCSSValue<Length<>>(state, value) };
+    return ScrollMarginEdge { toStyleFromCSSValue<ScrollMarginEdge::Fixed>(state, value) };
 }
 
 // MARK: - Evaluation
 
-auto Evaluation<ScrollMarginEdge, LayoutUnit>::operator()(const ScrollMarginEdge& edge, LayoutUnit, ZoomNeeded token) -> LayoutUnit
+auto Evaluation<ScrollMarginEdge, LayoutUnit>::operator()(const ScrollMarginEdge& edge, LayoutUnit, ZoomFactor zoom) -> LayoutUnit
 {
-    return evaluate<LayoutUnit>(edge.m_value, token);
+    return evaluate<LayoutUnit>(edge.m_value, zoom);
 }
 
-auto Evaluation<ScrollMarginEdge, LayoutUnit>::operator()(const ScrollMarginEdge& edge, ZoomNeeded token) -> LayoutUnit
+auto Evaluation<ScrollMarginEdge, LayoutUnit>::operator()(const ScrollMarginEdge& edge, ZoomFactor zoom) -> LayoutUnit
 {
-    return evaluate<LayoutUnit>(edge.m_value, token);
+    return evaluate<LayoutUnit>(edge.m_value, zoom);
 }
 
-auto Evaluation<ScrollMarginEdge, float>::operator()(const ScrollMarginEdge& edge, float, ZoomNeeded token) -> float
+auto Evaluation<ScrollMarginEdge, float>::operator()(const ScrollMarginEdge& edge, float, ZoomFactor zoom) -> float
 {
-    return evaluate<float>(edge.m_value, token);
+    return evaluate<float>(edge.m_value, zoom);
 }
 
-auto Evaluation<ScrollMarginEdge, float>::operator()(const ScrollMarginEdge& edge, ZoomNeeded token) -> float
+auto Evaluation<ScrollMarginEdge, float>::operator()(const ScrollMarginEdge& edge, ZoomFactor zoom) -> float
 {
-    return evaluate<float>(edge.m_value, token);
+    return evaluate<float>(edge.m_value, zoom);
 }
 
 // MARK: - Extent
 
-LayoutBoxExtent extentForRect(const ScrollMarginBox& margin, const LayoutRect& rect)
+LayoutBoxExtent extentForRect(const ScrollMarginBox& margin, const LayoutRect& rect, ZoomFactor zoom)
 {
     return LayoutBoxExtent {
-        evaluate<LayoutUnit>(margin.top(), rect.height(), ZoomNeeded { }),
-        evaluate<LayoutUnit>(margin.right(), rect.width(), ZoomNeeded { }),
-        evaluate<LayoutUnit>(margin.bottom(), rect.height(), ZoomNeeded { }),
-        evaluate<LayoutUnit>(margin.left(), rect.width(), ZoomNeeded { }),
+        evaluate<LayoutUnit>(margin.top(), rect.height(), zoom),
+        evaluate<LayoutUnit>(margin.right(), rect.width(), zoom),
+        evaluate<LayoutUnit>(margin.bottom(), rect.height(), zoom),
+        evaluate<LayoutUnit>(margin.left(), rect.width(), zoom),
     };
 }
 

--- a/Source/WebCore/style/values/scroll-snap/StyleScrollMargin.h
+++ b/Source/WebCore/style/values/scroll-snap/StyleScrollMargin.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2025-2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -38,7 +38,7 @@ namespace Style {
 // <'scroll-margin-*'> = <length>
 // https://drafts.csswg.org/css-scroll-snap-1/#margin-longhands-physical
 struct ScrollMarginEdge {
-    using Fixed = Length<>;
+    using Fixed = Length<CSS::AllUnzoomed>;
 
     ScrollMarginEdge(Fixed&& fixed) : m_value(fixed) { }
     ScrollMarginEdge(const Fixed& fixed) : m_value(fixed) { }
@@ -62,7 +62,7 @@ private:
     friend struct Evaluation<ScrollMarginEdge, LayoutUnit>;
     friend struct Evaluation<ScrollMarginEdge, float>;
 
-    Length<> m_value;
+    Fixed m_value;
 };
 
 // <'scroll-margin'> = <length>{1,4}
@@ -76,17 +76,17 @@ template<> struct CSSValueConversion<ScrollMarginEdge> { auto operator()(Builder
 // MARK: - Evaluation
 
 template<> struct Evaluation<ScrollMarginEdge, LayoutUnit> {
-    auto operator()(const ScrollMarginEdge&, LayoutUnit referenceLength, ZoomNeeded) -> LayoutUnit;
-    auto operator()(const ScrollMarginEdge&, ZoomNeeded) -> LayoutUnit;
+    auto operator()(const ScrollMarginEdge&, LayoutUnit referenceLength, ZoomFactor) -> LayoutUnit;
+    auto operator()(const ScrollMarginEdge&, ZoomFactor) -> LayoutUnit;
 };
 template<> struct Evaluation<ScrollMarginEdge, float> {
-    auto operator()(const ScrollMarginEdge&, float referenceLength, ZoomNeeded) -> float;
-    auto operator()(const ScrollMarginEdge&, ZoomNeeded) -> float;
+    auto operator()(const ScrollMarginEdge&, float referenceLength, ZoomFactor) -> float;
+    auto operator()(const ScrollMarginEdge&, ZoomFactor) -> float;
 };
 
 // MARK: - Extent
 
-LayoutBoxExtent extentForRect(const ScrollMarginBox&, const LayoutRect&);
+LayoutBoxExtent extentForRect(const ScrollMarginBox&, const LayoutRect&, ZoomFactor);
 
 } // namespace Style
 } // namespace WebCore


### PR DESCRIPTION
#### ac50a7521ca9371c4c481c12593d669ec9398b8b
<pre>
[EvaluationTimeZoom] Convert `scroll-margin-*` properties to evaluation time zoom
<a href="https://bugs.webkit.org/show_bug.cgi?id=305213">https://bugs.webkit.org/show_bug.cgi?id=305213</a>

Reviewed by Darin Adler.

Implement support for evaluation time zoom for the `scroll-margin-*` properties.
The progression is evident in the new `scroll-margin.html` test as inherited
values are now correctly zoomed.

Tests: imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/scroll-margin-ref.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/scroll-margin.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/scroll-margin-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/scroll-margin-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/scroll-margin.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-computed-style-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-computed-style.html:
* Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp:
* Source/WebCore/rendering/RenderElement.cpp:
* Source/WebCore/style/values/scroll-snap/StyleScrollMargin.cpp:
* Source/WebCore/style/values/scroll-snap/StyleScrollMargin.h:

Canonical link: <a href="https://commits.webkit.org/305390@main">https://commits.webkit.org/305390@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97062873f66620d5b15dbd95ee02376ef2f1c6ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138244 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10609 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49654 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146323 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91219 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140118 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11313 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10763 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105751 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/77140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141191 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8474 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123936 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86598 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8066 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5826 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6605 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117478 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42134 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149032 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10291 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42691 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114158 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10308 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8694 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114498 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29089 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8033 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120221 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/65114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10338 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38158 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10069 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73905 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10278 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10129 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->