### PR TITLE
Crashing in WebKit::WebPopupMenu::didChangeSelectedIndex.

### DIFF
--- a/Source/WebCore/platform/PopupMenuClient.h
+++ b/Source/WebCore/platform/PopupMenuClient.h
@@ -26,6 +26,7 @@
 #include <WebCore/PopupMenuStyle.h>
 #include <WebCore/ScrollTypes.h>
 #include <wtf/AbstractCanMakeCheckedPtr.h>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/Forward.h>
 
 namespace WebCore {
@@ -36,7 +37,7 @@ class HostWindow;
 class Scrollbar;
 class ScrollableArea;
 
-class PopupMenuClient : public AbstractCanMakeCheckedPtr {
+class PopupMenuClient : public AbstractCanMakeCheckedPtr  {
 public:
     virtual ~PopupMenuClient() = default;
     virtual void valueChanged(unsigned listIndex, bool fireEvents = true) = 0;
@@ -56,7 +57,7 @@ public:
     virtual LayoutUnit clientPaddingLeft() const = 0;
     virtual LayoutUnit clientPaddingRight() const = 0;
     virtual int listSize() const = 0;
-    virtual int selectedIndex() const = 0;
+    virtual int popupSelectedIndex() const = 0;
     virtual void popupDidHide() = 0;
     virtual bool itemIsSeparator(unsigned listIndex) const = 0;
     virtual bool itemIsLabel(unsigned listIndex) const = 0;
@@ -65,7 +66,7 @@ public:
     virtual void setTextFromItem(unsigned listIndex) = 0;
 
     virtual void listBoxSelectItem(int /*listIndex*/, bool /*allowMultiplySelections*/, bool /*shift*/, bool /*fireOnChangeNow*/ = true) { ASSERT_NOT_REACHED(); }
-    virtual bool multiple() const
+    virtual bool popupMultiple() const
     {
         ASSERT_NOT_REACHED();
         return false;

--- a/Source/WebCore/rendering/RenderMenuList.h
+++ b/Source/WebCore/rendering/RenderMenuList.h
@@ -28,18 +28,12 @@
 #include "PopupMenuClient.h"
 #include "RenderFlexibleBox.h"
 
-#if PLATFORM(COCOA)
-#define POPUP_MENU_PULLS_DOWN 0
-#else
-#define POPUP_MENU_PULLS_DOWN 1
-#endif
-
 namespace WebCore {
 
 class HTMLSelectElement;
 class RenderText;
 
-class RenderMenuList final : public RenderFlexibleBox, private PopupMenuClient {
+class RenderMenuList final : public RenderFlexibleBox {
     WTF_MAKE_TZONE_ALLOCATED(RenderMenuList);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderMenuList);
 public:
@@ -49,17 +43,18 @@ public:
     HTMLSelectElement& selectElement() const;
 
     // CheckedPtr interface.
-    uint32_t checkedPtrCount() const final { return RenderFlexibleBox::checkedPtrCount(); }
-    uint32_t checkedPtrCountWithoutThreadCheck() const final { return RenderFlexibleBox::checkedPtrCountWithoutThreadCheck(); }
-    void incrementCheckedPtrCount() const final { RenderFlexibleBox::incrementCheckedPtrCount(); }
-    void decrementCheckedPtrCount() const final { RenderFlexibleBox::decrementCheckedPtrCount(); }
-    void setDidBeginCheckedPtrDeletion() final { CanMakeCheckedPtr::setDidBeginCheckedPtrDeletion(); }
+    uint32_t checkedPtrCount() const { return RenderFlexibleBox::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const { return RenderFlexibleBox::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const { RenderFlexibleBox::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const { RenderFlexibleBox::decrementCheckedPtrCount(); }
+    void setDidBeginCheckedPtrDeletion() { CanMakeCheckedPtr::setDidBeginCheckedPtrDeletion(); }
 
 #if !PLATFORM(IOS_FAMILY)
     bool popupIsVisible() const { return m_popupIsVisible; }
 #endif
     void showPopup();
     void hidePopup();
+    void popupDidHide();
 
     void setOptionsChanged(bool changed) { m_needsOptionsWidthUpdate = changed; }
 
@@ -75,6 +70,16 @@ public:
     void setInnerRenderer(RenderBlock&);
 
     void didAttachChild(RenderObject& child, RenderObject* beforeChild);
+
+    void getItemBackgroundColor(unsigned listIndex, Color&, bool& itemHasCustomBackgroundColor) const;
+
+    PopupMenuStyle::Size popupMenuSize(const RenderStyle&);
+
+    LayoutUnit clientPaddingLeft() const;
+    LayoutUnit clientPaddingRight() const;
+
+    HostWindow* hostWindow() const;
+    void setTextFromOption(int optionIndex);
 
 private:
     void willBeDestroyed() override;
@@ -96,45 +101,12 @@ private:
 
     void styleDidChange(Style::Difference, const RenderStyle* oldStyle) override;
 
-    // PopupMenuClient methods
-    void valueChanged(unsigned listIndex, bool fireOnChange = true) override;
-    void selectionChanged(unsigned, bool) override { }
-    void selectionCleared() override { }
-    String itemText(unsigned listIndex) const override;
-    String itemLabel(unsigned listIndex) const override;
-    String itemIcon(unsigned listIndex) const override;
-    String itemToolTip(unsigned listIndex) const override;
-    String itemAccessibilityText(unsigned listIndex) const override;
-    bool itemIsEnabled(unsigned listIndex) const override;
-    PopupMenuStyle itemStyle(unsigned listIndex) const override;
-    PopupMenuStyle menuStyle() const override;
-    int clientInsetLeft() const override;
-    int clientInsetRight() const override;
-    LayoutUnit clientPaddingLeft() const override;
-    LayoutUnit clientPaddingRight() const override;
-    int listSize() const override;
-    int selectedIndex() const override;
-    void popupDidHide() override;
-    bool itemIsSeparator(unsigned listIndex) const override;
-    bool itemIsLabel(unsigned listIndex) const override;
-    bool itemIsSelected(unsigned listIndex) const override;
-    bool shouldPopOver() const override { return !POPUP_MENU_PULLS_DOWN; }
-    void setTextFromItem(unsigned listIndex) override;
-    void listBoxSelectItem(int listIndex, bool allowMultiplySelections, bool shift, bool fireOnChangeNow = true) override;
-    bool multiple() const override;
-    FontSelector* fontSelector() const override;
-    HostWindow* hostWindow() const override;
-    Ref<Scrollbar> createScrollbar(ScrollableArea&, ScrollbarOrientation, ScrollbarWidth) override;
-
     bool hasLineIfEmpty() const override { return true; }
 
     std::optional<LayoutUnit> firstLineBaseline() const override { return RenderBlock::firstLineBaseline(); }
 
-    void getItemBackgroundColor(unsigned listIndex, Color&, bool& itemHasCustomBackgroundColor) const;
-
     void adjustInnerStyle();
     void setText(const String&);
-    void setTextFromOption(int optionIndex);
     void updateOptionsWidth();
 
     void didUpdateActiveOption(int optionIndex);

--- a/Source/WebCore/rendering/RenderSearchField.cpp
+++ b/Source/WebCore/rendering/RenderSearchField.cpp
@@ -348,7 +348,7 @@ int RenderSearchField::listSize() const
     return m_recentSearches.size() + 3;
 }
 
-int RenderSearchField::selectedIndex() const
+int RenderSearchField::popupSelectedIndex() const
 {
     return -1;
 }

--- a/Source/WebCore/rendering/RenderSearchField.h
+++ b/Source/WebCore/rendering/RenderSearchField.h
@@ -77,7 +77,7 @@ private:
     LayoutUnit clientPaddingLeft() const override;
     LayoutUnit clientPaddingRight() const override;
     int listSize() const override;
-    int selectedIndex() const override;
+    int popupSelectedIndex() const override;
     void popupDidHide() override;
     bool itemIsSeparator(unsigned listIndex) const override;
     bool itemIsLabel(unsigned listIndex) const override;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/PopupMenuMac.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/PopupMenuMac.h
@@ -21,13 +21,10 @@
 #define PopupMenuMac_h
 
 #include <WebCore/PopupMenu.h>
+#include <WebCore/PopupMenuClient.h>
 #include <wtf/RetainPtr.h>
 
 @class NSPopUpButtonCell;
-
-namespace WebCore {
-class PopupMenuClient;
-}
 
 class PopupMenuMac : public WebCore::PopupMenu {
 public:
@@ -42,8 +39,9 @@ public:
 private:
     void clear();
     void populate();
+    CheckedPtr<WebCore::PopupMenuClient> checkedClient() const { return m_client; }
 
-    WebCore::PopupMenuClient* m_client;
+    CheckedPtr<WebCore::PopupMenuClient> m_client;
     RetainPtr<NSPopUpButtonCell> m_popup;
 };
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/PopupMenuMac.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/PopupMenuMac.mm
@@ -57,31 +57,31 @@ void PopupMenuMac::clear()
 
 void PopupMenuMac::populate()
 {
+    ASSERT(m_client);
     if (m_popup)
         clear();
     else {
-        m_popup = adoptNS([[NSPopUpButtonCell alloc] initTextCell:@"" pullsDown:!m_client->shouldPopOver()]);
+        m_popup = adoptNS([[NSPopUpButtonCell alloc] initTextCell:@"" pullsDown:!checkedClient()->shouldPopOver()]);
         [m_popup setUsesItemFromMenu:NO];
         [m_popup setAutoenablesItems:NO];
     }
     
     // For pullDown menus the first item is hidden.
-    if (!m_client->shouldPopOver())
+    if (m_client && !checkedClient()->shouldPopOver())
         [m_popup addItemWithTitle:@""];
 
-    TextDirection menuTextDirection = m_client->menuStyle().textDirection();
+    TextDirection menuTextDirection = checkedClient()->menuStyle().textDirection();
     [m_popup setUserInterfaceLayoutDirection:menuTextDirection == TextDirection::LTR ? NSUserInterfaceLayoutDirectionLeftToRight : NSUserInterfaceLayoutDirectionRightToLeft];
 
-    ASSERT(m_client);
-    int size = m_client->listSize();
+    int size = checkedClient()->listSize();
 
     for (int i = 0; i < size; i++) {
-        if (m_client->itemIsSeparator(i)) {
+        if (checkedClient()->itemIsSeparator(i)) {
             [[m_popup menu] addItem:[NSMenuItem separatorItem]];
             continue;
         }
 
-        PopupMenuStyle style = m_client->itemStyle(i);
+        PopupMenuStyle style = checkedClient()->itemStyle(i);
         RetainPtr<NSMutableDictionary> attributes = adoptNS([[NSMutableDictionary alloc] init]);
         if (style.font() != FontCascade()) {
             RetainPtr<CTFontRef> font = style.font().primaryFont()->ctFont();
@@ -106,7 +106,7 @@ void PopupMenuMac::populate()
 
         // FIXME: Add support for styling the foreground and background colors.
         // FIXME: Find a way to customize text color when an item is highlighted.
-        RetainPtr<NSAttributedString> string = adoptNS([[NSAttributedString alloc] initWithString:m_client->itemText(i).createNSString().get() attributes:attributes.get()]);
+        RetainPtr<NSAttributedString> string = adoptNS([[NSAttributedString alloc] initWithString:checkedClient()->itemText(i).createNSString().get() attributes:attributes.get()]);
 
         [m_popup addItemWithTitle:@""];
         NSMenuItem *menuItem = [m_popup lastItem];
@@ -114,13 +114,13 @@ void PopupMenuMac::populate()
         // We set the title as well as the attributed title here. The attributed title will be displayed in the menu,
         // but typeahead will use the non-attributed string that doesn't contain any leading or trailing whitespace.
         [menuItem setTitle:[[string string] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]]];
-        [menuItem setEnabled:m_client->itemIsEnabled(i)];
-        [menuItem setToolTip:m_client->itemToolTip(i).createNSString().get()];
+        [menuItem setEnabled:checkedClient()->itemIsEnabled(i)];
+        [menuItem setToolTip:checkedClient()->itemToolTip(i).createNSString().get()];
 
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         // Allow the accessible text of the item to be overridden if necessary.
         if (AXObjectCache::accessibilityEnabled()) {
-            RetainPtr accessibilityOverride = m_client->itemAccessibilityText(i).createNSString();
+            RetainPtr accessibilityOverride = checkedClient()->itemAccessibilityText(i).createNSString();
             if ([accessibilityOverride length])
                 [menuItem accessibilitySetOverrideValue:accessibilityOverride.get() forAttribute:NSAccessibilityDescriptionAttribute];
         }
@@ -134,18 +134,18 @@ void PopupMenuMac::show(const IntRect& r, LocalFrameView& frameView, int selecte
     int numItems = [m_popup numberOfItems];
     if (numItems <= 0) {
         if (m_client)
-            m_client->popupDidHide();
+            checkedClient()->popupDidHide();
         return;
     }
     ASSERT(numItems > selectedIndex);
 
     // Workaround for crazy bug where a selectedIndex of -1 for a menu with only 1 item will cause a blank menu.
-    if (selectedIndex == -1 && numItems == 2 && !m_client->shouldPopOver() && ![[m_popup itemAtIndex:1] isEnabled])
+    if (selectedIndex == -1 && numItems == 2 && !checkedClient()->shouldPopOver() && ![[m_popup itemAtIndex:1] isEnabled])
         selectedIndex = 0;
 
     NSView* view = frameView.documentView();
 
-    TextDirection textDirection = m_client->menuStyle().textDirection();
+    TextDirection textDirection = checkedClient()->menuStyle().textDirection();
 
     [m_popup attachPopUpWithFrame:r inView:view];
     [m_popup selectItemAtIndex:selectedIndex];
@@ -155,13 +155,13 @@ void PopupMenuMac::show(const IntRect& r, LocalFrameView& frameView, int selecte
     [menu setUserInterfaceLayoutDirection:textDirection == TextDirection::LTR ? NSUserInterfaceLayoutDirectionLeftToRight : NSUserInterfaceLayoutDirectionRightToLeft];
 
     NSPoint location;
-    CTFontRef font = m_client->menuStyle().font().primaryFont()->ctFont();
+    CTFontRef font = checkedClient()->menuStyle().font().primaryFont()->ctFont();
 
     // These values were borrowed from AppKit to match their placement of the menu.
     const int popOverHorizontalAdjust = -13;
     const int popUnderHorizontalAdjust = 6;
     const int popUnderVerticalAdjust = 6;
-    if (m_client->shouldPopOver()) {
+    if (checkedClient()->shouldPopOver()) {
         NSRect titleFrame = [m_popup titleRectForBounds:r];
         if (titleFrame.size.width <= 0 || titleFrame.size.height <= 0)
             titleFrame = r;
@@ -200,7 +200,7 @@ void PopupMenuMac::show(const IntRect& r, LocalFrameView& frameView, int selecte
     }
 
     NSControlSize controlSize;
-    switch (m_client->menuStyle().menuSize()) {
+    switch (checkedClient()->menuStyle().menuSize()) {
     case PopupMenuStyle::Size::Normal:
         controlSize = NSControlSizeRegular;
         break;
@@ -215,7 +215,7 @@ void PopupMenuMac::show(const IntRect& r, LocalFrameView& frameView, int selecte
         break;
     }
 
-    PAL::popUpMenu(menu, location, roundf(NSWidth(r)), dummyView.get(), selectedIndex, (__bridge NSFont *)font, controlSize, !m_client->menuStyle().hasDefaultAppearance());
+    PAL::popUpMenu(menu, location, roundf(NSWidth(r)), dummyView.get(), selectedIndex, (__bridge NSFont *)font, controlSize, !checkedClient()->menuStyle().hasDefaultAppearance());
 
     [m_popup dismissPopUp];
     [dummyView removeFromSuperview];
@@ -224,14 +224,14 @@ void PopupMenuMac::show(const IntRect& r, LocalFrameView& frameView, int selecte
         return;
 
     int newIndex = [m_popup indexOfSelectedItem];
-    m_client->popupDidHide();
+    checkedClient()->popupDidHide();
 
     // Adjust newIndex for hidden first item.
-    if (!m_client->shouldPopOver())
+    if (!checkedClient()->shouldPopOver())
         newIndex--;
 
     if (selectedIndex != newIndex && newIndex >= 0)
-        m_client->valueChanged(newIndex);
+        checkedClient()->valueChanged(newIndex);
 
     // Give the frame a chance to fix up its event state, since the popup eats all the
     // events during tracking.
@@ -242,7 +242,7 @@ void PopupMenuMac::hide()
 {
     [[m_popup menu] cancelTracking];
     if (m_client)
-        m_client->popupDidHide();
+        checkedClient()->popupDidHide();
 }
 
 void PopupMenuMac::updateFromElement()
@@ -251,5 +251,5 @@ void PopupMenuMac::updateFromElement()
 
 void PopupMenuMac::disconnectClient()
 {
-    m_client = 0;
+    m_client = nullptr;
 }


### PR DESCRIPTION
#### a6c2be651136ac9e13e22606b8e883f92c2b1503
<pre>
Crashing in WebKit::WebPopupMenu::didChangeSelectedIndex.
<a href="https://bugs.webkit.org/show_bug.cgi?id=305237">https://bugs.webkit.org/show_bug.cgi?id=305237</a>
<a href="https://rdar.apple.com/167878765">rdar://167878765</a>

Reviewed by Abrar Rahman Protyasha.

Refactor RenderMenuList and HTMLSelectElement to have
the PopupMenuClient be the HTMLSelectElement, since
we can have a pointer that we can check to the element
instead of a reference that is destroyed already to
the renderer.

* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::valueChanged):
(WebCore::HTMLSelectElement::itemText const):
(WebCore::HTMLSelectElement::itemLabel const):
(WebCore::HTMLSelectElement::itemIcon const):
(WebCore::HTMLSelectElement::itemToolTip const):
(WebCore::HTMLSelectElement::itemAccessibilityText const):
(WebCore::HTMLSelectElement::itemIsEnabled const):
(WebCore::HTMLSelectElement::itemStyle const):
(WebCore::HTMLSelectElement::menuStyle const):
(WebCore::HTMLSelectElement::clientInsetLeft const):
(WebCore::HTMLSelectElement::clientInsetRight const):
(WebCore::HTMLSelectElement::clientPaddingLeft const):
(WebCore::HTMLSelectElement::clientPaddingRight const):
(WebCore::HTMLSelectElement::listSize const):
(WebCore::HTMLSelectElement::popupSelectedIndex const):
(WebCore::HTMLSelectElement::popupDidHide):
(WebCore::HTMLSelectElement::itemIsSeparator const):
(WebCore::HTMLSelectElement::itemIsLabel const):
(WebCore::HTMLSelectElement::itemIsSelected const):
(WebCore::HTMLSelectElement::setTextFromItem):
(WebCore::HTMLSelectElement::listBoxSelectItem):
(WebCore::HTMLSelectElement::fontSelector const):
(WebCore::HTMLSelectElement::hostWindow const):
(WebCore::HTMLSelectElement::createScrollbar):
* Source/WebCore/html/HTMLSelectElement.h:
* Source/WebCore/platform/PopupMenuClient.h:
(WebCore::PopupMenuClient::popupMultiple const):
(WebCore::PopupMenuClient::multiple const): Deleted.
* Source/WebCore/rendering/RenderMenuList.cpp:
(WebCore::RenderMenuList::getItemBackgroundColor const):
(WebCore::RenderMenuList::popupMenuSize):
(WebCore::RenderMenuList::clientPaddingLeft const):
(WebCore::RenderMenuList::clientPaddingRight const):
(WebCore::RenderMenuList::hostWindow const):
(WebCore::RenderMenuList::adjustInnerStyle):
(RenderMenuList::setTextFromOption):
(RenderMenuList::showPopup):
(RenderMenuList::popupDidHide):
(RenderMenuList::valueChanged): Deleted.
(RenderMenuList::listBoxSelectItem): Deleted.
(RenderMenuList::multiple const): Deleted.
(RenderMenuList::itemText const): Deleted.
(RenderMenuList::itemLabel const): Deleted.
(RenderMenuList::itemIcon const): Deleted.
(RenderMenuList::itemAccessibilityText const): Deleted.
(RenderMenuList::itemToolTip const): Deleted.
(RenderMenuList::itemIsEnabled const): Deleted.
(RenderMenuList::itemStyle const): Deleted.
(RenderMenuList::getItemBackgroundColor const): Deleted.
(RenderMenuList::menuStyle const): Deleted.
(RenderMenuList::hostWindow const): Deleted.
(RenderMenuList::createScrollbar): Deleted.
(RenderMenuList::clientInsetLeft const): Deleted.
(RenderMenuList::clientInsetRight const): Deleted.
(RenderMenuList::clientPaddingLeft const): Deleted.
(RenderMenuList::clientPaddingRight const): Deleted.
(RenderMenuList::listSize const): Deleted.
(RenderMenuList::selectedIndex const): Deleted.
(RenderMenuList::itemIsSeparator const): Deleted.
(RenderMenuList::itemIsLabel const): Deleted.
(RenderMenuList::itemIsSelected const): Deleted.
(RenderMenuList::setTextFromItem): Deleted.
(RenderMenuList::fontSelector const): Deleted.
* Source/WebCore/rendering/RenderMenuList.h:
* Source/WebCore/rendering/RenderSearchField.cpp:
(WebCore::RenderSearchField::popupSelectedIndex const):
(WebCore::RenderSearchField::selectedIndex const): Deleted.
* Source/WebCore/rendering/RenderSearchField.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView setUpInteraction]):

Canonical link: <a href="https://commits.webkit.org/305556@main">https://commits.webkit.org/305556@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f40d964cdb05a55d667cd7210d5cfb29be31e64c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138751 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11117 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/233 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146867 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91726 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2b7e3588-b1da-44ae-a59b-85c19fe467b6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140624 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11821 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11272 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106173 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/77471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2568ac1d-00ad-4cde-82f0-8df072f3d477) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141698 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8912 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/124341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87044 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bf6a1175-1aae-4990-b83e-6f20551ba577) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8494 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6245 "Found 1 new API test failure: TestWebKitAPI.NowPlayingControlsTests.NowPlayingUpdatesThrottled (failure)") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7165 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117917 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/195 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149625 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10799 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/197 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114557 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10817 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9133 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114898 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29203 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8762 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120651 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65694 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10847 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/194 "Passed tests") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/10582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74488 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10786 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10636 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->