### PR TITLE
[CSS] Early skip rule matching for pseudo-element selector

### DIFF
--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -983,6 +983,20 @@ bool complexSelectorMatchesElementBackedPseudoElement(const CSSSelector& complex
     return result;
 }
 
+bool complexSelectorMatchesOnlyPseudoElement(const CSSSelector& complexSelector)
+{
+    if (!complexSelector.matchesPseudoElement())
+        return false;
+
+    for (auto* selector = complexSelector.precedingInComplexSelector(); selector; selector = selector->precedingInComplexSelector()) {
+        // Pseudo-elements and pseudo-classes don't match elements, everything else does
+        if (!selector->matchesPseudoElement() && selector->match() != CSSSelector::Match::PseudoClass)
+            return false;
+    }
+
+    return true;
+}
+
 bool CSSSelector::simpleSelectorEqual(const CSSSelector& other) const
 {
     auto valuesEqual = [&] {

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -277,6 +277,8 @@ private:
 
 bool complexSelectorCanMatchPseudoElement(const CSSSelector&);
 bool complexSelectorMatchesElementBackedPseudoElement(const CSSSelector&);
+// Check if selector is pseudo-element-only (e.g., "::before" or "::before:hover")
+bool complexSelectorMatchesOnlyPseudoElement(const CSSSelector&);
 
 // In the AllowNonElementBackedPseudoElements mode `.foo::before` and `.foo` compare equal.
 enum class ComplexSelectorsEqualMode : bool { Full, IgnoreNonElementBackedPseudoElements };

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -587,6 +587,9 @@ void ElementRuleCollector::collectMatchingRulesForList(const RuleSet::RuleDataVe
         if (!ruleData.isEnabled()) [[unlikely]]
             continue;
 
+        if (!m_pseudoElementRequest && complexSelectorMatchesOnlyPseudoElement(*ruleData.selector()))
+            continue;
+
         if (!ruleData.canMatchPseudoElement() && m_pseudoElementRequest)
             continue;
 


### PR DESCRIPTION
#### 2d3026bb585a994a05014f45d664985ba5c7f5cd
<pre>
[CSS] Early skip rule matching for pseudo-element selector
<a href="https://bugs.webkit.org/show_bug.cgi?id=305249">https://bugs.webkit.org/show_bug.cgi?id=305249</a>
<a href="https://rdar.apple.com/158728258">rdar://158728258</a>

Reviewed by NOBODY (OOPS!).

No new tests (OOPS!).
* Source/WebCore/css/CSSSelector.cpp:
(WebCore::complexSelectorMatchesOnlyPseudoElement):
* Source/WebCore/css/CSSSelector.h:
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::collectMatchingRulesForList):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d3026bb585a994a05014f45d664985ba5c7f5cd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138325 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10690 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49735 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146407 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91300 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/74cb8733-666c-42f2-a0d2-8a7669a0c795) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140199 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11394 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10844 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105831 "Found 88 new test failures: compositing/tiling/sticky-change-to-tiled.html compositing/transforms/clipping-layer-and-flattening-layer.html css3/scroll-snap/scroll-snap-2d-change-axis-type-rtl.html css3/scroll-snap/scroll-snap-2d-change-axis-type.html css3/scroll-snap/scroll-snap-2d-offsets-computed-independently.html css3/scroll-snap/scroll-snap-2d-offsets-computed-independently.rtl.html css3/scroll-snap/scroll-snap-drag-scrollbar-thumb-with-relayouts.html css3/scroll-snap/scroll-snap-drag-scrollbar-thumb.html css3/scroll-snap/scroll-snap-positions.html editing/selection/modify-by-lineboundary-toward-pseudo-element.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77184 "13 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/385ab97c-f7e7-43ee-9f93-a0ea952abbf1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141272 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8543 "Found 27 new test failures: compositing/scrolling/scroller-inside-hidden-layer.html compositing/transforms/clipping-layer-and-flattening-layer.html css3/scroll-snap/scroll-snap-2d-change-axis-type-rtl.html css3/scroll-snap/scroll-snap-2d-change-axis-type.html css3/scroll-snap/scroll-snap-2d-offsets-computed-independently.html css3/scroll-snap/scroll-snap-2d-offsets-computed-independently.rtl.html editing/selection/modify-by-lineboundary-toward-pseudo-element.html editing/spelling/grammar-and-spelling-error-styling.html editing/spelling/spellcheck-attribute-toggle.html fast/block/float/float-pseudo-element-not-removed-crash.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124002 "Found 1 new API test failure: TestWebKitAPI.WKWebView.AlwaysShowsScroller (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86673 "Found 1 new API test failure: WPE/TestWebKitWebXR:/webkit/WebKitWebXR/leave-immersive-mode (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/016ca497-0a8e-4242-91ba-2ba851c4b431) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8130 "Found 53 new test failures: imported/w3c/web-platform-tests/css/css-cascade/scope-part.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-for-shadow-dom.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/style-container-for-shadow-dom.html imported/w3c/web-platform-tests/css/css-highlight-api/highlight-image.html imported/w3c/web-platform-tests/css/css-highlight-api/highlight-priority-painting.html imported/w3c/web-platform-tests/css/css-highlight-api/highlight-text-across-elements.html imported/w3c/web-platform-tests/css/css-highlight-api/highlight-text-decorations.html imported/w3c/web-platform-tests/css/css-highlight-api/highlight-text-dynamic.html imported/w3c/web-platform-tests/css/css-highlight-api/highlight-text-replace.html imported/w3c/web-platform-tests/css/css-highlight-api/highlight-text.html ... (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5896 "Found 1 new API test failure: TestWebKitAPI.WKWebView.AlwaysShowsScroller (failure)") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6694 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117547 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42203 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149119 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10372 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42760 "Found 60 new test failures: compositing/cocoa/clip-sticky-element-to-viewport.html compositing/scrolling/async-overflow-scrolling/position-inside-rtl-overflow.html compositing/scrolling/scroller-inside-hidden-layer.html compositing/tiling/sticky-change-to-tiled.html compositing/transforms/clipping-layer-and-flattening-layer.html css3/scroll-snap/scroll-snap-2d-change-axis-type-rtl.html css3/scroll-snap/scroll-snap-2d-change-axis-type.html css3/scroll-snap/scroll-snap-2d-offsets-computed-independently.html css3/scroll-snap/scroll-snap-2d-offsets-computed-independently.rtl.html css3/scroll-snap/scroll-snap-drag-scrollbar-thumb-with-relayouts.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114230 "Found 93 new test failures: compositing/scrolling/scroller-inside-hidden-layer.html compositing/tiling/sticky-change-to-tiled.html compositing/transforms/clipping-layer-and-flattening-layer.html css3/scroll-snap/scroll-snap-2d-change-axis-type-rtl.html css3/scroll-snap/scroll-snap-2d-change-axis-type.html css3/scroll-snap/scroll-snap-2d-offsets-computed-independently.html css3/scroll-snap/scroll-snap-2d-offsets-computed-independently.rtl.html css3/scroll-snap/scroll-snap-drag-scrollbar-thumb-with-relayouts.html css3/scroll-snap/scroll-snap-drag-scrollbar-thumb.html css3/scroll-snap/scroll-snap-positions.html ... (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10389 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8768 "Found 60 new test failures: compositing/cocoa/clip-sticky-element-to-viewport.html compositing/scrolling/async-overflow-scrolling/position-inside-rtl-overflow.html compositing/scrolling/scroller-inside-hidden-layer.html compositing/tiling/sticky-change-to-tiled.html compositing/transforms/clipping-layer-and-flattening-layer.html css3/scroll-snap/scroll-snap-2d-change-axis-type-rtl.html css3/scroll-snap/scroll-snap-2d-change-axis-type.html css3/scroll-snap/scroll-snap-2d-offsets-computed-independently.html css3/scroll-snap/scroll-snap-2d-offsets-computed-independently.rtl.html css3/scroll-snap/scroll-snap-drag-scrollbar-thumb-with-relayouts.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114574 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8106 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120290 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65195 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10419 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38223 "Found 60 new test failures: compositing/cocoa/clip-sticky-element-to-viewport.html compositing/scrolling/async-overflow-scrolling/position-inside-rtl-overflow.html compositing/scrolling/scroller-inside-hidden-layer.html compositing/tiling/empty-to-tiled.html compositing/tiling/sticky-change-to-tiled.html compositing/transforms/clipping-layer-and-flattening-layer.html css3/scroll-snap/scroll-snap-2d-change-axis-type-rtl.html css3/scroll-snap/scroll-snap-2d-change-axis-type.html css3/scroll-snap/scroll-snap-2d-offsets-computed-independently.html css3/scroll-snap/scroll-snap-2d-offsets-computed-independently.rtl.html ... (failure)") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10152 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/73987 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10359 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10210 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->