### PR TITLE
[JSC] Merge boolean fields in `JSRegExpStringIterator` into a single bitfield

### DIFF
--- a/Source/JavaScriptCore/builtins/RegExpStringIteratorPrototype.js
+++ b/Source/JavaScriptCore/builtins/RegExpStringIteratorPrototype.js
@@ -33,17 +33,17 @@ function next()
     if (!@isRegExpStringIterator(this))
         @throwTypeError("%RegExpStringIteratorPrototype%.next requires |this| to be an RegExp String Iterator instance");
 
-    var done = @getRegExpStringIteratorInternalField(this, @regExpStringIteratorFieldDone);
-    if (done)
+    var flags = @getRegExpStringIteratorInternalField(this, @regExpStringIteratorFieldFlags);
+    if (flags & @regExpStringIteratorFlagDone)
         return { value: @undefined, done: true };
 
     var regExp = @getRegExpStringIteratorInternalField(this, @regExpStringIteratorFieldRegExp);
     var string = @getRegExpStringIteratorInternalField(this, @regExpStringIteratorFieldString);
-    var global = @getRegExpStringIteratorInternalField(this, @regExpStringIteratorFieldGlobal);
-    var fullUnicode = @getRegExpStringIteratorInternalField(this, @regExpStringIteratorFieldFullUnicode);
+    var global = flags & @regExpStringIteratorFlagGlobal;
+    var fullUnicode = flags & @regExpStringIteratorFlagFullUnicode;
     var match = @regExpExec(regExp, string);
     if (match === null) {
-        @putRegExpStringIteratorInternalField(this, @regExpStringIteratorFieldDone, true);
+        @putRegExpStringIteratorInternalField(this, @regExpStringIteratorFieldFlags, flags | @regExpStringIteratorFlagDone);
         return { value: @undefined, done: true };
     }
 
@@ -54,7 +54,7 @@ function next()
             regExp.lastIndex = @advanceStringIndex(string, thisIndex, fullUnicode);
         }
     } else
-        @putRegExpStringIteratorInternalField(this, @regExpStringIteratorFieldDone, true);
+        @putRegExpStringIteratorInternalField(this, @regExpStringIteratorFieldFlags, flags | @regExpStringIteratorFlagDone);
 
     return { value: match, done: false };
 }

--- a/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.cpp
+++ b/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.cpp
@@ -139,9 +139,10 @@ BytecodeIntrinsicRegistry::BytecodeIntrinsicRegistry(VM& vm)
     m_wrapForValidIteratorFieldIteratedNextMethod.set(m_vm, jsNumber(static_cast<int32_t>(JSWrapForValidIterator::Field::IteratedNextMethod)));
     m_regExpStringIteratorFieldRegExp.set(m_vm, jsNumber(static_cast<int32_t>(JSRegExpStringIterator::Field::RegExp)));
     m_regExpStringIteratorFieldString.set(m_vm, jsNumber(static_cast<int32_t>(JSRegExpStringIterator::Field::String)));
-    m_regExpStringIteratorFieldGlobal.set(m_vm, jsNumber(static_cast<int32_t>(JSRegExpStringIterator::Field::Global)));
-    m_regExpStringIteratorFieldFullUnicode.set(m_vm, jsNumber(static_cast<int32_t>(JSRegExpStringIterator::Field::FullUnicode)));
-    m_regExpStringIteratorFieldDone.set(m_vm, jsNumber(static_cast<int32_t>(JSRegExpStringIterator::Field::Done)));
+    m_regExpStringIteratorFieldFlags.set(m_vm, jsNumber(static_cast<int32_t>(JSRegExpStringIterator::Field::Flags)));
+    m_regExpStringIteratorFlagGlobal.set(m_vm, jsNumber(static_cast<int32_t>(JSRegExpStringIterator::FlagBit::Global)));
+    m_regExpStringIteratorFlagFullUnicode.set(m_vm, jsNumber(static_cast<int32_t>(JSRegExpStringIterator::FlagBit::FullUnicode)));
+    m_regExpStringIteratorFlagDone.set(m_vm, jsNumber(static_cast<int32_t>(JSRegExpStringIterator::FlagBit::Done)));
     m_iteratorHelperFieldGenerator.set(m_vm, jsNumber(static_cast<int32_t>(JSIteratorHelper::Field::Generator)));
     m_iteratorHelperFieldUnderlyingIterator.set(m_vm, jsNumber(static_cast<int32_t>(JSIteratorHelper::Field::UnderlyingIterator)));
     m_disposableStackFieldState.set(m_vm, jsNumber(static_cast<int32_t>(JSDisposableStack::Field::State)));

--- a/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h
+++ b/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h
@@ -203,9 +203,10 @@ enum class LinkTimeConstant : int32_t;
     macro(wrapForValidIteratorFieldIteratedNextMethod) \
     macro(regExpStringIteratorFieldRegExp) \
     macro(regExpStringIteratorFieldString) \
