### PR TITLE
[webkitscmpy] Add unit tests for Git.branches_for

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
@@ -1408,7 +1408,7 @@ class Git(Scm):
         return output.stdout.rstrip().splitlines()
 
     def remote_for(self, argument):
-        candidates = self.source_remotes()
+        candidates = list(self.source_remotes())
         while candidates:
             if argument not in self.branches_for(remote=candidates[-1]):
                 candidates.remove(candidates[-1])

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/track_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/track_unittest.py
@@ -68,8 +68,16 @@ class TestTrack(testing.PathTestCase):
             'security': 'git@github.example.com:WebKit/WebKit-security.git',
             'security-fork': 'git@github.example.com:Contributor/WebKit-security.git',
         }) as mocked, mocks.local.Svn(), MockTime, Terminal.override_atty(sys.stdin, isatty=False):
-            mocked.remotes['security/hidden-branch'] = [mocked.commits[mocked.branch][-1]]
-            mocked.remotes['security-fork/hidden-branch'] = [mocked.commits[mocked.branch][-1]]
+            secret_commit = Commit(
+                hash='7da1053cf88b52d3768dedea733c023fcf0b6cff',
+                author={'name': 'Jonathan Bedard', 'emails': ['jbedard@apple.com']},
+                timestamp=1601669000,
+                branch='hidden-branch',
+                message='Secret commit\n',
+                identifier='1@hidden-branch',
+            )
+            mocked.remotes['security/hidden-branch'] = [mocked.commits[mocked.branch][-1], secret_commit]
+            mocked.remotes['security-fork/hidden-branch'] = [mocked.commits[mocked.branch][-1], secret_commit]
 
             project_config = os.path.join(self.path, 'metadata', local.Git.GIT_CONFIG_EXTENSION)
             os.mkdir(os.path.dirname(project_config))


### PR DESCRIPTION
#### bb7321c89b8c945490a86f2f728de8eb637d2306
<pre>
[webkitscmpy] Add unit tests for Git.branches_for
<a href="https://bugs.webkit.org/show_bug.cgi?id=305167">https://bugs.webkit.org/show_bug.cgi?id=305167</a>

Reviewed by Darin Adler.

This adds tests, and fixes various bugs in our mocks.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py:
(Git.remote_for): Avoid mutating the cached `self.source_remotes()` list.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py:
(Git.__init__): Adopt the below API change.
(Git.branches_on): Change this from taking a hash (which might match
                   nothing) to a commit, thereby forcing callers to deal
                   with ensuring a commit matches. Then, rewrite the
                   entire method to the simplest and most obvious
                   definition, as being correct is more important than
                   being fast.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py:
(TestGit.test_branches_for): The actual tests.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/track_unittest.py:
(TestTrack.test_branch): Fix this to have a novel commit only on the
                         security remotes, now Git.branches_on correctly
                         determines the canonical remote of 5@main is
                         origin.

Canonical link: <a href="https://commits.webkit.org/305386@main">https://commits.webkit.org/305386@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a8404589171a555cd2cdb5f4b022de627441746b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138286 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10651 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49696 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146366 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/91261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140160 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11355 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10805 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/105796 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/91261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141233 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8510 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/123972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/86641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/137634 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/8098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/5862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6650 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/117513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/42173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149077 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10333 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/42730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/114198 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/137712 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10350 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/8734 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/114544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8073 "Passed tests") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/120260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/65156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21293 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10380 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/38193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10111 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10320 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10171 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->