### PR TITLE
SaferCPP: Fix a large batch of uncounted local variables warnings

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1382,6 +1382,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/ElementIterator.h
     dom/ElementIteratorAssertions.h
     dom/ElementIteratorInlines.h
+    dom/ElementRareData.h
     dom/ElementTraversal.h
     dom/EpochTimeStamp.h
     dom/Event.h

--- a/Source/WebCore/Modules/mediasession/MediaSession.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaSession.cpp
@@ -161,7 +161,7 @@ MediaSession::MediaSession(Navigator& navigator)
 
 #if ENABLE(MEDIA_SESSION_COORDINATOR)
     RefPtr frame = navigator.frame();
-    auto* page = frame ? frame->page() : nullptr;
+    RefPtr page = frame ? frame->page() : nullptr;
     if (page && page->mediaSessionCoordinator())
         m_coordinator->setMediaSessionCoordinatorPrivate(*page->mediaSessionCoordinator());
     m_coordinator->setMediaSession(this);

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -425,7 +425,7 @@ void HTMLModelElement::didUpdateBoundingBox(ModelPlayer&, const FloatPoint3D& ce
 
 RefPtr<GraphicsLayer> HTMLModelElement::graphicsLayer() const
 {
-    auto* page = document().page();
+    RefPtr page = document().page();
     if (!page)
         return nullptr;
 
@@ -460,7 +460,7 @@ void HTMLModelElement::logWarning(ModelPlayer& modelPlayer, const String& warnin
 
 void HTMLModelElement::modelDidChange()
 {
-    auto* page = document().page();
+    RefPtr page = document().page();
     if (!page) {
         if (!m_readyPromise->isFulfilled())
             m_readyPromise->reject(Exception { ExceptionCode::AbortError });

--- a/Source/WebCore/Modules/webdatabase/DatabaseManager.cpp
+++ b/Source/WebCore/Modules/webdatabase/DatabaseManager.cpp
@@ -235,7 +235,7 @@ bool DatabaseManager::hasOpenDatabases(Document& document)
 
 void DatabaseManager::stopDatabases(Document& document, DatabaseTaskSynchronizer* synchronizer)
 {
-    auto databaseContext = document.databaseContext();
+    RefPtr databaseContext = document.databaseContext();
     if (!databaseContext || !databaseContext->stopDatabases(synchronizer)) {
         if (synchronizer)
             synchronizer->taskCompleted();

--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -41,7 +41,6 @@ editing/TextIterator.cpp
 html/HTMLMediaElement.cpp
 html/canvas/PlaceholderRenderingContext.cpp
 html/shadow/DateTimeEditElement.h
-inspector/InspectorInstrumentation.h
 inspector/InspectorStyleSheet.h
 inspector/InstrumentingAgents.h
 inspector/PageInspectorController.h

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -23,7 +23,6 @@ bindings/js/JSAttrCustom.cpp
 bindings/js/JSCSSStyleDeclarationCustom.cpp
 bindings/js/JSCustomElementInterface.cpp
 bindings/js/JSDOMAbstractOperations.h
-bindings/js/JSDOMConvertInterface.h
 bindings/js/JSDOMConvertPromise.h
 bindings/js/JSDOMGlobalObject.cpp
 bindings/js/JSDOMPromiseDeferred.cpp
@@ -36,7 +35,6 @@ bindings/js/JSHTMLTemplateElementCustom.cpp
 bindings/js/JSLazyEventListener.cpp
 bindings/js/JSNodeCustom.cpp
 bindings/js/JSPluginElementFunctions.cpp
-bindings/js/JSStyleSheetCustom.h
 bindings/js/JSUndoItemCustom.cpp
 bindings/js/JSWebAnimationCustom.cpp
 bindings/js/JSWorkerGlobalScopeBase.cpp
@@ -51,20 +49,13 @@ css/SelectorChecker.cpp
 css/SelectorFilter.cpp
 css/StyleAttributeMutationScope.h
 css/StyleRuleImport.cpp
-css/StyleSheetContents.cpp
 css/query/ContainerQueryFeatures.cpp
 css/typedom/ComputedStylePropertyMapReadOnly.cpp
 dom/CollectionIndexCacheInlines.h
-dom/ComposedTreeAncestorIterator.h
-dom/ComposedTreeIterator.cpp
-dom/ComposedTreeIterator.h
-dom/ContainerNodeAlgorithms.cpp
 dom/CustomElementReactionQueue.cpp
 dom/Document.cpp
 dom/Element.cpp
-dom/ElementAndTextDescendantIterator.h
 dom/ElementInlines.h
-dom/ElementIteratorInlines.h
 dom/ElementTextDirection.cpp
 dom/ElementTraversal.h
 dom/EventLoop.cpp
@@ -73,7 +64,6 @@ dom/InlineStyleSheetOwner.cpp
 dom/MouseRelatedEvent.cpp
 dom/Node.cpp
 dom/NodeTraversal.cpp
-dom/NodeTraversal.h
 dom/Position.cpp
 dom/PositionIterator.cpp
 dom/RadioButtonGroups.cpp
@@ -87,7 +77,6 @@ dom/TypedElementDescendantIteratorInlines.h
 dom/ViewTransition.cpp
 [ Mac ] editing/AlternativeTextController.cpp
 editing/ApplyBlockElementCommand.cpp
-editing/ApplyStyleCommand.cpp
 editing/BreakBlockquoteCommand.cpp
 editing/ChangeListTypeCommand.cpp
 editing/DictationCommand.cpp
@@ -101,7 +90,6 @@ editing/TextIterator.cpp
 editing/TextManipulationController.cpp
 editing/VisibleUnits.cpp
 editing/cocoa/DataDetection.mm
-editing/cocoa/DictionaryLookup.mm
 editing/cocoa/EditingHTMLConverter.mm
 [ iOS ] editing/cocoa/EditorCocoa.mm
 editing/cocoa/NodeHTMLConverter.mm
@@ -130,7 +118,6 @@ inspector/InspectorAuditAccessibilityObject.cpp
 inspector/InspectorCanvas.cpp
 inspector/InspectorCanvasCallTracer.cpp
 inspector/InspectorInstrumentation.cpp
-inspector/InspectorInstrumentation.h
 inspector/InspectorNodeFinder.cpp
 inspector/InspectorOverlay.cpp
 inspector/InspectorStyleSheet.cpp
@@ -204,14 +191,12 @@ layout/integration/inline/LineSelection.h
 layout/layouttree/LayoutBox.cpp
 layout/layouttree/LayoutElementBox.cpp
 layout/layouttree/LayoutTreeBuilder.cpp
-loader/EmptyClients.cpp
 loader/FrameLoader.cpp
 loader/archive/cf/LegacyWebArchive.cpp
 loader/cache/MemoryCache.cpp
 mathml/MathMLSelectElement.cpp
 page/AutoscrollController.cpp
 [ iOS ] page/Chrome.cpp
-[ Mac ] page/ContextMenuController.cpp
 [ iOS ] page/DOMTimer.cpp
 page/DragController.cpp
 page/ElementTargetingController.cpp
@@ -329,7 +314,6 @@ rendering/RenderObject.h
 rendering/RenderProgress.cpp
 rendering/RenderQuote.cpp
 rendering/RenderReplaced.cpp
-rendering/RenderReplica.cpp
 rendering/RenderSearchField.cpp
 rendering/RenderTable.cpp
 rendering/RenderTableCell.cpp
@@ -372,7 +356,6 @@ rendering/shapes/ShapeOutsideInfo.cpp
 rendering/style/StyleCachedImage.cpp
 rendering/style/StyleCanvasImage.cpp
 rendering/style/StyleCrossfadeImage.cpp
-rendering/style/StyleCursorImage.cpp
 rendering/style/StyleFilterImage.cpp
 rendering/style/StyleGradientImage.cpp
 rendering/svg/RenderSVGContainer.cpp
@@ -403,7 +386,6 @@ rendering/svg/SVGTextLayoutEngineBaseline.cpp
 rendering/svg/SVGTextMetrics.cpp
 rendering/svg/SVGTextMetricsBuilder.cpp
 rendering/svg/legacy/LegacyRenderSVGContainer.cpp
-rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
 rendering/svg/legacy/LegacyRenderSVGPath.cpp
 rendering/svg/legacy/LegacyRenderSVGResource.cpp
 rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp
@@ -431,60 +413,39 @@ rendering/updating/RenderTreeUpdater.cpp
 rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
 rendering/updating/RenderTreeUpdaterViewTransition.cpp
 style/AnchorPositionEvaluator.cpp
-style/AttributeChangeInvalidation.cpp
 style/ChildChangeInvalidation.cpp
-style/ClassChangeInvalidation.cpp
 style/ContainerQueryEvaluator.cpp
 style/ElementRuleCollector.cpp
-style/IdChangeInvalidation.cpp
 style/InlineTextBoxStyle.cpp
 style/MatchResultCache.cpp
-style/PseudoClassChangeInvalidation.cpp
 style/StyleAdjuster.cpp
 style/StyleBuilder.cpp
 style/StyleBuilderCustom.h
 style/StyleBuilderStateInlines.h
-style/StyleCustomPropertyRegistry.cpp
 style/StyleDifference.cpp
 style/StyleExtractor.cpp
 style/StyleExtractorCustom.h
 style/StyleInvalidationFunctions.h
-style/StyleInvalidator.cpp
 style/StylePendingResources.cpp
 style/StyleRelations.cpp
 style/StyleResolveForDocument.cpp
 style/StyleResolver.cpp
 style/StyleScope.cpp
 style/StyleTreeResolver.cpp
-style/StyleUpdate.cpp
 style/Styleable.cpp
 style/computed/StyleComputedStyleBase.cpp
 style/values/grid/StyleGridPositionsResolver.cpp
 style/values/primitives/StyleLengthResolution.cpp
 style/values/text/StyleTextAlign.cpp
 style/values/transforms/StyleTransformList.cpp
-svg/SVGAnimateMotionElement.cpp
 svg/SVGClipPathElement.cpp
-svg/SVGElement.cpp
-svg/SVGFEComponentTransferElement.cpp
 svg/SVGFEFloodElement.cpp
-svg/SVGFELightElement.cpp
-svg/SVGFEMergeElement.cpp
 svg/SVGFilterPrimitiveStandardAttributes.cpp
-svg/SVGFontFaceSrcElement.cpp
 svg/SVGGeometryElement.cpp
-svg/SVGGradientElement.cpp
 svg/SVGLengthContext.cpp
-svg/SVGLinearGradientElement.cpp
-svg/SVGLocatable.cpp
 svg/SVGMaskElement.cpp
-svg/SVGSVGElement.cpp
 svg/SVGStopElement.cpp
-svg/SVGSwitchElement.cpp
-svg/SVGToOTFFontConversion.cpp
 svg/SVGUseElement.cpp
-svg/graphics/SVGImage.cpp
-svg/properties/SVGAnimatedString.cpp
 testing/Internals.cpp
 testing/js/WebCoreTestSupport.cpp
 workers/WorkerGlobalScope.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -1,5 +1,3 @@
-[ Mac ] Modules/mediasession/MediaSession.cpp
-Modules/model-element/HTMLModelElement.cpp
 Modules/webaudio/AudioBasicProcessorNode.cpp
 Modules/webaudio/AudioBufferSourceNode.cpp
 Modules/webaudio/AudioDestinationNode.cpp
@@ -17,14 +15,11 @@ Modules/webaudio/OscillatorNode.cpp
 Modules/webaudio/PannerNode.cpp
 Modules/webaudio/ScriptProcessorNode.cpp
 Modules/webaudio/StereoPannerNode.cpp
-Modules/webdatabase/DatabaseManager.cpp
 accessibility/AXObjectCache.cpp
 [ iOS ] accessibility/AccessibilityNodeObject.cpp
 [ iOS ] accessibility/ios/AccessibilityObjectIOS.mm
 [ iOS ] accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
-animation/AcceleratedEffectStackUpdater.cpp
 animation/KeyframeEffect.cpp
-bindings/js/DOMWrapperWorld.cpp
 bindings/js/JSAbortSignalCustom.cpp
 bindings/js/JSAttrCustom.cpp
 bindings/js/JSAudioWorkletProcessorCustom.cpp
@@ -34,9 +29,6 @@ bindings/js/JSCustomElementInterface.cpp
 bindings/js/JSCustomElementRegistryCustom.cpp
 bindings/js/JSDOMAbstractOperations.h
 bindings/js/JSDOMBindingSecurity.cpp
-bindings/js/JSDOMConvertInterface.h
-bindings/js/JSDOMConvertPromise.h
-bindings/js/JSDOMConvertUnion.h
 bindings/js/JSDOMGlobalObject.cpp
 bindings/js/JSDOMPromiseDeferred.cpp
 bindings/js/JSDOMWindowBase.cpp
@@ -44,7 +36,6 @@ bindings/js/JSDOMWindowCustom.cpp
 bindings/js/JSDOMWindowProperties.cpp
 bindings/js/JSDocumentCustom.cpp
 bindings/js/JSErrorHandler.cpp
-bindings/js/JSEventTargetCustom.h
 bindings/js/JSHTMLAllCollectionCustom.cpp
 bindings/js/JSHTMLElementCustom.cpp
 bindings/js/JSHTMLTemplateElementCustom.cpp
@@ -54,7 +45,6 @@ bindings/js/JSIDBRequestCustom.cpp
 bindings/js/JSIntersectionObserverCustom.cpp
 bindings/js/JSLazyEventListener.cpp
 bindings/js/JSLocationCustom.cpp
-bindings/js/JSMediaListCustom.h
 bindings/js/JSMessagePortCustom.cpp
 bindings/js/JSNavigateEventCustom.cpp
 bindings/js/JSNodeCustom.cpp
@@ -63,7 +53,6 @@ bindings/js/JSPluginElementFunctions.cpp
 bindings/js/JSPopStateEventCustom.cpp
 bindings/js/JSResizeObserverCustom.cpp
 bindings/js/JSStylePropertyMapReadOnlyCustom.cpp
-bindings/js/JSStyleSheetCustom.h
 bindings/js/JSSubscriberCustom.cpp
 bindings/js/JSTextTrackCueCustom.cpp
 bindings/js/JSUndoItemCustom.cpp
@@ -75,22 +64,10 @@ bindings/js/ScriptCachedFrameData.cpp
 bindings/js/ScriptModuleLoader.cpp
 bindings/js/StructuredClone.cpp
 contentextensions/ContentExtensionsBackend.cpp
-crypto/algorithms/CryptoAlgorithmECDH.cpp
-crypto/algorithms/CryptoAlgorithmX25519.cpp
 css/CSSCounterStyleDescriptors.cpp
 css/CSSFontFace.cpp
-css/CSSFontFaceSet.cpp
-css/CSSGroupingRule.cpp
-css/CSSImageSetValue.cpp
-css/CSSImageValue.cpp
-css/CSSLayerBlockRule.cpp
-css/CSSStyleProperties.cpp
-css/CSSStyleRule.cpp
 css/CSSStyleSheet.cpp
-css/CSSStyleSheetObservableArray.cpp
-css/CSSValue.cpp
 css/CSSValueList.cpp
-css/CSSValueList.h
 css/DeprecatedCSSOMPrimitiveValue.cpp
 css/FontFaceSet.cpp
 css/ImmutableStyleProperties.cpp
@@ -100,23 +77,13 @@ css/SelectorFilter.cpp
 css/ShorthandSerializer.cpp
 css/StyleProperties.cpp
 css/StyleRuleImport.cpp
-css/StyleSheetContents.cpp
-css/query/ContainerQueryFeatures.cpp
 css/query/MediaQueryFeatures.cpp
-css/typedom/CSSStyleValueFactory.cpp
 css/typedom/ComputedStylePropertyMapReadOnly.cpp
-css/typedom/numeric/CSSMathValue.h
 css/values/CSSValueAggregates.h
 cssjit/SelectorCompiler.cpp
 dom/CollectionIndexCacheInlines.h
-dom/ComposedTreeAncestorIterator.h
-dom/ComposedTreeIterator.cpp
-dom/ComposedTreeIterator.h
-dom/ContainerNodeAlgorithms.cpp
 dom/Document.cpp
 dom/Element.cpp
-dom/ElementAndTextDescendantIterator.h
-dom/ElementIteratorInlines.h
 dom/ElementTextDirection.cpp
 dom/ElementTraversal.h
 dom/EventPath.cpp
@@ -124,7 +91,6 @@ dom/InlineStyleSheetOwner.cpp
 dom/MouseRelatedEvent.cpp
 dom/Node.cpp
 dom/NodeTraversal.cpp
-dom/NodeTraversal.h
 dom/Position.cpp
 dom/QualifiedNameCache.cpp
 dom/RadioButtonGroups.cpp
@@ -139,20 +105,15 @@ dom/StyledElement.cpp
 dom/TreeScope.cpp
 dom/TypedElementDescendantIteratorInlines.h
 dom/ViewTransition.cpp
-editing/ApplyStyleCommand.cpp
 editing/ChangeListTypeCommand.cpp
 editing/Editing.cpp
 editing/Editor.cpp
-editing/EditorCommand.cpp
 editing/FrameSelection.cpp
 editing/MarkupAccumulator.cpp
 editing/cocoa/DataDetection.mm
-editing/cocoa/DictionaryLookup.mm
-editing/cocoa/EditorCocoa.mm
 editing/cocoa/NodeHTMLConverter.mm
 [ iOS ] editing/ios/DictationCommandIOS.cpp
 [ iOS ] editing/ios/EditorIOS.mm
-[ Mac ] editing/mac/EditorMac.mm
 [ Mac ] editing/mac/FrameSelectionMac.mm
 html/CachedHTMLCollectionInlines.h
 html/CollectionTraversalInlines.h
@@ -170,7 +131,6 @@ html/MediaElementSession.cpp
 html/ModelDocument.cpp
 html/OffscreenCanvas.cpp
 html/ValidatedFormListedElement.cpp
-html/canvas/CanvasRenderingContext2D.cpp
 html/canvas/CanvasRenderingContext2DBase.cpp
 html/canvas/OffscreenCanvasRenderingContext2D.cpp
 html/parser/HTMLConstructionSite.cpp
@@ -181,7 +141,6 @@ inspector/InspectorCanvas.cpp
 inspector/InspectorCanvasCallTracer.cpp
 inspector/InspectorFrontendHost.cpp
 inspector/InspectorInstrumentation.cpp
-inspector/InspectorInstrumentation.h
 inspector/InspectorNodeFinder.cpp
 inspector/InspectorOverlay.cpp
 inspector/InspectorResourceUtilities.cpp
@@ -201,11 +160,8 @@ layout/formattingContexts/inline/InlineItemsBuilder.cpp
 layout/formattingContexts/inline/InlineLineBoxBuilder.cpp
 layout/integration/inline/LayoutIntegrationLineLayout.cpp
 layout/layouttree/LayoutTreeBuilder.cpp
-loader/ApplicationManifestLoader.cpp
-loader/EmptyClients.cpp
 mathml/MathMLSelectElement.cpp
 [ iOS ] page/Chrome.cpp
-[ Mac ] page/ContextMenuController.cpp
 page/ElementTargetingController.cpp
 page/EventHandler.cpp
 page/FocusController.cpp
@@ -244,7 +200,6 @@ page/scrolling/ScrollAnchoringController.cpp
 page/scrolling/ScrollingCoordinator.cpp
 page/scrolling/ScrollingTreeOverflowScrollProxyNode.cpp
 page/scrolling/ScrollingTreeStickyNode.cpp
-platform/DictationCaretAnimator.cpp
 platform/KeyboardScrollingAnimator.cpp
 platform/ScrollView.cpp
 platform/ScrollableArea.cpp
@@ -252,11 +207,7 @@ platform/ScrollbarsController.cpp
 [ iOS ] platform/audio/ios/AudioSessionIOS.mm
 platform/cocoa/PlaybackSessionModelMediaElement.mm
 platform/graphics/ComplexTextController.cpp
-platform/graphics/DisplayRefreshMonitorManager.cpp
-platform/graphics/FontCache.cpp
-platform/graphics/FontRanges.cpp
 platform/graphics/GraphicsLayer.cpp
-platform/graphics/Image.cpp
 platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm
 platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
 platform/graphics/ca/GraphicsLayerCA.cpp
@@ -264,22 +215,7 @@ platform/graphics/ca/TileGrid.cpp
 [ iOS ] platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
 platform/graphics/coreimage/FEColorMatrixCoreImageApplier.mm
 platform/graphics/coreimage/SourceGraphicCoreImageApplier.mm
-platform/graphics/filters/FilterOperations.cpp
-platform/graphics/filters/software/FEBlendSoftwareApplier.cpp
-platform/graphics/filters/software/FEColorMatrixSoftwareApplier.cpp
-platform/graphics/filters/software/FEComponentTransferSoftwareApplier.cpp
-platform/graphics/filters/software/FECompositeSoftwareApplier.cpp
-platform/graphics/filters/software/FECompositeSoftwareArithmeticApplier.cpp
-platform/graphics/filters/software/FEConvolveMatrixSoftwareApplier.cpp
-platform/graphics/filters/software/FEDisplacementMapSoftwareApplier.cpp
-platform/graphics/filters/software/FEDropShadowSoftwareApplier.cpp
-platform/graphics/filters/software/FEGaussianBlurSoftwareApplier.cpp
-platform/graphics/filters/software/FEImageSoftwareApplier.cpp
-platform/graphics/filters/software/FELightingSoftwareApplier.cpp
 platform/graphics/filters/software/FEMorphologySoftwareApplier.cpp
-platform/graphics/filters/software/FEOffsetSoftwareApplier.cpp
-platform/graphics/filters/software/FETileSoftwareApplier.cpp
-platform/graphics/filters/software/FETurbulenceSoftwareApplier.cpp
 platform/graphics/filters/software/SourceAlphaSoftwareApplier.cpp
 platform/graphics/filters/software/SourceGraphicSoftwareApplier.cpp
 platform/graphics/transforms/RotateTransformOperation.cpp
@@ -287,9 +223,7 @@ platform/graphics/transforms/RotateTransformOperation.cpp
 [ iOS ] platform/ios/LegacyTileGrid.mm
 [ iOS ] platform/ios/WebVideoFullscreenControllerAVKit.mm
 platform/mock/MockRealtimeVideoSource.cpp
-platform/text/BidiContext.cpp
 platform/text/BidiResolver.h
-rendering/BackgroundPainter.cpp
 rendering/HitTestResult.cpp
 rendering/ImageQualityController.cpp
 rendering/MarkedText.cpp
@@ -318,13 +252,8 @@ rendering/RenderMenuList.cpp
 rendering/RenderObject.cpp
 rendering/RenderProgress.cpp
 rendering/RenderQuote.cpp
-rendering/RenderReplaced.cpp
-rendering/RenderReplica.cpp
 rendering/RenderTableCell.cpp
-rendering/RenderTextControl.cpp
-rendering/RenderTextControlMultiLine.cpp
 rendering/RenderTextControlSingleLine.cpp
-rendering/RenderTheme.cpp
 rendering/RenderTreeAsText.cpp
 rendering/RenderView.cpp
 rendering/RenderWidget.cpp
@@ -332,79 +261,24 @@ rendering/RenderWidget.cpp
 rendering/mathml/MathMLStyle.cpp
 rendering/style/StyleCachedImage.cpp
 rendering/style/StyleCanvasImage.cpp
-rendering/style/StyleCursorImage.cpp
 rendering/svg/RenderSVGPath.cpp
-rendering/svg/RenderSVGTextPath.cpp
-rendering/svg/SVGLayerTransformComputation.h
-rendering/svg/SVGRenderTreeAsText.cpp
-rendering/svg/SVGRenderingContext.cpp
 rendering/svg/SVGTextLayoutAttributesBuilder.cpp
-rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
-rendering/svg/legacy/LegacyRenderSVGPath.cpp
-rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp
-rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp
-rendering/svg/legacy/LegacyRenderSVGResourcePattern.cpp
-rendering/updating/RenderTreeBuilder.cpp
-rendering/updating/RenderTreeBuilderFirstLetter.cpp
-rendering/updating/RenderTreeBuilderMathML.cpp
 rendering/updating/RenderTreePosition.cpp
-rendering/updating/RenderTreeUpdater.cpp
 rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
-style/AttributeChangeInvalidation.cpp
-style/ClassChangeInvalidation.cpp
 style/ElementRuleCollector.cpp
-style/IdChangeInvalidation.cpp
-style/InspectorCSSOMWrappers.cpp
 style/MatchResultCache.cpp
-style/MatchedDeclarationsCache.cpp
 style/PageRuleCollector.cpp
-style/PropertyCascade.cpp
-style/PseudoClassChangeInvalidation.cpp
 style/RuleSetBuilder.cpp
-style/StyleAdjuster.cpp
 style/StyleBuilder.cpp
 style/StyleBuilderCustom.h
-style/StyleBuilderState.cpp
-style/StyleCustomPropertyRegistry.cpp
 style/StyleDifference.cpp
-style/StyleExtractor.cpp
 style/StyleExtractorCustom.h
 style/StyleInvalidationFunctions.h
-style/StyleInvalidator.cpp
 style/StyleRelations.cpp
-style/StyleResolver.cpp
-style/StyleScope.cpp
-style/StyleScopeRuleSets.cpp
-style/StyleTreeResolver.cpp
-style/StyleUpdate.cpp
-style/Styleable.cpp
 style/UserAgentStyle.cpp
 style/computed/StyleComputedStyleBase+SettersInlines.h
-style/computed/StyleComputedStyleBase.cpp
 style/computed/StyleComputedStyleProperties+SettersCustomInlines.h
-style/computed/data/StyleCustomPropertyData.cpp
-style/values/transforms/StyleTransformFunction.cpp
-svg/SVGAnimateMotionElement.cpp
 svg/SVGClipPathElement.cpp
-svg/SVGCursorElement.cpp
-svg/SVGElement.cpp
-svg/SVGFEComponentTransferElement.cpp
-svg/SVGFEConvolveMatrixElement.cpp
-svg/SVGFELightElement.cpp
-svg/SVGFEMergeElement.cpp
-svg/SVGFontFaceSrcElement.cpp
-svg/SVGGradientElement.cpp
-svg/SVGLinearGradientElement.cpp
-svg/SVGLocatable.cpp
-svg/SVGMPathElement.cpp
-svg/SVGMaskElement.cpp
-svg/SVGSVGElement.cpp
-svg/SVGSwitchElement.cpp
-svg/SVGToOTFFontConversion.cpp
 svg/SVGUseElement.cpp
-svg/graphics/SVGImage.cpp
-svg/graphics/SVGImageCache.cpp
-svg/properties/SVGAnimatedString.cpp
-svg/properties/SVGPropertyOwnerRegistry.h
 testing/Internals.cpp
 testing/LegacyMockCDM.cpp

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -985,12 +985,6 @@ private:
 #endif
 };
 
-inline bool AccessibilityObject::hasDisplayContents() const
-{
-    RefPtr element = this->element();
-    return element && element->hasDisplayContents();
-}
-
 inline std::optional<BoundaryPoint> AccessibilityObject::lastBoundaryPointContainedInRect(const Vector<BoundaryPoint>& boundaryPoints, const BoundaryPoint& startBoundaryPoint, const FloatRect& targetRect, bool isFlippedWritingMode) const
 {
     return lastBoundaryPointContainedInRect(boundaryPoints, startBoundaryPoint, targetRect, 0, boundaryPoints.size() - 1, isFlippedWritingMode);

--- a/Source/WebCore/accessibility/AccessibilityObjectInlines.h
+++ b/Source/WebCore/accessibility/AccessibilityObjectInlines.h
@@ -33,6 +33,7 @@
 #include <WebCore/Color.h>
 #include <WebCore/Document.h>
 #include <WebCore/Element.h>
+#include <WebCore/ElementRareData.h>
 #include <WebCore/FrameDestructionObserverInlines.h>
 #include <WebCore/HTMLParserIdioms.h>
 #include <WebCore/LocalFrame.h>
@@ -313,6 +314,12 @@ inline void AccessibilityObject::recomputeIsIgnored()
 {
     // isIgnoredWithoutCache will update m_lastKnownIsIgnoredValue and perform any necessary actions if it has changed.
     isIgnoredWithoutCache(axObjectCache());
+}
+
+inline bool AccessibilityObject::hasDisplayContents() const
+{
+    auto* element = this->element();
+    return element && element->hasDisplayContents();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/animation/AcceleratedEffectStackUpdater.cpp
+++ b/Source/WebCore/animation/AcceleratedEffectStackUpdater.cpp
@@ -65,7 +65,7 @@ void AcceleratedEffectStackUpdater::update()
         if (!renderer || !renderer->isComposited())
             continue;
 
-        auto* renderLayer = renderer->layer();
+        CheckedPtr renderLayer = renderer->layer();
         ASSERT(renderLayer && renderLayer->backing());
         renderLayer->backing()->updateAcceleratedEffectsAndBaseValues(timelinesInUpdate);
     }

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -46,6 +46,7 @@
 #include "DocumentQuirks.h"
 #include "DocumentView.h"
 #include "Element.h"
+#include "ElementRareData.h"
 #include "EventLoop.h"
 #include "EventTargetInlines.h"
 #include "FontCascade.h"

--- a/Source/WebCore/bindings/js/DOMWrapperWorld.cpp
+++ b/Source/WebCore/bindings/js/DOMWrapperWorld.cpp
@@ -72,8 +72,8 @@ DOMWrapperWorld& normalWorld(JSC::VM& vm)
 DOMWrapperWorld& mainThreadNormalWorldSingleton()
 {
     ASSERT(isMainThread());
-    static DOMWrapperWorld& cachedNormalWorld = normalWorld(commonVM());
-    return cachedNormalWorld;
+    static NeverDestroyed<Ref<DOMWrapperWorld>> cachedNormalWorld = normalWorld(commonVM());
+    return cachedNormalWorld->get();
 }
 
 bool isWorldCompatible(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value)

--- a/Source/WebCore/bindings/js/JSDOMConvertInterface.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertInterface.h
@@ -66,13 +66,13 @@ template<typename T> struct Converter<IDLInterface<T>> : DefaultConverter<IDLInt
         auto& vm = JSC::getVM(&lexicalGlobalObject);
         auto scope = DECLARE_THROW_SCOPE(vm);
 
-        auto object = JSToWrappedOverloader<T>::toWrapped(lexicalGlobalObject, value);
+        RefPtr object = JSToWrappedOverloader<T>::toWrapped(lexicalGlobalObject, value);
         if (!object) [[unlikely]] {
             exceptionThrower(lexicalGlobalObject, scope);
             return Result::exception();
         }
 
-        return Result { object };
+        return Result { object.get() };
     }
 };
 

--- a/Source/WebCore/bindings/js/JSDOMConvertPromise.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertPromise.h
@@ -49,8 +49,8 @@ template<typename T> struct Converter<IDLPromise<T>> : DefaultConverter<IDLPromi
         // 2. Let promise be the result of calling resolve with %Promise% as the this value and V as the single argument value.
         auto* promise = JSC::JSPromise::resolvedPromise(globalObject, value);
         if (scope.exception()) {
-            auto* scriptExecutionContext = globalObject->scriptExecutionContext();
-            if (auto* globalScope = dynamicDowncast<WorkerGlobalScope>(scriptExecutionContext)) {
+            CheckedPtr scriptExecutionContext = globalObject->scriptExecutionContext();
+            if (RefPtr globalScope = dynamicDowncast<WorkerGlobalScope>(scriptExecutionContext.get())) {
                 auto* scriptController = globalScope->script();
                 bool terminatorCausedException = vm.isTerminationException(scope.exception());
                 if (terminatorCausedException || (scriptController && scriptController->isTerminatingExecution())) {

--- a/Source/WebCore/bindings/js/JSDOMConvertUnion.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertUnion.h
@@ -202,7 +202,7 @@ template<typename... T> struct Converter<IDLUnion<T...>> : DefaultConverter<IDLU
         //     2. If types includes object, then return the IDL value that is a reference to the object V.
         constexpr bool hasArrayBufferType = brigand::any<TypeList, IsIDLArrayBuffer<brigand::_1>>::value;
         if constexpr (hasArrayBufferType || hasObjectType) {
-            auto arrayBuffer = (brigand::any<TypeList, IsIDLArrayBufferAllowShared<brigand::_1>>::value) ? JSC::JSArrayBuffer::toWrappedAllowShared(vm, value) : JSC::JSArrayBuffer::toWrapped(vm, value);
+            RefPtr arrayBuffer = (brigand::any<TypeList, IsIDLArrayBufferAllowShared<brigand::_1>>::value) ? JSC::JSArrayBuffer::toWrappedAllowShared(vm, value) : JSC::JSArrayBuffer::toWrapped(vm, value);
             if (arrayBuffer) {
                 if constexpr (hasArrayBufferType) {
                     return functor(WTF::move(arrayBuffer));

--- a/Source/WebCore/bindings/js/JSEventTargetCustom.h
+++ b/Source/WebCore/bindings/js/JSEventTargetCustom.h
@@ -71,8 +71,8 @@ public:
         if (thisObject.isNull()) [[unlikely]]
             return throwThisTypeError(lexicalGlobalObject, throwScope, "EventTarget", operationName);
 
-        auto& wrapped = thisObject.wrapped();
-        if (auto window = dynamicDowncast<DOMWindow>(wrapped)) {
+        Ref wrapped = thisObject.wrapped();
+        if (RefPtr window = dynamicDowncast<DOMWindow>(wrapped)) {
             if (!window->frame() || !BindingSecurity::shouldAllowAccessToDOMWindow(&lexicalGlobalObject, *window, ThrowSecurityError))
                 return JSC::JSValue::encode(JSC::jsUndefined());
         }

--- a/Source/WebCore/bindings/js/JSMediaListCustom.h
+++ b/Source/WebCore/bindings/js/JSMediaListCustom.h
@@ -35,9 +35,9 @@ namespace WebCore {
 
 inline WebCoreOpaqueRoot root(MediaList* mediaList)
 {
-    if (CSSRule* parentRule = mediaList->parentRule())
+    if (SUPPRESS_UNCOUNTED_LOCAL CSSRule* parentRule = mediaList->parentRule())
         return root(parentRule);
-    if (CSSStyleSheet* parentStyleSheet = mediaList->parentStyleSheet())
+    if (SUPPRESS_UNCOUNTED_LOCAL CSSStyleSheet* parentStyleSheet = mediaList->parentStyleSheet())
         return root(parentStyleSheet);
     return WebCoreOpaqueRoot { mediaList };
 }

--- a/Source/WebCore/bindings/js/JSStyleSheetCustom.h
+++ b/Source/WebCore/bindings/js/JSStyleSheetCustom.h
@@ -35,9 +35,9 @@ namespace WebCore {
 
 inline WebCoreOpaqueRoot root(StyleSheet* styleSheet)
 {
-    if (CSSImportRule* ownerRule = styleSheet->ownerRule())
+    if (SUPPRESS_UNCOUNTED_LOCAL CSSImportRule* ownerRule = styleSheet->ownerRule())
         return root(ownerRule);
-    if (Node* ownerNode = styleSheet->ownerNode())
+    if (SUPPRESS_UNCOUNTED_LOCAL Node* ownerNode = styleSheet->ownerNode())
         return root(ownerNode);
     return WebCoreOpaqueRoot { styleSheet };
 }

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmECDH.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmECDH.cpp
@@ -82,8 +82,8 @@ void CryptoAlgorithmECDH::deriveBits(const CryptoAlgorithmParameters& parameters
         return;
     }
     auto& ecBaseKey = downcast<CryptoKeyEC>(baseKey.get());
-    auto& ecPublicKey = downcast<CryptoKeyEC>(*(ecParameters.publicKey.get()));
-    if (ecBaseKey.namedCurve() != ecPublicKey.namedCurve()) {
+    Ref ecPublicKey = downcast<CryptoKeyEC>(*(ecParameters.publicKey.get()));
+    if (ecBaseKey.namedCurve() != ecPublicKey->namedCurve()) {
         exceptionCallback(ExceptionCode::InvalidAccessError);
         return;
     }

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmX25519.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmX25519.cpp
@@ -82,8 +82,8 @@ void CryptoAlgorithmX25519::deriveBits(const CryptoAlgorithmParameters& paramete
         return;
     }
     auto& ecBaseKey = downcast<CryptoKeyOKP>(baseKey.get());
-    auto& ecPublicKey = downcast<CryptoKeyOKP>(*(ecParameters.publicKey.get()));
-    if (ecBaseKey.namedCurve() != ecPublicKey.namedCurve()) {
+    Ref ecPublicKey = downcast<CryptoKeyOKP>(*(ecParameters.publicKey.get()));
+    if (ecBaseKey.namedCurve() != ecPublicKey->namedCurve()) {
         exceptionCallback(ExceptionCode::InvalidAccessError);
         return;
     }

--- a/Source/WebCore/css/CSSFontFaceSet.cpp
+++ b/Source/WebCore/css/CSSFontFaceSet.cpp
@@ -438,7 +438,7 @@ ExceptionOr<Vector<std::reference_wrapper<CSSFontFace>>> CSSFontFaceSet::matchin
     for (auto codePoint : codePointsFromString(string)) {
         bool found = false;
         for (auto& family : familyOrder) {
-            auto* faces = fontFace(request, family);
+            RefPtr faces = fontFace(request, family);
             if (!faces)
                 continue;
             for (auto& constituentFace : faces->constituentFaces()) {
@@ -491,10 +491,10 @@ CSSSegmentedFontFace* CSSFontFaceSet::fontFace(FontSelectionRequest request, con
 
     Vector<std::reference_wrapper<CSSFontFace>, 32> candidateFontFaces;
     for (int i = familyFontFaces.size() - 1; i >= 0; --i) {
-        CSSFontFace& candidate = familyFontFaces[i];
-        if (candidate.status() == CSSFontFace::Status::Failure)
+        Ref candidate = familyFontFaces[i];
+        if (candidate->status() == CSSFontFace::Status::Failure)
             continue;
-        if (!isItalic(request.slope) && isItalic(candidate.fontSelectionCapabilities().slope.minimum))
+        if (!isItalic(request.slope) && isItalic(candidate->fontSelectionCapabilities().slope.minimum))
             continue;
         candidateFontFaces.append(candidate);
     }
@@ -539,9 +539,9 @@ CSSSegmentedFontFace* CSSFontFaceSet::fontFace(FontSelectionRequest request, con
                 return true;
             return false;
         });
-        CSSFontFace* previousCandidate = nullptr;
+        RefPtr<CSSFontFace> previousCandidate;
         for (auto& candidate : candidateFontFaces) {
-            if (&candidate.get() == previousCandidate)
+            if (&candidate.get() == previousCandidate.get())
                 continue;
             previousCandidate = &candidate.get();
             face->appendFontFace(candidate.get());

--- a/Source/WebCore/css/CSSGroupingRule.cpp
+++ b/Source/WebCore/css/CSSGroupingRule.cpp
@@ -178,7 +178,7 @@ void CSSGroupingRule::cssTextForRulesWithReplacementURLs(StringBuilder& rules, c
 {
     auto& childRules = m_groupRule->childRules();
     for (unsigned index = 0; index < childRules.size(); index++) {
-        auto wrappedRule = item(index);
+        RefPtr wrappedRule = item(index);
         rules.append("\n  "_s, wrappedRule->cssText(context));
     }
 }

--- a/Source/WebCore/css/CSSImageSetValue.cpp
+++ b/Source/WebCore/css/CSSImageSetValue.cpp
@@ -65,7 +65,7 @@ RefPtr<StyleImage> CSSImageSetValue::createStyleImage(const Style::BuilderState&
     size_t length = this->length();
 
     Vector<ImageWithScale> images(length, [&](size_t i) {
-        auto option = downcast<CSSImageSetOptionValue>(item(i));
+        RefPtr<const CSSImageSetOptionValue> option = downcast<CSSImageSetOptionValue>(item(i));
         return ImageWithScale { state.createStyleImage(option->image()), option->protectedResolution()->resolveAsResolution<float>(state.cssToLengthConversionData()), option->type() };
     });
 

--- a/Source/WebCore/css/CSSImageValue.cpp
+++ b/Source/WebCore/css/CSSImageValue.cpp
@@ -122,7 +122,7 @@ CachedImage* CSSImageValue::loadImage(CachedResourceLoader& loader, const Resour
         if (options.mode == FetchOptions::Mode::Cors)
             request.updateForAccessControl(*loader.document());
         m_cachedImage = loader.requestImage(WTF::move(request)).value_or(nullptr);
-        for (auto imageValue = this; (imageValue = imageValue->m_unresolvedValue.get()); )
+        for (RefPtr<CSSImageValue> imageValue = this; (imageValue = imageValue->m_unresolvedValue.get()); )
             imageValue->m_cachedImage = m_cachedImage;
     }
     return m_cachedImage.value().get();

--- a/Source/WebCore/css/CSSLayerBlockRule.cpp
+++ b/Source/WebCore/css/CSSLayerBlockRule.cpp
@@ -61,12 +61,12 @@ String CSSLayerBlockRule::cssText() const
 
 String CSSLayerBlockRule::name() const
 {
-    auto& layer = downcast<StyleRuleLayer>(groupRule());
+    Ref layer = downcast<StyleRuleLayer>(groupRule());
 
-    if (layer.name().isEmpty())
+    if (layer->name().isEmpty())
         return emptyString();
 
-    return stringFromCascadeLayerName(layer.name());
+    return stringFromCascadeLayerName(layer->name());
 }
 
 String stringFromCascadeLayerName(const CascadeLayerName& name)

--- a/Source/WebCore/css/CSSStyleProperties.cpp
+++ b/Source/WebCore/css/CSSStyleProperties.cpp
@@ -532,7 +532,7 @@ RefPtr<DeprecatedCSSOMValue> PropertySetCSSStyleProperties::wrapForDeprecatedCSS
 
 StyleSheetContents* PropertySetCSSStyleProperties::contextStyleSheet() const
 {
-    CSSStyleSheet* cssStyleSheet = parentStyleSheet();
+    RefPtr cssStyleSheet = parentStyleSheet();
     return cssStyleSheet ? &cssStyleSheet->contents() : nullptr;
 }
 
@@ -593,7 +593,7 @@ CSSRule* StyleRuleCSSStyleProperties::parentRule() const
 
 OptionalOrReference<CSSParserContext> StyleRuleCSSStyleProperties::cssParserContext() const
 {
-    auto* styleSheet = contextStyleSheet();
+    RefPtr styleSheet = contextStyleSheet();
     if (!styleSheet)
         return PropertySetCSSStyleProperties::cssParserContext();
 

--- a/Source/WebCore/css/CSSStyleRule.cpp
+++ b/Source/WebCore/css/CSSStyleRule.cpp
@@ -89,7 +89,7 @@ StylePropertyMap& CSSStyleRule::styleMap()
 
 String CSSStyleRule::generateSelectorText() const
 {
-    if (auto* styleRule = dynamicDowncast<StyleRuleWithNesting>(m_styleRule.get()))
+    if (RefPtr styleRule = dynamicDowncast<StyleRuleWithNesting>(m_styleRule.get()))
         return styleRule->originalSelectorList().selectorsText();
 
     return m_styleRule->selectorList().selectorsText();
@@ -127,7 +127,7 @@ void CSSStyleRule::setSelectorText(const String& selectorText)
 
     CSSStyleSheet::RuleMutationScope mutationScope(this);
 
-    if (auto* styleRule = dynamicDowncast<StyleRuleWithNesting>(m_styleRule.get()))
+    if (RefPtr styleRule = dynamicDowncast<StyleRuleWithNesting>(m_styleRule.get()))
         styleRule->wrapperAdoptOriginalSelectorList(WTF::move(*selectorList));
     else
         m_styleRule->wrapperAdoptSelectorList(WTF::move(*selectorList));
@@ -140,7 +140,7 @@ void CSSStyleRule::setSelectorText(const String& selectorText)
 
 Vector<Ref<StyleRuleBase>> CSSStyleRule::nestedRules() const
 {
-    if (auto* styleRule = dynamicDowncast<StyleRuleWithNesting>(m_styleRule.get()))
+    if (RefPtr styleRule = dynamicDowncast<StyleRuleWithNesting>(m_styleRule.get()))
         return styleRule->nestedRules();
 
     return { };

--- a/Source/WebCore/css/CSSStyleSheetObservableArray.cpp
+++ b/Source/WebCore/css/CSSStyleSheetObservableArray.cpp
@@ -110,7 +110,7 @@ std::optional<Exception> CSSStyleSheetObservableArray::shouldThrowWhenAddingShee
 {
     if (!sheet.wasConstructedByJS())
         return Exception { ExceptionCode::NotAllowedError, "Sheet needs to be constructed by JavaScript"_s };
-    auto* treeScope = this->treeScope();
+    RefPtr treeScope = this->treeScope();
     if (!treeScope || sheet.constructorDocument() != &treeScope->documentScope())
         return Exception { ExceptionCode::NotAllowedError, "Sheet constructor document doesn't match"_s };
     return std::nullopt;

--- a/Source/WebCore/css/CSSValue.cpp
+++ b/Source/WebCore/css/CSSValue.cpp
@@ -279,8 +279,8 @@ void CSSValue::collectComputedStyleDependencies(ComputedStyleDependencies& depen
     // FIXME: Unclear why it's OK that we do not cover CSSValuePair, CSSQuadValue, CSSRectValue, CSSBorderImageSliceValue, CSSBorderImageWidthValue, and others here. Probably should use visitDerived unless they don't allow the primitive values that can have dependencies. May want to base this on a traverseValues or forEachValue function instead.
     // FIXME: Consider a non-recursive algorithm for walking this tree of dependencies.
     if (auto* asList = dynamicDowncast<CSSValueContainingVector>(*this)) {
-        for (auto& listValue : *asList)
-            listValue.collectComputedStyleDependencies(dependencies);
+        for (Ref listValue : *asList)
+            listValue->collectComputedStyleDependencies(dependencies);
         return;
     }
     if (auto* asPrimitiveValue = dynamicDowncast<CSSPrimitiveValue>(*this))

--- a/Source/WebCore/css/CSSValueList.h
+++ b/Source/WebCore/css/CSSValueList.h
@@ -139,7 +139,7 @@ private:
 
 inline CSSValueContainingVector::~CSSValueContainingVector()
 {
-    for (auto& value : *this)
+    for (SUPPRESS_UNCOUNTED_LOCAL auto& value : *this)
         value.deref();
 }
 

--- a/Source/WebCore/css/FontFaceSet.cpp
+++ b/Source/WebCore/css/FontFaceSet.cpp
@@ -222,28 +222,29 @@ void FontFaceSet::load(ScriptExecutionContext& context, const String& font, cons
     for (auto& face : matchingFaces)
         face.get().load();
 
-    auto* document = dynamicDowncast<Document>(scriptExecutionContext());
-    if (document && document->quirks().shouldEnableFontLoadingAPIQuirk()) {
-        // HBOMax.com expects that loading fonts will succeed, and will totally break when it doesn't. But when lockdown mode is enabled, fonts
-        // fail to load, because that's the whole point of lockdown mode.
-        //
-        // This is a bit of a hack to say "When lockdown mode is enabled, and lockdown mode has removed all the remote fonts, then just pretend
-        // that the fonts loaded successfully." If there are any non-remote fonts still present, don't make any behavior change.
-        //
-        // See also: https://github.com/w3c/csswg-drafts/issues/7680
+    if (auto document = dynamicDowncast<Document>(scriptExecutionContext())) {
+        if (document->quirks().shouldEnableFontLoadingAPIQuirk()) {
+            // HBOMax.com expects that loading fonts will succeed, and will totally break when it doesn't. But when lockdown mode is enabled, fonts
+            // fail to load, because that's the whole point of lockdown mode.
+            //
+            // This is a bit of a hack to say "When lockdown mode is enabled, and lockdown mode has removed all the remote fonts, then just pretend
+            // that the fonts loaded successfully." If there are any non-remote fonts still present, don't make any behavior change.
+            //
+            // See also: https://github.com/w3c/csswg-drafts/issues/7680
 
-        bool hasSource = false;
-        for (auto& face : matchingFaces) {
-            if (face.get().sourceCount()) {
-                hasSource = true;
-                break;
+            bool hasSource = false;
+            for (auto& face : matchingFaces) {
+                if (face.get().sourceCount()) {
+                    hasSource = true;
+                    break;
+                }
             }
-        }
-        if (!hasSource) {
-            promise.resolve(matchingFaces.map([scriptExecutionContext = scriptExecutionContext()] (const auto& matchingFace) {
-                return matchingFace.get().wrapper(scriptExecutionContext);
-            }));
-            return;
+            if (!hasSource) {
+                promise.resolve(matchingFaces.map([scriptExecutionContext = CheckedPtr { scriptExecutionContext() }] (const auto& matchingFace) {
+                    return matchingFace.get().wrapper(scriptExecutionContext.get());
+                }));
+                return;
+            }
         }
     }
 

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -501,13 +501,13 @@ SelectorChecker::MatchResult SelectorChecker::matchRecursively(CheckingContext& 
     }
     case CSSSelector::Relation::ShadowPartDescendant: {
         // Continue matching in the scope where this rule came from.
-        auto* host = checkingContext.styleScopeOrdinal == Style::ScopeOrdinal::Element
+        RefPtr host = checkingContext.styleScopeOrdinal == Style::ScopeOrdinal::Element
             ? context.element->shadowHost()
             : Style::hostForScopeOrdinal(*context.element, checkingContext.styleScopeOrdinal);
         if (!host)
             return MatchResult::fails(Match::SelectorFailsCompletely);
 
-        nextContext.element = host;
+        nextContext.element = host.get();
         nextContext.firstSelectorOfTheFragment = nextContext.selector;
         nextContext.isSubjectOrAdjacentElement = false;
         // ::part rules from the element's own scope can only match if they apply to :host.
@@ -523,7 +523,7 @@ SelectorChecker::MatchResult SelectorChecker::matchRecursively(CheckingContext& 
         if (!slot)
             return MatchResult::fails(Match::SelectorFailsCompletely);
 
-        nextContext.element = slot;
+        nextContext.element = slot.get();
         nextContext.firstSelectorOfTheFragment = nextContext.selector;
         nextContext.isSubjectOrAdjacentElement = false;
         EnumSet<PseudoElementType> ignoredPseudoElements;
@@ -1282,12 +1282,12 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, LocalContext& c
                     return;
                 }
 
-                auto* ruleScopeHost = Style::hostForScopeOrdinal(*context.element, checkingContext.styleScopeOrdinal);
+                RefPtr ruleScopeHost = Style::hostForScopeOrdinal(*context.element, checkingContext.styleScopeOrdinal);
 
                 Vector<AtomString, 1> mappedNames { partName };
                 for (auto* shadowRoot = element.containingShadowRoot(); shadowRoot; shadowRoot = shadowRoot->host()->containingShadowRoot()) {
                     // Apply mappings up to the scope the rules are coming from.
-                    if (shadowRoot->host() == ruleScopeHost)
+                    if (shadowRoot->host() == ruleScopeHost.get())
                         break;
 
                     Vector<AtomString, 1> newMappedNames;

--- a/Source/WebCore/css/query/ContainerQueryFeatures.cpp
+++ b/Source/WebCore/css/query/ContainerQueryFeatures.cpp
@@ -192,7 +192,7 @@ struct StyleFeatureSchema : public FeatureSchema {
 
         auto& style = *context.conversionData.style();
 
-        auto* customPropertyValue = style.customPropertyValue(feature.name);
+        RefPtr customPropertyValue = style.customPropertyValue(feature.name);
         if (!feature.rightComparison)
             return toEvaluationResult(customPropertyValue && !customPropertyValue->isGuaranteedInvalid());
 

--- a/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
+++ b/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
@@ -148,8 +148,8 @@ ExceptionOr<Vector<Ref<CSSStyleValue>>> CSSStyleValueFactory::parseStyleValue(Do
         // https://drafts.css-houdini.org/css-typed-om/#subdivide-into-iterations
         if (CSSProperty::isListValuedProperty(propertyID)) {
             if (auto* values = dynamicDowncast<CSSValueContainingVector>(*cssValue)) {
-                for (auto& value : *values)
-                    cssValues.append(Ref { const_cast<CSSValue&>(value) });
+                for (Ref value : *values)
+                    cssValues.append(Ref { const_cast<CSSValue&>(value.get()) });
             }
         }
         if (cssValues.isEmpty())

--- a/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp
+++ b/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp
@@ -100,10 +100,10 @@ Vector<StylePropertyMapReadOnly::StylePropertyMapEntry> ComputedStylePropertyMap
         return values;
 
     Ref document = element->document();
-    const auto& inheritedCustomProperties = style->inheritedCustomProperties();
-    const auto& nonInheritedCustomProperties = style->nonInheritedCustomProperties();
+    Ref inheritedCustomProperties = style->inheritedCustomProperties();
+    Ref nonInheritedCustomProperties = style->nonInheritedCustomProperties();
     const auto& exposedComputedCSSPropertyIDs = document->exposedComputedCSSPropertyIDs();
-    values.reserveInitialCapacity(exposedComputedCSSPropertyIDs.size() + inheritedCustomProperties.size() + nonInheritedCustomProperties.size());
+    values.reserveInitialCapacity(exposedComputedCSSPropertyIDs.size() + inheritedCustomProperties->size() + nonInheritedCustomProperties->size());
 
     Style::Extractor computedStyleExtractor { element.get() };
     values.appendContainerWithMapping(exposedComputedCSSPropertyIDs, [&](auto propertyID) {
@@ -111,7 +111,7 @@ Vector<StylePropertyMapReadOnly::StylePropertyMapEntry> ComputedStylePropertyMap
         return makeKeyValuePair(nameString(propertyID), StylePropertyMapReadOnly::reifyValueToVector(document, WTF::move(value), propertyID));
     });
 
-    for (auto* map : { &nonInheritedCustomProperties, &inheritedCustomProperties }) {
+    for (const auto* map : { nonInheritedCustomProperties.ptr(), inheritedCustomProperties.ptr() }) {
         map->forEach([&](auto& it) {
             values.append(
                 makeKeyValuePair(

--- a/Source/WebCore/css/typedom/numeric/CSSMathValue.h
+++ b/Source/WebCore/css/typedom/numeric/CSSMathValue.h
@@ -54,14 +54,14 @@ template<typename T> bool CSSMathValue::equalsImpl(const CSSNumericValue& other)
         return false;
 
     ASSERT(styleValueType() == other.styleValueType());
-    auto& thisValues = static_cast<const T*>(this)->values();
-    auto& otherValues = otherT->values();
-    auto length = thisValues.length();
-    if (length != otherValues.length())
+    Ref thisValues = static_cast<const T*>(this)->values();
+    Ref otherValues = otherT->values();
+    auto length = thisValues->length();
+    if (length != otherValues->length())
         return false;
 
     for (size_t i = 0 ; i < length; ++i) {
-        if (!thisValues.array()[i]->equals(otherValues.array()[i].get()))
+        if (!thisValues->array()[i]->equals(otherValues->array()[i].get()))
             return false;
     }
 

--- a/Source/WebCore/css/typedom/transform/CSSMatrixComponent.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSMatrixComponent.cpp
@@ -58,7 +58,7 @@ ExceptionOr<Ref<CSSTransformComponent>> CSSMatrixComponent::create(Ref<const CSS
     auto makeMatrix = [&](NOESCAPE const Function<Ref<CSSTransformComponent>(Vector<double>&&)>& create, size_t expectedNumberOfComponents) -> ExceptionOr<Ref<CSSTransformComponent>> {
         Vector<double> components;
         for (Ref componentCSSValue : cssFunctionValue.get()) {
-            auto valueOrException = CSSStyleValueFactory::reifyValue(document, componentCSSValue, std::nullopt);
+            auto valueOrException = CSSStyleValueFactory::reifyValue(document, componentCSSValue.get(), std::nullopt);
             if (valueOrException.hasException())
                 return valueOrException.releaseException();
             RefPtr unitValue = dynamicDowncast<CSSUnitValue>(valueOrException.releaseReturnValue());

--- a/Source/WebCore/css/typedom/transform/CSSRotate.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSRotate.cpp
@@ -77,7 +77,7 @@ ExceptionOr<Ref<CSSRotate>> CSSRotate::create(Ref<const CSSFunctionValue> cssFun
     auto makeRotate = [&](NOESCAPE const Function<ExceptionOr<Ref<CSSRotate>>(Vector<RefPtr<CSSNumericValue>>&&)>& create, size_t expectedNumberOfComponents) -> ExceptionOr<Ref<CSSRotate>> {
         Vector<RefPtr<CSSNumericValue>> components;
         for (Ref componentCSSValue : cssFunctionValue.get()) {
-            auto valueOrException = CSSStyleValueFactory::reifyValue(document, componentCSSValue, std::nullopt);
+            auto valueOrException = CSSStyleValueFactory::reifyValue(document, componentCSSValue.get(), std::nullopt);
             if (valueOrException.hasException())
                 return valueOrException.releaseException();
             RefPtr numericValue = dynamicDowncast<CSSNumericValue>(valueOrException.releaseReturnValue());

--- a/Source/WebCore/css/typedom/transform/CSSTransformValue.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSTransformValue.cpp
@@ -100,7 +100,7 @@ ExceptionOr<Ref<CSSTransformValue>> CSSTransformValue::create(Ref<const CSSTrans
 {
     Vector<Ref<CSSTransformComponent>> components;
     for (Ref value : list.get()) {
-        RefPtr functionValue = dynamicDowncast<CSSFunctionValue>(value);
+        RefPtr functionValue = dynamicDowncast<CSSFunctionValue>(value.ptr());
         if (!functionValue)
             return Exception { ExceptionCode::TypeError, "Expected only function values in a transform list."_s };
         auto component = createTransformComponent(functionValue.releaseNonNull(), document);

--- a/Source/WebCore/css/typedom/transform/CSSTranslate.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSTranslate.cpp
@@ -63,7 +63,7 @@ ExceptionOr<Ref<CSSTranslate>> CSSTranslate::create(Ref<const CSSFunctionValue> 
     auto makeTranslate = [&](NOESCAPE const Function<ExceptionOr<Ref<CSSTranslate>>(Vector<Ref<CSSNumericValue>>&&)>& create, size_t minNumberOfComponents, std::optional<size_t> maxNumberOfComponents = std::nullopt) -> ExceptionOr<Ref<CSSTranslate>> {
         Vector<Ref<CSSNumericValue>> components;
         for (Ref componentCSSValue : cssFunctionValue.get()) {
-            auto valueOrException = CSSStyleValueFactory::reifyValue(document, componentCSSValue, std::nullopt);
+            auto valueOrException = CSSStyleValueFactory::reifyValue(document, componentCSSValue.get(), std::nullopt);
             if (valueOrException.hasException())
                 return valueOrException.releaseException();
             RefPtr numericValue = dynamicDowncast<CSSNumericValue>(valueOrException.releaseReturnValue());

--- a/Source/WebCore/css/values/CSSValueAggregates.h
+++ b/Source/WebCore/css/values/CSSValueAggregates.h
@@ -287,7 +287,7 @@ struct SpaceSeparatedEnumSet {
     static SpaceSeparatedEnumSet map(SizedRange&& range, NOESCAPE Mapper&& mapper)
     {
         Container result;
-        for (auto&& value : range)
+        for (auto& value : range)
             result.add(mapper(value));
         return result;
     }

--- a/Source/WebCore/dom/CollectionIndexCacheInlines.h
+++ b/Source/WebCore/dom/CollectionIndexCacheInlines.h
@@ -46,7 +46,7 @@ inline unsigned CollectionIndexCache<Collection, Iterator>::nodeCount(const Coll
 template <class Collection, class Iterator>
 unsigned CollectionIndexCache<Collection, Iterator>::computeNodeCountUpdatingListCache(const Collection& collection)
 {
-    auto current = collection.collectionBegin();
+    Iterator current = collection.collectionBegin();
     if (!current)
         return 0;
 

--- a/Source/WebCore/dom/ComposedTreeAncestorIterator.h
+++ b/Source/WebCore/dom/ComposedTreeAncestorIterator.h
@@ -55,7 +55,7 @@ public:
 
 private:
     void traverseParentInShadowTree();
-    static Element* traverseParent(Node*);
+    static CheckedPtr<Element> traverseParent(Node*);
 
     CheckedPtr<Element> m_current;
 };
@@ -75,19 +75,19 @@ inline ComposedTreeAncestorIterator::ComposedTreeAncestorIterator(Element& curre
 {
 }
 
-inline Element* ComposedTreeAncestorIterator::traverseParent(Node* current)
+inline CheckedPtr<Element> ComposedTreeAncestorIterator::traverseParent(Node* current)
 {
-    auto* parent = current->parentNode();
+    RefPtr parent = current->parentNode();
     if (!parent)
         return nullptr;
     if (auto* shadowRoot = dynamicDowncast<ShadowRoot>(*parent))
         return shadowRoot->host();
-    auto* parentElement = dynamicDowncast<Element>(*parent);
+    RefPtr parentElement = dynamicDowncast<Element>(*parent);
     if (!parentElement)
         return nullptr;
-    if (auto* shadowRoot = parentElement->shadowRoot())
+    if (RefPtr shadowRoot = parentElement->shadowRoot())
         return shadowRoot->findAssignedSlot(*current);
-    return parentElement;
+    return parentElement.get();
 }
 
 class ComposedTreeAncestorAdapter {

--- a/Source/WebCore/dom/ComposedTreeIterator.cpp
+++ b/Source/WebCore/dom/ComposedTreeIterator.cpp
@@ -44,9 +44,9 @@ String composedTreeAsText(ContainerNode& root, ComposedTreeAsTextMode mode)
             stream << "\n";
             continue;
         }
-        auto& element = downcast<Element>(*it);
-        stream << element.localName();
-        if (element.shadowRoot())
+        Ref element = downcast<Element>(*it);
+        stream << element->localName();
+        if (element->shadowRoot())
             stream << " (shadow root)";
         if (mode == ComposedTreeAsTextMode::WithPointers)
             stream << " " << &*it;

--- a/Source/WebCore/dom/ContainerNodeAlgorithms.cpp
+++ b/Source/WebCore/dom/ContainerNodeAlgorithms.cpp
@@ -220,16 +220,16 @@ static void collectFrameOwners(Vector<Ref<HTMLFrameOwnerElement>>& frameOwners, 
     auto it = elementDescendants.begin();
     auto end = elementDescendants.end();
     while (it != end) {
-        Element& element = *it;
-        if (!element.connectedSubframeCount()) {
+        Ref element = *it;
+        if (!element->connectedSubframeCount()) {
             it.traverseNextSkippingChildren();
             continue;
         }
 
-        if (RefPtr frameOwnerElement = dynamicDowncast<HTMLFrameOwnerElement>(element))
+        if (RefPtr frameOwnerElement = dynamicDowncast<HTMLFrameOwnerElement>(element.get()))
             frameOwners.append(frameOwnerElement.releaseNonNull());
 
-        if (RefPtr shadowRoot = element.shadowRoot())
+        if (RefPtr shadowRoot = element->shadowRoot())
             collectFrameOwners(frameOwners, *shadowRoot);
         ++it;
     }

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2779,14 +2779,6 @@ void Element::invalidateEventListenerRegions()
     invalidateStyleInternal();
 }
 
-bool Element::hasDisplayContents() const
-{
-    if (!hasRareData())
-        return false;
-    auto* style = elementRareData()->displayContentsOrNoneStyle();
-    return style && style->display() == DisplayType::Contents;
-}
-
 bool Element::hasDisplayNone() const
 {
     if (!hasRareData())

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -856,7 +856,7 @@ public:
 
     void invalidateEventListenerRegions();
 
-    bool hasDisplayContents() const;
+    inline bool hasDisplayContents() const;
     bool hasDisplayNone() const;
     void storeDisplayContentsOrNoneStyle(std::unique_ptr<RenderStyle>);
     void clearDisplayContentsOrNoneStyle();

--- a/Source/WebCore/dom/ElementAndTextDescendantIterator.h
+++ b/Source/WebCore/dom/ElementAndTextDescendantIterator.h
@@ -121,16 +121,16 @@ inline ElementAndTextDescendantIterator::ElementAndTextDescendantIterator(const 
         return;
 
     Vector<Node*, 20> ancestorStack;
-    auto* ancestor = m_current->parentNode();
+    RefPtr ancestor = m_current->parentNode();
     while (ancestor != &root) {
-        ancestorStack.append(ancestor);
+        ancestorStack.append(ancestor.get());
         ancestor = ancestor->parentNode();
     }
 
     m_ancestorSiblingStack.append({ nullptr, 0 });
     for (unsigned i = ancestorStack.size(); i; --i) {
-        if (auto* sibling = nextSibling(*ancestorStack[i - 1]))
-            m_ancestorSiblingStack.append({ sibling, i });
+        if (RefPtr sibling = nextSibling(*ancestorStack[i - 1]))
+            m_ancestorSiblingStack.append({ sibling.get(), i });
     }
 
     m_depth = ancestorStack.size() + 1;
@@ -185,13 +185,13 @@ inline ElementAndTextDescendantIterator& ElementAndTextDescendantIterator::trave
     ASSERT(m_current);
     ASSERT(!m_assertions.domTreeHasMutated());
 
-    auto* firstChild = ElementAndTextDescendantIterator::firstChild(*m_current);
-    auto* nextSibling = ElementAndTextDescendantIterator::nextSibling(*m_current);
+    RefPtr firstChild = ElementAndTextDescendantIterator::firstChild(*m_current);
+    RefPtr nextSibling = ElementAndTextDescendantIterator::nextSibling(*m_current);
     if (firstChild) {
         if (nextSibling)
-            m_ancestorSiblingStack.append({ nextSibling, m_depth });
+            m_ancestorSiblingStack.append({ nextSibling.get(), m_depth });
         ++m_depth;
-        m_current = firstChild;
+        m_current = firstChild.get();
         return *this;
     }
     if (!nextSibling) {
@@ -199,7 +199,7 @@ inline ElementAndTextDescendantIterator& ElementAndTextDescendantIterator::trave
         return *this;
     }
 
-    m_current = nextSibling;
+    m_current = nextSibling.get();
     return *this;
 }
 

--- a/Source/WebCore/dom/ElementIteratorInlines.h
+++ b/Source/WebCore/dom/ElementIteratorInlines.h
@@ -104,7 +104,7 @@ inline ElementIterator<ElementType>& ElementIterator<ElementType>::traverseNextS
 template <typename ElementType>
 inline ElementType* findElementAncestorOfType(const Node& current)
 {
-    for (Element* ancestor = current.parentElement(); ancestor; ancestor = ancestor->parentElement()) {
+    for (RefPtr ancestor = current.parentElement(); ancestor; ancestor = ancestor->parentElement()) {
         if (auto* element = dynamicDowncast<ElementType>(*ancestor))
             return element;
     }

--- a/Source/WebCore/dom/ElementRareData.h
+++ b/Source/WebCore/dom/ElementRareData.h
@@ -40,6 +40,7 @@
 #include "PseudoElement.h"
 #include "PseudoElementIdentifier.h"
 #include "RenderElement.h"
+#include "RenderStyle+GettersInlines.h"
 #include "ResizeObserver.h"
 #include "ShadowRoot.h"
 #include "SpaceSplitString.h"
@@ -391,6 +392,14 @@ inline void Element::removeShadowRoot()
     if (!shadowRoot) [[likely]]
         return;
     removeShadowRootSlow(*shadowRoot);
+}
+
+inline bool Element::hasDisplayContents() const
+{
+    if (!hasRareData())
+        return false;
+    auto* style = elementRareData()->displayContentsOrNoneStyle();
+    return style && style->display() == DisplayType::Contents;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/ElementTraversal.h
+++ b/Source/WebCore/dom/ElementTraversal.h
@@ -185,7 +185,7 @@ inline ElementType* Traversal<ElementType>::nextTemplate(CurrentType& current, c
 template <typename ElementType>
 inline ElementType* Traversal<ElementType>::previous(const Node& current)
 {
-    for (auto* node = NodeTraversal::previous(current); node; node = NodeTraversal::previous(*node)) {
+    for (RefPtr node = NodeTraversal::previous(current); node; node = NodeTraversal::previous(*node)) {
         if (auto* element = dynamicDowncast<ElementType>(*node))
             return element;
     }
@@ -195,7 +195,7 @@ inline ElementType* Traversal<ElementType>::previous(const Node& current)
 template <typename ElementType>
 inline ElementType* Traversal<ElementType>::previous(const Node& current, const Node* stayWithin)
 {
-    for (auto* node = NodeTraversal::previous(current, stayWithin); node; node = NodeTraversal::previous(*node, stayWithin)) {
+    for (RefPtr node = NodeTraversal::previous(current, stayWithin); node; node = NodeTraversal::previous(*node, stayWithin)) {
         if (auto* element = dynamicDowncast<ElementType>(*node))
             return element;
     }
@@ -205,7 +205,7 @@ inline ElementType* Traversal<ElementType>::previous(const Node& current, const 
 template <typename ElementType>
 inline ElementType* Traversal<ElementType>::nextSibling(const Node& current)
 {
-    for (auto* node = current.nextSibling(); node; node = node->nextSibling()) {
+    for (RefPtr node = current.nextSibling(); node; node = node->nextSibling()) {
         if (auto* element = dynamicDowncast<ElementType>(*node))
             return element;
     }
@@ -215,7 +215,7 @@ inline ElementType* Traversal<ElementType>::nextSibling(const Node& current)
 template <typename ElementType>
 inline ElementType* Traversal<ElementType>::previousSibling(const Node& current)
 {
-    for (auto* node = current.previousSibling(); node; node = node->previousSibling()) {
+    for (RefPtr node = current.previousSibling(); node; node = node->previousSibling()) {
         if (auto* element = dynamicDowncast<ElementType>(*node))
             return element;
     }
@@ -225,7 +225,7 @@ inline ElementType* Traversal<ElementType>::previousSibling(const Node& current)
 template <typename ElementType>
 inline ElementType* Traversal<ElementType>::nextSkippingChildren(const Node& current)
 {
-    for (auto* node = NodeTraversal::nextSkippingChildren(current); node; node = NodeTraversal::nextSkippingChildren(*node)) {
+    for (RefPtr node = NodeTraversal::nextSkippingChildren(current); node; node = NodeTraversal::nextSkippingChildren(*node)) {
         if (auto* element = dynamicDowncast<ElementType>(*node))
             return element;
     }
@@ -235,7 +235,7 @@ inline ElementType* Traversal<ElementType>::nextSkippingChildren(const Node& cur
 template <typename ElementType>
 inline ElementType* Traversal<ElementType>::nextSkippingChildren(const Node& current, const Node* stayWithin)
 {
-    for (auto* node = NodeTraversal::nextSkippingChildren(current, stayWithin); node; node = NodeTraversal::nextSkippingChildren(*node, stayWithin)) {
+    for (RefPtr node = NodeTraversal::nextSkippingChildren(current, stayWithin); node; node = NodeTraversal::nextSkippingChildren(*node, stayWithin)) {
         if (auto* element = dynamicDowncast<ElementType>(*node))
             return element;
     }
@@ -306,7 +306,7 @@ inline ElementType* Traversal<ElementType>::next(const Node& current, const Node
 // FIXME: These should go somewhere else.
 inline Element* ElementTraversal::previousIncludingPseudo(const Node& current, const Node* stayWithin)
 {
-    for (auto* node = NodeTraversal::previousIncludingPseudo(current, stayWithin); node; node = NodeTraversal::previousIncludingPseudo(*node, stayWithin)) {
+    for (RefPtr node = NodeTraversal::previousIncludingPseudo(current, stayWithin); node; node = NodeTraversal::previousIncludingPseudo(*node, stayWithin)) {
         if (auto* element = dynamicDowncast<Element>(*node))
             return element;
     }
@@ -315,7 +315,7 @@ inline Element* ElementTraversal::previousIncludingPseudo(const Node& current, c
 
 inline Element* ElementTraversal::nextIncludingPseudo(const Node& current, const Node* stayWithin)
 {
-    for (auto* node = NodeTraversal::nextIncludingPseudo(current, stayWithin); node; node = NodeTraversal::nextIncludingPseudo(*node, stayWithin)) {
+    for (RefPtr node = NodeTraversal::nextIncludingPseudo(current, stayWithin); node; node = NodeTraversal::nextIncludingPseudo(*node, stayWithin)) {
         if (auto* element = dynamicDowncast<Element>(*node))
             return element;
     }
@@ -324,7 +324,7 @@ inline Element* ElementTraversal::nextIncludingPseudo(const Node& current, const
 
 inline Element* ElementTraversal::nextIncludingPseudoSkippingChildren(const Node& current, const Node* stayWithin)
 {
-    for (auto* node = NodeTraversal::nextIncludingPseudoSkippingChildren(current, stayWithin); node; node = NodeTraversal::nextIncludingPseudoSkippingChildren(*node, stayWithin)) {
+    for (RefPtr node = NodeTraversal::nextIncludingPseudoSkippingChildren(current, stayWithin); node; node = NodeTraversal::nextIncludingPseudoSkippingChildren(*node, stayWithin)) {
         if (auto* element = dynamicDowncast<Element>(*node))
             return element;
     }
@@ -333,7 +333,7 @@ inline Element* ElementTraversal::nextIncludingPseudoSkippingChildren(const Node
 
 inline Element* ElementTraversal::pseudoAwarePreviousSibling(const Node& current)
 {
-    for (auto* node = current.pseudoAwarePreviousSibling(); node; node = node->pseudoAwarePreviousSibling()) {
+    for (RefPtr node = current.pseudoAwarePreviousSibling(); node; node = node->pseudoAwarePreviousSibling()) {
         if (auto* element = dynamicDowncast<Element>(*node))
             return element;
     }

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -242,7 +242,7 @@ void Node::dumpStatistics()
     for (auto& node : liveNodeSet()) {
         if (node.hasRareData()) {
             ++nodesWithRareData;
-            if (auto* element = dynamicDowncast<Element>(node)) {
+            if (CheckedPtr element = dynamicDowncast<Element>(node)) {
                 ++elementsWithRareData;
                 if (element->hasNamedNodeMap())
                     ++elementsWithNamedNodeMap;

--- a/Source/WebCore/dom/NodeTraversal.h
+++ b/Source/WebCore/dom/NodeTraversal.h
@@ -120,7 +120,7 @@ inline Node* next(const Text& current, const Node* stayWithin) { return nextSkip
 
 inline Node* previous(const Node& current, const Node* stayWithin)
 {
-    if (Node* previous = current.previousSibling())
+    if (RefPtr previous = current.previousSibling())
         return deepLastChild(*previous);
     if (current.parentNode() == stayWithin)
         return nullptr;

--- a/Source/WebCore/dom/TypedElementDescendantIterator.h
+++ b/Source/WebCore/dom/TypedElementDescendantIterator.h
@@ -132,7 +132,7 @@ public:
     inline Iterator begin() const;
     static constexpr std::nullptr_t end() { return nullptr; }
 
-    inline ElementType* first() const;
+    inline RefPtr<ElementType> first() const;
 
 private:
     CheckedRef<const ContainerNode> m_root;

--- a/Source/WebCore/dom/TypedElementDescendantIteratorInlines.h
+++ b/Source/WebCore/dom/TypedElementDescendantIteratorInlines.h
@@ -149,12 +149,12 @@ template<typename ElementType, bool filter(const ElementType&)> FilteredElementD
 
 template<typename ElementType, bool filter(const ElementType&)> auto FilteredElementDescendantRange<ElementType, filter>::begin() const -> Iterator
 {
-    return { m_root, first() };
+    return { m_root, first().get() };
 }
 
-template<typename ElementType, bool filter(const ElementType&)> ElementType* FilteredElementDescendantRange<ElementType, filter>::first() const
+template<typename ElementType, bool filter(const ElementType&)> RefPtr<ElementType> FilteredElementDescendantRange<ElementType, filter>::first() const
 {
-    for (auto* element = Traversal<ElementType>::firstWithin(m_root.get()); element; element = Traversal<ElementType>::next(*element, m_root.ptr())) {
+    for (RefPtr element = Traversal<ElementType>::firstWithin(m_root.get()); element; element = Traversal<ElementType>::next(*element, m_root.ptr())) {
         if (filter(*element))
             return element;
     }

--- a/Source/WebCore/editing/ApplyStyleCommand.cpp
+++ b/Source/WebCore/editing/ApplyStyleCommand.cpp
@@ -1066,7 +1066,7 @@ void ApplyStyleCommand::pushDownInlineStyleAroundNode(EditingStyle& style, Node*
         }
 
         auto styleToPushDown = EditingStyle::create();
-        if (auto* htmlElement = dynamicDowncast<HTMLElement>(*current))
+        if (RefPtr htmlElement = dynamicDowncast<HTMLElement>(*current))
             removeInlineStyleFromElement(style, *htmlElement, InlineStyleRemovalMode::IfNeeded, styleToPushDown.ptr());
 
         // The inner loop will go through children on each level
@@ -1439,11 +1439,11 @@ void ApplyStyleCommand::applyInlineStyleChange(Node& passedStart, Node& passedEn
     RefPtr<HTMLFontElement> fontContainer;
     RefPtr<HTMLElement> styleContainer;
     while (startNode == endNode) {
-        if (auto* container = dynamicDowncast<HTMLElement>(*startNode)) {
-            if (auto* fontElement = dynamicDowncast<HTMLFontElement>(*container))
+        if (RefPtr container = dynamicDowncast<HTMLElement>(*startNode)) {
+            if (auto* fontElement = dynamicDowncast<HTMLFontElement>(*container.get()))
                 fontContainer = fontElement;
-            if (is<HTMLSpanElement>(*container) || (!is<HTMLSpanElement>(styleContainer) && container->hasChildNodes()))
-                styleContainer = container;
+            if (is<HTMLSpanElement>(*container.get()) || (!is<HTMLSpanElement>(styleContainer) && container->hasChildNodes()))
+                styleContainer = container.get();
             if (!canHaveChildrenForEditing(*startNode))
                 break;
         }

--- a/Source/WebCore/editing/Editing.cpp
+++ b/Source/WebCore/editing/Editing.cpp
@@ -34,6 +34,7 @@
 #include "Editor.h"
 #include "ElementChildIteratorInlines.h"
 #include "ElementInlines.h"
+#include "ElementRareData.h"
 #include "FrameDestructionObserverInlines.h"
 #include "GraphicsLayer.h"
 #include "HTMLBodyElement.h"

--- a/Source/WebCore/editing/EditorCommand.cpp
+++ b/Source/WebCore/editing/EditorCommand.cpp
@@ -357,16 +357,16 @@ static bool executeDeleteToEndOfParagraph(LocalFrame& frame, Event*, EditorComma
 
 static bool executeDeleteToMark(LocalFrame& frame, Event*, EditorCommandSource, const String&)
 {
-    auto& editor = frame.editor();
+    Ref editor = frame.editor();
     auto& selection = frame.selection();
-    auto markRange = editor.mark().toNormalizedRange();
+    auto markRange = editor->mark().toNormalizedRange();
     auto selectionRange = selection.selection().toNormalizedRange();
     if (markRange && selectionRange) {
         if (!selection.setSelectedRange(unionRange(*markRange, *selectionRange), Affinity::Downstream, FrameSelection::ShouldCloseTyping::Yes))
             return false;
     }
-    editor.performDelete();
-    editor.setMark(selection.selection());
+    editor->performDelete();
+    editor->setMark(selection.selection());
     return true;
 }
 
@@ -997,7 +997,7 @@ static bool executePasteAsQuotation(LocalFrame& frame, Event*, EditorCommandSour
 
 static bool executePrint(LocalFrame& frame, Event*, EditorCommandSource, const String&)
 {
-    Page* page = frame.page();
+    RefPtr page = frame.page();
     if (!page)
         return false;
     return page->chrome().print(frame);
@@ -1080,9 +1080,9 @@ static bool executeSelectSentence(LocalFrame& frame, Event*, EditorCommandSource
 
 static bool executeSelectToMark(LocalFrame& frame, Event*, EditorCommandSource, const String&)
 {
-    auto& editor = frame.editor();
+    Ref editor = frame.editor();
     auto& selection = frame.selection();
-    auto markRange = editor.mark().toNormalizedRange();
+    auto markRange = editor->mark().toNormalizedRange();
     auto selectionRange = selection.selection().toNormalizedRange();
     if (!markRange || !selectionRange) {
         SystemSoundManager::singleton().systemBeep();

--- a/Source/WebCore/editing/cocoa/DictionaryLookup.mm
+++ b/Source/WebCore/editing/cocoa/DictionaryLookup.mm
@@ -292,11 +292,11 @@ std::optional<SimpleRange> DictionaryLookup::rangeAtHitTestResult(const HitTestR
     if (!canCreateRevealItems())
         return std::nullopt;
     
-    auto* node = hitTestResult.innerNonSharedNode();
+    RefPtr node = hitTestResult.innerNonSharedNode();
     if (!node || !node->renderer())
         return std::nullopt;
 
-    auto* frame = node->document().frame();
+    RefPtr frame = node->document().frame();
     if (!frame)
         return std::nullopt;
 
@@ -307,7 +307,7 @@ std::optional<SimpleRange> DictionaryLookup::rangeAtHitTestResult(const HitTestR
 
     auto position = frame->visiblePositionForPoint(framePoint);
     if (position.isNull())
-        position = firstPositionInOrBeforeNode(node);
+        position = firstPositionInOrBeforeNode(node.get());
 
     RefPtr focusedOrMainFrame = frame->page()->focusController().focusedOrMainFrame();
     if (!focusedOrMainFrame)

--- a/Source/WebCore/editing/cocoa/EditorCocoa.mm
+++ b/Source/WebCore/editing/cocoa/EditorCocoa.mm
@@ -110,7 +110,7 @@ void Editor::getPasteboardTypesAndDataForAttachment(Element& element, Vector<std
 static RetainPtr<NSAttributedString> selectionInImageOverlayAsAttributedString(const VisibleSelection& selection)
 {
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
-    auto* page = selection.document()->page();
+    RefPtr page = selection.document()->page();
     if (!page)
         return nil;
 

--- a/Source/WebCore/editing/mac/EditorMac.mm
+++ b/Source/WebCore/editing/mac/EditorMac.mm
@@ -256,7 +256,7 @@ void Editor::writeImageToPasteboard(Pasteboard& pasteboard, Element& imageElemen
     pasteboardImage.url.url = url;
     pasteboardImage.url.title = title;
     pasteboardImage.url.userVisibleForm = WTF::userVisibleString(pasteboardImage.url.url.createNSURL().get());
-    if (auto* buffer = cachedImage->resourceBuffer())
+    if (RefPtr buffer = cachedImage->resourceBuffer())
         pasteboardImage.resourceData = buffer->makeContiguous();
     pasteboardImage.resourceMIMEType = cachedImage->response().mimeType();
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
@@ -193,11 +193,11 @@ void CanvasRenderingContext2D::setFontWithoutUpdatingStyle(const String& newFont
         return;
 
     Ref canvas = this->canvas();
-    auto& document = canvas->document();
+    Ref document = canvas->document();
 
     // According to http://lists.w3.org/Archives/Public/public-html/2009Jul/0947.html,
     // the "inherit" and "initial" values must be ignored. CSSPropertyParserHelpers::parseUnresolvedFont() ignores these.
-    auto unresolvedFont = CSSPropertyParserHelpers::parseUnresolvedFont(newFont, document, strictToCSSParserMode(!usesCSSCompatibilityParseMode()));
+    auto unresolvedFont = CSSPropertyParserHelpers::parseUnresolvedFont(newFont, document.get(), strictToCSSParserMode(!usesCSSCompatibilityParseMode()));
     if (!unresolvedFont)
         return;
 
@@ -213,7 +213,7 @@ void CanvasRenderingContext2D::setFontWithoutUpdatingStyle(const String& newFont
 
     // Map the <canvas> font into the text style. If the font uses keywords like larger/smaller, these will work
     // relative to the canvas.
-    auto fontCascade = Style::resolveForUnresolvedFont(*unresolvedFont, WTF::move(fontDescription), document);
+    auto fontCascade = Style::resolveForUnresolvedFont(*unresolvedFont, WTF::move(fontDescription), document.get());
     if (!fontCascade)
         return;
 
@@ -221,7 +221,7 @@ void CanvasRenderingContext2D::setFontWithoutUpdatingStyle(const String& newFont
     realizeSaves();
     modifiableState().unparsedFont = newFontSafeCopy;
 
-    modifiableState().font.initialize(document.fontSelector(), *fontCascade);
+    modifiableState().font.initialize(document->fontSelector(), *fontCascade);
     ASSERT(state().font.realized());
     ASSERT(state().font.isPopulated());
 

--- a/Source/WebCore/inspector/InspectorInstrumentation.h
+++ b/Source/WebCore/inspector/InspectorInstrumentation.h
@@ -41,6 +41,7 @@
 #include "Frame.h"
 #include "HitTestResult.h"
 #include "InspectorInstrumentationPublic.h"
+#include "InstrumentingAgents.h"
 #include "LocalFrame.h"
 #include "NodeDocument.h"
 #include "Page.h"
@@ -564,7 +565,7 @@ inline void InspectorInstrumentation::didClearWindowObjectInWorld(LocalFrame& fr
 inline bool InspectorInstrumentation::isDebuggerPaused(LocalFrame* frame)
 {
     FAST_RETURN_IF_NO_FRONTENDS(false);
-    if (auto* agents = instrumentingAgents(frame))
+    if (RefPtr agents = instrumentingAgents(frame))
         return isDebuggerPausedImpl(*agents);
     return false;
 }
@@ -572,7 +573,7 @@ inline bool InspectorInstrumentation::isDebuggerPaused(LocalFrame* frame)
 inline int InspectorInstrumentation::identifierForNode(Node& node)
 {
     FAST_RETURN_IF_NO_FRONTENDS(0);
-    if (auto* agents = instrumentingAgents(node.document()))
+    if (RefPtr agents = instrumentingAgents(node.document()))
         return identifierForNodeImpl(*agents, node);
     return 0;
 }
@@ -580,49 +581,49 @@ inline int InspectorInstrumentation::identifierForNode(Node& node)
 inline void InspectorInstrumentation::addEventListenersToNode(Node& node)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(node.document()))
+    if (RefPtr agents = instrumentingAgents(node.document()))
         addEventListenersToNodeImpl(*agents, node);
 }
 
 inline void InspectorInstrumentation::willInsertDOMNode(Document& document, Node& parent)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(document))
+    if (RefPtr agents = instrumentingAgents(document))
         willInsertDOMNodeImpl(*agents, parent);
 }
 
 inline void InspectorInstrumentation::didInsertDOMNode(Document& document, Node& node)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(document))
+    if (RefPtr agents = instrumentingAgents(document))
         didInsertDOMNodeImpl(*agents, node);
 }
 
 inline void InspectorInstrumentation::willRemoveDOMNode(Document& document, Node& node)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(document))
+    if (RefPtr agents = instrumentingAgents(document))
         willRemoveDOMNodeImpl(*agents, node);
 }
 
 inline void InspectorInstrumentation::didRemoveDOMNode(Document& document, Node& node)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(document))
+    if (RefPtr agents = instrumentingAgents(document))
         didRemoveDOMNodeImpl(*agents, node);
 }
 
 inline void InspectorInstrumentation::willDestroyDOMNode(Node& node)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(node.document()))
+    if (RefPtr agents = instrumentingAgents(node.document()))
         willDestroyDOMNodeImpl(*agents, node);
 }
 
 inline void InspectorInstrumentation::didChangeRendererForDOMNode(Node& node)
 {
     ASSERT(InspectorInstrumentationPublic::hasFrontends());
-    if (auto* agents = instrumentingAgents(node.document()))
+    if (RefPtr agents = instrumentingAgents(node.document()))
         didChangeRendererForDOMNodeImpl(*agents, node);
 }
 
@@ -641,42 +642,42 @@ inline void InspectorInstrumentation::didAddOrRemoveScrollbars(RenderObject& ren
 inline void InspectorInstrumentation::willModifyDOMAttr(Document& document, Element& element, const AtomString& oldValue, const AtomString& newValue)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(document))
+    if (RefPtr agents = instrumentingAgents(document))
         willModifyDOMAttrImpl(*agents, element, oldValue, newValue);
 }
 
 inline void InspectorInstrumentation::didModifyDOMAttr(Document& document, Element& element, const AtomString& name, const AtomString& value)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(document))
+    if (RefPtr agents = instrumentingAgents(document))
         didModifyDOMAttrImpl(*agents, element, name, value);
 }
 
 inline void InspectorInstrumentation::didRemoveDOMAttr(Document& document, Element& element, const AtomString& name)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(document))
+    if (RefPtr agents = instrumentingAgents(document))
         didRemoveDOMAttrImpl(*agents, element, name);
 }
 
 inline void InspectorInstrumentation::willInvalidateStyleAttr(Element& element)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(element.document()))
+    if (RefPtr agents = instrumentingAgents(element.document()))
         willInvalidateStyleAttrImpl(*agents, element);
 }
 
 inline void InspectorInstrumentation::didInvalidateStyleAttr(Element& element)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(element.document()))
+    if (RefPtr agents = instrumentingAgents(element.document()))
         didInvalidateStyleAttrImpl(*agents, element);
 }
 
 inline void InspectorInstrumentation::documentDetached(Document& document)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(document))
+    if (RefPtr agents = instrumentingAgents(document))
         documentDetachedImpl(*agents, document);
 }
 
@@ -688,98 +689,98 @@ inline void InspectorInstrumentation::frameWindowDiscarded(LocalFrame& frame, Lo
 inline void InspectorInstrumentation::mediaQueryResultChanged(Document& document)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(document))
+    if (RefPtr agents = instrumentingAgents(document))
         mediaQueryResultChangedImpl(*agents);
 }
 
 inline void InspectorInstrumentation::activeStyleSheetsUpdated(Document& document)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(document))
+    if (RefPtr agents = instrumentingAgents(document))
         activeStyleSheetsUpdatedImpl(*agents, document);
 }
 
 inline void InspectorInstrumentation::didPushShadowRoot(Element& host, ShadowRoot& root)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(host.document()))
+    if (RefPtr agents = instrumentingAgents(host.document()))
         didPushShadowRootImpl(*agents, host, root);
 }
 
 inline void InspectorInstrumentation::willPopShadowRoot(Element& host, ShadowRoot& root)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(host.document()))
+    if (RefPtr agents = instrumentingAgents(host.document()))
         willPopShadowRootImpl(*agents, host, root);
 }
 
 inline void InspectorInstrumentation::didChangeAssignedSlot(Node& slotable)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(slotable.document()))
+    if (RefPtr agents = instrumentingAgents(slotable.document()))
         didChangeAssignedSlotImpl(*agents, slotable);
 }
 
 inline void InspectorInstrumentation::didChangeAssignedNodes(Element& slotElement)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(slotElement.document()))
+    if (RefPtr agents = instrumentingAgents(slotElement.document()))
         didChangeAssignedNodesImpl(*agents, slotElement);
 }
 
 inline void InspectorInstrumentation::didChangeCustomElementState(Element& element)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(element.document()))
+    if (RefPtr agents = instrumentingAgents(element.document()))
         didChangeCustomElementStateImpl(*agents, element);
 }
 
 inline void InspectorInstrumentation::pseudoElementCreated(Page* page, PseudoElement& pseudoElement)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(page))
+    if (RefPtr agents = instrumentingAgents(page))
         pseudoElementCreatedImpl(*agents, pseudoElement);
 }
 
 inline void InspectorInstrumentation::pseudoElementDestroyed(Page* page, PseudoElement& pseudoElement)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(page))
+    if (RefPtr agents = instrumentingAgents(page))
         pseudoElementDestroyedImpl(*agents, pseudoElement);
 }
 
 inline void InspectorInstrumentation::didCreateNamedFlow(Document* document, WebKitNamedFlow& namedFlow)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(document))
+    if (RefPtr agents = instrumentingAgents(document))
         didCreateNamedFlowImpl(*agents, document, namedFlow);
 }
 
 inline void InspectorInstrumentation::willRemoveNamedFlow(Document* document, WebKitNamedFlow& namedFlow)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(document))
+    if (RefPtr agents = instrumentingAgents(document))
         willRemoveNamedFlowImpl(*agents, document, namedFlow);
 }
 
 inline void InspectorInstrumentation::didChangeRegionOverset(Document& document, WebKitNamedFlow& namedFlow)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(document))
+    if (RefPtr agents = instrumentingAgents(document))
         didChangeRegionOversetImpl(*agents, document, namedFlow);
 }
 
 inline void InspectorInstrumentation::didRegisterNamedFlowContentElement(Document& document, WebKitNamedFlow& namedFlow, Node& contentElement, Node* nextContentElement)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(document))
+    if (RefPtr agents = instrumentingAgents(document))
         didRegisterNamedFlowContentElementImpl(*agents, document, namedFlow, contentElement, nextContentElement);
 }
 
 inline void InspectorInstrumentation::didUnregisterNamedFlowContentElement(Document& document, WebKitNamedFlow& namedFlow, Node& contentElement)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(document))
+    if (RefPtr agents = instrumentingAgents(document))
         didUnregisterNamedFlowContentElementImpl(*agents, document, namedFlow, contentElement);
 }
 
@@ -804,7 +805,7 @@ inline bool InspectorInstrumentation::handleMousePress(LocalFrame& frame)
 inline bool InspectorInstrumentation::forcePseudoState(const Element& element, CSSSelector::PseudoClass pseudoState)
 {
     FAST_RETURN_IF_NO_FRONTENDS(false);
-    if (auto* agents = instrumentingAgents(element.document()))
+    if (RefPtr agents = instrumentingAgents(element.document()))
         return forcePseudoStateImpl(*agents, element, pseudoState);
     return false;
 }
@@ -812,56 +813,56 @@ inline bool InspectorInstrumentation::forcePseudoState(const Element& element, C
 inline void InspectorInstrumentation::characterDataModified(Document& document, CharacterData& characterData)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(document))
+    if (RefPtr agents = instrumentingAgents(document))
         characterDataModifiedImpl(*agents, characterData);
 }
 
 inline void InspectorInstrumentation::willSendXMLHttpRequest(ScriptExecutionContext* context, const String& url)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(context))
+    if (RefPtr agents = instrumentingAgents(context))
         willSendXMLHttpRequestImpl(*agents, url);
 }
 
 inline void InspectorInstrumentation::willFetch(ScriptExecutionContext& context, const String& url)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(context))
+    if (RefPtr agents = instrumentingAgents(context))
         willFetchImpl(*agents, url);
 }
 
 inline void InspectorInstrumentation::didInstallTimer(ScriptExecutionContext& context, int timerId, Seconds timeout, bool singleShot)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(context))
+    if (RefPtr agents = instrumentingAgents(context))
         didInstallTimerImpl(*agents, timerId, timeout, singleShot, context);
 }
 
 inline void InspectorInstrumentation::didRemoveTimer(ScriptExecutionContext& context, int timerId)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(context))
+    if (RefPtr agents = instrumentingAgents(context))
         didRemoveTimerImpl(*agents, timerId);
 }
 
 inline void InspectorInstrumentation::didAddEventListener(EventTarget& target, const AtomString& eventType, EventListener& listener, bool capture)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(target.scriptExecutionContext()))
+    if (RefPtr agents = instrumentingAgents(target.scriptExecutionContext()))
         didAddEventListenerImpl(*agents, target, eventType, listener, capture);
 }
 
 inline void InspectorInstrumentation::willRemoveEventListener(EventTarget& target, const AtomString& eventType, EventListener& listener, bool capture)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(target.scriptExecutionContext()))
+    if (RefPtr agents = instrumentingAgents(target.scriptExecutionContext()))
         willRemoveEventListenerImpl(*agents, target, eventType, listener, capture);
 }
 
 inline bool InspectorInstrumentation::isEventListenerDisabled(EventTarget& target, const AtomString& eventType, EventListener& listener, bool capture)
 {
     FAST_RETURN_IF_NO_FRONTENDS(false);
-    if (auto* agents = instrumentingAgents(target.scriptExecutionContext()))
+    if (RefPtr agents = instrumentingAgents(target.scriptExecutionContext()))
         return isEventListenerDisabledImpl(*agents, target, eventType, listener, capture);
     return false;
 }
@@ -899,56 +900,56 @@ inline void InspectorInstrumentation::didDispatchPostMessage(LocalFrame& frame, 
 inline void InspectorInstrumentation::willCallFunction(ScriptExecutionContext* context, const String& scriptName, int scriptLine, int scriptColumn)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(context))
+    if (RefPtr agents = instrumentingAgents(context))
         willCallFunctionImpl(*agents, scriptName, scriptLine, scriptColumn);
 }
 
 inline void InspectorInstrumentation::didCallFunction(ScriptExecutionContext* context)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(context))
+    if (RefPtr agents = instrumentingAgents(context))
         didCallFunctionImpl(*agents);
 }
 
 inline void InspectorInstrumentation::willDispatchEvent(ScriptExecutionContext& context, const Event& event)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(context))
+    if (RefPtr agents = instrumentingAgents(context))
         willDispatchEventImpl(*agents, event);
 }
 
 inline void InspectorInstrumentation::didDispatchEvent(ScriptExecutionContext& context, const Event& event)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(context))
+    if (RefPtr agents = instrumentingAgents(context))
         didDispatchEventImpl(*agents, event);
 }
 
 inline void InspectorInstrumentation::willHandleEvent(ScriptExecutionContext& context, Event& event, const RegisteredEventListener& listener)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(context))
+    if (RefPtr agents = instrumentingAgents(context))
         return willHandleEventImpl(*agents, context, event, listener);
 }
 
 inline void InspectorInstrumentation::didHandleEvent(ScriptExecutionContext& context, Event& event, const RegisteredEventListener& listener)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(context))
+    if (RefPtr agents = instrumentingAgents(context))
         return didHandleEventImpl(*agents, context, event, listener);
 }
 
 inline void InspectorInstrumentation::willDispatchEventOnWindow(LocalFrame* frame, const Event& event)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
+    if (RefPtr agents = instrumentingAgents(frame))
         willDispatchEventOnWindowImpl(*agents, event);
 }
 
 inline void InspectorInstrumentation::didDispatchEventOnWindow(LocalFrame* frame, const Event& event)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
+    if (RefPtr agents = instrumentingAgents(frame))
         didDispatchEventOnWindowImpl(*agents, event);
 }
 
@@ -959,8 +960,8 @@ inline void InspectorInstrumentation::eventDidResetAfterDispatch(const Event& ev
     if (!is<Node>(event.target()))
         return;
 
-    auto* node = downcast<Node>(event.target());
-    if (auto* agents = instrumentingAgents(node->scriptExecutionContext()))
+    RefPtr node = downcast<Node>(event.target());
+    if (RefPtr agents = instrumentingAgents(node->scriptExecutionContext()))
         return eventDidResetAfterDispatchImpl(*agents, event);
 }
 
@@ -991,14 +992,14 @@ inline void InspectorInstrumentation::didEvaluateScript(WorkerOrWorkletGlobalSco
 inline void InspectorInstrumentation::willFireTimer(ScriptExecutionContext& context, int timerId, bool oneShot)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(context))
+    if (RefPtr agents = instrumentingAgents(context))
         willFireTimerImpl(*agents, timerId, oneShot);
 }
 
 inline void InspectorInstrumentation::didFireTimer(ScriptExecutionContext& context, int timerId, bool oneShot)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(context))
+    if (RefPtr agents = instrumentingAgents(context))
         didFireTimerImpl(*agents, timerId, oneShot);
 }
 
@@ -1053,21 +1054,21 @@ inline void InspectorInstrumentation::didPaint(RenderObject& renderer, const Lay
 inline void InspectorInstrumentation::willRecalculateStyle(Document& document)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(document))
+    if (RefPtr agents = instrumentingAgents(document))
         willRecalculateStyleImpl(*agents);
 }
 
 inline void InspectorInstrumentation::didRecalculateStyle(Document& document)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(document))
+    if (RefPtr agents = instrumentingAgents(document))
         didRecalculateStyleImpl(*agents);
 }
 
 inline void InspectorInstrumentation::didScheduleStyleRecalculation(Document& document)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(document))
+    if (RefPtr agents = instrumentingAgents(document))
         didScheduleStyleRecalculationImpl(*agents, document);
 }
 
@@ -1098,7 +1099,7 @@ inline void InspectorInstrumentation::flexibleBoxRendererWrappedToNextLine(const
 inline void InspectorInstrumentation::willSendRequest(LocalFrame* frame, ResourceLoaderIdentifier identifier, DocumentLoader* loader, ResourceRequest& request, const ResourceResponse& redirectResponse, const CachedResource* cachedResource, ResourceLoader* resourceLoader)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
+    if (RefPtr agents = instrumentingAgents(frame))
         willSendRequestImpl(*agents, identifier, loader, request, redirectResponse, cachedResource, resourceLoader);
 }
 
@@ -1111,7 +1112,7 @@ inline void InspectorInstrumentation::willSendRequest(ServiceWorkerGlobalScope& 
 inline void InspectorInstrumentation::willSendRequestOfType(LocalFrame* frame, ResourceLoaderIdentifier identifier, DocumentLoader* loader, ResourceRequest& request, LoadType loadType)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
+    if (RefPtr agents = instrumentingAgents(frame))
         willSendRequestOfTypeImpl(*agents, identifier, loader, request, loadType);
 }
 
@@ -1134,14 +1135,14 @@ inline void InspectorInstrumentation::didReceiveResourceResponse(ServiceWorkerGl
 inline void InspectorInstrumentation::didReceiveThreadableLoaderResponse(Document& document, DocumentThreadableLoader& documentThreadableLoader, ResourceLoaderIdentifier identifier)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(document))
+    if (RefPtr agents = instrumentingAgents(document))
         didReceiveThreadableLoaderResponseImpl(*agents, documentThreadableLoader, identifier);
 }
 
 inline void InspectorInstrumentation::didReceiveData(LocalFrame* frame, ResourceLoaderIdentifier identifier, const SharedBuffer* buffer, int encodedDataLength)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
+    if (RefPtr agents = instrumentingAgents(frame))
         didReceiveDataImpl(*agents, identifier, buffer, encodedDataLength);
 }
 
@@ -1154,7 +1155,7 @@ inline void InspectorInstrumentation::didReceiveData(ServiceWorkerGlobalScope& g
 inline void InspectorInstrumentation::didFinishLoading(LocalFrame* frame, DocumentLoader* loader, ResourceLoaderIdentifier identifier, const NetworkLoadMetrics& networkLoadMetrics, ResourceLoader* resourceLoader)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
+    if (RefPtr agents = instrumentingAgents(frame))
         didFinishLoadingImpl(*agents, identifier, loader, networkLoadMetrics, resourceLoader);
 }
 
@@ -1166,7 +1167,7 @@ inline void InspectorInstrumentation::didFinishLoading(ServiceWorkerGlobalScope&
 
 inline void InspectorInstrumentation::didFailLoading(LocalFrame* frame, DocumentLoader* loader, ResourceLoaderIdentifier identifier, const ResourceError& error)
 {
-    if (auto* agents = instrumentingAgents(frame))
+    if (RefPtr agents = instrumentingAgents(frame))
         didFailLoadingImpl(*agents, identifier, loader, error);
 }
 
@@ -1196,35 +1197,35 @@ inline void InspectorInstrumentation::continueWithPolicyIgnore(LocalFrame& frame
 inline void InspectorInstrumentation::willLoadXHRSynchronously(ScriptExecutionContext* context)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(context))
+    if (RefPtr agents = instrumentingAgents(context))
         willLoadXHRSynchronouslyImpl(*agents);
 }
 
 inline void InspectorInstrumentation::didLoadXHRSynchronously(ScriptExecutionContext* context)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(context))
+    if (RefPtr agents = instrumentingAgents(context))
         didLoadXHRSynchronouslyImpl(*agents);
 }
 
 inline void InspectorInstrumentation::scriptImported(ScriptExecutionContext& context, ResourceLoaderIdentifier identifier, const String& sourceString)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(context))
+    if (RefPtr agents = instrumentingAgents(context))
         scriptImportedImpl(*agents, identifier, sourceString);
 }
 
 inline void InspectorInstrumentation::scriptExecutionBlockedByCSP(ScriptExecutionContext* context, const String& directiveText)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(context))
+    if (RefPtr agents = instrumentingAgents(context))
         scriptExecutionBlockedByCSPImpl(*agents, directiveText);
 }
 
 inline void InspectorInstrumentation::didReceiveScriptResponse(ScriptExecutionContext& context, ResourceLoaderIdentifier identifier)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(context))
+    if (RefPtr agents = instrumentingAgents(context))
         didReceiveScriptResponseImpl(*agents, identifier);
 }
 
@@ -1237,7 +1238,7 @@ inline void InspectorInstrumentation::domContentLoadedEventFired(LocalFrame& fra
 inline void InspectorInstrumentation::loadEventFired(LocalFrame* frame)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
+    if (RefPtr agents = instrumentingAgents(frame))
         loadEventFiredImpl(*agents, frame);
 }
 
@@ -1305,7 +1306,7 @@ inline void InspectorInstrumentation::willDestroyCachedResource(CachedResource& 
 inline bool InspectorInstrumentation::willIntercept(const LocalFrame* frame, const ResourceRequest& request)
 {
     FAST_RETURN_IF_NO_FRONTENDS(false);
-    if (auto* agents = instrumentingAgents(frame))
+    if (RefPtr agents = instrumentingAgents(frame))
         return willInterceptImpl(*agents, request);
     return false;
 }
@@ -1313,7 +1314,7 @@ inline bool InspectorInstrumentation::willIntercept(const LocalFrame* frame, con
 inline bool InspectorInstrumentation::shouldInterceptRequest(const ResourceLoader& loader)
 {
     ASSERT(InspectorInstrumentationPublic::hasFrontends());
-    if (auto* agents = instrumentingAgents(loader.frame()))
+    if (RefPtr agents = instrumentingAgents(loader.frame()))
         return shouldInterceptRequestImpl(*agents, loader);
     return false;
 }
@@ -1327,7 +1328,7 @@ inline bool InspectorInstrumentation::shouldInterceptResponse(const LocalFrame& 
 inline void InspectorInstrumentation::interceptRequest(ResourceLoader& loader, Function<void(const ResourceRequest&)>&& handler)
 {
     ASSERT(InspectorInstrumentation::shouldInterceptRequest(loader));
-    if (auto* agents = instrumentingAgents(loader.frame()))
+    if (RefPtr agents = instrumentingAgents(loader.frame()))
         interceptRequestImpl(*agents, loader, WTF::move(handler));
 }
 
@@ -1346,7 +1347,7 @@ inline void InspectorInstrumentation::didDispatchDOMStorageEvent(Page& page, con
 inline bool InspectorInstrumentation::shouldWaitForDebuggerOnStart(ScriptExecutionContext& context)
 {
     FAST_RETURN_IF_NO_FRONTENDS(false);
-    if (auto* agents = instrumentingAgents(context))
+    if (RefPtr agents = instrumentingAgents(context))
         return shouldWaitForDebuggerOnStartImpl(*agents);
     return false;
 }
@@ -1354,63 +1355,63 @@ inline bool InspectorInstrumentation::shouldWaitForDebuggerOnStart(ScriptExecuti
 inline void InspectorInstrumentation::workerStarted(WorkerInspectorProxy& proxy)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(proxy.scriptExecutionContext()))
+    if (RefPtr agents = instrumentingAgents(proxy.scriptExecutionContext()))
         workerStartedImpl(*agents, proxy);
 }
 
 inline void InspectorInstrumentation::workerTerminated(WorkerInspectorProxy& proxy)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(proxy.scriptExecutionContext()))
+    if (RefPtr agents = instrumentingAgents(proxy.scriptExecutionContext()))
         workerTerminatedImpl(*agents, proxy);
 }
 
 inline void InspectorInstrumentation::didCreateWebSocket(Document* document, WebSocketChannelIdentifier identifier, const URL& requestURL)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(document))
+    if (RefPtr agents = instrumentingAgents(document))
         didCreateWebSocketImpl(*agents, identifier, requestURL);
 }
 
 inline void InspectorInstrumentation::willSendWebSocketHandshakeRequest(Document* document, WebSocketChannelIdentifier identifier, const ResourceRequest& request)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(document))
+    if (RefPtr agents = instrumentingAgents(document))
         willSendWebSocketHandshakeRequestImpl(*agents, identifier, request);
 }
 
 inline void InspectorInstrumentation::didReceiveWebSocketHandshakeResponse(Document* document, WebSocketChannelIdentifier identifier, const ResourceResponse& response)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(document))
+    if (RefPtr agents = instrumentingAgents(document))
         didReceiveWebSocketHandshakeResponseImpl(*agents, identifier, response);
 }
 
 inline void InspectorInstrumentation::didCloseWebSocket(Document* document, WebSocketChannelIdentifier identifier)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(document))
+    if (RefPtr agents = instrumentingAgents(document))
         didCloseWebSocketImpl(*agents, identifier);
 }
 
 inline void InspectorInstrumentation::didReceiveWebSocketFrame(Document* document, WebSocketChannelIdentifier identifier, const WebSocketFrame& frame)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(document))
+    if (RefPtr agents = instrumentingAgents(document))
         didReceiveWebSocketFrameImpl(*agents, identifier, frame);
 }
 
 inline void InspectorInstrumentation::didReceiveWebSocketFrameError(Document* document, WebSocketChannelIdentifier identifier, const String& errorMessage)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(document))
+    if (RefPtr agents = instrumentingAgents(document))
         didReceiveWebSocketFrameErrorImpl(*agents, identifier, errorMessage);
 }
 
 inline void InspectorInstrumentation::didSendWebSocketFrame(Document* document, WebSocketChannelIdentifier identifier, const WebSocketFrame& frame)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(document))
+    if (RefPtr agents = instrumentingAgents(document))
         didSendWebSocketFrameImpl(*agents, identifier, frame);
 }
 
@@ -1425,35 +1426,35 @@ inline void InspectorInstrumentation::didHandleMemoryPressure(Page& page, Critic
 inline void InspectorInstrumentation::didChangeCSSCanvasClientNodes(CanvasBase& canvasBase)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(canvasBase.scriptExecutionContext()))
+    if (RefPtr agents = instrumentingAgents(canvasBase.scriptExecutionContext()))
         didChangeCSSCanvasClientNodesImpl(*agents, canvasBase);
 }
 
 inline void InspectorInstrumentation::didCreateCanvasRenderingContext(CanvasRenderingContext& context)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(context.canvasBase().scriptExecutionContext()))
+    if (RefPtr agents = instrumentingAgents(context.canvasBase().scriptExecutionContext()))
         didCreateCanvasRenderingContextImpl(*agents, context);
 }
 
 inline void InspectorInstrumentation::didChangeCanvasSize(CanvasRenderingContext& context)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(context.canvasBase().scriptExecutionContext()))
+    if (RefPtr agents = instrumentingAgents(context.canvasBase().scriptExecutionContext()))
         didChangeCanvasSizeImpl(*agents, context);
 }
 
 inline void InspectorInstrumentation::didChangeCanvasMemory(CanvasRenderingContext& context)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(context.canvasBase().scriptExecutionContext()))
+    if (RefPtr agents = instrumentingAgents(context.canvasBase().scriptExecutionContext()))
         didChangeCanvasMemoryImpl(*agents, context);
 }
 
 inline void InspectorInstrumentation::didFinishRecordingCanvasFrame(CanvasRenderingContext& context, bool forceDispatch)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(context.canvasBase().scriptExecutionContext()))
