### PR TITLE
[JSC] Fix ref return type nullability in signatures for wasm js-string builtins

### DIFF
--- a/JSTests/wasm/stress/wasm-js-string-builtins-signature-validation.js
+++ b/JSTests/wasm/stress/wasm-js-string-builtins-signature-validation.js
@@ -1,0 +1,121 @@
+//@ requireOptions("--useWasmJSStringBuiltins=true")
+
+// Test case from rdar://166830652.
+// The return type of js-string builtins cast, fromCharCode, fromCodePoint, concat and substring
+// is supposed to be (ref extern) instead of externref (aka `(ref null extern)`).
+// This is because the JS equivalents of those methods always return a string and never null.
+
+import * as assert from '../assert.js';
+
+async function test() {
+    /*
+        (module
+            (import "wasm:js-string" "cast" (func $cast (param externref) (result (ref extern))))
+            (import "wasm:js-string" "test" (func $test (param externref) (result i32)))
+            (import "wasm:js-string" "fromCharCode" (func $fromCharCode (param i32) (result (ref extern))))
+            (import "wasm:js-string" "fromCodePoint" (func $fromCodePoint (param i32) (result (ref extern))))
+            (import "wasm:js-string" "charCodeAt" (func $charCodeAt (param externref i32) (result i32)))
+            (import "wasm:js-string" "codePointAt" (func $codePointAt (param externref i32) (result i32)))
+            (import "wasm:js-string" "length" (func $length (param externref) (result i32)))
+            (import "wasm:js-string" "concat" (func $concat (param externref externref) (result (ref extern))))
+            (import "wasm:js-string" "substring" (func $substring (param externref i32 i32) (result (ref extern))))
+            (import "wasm:js-string" "equals" (func $equals (param externref externref) (result i32)))
+            (import "wasm:js-string" "compare" (func $compare (param externref externref) (result i32)))
+            (func (export "doublehalf") (param $str externref) (result (ref extern))
+                (local.set $str
+                    (call $substring
+                        (local.get $str)
+                        (i32.const 0)
+                        (i32.div_u
+                            (call $length
+                                (local.get $str))
+                            (i32.const 2))))
+                (call $concat
+                    (local.get $str)
+                    (local.get $str))
+            )
+        )
+    */
+    let {instance} = await WebAssembly.instantiate(Uint8Array.fromBase64(
+        "AGFzbQEAAAABLQdgAW8BZG9gAW8Bf2ABfwFkb2ACb38Bf2ACb28BZG9gA29/fwFkb2ACb28BfwKfAgsOd2FzbTpqcy1zdHJpbmcEY2FzdAAADndhc206anMtc3RyaW5nBHRlc3QAAQ53YXNtOmpzLXN0cmluZwxmcm9tQ2hhckNvZGUAAg53YXNtOmpzLXN0cmluZw1mcm9tQ29kZVBvaW50AAIOd2FzbTpqcy1zdHJpbmcKY2hhckNvZGVBdAADDndhc206anMtc3RyaW5nC2NvZGVQb2ludEF0AAMOd2FzbTpqcy1zdHJpbmcGbGVuZ3RoAAEOd2FzbTpqcy1zdHJpbmcGY29uY2F0AAQOd2FzbTpqcy1zdHJpbmcJc3Vic3RyaW5nAAUOd2FzbTpqcy1zdHJpbmcGZXF1YWxzAAYOd2FzbTpqcy1zdHJpbmcHY29tcGFyZQAGAwIBAAcOAQpkb3VibGVoYWxmAAsKGQEXACAAQQAgABAGQQJuEAghACAAIAAQBwsAgAEEbmFtZQFvCwAEY2FzdAEEdGVzdAIMZnJvbUNoYXJDb2RlAw1mcm9tQ29kZVBvaW50BApjaGFyQ29kZUF0BQtjb2RlUG9pbnRBdAYGbGVuZ3RoBwZjb25jYXQICXN1YnN0cmluZwkGZXF1YWxzCgdjb21wYXJlAggBCwEAA3N0cg=="
+    ), {}, {builtins: ["js-string"]});
+
+    assert.eq(instance.exports.doublehalf("fhqwhgads"), "fhqwfhqw");
+
+    /*
+        (module
+            (import "wasm:js-string" "cast" (func $cast (param externref) (result externref)))
+            (import "wasm:js-string" "test" (func $test (param externref) (result i32)))
+            (import "wasm:js-string" "fromCharCode" (func $fromCharCode (param i32) (result externref)))
+            (import "wasm:js-string" "fromCodePoint" (func $fromCodePoint (param i32) (result externref)))
+            (import "wasm:js-string" "charCodeAt" (func $charCodeAt (param externref i32) (result i32)))
+            (import "wasm:js-string" "codePointAt" (func $codePointAt (param externref i32) (result i32)))
+            (import "wasm:js-string" "length" (func $length (param externref) (result i32)))
+            (import "wasm:js-string" "concat" (func $concat (param externref externref) (result externref)))
+            (import "wasm:js-string" "substring" (func $substring (param externref i32 i32) (result externref)))
+            (import "wasm:js-string" "equals" (func $equals (param externref externref) (result i32)))
+            (import "wasm:js-string" "compare" (func $compare (param externref externref) (result i32)))
+            (func (export "doublehalf") (param $str externref) (result externref)
+                (local.set $str
+                    (call $substring
+                        (local.get $str)
+                        (i32.const 0)
+                        (i32.div_u
+                            (call $length
+                                (local.get $str))
+                            (i32.const 2))))
+                (call $concat
+                    (local.get $str)
+                    (local.get $str))
+            )
+        )
+    */
+    await assert.throwsAsync(WebAssembly.instantiate(
+        Uint8Array.fromBase64(
+            "AGFzbQEAAAABKQdgAW8Bb2ABbwF/YAF/AW9gAm9/AX9gAm9vAW9gA29/fwFvYAJvbwF/Ap8CCw53YXNtOmpzLXN0cmluZwRjYXN0AAAOd2FzbTpqcy1zdHJpbmcEdGVzdAABDndhc206anMtc3RyaW5nDGZyb21DaGFyQ29kZQACDndhc206anMtc3RyaW5nDWZyb21Db2RlUG9pbnQAAg53YXNtOmpzLXN0cmluZwpjaGFyQ29kZUF0AAMOd2FzbTpqcy1zdHJpbmcLY29kZVBvaW50QXQAAw53YXNtOmpzLXN0cmluZwZsZW5ndGgAAQ53YXNtOmpzLXN0cmluZwZjb25jYXQABA53YXNtOmpzLXN0cmluZwlzdWJzdHJpbmcABQ53YXNtOmpzLXN0cmluZwZlcXVhbHMABg53YXNtOmpzLXN0cmluZwdjb21wYXJlAAYDAgEABw4BCmRvdWJsZWhhbGYACwoZARcAIABBACAAEAZBAm4QCCEAIAAgABAHCwCAAQRuYW1lAW8LAARjYXN0AQR0ZXN0Agxmcm9tQ2hhckNvZGUDDWZyb21Db2RlUG9pbnQECmNoYXJDb2RlQXQFC2NvZGVQb2ludEF0BgZsZW5ndGgHBmNvbmNhdAgJc3Vic3RyaW5nCQZlcXVhbHMKB2NvbXBhcmUCCAELAQADc3Ry"
+        ), {}, {builtins: ["js-string"]}),
+        WebAssembly.CompileError,
+        "builtin import wasm:js-string:cast has an unexpected signature");
+
+    /*
+        (module
+            (import "wasm:js-string" "cast" (func $cast (param externref) (result externref)))
+        )
+    */
+    await assert.throwsAsync(WebAssembly.instantiate(Uint8Array.fromBase64("AGFzbQEAAAABBgFgAW8BbwIXAQ53YXNtOmpzLXN0cmluZwRjYXN0AAAADgRuYW1lAQcBAARjYXN0"), {}, {builtins: ["js-string"]}),
+        WebAssembly.CompileError, "builtin import wasm:js-string:cast has an unexpected signature");
+
+    /*
+        (module
+            (import "wasm:js-string" "fromCharCode" (func $fromCharCode (param i32) (result externref)))
+        )
+    */
+   await assert.throwsAsync(WebAssembly.instantiate(Uint8Array.fromBase64("AGFzbQEAAAABBgFgAX8BbwIfAQ53YXNtOmpzLXN0cmluZwxmcm9tQ2hhckNvZGUAAAAWBG5hbWUBDwEADGZyb21DaGFyQ29kZQ=="), {}, {builtins: ["js-string"]}),
+        WebAssembly.CompileError, "builtin import wasm:js-string:fromCharCode has an unexpected signature");
+
+    /*
+        (module
+            (import "wasm:js-string" "fromCodePoint" (func $fromCodePoint (param i32) (result externref)))
+        )
+    */
+    await assert.throwsAsync(WebAssembly.instantiate(Uint8Array.fromBase64("AGFzbQEAAAABBgFgAX8BbwIgAQ53YXNtOmpzLXN0cmluZw1mcm9tQ29kZVBvaW50AAAAFwRuYW1lARABAA1mcm9tQ29kZVBvaW50"), {}, {builtins: ["js-string"]}),
+        WebAssembly.CompileError, "builtin import wasm:js-string:fromCodePoint has an unexpected signature");
+
+    /*
+        (module
+            (import "wasm:js-string" "concat" (func $concat (param externref externref) (result externref)))
+        )
+    */
+    await assert.throwsAsync(WebAssembly.instantiate(Uint8Array.fromBase64("AGFzbQEAAAABBwFgAm9vAW8CGQEOd2FzbTpqcy1zdHJpbmcGY29uY2F0AAAAEARuYW1lAQkBAAZjb25jYXQ="), {}, {builtins: ["js-string"]}),
+        WebAssembly.CompileError, "builtin import wasm:js-string:concat has an unexpected signature");
+
+    /*
+        (module
+            (import "wasm:js-string" "substring" (func $substring (param externref i32 i32) (result externref)))
+        )
+    */
+    await assert.throwsAsync(WebAssembly.instantiate(Uint8Array.fromBase64("AGFzbQEAAAABCAFgA29/fwFvAhwBDndhc206anMtc3RyaW5nCXN1YnN0cmluZwAAABMEbmFtZQEMAQAJc3Vic3RyaW5n"), {}, {builtins: ["js-string"]}),
+        WebAssembly.CompileError, "builtin import wasm:js-string:substring has an unexpected signature");
+}
+
+await assert.asyncTest(test());


