### PR TITLE
Reduce RefPtr usage in favor of Ref in XPath

### DIFF
--- a/Source/WebCore/xml/XPathFunctions.cpp
+++ b/Source/WebCore/xml/XPathFunctions.cpp
@@ -43,8 +43,7 @@
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
 
-namespace WebCore {
-namespace XPath {
+namespace WebCore::XPath {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(Function);
 
@@ -374,7 +373,7 @@ Value FunId::evaluate() const
         // In WebKit, getElementById behaves so, too, although its behavior in this case is formally undefined.
         RefPtr node = contextScope->getElementById(StringView(idList).substring(startPos, endPos - startPos));
         if (node && resultSet.add(*node).isNewEntry)
-            result.append(WTF::move(node));
+            result.append(node.releaseNonNull());
         
         startPos = endPos;
     }
@@ -449,7 +448,7 @@ Value FunCount::evaluate() const
 Value FunString::evaluate() const
 {
     if (!argumentCount())
-        return Value(Expression::evaluationContext().node.get()).toString();
+        return Value(NodeSet(*Expression::evaluationContext().node)).toString();
     return argument(0).evaluate().toString();
 }
 
@@ -602,7 +601,7 @@ Value FunSubstring::evaluate() const
 Value FunStringLength::evaluate() const
 {
     if (!argumentCount())
-        return Value(Expression::evaluationContext().node.get()).toString().length();
+        return Value(NodeSet(*Expression::evaluationContext().node)).toString().length();
     return argument(0).evaluate().toString().length();
 }
 
@@ -610,7 +609,7 @@ Value FunNormalizeSpace::evaluate() const
 {
     // https://www.w3.org/TR/1999/REC-xpath-19991116/#function-normalize-space
     if (!argumentCount()) {
-        String s = Value(Expression::evaluationContext().node.get()).toString();
+        String s = Value(NodeSet(*Expression::evaluationContext().node)).toString();
         return s.simplifyWhiteSpace(isASCIIWhitespaceWithoutFF<char16_t>);
     }
     String s = argument(0).evaluate().toString();
@@ -705,7 +704,7 @@ Value FunFalse::evaluate() const
 Value FunNumber::evaluate() const
 {
     if (!argumentCount())
-        return Value(Expression::evaluationContext().node.get()).toNumber();
+        return Value(NodeSet(*Expression::evaluationContext().node)).toNumber();
     return argument(0).evaluate().toNumber();
 }
 
@@ -827,5 +826,4 @@ std::unique_ptr<Function> Function::create(const String& name, Vector<std::uniqu
     return function;
 }
 
-} // namespace XPath
-} // namespace WebCore
+} // namespace WebCore::XPath

--- a/Source/WebCore/xml/XPathNodeSet.h
+++ b/Source/WebCore/xml/XPathNodeSet.h
@@ -28,52 +28,50 @@
 
 #include <WebCore/Node.h>
 
