### PR TITLE
Fix outstanding smart pointer warnings

### DIFF
--- a/Source/WebCore/bindings/js/JSFontFaceSetLoadEventCustom.cpp
+++ b/Source/WebCore/bindings/js/JSFontFaceSetLoadEventCustom.cpp
@@ -35,7 +35,8 @@ namespace WebCore {
 template<typename Visitor>
 void JSFontFaceSetLoadEvent::visitAdditionalChildren(Visitor& visitor)
 {
-    for (auto& face : wrapped().fontfaces())
+    // Can't use Ref/RefPtr here since this function may run concurrently while the main thread is running.
+    SUPPRESS_UNCOUNTED_ARG for (auto& face : wrapped().fontfaces())
         addWebCoreOpaqueRoot(visitor, face.get());
 }
 

--- a/Source/WebCore/inspector/PageInspectorController.cpp
+++ b/Source/WebCore/inspector/PageInspectorController.cpp
@@ -330,7 +330,7 @@ void PageInspectorController::show()
 
 void PageInspectorController::evaluateForTestInFrontend(const String& script)
 {
-    ensureInspectorAgent().evaluateForTestInFrontend(script);
+    CheckedRef { ensureInspectorAgent() }->evaluateForTestInFrontend(script);
 }
 
 void PageInspectorController::drawHighlight(GraphicsContext& context) const

--- a/Source/WebCore/page/PageOverlayController.cpp
+++ b/Source/WebCore/page/PageOverlayController.cpp
@@ -78,7 +78,7 @@ void PageOverlayController::installedPageOverlaysChanged()
     else
         detachViewOverlayLayers();
 
-    if (RefPtr localMainFrame = m_page->localMainFrame()) {
+    if (RefPtr localMainFrame = protectedPage()->localMainFrame()) {
         if (RefPtr frameView = localMainFrame->view())
             frameView->setNeedsCompositingConfigurationUpdate();
     }
@@ -224,7 +224,7 @@ void PageOverlayController::installPageOverlay(PageOverlay& overlay, PageOverlay
 
     overlay.setPage(protectedPage().ptr());
 
-    if (RefPtr localMainFrame = m_page->localMainFrame()) {
+    if (RefPtr localMainFrame = protectedPage()->localMainFrame()) {
         if (RefPtr frameView = localMainFrame->view())
             frameView->enterCompositingMode();
     }

--- a/Source/WebCore/rendering/style/StyleFilterImage.cpp
+++ b/Source/WebCore/rendering/style/StyleFilterImage.cpp
@@ -142,7 +142,7 @@ RefPtr<Image> StyleFilterImage::image(const RenderElement* renderElement, const 
             .referenceBox = sourceImageRect,
             .filterRegion = sourceImageRect,
             .scale = { 1, 1 },
-        }, preferredFilterRenderingModes, renderer->settings().showDebugBorders(), NullGraphicsContext());
+        }, preferredFilterRenderingModes, Ref { renderer->settings() }->showDebugBorders(), NullGraphicsContext());
     if (!cssFilter)
         return &Image::nullImage();
 

--- a/Source/WebKitLegacy/Storage/StorageAreaSync.h
+++ b/Source/WebKitLegacy/Storage/StorageAreaSync.h
@@ -68,7 +68,7 @@ private:
     RefPtr<WebCore::StorageSyncManager> m_syncManager;
 
     // The database handle will only ever be opened and used on the background thread.
-    UniqueRef<WebCore::SQLiteDatabase> m_database;
+    const UniqueRef<WebCore::SQLiteDatabase> m_database;
 
     // The following members are subject to thread synchronization issues.
 public:


### PR DESCRIPTION
#### 6a25e9bef4239551d1a895abe03d3e6d2bef6571
<pre>
Fix outstanding smart pointer warnings
<a href="https://bugs.webkit.org/show_bug.cgi?id=305220">https://bugs.webkit.org/show_bug.cgi?id=305220</a>

Reviewed by Geoffrey Garen.

Fix the outstanding unexpected smart pointer clang static analyzer warnings.

No new tests since there should be no behavioral changes.

* Source/WebCore/bindings/js/JSFontFaceSetLoadEventCustom.cpp:
(WebCore::JSFontFaceSetLoadEvent::visitAdditionalChildren):
* Source/WebCore/inspector/PageInspectorController.cpp:
(WebCore::PageInspectorController::evaluateForTestInFrontend):
* Source/WebCore/page/PageOverlayController.cpp:
(WebCore::PageOverlayController::installedPageOverlaysChanged):
(WebCore::PageOverlayController::installPageOverlay):
* Source/WebCore/rendering/style/StyleFilterImage.cpp:
(WebCore::StyleFilterImage::image const):
* Source/WebKitLegacy/Storage/StorageAreaSync.h:

Canonical link: <a href="https://commits.webkit.org/305379@main">https://commits.webkit.org/305379@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d77de358ce61dbb96d9ae676628b7745f34c9d9b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138268 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10633 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49678 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146348 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91243 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/ba9b0cfa-8ea3-4582-a830-a8633d2af599) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140142 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11337 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10787 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/105780 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/77153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/89d9d260-9f4e-41da-85e6-29da020a73bf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141215 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8491 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/123953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86624 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/af6b2ead-1dc5-45f4-b4ca-3aca54122289) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/8081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/5846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6629 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117494 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42153 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149060 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10315 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42710 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/114177 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10332 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/8717 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/114519 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29083 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8054 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120240 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/65138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10362 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/38174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10093 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/73929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10302 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10153 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->