### PR TITLE
[WebKit] Fix -Wreturn-stack-address in -currentTextPointer

### DIFF
--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -99,6 +99,7 @@ public:
     const void* rawCharacters() const LIFETIME_BOUND { return m_characters; }
     std::span<const Latin1Character> span8() const LIFETIME_BOUND;
     std::span<const char16_t> span16() const LIFETIME_BOUND;
+    std::span<const char16_t> unsafeSpan16() const { return span16(); }
     template<typename CharacterType> std::span<const CharacterType> span() const LIFETIME_BOUND;
 
     unsigned hash() const;

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMTextIterator.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMTextIterator.mm
@@ -79,7 +79,7 @@
     if (!length)
         return nullptr;
     if (!text.is8Bit())
-        return reinterpret_cast<const unichar*>(text.span16().data());
+        return reinterpret_cast<const unichar*>(text.unsafeSpan16().data());
     if (_upconvertedText.isEmpty()) {
         auto characters = text.span8();
         _upconvertedText.appendRange(characters.begin(), characters.end());

--- a/Source/WebKitLegacy/mac/WebView/WebTextIterator.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebTextIterator.mm
@@ -106,7 +106,7 @@
     if (!length)
         return nullptr;
     if (!text.is8Bit())
-        return reinterpret_cast<const unichar*>(text.span16().data());
+        return reinterpret_cast<const unichar*>(text.unsafeSpan16().data());
     if (_private->_upconvertedText.isEmpty()) {
         auto characters = text.span8();
         _private->_upconvertedText.appendRange(characters.begin(), characters.end());


### PR DESCRIPTION
#### fc03b8e1ac8ca9e9ebcd02517c1317d810ea6bc9
<pre>
[WebKit] Fix -Wreturn-stack-address in -currentTextPointer
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=305247">https://bugs.webkit.org/show_bug.cgi?id=305247</a>&gt;
&lt;<a href="https://rdar.apple.com/167885469">rdar://167885469</a>&gt;

Reviewed by Geoffrey Garen.

No new tests since no change in behavior.

* Source/WTF/wtf/text/StringView.h:
(WTF::StringView::unsafeSpan16): Add.
- Add version of span16() without lifetimebound attribute.
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMTextIterator.mm:
(-[WKDOMTextIterator currentTextPointer]):
- Use unsafeSpan16() to avoid lifetimebound warning.
* Source/WebKitLegacy/mac/WebView/WebTextIterator.mm:
(-[WebTextIterator currentTextPointer]):
- Ditto.

Canonical link: <a href="https://commits.webkit.org/305431@main">https://commits.webkit.org/305431@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/893897eb788ac47d70046bb295186e2678d685dc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138403 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10768 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49813 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146486 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91378 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9d787bdd-9d68-4dce-8ceb-3e734965304b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11472 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10922 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105898 "Build is in progress. Recent messages:") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77249 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b7493ec2-cc0c-42ad-9d26-b5bbecd6b76a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141350 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8614 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124071 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86743 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8a5a7e98-361b-4350-8a3f-7553ecd13dd8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8201 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5967 "Found 1 new API test failure: TestWebKitAPI.WebKit.PreferenceChanges (failure)") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6773 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/130367 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117620 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42271 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149201 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/136985 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10450 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42828 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/114296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10467 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8836 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/114639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8247 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120358 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65313 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21317 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10497 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38291 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/169676 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10232 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74090 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44227 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10437 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10288 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->