-namespace WebCore {
-    namespace XPath {
+namespace WebCore::XPath {
 
-        class NodeSet {
-        public:
-            NodeSet() : m_isSorted(true), m_subtreesAreDisjoint(false) { }
-            explicit NodeSet(RefPtr<Node>&& node)
-                : m_isSorted(true), m_subtreesAreDisjoint(false), m_nodes(1, WTF::move(node))
-            { }
-            
-            size_t size() const { return m_nodes.size(); }
-            bool isEmpty() const { return m_nodes.isEmpty(); }
-            Node* operator[](unsigned i) const LIFETIME_BOUND { return m_nodes.at(i).get(); }
-            void reserveCapacity(size_t newCapacity) { m_nodes.reserveCapacity(newCapacity); }
-            void clear() { m_nodes.clear(); }
+class NodeSet {
+public:
+    NodeSet() : m_isSorted(true), m_subtreesAreDisjoint(false) { }
+    explicit NodeSet(Ref<Node>&& node)
+        : m_isSorted(true), m_subtreesAreDisjoint(false), m_nodes(1, WTF::move(node))
+    { }
 
-            // NodeSet itself does not verify that nodes in it are unique.
-            void append(RefPtr<Node>&& node) { m_nodes.append(WTF::move(node)); }
-            void append(const NodeSet& nodeSet) { m_nodes.appendVector(nodeSet.m_nodes); }
+    size_t size() const { return m_nodes.size(); }
+    bool isEmpty() const { return m_nodes.isEmpty(); }
+    Node* operator[](unsigned i) const LIFETIME_BOUND { return m_nodes.at(i).ptr(); }
+    void reserveCapacity(size_t newCapacity) { m_nodes.reserveCapacity(newCapacity); }
+    void clear() { m_nodes.clear(); }
 
-            // Returns the set's first node in document order, or nullptr if the set is empty.
-            Node* firstNode() const;
+    // NodeSet itself does not verify that nodes in it are unique.
+    void append(Ref<Node>&& node) { m_nodes.append(WTF::move(node)); }
+    void append(const NodeSet& nodeSet) { m_nodes.appendVector(nodeSet.m_nodes); }
 
-            // Returns nullptr if the set is empty.
-            Node* anyNode() const;
+    // Returns the set's first node in document order, or nullptr if the set is empty.
+    Node* firstNode() const;
 
-            // NodeSet itself doesn't check if it contains nodes in document order - the caller should tell it if it does not.
-            void markSorted(bool isSorted) { m_isSorted = isSorted; }
-            bool isSorted() const { return m_isSorted || m_nodes.size() < 2; }
+    // Returns nullptr if the set is empty.
+    Node* anyNode() const;
 
-            void sort() const;
+    // NodeSet itself doesn't check if it contains nodes in document order - the caller should tell it if it does not.
+    void markSorted(bool isSorted) { m_isSorted = isSorted; }
+    bool isSorted() const { return m_isSorted || m_nodes.size() < 2; }
 
-            // No node in the set is ancestor of another. Unlike m_isSorted, this is assumed to be false, unless the caller sets it to true.
-            void markSubtreesDisjoint(bool disjoint) { m_subtreesAreDisjoint = disjoint; }
-            bool subtreesAreDisjoint() const { return m_subtreesAreDisjoint || m_nodes.size() < 2; }
+    void sort() const;
 
-            const RefPtr<Node>* begin() const LIFETIME_BOUND { return m_nodes.begin(); }
-            const RefPtr<Node>* end() const LIFETIME_BOUND { return m_nodes.end(); }
+    // No node in the set is ancestor of another. Unlike m_isSorted, this is assumed to be false, unless the caller sets it to true.
+    void markSubtreesDisjoint(bool disjoint) { m_subtreesAreDisjoint = disjoint; }
+    bool subtreesAreDisjoint() const { return m_subtreesAreDisjoint || m_nodes.size() < 2; }
 
-        private:
-            void traversalSort() const;
+    auto begin() const LIFETIME_BOUND { return m_nodes.begin(); }
+    auto end() const LIFETIME_BOUND { return m_nodes.end(); }
 
-            mutable bool m_isSorted;
-            bool m_subtreesAreDisjoint;
-            mutable Vector<RefPtr<Node>> m_nodes;
-        };
+private:
+    void traversalSort() const;
 
-    } // namespace XPath
-} // namespace WebCore
+    mutable bool m_isSorted;
+    bool m_subtreesAreDisjoint;
+    mutable Vector<Ref<Node>> m_nodes;
+};
+
+} // namespace WebCore::XPath

--- a/Source/WebCore/xml/XPathPredicate.cpp
+++ b/Source/WebCore/xml/XPathPredicate.cpp
@@ -35,8 +35,7 @@
 #include <wtf/SetForScope.h>
 #include <wtf/TZoneMallocInlines.h>
 
-namespace WebCore {
-namespace XPath {
+namespace WebCore::XPath {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(Number);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(StringExpression);
@@ -272,7 +271,7 @@ Value Union::evaluate() const
     NodeSet& resultSet = lhsResult.modifiableNodeSet();
     const NodeSet& rhsNodes = rhsResult.toNodeSet();
 
-    HashSet<RefPtr<Node>> nodes;
+    HashSet<Ref<Node>> nodes;
     for (auto& result : resultSet)
         nodes.add(result.get());
 
@@ -309,5 +308,4 @@ bool predicateIsContextPositionSensitive(const Expression& expression)
     return expression.isContextPositionSensitive() || expression.resultType() == Value::Type::Number;
 }
 
-} // namespace XPath
-} // namespace WebCore
+} // namespace WebCore::XPath

--- a/Source/WebCore/xml/XPathUtil.cpp
+++ b/Source/WebCore/xml/XPathUtil.cpp
@@ -31,26 +31,25 @@
 #include "ContainerNode.h"
 #include "TextNodeTraversal.h"
 
-namespace WebCore {
-namespace XPath {
+namespace WebCore::XPath {
         
 bool isRootDomNode(Node* node)
 {
     return node && !node->parentNode();
 }
 
-String stringValue(Node* node)
+String stringValue(Node& node)
 {
-    switch (node->nodeType()) {
+    switch (node.nodeType()) {
         case Node::ATTRIBUTE_NODE:
         case Node::PROCESSING_INSTRUCTION_NODE:
         case Node::COMMENT_NODE:
         case Node::TEXT_NODE:
         case Node::CDATA_SECTION_NODE:
-            return node->nodeValue();
+            return node.nodeValue();
         default:
-            if (isRootDomNode(node) || node->isElementNode())
-                return TextNodeTraversal::contentsAsString(*node);
+            if (isRootDomNode(&node) || node.isElementNode())
+                return TextNodeTraversal::contentsAsString(node);
     }
     return String();
 }
@@ -74,5 +73,4 @@ bool isValidContextNode(Node& node)
     return false;
 }
 
-}
-}
+} // namespace WebCore::XPath