### PR DESCRIPTION
#### 22b6a610f6fff9e3e34f6b1a872b544fe6da75cb
<pre>
[JSC] Fix ref return type nullability in signatures for wasm js-string builtins
<a href="https://bugs.webkit.org/show_bug.cgi?id=305134">https://bugs.webkit.org/show_bug.cgi?id=305134</a>
<a href="https://rdar.apple.com/166830652">rdar://166830652</a>

Reviewed by Yusuke Suzuki.

Updates the signature validation for wasm js-string builtins that produce
strings. Said builtins can never return null, and their correct return type
is non-nullable `(ref extern)`, but current validation expects nullable `externref`.
This affects `cast`, `fromCharCode`, `fromCodePoint`, `concat` and `substring`.

Test: JSTests/wasm/stress/wasm-js-string-builtins-signature-validation.js

* JSTests/wasm/stress/wasm-js-string-builtins-signature-validation.js: Added.
(async test): Tests that the updated signatures are accepted and that the old signatures are rejected.
* JSTests/wasm/stress/wasm-js-string-builtins.js: Updated test to use the correct signatures.
(async testInstantiation):
(async testInstantiationWithEmptyCompileOptions):
(async instantiate):
(async testImportedStringConstants):
(async testImportInElem):
* Source/JavaScriptCore/wasm/js/WebAssemblyBuiltin.h: Added new signatures and type expectations.
(JSC::WebAssemblyBuiltinRefExternTypeExpectation::isValid const):
(JSC::WebAssemblyBuiltinTypeExpectation::refExtern):

