### PR TITLE
[GLib] Fix inconsistent-missing-override warning after 305364@main

### DIFF
--- a/Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.h
+++ b/Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.h
@@ -67,7 +67,7 @@ protected:
     MediaSessionManagerGLib(GRefPtr<GDBusNodeInfo>&&, PageIdentifier);
 
     void scheduleSessionStatusUpdate() final;
-    void updateNowPlayingInfo();
+    void updateNowPlayingInfo() final;
 
     void removeSession(PlatformMediaSessionInterface&) final;
     void addSession(PlatformMediaSessionInterface&) final;


### PR DESCRIPTION
#### 2cc5b5477540971a051cbf3535453ddffe52c593
<pre>
[GLib] Fix inconsistent-missing-override warning after <a href="https://commits.webkit.org/305364@main">305364@main</a>

Unreviewed.

* Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2cc5b5477540971a051cbf3535453ddffe52c593

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138336 "Failed to checkout and rebase branch from PR 56386") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10701 "Failed to checkout and rebase branch from PR 56386") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49746 "Failed to checkout and rebase branch from PR 56386") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/146418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/91311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140210 "Failed to checkout and rebase branch from PR 56386") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11405 "Failed to checkout and rebase branch from PR 56386") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10855 "Failed to checkout and rebase branch from PR 56386") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/146418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/91311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141283 "Failed to checkout and rebase branch from PR 56386") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/11405 "Failed to checkout and rebase branch from PR 56386") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/49746 "Failed to checkout and rebase branch from PR 56386") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/146418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/11405 "Failed to checkout and rebase branch from PR 56386") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/138/builds/49746 "Failed to checkout and rebase branch from PR 56386") | [  ~~🛠 wpe-cairo-libwebrtc~~](https://ews-build.webkit.org/#/builders/166/builds/6705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/11405 "Failed to checkout and rebase branch from PR 56386") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/49746 "Failed to checkout and rebase branch from PR 56386") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149131 "Failed to checkout and rebase branch from PR 56386") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10383 "Failed to checkout and rebase branch from PR 56386") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/49746 "Failed to checkout and rebase branch from PR 56386") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/149131 "Failed to checkout and rebase branch from PR 56386") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10400 "Failed to checkout and rebase branch from PR 56386") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/10855 "Failed to checkout and rebase branch from PR 56386") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/149131 "Failed to checkout and rebase branch from PR 56386") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/49746 "Failed to checkout and rebase branch from PR 56386") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/65206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21303 "Failed to checkout and rebase branch from PR 56386") | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10430 "Failed to checkout and rebase branch from PR 56386") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/49746 "Failed to checkout and rebase branch from PR 56386") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10164 "Failed to checkout and rebase branch from PR 56386") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74000 "Failed to checkout and rebase branch from PR 56386") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10370 "Failed to checkout and rebase branch from PR 56386") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10221 "Failed to checkout and rebase branch from PR 56386") | | | 
<!--EWS-Status-Bubble-End-->