### PR TITLE
REGRESSION (296844@main): filter region fails to cover transformed children of the filtered element

### DIFF
--- a/LayoutTests/compositing/filters/filter-region-translated-child-expected.html
+++ b/LayoutTests/compositing/filters/filter-region-translated-child-expected.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+.container {
+    position: relative;
+    width: 300px;
+    height: 100px;
+}
+
+.box1 {
+    will-change: transform;
+    background: thistle;
+    filter: invert(1);
+    width: 150px;
+    height: 100px;
+    position: absolute;
+    left: 0;
+    top: 0;
+}
+
+.box2 {
+    will-change: transform;
+    background: blueviolet;
+    filter: invert(1);
+    width: 150px;
+    height: 100px;
+    position: absolute;
+    left: 150px;
+    top: 0;
+}
+</style>
+</head>
+<body>
+<div class="container">
+    <div class="box1"></div>
+    <div class="box2"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/compositing/filters/filter-region-translated-child.html
+++ b/LayoutTests/compositing/filters/filter-region-translated-child.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Filter region should include the child when the child translates. There should be two boxes side by side that have been filtered.</title>
+<style>
+.test {
+    display: grid;
+    background: thistle;
+    filter: invert(1);
+    width: 150px;
+    height: 100px;
+}
+
+.test::after {
+    translate: 100%;
+    background: blueviolet;
+    content: '';
+    width: 150px;
+    height: 100px;
+}
+</style>
+</head>
+<body>
+
+<div class="test"></div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -538,6 +538,8 @@ public:
     LayoutRect visualOverflowRectForPropagation(const WritingMode) const;
     LayoutRect logicalLayoutOverflowRectForPropagation(const WritingMode) const;
     LayoutRect layoutOverflowRectForPropagation(const WritingMode) const;
+    LayoutRect applyPaintGeometryTransformToRect(LayoutRect) const;
+    LayoutRect convertRectToParentWritingMode(LayoutRect, const WritingMode parentWritingMode) const;
 
     bool hasRenderOverflow() const { return !!m_overflow; }
     bool hasVisualOverflow() const { return m_overflow && !borderBoxRect().contains(m_overflow->visualOverflowRect()); }


### PR DESCRIPTION
#### 0cb4b26572e403b8b116c5e63d5cf2f15ebac897
<pre>
REGRESSION (296844@main): filter region fails to cover transformed children of the filtered element
<a href="https://bugs.webkit.org/show_bug.cgi?id=305032">https://bugs.webkit.org/show_bug.cgi?id=305032</a>
<a href="https://rdar.apple.com/167671935">rdar://167671935</a>

Reviewed by Simon Fraser.

If a parent element has a filter applied and contains a child element
with transforms or relative positioning, the filter region calculated
by the parent may not include the child&apos;s transformed position. If the
filter region is not included, then this causes incorrect visual
results where the filter is only applied onto the parent but not the
child (ex: a gaussian blur is only on the parent element but not on
the child element).

Fix this by modifying addOverflowWithRendererOffset() to include
children with self-painting layers in the parent&apos;s visual overflow
calculation when the parent has a filter. Previously, we assumed that
if a child has its own painting layer, the parent does not need to
track the child&apos;s visual overflow. However, this assumption is
incorrect when the parent has a filter, because the filter effect
requires accurate bounds that include all visual children regardless
of their layer status.

Additionally, fix visualOverflowRectForPropagation() to correctly
compute the visual overflow rectangle when the child element has CSS
transforms or relative positioning. The overflow rectangle must be
converted from the child&apos;s local coordinate space to the parent&apos;s
coordinate space.

Test: compositing/filters/filter-region-translated-child.html

* LayoutTests/compositing/filters/filter-region-translated-child-expected.html: Added.
* LayoutTests/compositing/filters/filter-region-translated-child.html: Added.
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::addOverflowWithRendererOffset):
(WebCore::RenderBox::applyPaintGeometryTransformToRect const):
(WebCore::RenderBox::convertRectToParentWritingMode const):
(WebCore::RenderBox::visualOverflowRectForPropagation const):
(WebCore::RenderBox::layoutOverflowRectForPropagation const):
* Source/WebCore/rendering/RenderBox.h:

Canonical link: <a href="https://commits.webkit.org/305393@main">https://commits.webkit.org/305393@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a096b91df0c97ff21ba299ce4cfacea39e9cc3b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138262 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10627 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49672 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146342 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91237 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/11ec5b11-a6d2-424f-8cc0-823f23970a43) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140136 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11331 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10781 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105769 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/77148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/28a22cc1-836c-4c18-b4f3-4fd6ae3c5524) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141209 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8492 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123948 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86616 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/1145afbf-6430-4466-a77d-dc234d1ec78b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8082 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5841 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6623 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117495 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42149 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149051 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10309 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42706 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114173 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10326 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8712 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114515 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29090 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8049 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120236 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/65132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10356 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38170 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10087 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73923 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10296 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10147 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->