+    if (RefPtr agents = instrumentingAgents(context.canvasBase().scriptExecutionContext()))
         didFinishRecordingCanvasFrameImpl(*agents, context, forceDispatch);
 }
 
@@ -1461,21 +1462,21 @@ inline void InspectorInstrumentation::didFinishRecordingCanvasFrame(CanvasRender
 inline void InspectorInstrumentation::didEnableExtension(WebGLRenderingContextBase& contextWebGLBase, const String& extension)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(contextWebGLBase.canvasBase().scriptExecutionContext()))
+    if (RefPtr agents = instrumentingAgents(contextWebGLBase.canvasBase().scriptExecutionContext()))
         didEnableExtensionImpl(*agents, contextWebGLBase, extension);
 }
 
 inline void InspectorInstrumentation::didCreateWebGLProgram(WebGLRenderingContextBase& contextWebGLBase, WebGLProgram& program)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(contextWebGLBase.canvasBase().scriptExecutionContext()))
+    if (RefPtr agents = instrumentingAgents(contextWebGLBase.canvasBase().scriptExecutionContext()))
         didCreateWebGLProgramImpl(*agents, contextWebGLBase, program);
 }
 
 inline bool InspectorInstrumentation::isWebGLProgramDisabled(WebGLRenderingContextBase& contextWebGLBase, WebGLProgram& program)
 {
     FAST_RETURN_IF_NO_FRONTENDS(false);
-    if (auto* agents = instrumentingAgents(contextWebGLBase.canvasBase().scriptExecutionContext()))
+    if (RefPtr agents = instrumentingAgents(contextWebGLBase.canvasBase().scriptExecutionContext()))
         return isWebGLProgramDisabledImpl(*agents, program);
     return false;
 }