Canonical link: <a href="https://commits.webkit.org/305487@main">https://commits.webkit.org/305487@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b927b53adb097f4f389dc1f765e94d0eaa8d0a34

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138275 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10640 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49685 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146355 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91250 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/0b5267b2-7a04-4a7d-b943-dc72f681f2d3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11344 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10794 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105787 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77157 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141222 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8497 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123959 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86628 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8a470a0d-32a2-4bee-9677-82ff69e30bde) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8087 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5851 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6636 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/130239 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117500 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42159 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149066 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/136887 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10322 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42716 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114186 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10339 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8722 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114527 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29151 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8061 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120246 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/65145 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10369 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38180 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/169547 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10100 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73936 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44193 "Found 8 new JSC stress test failures: wasm.yaml/wasm/stress/wasm-js-string-builtins-signature-validation.js.default-wasm, wasm.yaml/wasm/stress/wasm-js-string-builtins-signature-validation.js.wasm-bbq, wasm.yaml/wasm/stress/wasm-js-string-builtins-signature-validation.js.wasm-bbq-no-consts, wasm.yaml/wasm/stress/wasm-js-string-builtins-signature-validation.js.wasm-collect-continuously, wasm.yaml/wasm/stress/wasm-js-string-builtins-signature-validation.js.wasm-eager, wasm.yaml/wasm/stress/wasm-js-string-builtins-signature-validation.js.wasm-eager-jettison, wasm.yaml/wasm/stress/wasm-js-string-builtins-signature-validation.js.wasm-no-cjit, wasm.yaml/wasm/stress/wasm-js-string-builtins-signature-validation.js.wasm-slow-memory (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10309 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10160 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->