### PR TITLE
[iOS] Text is illegible when copying dark text in a light webpage and pasting into mail compose in dark mode

### DIFF
--- a/Source/WebCore/editing/ReplaceSelectionCommand.h
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.h
@@ -129,6 +129,8 @@ private:
 
     void updateDirectionForStartOfInsertedContentIfNeeded(const InsertedNodes&);
 
+    void removeForegroundColorsInDarkModeIfNeeded(const InsertedNodes&);
+
     RefPtr<DocumentFragment> protectedDocumentFragment() const { return m_documentFragment; }
 
     VisibleSelection m_visibleSelectionForInsertedText;


### PR DESCRIPTION
#### e1bc930edef95d5fe08fe76b2a195b82c9123790
<pre>
[iOS] Text is illegible when copying dark text in a light webpage and pasting into mail compose in dark mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=305232">https://bugs.webkit.org/show_bug.cgi?id=305232</a>
<a href="https://rdar.apple.com/165743699">rdar://165743699</a>

Reviewed by Richard Robinson.

After the changes in <a href="https://rdar.apple.com/81883755">rdar://81883755</a> (in iOS 26), the Mail compose body field no longer uses
`-apple-color-filter: apple-invert-lightness();`, but still honors dark mode via the meta tag
`color-scheme: light dark;` (and additionally punches out white backgrounds in dark mode using
`WKPreferences` SPI).

This means that when copying and pasting dark text on a white background in Safari into Mail
compose, we now end up with something like:

```
&lt;span style=&quot;color: black; background-color: white;&quot;&gt;&lt;/span&gt;
```

While this _looks_ like it should be legible due to the white background color, the background color
effectively becomes transparent when painting due to `_punchOutWhiteBackgroundsInDarkMode`. The end
result is black text on a dark background, which is barely readable.

To fix this, we heuristically remove `color` and `caret-color` style properties when pasting dark
text into Mail compose in dark mode, and instead fall back on default styling (which should result
in white text against a dark background).

See below for more details.

Test: PasteHTML.PasteDarkTextOnWhiteBackgroundIntoDarkModeEditor

* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
(WebCore::ReplaceSelectionCommand::doApply):
(WebCore::collectStylesToRemove):
(WebCore::ReplaceSelectionCommand::removeForegroundColorsInDarkModeIfNeeded):

Add a heuristic to remove inline `color` and `caret-color` styles from pasted elements that
otherwise have no background or a punched out background color, only for editable web views to limit
compat risk. We determine if the color or caret color are non-legible by comparing luminance against
the document&apos;s background color; if it&apos;s too close (with an arbitrary threshold of 0.1), we simply
remove those inline CSS properties and allow the color to fall back to default colors.

Note that I also first collect all the style properties to remove and elements to adjust up front
first, (prior to mutating any DOM state), to ensure that style invalidation doesn&apos;t trigger layout
or style recalc in the middle of iterating through the DOM.

* Source/WebCore/editing/ReplaceSelectionCommand.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteHTML.mm:
(TEST(PasteHTML, PasteDarkTextOnWhiteBackgroundIntoDarkModeEditor)):

Add an API test to exercise the change by copying light text in a white webpage and pasting into a
dark mode editable web view where white backgrounds are punched out (simulating Mail compose). The
resulting text (and caret) color should be white, instead of dark.

Canonical link: <a href="https://commits.webkit.org/305399@main">https://commits.webkit.org/305399@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53002cb3ef0b1ac2a0ff7da1c3b656266964a952

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138304 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10669 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49714 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146384 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91279 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/911ab88e-5ab1-467f-bb6d-aa8f8b2e4aeb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140178 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11373 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10823 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105821 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/77174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/26b461be-23ec-4fec-965d-e08043558fce) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141251 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8521 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/123984 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86655 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/a009c4f2-29f1-4caa-8439-f78e1b88df3d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8108 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5877 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6670 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117524 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42185 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149095 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10351 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42742 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114211 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10368 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8749 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114554 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29092 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8084 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120272 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65174 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10398 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38205 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10129 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73965 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10338 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10189 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->