@@ -1483,7 +1484,7 @@ inline bool InspectorInstrumentation::isWebGLProgramDisabled(WebGLRenderingConte
 inline bool InspectorInstrumentation::isWebGLProgramHighlighted(WebGLRenderingContextBase& contextWebGLBase, WebGLProgram& program)
 {
     FAST_RETURN_IF_NO_FRONTENDS(false);
-    if (auto* agents = instrumentingAgents(contextWebGLBase.canvasBase().scriptExecutionContext()))
+    if (RefPtr agents = instrumentingAgents(contextWebGLBase.canvasBase().scriptExecutionContext()))
         return isWebGLProgramHighlightedImpl(*agents, program);
     return false;
 }
@@ -1492,49 +1493,49 @@ inline bool InspectorInstrumentation::isWebGLProgramHighlighted(WebGLRenderingCo
 inline void InspectorInstrumentation::willApplyKeyframeEffect(const Styleable& target, KeyframeEffect& effect, const ComputedEffectTiming& computedTiming)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(target.element.document()))
+    if (RefPtr agents = instrumentingAgents(target.element.document()))
         willApplyKeyframeEffectImpl(*agents, target, effect, computedTiming);
 }
 
 inline void InspectorInstrumentation::didChangeWebAnimationName(WebAnimation& animation)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(animation.scriptExecutionContext()))
