### PR TITLE
[JSC] JSC::getCallDataInline has fragile include dependency on unified sources

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -64,7 +64,7 @@
 #include "JSArrayBufferConstructor.h"
 #include "JSArrayIterator.h"
 #include "JSAsyncFromSyncIterator.h"
-#include "JSBoundFunction.h"
+#include "JSBoundFunctionInlines.h"
 #include "JSRegExpStringIterator.h"
 #include "JSCInlines.h"
 #include "JSCellButterfly.h"

--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -35,6 +35,7 @@
 #include "DFGInsertionSet.h"
 #include "DFGJITCode.h"
 #include "DFGPhase.h"
+#include "JSBoundFunctionInlines.h"
 #include "JSObjectInlines.h"
 #include "JSWebAssemblyInstance.h"
 #include "MathCommon.h"

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -51,7 +51,7 @@
 #include "InterpreterInlines.h"
 #include "JITCode.h"
 #include "JSArrayInlines.h"
-#include "JSBoundFunction.h"
+#include "JSBoundFunctionInlines.h"
 #include "JSCInlines.h"
 #include "JSCellButterfly.h"
 #include "JSLexicalEnvironment.h"

--- a/Source/JavaScriptCore/runtime/JSBoundFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSBoundFunction.cpp
@@ -29,6 +29,7 @@
 #include "DeferTermination.h"
 #include "ExecutableBaseInlines.h"
 #include "FunctionPrototype.h"
+#include "JSBoundFunctionInlines.h"
 #include "JSCInlines.h"
 #include "VMTrapsInlines.h"
 

--- a/Source/JavaScriptCore/runtime/JSBoundFunction.h
+++ b/Source/JavaScriptCore/runtime/JSBoundFunction.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include <JavaScriptCore/JSCellButterfly.h>
 #include <JavaScriptCore/JSFunction.h>
+#include <JavaScriptCore/JSString.h>
 
 namespace JSC {
 
@@ -100,24 +100,7 @@ public:
     static constexpr ptrdiff_t offsetOfLength() { return OBJECT_OFFSETOF(JSBoundFunction, m_length); }
     static constexpr ptrdiff_t offsetOfCanConstruct() { return OBJECT_OFFSETOF(JSBoundFunction, m_canConstruct); }
 
-    template<typename Functor>
-    void forEachBoundArg(const Functor& func)
-    {
-        unsigned length = boundArgsLength();
-        if (!length)
-            return;
-        if (length <= m_boundArgs.size()) {
-            for (unsigned index = 0; index < length; ++index) {
-                if (func(m_boundArgs[index].get()) == IterationStatus::Done)
-                    return;
-            }
-            return;
-        }
-        for (unsigned index = 0; index < length; ++index) {
-            if (func(jsCast<JSCellButterfly*>(m_boundArgs[0].get())->get(index)) == IterationStatus::Done)
-                return;
-        }
-    }
+    void forEachBoundArg(const Invocable<IterationStatus(JSValue)> auto& func);
 
     bool canConstruct()
     {

--- a/Source/JavaScriptCore/runtime/JSBoundFunctionInlines.h
+++ b/Source/JavaScriptCore/runtime/JSBoundFunctionInlines.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "JSBoundFunction.h"
+#include "JSCellButterfly.h"
 
 namespace JSC {
 
@@ -33,6 +34,24 @@ inline Structure* JSBoundFunction::createStructure(VM& vm, JSGlobalObject* globa
 {
     ASSERT(globalObject);
     return Structure::create(vm, globalObject, prototype, TypeInfo(JSFunctionType, StructureFlags), info());
+}
+
+inline void JSBoundFunction::forEachBoundArg(const Invocable<IterationStatus(JSValue)> auto& func)
+{
+    unsigned length = boundArgsLength();
+    if (!length)
+        return;
+    if (length <= m_boundArgs.size()) {
+        for (unsigned index = 0; index < length; ++index) {
+            if (func(m_boundArgs[index].get()) == IterationStatus::Done)
+                return;
+        }
+        return;
+    }
+    for (unsigned index = 0; index < length; ++index) {
+        if (func(jsCast<JSCellButterfly*>(m_boundArgs[0].get())->get(index)) == IterationStatus::Done)
+            return;
+    }
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSObjectInlines.h
@@ -28,7 +28,7 @@
 #include <JavaScriptCore/ButterflyInlines.h>
 #include <JavaScriptCore/Error.h>
 #include <JavaScriptCore/JSArrayInlines.h>
-#include <JavaScriptCore/JSFunction.h>
+#include <JavaScriptCore/JSFunctionInlines.h>
 #include <JavaScriptCore/JSGenericTypedArrayViewInlines.h>
 #include <JavaScriptCore/JSGlobalProxy.h>
 #include <JavaScriptCore/JSObject.h>


### PR DESCRIPTION
#### cda9486754462a7344ad56205ace79a0c9480655
<pre>
[JSC] JSC::getCallDataInline has fragile include dependency on unified sources
<a href="https://rdar.apple.com/167876001">rdar://167876001</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=305233">https://bugs.webkit.org/show_bug.cgi?id=305233</a>

Reviewed by Mark Lam and Keith Miller.

The inline function JSC::getCallDataInline() in JSObjectInlines.h calls the inline
function JSFunction::getCallDataInline() from JSFunctionInlines.h. That requires
JSFunctionInlines.h to be included at that point. However, there is no explicit include to
guarantee this. The code builds because the header happens to be included earlier by other
files into the unified sources. This is fragile, and I encountered a failure building on
Sonoma with an old toolchain.

This patch includes JSFunctionInlines.h into JSObjectInlines.h to make it self-sufficient.
That creates an include cycle causing unresolved forward references. The cycle is broken
by removing the inclusion of JSCellButterfly.h from JSBoundFunction.h and moving it and
the JSBoundFunction::forEachBoundArg() inlined function that depends on it into
JSBoundFunctionInlines.h. JSBoundFunctionInlines.h is included as needed.

Covered by existing tests.

Canonical link: <a href="https://commits.webkit.org/305548@main">https://commits.webkit.org/305548@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5c2a02fa40025a5cb87696b1d7028bc76860a3b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138683 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11049 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/165 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146797 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91658 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0e724d36-d8e1-492d-920b-9139828d4271) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11753 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11203 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106119 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77437 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/32015da5-71b1-4e46-bb4b-db6748f3e5b8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141630 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8857 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/124299 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86990 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/82aff592-3554-4575-869c-eb14463ddb74) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8445 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6203 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7095 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/130654 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117866 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/139 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149553 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/137284 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10731 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/140 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114506 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10748 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9080 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114843 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29199 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8690 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120596 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65626 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10779 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/140 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/169956 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10514 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74420 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44302 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10717 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10568 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->