### PR TITLE
Web Inspector: send Target.targetCreated after WebPage/WebFrame has been created

### DIFF
--- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
@@ -28,7 +28,9 @@
 
 #include "APIUIClient.h"
 #include "InspectorBrowserAgent.h"
+#include "ProcessTerminationReason.h"
 #include "ProvisionalPageProxy.h"
+#include "WebFrameInspectorTarget.h"
 #include "WebFrameInspectorTargetProxy.h"
 #include "WebFrameProxy.h"
 #include "WebPageInspectorAgentBase.h"
@@ -67,10 +69,12 @@ WebPageInspectorController::WebPageInspectorController(WebPageProxy& inspectedPa
 
 WebPageInspectorController::~WebPageInspectorController() = default;
 
-void WebPageInspectorController::init()
+void WebPageInspectorController::didInitializeWebPage()
 {
     String pageTargetId = WebPageInspectorTarget::toTargetID(m_inspectedPage->webPageIDInMainFrameProcess());
     createWebPageInspectorTarget(pageTargetId, Inspector::InspectorTargetType::Page);
+    if (RefPtr mainFrame = m_inspectedPage->mainFrame())
+        createWebFrameInspectorTarget(*mainFrame);
 }
 
 void WebPageInspectorController::pageClosed()
@@ -78,6 +82,15 @@ void WebPageInspectorController::pageClosed()
     disconnectAllFrontends();
 
     m_agents.discardValues();
+}
+
+void WebPageInspectorController::pageProcessDidTerminate(ProcessTerminationReason reason)
+{
+    if (reason == ProcessTerminationReason::NavigationSwap)
+        return;
+
+    String targetId = WebPageInspectorTarget::toTargetID(m_inspectedPage->webPageIDInMainFrameProcess());
+    destroyInspectorTarget(targetId);
 }
 
 bool WebPageInspectorController::hasLocalFrontend() const
@@ -168,9 +181,15 @@ void WebPageInspectorController::createWebPageInspectorTarget(const String& targ
     addTarget(WebPageInspectorTargetProxy::create(protect(m_inspectedPage), targetId, type));
 }
 
-void WebPageInspectorController::createWebFrameInspectorTarget(WebFrameProxy& frame, const String& targetId)
+void WebPageInspectorController::createWebFrameInspectorTarget(WebFrameProxy& frame)
 {
+    String targetId = WebFrameInspectorTarget::toTargetID(frame.frameID());
     addTarget(WebFrameInspectorTargetProxy::create(frame, targetId));
+}
+
+void WebPageInspectorController::destroyWebFrameInspectorTarget(WebFrameProxy& frame)
+{
+    destroyInspectorTarget(WebFrameInspectorTarget::toTargetID(frame.frameID()));
 }
 
 void WebPageInspectorController::destroyInspectorTarget(const String& targetId)