--- a/Source/WebCore/xml/XPathUtil.h
+++ b/Source/WebCore/xml/XPathUtil.h
@@ -32,19 +32,19 @@
 
 namespace WebCore {
 
-    class Node;
+class Node;
 
-    namespace XPath {
+namespace XPath {
 
-        /* @return whether the given node is the root node */
-        bool isRootDomNode(Node*);
+/* @return whether the given node is the root node */
+bool isRootDomNode(Node*);
 
-        /* @return the 'string-value' of the given node as specified by http://www.w3.org/TR/xpath */
-        String stringValue(Node*);
+/* @return the 'string-value' of the given node as specified by http://www.w3.org/TR/xpath */
+String stringValue(Node&);
 
-        /* @return whether the given node is a valid context node */
-        bool isValidContextNode(Node&);
+/* @return whether the given node is a valid context node */
+bool isValidContextNode(Node&);
 
-    } // namespace XPath
+} // namespace XPath
 
 } // namespace WebCore

--- a/Source/WebCore/xml/XPathValue.cpp
+++ b/Source/WebCore/xml/XPathValue.cpp
@@ -35,8 +35,7 @@
 #include <wtf/NeverDestroyed.h>
 #include <wtf/StdLibExtras.h>
 
-namespace WebCore {
-namespace XPath {
+namespace WebCore::XPath {
 
 const NodeSet& Value::toNodeSet() const
 {
@@ -117,7 +116,7 @@ String Value::toString() const
     case Type::NodeSet:
         if (m_data->nodeSet.isEmpty())
             return emptyString();
-        return stringValue(RefPtr { m_data->nodeSet.firstNode() }.get());
+        return stringValue(Ref { *m_data->nodeSet.firstNode() });
     case Type::String:
         return m_data->string;
     case Type::Number:
@@ -136,5 +135,4 @@ String Value::toString() const
     return String();
 }
 
-} // namespace XPath
-} // namespace WebCore
+} // namespace WebCore::XPath

--- a/Source/WebCore/xml/XPathValue.h
+++ b/Source/WebCore/xml/XPathValue.h
@@ -28,8 +28,7 @@
 
 #include <WebCore/XPathNodeSet.h>
 
-namespace WebCore {
-namespace XPath {
+namespace WebCore::XPath {
 
 class Value {
 public:
@@ -57,12 +56,6 @@ public:
     explicit Value(NodeSet&& value)
         : m_type(Type::NodeSet), m_data(Data::create(WTF::move(value)))
     { }
-    explicit Value(Node* value)
-        : m_type(Type::NodeSet), m_data(Data::create(value))
-    { }
-    explicit Value(RefPtr<Node>&& value)
-        : m_type(Type::NodeSet), m_data(Data::create(WTF::move(value)))
-    { }
 
     Type type() const { return m_type; }
 
@@ -87,7 +80,6 @@ private:
         static Ref<Data> create() { return adoptRef(*new Data); }
         static Ref<Data> create(const String& string) { return adoptRef(*new Data(string)); }
         static Ref<Data> create(NodeSet&& nodeSet) { return adoptRef(*new Data(WTF::move(nodeSet))); }
-        static Ref<Data> create(RefPtr<Node>&& node) { return adoptRef(*new Data(WTF::move(node))); }
 
         String string;
         NodeSet nodeSet;
@@ -100,9 +92,6 @@ private:
         explicit Data(NodeSet&& nodeSet)
             : nodeSet(WTF::move(nodeSet))
         { }
-        explicit Data(RefPtr<Node>&& node)
-            : nodeSet(WTF::move(node))
-        { }
     };
 
     Type m_type;
@@ -111,5 +100,4 @@ private:
     RefPtr<Data> m_data;
 };
 
-} // namespace XPath
-} // namespace WebCore
+} // namespace WebCore::XPath


### PR DESCRIPTION
#### 2d005b88adb989c0842dbd6b1b09c0930f0598db
<pre>
Reduce RefPtr usage in favor of Ref in XPath
<a href="https://bugs.webkit.org/show_bug.cgi?id=305262">https://bugs.webkit.org/show_bug.cgi?id=305262</a>

Reviewed by Chris Dumez.

Claude AI assisted rewrite of XPath code to reduce usage of RefPtr.
Unfortunately it does depend on knowing that evaluationContext().node
is non-null, which is not immediately obvious.

Canonical link: <a href="https://commits.webkit.org/305498@main">https://commits.webkit.org/305498@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ea55d3cf323d12befa346ad731d6633d04d92cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138501 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10866 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49911 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146598 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/91476 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b34ad97c-9352-41bd-a6bf-d0f43e763b70) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140375 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11570 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11021 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/105996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/91476 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a6091f17-64c8-45cb-950d-4116abd3c220) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141448 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8697 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124158 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86861 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d50bcfab-1112-47fc-8f4f-65e5e1d6bab3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8283 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6049 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6891 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117704 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42359 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149350 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10548 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42916 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114374 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10565 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8916 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114711 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8418 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120446 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65437 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21340 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10597 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38377 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10331 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74211 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10535 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10386 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->