+    if (RefPtr agents = instrumentingAgents(animation.scriptExecutionContext()))
         didChangeWebAnimationNameImpl(*agents, animation);
 }
 
 inline void InspectorInstrumentation::didSetWebAnimationEffect(WebAnimation& animation)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(animation.scriptExecutionContext()))
+    if (RefPtr agents = instrumentingAgents(animation.scriptExecutionContext()))
         didSetWebAnimationEffectImpl(*agents, animation);
 }
 
 inline void InspectorInstrumentation::didChangeWebAnimationEffectTiming(WebAnimation& animation)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(animation.scriptExecutionContext()))
+    if (RefPtr agents = instrumentingAgents(animation.scriptExecutionContext()))
         didChangeWebAnimationEffectTimingImpl(*agents, animation);
 }
 
 inline void InspectorInstrumentation::didChangeWebAnimationEffectTarget(WebAnimation& animation)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(animation.scriptExecutionContext()))
+    if (RefPtr agents = instrumentingAgents(animation.scriptExecutionContext()))
         didChangeWebAnimationEffectTargetImpl(*agents, animation);
 }
 
 inline void InspectorInstrumentation::didCreateWebAnimation(WebAnimation& animation)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(animation.scriptExecutionContext()))
+    if (RefPtr agents = instrumentingAgents(animation.scriptExecutionContext()))
         didCreateWebAnimationImpl(*agents, animation);
 }
 
 inline void InspectorInstrumentation::willDestroyWebAnimation(WebAnimation& animation)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(animation.scriptExecutionContext()))
+    if (RefPtr agents = instrumentingAgents(animation.scriptExecutionContext()))
         willDestroyWebAnimationImpl(*agents, animation);
 }
 
@@ -1649,90 +1650,90 @@ inline void InspectorInstrumentation::stopProfiling(WorkerOrWorkletGlobalScope& 
 
 inline void InspectorInstrumentation::consoleStartRecordingCanvas(CanvasRenderingContext& context, JSC::JSGlobalObject& exec, JSC::JSObject* options)
 {
-    if (auto* agents = instrumentingAgents(context.canvasBase().scriptExecutionContext()))
+    if (RefPtr agents = instrumentingAgents(context.canvasBase().scriptExecutionContext()))
         consoleStartRecordingCanvasImpl(*agents, context, exec, options);
 }
 
 inline void InspectorInstrumentation::consoleStopRecordingCanvas(CanvasRenderingContext& context)
 {
-    if (auto* agents = instrumentingAgents(context.canvasBase().scriptExecutionContext()))
+    if (RefPtr agents = instrumentingAgents(context.canvasBase().scriptExecutionContext()))
         consoleStopRecordingCanvasImpl(*agents, context);
 }
 
 inline void InspectorInstrumentation::performanceMark(ScriptExecutionContext& context, const String& label, std::optional<MonotonicTime> startTime)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(context))
+    if (RefPtr agents = instrumentingAgents(context))
         performanceMarkImpl(*agents, label, WTF::move(startTime));
 }
 
 inline void InspectorInstrumentation::didEnqueueFirstContentfulPaint(ScriptExecutionContext& context)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(context))
+    if (RefPtr agents = instrumentingAgents(context))
         didEnqueueFirstContentfulPaintImpl(*agents);
 }
 
 inline void InspectorInstrumentation::didEnqueueLargestContentfulPaint(ScriptExecutionContext& context, const LargestContentfulPaint& entry)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(context))
+    if (RefPtr agents = instrumentingAgents(context))
         didEnqueueLargestContentfulPaintImpl(*agents, entry);
 }
 
 inline void InspectorInstrumentation::didRequestAnimationFrame(ScriptExecutionContext& scriptExecutionContext, int callbackId)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(scriptExecutionContext))
+    if (RefPtr agents = instrumentingAgents(scriptExecutionContext))
         didRequestAnimationFrameImpl(*agents, callbackId, scriptExecutionContext);
 }
 
 inline void InspectorInstrumentation::didCancelAnimationFrame(ScriptExecutionContext& scriptExecutionContext, int callbackId)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(scriptExecutionContext))
+    if (RefPtr agents = instrumentingAgents(scriptExecutionContext))
         didCancelAnimationFrameImpl(*agents, callbackId);
 }
 
 inline void InspectorInstrumentation::willFireAnimationFrame(ScriptExecutionContext& scriptExecutionContext, int callbackId)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(scriptExecutionContext))
+    if (RefPtr agents = instrumentingAgents(scriptExecutionContext))
         willFireAnimationFrameImpl(*agents, callbackId);
 }
 
 inline void InspectorInstrumentation::didFireAnimationFrame(ScriptExecutionContext& scriptExecutionContext, int callbackId)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(scriptExecutionContext))
+    if (RefPtr agents = instrumentingAgents(scriptExecutionContext))
         didFireAnimationFrameImpl(*agents, callbackId);
 }
 
 inline void InspectorInstrumentation::willFireObserverCallback(ScriptExecutionContext& context, const String& callbackType)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(context))
+    if (RefPtr agents = instrumentingAgents(context))
         willFireObserverCallbackImpl(*agents, callbackType);
 }
 
 inline void InspectorInstrumentation::didFireObserverCallback(ScriptExecutionContext& context)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(context))
+    if (RefPtr agents = instrumentingAgents(context))
         didFireObserverCallbackImpl(*agents);
 }
 
 inline void InspectorInstrumentation::layerTreeDidChange(Page* page)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(page))
+    if (RefPtr agents = instrumentingAgents(page))
         layerTreeDidChangeImpl(*agents);
 }
 
 inline void InspectorInstrumentation::renderLayerDestroyed(Page* page, const RenderLayer& renderLayer)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(page))
+    if (RefPtr agents = instrumentingAgents(page))
         renderLayerDestroyedImpl(*agents, renderLayer);
 }
 

--- a/Source/WebCore/loader/ApplicationManifestLoader.cpp
+++ b/Source/WebCore/loader/ApplicationManifestLoader.cpp
@@ -115,7 +115,7 @@ std::optional<ApplicationManifest>& ApplicationManifestLoader::processManifest()
         if (CachedResourceHandle resource = m_resource) {
             auto manifestURL = m_url;
             auto documentURL = m_documentLoader->url();
-            auto frame = m_documentLoader->frame();
+            RefPtr frame = m_documentLoader->frame();
             RefPtr document = frame ? frame->document() : nullptr;
             m_processedManifest = resource->process(manifestURL, documentURL, document.get());
         }

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -248,8 +248,8 @@ class EmptyDatabaseProvider final : public DatabaseProvider {
     IDBClient::IDBConnectionToServer& idbConnectionToServerForSession(PAL::SessionID sessionID) final
     {
         static NeverDestroyed<Ref<EmptyIDBConnectionToServerDeletegate>> emptyDelegate = EmptyIDBConnectionToServerDeletegate::create();
-        static auto& emptyConnection = IDBClient::IDBConnectionToServer::create(emptyDelegate.get(), sessionID).leakRef();
-        return emptyConnection;
+        static NeverDestroyed<Ref<IDBClient::IDBConnectionToServer>> emptyConnection = IDBClient::IDBConnectionToServer::create(emptyDelegate.get(), sessionID).leakRef();
+        return emptyConnection->get();
     }
 };
 

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -191,9 +191,9 @@ static void prepareContextForQRCode(ContextMenuContext& context)
         return;
 
     RefPtr<Element> element;