@@ -207,6 +226,8 @@ void WebPageInspectorController::setContinueLoadingCallback(const ProvisionalPag
 void WebPageInspectorController::didCreateProvisionalPage(ProvisionalPageProxy& provisionalPage)
 {
     addTarget(WebPageInspectorTargetProxy::create(provisionalPage, getTargetID(provisionalPage), Inspector::InspectorTargetType::Page));
+    if (RefPtr mainFrame = provisionalPage.mainFrame())
+        createWebFrameInspectorTarget(*mainFrame);
 }
 
 void WebPageInspectorController::willDestroyProvisionalPage(const ProvisionalPageProxy& provisionalPage)
@@ -224,6 +245,10 @@ void WebPageInspectorController::didCommitProvisionalPage(WebCore::PageIdentifie
     newTarget->didCommitProvisionalTarget();
     targetAgent->didCommitProvisionalTarget(oldID, newID);
 
+    String newMainFrameTargetID = WebFrameInspectorTarget::toTargetID(m_inspectedPage->mainFrame()->frameID());
+    auto newMainFrameTarget = m_targets.take(newMainFrameTargetID);
+    ASSERT(newMainFrameTarget);
+
     // We've disconnected from the old page and will not receive any message from it, so
     // we destroy everything but the new target here.
     // FIXME: <https://webkit.org/b/202937> do not destroy targets that belong to the committed page.
@@ -231,6 +256,7 @@ void WebPageInspectorController::didCommitProvisionalPage(WebCore::PageIdentifie
         targetAgent->targetDestroyed(*target);
     m_targets.clear();
     m_targets.set(newTarget->identifier(), WTF::move(newTarget));
+    m_targets.set(newMainFrameTarget->identifier(), WTF::move(newMainFrameTarget));
 }
 
 InspectorBrowserAgent* WebPageInspectorController::enabledBrowserAgent() const

--- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h
+++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h
@@ -49,6 +49,8 @@ class InspectorBrowserAgent;
 class ProvisionalPageProxy;
 struct WebPageAgentContext;
 
+enum class ProcessTerminationReason : uint8_t;
+
 class WebPageInspectorController {
     WTF_MAKE_TZONE_ALLOCATED(WebPageInspectorController);
     WTF_MAKE_NONCOPYABLE(WebPageInspectorController);
@@ -56,8 +58,9 @@ public:
     WebPageInspectorController(WebPageProxy&);
     ~WebPageInspectorController();
 
-    void init();
+    void didInitializeWebPage();
     void pageClosed();
+    void pageProcessDidTerminate(ProcessTerminationReason);
 
     bool hasLocalFrontend() const;
 
@@ -72,7 +75,8 @@ public:
 #endif
 
     void createWebPageInspectorTarget(const String& targetId, Inspector::InspectorTargetType);
-    void createWebFrameInspectorTarget(WebFrameProxy&, const String& targetId);
+    void createWebFrameInspectorTarget(WebFrameProxy&);
+    void destroyWebFrameInspectorTarget(WebFrameProxy&);
     void destroyInspectorTarget(const String& targetId);
     void sendMessageToInspectorFrontend(const String& targetId, const String& message);
 

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -44,7 +44,6 @@
 #include "ProvisionalPageProxy.h"
 #include "RemotePageProxy.h"
 #include "WebBackForwardListFrameItem.h"
-#include "WebFrameInspectorTarget.h"
 #include "WebFrameMessages.h"
 #include "WebFramePolicyListenerProxy.h"
 #include "WebNavigationState.h"
@@ -128,15 +127,13 @@ WebFrameProxy::WebFrameProxy(WebPageProxy& page, FrameProcess& process, FrameIde
     allFrames().set(frameID, *this);
     WebProcessPool::statistics().wkFrameCount++;
 
-    page.inspectorController().createWebFrameInspectorTarget(*this, WebFrameInspectorTarget::toTargetID(frameID));
-
     protect(m_frameProcess)->incrementFrameCount();
 }
 
 WebFrameProxy::~WebFrameProxy()
 {
     if (RefPtr page = m_page.get())
-        page->inspectorController().destroyInspectorTarget(WebFrameInspectorTarget::toTargetID(frameID()));
+        page->inspectorController().destroyWebFrameInspectorTarget(*this);
 
     WebProcessPool::statistics().wkFrameCount--;
 #if PLATFORM(GTK)
@@ -191,7 +188,7 @@ void WebFrameProxy::webProcessWillShutDown()
         childFrame->webProcessWillShutDown();
 
     if (RefPtr page = m_page.get())
-        page->inspectorController().destroyInspectorTarget(WebFrameInspectorTarget::toTargetID(frameID()));
+        page->inspectorController().destroyWebFrameInspectorTarget(*this);
 
     m_page = nullptr;
 
@@ -514,6 +511,8 @@ void WebFrameProxy::didCreateSubframe(WebCore::FrameIdentifier frameID, String&&
     if (RefPtr session = page->activeAutomationSession())
         session->didCreateFrame(child);
 #endif
+
+    page->inspectorController().createWebFrameInspectorTarget(child);
 }
 
 void WebFrameProxy::prepareForProvisionalLoadInProcess(WebProcessProxy& process, API::Navigation& navigation, BrowsingContextGroup& group, std::optional<SecurityOriginData> effectiveOrigin, CompletionHandler<void(WebCore::PageIdentifier)>&& completionHandler)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -968,7 +968,6 @@ WebPageProxy::WebPageProxy(PageClient& pageClient, WebProcessProxy& process, Ref
     inspectorDebuggable->setPresentingApplicationPID(process.processPool().configuration().presentingApplicationPID());
     inspectorDebuggable->init();
 #endif
-    m_inspectorController->init();
 
 #if ENABLE(WEBDRIVER_BIDI)
     if (m_controlledByAutomation) {
@@ -1790,6 +1789,8 @@ void WebPageProxy::initializeWebPage(const Site& site, WebCore::SandboxFlags eff
     if (preferences->siteIsolationEnabled())
         browsingContextGroup->addPage(*this);
     process->send(Messages::WebProcess::CreateWebPage(m_webPageID, creationParameters(process, *protect(drawingArea()), m_mainFrame->frameID(), std::nullopt)), 0);
+
+    m_inspectorController->didInitializeWebPage();
 
 #if ENABLE(WINDOW_PROXY_PROPERTY_ACCESS_NOTIFICATION)
     internals().frameLoadStateObserver = WebPageProxyFrameLoadStateObserver::create();
@@ -11936,6 +11937,8 @@ void WebPageProxy::dispatchProcessDidTerminate(WebProcessProxy& process, Process
         processDidBecomeResponsive(process); // Check if all other processes are responsive.
         protect(browsingContextGroup())->processDidTerminate(*this, process);
     }
+
+    m_inspectorController->pageProcessDidTerminate(reason);
 
     bool handledByClient = false;
     if (m_loaderClient)


### PR DESCRIPTION
#### 37189708ca4e971c70df651c6eae4b630623ed31
<pre>
Web Inspector: send Target.targetCreated after WebPage/WebFrame has been created
<a href="https://bugs.webkit.org/show_bug.cgi?id=305242">https://bugs.webkit.org/show_bug.cgi?id=305242</a>

Reviewed by NOBODY (OOPS!).

Make sure that Page and Frame inspector targets are created only after
corresponding WebPage/WebFrame has been created in the Web Process. Otherwise
any messages sent to the target are lost.

* Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp:
(WebKit::WebPageInspectorController::didInitializeWebPage):
(WebKit::WebPageInspectorController::pageProcessDidTerminate):
(WebKit::WebPageInspectorController::createWebFrameInspectorTarget):
(WebKit::WebPageInspectorController::destroyWebFrameInspectorTarget):
(WebKit::WebPageInspectorController::didCreateProvisionalPage):
(WebKit::WebPageInspectorController::didCommitProvisionalPage):
(WebKit::WebPageInspectorController::init): Deleted.
* Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h:
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::WebFrameProxy):
(WebKit::WebFrameProxy::~WebFrameProxy):
(WebKit::WebFrameProxy::webProcessWillShutDown):
(WebKit::WebFrameProxy::didCreateSubframe):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::initializeWebPage):
(WebKit::WebPageProxy::dispatchProcessDidTerminate): report the target as
destroyed if the process crashes.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37189708ca4e971c70df651c6eae4b630623ed31

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142481 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14949 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5299 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151137 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95668 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15608 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15031 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109566 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79067 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145430 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12063 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127509 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90474 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11573 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9238 "Found 33 new API test failures: TestWebKitAPI.SiteIsolation.CrossOriginPopupWithCOOPValueSameOrigin, TestWebKitAPI.SiteIsolation.LoadStringAfterOpen, TestWebKitAPI.SiteIsolation.OpenProvisionalFailure, TestWebKitAPI.SiteIsolation.NavigateOpenerToProvisionalNavigationFailure, TestWebKitAPI.SiteIsolation.ClosedStatePropagation, TestWebKitAPI.SiteIsolation.CrossSiteIFrameWindowOpensMainFrameSite, TestWebKitAPI.SiteIsolation.AccessibilityTokenAfterPageNavigation, TestWebKitAPI.SiteIsolation.CloseAfterWindowOpen, TestWebKitAPI.SiteIsolation.OpenedWindowFocusDelegates, TestWebKitAPI.SiteIsolation.FocusOpenedWindow ... (failure)") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1149 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120929 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153464 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14577 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4620 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117593 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14610 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12685 "Found 6 new test failures: http/tests/site-isolation/cross-site-window-open-uses-different-process.html http/tests/site-isolation/frame-access-after-window-open.html http/tests/site-isolation/iframe-and-window-open.html http/tests/site-isolation/mixedContent/insecure-audio-video-in-main-frame.html http/tests/site-isolation/mixedContent/redirect-https-to-http-iframe-in-main-frame.html http/tests/site-isolation/window-open-with-name.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117928 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13963 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124796 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70268 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14619 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3756 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14356 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78321 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14564 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14417 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->