-    macro(regExpStringIteratorFieldGlobal) \
-    macro(regExpStringIteratorFieldFullUnicode) \
-    macro(regExpStringIteratorFieldDone) \
+    macro(regExpStringIteratorFieldFlags) \
+    macro(regExpStringIteratorFlagGlobal) \
+    macro(regExpStringIteratorFlagFullUnicode) \
+    macro(regExpStringIteratorFlagDone) \
     macro(disposableStackFieldState) \
     macro(disposableStackFieldCapability) \
     macro(DisposableStackStatePending) \

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -1731,12 +1731,8 @@ static JSRegExpStringIterator::Field regExpStringIteratorInternalFieldIndex(Byte
         return JSRegExpStringIterator::Field::RegExp;
     if (node->entry().emitter() == &BytecodeIntrinsicNode::emit_intrinsic_regExpStringIteratorFieldString)
         return JSRegExpStringIterator::Field::String;
-    if (node->entry().emitter() == &BytecodeIntrinsicNode::emit_intrinsic_regExpStringIteratorFieldGlobal)
-        return JSRegExpStringIterator::Field::Global;
-    if (node->entry().emitter() == &BytecodeIntrinsicNode::emit_intrinsic_regExpStringIteratorFieldFullUnicode)
-        return JSRegExpStringIterator::Field::FullUnicode;
-    if (node->entry().emitter() == &BytecodeIntrinsicNode::emit_intrinsic_regExpStringIteratorFieldDone)
-        return JSRegExpStringIterator::Field::Done;
+    if (node->entry().emitter() == &BytecodeIntrinsicNode::emit_intrinsic_regExpStringIteratorFieldFlags)
+        return JSRegExpStringIterator::Field::Flags;
     RELEASE_ASSERT_NOT_REACHED();
     return JSRegExpStringIterator::Field::RegExp;
 }

--- a/Source/JavaScriptCore/runtime/JSRegExpStringIterator.cpp
+++ b/Source/JavaScriptCore/runtime/JSRegExpStringIterator.cpp
@@ -73,8 +73,7 @@ JSC_DEFINE_HOST_FUNCTION(regExpStringIteratorPrivateFuncCreate, (JSGlobalObject*
 
     regExpStringIterator->setRegExp(vm, asObject(callFrame->uncheckedArgument(0)));
     regExpStringIterator->setString(vm, callFrame->uncheckedArgument(1));
-    regExpStringIterator->setGlobal(vm, callFrame->argument(2));
-    regExpStringIterator->setFullUnicode(vm, callFrame->argument(3));
+    regExpStringIterator->setFlags(callFrame->argument(2).asBoolean(), callFrame->argument(3).asBoolean());
 
     return JSValue::encode(regExpStringIterator);
 }

--- a/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
@@ -1223,8 +1223,7 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoFuncMatchAll, (JSGlobalObject* globalObject,
         auto* iterator = JSRegExpStringIterator::createWithInitialValues(vm, globalObject->regExpStringIteratorStructure());
         iterator->setRegExp(vm, matcher);
         iterator->setString(vm, string);
-        iterator->setGlobal(vm, jsBoolean(global));
-        iterator->setFullUnicode(vm, jsBoolean(fullUnicode));
+        iterator->setFlags(global, fullUnicode);
 
         return JSValue::encode(iterator);
     }
@@ -1280,8 +1279,7 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoFuncMatchAll, (JSGlobalObject* globalObject,
 
     regExpStringIterator->setRegExp(vm, matcher);
     regExpStringIterator->setString(vm, string);
-    regExpStringIterator->setGlobal(vm, jsBoolean(global));
-    regExpStringIterator->setFullUnicode(vm, jsBoolean(fullUnicode));
+    regExpStringIterator->setFlags(global, fullUnicode);
 
     return JSValue::encode(regExpStringIterator);
 }


### PR DESCRIPTION
#### 31bc5e6778d429c8b07a8bc78380e7b5e47a906f
<pre>
[JSC] Merge boolean fields in `JSRegExpStringIterator` into a single bitfield
<a href="https://bugs.webkit.org/show_bug.cgi?id=305258">https://bugs.webkit.org/show_bug.cgi?id=305258</a>

Reviewed by Yusuke Suzuki.

The Global, FullUnicode, and Done fields are now stored as bit flags in a
single Flags field, reducing the object size from 56 to 40 bytes.

* Source/JavaScriptCore/builtins/RegExpStringIteratorPrototype.js:
(next): Use bitwise operations to read/write flags.
* Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.cpp:
(JSC::BytecodeIntrinsicRegistry::BytecodeIntrinsicRegistry):
* Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h:
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::regExpStringIteratorInternalFieldIndex):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/runtime/JSRegExpStringIterator.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSRegExpStringIterator.h:
* Source/JavaScriptCore/runtime/RegExpPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/305552@main">https://commits.webkit.org/305552@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/646383105b8a6649a2af688af240aaa51746113c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138584 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10949 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/65 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146696 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91559 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11653 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11104 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106035 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77375 "5 flakes 1 failures") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141531 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed webkitperl tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8772 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124217 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86905 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8360 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6120 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6988 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/130550 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117777 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/56 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149447 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/137207 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10631 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/52 "Found 1 new test failure: http/tests/performance/performance-resource-timing-redirection-cross-origin-media.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114419 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10648 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8998 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114759 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29201 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8547 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120513 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65523 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10680 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/55 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/169858 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10414 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74312 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44283 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10618 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10469 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->