-    for (auto& lineage : lineageOfType<Element>(*nodeElement)) {
+    for (Ref lineage : lineageOfType<Element>(*nodeElement)) {
         if (is<HTMLTableElement>(lineage) || is<HTMLCanvasElement>(lineage) || is<HTMLImageElement>(lineage) || is<SVGSVGElement>(lineage)) {
-            element = lineage;
+            element = lineage.ptr();
             break;
         }
     }

--- a/Source/WebCore/platform/DictationCaretAnimator.cpp
+++ b/Source/WebCore/platform/DictationCaretAnimator.cpp
@@ -113,12 +113,12 @@ FloatRect DictationCaretAnimator::computeTailRect() const
 
 int DictationCaretAnimator::computeScrollLeft() const
 {
-    auto document = m_client.document();
+    RefPtr document = m_client.document();
     if (!document)
         return 0;
 
-    if (auto* caretNode = m_client.caretNode()) {
-        if (auto* rendererForCaret = rendererForCaretPainting(caretNode))
+    if (RefPtr caretNode = m_client.caretNode()) {
+        if (auto* rendererForCaret = rendererForCaretPainting(caretNode.get()))
             return rendererForCaret->scrollLeft();
     }
 
@@ -127,7 +127,7 @@ int DictationCaretAnimator::computeScrollLeft() const
 
 void DictationCaretAnimator::updateGlowTail(Seconds elapsedTime)
 {
-    auto document = m_client.document();
+    RefPtr document = m_client.document();
     if (!document)
         return;
 

--- a/Source/WebCore/platform/graphics/DisplayRefreshMonitorManager.cpp
+++ b/Source/WebCore/platform/graphics/DisplayRefreshMonitorManager.cpp
@@ -42,19 +42,18 @@ DisplayRefreshMonitorManager& DisplayRefreshMonitorManager::sharedManager()
     return manager.get();
 }
 
-DisplayRefreshMonitor* DisplayRefreshMonitorManager::ensureMonitorForDisplayID(PlatformDisplayID displayID, DisplayRefreshMonitorFactory* factory)
+RefPtr<DisplayRefreshMonitor> DisplayRefreshMonitorManager::ensureMonitorForDisplayID(PlatformDisplayID displayID, DisplayRefreshMonitorFactory* factory)
 {
     if (auto* existingMonitor = monitorForDisplayID(displayID))
         return existingMonitor;
 
-    auto monitor = DisplayRefreshMonitor::create(factory, displayID);
+    RefPtr monitor = DisplayRefreshMonitor::create(factory, displayID);
     if (!monitor)
         return nullptr;
 
     LOG_WITH_STREAM(DisplayLink, stream << "[Web] DisplayRefreshMonitorManager::ensureMonitorForDisplayID() - created monitor " << monitor.get() << " for display " << displayID);
-    DisplayRefreshMonitor* result = monitor.get();
-    m_monitors.append(DisplayRefreshMonitorWrapper { WTF::move(monitor) });
-    return result;
+    m_monitors.append(DisplayRefreshMonitorWrapper { monitor });
+    return monitor;
 }
 
 void DisplayRefreshMonitorManager::unregisterClient(DisplayRefreshMonitorClient& client)

--- a/Source/WebCore/platform/graphics/DisplayRefreshMonitorManager.h
+++ b/Source/WebCore/platform/graphics/DisplayRefreshMonitorManager.h
@@ -63,7 +63,7 @@ private:
     DisplayRefreshMonitor* monitorForDisplayID(PlatformDisplayID) const;
     RefPtr<DisplayRefreshMonitor> monitorForClient(DisplayRefreshMonitorClient&);
 
-    DisplayRefreshMonitor* ensureMonitorForDisplayID(PlatformDisplayID, DisplayRefreshMonitorFactory*);
+    RefPtr<DisplayRefreshMonitor> ensureMonitorForDisplayID(PlatformDisplayID, DisplayRefreshMonitorFactory*);
 
     struct DisplayRefreshMonitorWrapper {
         ~DisplayRefreshMonitorWrapper()

--- a/Source/WebCore/platform/graphics/FontCache.cpp
+++ b/Source/WebCore/platform/graphics/FontCache.cpp
@@ -416,8 +416,8 @@ static void dispatchToAllFontCaches(F function)
 
     function(FontCache::forCurrentThread().get());
 
-    for (auto& thread : WorkerOrWorkletThread::workerOrWorkletThreads()) {
-        thread.runLoop().postTask([function](ScriptExecutionContext&) {
+    for (Ref thread : WorkerOrWorkletThread::workerOrWorkletThreads()) {
+        thread->runLoop().postTask([function](ScriptExecutionContext&) {
             if (CheckedPtr fontCache = FontCache::forCurrentThreadIfExists())
                 function(*fontCache);
         });

--- a/Source/WebCore/platform/graphics/FontRanges.cpp
+++ b/Source/WebCore/platform/graphics/FontRanges.cpp
@@ -87,15 +87,15 @@ GlyphData FontRanges::glyphDataForCharacter(char32_t character, ExternalResource
 
     for (auto& range : m_ranges) {
         if (range.from() <= character && character <= range.to()) {
-            if (auto* font = range.font(policy)) {
+            if (RefPtr font = range.font(policy)) {
                 if (font->isInterstitial()) {
                     policy = ExternalResourceDownloadPolicy::Forbid;
                     if (!resultFont)
-                        resultFont = font;
+                        resultFont = font.get();
                 } else {
                     auto glyphData = font->glyphDataForCharacter(character);
                     if (glyphData.isValid()) {
-                        auto* glyphDataFont = glyphData.font.get();
+                        RefPtr glyphDataFont = glyphData.font.get();
                         if (glyphDataFont && glyphDataFont->visibility() == Font::Visibility::Visible && resultFont && resultFont->visibility() == Font::Visibility::Invisible)
                             return GlyphData(glyphData.glyph, &glyphDataFont->invisibleFont());
                         return glyphData;
@@ -123,7 +123,8 @@ const Font* FontRanges::fontForCharacter(char32_t character) const
 
 const Font& FontRanges::fontForFirstRange() const
 {
-    auto* font = m_ranges[0].font(ExternalResourceDownloadPolicy::Forbid);
+    // This is a false positive because the non-trivial expression is the RHS before we initialize the pointer local.
+    SUPPRESS_UNCOUNTED_LOCAL auto* font = m_ranges[0].font(ExternalResourceDownloadPolicy::Forbid);
     ASSERT(font);
     return *font;
 }

--- a/Source/WebCore/platform/graphics/Image.cpp
+++ b/Source/WebCore/platform/graphics/Image.cpp
@@ -86,8 +86,8 @@ void Image::invalidateAdapter()
 Image& Image::nullImage()
 {
     ASSERT(isMainThread());
-    static Image& nullImage = BitmapImage::create().leakRef();
-    return nullImage;
+    static NeverDestroyed<Ref<BitmapImage>> nullImage = BitmapImage::create();
+    return nullImage->get();
 }
 
 static bool isPDFResource(const String& mimeType, const URL& url)

--- a/Source/WebCore/platform/graphics/coreimage/FEColorMatrixCoreImageApplier.mm
+++ b/Source/WebCore/platform/graphics/coreimage/FEColorMatrixCoreImageApplier.mm
@@ -54,9 +54,8 @@ bool FEColorMatrixCoreImageApplier::apply(const Filter& filter, std::span<const 
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS
     ASSERT(inputs.size() == 1);
-    Ref input = inputs[0].get();
 
-    RetainPtr inputImage = input->ciImage();
+    RetainPtr inputImage = Ref { inputs[0] }->ciImage();
     if (!inputImage)
         return false;
 

--- a/Source/WebCore/platform/graphics/filters/FilterOperations.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterOperations.cpp
@@ -69,8 +69,8 @@ IntOutsets FilterOperations::outsets() const
     for (auto& operation : m_operations) {
         switch (operation->type()) {
         case FilterOperation::Type::Blur: {
-            auto& blurOperation = downcast<BlurFilterOperation>(operation.get());
-            float stdDeviation = blurOperation.stdDeviation();
+            Ref blurOperation = downcast<BlurFilterOperation>(operation.get());
+            float stdDeviation = blurOperation->stdDeviation();
             IntSize outsetSize = FEGaussianBlur::calculateOutsetSize({ stdDeviation, stdDeviation });
             IntOutsets outsets(outsetSize.height(), outsetSize.width(), outsetSize.height(), outsetSize.width());
             totalOutsets += outsets;
@@ -78,14 +78,14 @@ IntOutsets FilterOperations::outsets() const
         }
         case FilterOperation::Type::DropShadow:
         case FilterOperation::Type::DropShadowWithStyleColor: {
-            auto& dropShadowOperation = downcast<DropShadowFilterOperationBase>(operation.get());
-            float stdDeviation = dropShadowOperation.stdDeviation();
+            Ref dropShadowOperation = downcast<DropShadowFilterOperationBase>(operation.get());
+            float stdDeviation = dropShadowOperation->stdDeviation();
             IntSize outsetSize = FEGaussianBlur::calculateOutsetSize({ stdDeviation, stdDeviation });
-            
-            int top = std::max(0, outsetSize.height() - dropShadowOperation.y());
-            int right = std::max(0, outsetSize.width() + dropShadowOperation.x());
-            int bottom = std::max(0, outsetSize.height() + dropShadowOperation.y());
-            int left = std::max(0, outsetSize.width() - dropShadowOperation.x());
+
+            int top = std::max(0, outsetSize.height() - dropShadowOperation->y());
+            int right = std::max(0, outsetSize.width() + dropShadowOperation->x());
+            int bottom = std::max(0, outsetSize.height() + dropShadowOperation->y());
+            int left = std::max(0, outsetSize.width() - dropShadowOperation->x());
             
             auto outsets = IntOutsets { top, right, bottom, left };
             totalOutsets += outsets;

--- a/Source/WebCore/platform/graphics/filters/software/FEBlendSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEBlendSoftwareApplier.cpp
@@ -40,21 +40,21 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(FEBlendSoftwareApplier);
 
 bool FEBlendSoftwareApplier::apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
 {
-    auto& input = inputs[0].get();
-    auto& input2 = inputs[1].get();
+    Ref input = inputs[0];
+    Ref input2 = inputs[1];
 
     RefPtr resultImage = result.imageBuffer();
     if (!resultImage)
         return false;
 
-    RefPtr inputImage = input.imageBuffer();
-    RefPtr inputImage2 = input2.imageBuffer();
+    RefPtr inputImage = input->imageBuffer();
+    RefPtr inputImage2 = input2->imageBuffer();
     if (!inputImage || !inputImage2)
         return false;
 
     auto& filterContext = resultImage->context();
-    auto inputImageRect = input.absoluteImageRectRelativeTo(result);
-    auto inputImageRect2 = input2.absoluteImageRectRelativeTo(result);
+    auto inputImageRect = input->absoluteImageRectRelativeTo(result);
+    auto inputImageRect2 = input2->absoluteImageRectRelativeTo(result);
 
     filterContext.drawImageBuffer(*inputImage2, inputImageRect2);
     filterContext.drawImageBuffer(*inputImage, inputImageRect, { { }, inputImage->logicalSize() }, { CompositeOperator::SourceOver, m_effect->blendMode() });

--- a/Source/WebCore/platform/graphics/filters/software/FEColorMatrixSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEColorMatrixSoftwareApplier.cpp
@@ -260,15 +260,15 @@ void FEColorMatrixSoftwareApplier::applyPlatform(PixelBuffer& pixelBuffer) const
 
 bool FEColorMatrixSoftwareApplier::apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
 {
-    auto& input = inputs[0].get();
+    Ref input = inputs[0];
 
     RefPtr resultImage = result.imageBuffer();
     if (!resultImage)
         return false;
 
-    RefPtr inputImage = input.imageBuffer();
+    RefPtr inputImage = input->imageBuffer();
     if (inputImage) {
-        auto inputImageRect = input.absoluteImageRectRelativeTo(result);
+        auto inputImageRect = input->absoluteImageRectRelativeTo(result);
         resultImage->context().drawImageBuffer(*inputImage, inputImageRect);
     }
 

--- a/Source/WebCore/platform/graphics/filters/software/FEComponentTransferSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEComponentTransferSoftwareApplier.cpp
@@ -57,14 +57,14 @@ void FEComponentTransferSoftwareApplier::applyPlatform(PixelBuffer& pixelBuffer)
 
 bool FEComponentTransferSoftwareApplier::apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
 {
-    auto& input = inputs[0].get();
-    
-    auto destinationPixelBuffer = result.pixelBuffer(AlphaPremultiplication::Unpremultiplied);
+    Ref input = inputs[0];
+
+    RefPtr destinationPixelBuffer = result.pixelBuffer(AlphaPremultiplication::Unpremultiplied);
     if (!destinationPixelBuffer)
         return false;
 
-    auto drawingRect = result.absoluteImageRectRelativeTo(input);
-    input.copyPixelBuffer(*destinationPixelBuffer, drawingRect);
+    auto drawingRect = result.absoluteImageRectRelativeTo(input.get());
+    input->copyPixelBuffer(*destinationPixelBuffer, drawingRect);
 
     applyPlatform(*destinationPixelBuffer);
     return true;

--- a/Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareApplier.cpp
@@ -44,21 +44,21 @@ FECompositeSoftwareApplier::FECompositeSoftwareApplier(const FEComposite& effect
 
 bool FECompositeSoftwareApplier::apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
 {
-    auto& input = inputs[0].get();
-    auto& input2 = inputs[1].get();
+    Ref input = inputs[0].get();
+    Ref input2 = inputs[1].get();
 
     RefPtr resultImage = result.imageBuffer();
     if (!resultImage)
         return false;
 
-    RefPtr inputImage = input.imageBuffer();
-    RefPtr inputImage2 = input2.imageBuffer();
+    RefPtr inputImage = input->imageBuffer();
+    RefPtr inputImage2 = input2->imageBuffer();
     if (!inputImage || !inputImage2)
         return false;
 
     auto& filterContext = resultImage->context();
-    auto inputImageRect = input.absoluteImageRectRelativeTo(result);
-    auto inputImageRect2 = input2.absoluteImageRectRelativeTo(result);
+    auto inputImageRect = input->absoluteImageRectRelativeTo(result);
+    auto inputImageRect2 = input2->absoluteImageRectRelativeTo(result);
 
     switch (m_effect->operation()) {
     case CompositeOperationType::FECOMPOSITE_OPERATOR_UNKNOWN:
@@ -71,14 +71,14 @@ bool FECompositeSoftwareApplier::apply(const Filter&, std::span<const Ref<Filter
 
     case CompositeOperationType::FECOMPOSITE_OPERATOR_IN: {
         // Applies only to the intersected region.
-        IntRect destinationRect = input.absoluteImageRect();
-        destinationRect.intersect(input2.absoluteImageRect());
+        IntRect destinationRect = input->absoluteImageRect();
+        destinationRect.intersect(input2->absoluteImageRect());
         destinationRect.intersect(result.absoluteImageRect());
         if (destinationRect.isEmpty())
             break;
         IntRect adjustedDestinationRect = destinationRect - result.absoluteImageRect().location();
-        IntRect sourceRect = destinationRect - input.absoluteImageRect().location();
-        IntRect source2Rect = destinationRect - input2.absoluteImageRect().location();
+        IntRect sourceRect = destinationRect - input->absoluteImageRect().location();
+        IntRect source2Rect = destinationRect - input2->absoluteImageRect().location();
         filterContext.drawImageBuffer(*inputImage2, FloatRect(adjustedDestinationRect), FloatRect(source2Rect));
         filterContext.drawImageBuffer(*inputImage, FloatRect(adjustedDestinationRect), FloatRect(sourceRect), { CompositeOperator::SourceIn });
         break;

--- a/Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareArithmeticApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareArithmeticApplier.cpp
@@ -133,20 +133,20 @@ inline void FECompositeSoftwareArithmeticApplier::applyPlatform(std::span<unsign
 
 bool FECompositeSoftwareArithmeticApplier::apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
 {
-    auto& input = inputs[0].get();
-    auto& input2 = inputs[1].get();
+    Ref input = inputs[0];
+    Ref input2 = inputs[1];
 
-    auto destinationPixelBuffer = result.pixelBuffer(AlphaPremultiplication::Premultiplied);
+    RefPtr destinationPixelBuffer = result.pixelBuffer(AlphaPremultiplication::Premultiplied);
     if (!destinationPixelBuffer)
         return false;
 
-    IntRect effectADrawingRect = result.absoluteImageRectRelativeTo(input);
-    auto sourcePixelBuffer = input.getPixelBuffer(AlphaPremultiplication::Premultiplied, effectADrawingRect, m_effect->operatingColorSpace());
+    IntRect effectADrawingRect = result.absoluteImageRectRelativeTo(input.get());
+    auto sourcePixelBuffer = input->getPixelBuffer(AlphaPremultiplication::Premultiplied, effectADrawingRect, m_effect->operatingColorSpace());
     if (!sourcePixelBuffer)
         return false;
 
-    IntRect effectBDrawingRect = result.absoluteImageRectRelativeTo(input2);
-    input2.copyPixelBuffer(*destinationPixelBuffer, effectBDrawingRect);
+    IntRect effectBDrawingRect = result.absoluteImageRectRelativeTo(input2.get());
+    input2->copyPixelBuffer(*destinationPixelBuffer, effectBDrawingRect);
 
     auto sourcePixelBytes = sourcePixelBuffer->bytes();
     auto destinationPixelBytes = destinationPixelBuffer->bytes();

--- a/Source/WebCore/platform/graphics/filters/software/FEConvolveMatrixSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEConvolveMatrixSoftwareApplier.cpp
@@ -304,15 +304,15 @@ void FEConvolveMatrixSoftwareApplier::applyPlatform(PaintingData& paintingData) 
 
 bool FEConvolveMatrixSoftwareApplier::apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
 {
-    auto& input = inputs[0].get();
+    Ref input = inputs[0];
 
     auto alphaFormat = m_effect->preserveAlpha() ? AlphaPremultiplication::Unpremultiplied : AlphaPremultiplication::Premultiplied;
-    auto destinationPixelBuffer = result.pixelBuffer(alphaFormat);
+    RefPtr destinationPixelBuffer = result.pixelBuffer(alphaFormat);
     if (!destinationPixelBuffer)
         return false;
 
     auto effectDrawingRect = result.absoluteImageRectRelativeTo(input);
-    auto sourcePixelBuffer = input.getPixelBuffer(alphaFormat, effectDrawingRect, m_effect->operatingColorSpace());
+    auto sourcePixelBuffer = input->getPixelBuffer(alphaFormat, effectDrawingRect, m_effect->operatingColorSpace());
     if (!sourcePixelBuffer)
         return false;
 

--- a/Source/WebCore/platform/graphics/filters/software/FEDisplacementMapSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEDisplacementMapSoftwareApplier.cpp
@@ -55,19 +55,19 @@ int FEDisplacementMapSoftwareApplier::yChannelIndex() const
 
 bool FEDisplacementMapSoftwareApplier::apply(const Filter& filter, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
 {
-    auto& input = inputs[0].get();
-    auto& input2 = inputs[1].get();
+    Ref input = inputs[0].get();
+    Ref input2 = inputs[1].get();
 
-    auto destinationPixelBuffer = result.pixelBuffer(AlphaPremultiplication::Premultiplied);
+    RefPtr destinationPixelBuffer = result.pixelBuffer(AlphaPremultiplication::Premultiplied);
     if (!destinationPixelBuffer)
         return false;
 
     auto effectADrawingRect = result.absoluteImageRectRelativeTo(input);
-    auto inputPixelBuffer = input.getPixelBuffer(AlphaPremultiplication::Premultiplied, effectADrawingRect);
+    auto inputPixelBuffer = input->getPixelBuffer(AlphaPremultiplication::Premultiplied, effectADrawingRect);
 
     auto effectBDrawingRect = result.absoluteImageRectRelativeTo(input2);
     // The calculations using the pixel values from ‘in2’ are performed using non-premultiplied color values.
-    auto displacementPixelBuffer = input2.getPixelBuffer(AlphaPremultiplication::Unpremultiplied, effectBDrawingRect);
+    auto displacementPixelBuffer = input2->getPixelBuffer(AlphaPremultiplication::Unpremultiplied, effectBDrawingRect);
     
     if (!inputPixelBuffer || !displacementPixelBuffer)
         return false;

--- a/Source/WebCore/platform/graphics/filters/software/FEDropShadowSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEDropShadowSoftwareApplier.cpp
@@ -35,7 +35,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(FEDropShadowSoftwareApplier);
 
 bool FEDropShadowSoftwareApplier::apply(const Filter& filter, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
 {
-    auto& input = inputs[0].get();
+    Ref input = inputs[0];
 
     RefPtr resultImage = result.imageBuffer();
     if (!resultImage)
@@ -47,11 +47,11 @@ bool FEDropShadowSoftwareApplier::apply(const Filter& filter, std::span<const Re
     auto offset = filter.resolvedSize({ m_effect->dx(), m_effect->dy() });
     auto absoluteOffset = filter.scaledByFilterScale(offset);
 
-    FloatRect inputImageRect = input.absoluteImageRectRelativeTo(result);
+    FloatRect inputImageRect = input->absoluteImageRectRelativeTo(result);
     FloatRect inputImageRectWithOffset(inputImageRect);
     inputImageRectWithOffset.move(absoluteOffset);
 
-    RefPtr inputImage = input.imageBuffer();
+    RefPtr inputImage = input->imageBuffer();
     if (!inputImage)
         return false;
 

--- a/Source/WebCore/platform/graphics/filters/software/FEGaussianBlurSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEGaussianBlurSoftwareApplier.cpp
@@ -432,14 +432,14 @@ inline void FEGaussianBlurSoftwareApplier::applyPlatform(PixelBuffer& ioBuffer, 
 
 bool FEGaussianBlurSoftwareApplier::apply(const Filter& filter, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
 {
-    auto& input = inputs[0].get();
+    Ref input = inputs[0];
 
-    auto destinationPixelBuffer = result.pixelBuffer(AlphaPremultiplication::Premultiplied);
+    RefPtr destinationPixelBuffer = result.pixelBuffer(AlphaPremultiplication::Premultiplied);
     if (!destinationPixelBuffer)
         return false;
 
     auto effectDrawingRect = result.absoluteImageRectRelativeTo(input);
-    input.copyPixelBuffer(*destinationPixelBuffer, effectDrawingRect);
+    input->copyPixelBuffer(*destinationPixelBuffer, effectDrawingRect);
     if (!m_effect->stdDeviationX() && !m_effect->stdDeviationY())
         return true;
 

--- a/Source/WebCore/platform/graphics/filters/software/FEImageSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEImageSoftwareApplier.cpp
@@ -56,7 +56,7 @@ bool FEImageSoftwareApplier::apply(const Filter& filter, std::span<const Ref<Fil
         return true;
     }
 
-    if (auto imageBuffer = sourceImage.imageBufferIfExists()) {
+    if (RefPtr imageBuffer = sourceImage.imageBufferIfExists()) {
         auto destRect = m_effect->sourceImageRect();
         destRect.moveBy(primitiveSubregion.location());
         destRect.scale(filter.filterScale());

--- a/Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplier.cpp
@@ -173,14 +173,14 @@ void FELightingSoftwareApplier::applyPlatform(const LightingData& data) const
 
 bool FELightingSoftwareApplier::apply(const Filter& filter, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
 {
-    auto& input = inputs[0].get();
+    Ref input = inputs[0];
 
-    auto destinationPixelBuffer = result.pixelBuffer(AlphaPremultiplication::Premultiplied);
+    RefPtr destinationPixelBuffer = result.pixelBuffer(AlphaPremultiplication::Premultiplied);
     if (!destinationPixelBuffer)
         return false;
 
     auto effectDrawingRect = result.absoluteImageRectRelativeTo(input);
-    input.copyPixelBuffer(*destinationPixelBuffer, effectDrawingRect);
+    input->copyPixelBuffer(*destinationPixelBuffer, effectDrawingRect);
 
     // FIXME: support kernelUnitLengths other than (1,1). The issue here is that the W3
     // standard has no test case for them, and other browsers (like Firefox) has strange
@@ -206,7 +206,7 @@ bool FELightingSoftwareApplier::apply(const Filter& filter, std::span<const Ref<
     data.lightSource = &m_effect->lightSource();
     data.operatingColorSpace = &m_effect->operatingColorSpace();
 
-    data.pixels = destinationPixelBuffer;
+    data.pixels = destinationPixelBuffer.get();
     data.widthMultipliedByPixelSize = size.width() * cPixelSize;
     data.width = size.width();
     data.height = size.height();

--- a/Source/WebCore/platform/graphics/filters/software/FEOffsetSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEOffsetSoftwareApplier.cpp
@@ -37,14 +37,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(FEOffsetSoftwareApplier);
 
 bool FEOffsetSoftwareApplier::apply(const Filter& filter, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
 {
-    auto& input = inputs[0].get();
+    Ref input = inputs[0];
 
     RefPtr resultImage = result.imageBuffer();
-    RefPtr inputImage = input.imageBuffer();
+    RefPtr inputImage = input->imageBuffer();
     if (!resultImage || !inputImage)
         return false;
 
-    FloatRect inputImageRect = input.absoluteImageRectRelativeTo(result);
+    FloatRect inputImageRect = input->absoluteImageRectRelativeTo(result);
 
     auto offset = filter.resolvedSize({ m_effect->dx(), m_effect->dy() });
     auto absoluteOffset = filter.scaledByFilterScale(offset);

--- a/Source/WebCore/platform/graphics/filters/software/FETileSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FETileSoftwareApplier.cpp
@@ -37,17 +37,17 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(FETileSoftwareApplier);
 
 bool FETileSoftwareApplier::apply(const Filter& filter, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
 {
-    auto& input = inputs[0].get();
+    Ref input = inputs[0];
 
     RefPtr resultImage = result.imageBuffer();
-    RefPtr inputImage = input.imageBuffer();
+    RefPtr inputImage = input->imageBuffer();
     if (!resultImage || !inputImage)
         return false;
 
-    auto inputImageRect = input.absoluteImageRect();
+    auto inputImageRect = input->absoluteImageRect();
     auto resultImageRect = result.absoluteImageRect();
 
-    auto tileRect = input.maxEffectRect(filter);
+    auto tileRect = input->maxEffectRect(filter);
     tileRect.scale(filter.filterScale());
 
     auto maxResultRect = result.maxEffectRect(filter);

--- a/Source/WebCore/platform/graphics/filters/software/FETurbulenceSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FETurbulenceSoftwareApplier.cpp
@@ -375,7 +375,7 @@ void FETurbulenceSoftwareApplier::applyPlatform(const IntRect& filterRegion, con
 
 bool FETurbulenceSoftwareApplier::apply(const Filter& filter, std::span<const Ref<FilterImage>>, FilterImage& result) const
 {
-    auto destinationPixelBuffer = result.pixelBuffer(AlphaPremultiplication::Unpremultiplied);
+    RefPtr destinationPixelBuffer = result.pixelBuffer(AlphaPremultiplication::Unpremultiplied);
     if (!destinationPixelBuffer)
         return false;
 

--- a/Source/WebCore/platform/graphics/mac/controls/SwitchTrackMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SwitchTrackMac.mm
@@ -75,19 +75,19 @@ static RefPtr<ImageBuffer> trackImage(GraphicsContext& context, RefPtr<ImageBuff
     if (!trackImage)
         return nullptr;
 
-    auto cgContext = trackImage->context().platformContext();
+    RetainPtr cgContext = trackImage->context().platformContext();
 
     auto coreUIValue = @(isOn ? 1 : 0);
     auto coreUIState = (__bridge NSString *)(!isEnabled ? kCUIStateDisabled : isPressed ? kCUIStatePressed : kCUIStateActive);
     auto coreUIPresentation = (__bridge NSString *)(isInActiveWindow ? kCUIPresentationStateActiveKey : kCUIPresentationStateInactive);
     auto coreUIDirection = (__bridge NSString *)(isInlineFlipped ? kCUIUserInterfaceLayoutDirectionRightToLeft : kCUIUserInterfaceLayoutDirectionLeftToRight);
 
-    CGContextStateSaver stateSaver(cgContext);
+    CGContextStateSaver stateSaver(cgContext.get());
 
     // FIXME: clipping in context() might not always be accurate for context().platformContext().
     trackImage->context().clipToImageBuffer(*trackMaskImage, drawingTrackRect);
 
-    [[NSAppearance currentDrawingAppearance] _drawInRect:drawingTrackRect context:cgContext options:@{
+    [[NSAppearance currentDrawingAppearance] _drawInRect:drawingTrackRect context:cgContext.get() options:@{
         (__bridge NSString *)kCUIWidgetKey: (__bridge NSString *)kCUIWidgetSwitchFill,
         (__bridge NSString *)kCUIStateKey: coreUIState,
         (__bridge NSString *)kCUIValueKey: coreUIValue,
@@ -97,7 +97,7 @@ static RefPtr<ImageBuffer> trackImage(GraphicsContext& context, RefPtr<ImageBuff
         (__bridge NSString *)kCUIScaleKey: @(deviceScaleFactor),
     }];
 
-    [[NSAppearance currentDrawingAppearance] _drawInRect:drawingTrackRect context:cgContext options:@{
+    [[NSAppearance currentDrawingAppearance] _drawInRect:drawingTrackRect context:cgContext.get() options:@{
         (__bridge NSString *)kCUIWidgetKey: (__bridge NSString *)kCUIWidgetSwitchBorder,
         (__bridge NSString *)kCUISizeKey: coreUISize,
         (__bridge NSString *)kCUIUserInterfaceLayoutDirectionKey: coreUIDirection,
@@ -118,7 +118,7 @@ static RefPtr<ImageBuffer> trackImage(GraphicsContext& context, RefPtr<ImageBuff
             SwitchMacUtilities::rotateContextForVerticalWritingMode(trackImage->context(), drawingTrackRect);
         }
 
-        [[NSAppearance currentDrawingAppearance] _drawInRect:drawingTrackRect context:cgContext options:@{
+        [[NSAppearance currentDrawingAppearance] _drawInRect:drawingTrackRect context:cgContext.get() options:@{
             (__bridge NSString *)kCUIWidgetKey: (__bridge NSString *)kCUIWidgetSwitchOnOffLabel,
             // FIXME: Below does not pass kCUIStatePressed like NSCoreUIStateForSwitchState does,
             // as passing that does not appear to work correctly. Might be related to

--- a/Source/WebCore/platform/text/BidiContext.cpp
+++ b/Source/WebCore/platform/text/BidiContext.cpp
@@ -92,9 +92,9 @@ static inline Ref<BidiContext> copyContextAndRebaselineLevel(BidiContext& contex
 Ref<BidiContext> BidiContext::copyStackRemovingUnicodeEmbeddingContexts()
 {
     Vector<BidiContext*, 64> contexts;
-    for (auto* ancestor = this; ancestor; ancestor = ancestor->parent()) {
+    for (RefPtr ancestor = this; ancestor; ancestor = ancestor->parent()) {
         if (ancestor->source() != FromUnicode)
-            contexts.append(ancestor);
+            contexts.append(ancestor.get());
     }
     ASSERT(contexts.size());
     auto topContext = copyContextAndRebaselineLevel(*contexts.last(), nullptr);

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -610,7 +610,7 @@ template<typename Layer> BackgroundImageGeometry BackgroundPainter::calculateFil
     LayoutSize positioningAreaSize;
     // Determine the background positioning area and set destination rect to the background painting area.
     // Destination rect will be adjusted later if the background is non-repeating.
-    auto enclosingLayer = renderer.enclosingLayer();
+    CheckedPtr enclosingLayer = renderer.enclosingLayer();
     bool isTransformed = renderer.isTransformed() || (enclosingLayer && enclosingLayer->hasTransformedAncestor());
     bool fixedAttachment = fillLayer.attachment() == FillAttachment::FixedBackground && !isTransformed;
 

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -34,6 +34,7 @@
 #include "DocumentResourceLoader.h"
 #include "DocumentView.h"
 #include "ElementChildIteratorInlines.h"
+#include "ElementRareData.h"
 #include "EventHandler.h"
 #include "FocusController.h"
 #include "FrameSelection.h"

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -282,7 +282,7 @@ void RenderReplaced::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
 
     GraphicsContextStateSaver savedGraphicsContext(paintInfo.context(), false);
     if (element() && element()->parentOrShadowHostElement()) {
-        auto* parentContainer = element()->parentOrShadowHostElement();
+        RefPtr parentContainer = element()->parentOrShadowHostElement();
         ASSERT(parentContainer);
         CheckedPtr markers = document().markersIfExists();
         if (markers) {

--- a/Source/WebCore/rendering/RenderReplica.cpp
+++ b/Source/WebCore/rendering/RenderReplica.cpp
@@ -77,8 +77,8 @@ void RenderReplica::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
     if (paintInfo.phase == PaintPhase::Foreground) {
         // Turn around and paint the parent layer. Use temporary clipRects, so that the layer doesn't end up caching clip rects
         // computing using the wrong rootLayer
-        RenderLayer* rootPaintingLayer = layer()->transform() ? layer()->parent() : layer()->enclosingTransformedAncestor();
-        RenderLayer::LayerPaintingInfo paintingInfo(rootPaintingLayer, paintInfo.rect, PaintBehavior::Normal, LayoutSize(), 0);
+        CheckedPtr rootPaintingLayer = layer()->transform() ? layer()->parent() : layer()->enclosingTransformedAncestor();
+        RenderLayer::LayerPaintingInfo paintingInfo(rootPaintingLayer.get(), paintInfo.rect, PaintBehavior::Normal, LayoutSize(), 0);
         OptionSet<RenderLayer::PaintLayerFlag> flags { RenderLayer::PaintLayerFlag::HaveTransparency, RenderLayer::PaintLayerFlag::AppliedTransform, RenderLayer::PaintLayerFlag::TemporaryClipRects, RenderLayer::PaintLayerFlag::PaintingReflection };
         layer()->parent()->paintLayer(paintInfo.context(), paintingInfo, flags);
     } else if (paintInfo.phase == PaintPhase::Mask)

--- a/Source/WebCore/rendering/RenderTextControl.cpp
+++ b/Source/WebCore/rendering/RenderTextControl.cpp
@@ -224,7 +224,7 @@ void RenderTextControl::layoutExcludedChildren(RelayoutChildren relayoutChildren
 {
     RenderBlockFlow::layoutExcludedChildren(relayoutChildren);
 
-    auto* placeholder = textFormControlElement().placeholderElement();
+    RefPtr placeholder = textFormControlElement().placeholderElement();
     if (!placeholder)
         return;
 

--- a/Source/WebCore/rendering/RenderTextControlMultiLine.cpp
+++ b/Source/WebCore/rendering/RenderTextControlMultiLine.cpp
@@ -100,7 +100,7 @@ LayoutUnit RenderTextControlMultiLine::computeControlLogicalHeight(LayoutUnit li
 void RenderTextControlMultiLine::layoutExcludedChildren(RelayoutChildren relayoutChildren)
 {
     RenderTextControl::layoutExcludedChildren(relayoutChildren);
-    HTMLElement* placeholder = textFormControlElement().placeholderElement();
+    RefPtr placeholder = textFormControlElement().placeholderElement();
     RenderElement* placeholderRenderer = placeholder ? placeholder->renderer() : 0;
     if (!placeholderRenderer)
         return;

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -1254,7 +1254,7 @@ bool RenderTheme::isFocused(const RenderElement& renderer) const
         delegate = sliderThumb->hostInput();
 
     Ref document = delegate->document();
-    auto* frame = document->frame();
+    RefPtr frame = document->frame();
     return delegate == document->focusedElement() && frame && frame->checkedSelection()->isFocusedAndActive();
 }
 

--- a/Source/WebCore/rendering/style/StyleCursorImage.cpp
+++ b/Source/WebCore/rendering/style/StyleCursorImage.cpp
@@ -72,8 +72,8 @@ StyleCursorImage::StyleCursorImage(Ref<StyleImage>&& image, std::optional<IntPoi
 
 StyleCursorImage::~StyleCursorImage()
 {
-    for (auto& element : m_cursorElements)
-        element.removeClient(*this);
+    for (Ref element : m_cursorElements)
+        element->removeClient(*this);
 }
 
 bool StyleCursorImage::operator==(const StyleImage& other) const

--- a/Source/WebCore/rendering/svg/RenderSVGTextPath.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGTextPath.cpp
@@ -79,7 +79,7 @@ Path RenderSVGTextPath::layoutPath() const
     // http://www.w3.org/TR/SVG/text.html#TextPathElement
     if (element->renderer() && document().settings().layerBasedSVGEngineEnabled()) {
         auto& renderer = downcast<RenderSVGShape>(*element->renderer());
-        if (auto* layer = renderer.layer()) {
+        if (CheckedPtr layer = renderer.layer()) {
             const auto& layerTransform = layer->currentTransform(Style::TransformResolver::individualTransformOperations).toAffineTransform();
             if (!layerTransform.isIdentity())
                 path.transform(layerTransform);

--- a/Source/WebCore/rendering/svg/SVGLayerTransformComputation.h
+++ b/Source/WebCore/rendering/svg/SVGLayerTransformComputation.h
@@ -105,13 +105,13 @@ public:
     float calculateScreenFontSizeScalingFactor() const
     {
         // Walk up the render tree, accumulating transforms
-        auto* layer = m_renderer->enclosingLayer();
+        CheckedPtr layer = m_renderer->enclosingLayer();
 
         RenderLayer* stopAtLayer = nullptr;
         while (layer) {
             // We can stop at compositing layers, to match the backing resolution.
             if (layer->isComposited()) {
-                stopAtLayer = layer;
+                stopAtLayer = layer.get();
                 break;
             }
 

--- a/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
@@ -259,7 +259,7 @@ void writeSVGPaintingFeatures(TextStream& ts, const RenderElement& renderer, Opt
     }
 
     auto writeMarker = [&](ASCIILiteral name, const Style::SVGMarkerResource& value) {
-        auto* element = renderer.element();
+        RefPtr element = renderer.element();
         if (!element)
             return;
 

--- a/Source/WebCore/rendering/svg/SVGRenderingContext.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderingContext.cpp
@@ -229,7 +229,7 @@ AffineTransform SVGRenderingContext::calculateTransformationToOutermostCoordinat
     }
 
     // Continue walking up the layer tree, accumulating CSS transforms.
-    RenderLayer* layer = ancestor ? ancestor->enclosingLayer() : nullptr;
+    CheckedPtr layer = ancestor ? ancestor->enclosingLayer() : nullptr;
     while (layer) {
         if (TransformationMatrix* layerTransform = layer->transform())
             absoluteTransform = layerTransform->toAffineTransform() * absoluteTransform;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
@@ -158,9 +158,9 @@ static void getElementCTM(SVGElement* element, AffineTransform& transform)
     ASSERT(stopAtElement);
 
     AffineTransform localTransform;
-    Node* current = element;
+    RefPtr<Node> current = element;
 
-    while (RefPtr currentElement = dynamicDowncast<SVGElement>(current)) {
+    while (RefPtr currentElement = dynamicDowncast<SVGElement>(current.get())) {
         localTransform = currentElement->renderer()->localToParentTransform();
         transform = localTransform.multiply(transform);
         // For getCTM() computation, stop at the nearest viewport element

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp
@@ -105,9 +105,9 @@ FloatRect LegacyRenderSVGPath::adjustStrokeBoundingBoxForMarkersAndZeroLengthLin
 
 static void useStrokeStyleToFill(GraphicsContext& context)
 {
-    if (auto gradient = context.strokeGradient())
+    if (RefPtr gradient = context.strokeGradient())
         context.setFillGradient(*gradient, context.strokeGradientSpaceTransform());
-    else if (Pattern* pattern = context.strokePattern())
+    else if (RefPtr pattern = context.strokePattern())
         context.setFillPattern(*pattern);
     else
         context.setFillColor(context.strokeColor());

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp
@@ -114,7 +114,7 @@ auto LegacyRenderSVGResourceClipper::pathOnlyClipping(GraphicsContext& context, 
     // visible shape, the additive clipping may not work, caused by the clipRule. EvenOdd
     // as well as NonZero can cause self-clipping of the elements.
     // See also http://www.w3.org/TR/SVG/painting.html#FillRuleProperty
-    for (Node* childNode = clipPathElement().firstChild(); childNode; childNode = childNode->nextSibling()) {
+    for (RefPtr childNode = clipPathElement().firstChild(); childNode; childNode = childNode->nextSibling()) {
         RefPtr graphicsElement = dynamicDowncast<SVGGraphicsElement>(*childNode);
         if (!graphicsElement)
             continue;
@@ -123,7 +123,7 @@ auto LegacyRenderSVGResourceClipper::pathOnlyClipping(GraphicsContext& context, 
             continue;
 
         // For <use> elements, check visibility of the target element and skip if no visible target.
-        if (auto* useElement = dynamicDowncast<SVGUseElement>(graphicsElement.get())) {
+        if (RefPtr useElement = dynamicDowncast<SVGUseElement>(graphicsElement.get())) {
             auto* clipChildRenderer = useElement->rendererClipChild();
             if (!clipChildRenderer)
                 continue;
@@ -259,8 +259,8 @@ bool LegacyRenderSVGResourceClipper::drawContentIntoMaskImage(ImageBuffer& maskI
     view().frameView().setPaintBehavior(oldBehavior | PaintBehavior::RenderingSVGClipOrMask);
 
     // Draw all clipPath children into a global mask.
-    for (auto& child : childrenOfType<SVGElement>(protectedClipPathElement())) {
-        auto renderer = child.renderer();
+    for (Ref child : childrenOfType<SVGElement>(protectedClipPathElement())) {
+        auto renderer = child->renderer();
         if (!renderer)
             continue;
         if (renderer->needsLayout()) {
@@ -290,7 +290,7 @@ bool LegacyRenderSVGResourceClipper::drawContentIntoMaskImage(ImageBuffer& maskI
         // In the case of a <use> element, we obtained its renderere above, to retrieve its clipRule.
         // We have to pass the <use> renderer itself to renderSubtreeToContext() to apply it's x/y/transform/etc. values when rendering.
         // So if useElement is non-null, refetch the childNode->renderer(), as renderer got overridden above.
-        SVGRenderingContext::renderSubtreeToContext(maskContext, useElement ? *child.renderer() : *renderer, maskContentTransformation);
+        SVGRenderingContext::renderSubtreeToContext(maskContext, useElement ? *child->renderer() : *renderer, maskContentTransformation);
     }
 
     view().frameView().setPaintBehavior(oldBehavior);
@@ -300,7 +300,7 @@ bool LegacyRenderSVGResourceClipper::drawContentIntoMaskImage(ImageBuffer& maskI
 void LegacyRenderSVGResourceClipper::calculateClipContentRepaintRect(RepaintRectCalculation repaintRectCalculation)
 {
     // This is a rough heuristic to appraise the clip size and doesn't consider clip on clip.
-    for (Node* childNode = clipPathElement().firstChild(); childNode; childNode = childNode->nextSibling()) {
+    for (RefPtr childNode = clipPathElement().firstChild(); childNode; childNode = childNode->nextSibling()) {
         CheckedPtr renderer = dynamicDowncast<RenderElement>(childNode->renderer());
         if (!renderer || !childNode->isSVGElement())
             continue;
@@ -311,7 +311,7 @@ void LegacyRenderSVGResourceClipper::calculateClipContentRepaintRect(RepaintRect
             continue;
 
         // For <use> elements, check if the clipping target is visible.
-        if (auto* useElement = dynamicDowncast<SVGUseElement>(childNode)) {
+        if (RefPtr useElement = dynamicDowncast<SVGUseElement>(childNode)) {
             if (!useElement->visibleTargetGraphicsElement())
                 continue;
         }
@@ -344,7 +344,7 @@ bool LegacyRenderSVGResourceClipper::hitTestClipContent(const FloatRect& objectB
         point = valueOrDefault(transform.inverse()).mapPoint(point);
     }
 
-    for (Node* childNode = clipPathElement().firstChild(); childNode; childNode = childNode->nextSibling()) {
+    for (RefPtr childNode = clipPathElement().firstChild(); childNode; childNode = childNode->nextSibling()) {
         RenderObject* renderer = childNode->renderer();
         if (!childNode->isSVGElement() || !renderer)
             continue;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp
@@ -156,16 +156,16 @@ void LegacyRenderSVGResourceContainer::markAllClientLayersForInvalidation()
         return;
 
     auto inLayout = document->view()->layoutContext().isInLayout();
-    for (auto& clientLayer : m_clientLayers | dereferenceView) {
+    for (CheckedRef clientLayer : m_clientLayers | dereferenceView) {
         // FIXME: We should not get here while in layout. See webkit.org/b/208903.
         // Repaint should also be triggered through some other means.
         if (inLayout) {
-            clientLayer.renderer().repaint();
+            clientLayer->renderer().repaint();
             continue;
         }
-        if (auto* enclosingElement = clientLayer.enclosingElement())
+        if (RefPtr enclosingElement = clientLayer->enclosingElement())
             enclosingElement->invalidateStyleAndLayerComposition();
-        clientLayer.renderer().repaint();
+        clientLayer->renderer().repaint();
     }
 }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.cpp
@@ -273,12 +273,12 @@ RefPtr<ImageBuffer> LegacyRenderSVGResourcePattern::createTileImage(GraphicsCont
         contentTransformation = tileImageTransform;
 
     // Draw the content into the ImageBuffer.
-    for (auto& child : childrenOfType<SVGElement>(Ref { *attributes.patternContentElement() })) {
-        if (!child.renderer())
+    for (Ref child : childrenOfType<SVGElement>(Ref { *attributes.patternContentElement() })) {
+        if (!child->renderer())
             continue;
-        if (child.renderer()->needsLayout())
+        if (child->renderer()->needsLayout())
             return nullptr;
-        SVGRenderingContext::renderSubtreeToContext(tileImageContext, *child.renderer(), contentTransformation);
+        SVGRenderingContext::renderSubtreeToContext(tileImageContext, *child->renderer(), contentTransformation);
     }
 
     return tileImage;

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
@@ -245,7 +245,7 @@ void RenderTreeBuilder::destroy(RenderObject& renderer, CanCollapseAnonymousBloc
         auto subtreeTearDownType = SetForScope { m_tearDownType, TearDownType::SubtreeWithRootAlreadyDetached };
         while (rendererToDelete->firstChild()) {
             auto& firstChild = *rendererToDelete->firstChild();
-            if (auto* node = firstChild.node())
+            if (RefPtr node = firstChild.node())
                 node->setRenderer(nullptr);
             destroy(firstChild);
         }

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
@@ -263,7 +263,7 @@ void RenderTreeBuilder::FirstLetter::createRenderers(RenderText& currentTextChil
                 length = scanLength + numCodeUnits;
         }
 
-        auto* textNode = currentTextChild.textNode();
+        RefPtr textNode = currentTextChild.textNode();
         WeakPtr beforeChild = currentTextChild.nextSibling();
         WeakPtr inlineWrapperForDisplayContents = currentTextChild.inlineWrapperForDisplayContents();
         auto hasInlineWrapperForDisplayContents = inlineWrapperForDisplayContents.get();

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderMathML.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderMathML.cpp
@@ -73,7 +73,7 @@ void RenderTreeBuilder::MathML::attach(RenderMathMLFenced& parent, RenderPtr<Ren
     // if they're different, as later child positions change by +1 or -1.
     // This should also handle surrogate pairs. See https://bugs.webkit.org/show_bug.cgi?id=125938.
     RenderPtr<RenderMathMLFencedOperator> separatorRenderer;
-    auto* separators = parent.separators();
+    RefPtr separators = parent.separators();
     if (separators) {
         unsigned count = 0;
         for (Node* position = child->node(); position; position = position->previousSibling()) {

--- a/Source/WebCore/style/AttributeChangeInvalidation.cpp
+++ b/Source/WebCore/style/AttributeChangeInvalidation.cpp
@@ -93,7 +93,7 @@ void AttributeChangeInvalidation::invalidateStyle(const QualifiedName& attribute
 
     collect(m_element->styleResolver().ruleSets());
 
-    if (auto* shadowRoot = m_element->shadowRoot())
+    if (RefPtr shadowRoot = m_element->shadowRoot())
         collect(shadowRoot->styleScope().resolver().ruleSets(), MatchElement::Host);
 }
 

--- a/Source/WebCore/style/ClassChangeInvalidation.cpp
+++ b/Source/WebCore/style/ClassChangeInvalidation.cpp
@@ -173,7 +173,7 @@ void ClassChangeInvalidation::computeInvalidation(const SpaceSplitString& oldCla
 
     collect(m_element->styleResolver().ruleSets());
 
-    if (auto* shadowRoot = m_element->shadowRoot())
+    if (RefPtr shadowRoot = m_element->shadowRoot())
         collect(shadowRoot->styleScope().resolver().ruleSets(), MatchElement::Host);
 }
 

--- a/Source/WebCore/style/ContainerQueryEvaluator.cpp
+++ b/Source/WebCore/style/ContainerQueryEvaluator.cpp
@@ -159,7 +159,7 @@ RefPtr<const Element> ContainerQueryEvaluator::selectContainer(OptionSet<CQ::Axi
         });
     };
 
-    auto findOriginatingElement = [&]() -> const Element* {
+    auto findOriginatingElement = [&]() -> RefPtr<const Element> {
         if (selectionMode == SelectionMode::PseudoElement)
             return &element;
 

--- a/Source/WebCore/style/IdChangeInvalidation.cpp
+++ b/Source/WebCore/style/IdChangeInvalidation.cpp
@@ -81,7 +81,7 @@ void IdChangeInvalidation::invalidateStyle(const AtomString& changedId)
 
     collect(m_element->styleResolver().ruleSets());
 
-    if (auto* shadowRoot = m_element->shadowRoot())
+    if (RefPtr shadowRoot = m_element->shadowRoot())
         collect(shadowRoot->styleScope().resolver().ruleSets(), MatchElement::Host);
 
 }

--- a/Source/WebCore/style/InspectorCSSOMWrappers.cpp
+++ b/Source/WebCore/style/InspectorCSSOMWrappers.cpp
@@ -63,37 +63,37 @@ void InspectorCSSOMWrappers::collect(ListType* listType)
         return;
     unsigned size = listType->length();
     for (unsigned i = 0; i < size; ++i) {
-        CSSRule* cssRule = listType->item(i);
+        RefPtr cssRule = listType->item(i);
         if (!cssRule)
             continue;
-        
+
         switch (cssRule->styleRuleType()) {
         case StyleRuleType::Container:
-            collect(uncheckedDowncast<CSSContainerRule>(cssRule));
+            collect(uncheckedDowncast<CSSContainerRule>(cssRule.get()));
             break;
         case StyleRuleType::Import:
             collect(uncheckedDowncast<CSSImportRule>(*cssRule).styleSheet());
             break;
         case StyleRuleType::LayerBlock:
-            collect(uncheckedDowncast<CSSLayerBlockRule>(cssRule));
+            collect(uncheckedDowncast<CSSLayerBlockRule>(cssRule.get()));
             break;
         case StyleRuleType::Media:
-            collect(uncheckedDowncast<CSSMediaRule>(cssRule));
+            collect(uncheckedDowncast<CSSMediaRule>(cssRule.get()));
             break;
         case StyleRuleType::Supports:
-            collect(uncheckedDowncast<CSSSupportsRule>(cssRule));
+            collect(uncheckedDowncast<CSSSupportsRule>(cssRule.get()));
             break;
         case StyleRuleType::Scope:
-            collect(uncheckedDowncast<CSSScopeRule>(cssRule));
+            collect(uncheckedDowncast<CSSScopeRule>(cssRule.get()));
             break;
         case StyleRuleType::StartingStyle:
-            collect(uncheckedDowncast<CSSStartingStyleRule>(cssRule));
+            collect(uncheckedDowncast<CSSStartingStyleRule>(cssRule.get()));
             break;
         case StyleRuleType::Style:
-            m_styleRuleToCSSOMWrapperMap.add(&uncheckedDowncast<CSSStyleRule>(*cssRule).styleRule(), uncheckedDowncast<CSSStyleRule>(cssRule));
+            m_styleRuleToCSSOMWrapperMap.add(&uncheckedDowncast<CSSStyleRule>(*cssRule).styleRule(), uncheckedDowncast<CSSStyleRule>(cssRule.get()));
 
             // Eagerly collect rules nested in this style rule.
-            collect(uncheckedDowncast<CSSStyleRule>(cssRule));
+            collect(uncheckedDowncast<CSSStyleRule>(cssRule.get()));
             break;
         default:
             break;

--- a/Source/WebCore/style/MatchedDeclarationsCache.cpp
+++ b/Source/WebCore/style/MatchedDeclarationsCache.cpp
@@ -93,10 +93,10 @@ bool MatchedDeclarationsCache::isCacheable(const Element& element, const RenderS
 
     // Getting computed style after a font environment change but before full style resolution may involve styles with non-current fonts.
     // Avoid caching them.
-    auto& fontSelector = element.document().fontSelector();
-    if (!style.fontCascade().isCurrent(fontSelector))
+    Ref fontSelector = element.document().fontSelector();
+    if (!style.fontCascade().isCurrent(fontSelector.get()))
         return false;
-    if (!parentStyle.fontCascade().isCurrent(fontSelector))
+    if (!parentStyle.fontCascade().isCurrent(fontSelector.get()))
         return false;
 
     if (element.hasRandomCachingKeyMap())

--- a/Source/WebCore/style/PropertyCascade.cpp
+++ b/Source/WebCore/style/PropertyCascade.cpp
@@ -304,7 +304,7 @@ bool PropertyCascade::shouldApplyAfterAnimation(const StyleProperties::PropertyR
     ASSERT(m_animationLayer);
 
     auto id = property.id();
-    auto* customProperty = dynamicDowncast<CSSCustomPropertyValue>(*property.value());
+    RefPtr customProperty = dynamicDowncast<CSSCustomPropertyValue>(*property.value());
 
     auto isAnimatedProperty = [&] {
         if (customProperty)

--- a/Source/WebCore/style/PseudoClassChangeInvalidation.cpp
+++ b/Source/WebCore/style/PseudoClassChangeInvalidation.cpp
@@ -128,7 +128,7 @@ void PseudoClassChangeInvalidation::collectRuleSets(const PseudoClassInvalidatio
 
     collect(m_element.styleResolver().ruleSets());
 
-    if (auto* shadowRoot = m_element.shadowRoot())
+    if (RefPtr shadowRoot = m_element.shadowRoot())
         collect(shadowRoot->styleScope().resolver().ruleSets(), MatchElement::Host);
 }
 

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -248,7 +248,7 @@ static bool shouldInheritTextDecorationsInEffect(const RenderStyle& style, const
 #if ENABLE(VIDEO)
         if (!element)
             return false;
-        auto* parentNode = element->parentNode();
+        RefPtr parentNode = element->parentNode();
         return parentNode && parentNode->isUserAgentShadowRoot() && parentNode->parentOrShadowHostElement()->isMediaElement();
 #else
         return false;
@@ -1180,7 +1180,7 @@ void Adjuster::adjustForSiteSpecificQuirks(RenderStyle& style) const
 
 void Adjuster::propagateToDocumentElementAndInitialContainingBlock(Update& update, const Document& document)
 {
-    auto* body = document.body();
+    RefPtr body = document.body();
     auto* bodyStyle = body ? update.elementStyle(*body) : nullptr;
     auto* documentElementStyle = update.elementStyle(*document.documentElement());
 
@@ -1263,10 +1263,10 @@ auto Adjuster::adjustmentForTextAutosizing(const RenderStyle& style, const Eleme
 {
     AdjustmentForTextAutosizing adjustmentForTextAutosizing;
 
-    auto& document = element.document();
-    if (!document.settings().textAutosizingEnabled()
-        || !document.settings().textAutosizingUsesIdempotentMode()
-        || document.settings().idempotentModeAutosizingOnlyHonorsPercentages())
+    Ref document = element.document();
+    if (!document->settings().textAutosizingEnabled()
+        || !document->settings().textAutosizingUsesIdempotentMode()
+        || document->settings().idempotentModeAutosizingOnlyHonorsPercentages())
         return adjustmentForTextAutosizing;
 
     auto newStatus = AutosizeStatus::computeStatus(style);
@@ -1276,7 +1276,7 @@ auto Adjuster::adjustmentForTextAutosizing(const RenderStyle& style, const Eleme
     if (style.textSizeAdjust().isNone())
         return adjustmentForTextAutosizing;
 
-    float initialScale = document.page() ? document.page()->initialScaleIgnoringContentSize() : 1;
+    float initialScale = document->page() ? document->page()->initialScaleIgnoringContentSize() : 1;
     auto adjustLineHeightIfNeeded = [&](auto computedFontSize) {
         auto lineHeight = style.specifiedLineHeight();
         constexpr static unsigned eligibleFontSize = 12;

--- a/Source/WebCore/style/StyleBuilderState.cpp
+++ b/Source/WebCore/style/StyleBuilderState.cpp
@@ -159,7 +159,7 @@ void BuilderState::adjustStyleForInterCharacterRuby()
 
 void BuilderState::updateFont()
 {
-    auto& fontSelector = const_cast<Document&>(document()).fontSelector();
+    Ref fontSelector = const_cast<Document&>(document()).fontSelector();
 
     auto needsUpdate = [&] {
         return m_fontDirty || !m_style.fontCascade().fonts();
@@ -176,7 +176,7 @@ void BuilderState::updateFont()
     updateFontForOrientationChange();
     updateFontForSizeChange();
 
-    m_style.fontCascade().update(&fontSelector);
+    m_style.fontCascade().update(fontSelector.ptr());
 
     m_fontDirty = false;
 }

--- a/Source/WebCore/style/StyleCustomPropertyRegistry.cpp
+++ b/Source/WebCore/style/StyleCustomPropertyRegistry.cpp
@@ -182,7 +182,7 @@ void CustomPropertyRegistry::notifyAnimationsOfCustomPropertyRegistration(const 
     auto& document = m_scope.document();
     for (auto& animation : WebAnimation::instances()) {
         if (RefPtr keyframeEffect = animation->keyframeEffect()) {
-            if (auto* target = keyframeEffect->target()) {
+            if (RefPtr target = keyframeEffect->target()) {
                 if (&target->document() == &document)
                     keyframeEffect->customPropertyRegistrationDidChange(customProperty);
             }

--- a/Source/WebCore/style/StyleExtractor.cpp
+++ b/Source/WebCore/style/StyleExtractor.cpp
@@ -162,17 +162,17 @@ static inline bool hasValidStyleForProperty(Element& element, CSSPropertyID prop
         return false;
 
     const auto* currentElement = &element;
-    for (auto& ancestor : composedTreeAncestors(element)) {
-        if (ancestor.styleValidity() != Style::Validity::Valid)
+    for (Ref ancestor : composedTreeAncestors(element)) {
+        if (ancestor->styleValidity() != Style::Validity::Valid)
             return false;
 
-        if (isQueryContainer(ancestor))
+        if (isQueryContainer(ancestor.get()))
             return false;
 
-        if (ancestor.directChildNeedsStyleRecalc() && currentElement->styleIsAffectedByPreviousSibling())
+        if (ancestor->directChildNeedsStyleRecalc() && currentElement->styleIsAffectedByPreviousSibling())
             return false;
 
-        currentElement = &ancestor;
+        currentElement = ancestor.ptr();
     }
 
     return true;

--- a/Source/WebCore/style/StyleInvalidator.cpp
+++ b/Source/WebCore/style/StyleInvalidator.cpp
@@ -49,12 +49,12 @@ namespace Style {
 static bool shouldDirtyAllStyle(const Vector<Ref<StyleRuleBase>>& rules)
 {
     for (auto& rule : rules) {
-        if (auto* styleRuleMedia = dynamicDowncast<StyleRuleMedia>(rule.get())) {
+        if (RefPtr styleRuleMedia = dynamicDowncast<StyleRuleMedia>(rule.get())) {
             if (shouldDirtyAllStyle(styleRuleMedia->childRules()))
                 return true;
             continue;
         }
-        if (auto* styleRuleWithNesting = dynamicDowncast<StyleRuleWithNesting>(rule.get())) {
+        if (RefPtr styleRuleWithNesting = dynamicDowncast<StyleRuleWithNesting>(rule.get())) {
             if (shouldDirtyAllStyle(styleRuleWithNesting->nestedRules()))
                 return true;
             continue;
@@ -141,10 +141,10 @@ static void invalidateAssignedElements(HTMLSlotElement& slot)
     if (!assignedNodes)
         return;
     for (auto& node : *assignedNodes) {
-        auto* element = dynamicDowncast<Element>(node.get());
+        RefPtr element = dynamicDowncast<Element>(node.get());
         if (!element)
             continue;
-        if (auto* slotElement = dynamicDowncast<HTMLSlotElement>(*element); slotElement && node->containingShadowRoot()) {
+        if (RefPtr slotElement = dynamicDowncast<HTMLSlotElement>(*element); slotElement && node->containingShadowRoot()) {
             invalidateAssignedElements(*slotElement);
             continue;
         }
@@ -196,26 +196,26 @@ void Invalidator::invalidateStyleForTree(Element& root, SelectorMatchingState* s
 void Invalidator::invalidateStyleForDescendants(Element& root, SelectorMatchingState* selectorMatchingState)
 {
     Vector<Element*, 20> parentStack;
-    Element* previousElement = &root;
+    RefPtr previousElement = &root;
     for (auto it = descendantsOfType<Element>(root).begin(); it; ) {
-        auto& descendant = *it;
-        auto* parent = descendant.parentElement();
-        if (parentStack.isEmpty() || parentStack.last() != parent) {
-            if (parent == previousElement) {
-                parentStack.append(parent);
+        Ref descendant = *it;
+        RefPtr parent = descendant->parentElement();
+        if (parentStack.isEmpty() || parentStack.last() != parent.get()) {
+            if (parent.get() == previousElement.get()) {
+                parentStack.append(parent.get());
                 if (selectorMatchingState)
                     selectorMatchingState->selectorFilter.pushParentInitializingIfNeeded(*parent);
             } else {
-                while (parentStack.last() != parent) {
+                while (parentStack.last() != parent.get()) {
                     parentStack.removeLast();
                     if (selectorMatchingState)
                         selectorMatchingState->selectorFilter.popParent();
                 }
             }
         }
-        previousElement = &descendant;
+        previousElement = descendant.ptr();
 
-        if (invalidateIfNeeded(descendant, selectorMatchingState) == CheckDescendants::Yes)
+        if (invalidateIfNeeded(descendant.get(), selectorMatchingState) == CheckDescendants::Yes)
             it.traverseNext();
         else
             it.traverseNextSkippingChildren();
@@ -226,7 +226,7 @@ void Invalidator::invalidateStyle(Document& document)
 {
     ASSERT(!m_dirtiesAllStyle);
 
-    Element* documentElement = document.documentElement();
+    RefPtr documentElement = document.documentElement();
     if (!documentElement)
         return;
 
@@ -241,7 +241,7 @@ void Invalidator::invalidateStyle(Scope& scope)
         return;
     }
 
-    if (auto* shadowRoot = scope.shadowRoot()) {
+    if (RefPtr shadowRoot = scope.shadowRoot()) {
         invalidateStyle(*shadowRoot);
         return;
     }
@@ -256,9 +256,9 @@ void Invalidator::invalidateStyle(ShadowRoot& shadowRoot)
     if (m_ruleInformation.hasHostPseudoClassRules && shadowRoot.host())
         shadowRoot.host()->invalidateStyleInternal();
 
-    for (auto& child : childrenOfType<Element>(shadowRoot)) {
+    for (Ref child : childrenOfType<Element>(shadowRoot)) {
         SelectorMatchingState selectorMatchingState;
-        invalidateStyleForTree(child, &selectorMatchingState);
+        invalidateStyleForTree(child.get(), &selectorMatchingState);
     }
 }
 
@@ -281,8 +281,8 @@ void Invalidator::invalidateStyleWithMatchElement(Element& element, MatchElement
     case MatchElement::Parent: {
         // .changed > .subject
         auto children = childrenOfType<Element>(element);
-        for (auto& child : children)
-            invalidateIfNeeded(child, nullptr);
+        for (Ref child : children)
+            invalidateIfNeeded(child.get(), nullptr);
         break;
     }
     case MatchElement::Ancestor: {
@@ -293,31 +293,31 @@ void Invalidator::invalidateStyleWithMatchElement(Element& element, MatchElement
     }
     case MatchElement::DirectSibling:
         // .changed + .subject
-        if (auto* sibling = element.nextElementSibling())
+        if (RefPtr sibling = element.nextElementSibling())
             invalidateIfNeeded(*sibling, nullptr);
         break;
     case MatchElement::IndirectSibling:
         // .changed ~ .subject
-        for (auto* sibling = element.nextElementSibling(); sibling; sibling = sibling->nextElementSibling())
+        for (RefPtr sibling = element.nextElementSibling(); sibling; sibling = sibling->nextElementSibling())
             invalidateIfNeeded(*sibling, nullptr);
         break;
     case MatchElement::AnySibling:
         // :nth-last-child(even of .changed)
-        for (auto& parentChild : childrenOfType<Element>(*element.parentNode()))
-            invalidateIfNeeded(parentChild, nullptr);
+        for (Ref parentChild : childrenOfType<Element>(*element.parentNode()))
+            invalidateIfNeeded(parentChild.get(), nullptr);
         break;
     case MatchElement::ParentSibling:
         // .changed ~ .a > .subject
-        for (auto* sibling = element.nextElementSibling(); sibling; sibling = sibling->nextElementSibling()) {
+        for (RefPtr sibling = element.nextElementSibling(); sibling; sibling = sibling->nextElementSibling()) {
             auto siblingChildren = childrenOfType<Element>(*sibling);
-            for (auto& siblingChild : siblingChildren)
-                invalidateIfNeeded(siblingChild, nullptr);
+            for (Ref siblingChild : siblingChildren)
+                invalidateIfNeeded(siblingChild.get(), nullptr);
         }
         break;
     case MatchElement::AncestorSibling: {
         // .changed ~ .a .subject
         SelectorMatchingState selectorMatchingState;
-        for (auto* sibling = element.nextElementSibling(); sibling; sibling = sibling->nextElementSibling()) {
+        for (RefPtr sibling = element.nextElementSibling(); sibling; sibling = sibling->nextElementSibling()) {
             selectorMatchingState.selectorFilter.popParentsUntil(element.parentElement());
             invalidateStyleForDescendants(*sibling, &selectorMatchingState);
         }
@@ -325,44 +325,44 @@ void Invalidator::invalidateStyleWithMatchElement(Element& element, MatchElement
     }
     case MatchElement::ParentAnySibling:
         // :nth-last-child(even of .changed) > .subject
-        for (auto& sibling : childrenOfType<Element>(*element.parentNode())) {
-            auto siblingChildren = childrenOfType<Element>(sibling);
-            for (auto& siblingChild : siblingChildren)
-                invalidateIfNeeded(siblingChild, nullptr);
+        for (Ref sibling : childrenOfType<Element>(*element.parentNode())) {
+            auto siblingChildren = childrenOfType<Element>(sibling.get());
+            for (Ref siblingChild : siblingChildren)
+                invalidateIfNeeded(siblingChild.get(), nullptr);
         }
         break;
     case MatchElement::AncestorAnySibling: {
         // :nth-last-child(even of .changed) .subject
         SelectorMatchingState selectorMatchingState;
-        for (auto& sibling : childrenOfType<Element>(*element.parentNode())) {
+        for (Ref sibling : childrenOfType<Element>(*element.parentNode())) {
             selectorMatchingState.selectorFilter.popParentsUntil(element.parentElement());
-            invalidateStyleForDescendants(sibling, &selectorMatchingState);
+            invalidateStyleForDescendants(sibling.get(), &selectorMatchingState);
         }
         break;
     }
     case MatchElement::HasChild: {
         // :has(> .changed)
-        if (auto* parent = element.parentElement())
+        if (RefPtr parent = element.parentElement())
             invalidateIfNeeded(*parent, nullptr);
         break;
     }
     case MatchElement::HasDescendant: {
         // :has(.changed)
         Vector<Element*, 16> ancestors;
-        for (auto* parent = element.parentElement(); parent; parent = parent->parentElement())
-            ancestors.append(parent);
+        for (RefPtr parent = element.parentElement(); parent; parent = parent->parentElement())
+            ancestors.append(parent.get());
 
         SelectorMatchingState selectorMatchingState;
         selectorMatchingState.selectorFilter.parentStackReserveInitialCapacity(ancestors.size());
-        for (auto* ancestor : ancestors | std::views::reverse) {
+        for (RefPtr ancestor : ancestors | std::views::reverse) {
             invalidateIfNeeded(*ancestor, &selectorMatchingState);
-            selectorMatchingState.selectorFilter.pushParent(ancestor);
+            selectorMatchingState.selectorFilter.pushParent(ancestor.get());
         }
         break;
     }
     case MatchElement::HasSibling:
         // :has(~ .changed)
-        if (auto* sibling = element.previousElementSibling()) {
+        if (RefPtr sibling = element.previousElementSibling()) {
             SelectorMatchingState selectorMatchingState;
             if (RefPtr parent = element.parentElement())
                 selectorMatchingState.selectorFilter.pushParentInitializingIfNeeded(*parent);
@@ -377,41 +377,41 @@ void Invalidator::invalidateStyleWithMatchElement(Element& element, MatchElement
     case MatchElement::HasAnySibling: {
         // :has(~ :is(.changed ~ .x))
         SelectorMatchingState selectorMatchingState;
-        if (auto* parent = element.parentElement())
+        if (RefPtr parent = element.parentElement())
             selectorMatchingState.selectorFilter.pushParentInitializingIfNeeded(*parent);
-        for (auto& sibling : childrenOfType<Element>(*element.parentNode()))
-            invalidateIfNeeded(sibling, &selectorMatchingState);
+        for (Ref sibling : childrenOfType<Element>(*element.parentNode()))
+            invalidateIfNeeded(sibling.get(), &selectorMatchingState);
         break;
     }
     case MatchElement::HasSiblingDescendant: {
         // :has(~ .a .changed)
         Vector<Element*, 16> elementAndAncestors;
         elementAndAncestors.append(&element);
-        for (auto* parent = element.parentElement(); parent; parent = parent->parentElement())
-            elementAndAncestors.append(parent);
+        for (RefPtr parent = element.parentElement(); parent; parent = parent->parentElement())
+            elementAndAncestors.append(parent.get());
 
         SelectorMatchingState selectorMatchingState;
         selectorMatchingState.selectorFilter.parentStackReserveInitialCapacity(elementAndAncestors.size());
-        for (auto* elementOrAncestor : elementAndAncestors | std::views::reverse) {
-            for (auto* sibling = elementOrAncestor->previousElementSibling(); sibling; sibling = sibling->previousElementSibling())
+        for (RefPtr elementOrAncestor : elementAndAncestors | std::views::reverse) {
+            for (RefPtr sibling = elementOrAncestor->previousElementSibling(); sibling; sibling = sibling->previousElementSibling())
                 invalidateIfNeeded(*sibling, &selectorMatchingState);
 
-            selectorMatchingState.selectorFilter.pushParent(elementOrAncestor);
+            selectorMatchingState.selectorFilter.pushParent(elementOrAncestor.get());
         }
         break;
     }
     case MatchElement::HasDescendantParent: {
         // :has(.changed) > .subject
         Vector<Element*, 16> ancestors;
-        for (auto* parent = element.parentElement(); parent; parent = parent->parentElement())
-            ancestors.append(parent);
+        for (RefPtr parent = element.parentElement(); parent; parent = parent->parentElement())
+            ancestors.append(parent.get());
 
         SelectorMatchingState selectorMatchingState;
         selectorMatchingState.selectorFilter.parentStackReserveInitialCapacity(ancestors.size());
-        for (auto* ancestor : ancestors | std::views::reverse) {
-            selectorMatchingState.selectorFilter.pushParent(ancestor);
-            for (auto& ancestorChild : childrenOfType<Element>(*ancestor))
-                invalidateIfNeeded(ancestorChild, &selectorMatchingState);
+        for (RefPtr ancestor : ancestors | std::views::reverse) {
+            selectorMatchingState.selectorFilter.pushParent(ancestor.get());
+            for (Ref ancestorChild : childrenOfType<Element>(*ancestor))
+                invalidateIfNeeded(ancestorChild.get(), &selectorMatchingState);
         }
         break;
     }
@@ -437,9 +437,9 @@ void Invalidator::invalidateStyleWithMatchElement(Element& element, MatchElement
         break;
     case MatchElement::HostChild:
         // ::slotted(.changed)
-        if (auto* host = element.shadowHost()) {
-            for (auto& hostChild : childrenOfType<Element>(*host))
-                invalidateIfNeeded(hostChild, nullptr);
+        if (RefPtr host = element.shadowHost()) {
+            for (Ref hostChild : childrenOfType<Element>(*host))
+                invalidateIfNeeded(hostChild.get(), nullptr);
         }
         break;
     }
@@ -450,12 +450,12 @@ void Invalidator::invalidateShadowParts(ShadowRoot& shadowRoot)
     if (shadowRoot.mode() == ShadowRootMode::UserAgent)
         return;
 
-    for (auto& descendant : descendantsOfType<Element>(shadowRoot)) {
+    for (Ref descendant : descendantsOfType<Element>(shadowRoot)) {
         // FIXME: We could only invalidate part names that actually show up in rules.
-        if (!descendant.partNames().isEmpty())
-            descendant.invalidateStyleInternal();
+        if (!descendant->partNames().isEmpty())
+            descendant->invalidateStyleInternal();
 
-        auto* nestedShadowRoot = descendant.shadowRoot();
+        RefPtr nestedShadowRoot = descendant->shadowRoot();
         if (nestedShadowRoot && !nestedShadowRoot->partMappings().isEmpty())
             invalidateShadowParts(*nestedShadowRoot);
     }
@@ -466,20 +466,20 @@ void Invalidator::invalidateUserAgentParts(ShadowRoot& shadowRoot)
     if (shadowRoot.mode() != ShadowRootMode::UserAgent)
         return;
 
-    for (auto& descendant : descendantsOfType<Element>(shadowRoot)) {
-        auto& part = descendant.userAgentPart();
+    for (Ref descendant : descendantsOfType<Element>(shadowRoot)) {
+        auto& part = descendant->userAgentPart();
         if (!part)
             continue;
         for (auto& ruleSet : m_ruleSets) {
             if (ruleSet.ruleSet->userAgentPartRules(part))
-                descendant.invalidateStyleInternal();
+                descendant->invalidateStyleInternal();
         }
     }
 }
 
 void Invalidator::invalidateInShadowTreeIfNeeded(Element& element)
 {
-    auto* shadowRoot = element.shadowRoot();
+    RefPtr shadowRoot = element.shadowRoot();
     if (!shadowRoot)
         return;
 
@@ -487,9 +487,9 @@ void Invalidator::invalidateInShadowTreeIfNeeded(Element& element)
         invalidateUserAgentParts(*shadowRoot);
 
     if (m_ruleInformation.hasHostPseudoClassRulesMatchingInShadowTree) {
-        for (auto& child : childrenOfType<Element>(*shadowRoot)) {
+        for (Ref child : childrenOfType<Element>(*shadowRoot)) {
             SelectorMatchingState selectorMatchingState;
-            invalidateStyleForTree(child, &selectorMatchingState);
+            invalidateStyleForTree(child.get(), &selectorMatchingState);
         }
     }
 
@@ -536,9 +536,9 @@ void Invalidator::invalidateWithScopeBreakingHasPseudoClassRuleSet(Element& elem
 
 void Invalidator::invalidateAllStyle(Scope& scope)
 {
-    if (auto* shadowRoot = scope.shadowRoot()) {
-        for (auto& shadowChild : childrenOfType<Element>(*shadowRoot))
-            shadowChild.invalidateStyleForSubtreeInternal();
+    if (RefPtr shadowRoot = scope.shadowRoot()) {
+        for (Ref shadowChild : childrenOfType<Element>(*shadowRoot))
+            shadowChild->invalidateStyleForSubtreeInternal();
         invalidateHostAndSlottedStyleIfNeeded(*shadowRoot);
         return;
     }
@@ -548,15 +548,15 @@ void Invalidator::invalidateAllStyle(Scope& scope)
 
 void Invalidator::invalidateHostAndSlottedStyleIfNeeded(ShadowRoot& shadowRoot)
 {
-    auto& host = *shadowRoot.host();
-    auto* resolver = shadowRoot.styleScope().resolverIfExists();
+    Ref host = *shadowRoot.host();
+    RefPtr resolver = shadowRoot.styleScope().resolverIfExists();
 
     if (!resolver || resolver->ruleSets().hasMatchingUserOrAuthorStyle([] (auto& style) { return !style.hostPseudoClassRules().isEmpty(); }))
-        host.invalidateStyleInternal();
+        host->invalidateStyleInternal();
 
     if (!resolver || resolver->ruleSets().hasMatchingUserOrAuthorStyle([] (auto& style) { return !style.slottedPseudoElementRules().isEmpty(); })) {
-        for (auto& shadowChild : childrenOfType<Element>(host))
-            shadowChild.invalidateStyleInternal();
+        for (Ref shadowChild : childrenOfType<Element>(host.get()))
+            shadowChild->invalidateStyleInternal();
     }
 }
 

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -210,8 +210,8 @@ void Scope::clearViewTransitionStyles()
 void Scope::releaseMemory()
 {
     if (!m_shadowRoot) {
-        for (auto& descendantShadowRoot : m_document->inDocumentShadowRoots())
-            const_cast<ShadowRoot&>(descendantShadowRoot).styleScope().releaseMemory();
+        for (Ref descendantShadowRoot : m_document->inDocumentShadowRoots())
+            const_cast<ShadowRoot&>(descendantShadowRoot.get()).styleScope().releaseMemory();
     }
 
 #if ENABLE(CSS_SELECTOR_JIT)
@@ -232,7 +232,7 @@ void Scope::releaseMemory()
 Scope& Scope::forNode(Node& node)
 {
     ASSERT(node.isConnected());
-    auto* shadowRoot = node.containingShadowRoot();
+    RefPtr shadowRoot = node.containingShadowRoot();
     if (shadowRoot)
         return shadowRoot->styleScope();
     return node.document().styleScope();
@@ -251,14 +251,14 @@ Scope* Scope::forOrdinal(Element& element, ScopeOrdinal ordinal)
     if (ordinal == ScopeOrdinal::Element)
         return &forNode(element);
     if (ordinal == ScopeOrdinal::Shadow) {
-        auto* shadowRoot = element.shadowRoot();
+        RefPtr shadowRoot = element.shadowRoot();
         return shadowRoot ? &shadowRoot->styleScope() : nullptr;
     }
     if (ordinal <= ScopeOrdinal::ContainingHost) {
-        auto* host = hostForScopeOrdinal(element, ordinal);
+        RefPtr host = hostForScopeOrdinal(element, ordinal);
         return host ? &forNode(*host) : nullptr;
     }
-    auto* slot = assignedSlotForScopeOrdinal(element, ordinal);
+    RefPtr slot = assignedSlotForScopeOrdinal(element, ordinal);
     return slot ? &forNode(*slot) : nullptr;
 }
 
@@ -406,8 +406,8 @@ void Scope::removeStyleSheetCandidateNode(Node& node)
 Vector<Ref<ProcessingInstruction>> Scope::collectXSLTransforms()
 {
     Vector<Ref<ProcessingInstruction>> processingInstructions;
-    for (auto& node : m_styleSheetCandidateNodes) {
-        if (auto* processingInstruction = dynamicDowncast<ProcessingInstruction>(node); processingInstruction && processingInstruction->isXSL())
+    for (Ref node : m_styleSheetCandidateNodes) {
+        if (RefPtr processingInstruction = dynamicDowncast<ProcessingInstruction>(node); processingInstruction && processingInstruction->isXSL())
             processingInstructions.append(*processingInstruction);
     }
     return processingInstructions;
@@ -424,9 +424,9 @@ auto Scope::collectActiveStyleSheets() -> ActiveStyleSheetCollection
     Vector<Ref<StyleSheet>> sheets;
     Vector<Ref<StyleSheet>> styleSheetsForStyleSheetsList;
 
-    for (auto& node : m_styleSheetCandidateNodes) {
+    for (Ref node : m_styleSheetCandidateNodes) {
         RefPtr<StyleSheet> sheet;
-        if (auto* processingInstruction = dynamicDowncast<ProcessingInstruction>(node)) {
+        if (RefPtr processingInstruction = dynamicDowncast<ProcessingInstruction>(node)) {
             if (!processingInstruction->isCSS())
                 continue;
             // We don't support linking to embedded CSS stylesheets, see <https://bugs.webkit.org/show_bug.cgi?id=49281> for discussion.
@@ -435,10 +435,10 @@ auto Scope::collectActiveStyleSheets() -> ActiveStyleSheetCollection
                 styleSheetsForStyleSheetsList.append(*sheet);
             LOG_WITH_STREAM(StyleSheets, stream << " adding sheet " << sheet << " from ProcessingInstruction node " << node);
         } else if (is<HTMLLinkElement>(node) || is<HTMLStyleElement>(node) || is<SVGStyleElement>(node)) {
-            Element& element = uncheckedDowncast<Element>(node);
-            AtomString title = element.isInShadowTree() ? nullAtom() : element.attributeWithoutSynchronization(titleAttr);
+            Ref element = uncheckedDowncast<Element>(node);
+            AtomString title = element->isInShadowTree() ? nullAtom() : element->attributeWithoutSynchronization(titleAttr);
             bool enabledViaScript = false;
-            if (auto* linkElement = dynamicDowncast<HTMLLinkElement>(element)) {
+            if (RefPtr linkElement = dynamicDowncast<HTMLLinkElement>(element.get())) {
                 // <LINK> element
                 if (linkElement->isDisabled())
                     continue;
@@ -456,12 +456,12 @@ auto Scope::collectActiveStyleSheets() -> ActiveStyleSheetCollection
             }
             // Get the current preferred styleset. This is the
             // set of sheets that will be enabled.
-            if (auto* svgStyleElement = dynamicDowncast<SVGStyleElement>(element))
+            if (auto* svgStyleElement = dynamicDowncast<SVGStyleElement>(element.get()))
                 sheet = svgStyleElement->sheet();
-            else if (auto* htmlLinkElement = dynamicDowncast<HTMLLinkElement>(element))
+            else if (auto* htmlLinkElement = dynamicDowncast<HTMLLinkElement>(element.get()))
                 sheet = htmlLinkElement->sheet();
             else
-                sheet = downcast<HTMLStyleElement>(element).sheet();
+                sheet = downcast<HTMLStyleElement>(element.get()).sheet();
 
             if (sheet)
                 styleSheetsForStyleSheetsList.append(*sheet);
@@ -469,7 +469,7 @@ auto Scope::collectActiveStyleSheets() -> ActiveStyleSheetCollection
             // Check to see if this sheet belongs to a styleset
             // (thus making it PREFERRED or ALTERNATE rather than
             // PERSISTENT).
-            auto& rel = element.attributeWithoutSynchronization(relAttr);
+            auto& rel = element->attributeWithoutSynchronization(relAttr);
             if (!enabledViaScript && sheet && !title.isEmpty()) {
                 // Yes, we have a title.
                 if (m_preferredStylesheetSetName.isEmpty()) {
@@ -477,7 +477,7 @@ auto Scope::collectActiveStyleSheets() -> ActiveStyleSheetCollection
                     // we are NOT an alternate sheet, then establish
                     // us as the preferred set. Otherwise, just ignore
                     // this sheet.
-                    if (is<HTMLStyleElement>(element) || !rel.contains("alternate"_s))
+                    if (is<HTMLStyleElement>(element.get()) || !rel.contains("alternate"_s))
                         m_preferredStylesheetSetName = title;
                 }
                 if (title != m_preferredStylesheetSetName)
@@ -514,7 +514,7 @@ Scope::StyleSheetChange Scope::analyzeStyleSheetChange(const Vector<Ref<CSSStyle
 {
     unsigned newStylesheetCount = newStylesheets.size();
 
-    auto* resolver = resolverIfExists();
+    RefPtr resolver = resolverIfExists();
     if (!resolver)
         return { ResolverUpdateType::Reconstruct };
 
@@ -554,7 +554,7 @@ Scope::StyleSheetChange Scope::analyzeStyleSheetChange(const Vector<Ref<CSSStyle
 static void filterEnabledNonemptyCSSStyleSheets(Vector<Ref<CSSStyleSheet>>& result, const Vector<Ref<StyleSheet>>& sheets)
 {
     for (auto& sheet : sheets) {
-        auto* styleSheet = dynamicDowncast<CSSStyleSheet>(sheet.get());
+        RefPtr styleSheet = dynamicDowncast<CSSStyleSheet>(sheet.get());
         if (!styleSheet)
             continue;
         if (styleSheet->isLoading())
@@ -668,7 +668,7 @@ const Vector<Ref<CSSStyleSheet>> Scope::activeStyleSheetsForInspector()
     Vector<Ref<CSSStyleSheet>> result;
 
     if (CheckedPtr extensionStyleSheets = m_document->extensionStyleSheetsIfExists()) {
-        if (auto* pageUserSheet = extensionStyleSheets->pageUserSheet())
+        if (RefPtr pageUserSheet = extensionStyleSheets->pageUserSheet())
             result.append(*pageUserSheet);
         result.appendVector(extensionStyleSheets->documentUserStyleSheets());
         result.appendVector(extensionStyleSheets->injectedUserStyleSheets());
@@ -677,7 +677,7 @@ const Vector<Ref<CSSStyleSheet>> Scope::activeStyleSheetsForInspector()
     }
 
     for (auto& styleSheet : m_styleSheetsForStyleSheetList) {
-        auto* sheet = dynamicDowncast<CSSStyleSheet>(styleSheet.get());
+        RefPtr sheet = dynamicDowncast<CSSStyleSheet>(styleSheet.get());
         if (!sheet)
             continue;
 
@@ -717,8 +717,8 @@ void Scope::flushPendingDescendantUpdates()
 {
     ASSERT(m_hasDescendantWithPendingUpdate);
     ASSERT(!m_shadowRoot);
-    for (auto& descendantShadowRoot : m_document->inDocumentShadowRoots())
-        const_cast<ShadowRoot&>(descendantShadowRoot).styleScope().flushPendingUpdate();
+    for (Ref descendantShadowRoot : m_document->inDocumentShadowRoots())
+        const_cast<ShadowRoot&>(descendantShadowRoot.get()).styleScope().flushPendingUpdate();
     m_hasDescendantWithPendingUpdate = false;
 }
 
@@ -800,13 +800,13 @@ auto Scope::collectResolverScopes() -> ResolverScopes
 
     ResolverScopes resolverScopes;
 
-    if (auto* resolver = resolverIfExists())
+    if (RefPtr resolver = resolverIfExists())
         resolverScopes.add(*resolver, Vector<WeakPtr<Scope>> { this });
 
-    for (auto& shadowRoot : m_document->inDocumentShadowRoots()) {
-        auto& scope = const_cast<ShadowRoot&>(shadowRoot).styleScope();
+    for (Ref shadowRoot : m_document->inDocumentShadowRoots()) {
+        auto& scope = const_cast<ShadowRoot&>(shadowRoot.get()).styleScope();
 
-        if (auto* resolver = scope.resolverIfExists())
+        if (RefPtr resolver = scope.resolverIfExists())
             resolverScopes.add(*resolver, Vector<WeakPtr<Scope>> { }).iterator->value.append(&scope);
     }
     return resolverScopes;
@@ -860,8 +860,8 @@ void Scope::didChangeStyleSheetEnvironment()
     if (!m_shadowRoot) {
         m_sharedShadowTreeResolvers.clear();
 
-        for (auto& descendantShadowRoot : m_document->inDocumentShadowRoots())
-            const_cast<ShadowRoot&>(descendantShadowRoot).styleScope().scheduleUpdate(UpdateType::ContentsOrInterpretation);
+        for (Ref descendantShadowRoot : m_document->inDocumentShadowRoots())
+            const_cast<ShadowRoot&>(descendantShadowRoot.get()).styleScope().scheduleUpdate(UpdateType::ContentsOrInterpretation);
 
         m_document->invalidateCachedCSSParserContext();
     }
@@ -876,8 +876,8 @@ void Scope::didChangeExtensionStyleSheets()
     // Extension stylesheets may mutate in the middle of a style update when resource loading triggers
     // content extension processing. In this case we schedule an asyncronous full stylesheet update.
     // FIXME: We should defer all resource loading after style resolution completes.
-    for (auto& descendantShadowRoot : m_document->inDocumentShadowRoots())
-        const_cast<ShadowRoot&>(descendantShadowRoot).styleScope().scheduleUpdate(UpdateType::FullForExtensionStyleSheets);
+    for (Ref descendantShadowRoot : m_document->inDocumentShadowRoots())
+        const_cast<ShadowRoot&>(descendantShadowRoot.get()).styleScope().scheduleUpdate(UpdateType::FullForExtensionStyleSheets);
 
     scheduleUpdate(UpdateType::FullForExtensionStyleSheets);
 }
@@ -891,21 +891,21 @@ void Scope::didChangeViewportSize()
         if (!m_document->hasStyleWithViewportUnits())
             return;
 
-        for (auto& descendantShadowRoot : m_document->inDocumentShadowRoots()) {
-            if (descendantShadowRoot.mode() == ShadowRootMode::UserAgent)
+        for (Ref descendantShadowRoot : m_document->inDocumentShadowRoots()) {
+            if (descendantShadowRoot->mode() == ShadowRootMode::UserAgent)
                 continue;
-            const_cast<ShadowRoot&>(descendantShadowRoot).styleScope().didChangeViewportSize();
+            const_cast<ShadowRoot&>(descendantShadowRoot.get()).styleScope().didChangeViewportSize();
         }
     }
 
-    auto* resolver = resolverIfExists();
+    RefPtr resolver = resolverIfExists();
     if (!resolver)
         return;
     resolver->clearCachedDeclarationsAffectedByViewportUnits();
 
     if (customPropertyRegistry().invalidatePropertiesWithViewportUnits(m_document)) {
         if (!m_shadowRoot) {
-            if (auto element = m_document->documentElement())
+            if (RefPtr element = m_document->documentElement())
                 element->invalidateStyleForSubtree();
         }
         return;
@@ -922,11 +922,11 @@ void Scope::didChangeViewportSize()
 void Scope::invalidateMatchedDeclarationsCache()
 {
     if (!m_shadowRoot) {
-        for (auto& descendantShadowRoot : m_document->inDocumentShadowRoots())
-            const_cast<ShadowRoot&>(descendantShadowRoot).styleScope().invalidateMatchedDeclarationsCache();
+        for (Ref descendantShadowRoot : m_document->inDocumentShadowRoots())
+            const_cast<ShadowRoot&>(descendantShadowRoot.get()).styleScope().invalidateMatchedDeclarationsCache();
     }
 
-    if (auto* resolver = resolverIfExists())
+    if (RefPtr resolver = resolverIfExists())
         resolver->invalidateMatchedDeclarationsCache();
 }
 
@@ -1109,19 +1109,19 @@ MatchResultCache& Scope::matchResultCache()
     return *m_matchResultCache;
 }
 
-HTMLSlotElement* assignedSlotForScopeOrdinal(const Element& element, ScopeOrdinal scopeOrdinal)
+RefPtr<HTMLSlotElement> assignedSlotForScopeOrdinal(const Element& element, ScopeOrdinal scopeOrdinal)
 {
     ASSERT(scopeOrdinal >= ScopeOrdinal::FirstSlot);
-    auto* slot = element.assignedSlot();
+    RefPtr slot = element.assignedSlot();
     for (auto scopeDepth = ScopeOrdinal::FirstSlot; slot && scopeDepth != scopeOrdinal; ++scopeDepth)
         slot = slot->assignedSlot();
     return slot;
 }
 
-Element* hostForScopeOrdinal(const Element& element, ScopeOrdinal scopeOrdinal)
+RefPtr<Element> hostForScopeOrdinal(const Element& element, ScopeOrdinal scopeOrdinal)
 {
     ASSERT(scopeOrdinal <= ScopeOrdinal::ContainingHost);
-    auto* host = element.shadowHost();
+    RefPtr host = element.shadowHost();
     for (auto scopeDepth = ScopeOrdinal::ContainingHost; host && scopeDepth != scopeOrdinal; --scopeDepth)
         host = host->shadowHost();
     return host;

--- a/Source/WebCore/style/StyleScope.h
+++ b/Source/WebCore/style/StyleScope.h
@@ -296,8 +296,8 @@ private:
     AnchorPositionedToAnchorMap m_anchorPositionedToAnchorMap;
 };
 
-HTMLSlotElement* assignedSlotForScopeOrdinal(const Element&, ScopeOrdinal);
-Element* hostForScopeOrdinal(const Element&, ScopeOrdinal);
+RefPtr<HTMLSlotElement> assignedSlotForScopeOrdinal(const Element&, ScopeOrdinal);
+RefPtr<Element> hostForScopeOrdinal(const Element&, ScopeOrdinal);
 
 inline void Scope::flushPendingUpdate()
 {

--- a/Source/WebCore/style/StyleScopeRuleSets.cpp
+++ b/Source/WebCore/style/StyleScopeRuleSets.cpp
@@ -123,7 +123,7 @@ void ScopeRuleSets::initializeUserStyle()
 
     auto userStyle = RuleSet::create();
 
-    if (auto* pageUserSheet = extensionStyleSheets->pageUserSheet()) {
+    if (RefPtr pageUserSheet = extensionStyleSheets->pageUserSheet()) {
         RuleSetBuilder builder(userStyle, mediaQueryEvaluator, &m_styleResolver);
         builder.addRulesFromSheet(pageUserSheet->contents());
     }
@@ -282,12 +282,12 @@ void ScopeRuleSets::collectFeatures() const
         m_features.add(UserAgentStyle::defaultStyle->features());
     m_defaultStyleVersionOnFeatureCollection = UserAgentStyle::defaultStyleVersion;
 
-    if (auto* userAgentMediaQueryStyle = this->userAgentMediaQueryStyle())
+    if (RefPtr userAgentMediaQueryStyle = this->userAgentMediaQueryStyle())
         m_features.add(userAgentMediaQueryStyle->features());
 
     if (m_authorStyle)
         m_features.add(m_authorStyle->features());
-    if (auto* userStyle = this->userStyle())
+    if (RefPtr userStyle = this->userStyle())
         m_features.add(userStyle->features());
 
     m_scopeBreakingHasPseudoClassInvalidationRuleSet = makeRuleSet(m_features.scopeBreakingHasPseudoClassRules);
@@ -439,7 +439,7 @@ bool ScopeRuleSets::hasMatchingUserOrAuthorStyle(NOESCAPE const WTF::Function<bo
     if (m_authorStyle && predicate(*m_authorStyle))
         return true;
 
-    if (auto* userStyle = this->userStyle(); userStyle && predicate(*userStyle))
+    if (RefPtr userStyle = this->userStyle(); userStyle && predicate(*userStyle))
         return true;
 
     return false;

--- a/Source/WebCore/style/StyleUpdate.cpp
+++ b/Source/WebCore/style/StyleUpdate.cpp
@@ -134,9 +134,9 @@ void Update::addText(Text& text, TextUpdate&& textUpdate)
 
 void Update::addSVGRendererUpdate(SVGElement& element)
 {
-    auto parent = composedTreeAncestors(element).first();
+    RefPtr parent = composedTreeAncestors(element).first();
     m_roots.remove(&element);
-    addPossibleRoot(parent);
+    addPossibleRoot(parent.get());
     element.setNeedsSVGRendererUpdate(true);
 }
 

--- a/Source/WebCore/style/UserAgentStyle.cpp
+++ b/Source/WebCore/style/UserAgentStyle.cpp
@@ -113,14 +113,15 @@ static const MQ::MediaQueryEvaluator& printEval()
 
 static StyleSheetContents* parseUASheet(const String& str)
 {
-    StyleSheetContents& sheet = StyleSheetContents::create(CSSParserContext(UASheetMode)).leakRef(); // leak the sheet on purpose
-    sheet.parseString(str);
-    return &sheet;
+    Ref sheet = StyleSheetContents::create(CSSParserContext(UASheetMode));
+    sheet->parseString(str);
+    return &sheet.leakRef();
 }
+
 void static addToCounterStyleRegistry(StyleSheetContents& sheet)
 {
     for (auto& rule : sheet.childRules()) {
-        if (auto* counterStyleRule = dynamicDowncast<StyleRuleCounterStyle>(rule.get()))
+        if (RefPtr counterStyleRule = dynamicDowncast<StyleRuleCounterStyle>(rule.get()))
             CSSCounterStyleRegistry::addUserAgentCounterStyle(counterStyleRule->descriptors());
     }
     CSSCounterStyleRegistry::resolveUserAgentReferences();
@@ -130,7 +131,7 @@ void static addUserAgentKeyframes(StyleSheetContents& sheet)
 {
     // This does not handle nested rules.
     for (auto& rule : sheet.childRules()) {
-        if (auto* styleRuleKeyframes = dynamicDowncast<StyleRuleKeyframes>(rule.get()))
+        if (RefPtr styleRuleKeyframes = dynamicDowncast<StyleRuleKeyframes>(rule.get()))
             Style::Resolver::addUserAgentKeyframeStyle(*styleRuleKeyframes);
     }
 }

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h
@@ -34,7 +34,7 @@
 #define SET_NESTED(group, parent, variable, value) SET_STYLE_PROPERTY(group->parent->variable, group.access().parent.access().variable, value)
 #define SET_DOUBLY_NESTED(group, grandparent, parent, variable, value) SET_STYLE_PROPERTY(group->grandparent->parent->variable, group.access().grandparent.access().parent.access().variable, value)
 #define SET_NESTED_STRUCT(group, parent, variable, value) SET_STYLE_PROPERTY(group->parent.variable, group.access().parent.variable, value)
-#define SET_STYLE_PROPERTY_PAIR(read, write, variable1, value1, variable2, value2) do { auto& readable = *read; if (!compareEqual(readable.variable1, value1) || !compareEqual(readable.variable2, value2)) { auto& writable = write; writable.variable1 = value1; writable.variable2 = value2; } } while (0)
+#define SET_STYLE_PROPERTY_PAIR(read, write, variable1, value1, variable2, value2) do { Ref readable = Ref { *read }; if (!compareEqual(readable->variable1, value1) || !compareEqual(readable->variable2, value2)) { auto& writable = write; writable.variable1 = value1; writable.variable2 = value2; } } while (0)
 #define SET_PAIR(group, variable1, value1, variable2, value2) SET_STYLE_PROPERTY_PAIR(group, group.access(), variable1, value1, variable2, value2)
 #define SET_NESTED_PAIR(group, parent, variable1, value1, variable2, value2) SET_STYLE_PROPERTY_PAIR(group->parent, group.access().parent.access(), variable1, value1, variable2, value2)
 #define SET_DOUBLY_NESTED_PAIR(group, grandparent, parent, variable1, value1, variable2, value2) SET_STYLE_PROPERTY_PAIR(group->grandparent->parent, group.access().grandparent.access().parent.access(), variable1, value1, variable2, value2)

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.cpp
@@ -130,7 +130,7 @@ RenderStyle* ComputedStyleBase::addCachedPseudoStyle(std::unique_ptr<RenderStyle
 
 const CustomProperty* ComputedStyleBase::customPropertyValue(const AtomString& name) const
 {
-    for (auto* map : { &nonInheritedCustomProperties(), &inheritedCustomProperties() }) {
+    for (RefPtr map : { &nonInheritedCustomProperties(), &inheritedCustomProperties() }) {
         if (auto* value = map->get(name))
             return value;
     }
@@ -141,10 +141,10 @@ void ComputedStyleBase::setCustomPropertyValue(Ref<const CustomProperty>&& value
 {
     auto& name = value->name();
     if (isInherited) {
-        if (auto* existingValue = m_inheritedRareData->customProperties->get(name); !existingValue || *existingValue != value.get())
+        if (RefPtr existingValue = m_inheritedRareData->customProperties->get(name); !existingValue || *existingValue != value.get())
             m_inheritedRareData.access().customProperties.access().set(name, WTF::move(value));
     } else {
-        if (auto* existingValue = m_nonInheritedData->rareData->customProperties->get(name); !existingValue || *existingValue != value.get())
+        if (RefPtr existingValue = m_nonInheritedData->rareData->customProperties->get(name); !existingValue || *existingValue != value.get())
             m_nonInheritedData.access().rareData.access().customProperties.access().set(name, WTF::move(value));
     }
 }
@@ -154,8 +154,8 @@ bool ComputedStyleBase::customPropertyValueEqual(const ComputedStyleBase& other,
     if (&nonInheritedCustomProperties() == &other.nonInheritedCustomProperties() && &inheritedCustomProperties() == &other.inheritedCustomProperties())
         return true;
 
-    auto* value = customPropertyValue(name);
-    auto* otherValue = other.customPropertyValue(name);
+    RefPtr value = customPropertyValue(name);
+    RefPtr otherValue = other.customPropertyValue(name);
     if (value == otherValue)
         return true;
     if (!value || !otherValue)
@@ -187,8 +187,8 @@ void ComputedStyleBase::deduplicateCustomProperties(const ComputedStyleBase& oth
 
 void ComputedStyleBase::addCustomPaintWatchProperty(const AtomString& name)
 {
-    auto& data = m_nonInheritedData.access().rareData.access();
-    data.customPaintWatchedProperties.add(name);
+    Ref data = m_nonInheritedData.access().rareData.access();
+    data->customPaintWatchedProperties.add(name);
 }
 
 // MARK: - FontCascade support.

--- a/Source/WebCore/style/computed/StyleComputedStyleProperties+SettersCustomInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleProperties+SettersCustomInlines.h
@@ -32,7 +32,7 @@
 #define SET_NESTED(group, parent, variable, value) SET_STYLE_PROPERTY(group->parent->variable, group.access().parent.access().variable, value)
 #define SET_DOUBLY_NESTED(group, grandparent, parent, variable, value) SET_STYLE_PROPERTY(group->grandparent->parent->variable, group.access().grandparent.access().parent.access().variable, value)
 #define SET_NESTED_STRUCT(group, parent, variable, value) SET_STYLE_PROPERTY(group->parent.variable, group.access().parent.variable, value)
-#define SET_STYLE_PROPERTY_PAIR(read, write, variable1, value1, variable2, value2) do { auto& readable = *read; if (!compareEqual(readable.variable1, value1) || !compareEqual(readable.variable2, value2)) { auto& writable = write; writable.variable1 = value1; writable.variable2 = value2; } } while (0)
+#define SET_STYLE_PROPERTY_PAIR(read, write, variable1, value1, variable2, value2) do { Ref readable = Ref { *read }; if (!compareEqual(readable->variable1, value1) || !compareEqual(readable->variable2, value2)) { auto& writable = write; writable.variable1 = value1; writable.variable2 = value2; } } while (0)
 #define SET_PAIR(group, variable1, value1, variable2, value2) SET_STYLE_PROPERTY_PAIR(group, group.access(), variable1, value1, variable2, value2)
 #define SET_NESTED_PAIR(group, parent, variable1, value1, variable2, value2) SET_STYLE_PROPERTY_PAIR(group->parent, group.access().parent.access(), variable1, value1, variable2, value2)
 #define SET_DOUBLY_NESTED_PAIR(group, grandparent, parent, variable1, value1, variable2, value2) SET_STYLE_PROPERTY_PAIR(group->grandparent->parent, group.access().grandparent.access().parent.access(), variable1, value1, variable2, value2)

--- a/Source/WebCore/style/computed/data/StyleCustomPropertyData.cpp
+++ b/Source/WebCore/style/computed/data/StyleCustomPropertyData.cpp
@@ -106,8 +106,8 @@ bool CustomPropertyData::operator==(const CustomPropertyData& other) const
             return false;
 
         for (auto& entry : m_ownValues) {
-            auto* otherValue = other.m_ownValues.get(entry.key);
-            if (!otherValue || *entry.value != *otherValue)
+            auto it = other.m_ownValues.find(entry.key);
+            if (it == other.m_ownValues.end() || *entry.value != *it->value)
                 return false;
         }
         return true;
@@ -132,14 +132,14 @@ void CustomPropertyData::forEachInternal(Callback&& callback) const
     Vector<const CustomPropertyData*, maximumAncestorCount> descendants;
 
     auto isOverridenByDescendants = [&](auto& key) {
-        for (auto* descendant : descendants) {
+        for (RefPtr descendant : descendants) {
             if (descendant->m_ownValues.contains(key))
                 return true;
         }
         return false;
     };
 
-    auto* propertyData = this;
+    RefPtr propertyData = this;
     while (true) {
         for (auto& entry : propertyData->m_ownValues) {
             if (isOverridenByDescendants(entry.key))
@@ -150,8 +150,8 @@ void CustomPropertyData::forEachInternal(Callback&& callback) const
         }
         if (!propertyData->m_parentValues)
             return;
-        descendants.append(propertyData);
-        propertyData = propertyData->m_parentValues.get();
+        descendants.append(propertyData.get());
+        propertyData = propertyData->m_parentValues;
     }
 }
 

--- a/Source/WebCore/style/values/transforms/StyleTransformFunction.cpp
+++ b/Source/WebCore/style/values/transforms/StyleTransformFunction.cpp
@@ -450,19 +450,19 @@ static RefPtr<const TransformFunctionBase> createPerspectiveTransformFunction(co
     if (!function)
         return { };
 
-    auto& parameter = function->item(0);
-    if (parameter.isValueID()) {
-        ASSERT(parameter.valueID() == CSSValueNone);
+    Ref parameter = function->item(0);
+    if (parameter->isValueID()) {
+        ASSERT(parameter->valueID() == CSSValueNone);
         return PerspectiveTransformFunction::create(CSS::Keyword::None { });
     }
 
-    if (parameter.isLength())
-        return PerspectiveTransformFunction::create(toStyleFromCSSValue<Length<CSS::Nonnegative>>(state, parameter));
+    if (parameter->isLength())
+        return PerspectiveTransformFunction::create(toStyleFromCSSValue<Length<CSS::Nonnegative>>(state, parameter.get()));
 
     // FIXME: Support for <number> parameters for `perspective` is a quirk that should go away when 3d transforms are finalized.
     return PerspectiveTransformFunction::create(
         Length<CSS::Nonnegative> {
-            static_cast<float>(toStyleFromCSSValue<Number<CSS::Nonnegative>>(state, parameter).value)
+            static_cast<float>(toStyleFromCSSValue<Number<CSS::Nonnegative>>(state, parameter.get()).value)
         }
     );
 }
@@ -471,7 +471,7 @@ static RefPtr<const TransformFunctionBase> createPerspectiveTransformFunction(co
 
 auto CSSValueConversion<TransformFunction>::operator()(BuilderState& state, const CSSValue& value) -> TransformFunction
 {
-    auto transform = requiredDowncast<CSSFunctionValue>(state, value);
+    RefPtr transform = requiredDowncast<CSSFunctionValue>(state, value);
     if (!transform)
         return TransformFunction { MatrixTransformFunction::createIdentity() };
 
@@ -544,95 +544,96 @@ auto CSSValueCreation<TransformFunction>::operator()(CSSValuePool& pool, const R
         return !length.isKnownZero() || length.isPercent();
     };
 
-    auto& function = value.function();
-    switch (function.type()) {
+    Ref function = value.function();
+    switch (function->type()) {
     case TransformFunctionType::TranslateX:
-        return CSSFunctionValue::create(CSSValueTranslateX, translateLength(uncheckedDowncast<TranslateTransformFunction>(function).x()));
+        return CSSFunctionValue::create(CSSValueTranslateX, translateLength(uncheckedDowncast<TranslateTransformFunction>(function.get()).x()));
     case TransformFunctionType::TranslateY:
-        return CSSFunctionValue::create(CSSValueTranslateY, translateLength(uncheckedDowncast<TranslateTransformFunction>(function).y()));
+        return CSSFunctionValue::create(CSSValueTranslateY, translateLength(uncheckedDowncast<TranslateTransformFunction>(function.get()).y()));
     case TransformFunctionType::TranslateZ:
-        return CSSFunctionValue::create(CSSValueTranslateZ, translateLength(uncheckedDowncast<TranslateTransformFunction>(function).z()));
+        return CSSFunctionValue::create(CSSValueTranslateZ, translateLength(uncheckedDowncast<TranslateTransformFunction>(function.get()).z()));
     case TransformFunctionType::Translate:
     case TransformFunctionType::Translate3D: {
-        auto& translate = uncheckedDowncast<TranslateTransformFunction>(function);
-        if (!translate.is3DOperation()) {
-            if (!includeLength(translate.y()))
-                return CSSFunctionValue::create(CSSValueTranslate, translateLength(translate.x()));
+        Ref translate = uncheckedDowncast<TranslateTransformFunction>(function.get());
+        if (!translate->is3DOperation()) {
+            if (!includeLength(translate->y()))
+                return CSSFunctionValue::create(CSSValueTranslate, translateLength(translate->x()));
             return CSSFunctionValue::create(CSSValueTranslate,
-                translateLength(translate.x()),
-                translateLength(translate.y()));
+                translateLength(translate->x()),
+                translateLength(translate->y()));
         }
         return CSSFunctionValue::create(CSSValueTranslate3d,
-            translateLength(translate.x()),
-            translateLength(translate.y()),
-            translateLength(translate.z()));
+            translateLength(translate->x()),
+            translateLength(translate->y()),
+            translateLength(translate->z()));
     }
     case TransformFunctionType::ScaleX:
         return CSSFunctionValue::create(CSSValueScaleX,
-            createCSSValue(pool, style, uncheckedDowncast<ScaleTransformFunction>(function).x()));
+            createCSSValue(pool, style, uncheckedDowncast<ScaleTransformFunction>(function.get()).x()));
     case TransformFunctionType::ScaleY:
         return CSSFunctionValue::create(CSSValueScaleY,
-            createCSSValue(pool, style, uncheckedDowncast<ScaleTransformFunction>(function).y()));
+            createCSSValue(pool, style, uncheckedDowncast<ScaleTransformFunction>(function.get()).y()));
     case TransformFunctionType::ScaleZ:
         return CSSFunctionValue::create(CSSValueScaleZ,
-            createCSSValue(pool, style, uncheckedDowncast<ScaleTransformFunction>(function).z()));
+            createCSSValue(pool, style, uncheckedDowncast<ScaleTransformFunction>(function.get()).z()));
     case TransformFunctionType::Scale:
     case TransformFunctionType::Scale3D: {
-        auto& scale = uncheckedDowncast<ScaleTransformFunction>(function);
-        if (!scale.is3DOperation()) {
-            if (scale.x() == scale.y())
-                return CSSFunctionValue::create(CSSValueScale, createCSSValue(pool, style, scale.x()));
+        Ref scale = uncheckedDowncast<ScaleTransformFunction>(function.get());
+        if (!scale->is3DOperation()) {
+            if (scale->x() == scale->y())
+                return CSSFunctionValue::create(CSSValueScale, createCSSValue(pool, style, scale->x()));
             return CSSFunctionValue::create(CSSValueScale,
-                createCSSValue(pool, style, scale.x()),
-                createCSSValue(pool, style, scale.y()));
+                createCSSValue(pool, style, scale->x()),
+                createCSSValue(pool, style, scale->y()));
         }
         return CSSFunctionValue::create(CSSValueScale3d,
-            createCSSValue(pool, style, scale.x()),
-            createCSSValue(pool, style, scale.y()),
-            createCSSValue(pool, style, scale.z()));
+            createCSSValue(pool, style, scale->x()),
+            createCSSValue(pool, style, scale->y()),
+            createCSSValue(pool, style, scale->z()));
     }
     case TransformFunctionType::RotateX:
         return CSSFunctionValue::create(CSSValueRotateX,
-            createCSSValue(pool, style, uncheckedDowncast<RotateTransformFunction>(function).angle()));
+            createCSSValue(pool, style, uncheckedDowncast<RotateTransformFunction>(function.get()).angle()));
     case TransformFunctionType::RotateY:
         return CSSFunctionValue::create(CSSValueRotateY,
-            createCSSValue(pool, style, uncheckedDowncast<RotateTransformFunction>(function).angle()));
+            createCSSValue(pool, style, uncheckedDowncast<RotateTransformFunction>(function.get()).angle()));
     case TransformFunctionType::RotateZ:
         return CSSFunctionValue::create(CSSValueRotateZ,
-            createCSSValue(pool, style, uncheckedDowncast<RotateTransformFunction>(function).angle()));
+            createCSSValue(pool, style, uncheckedDowncast<RotateTransformFunction>(function.get()).angle()));
     case TransformFunctionType::Rotate:
         return CSSFunctionValue::create(CSSValueRotate,
-            createCSSValue(pool, style, uncheckedDowncast<RotateTransformFunction>(function).angle()));
+            createCSSValue(pool, style, uncheckedDowncast<RotateTransformFunction>(function.get()).angle()));
     case TransformFunctionType::Rotate3D: {
-        auto& rotate = uncheckedDowncast<RotateTransformFunction>(function);
+        Ref rotate = uncheckedDowncast<RotateTransformFunction>(function.get());
         return CSSFunctionValue::create(CSSValueRotate3d,
-            createCSSValue(pool, style, rotate.x()),
-            createCSSValue(pool, style, rotate.y()),
-            createCSSValue(pool, style, rotate.z()),
-            createCSSValue(pool, style, rotate.angle()));
+            createCSSValue(pool, style, rotate->x()),
+            createCSSValue(pool, style, rotate->y()),
+            createCSSValue(pool, style, rotate->z()),
+            createCSSValue(pool, style, rotate->angle()));
     }
     case TransformFunctionType::SkewX:
         return CSSFunctionValue::create(CSSValueSkewX,
-            createCSSValue(pool, style, uncheckedDowncast<SkewTransformFunction>(function).angleX()));
+            createCSSValue(pool, style, uncheckedDowncast<SkewTransformFunction>(function.get()).angleX()));
     case TransformFunctionType::SkewY:
         return CSSFunctionValue::create(CSSValueSkewY,
-            createCSSValue(pool, style, uncheckedDowncast<SkewTransformFunction>(function).angleY()));
+            createCSSValue(pool, style, uncheckedDowncast<SkewTransformFunction>(function.get()).angleY()));
     case TransformFunctionType::Skew: {
-        auto& skew = uncheckedDowncast<SkewTransformFunction>(function);
-        if (skew.angleY().isZero())
+        Ref skew = uncheckedDowncast<SkewTransformFunction>(function.get());
+        if (skew->angleY().isZero()) {
             return CSSFunctionValue::create(CSSValueSkew,
-                createCSSValue(pool, style, skew.angleX()));
+                createCSSValue(pool, style, skew->angleX()));
+        }
         return CSSFunctionValue::create(CSSValueSkew,
-            createCSSValue(pool, style, skew.angleX()),
-            createCSSValue(pool, style, skew.angleY()));
+            createCSSValue(pool, style, skew->angleX()),
+            createCSSValue(pool, style, skew->angleY()));
     }
     case TransformFunctionType::Perspective:
         return CSSFunctionValue::create(CSSValuePerspective,
-            createCSSValue(pool, style, uncheckedDowncast<PerspectiveTransformFunction>(function).perspective()));
+            createCSSValue(pool, style, uncheckedDowncast<PerspectiveTransformFunction>(function.get()).perspective()));
     case TransformFunctionType::Matrix:
     case TransformFunctionType::Matrix3D: {
         TransformationMatrix transform;
-        function.apply(transform, { });
+        function->apply(transform, { });
         return createCSSValue(pool, style, transform);
     }
     }
@@ -679,157 +680,157 @@ void Serialize<TransformFunction>::operator()(StringBuilder& builder, const CSS:
         return !length.isKnownZero() || length.isPercent();
     };
 
-    auto& function = value.function();
-    switch (function.type()) {
+    Ref function = value.function();
+    switch (function->type()) {
     case TransformFunctionType::TranslateX:
         builder.append(nameLiteral(CSSValueTranslateX), '(');
-        translateLength(uncheckedDowncast<TranslateTransformFunction>(function).x());
+        translateLength(uncheckedDowncast<TranslateTransformFunction>(function.get()).x());
         builder.append(')');
         return;
     case TransformFunctionType::TranslateY:
         builder.append(nameLiteral(CSSValueTranslateY), '(');
-        translateLength(uncheckedDowncast<TranslateTransformFunction>(function).y());
+        translateLength(uncheckedDowncast<TranslateTransformFunction>(function.get()).y());
         builder.append(')');
         return;
     case TransformFunctionType::TranslateZ:
         builder.append(nameLiteral(CSSValueTranslateZ), '(');
-        translateLength(uncheckedDowncast<TranslateTransformFunction>(function).z());
+        translateLength(uncheckedDowncast<TranslateTransformFunction>(function.get()).z());
         builder.append(')');
         return;
     case TransformFunctionType::Translate:
     case TransformFunctionType::Translate3D: {
-        auto& translate = uncheckedDowncast<TranslateTransformFunction>(function);
-        if (!translate.is3DOperation()) {
-            if (!includeLength(translate.y())) {
+        Ref translate = uncheckedDowncast<TranslateTransformFunction>(function.get());
+        if (!translate->is3DOperation()) {
+            if (!includeLength(translate->y())) {
                 builder.append(nameLiteral(CSSValueTranslate), '(');
-                translateLength(translate.x());
+                translateLength(translate->x());
                 builder.append(')');
                 return;
             }
             builder.append(nameLiteral(CSSValueTranslate), '(');
-            translateLength(translate.x());
+            translateLength(translate->x());
             builder.append(", "_s);
-            translateLength(translate.y());
+            translateLength(translate->y());
             builder.append(')');
             return;
         }
         builder.append(nameLiteral(CSSValueTranslate3d), '(');
-        translateLength(translate.x());
+        translateLength(translate->x());
         builder.append(", "_s);
-        translateLength(translate.y());
+        translateLength(translate->y());
         builder.append(", "_s);
-        translateLength(translate.z());
+        translateLength(translate->z());
         builder.append(')');
         return;
     }
     case TransformFunctionType::ScaleX:
         builder.append(nameLiteral(CSSValueScaleX), '(');
-        serializationForCSS(builder, context, style, uncheckedDowncast<ScaleTransformFunction>(function).x());
+        serializationForCSS(builder, context, style, uncheckedDowncast<ScaleTransformFunction>(function.get()).x());
         builder.append(')');
         return;
     case TransformFunctionType::ScaleY:
         builder.append(nameLiteral(CSSValueScaleY), '(');
-        serializationForCSS(builder, context, style, uncheckedDowncast<ScaleTransformFunction>(function).y());
+        serializationForCSS(builder, context, style, uncheckedDowncast<ScaleTransformFunction>(function.get()).y());
         builder.append(')');
         return;
     case TransformFunctionType::ScaleZ:
         builder.append(nameLiteral(CSSValueScaleZ), '(');
-        serializationForCSS(builder, context, style, uncheckedDowncast<ScaleTransformFunction>(function).z());
+        serializationForCSS(builder, context, style, uncheckedDowncast<ScaleTransformFunction>(function.get()).z());
         builder.append(')');
         return;
     case TransformFunctionType::Scale:
     case TransformFunctionType::Scale3D: {
-        auto& scale = uncheckedDowncast<ScaleTransformFunction>(function);
-        if (!scale.is3DOperation()) {
-            if (scale.x() == scale.y()) {
+        Ref scale = uncheckedDowncast<ScaleTransformFunction>(function.get());
+        if (!scale->is3DOperation()) {
+            if (scale->x() == scale->y()) {
                 builder.append(nameLiteral(CSSValueScale), '(');
-                serializationForCSS(builder, context, style, scale.x());
+                serializationForCSS(builder, context, style, scale->x());
                 builder.append(')');
                 return;
             }
             builder.append(nameLiteral(CSSValueScale), '(');
-            serializationForCSS(builder, context, style, scale.x());
+            serializationForCSS(builder, context, style, scale->x());
             builder.append(", "_s);
-            serializationForCSS(builder, context, style, scale.y());
+            serializationForCSS(builder, context, style, scale->y());
             builder.append(')');
             return;
         }
         builder.append(nameLiteral(CSSValueScale3d), '(');
-        serializationForCSS(builder, context, style, scale.x());
+        serializationForCSS(builder, context, style, scale->x());
         builder.append(", "_s);
-        serializationForCSS(builder, context, style, scale.y());
+        serializationForCSS(builder, context, style, scale->y());
         builder.append(", "_s);
-        serializationForCSS(builder, context, style, scale.z());
+        serializationForCSS(builder, context, style, scale->z());
         builder.append(')');
         return;
     }
     case TransformFunctionType::RotateX:
         builder.append(nameLiteral(CSSValueRotateX), '(');
-        serializationForCSS(builder, context, style, uncheckedDowncast<RotateTransformFunction>(function).angle());
+        serializationForCSS(builder, context, style, uncheckedDowncast<RotateTransformFunction>(function.get()).angle());
         builder.append(')');
         return;
     case TransformFunctionType::RotateY:
         builder.append(nameLiteral(CSSValueRotateY), '(');
-        serializationForCSS(builder, context, style, uncheckedDowncast<RotateTransformFunction>(function).angle());
+        serializationForCSS(builder, context, style, uncheckedDowncast<RotateTransformFunction>(function.get()).angle());
         builder.append(')');
         return;
     case TransformFunctionType::RotateZ:
         builder.append(nameLiteral(CSSValueRotateZ), '(');
-        serializationForCSS(builder, context, style, uncheckedDowncast<RotateTransformFunction>(function).angle());
+        serializationForCSS(builder, context, style, uncheckedDowncast<RotateTransformFunction>(function.get()).angle());
         builder.append(')');
         return;
     case TransformFunctionType::Rotate:
         builder.append(nameLiteral(CSSValueRotate), '(');
-        serializationForCSS(builder, context, style, uncheckedDowncast<RotateTransformFunction>(function).angle());
+        serializationForCSS(builder, context, style, uncheckedDowncast<RotateTransformFunction>(function.get()).angle());
         builder.append(')');
         return;
     case TransformFunctionType::Rotate3D: {
-        auto& rotate = uncheckedDowncast<RotateTransformFunction>(function);
+        Ref rotate = uncheckedDowncast<RotateTransformFunction>(function.get());
         builder.append(nameLiteral(CSSValueRotate3d), '(');
-        serializationForCSS(builder, context, style, rotate.x());
+        serializationForCSS(builder, context, style, rotate->x());
         builder.append(", "_s);
-        serializationForCSS(builder, context, style, rotate.y());
+        serializationForCSS(builder, context, style, rotate->y());
         builder.append(", "_s);
-        serializationForCSS(builder, context, style, rotate.z());
+        serializationForCSS(builder, context, style, rotate->z());
         builder.append(", "_s);
-        serializationForCSS(builder, context, style, rotate.angle());
+        serializationForCSS(builder, context, style, rotate->angle());
         builder.append(')');
         return;
     }
     case TransformFunctionType::SkewX:
         builder.append(nameLiteral(CSSValueSkewX), '(');
-        serializationForCSS(builder, context, style, uncheckedDowncast<SkewTransformFunction>(function).angleX());
+        serializationForCSS(builder, context, style, uncheckedDowncast<SkewTransformFunction>(function.get()).angleX());
         builder.append(')');
         return;
     case TransformFunctionType::SkewY:
         builder.append(nameLiteral(CSSValueSkewY), '(');
-        serializationForCSS(builder, context, style, uncheckedDowncast<SkewTransformFunction>(function).angleY());
+        serializationForCSS(builder, context, style, uncheckedDowncast<SkewTransformFunction>(function.get()).angleY());
         builder.append(')');
         return;
     case TransformFunctionType::Skew: {
-        auto& skew = uncheckedDowncast<SkewTransformFunction>(function);
-        if (skew.angleY().isZero()) {
+        Ref skew = uncheckedDowncast<SkewTransformFunction>(function.get());
+        if (skew->angleY().isZero()) {
             builder.append(nameLiteral(CSSValueSkew), '(');
-            serializationForCSS(builder, context, style, skew.angleX());
+            serializationForCSS(builder, context, style, skew->angleX());
             builder.append(')');
             return;
         }
         builder.append(nameLiteral(CSSValueSkew), '(');
-        serializationForCSS(builder, context, style, skew.angleX());
+        serializationForCSS(builder, context, style, skew->angleX());
         builder.append(", "_s);
-        serializationForCSS(builder, context, style, skew.angleY());
+        serializationForCSS(builder, context, style, skew->angleY());
         builder.append(')');
         return;
     }
     case TransformFunctionType::Perspective:
         builder.append(nameLiteral(CSSValuePerspective), '(');
-        serializationForCSS(builder, context, style, uncheckedDowncast<PerspectiveTransformFunction>(function).perspective());
+        serializationForCSS(builder, context, style, uncheckedDowncast<PerspectiveTransformFunction>(function.get()).perspective());
         builder.append(')');
         return;
     case TransformFunctionType::Matrix:
     case TransformFunctionType::Matrix3D: {
         TransformationMatrix transform;
-        function.apply(transform, { });
+        function->apply(transform, { });
         serializationForCSS(builder, context, style, transform);
         return;
     }

--- a/Source/WebCore/svg/SVGAnimateMotionElement.cpp
+++ b/Source/WebCore/svg/SVGAnimateMotionElement.cpp
@@ -127,8 +127,8 @@ void SVGAnimateMotionElement::updateAnimationPath()
     m_animationPath = Path();
     bool foundMPath = false;
 
-    for (auto& mPath : childrenOfType<SVGMPathElement>(*this)) {
-        if (RefPtr pathElement = mPath.pathElement()) {
+    for (Ref mPath : childrenOfType<SVGMPathElement>(*this)) {
+        if (RefPtr pathElement = mPath->pathElement()) {
             m_animationPath = pathFromGraphicsElement(*pathElement);
             foundMPath = true;
             break;

--- a/Source/WebCore/svg/SVGClipPathElement.cpp
+++ b/Source/WebCore/svg/SVGClipPathElement.cpp
@@ -139,7 +139,7 @@ RefPtr<SVGGraphicsElement> SVGClipPathElement::shouldApplyPathClipping() const
     // visible shape, the additive clipping may not work, caused by the clipRule. EvenOdd
     // as well as NonZero can cause self-clipping of the elements.
     // See also http://www.w3.org/TR/SVG/painting.html#FillRuleProperty
-    for (auto* childNode = firstChild(); childNode; childNode = childNode->nextSibling()) {
+    for (RefPtr childNode = firstChild(); childNode; childNode = childNode->nextSibling()) {
         RefPtr graphicsElement = dynamicDowncast<SVGGraphicsElement>(*childNode);
         if (!graphicsElement)
             continue;
@@ -189,7 +189,7 @@ FloatRect SVGClipPathElement::calculateClipContentRepaintRect(RepaintRectCalcula
 
     FloatRect clipContentRepaintRect;
     // This is a rough heuristic to appraise the clip size and doesn't consider clip on clip.
-    for (auto* childNode = firstChild(); childNode; childNode = childNode->nextSibling()) {
+    for (RefPtr childNode = firstChild(); childNode; childNode = childNode->nextSibling()) {
         CheckedPtr renderer = dynamicDowncast<RenderElement>(childNode->renderer());
         if (!renderer || !childNode->isSVGElement())
             continue;
@@ -201,7 +201,7 @@ FloatRect SVGClipPathElement::calculateClipContentRepaintRect(RepaintRectCalcula
             continue;
 
         // For <use> elements, verify the target is visible and valid
-        if (auto* useElement = dynamicDowncast<SVGUseElement>(childNode)) {
+        if (RefPtr useElement = dynamicDowncast<SVGUseElement>(childNode)) {
             if (!useElement->rendererClipChild())
                 continue;
         }

--- a/Source/WebCore/svg/SVGCursorElement.cpp
+++ b/Source/WebCore/svg/SVGCursorElement.cpp
@@ -58,8 +58,8 @@ Ref<SVGCursorElement> SVGCursorElement::create(const QualifiedName& tagName, Doc
 
 SVGCursorElement::~SVGCursorElement()
 {
-    for (auto& client : m_clients)
-        client.cursorElementRemoved(*this);
+    for (Ref client : m_clients)
+        client->cursorElementRemoved(*this);
 }
 
 void SVGCursorElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
@@ -92,8 +92,8 @@ void SVGCursorElement::svgAttributeChanged(const QualifiedName& attrName)
 {
     if (PropertyRegistry::isKnownAttribute(attrName)) {
         InstanceInvalidationGuard guard(*this);
-        for (auto& client : m_clients)
-            client.cursorElementChanged(*this);
+        for (Ref client : m_clients)
+            client->cursorElementChanged(*this);
         return;
     }
 

--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -96,8 +96,8 @@ SVGElement::~SVGElement()
 {
     if (m_svgRareData) {
         RELEASE_ASSERT(m_svgRareData->referencingElements().isEmptyIgnoringNullReferences());
-        for (SVGElement& instance : copyToVectorOf<Ref<SVGElement>>(instances()))
-            instance.m_svgRareData->setCorrespondingElement(nullptr);
+        for (Ref instance : copyToVectorOf<Ref<SVGElement>>(instances()))
+            instance->m_svgRareData->setCorrespondingElement(nullptr);
         RELEASE_ASSERT(!m_svgRareData->correspondingElement());
         m_svgRareData = nullptr;
     }
@@ -347,8 +347,8 @@ void SVGElement::setCorrespondingElement(SVGElement* correspondingElement)
 
 bool SVGElement::haveLoadedRequiredResources()
 {
-    for (auto& child : childrenOfType<SVGElement>(*this)) {
-        if (!child.haveLoadedRequiredResources())
+    for (Ref child : childrenOfType<SVGElement>(*this)) {
+        if (!child->haveLoadedRequiredResources())
             return false;
     }
     return true;
@@ -421,8 +421,8 @@ static bool hasLoadListener(Element* element)
     if (element->hasEventListeners(eventNames().loadEvent))
         return true;
 
-    for (element = element->parentOrShadowHostElement(); element; element = element->parentOrShadowHostElement()) {
-        if (element->hasCapturingEventListeners(eventNames().loadEvent))
+    for (CheckedPtr current = element->parentOrShadowHostElement(); current; current = current->parentOrShadowHostElement()) {
+        if (current->hasCapturingEventListeners(eventNames().loadEvent))
             return true;
     }
 

--- a/Source/WebCore/svg/SVGFEComponentTransferElement.cpp
+++ b/Source/WebCore/svg/SVGFEComponentTransferElement.cpp
@@ -76,8 +76,8 @@ RefPtr<FilterEffect> SVGFEComponentTransferElement::createFilterEffect(const Fil
 {
     ComponentTransferFunctions functions;
 
-    for (auto& child : childrenOfType<SVGComponentTransferFunctionElement>(*this))
-        functions[child.channel()] = child.transferFunction();
+    for (Ref child : childrenOfType<SVGComponentTransferFunctionElement>(*this))
+        functions[child->channel()] = child->transferFunction();
 
     return FEComponentTransfer::create(WTF::move(functions));
 }
@@ -88,7 +88,7 @@ static bool isRelevantTransferFunctionElement(const Element& child)
 
     ASSERT(is<SVGComponentTransferFunctionElement>(child));
 
-    for (auto laterSibling = child.nextElementSibling(); laterSibling; laterSibling = laterSibling->nextElementSibling()) {
+    for (CheckedPtr laterSibling = child.nextElementSibling(); laterSibling; laterSibling = laterSibling->nextElementSibling()) {
         if (laterSibling->elementName() == name)
             return false;
     }

--- a/Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp
+++ b/Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp
@@ -275,14 +275,14 @@ RefPtr<FilterEffect> SVGFEConvolveMatrixElement::createFilterEffect(const Filter
     if (order.isEmpty())
         return nullptr;
 
-    auto& kernelMatrix = this->kernelMatrix();
+    Ref kernelMatrix = this->kernelMatrix();
 
     // The spec says this is a requirement, and should bail out if fails
-    if (order.unclampedArea() != kernelMatrix.length())
+    if (order.unclampedArea() != kernelMatrix->length())
         return nullptr;
 
     // Spec says the specified divisor cannot be 0.
-    auto divisor = filterDivisor(kernelMatrix);
+    auto divisor = filterDivisor(kernelMatrix.get());
     if (!divisor)
         return nullptr;
 
@@ -295,7 +295,7 @@ RefPtr<FilterEffect> SVGFEConvolveMatrixElement::createFilterEffect(const Filter
     if (kernelUnitLength.isEmpty())
         return nullptr;
 
-    return FEConvolveMatrix::create(order, divisor, bias(), target, edgeMode(), FloatPoint(kernelUnitLength), preserveAlpha(), kernelMatrix);
+    return FEConvolveMatrix::create(order, divisor, bias(), target, edgeMode(), FloatPoint(kernelUnitLength), preserveAlpha(), kernelMatrix.get());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/svg/SVGFELightElement.cpp
+++ b/Source/WebCore/svg/SVGFELightElement.cpp
@@ -64,8 +64,8 @@ SVGFELightElement::SVGFELightElement(const QualifiedName& tagName, Document& doc
 
 SVGFELightElement* SVGFELightElement::findLightElement(const SVGElement* svgElement)
 {
-    for (auto& child : childrenOfType<SVGElement>(*svgElement)) {
-        if (auto* element = dynamicDowncast<SVGFELightElement>(child))
+    for (Ref child : childrenOfType<SVGElement>(*svgElement)) {
+        if (auto* element = dynamicDowncast<SVGFELightElement>(child.get()))
             return const_cast<SVGFELightElement*>(element);
     }
     return nullptr;
@@ -126,10 +126,10 @@ void SVGFELightElement::svgAttributeChanged(const QualifiedName& attrName)
         if (!renderer || !renderer->isRenderOrLegacyRenderSVGResourceFilterPrimitive())
             return;
 
-        if (auto* lightingElement = dynamicDowncast<SVGFEDiffuseLightingElement>(*parent)) {
+        if (CheckedPtr lightingElement = dynamicDowncast<SVGFEDiffuseLightingElement>(*parent)) {
             InstanceInvalidationGuard guard(*this);
             lightingElement->lightElementAttributeChanged(this, attrName);
-        } else if (auto* lightingElement = dynamicDowncast<SVGFESpecularLightingElement>(*parent)) {
+        } else if (CheckedPtr lightingElement = dynamicDowncast<SVGFESpecularLightingElement>(*parent)) {
             InstanceInvalidationGuard guard(*this);
             lightingElement->lightElementAttributeChanged(this, attrName);
         }

--- a/Source/WebCore/svg/SVGFEMergeElement.cpp
+++ b/Source/WebCore/svg/SVGFEMergeElement.cpp
@@ -55,8 +55,8 @@ void SVGFEMergeElement::childrenChanged(const ChildChange& change)
 Vector<AtomString> SVGFEMergeElement::filterEffectInputsNames() const
 {
     Vector<AtomString> inputsNames;
-    for (auto& mergeNode : childrenOfType<SVGFEMergeNodeElement>(*this))
-        inputsNames.append(mergeNode.in1());
+    for (Ref mergeNode : childrenOfType<SVGFEMergeNodeElement>(*this))
+        inputsNames.append(mergeNode->in1());
     return inputsNames;
 }
 

--- a/Source/WebCore/svg/SVGFontFaceSrcElement.cpp
+++ b/Source/WebCore/svg/SVGFontFaceSrcElement.cpp
@@ -51,11 +51,11 @@ Ref<SVGFontFaceSrcElement> SVGFontFaceSrcElement::create(const QualifiedName& ta
 Ref<CSSValueList> SVGFontFaceSrcElement::createSrcValue() const
 {
     CSSValueListBuilder list;
-    for (auto& child : childrenOfType<SVGElement>(*this)) {
-        if (RefPtr element = dynamicDowncast<SVGFontFaceUriElement>(child)) {
+    for (Ref child : childrenOfType<SVGElement>(*this)) {
+        if (RefPtr element = dynamicDowncast<SVGFontFaceUriElement>(child.get())) {
             if (auto srcValue = element->createSrcValue(); !srcValue->isEmpty())
                 list.append(WTF::move(srcValue));
-        } else if (RefPtr element = dynamicDowncast<SVGFontFaceNameElement>(child)) {
+        } else if (RefPtr element = dynamicDowncast<SVGFontFaceNameElement>(child.get())) {
             if (auto srcValue = element->createSrcValue(); !srcValue->isEmpty())
                 list.append(WTF::move(srcValue));
         }

--- a/Source/WebCore/svg/SVGGradientElement.cpp
+++ b/Source/WebCore/svg/SVGGradientElement.cpp
@@ -115,10 +115,10 @@ GradientColorStops SVGGradientElement::buildStops()
 {
     GradientColorStops stops;
     float previousOffset = 0.0f;
-    for (auto& stop : childrenOfType<SVGStopElement>(*this)) {
-        auto monotonicallyIncreasingOffset = std::clamp(stop.offset(), previousOffset, 1.0f);
+    for (Ref stop : childrenOfType<SVGStopElement>(*this)) {
+        auto monotonicallyIncreasingOffset = std::clamp(stop->offset(), previousOffset, 1.0f);
         previousOffset = monotonicallyIncreasingOffset;
-        stops.addColorStop({ monotonicallyIncreasingOffset, stop.stopColorIncludingOpacity() });
+        stops.addColorStop({ monotonicallyIncreasingOffset, stop->stopColorIncludingOpacity() });
     }
     return stops;
 }

--- a/Source/WebCore/svg/SVGLinearGradientElement.cpp
+++ b/Source/WebCore/svg/SVGLinearGradientElement.cpp
@@ -155,7 +155,7 @@ bool SVGLinearGradientElement::collectGradientAttributes(LinearGradientAttribute
     while (true) {
         // Respect xlink:href, take attributes from referenced element
         auto target = SVGURIReference::targetElementFromIRIString(current->href(), treeScopeForSVGReferences());
-        if (auto* gradientElement = dynamicDowncast<SVGGradientElement>(target.element.get())) {
+        if (RefPtr gradientElement = dynamicDowncast<SVGGradientElement>(target.element.get())) {
             current = *gradientElement;
 
             // Cycle detection

--- a/Source/WebCore/svg/SVGLocatable.cpp
+++ b/Source/WebCore/svg/SVGLocatable.cpp
@@ -108,7 +108,7 @@ AffineTransform SVGLocatable::computeCTM(SVGElement* element, CTMScope mode, Sty
 
     AffineTransform ctm;
 
-    for (Element* currentElement = element; currentElement; currentElement = currentElement->parentOrShadowHostElement()) {
+    for (RefPtr<Element> currentElement = element; currentElement; currentElement = currentElement->parentOrShadowHostElement()) {
         RefPtr svgElement = dynamicDowncast<SVGElement>(*currentElement);
         if (!svgElement)
             break;

--- a/Source/WebCore/svg/SVGMPathElement.cpp
+++ b/Source/WebCore/svg/SVGMPathElement.cpp
@@ -59,12 +59,12 @@ void SVGMPathElement::buildPendingResource()
     auto target = SVGURIReference::targetElementFromIRIString(href(), treeScopeForSVGReferences());
     if (!target.element) {
         // Do not register as pending if we are already pending this resource.
-        auto& treeScope = treeScopeForSVGReferences();
-        if (treeScope.isPendingSVGResource(*this, target.identifier))
+        Ref treeScope = treeScopeForSVGReferences();
+        if (treeScope->isPendingSVGResource(*this, target.identifier))
             return;
 
         if (!target.identifier.isEmpty()) {
-            treeScope.addPendingSVGResource(target.identifier, *this);
+            treeScope->addPendingSVGResource(target.identifier, *this);
             ASSERT(hasPendingResources());
         }
     } else if (RefPtr svgElement = dynamicDowncast<SVGElement>(*target.element))

--- a/Source/WebCore/svg/SVGMaskElement.cpp
+++ b/Source/WebCore/svg/SVGMaskElement.cpp
@@ -175,7 +175,7 @@ FloatRect SVGMaskElement::calculateMaskContentRepaintRect(RepaintRectCalculation
         return transform.isIdentity() ? std::nullopt : std::make_optional(WTF::move(transform));
     };
     FloatRect maskRepaintRect;
-    for (auto* childNode = firstChild(); childNode; childNode = childNode->nextSibling()) {
+    for (RefPtr childNode = firstChild(); childNode; childNode = childNode->nextSibling()) {
         CheckedPtr renderer = dynamicDowncast<RenderElement>(childNode->renderer());
         if (!renderer || !childNode->isSVGElement())
             continue;

--- a/Source/WebCore/svg/SVGSVGElement.cpp
+++ b/Source/WebCore/svg/SVGSVGElement.cpp
@@ -836,9 +836,9 @@ RefPtr<Element> SVGSVGElement::getElementById(const AtomString& id)
         return nullptr;
 
     if (!isInTreeScope()) [[unlikely]] {
-        for (auto& element : descendantsOfType<Element>(*this)) {
-            if (element.getIdAttribute() == id)
-                return &element;
+        for (Ref element : descendantsOfType<Element>(*this)) {
+            if (element->getIdAttribute() == id)
+                return element.ptr();
         }
         return nullptr;
     }

--- a/Source/WebCore/svg/SVGSwitchElement.cpp
+++ b/Source/WebCore/svg/SVGSwitchElement.cpp
@@ -49,10 +49,10 @@ bool SVGSwitchElement::childShouldCreateRenderer(const Node& child) const
 {
     // We create a renderer for the first valid SVG element child.
     // FIXME: The renderer must be updated after dynamic change of the requiredFeatures, requiredExtensions and systemLanguage attributes (https://bugs.webkit.org/show_bug.cgi?id=74749).
-    for (auto& element : childrenOfType<SVGElement>(*this)) {
-        if (!element.isValid())
+    for (Ref element : childrenOfType<SVGElement>(*this)) {
+        if (!element->isValid())
             continue;
-        return &element == &child; // Only allow this child if it's the first valid child
+        return element.ptr() == &child; // Only allow this child if it's the first valid child
     }
 
     return false;

--- a/Source/WebCore/svg/SVGToOTFFontConversion.cpp
+++ b/Source/WebCore/svg/SVGToOTFFontConversion.cpp
@@ -1061,8 +1061,8 @@ void SVGToOTFFontConverter::addKerningPair(Vector<KerningData>& data, SVGKerning
 template<typename T> inline size_t SVGToOTFFontConverter::appendKERNSubtable(std::optional<SVGKerningPair> (T::*buildKerningPair)() const, uint16_t coverage)
 {
     Vector<KerningData> kerningData;
-    for (auto& element : childrenOfType<T>(protectedFontElement())) {
-        if (auto kerningPair = (element.*buildKerningPair)())
+    for (Ref element : childrenOfType<T>(protectedFontElement())) {
+        if (auto kerningPair = (element.get().*buildKerningPair)())
             addKerningPair(kerningData, WTF::move(*kerningPair));
     }
     return finishAppendingKERNSubtable(WTF::move(kerningData), coverage);
@@ -1414,10 +1414,10 @@ SVGToOTFFontConverter::SVGToOTFFontConverter(const SVGFontElement& fontElement)
         boundingBox = FloatRect(0, 0, s_outputUnitsPerEm, s_outputUnitsPerEm);
     }
 
-    for (auto& glyphElement : childrenOfType<SVGGlyphElement>(protectedFontElement())) {
-        auto& unicodeAttribute = glyphElement.attributeWithoutSynchronization(SVGNames::unicodeAttr);
+    for (Ref glyphElement : childrenOfType<SVGGlyphElement>(protectedFontElement())) {
+        auto& unicodeAttribute = glyphElement->attributeWithoutSynchronization(SVGNames::unicodeAttr);
         if (!unicodeAttribute.isEmpty()) // If we can never actually trigger this glyph, ignore it completely
-            processGlyphElement(glyphElement, &glyphElement, defaultHorizontalAdvance, defaultVerticalAdvance, unicodeAttribute, boundingBox);
+            processGlyphElement(glyphElement.get(), glyphElement.ptr(), defaultHorizontalAdvance, defaultVerticalAdvance, unicodeAttribute, boundingBox);
     }
 
     m_boundingBox = valueOrDefault(boundingBox);

--- a/Source/WebCore/svg/SVGUseElement.cpp
+++ b/Source/WebCore/svg/SVGUseElement.cpp
@@ -509,8 +509,8 @@ RefPtr<SVGElement> SVGUseElement::findTarget(AtomString* targetID) const
         return nullptr;
 
     if (correspondingElement) {
-        for (auto& ancestor : lineageOfType<SVGElement>(*this)) {
-            if (ancestor.correspondingElement() == target)
+        for (Ref ancestor : lineageOfType<SVGElement>(*this)) {
+            if (ancestor->correspondingElement() == target)
                 return nullptr;
         }
     } else {

--- a/Source/WebCore/svg/graphics/SVGImage.cpp
+++ b/Source/WebCore/svg/graphics/SVGImage.cpp
@@ -109,13 +109,13 @@ bool SVGImage::renderingTaintsOrigin() const
     // FIXME: Once foreignObject elements within SVG images are updated to not leak cross-origin data
     // (e.g., visited links, spellcheck) we can remove the SVGForeignObjectElement check here and
     // research if we can remove the Image::renderingTaintsOrigin mechanism entirely.
-    for (auto& element : descendantsOfType<SVGElement>(*rootElement)) {
-        if (is<SVGForeignObjectElement>(element))
+    for (Ref element : descendantsOfType<SVGElement>(*rootElement)) {
+        if (is<SVGForeignObjectElement>(element.get()))
             return true;
-        if (RefPtr svgImage = dynamicDowncast<SVGImageElement>(element)) {
+        if (RefPtr svgImage = dynamicDowncast<SVGImageElement>(element.get())) {
             if (svgImage->renderingTaintsOrigin())
                 return true;
-        } else if (RefPtr svgFEImage = dynamicDowncast<SVGFEImageElement>(element)) {
+        } else if (RefPtr svgFEImage = dynamicDowncast<SVGFEImageElement>(element.get())) {
             if (svgFEImage->renderingTaintsOrigin())
                 return true;
         }

--- a/Source/WebCore/svg/graphics/SVGImageCache.cpp
+++ b/Source/WebCore/svg/graphics/SVGImageCache.cpp
@@ -87,11 +87,12 @@ FloatSize SVGImageCache::imageSizeForRenderer(const RenderObject* renderer) cons
 // restart on page load, nor will two animations in different pages have different timelines.
 Image* SVGImageCache::imageForRenderer(const RenderObject* renderer) const
 {
-    auto* image = findImageForRenderer(renderer);
-    if (!image)
-        return &Image::nullImage();
-    ASSERT(!image->size().isEmpty());
-    return image;
+    if (Image* image = findImageForRenderer(renderer)) {
+        ASSERT(!image->size().isEmpty());
+        return image;
+    }
+
+    return &Image::nullImage();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/svg/properties/SVGAnimatedString.cpp
+++ b/Source/WebCore/svg/properties/SVGAnimatedString.cpp
@@ -38,7 +38,7 @@ ExceptionOr<void> SVGAnimatedString::setBaseVal(const StringOrTrustedScriptURL& 
 {
     auto stringValueHolder = WTF::switchOn(baseVal,
         [&](const String& str) -> ExceptionOr<String> {
-            SVGElement* el = contextElement();
+            RefPtr el = contextElement();
             if (el && isScriptElement(*el) && m_isHrefProperty == IsHrefProperty::Yes)
                 return trustedTypeCompliantString(TrustedType::TrustedScriptURL, *contextElement()->scriptExecutionContext(), str, "SVGScriptElement href"_s);
             return String(str);

--- a/Source/WebCore/svg/properties/SVGPropertyOwnerRegistry.h
+++ b/Source/WebCore/svg/properties/SVGPropertyOwnerRegistry.h
@@ -240,7 +240,7 @@ public:
 
     void setAnimatedPropertyDirty(const QualifiedName& attributeName, SVGAnimatedProperty& animatedProperty) const override
     {
-        if (auto* property = fastAnimatedPropertyLookup(m_owner, attributeName)) {
+        if (RefPtr property = fastAnimatedPropertyLookup(m_owner, attributeName)) {
             property->setDirty();
             return;
         }
@@ -273,7 +273,7 @@ public:
     // string through the associated SVGMemberAccessor.
     std::optional<String> synchronize(const QualifiedName& attributeName) const override
     {
-        if (auto* property = fastAnimatedPropertyLookup(m_owner, attributeName))
+        if (RefPtr property = fastAnimatedPropertyLookup(m_owner, attributeName))
             return property->synchronize();
 
         std::optional<String> value;


### PR DESCRIPTION
#### 9af435118713086c2c396a167a3365a581100243
<pre>
SaferCPP: Fix a large batch of uncounted local variables warnings
<a href="https://bugs.webkit.org/show_bug.cgi?id=305227">https://bugs.webkit.org/show_bug.cgi?id=305227</a>
<a href="https://rdar.apple.com/167868980">rdar://167868980</a>

Reviewed by David Kilzer and Ryosuke Niwa.

Mechanical changes dictated by static analysis.

Canonical link: <a href="https://commits.webkit.org/305489@main">https://commits.webkit.org/305489@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f142ad1cf96dd181d24e36bcc551ca1fbe93909a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138513 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10878 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49923 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146610 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91488 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ae204a7d-9201-4efe-9515-9aa67950a913) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140387 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11582 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11033 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/106003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77328 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d8b6129c-b7dd-4b64-8ff5-0884d16d85da) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141460 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8709 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/124167 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; 1 api test failed or timed out; re-run-api-tests (cancelled)") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/86866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/309fb674-a709-4d90-a534-db6ac5e0bb0e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8300 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6061 "Passed tests") | [  ~~🛠 wpe-cairo-libwebrtc~~](https://ews-build.webkit.org/#/builders/166/builds/6923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/117716 "Build was cancelled. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42368 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149366 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10560 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42925 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/114386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10577 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8935 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/114721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8442 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120455 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65450 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21336 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10609 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38386 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10343 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74238 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10547 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10398 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->