### PR TITLE
Reduce usage of RefPtr in favor of Ref in WebCore/style

### DIFF
--- a/Source/WebCore/css/StyleSheetList.cpp
+++ b/Source/WebCore/css/StyleSheetList.cpp
@@ -45,7 +45,7 @@ StyleSheetList::StyleSheetList(ShadowRoot& shadowRoot)
 
 StyleSheetList::~StyleSheetList() = default;
 
-inline const Vector<RefPtr<StyleSheet>>& StyleSheetList::styleSheets() const
+inline const Vector<Ref<StyleSheet>>& StyleSheetList::styleSheets() const
 {
     if (RefPtr document = m_document.get())
         return document->styleScope().styleSheetsForStyleSheetList();
@@ -82,8 +82,8 @@ unsigned StyleSheetList::length() const
 
 StyleSheet* StyleSheetList::item(unsigned index)
 {
-    const Vector<RefPtr<StyleSheet>>& sheets = styleSheets();
-    return index < sheets.size() ? sheets[index].get() : 0;
+    const Vector<Ref<StyleSheet>>& sheets = styleSheets();
+    return index < sheets.size() ? sheets[index].ptr() : nullptr;
 }
 
 CSSStyleSheet* StyleSheetList::namedItem(const AtomString& name) const

--- a/Source/WebCore/css/StyleSheetList.h
+++ b/Source/WebCore/css/StyleSheetList.h
@@ -56,11 +56,11 @@ public:
 private:
     StyleSheetList(Document&);
     StyleSheetList(ShadowRoot&);
-    const Vector<RefPtr<StyleSheet>>& styleSheets() const;
+    const Vector<Ref<StyleSheet>>& styleSheets() const;
 
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
     WeakPtr<ShadowRoot, WeakPtrImplWithEventTargetData> m_shadowRoot;
-    Vector<RefPtr<StyleSheet>> m_detachedStyleSheets;
+    Vector<Ref<StyleSheet>> m_detachedStyleSheets;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -1425,10 +1425,7 @@ static Vector<String> authoredGridTrackSizes(Node* node, Style::GridTrackSizingD
     if (!cssValue) {
         auto styleRules = element->styleResolver().styleRulesForElement(element);
         styleRules.reverse();
-        for (auto styleRule : styleRules) {
-            ASSERT(styleRule);
-            if (!styleRule)
-                continue;
+        for (auto& styleRule : styleRules) {
             cssValue = styleRule->properties().getPropertyCSSValue(directionCSSPropertyID);
             if (cssValue)
                 break;

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
@@ -1368,7 +1368,7 @@ RefPtr<Inspector::Protocol::CSS::CSSRule> InspectorCSSAgent::buildObjectForRule(
     return inspectorStyleSheet ? inspectorStyleSheet->buildObjectForRule(rule) : nullptr;
 }
 
-Ref<JSON::ArrayOf<Inspector::Protocol::CSS::RuleMatch>> InspectorCSSAgent::buildArrayForMatchedRuleList(const Vector<RefPtr<const StyleRule>>& matchedRules, Style::Resolver& styleResolver, Element& element, std::optional<Style::PseudoElementIdentifier> pseudoElementIdentifier)
+Ref<JSON::ArrayOf<Inspector::Protocol::CSS::RuleMatch>> InspectorCSSAgent::buildArrayForMatchedRuleList(const Vector<Ref<const StyleRule>>& matchedRules, Style::Resolver& styleResolver, Element& element, std::optional<Style::PseudoElementIdentifier> pseudoElementIdentifier)
 {
     auto result = JSON::ArrayOf<Inspector::Protocol::CSS::RuleMatch>::create();
 
@@ -1378,7 +1378,7 @@ Ref<JSON::ArrayOf<Inspector::Protocol::CSS::RuleMatch>> InspectorCSSAgent::build
     SelectorChecker selectorChecker(element.document());
 
     for (auto& matchedRule : matchedRules) {
-        RefPtr<Inspector::Protocol::CSS::CSSRule> ruleObject = buildObjectForRule(matchedRule.get(), styleResolver, element);
+        RefPtr ruleObject = buildObjectForRule(matchedRule.ptr(), styleResolver, element);
         if (!ruleObject)
             continue;
 

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.h
@@ -179,7 +179,7 @@ private:
 
     RefPtr<Inspector::Protocol::CSS::CSSRule> buildObjectForRule(const StyleRule*, Style::Resolver&, Element&);
     RefPtr<Inspector::Protocol::CSS::CSSRule> buildObjectForRule(CSSStyleRule*);
-    Ref<JSON::ArrayOf<Inspector::Protocol::CSS::RuleMatch>> buildArrayForMatchedRuleList(const Vector<RefPtr<const StyleRule>>&, Style::Resolver&, Element&, std::optional<Style::PseudoElementIdentifier>);
+    Ref<JSON::ArrayOf<Inspector::Protocol::CSS::RuleMatch>> buildArrayForMatchedRuleList(const Vector<Ref<const StyleRule>>&, Style::Resolver&, Element&, std::optional<Style::PseudoElementIdentifier>);
     RefPtr<Inspector::Protocol::CSS::CSSStyle> buildObjectForAttributesStyle(StyledElement&);
 
     void nodeHasLayoutFlagsChange(Node&);

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -131,7 +131,7 @@ Ref<MatchResult> ElementRuleCollector::releaseMatchResult()
     return WTF::move(m_result);
 }
 
-const Vector<RefPtr<const StyleRule>>& ElementRuleCollector::matchedRuleList() const
+const Vector<Ref<const StyleRule>>& ElementRuleCollector::matchedRuleList() const
 {
     ASSERT(m_mode == SelectorChecker::Mode::CollectingRules);
     return m_matchedRuleList;
@@ -288,7 +288,7 @@ void ElementRuleCollector::transferMatchedRules(DeclarationOrigin declarationOri
             break;
 
         if (m_mode == SelectorChecker::Mode::CollectingRules) {
-            m_matchedRuleList.append(&matchedRule.ruleData->styleRule());
+            m_matchedRuleList.append(matchedRule.ruleData->styleRule());
             continue;
         }
 

--- a/Source/WebCore/style/ElementRuleCollector.h
+++ b/Source/WebCore/style/ElementRuleCollector.h
@@ -68,7 +68,7 @@ public:
     const MatchResult& matchResult() const;
     Ref<MatchResult> releaseMatchResult();
 
-    const Vector<RefPtr<const StyleRule>>& matchedRuleList() const;
+    const Vector<Ref<const StyleRule>>& matchedRuleList() const;
 
     void clearMatchedRules();
 
@@ -133,7 +133,7 @@ private:
     size_t m_matchedRuleTransferIndex { 0 };
 
     // Output.
-    Vector<RefPtr<const StyleRule>> m_matchedRuleList;
+    Vector<Ref<const StyleRule>> m_matchedRuleList;
     Ref<MatchResult> m_result;
     Relations m_styleRelations;
     EnumSet<PseudoElementType> m_matchedPseudoElements;

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -654,12 +654,12 @@ std::unique_ptr<RenderStyle> Resolver::defaultStyleForElement(const Element* ele
     return style;
 }
 
-Vector<RefPtr<const StyleRule>> Resolver::styleRulesForElement(const Element* element, unsigned rulesToInclude)
+Vector<Ref<const StyleRule>> Resolver::styleRulesForElement(const Element* element, unsigned rulesToInclude)
 {
     return pseudoStyleRulesForElement(element, { }, rulesToInclude);
 }
 
-Vector<RefPtr<const StyleRule>> Resolver::pseudoStyleRulesForElement(const Element* element, const std::optional<Style::PseudoElementRequest>& pseudoElementIdentifier, unsigned rulesToInclude)
+Vector<Ref<const StyleRule>> Resolver::pseudoStyleRulesForElement(const Element* element, const std::optional<Style::PseudoElementRequest>& pseudoElementIdentifier, unsigned rulesToInclude)
 {
     if (!element)
         return { };

--- a/Source/WebCore/style/StyleResolver.h
+++ b/Source/WebCore/style/StyleResolver.h
@@ -140,8 +140,8 @@ public:
         AllButEmptyCSSRules = UAAndUserCSSRules | AuthorCSSRules,
         AllCSSRules         = AllButEmptyCSSRules | EmptyCSSRules,
     };
-    Vector<RefPtr<const StyleRule>> styleRulesForElement(const Element*, unsigned rulesToInclude = AllButEmptyCSSRules);
-    Vector<RefPtr<const StyleRule>> pseudoStyleRulesForElement(const Element*, const std::optional<Style::PseudoElementRequest>&, unsigned rulesToInclude = AllButEmptyCSSRules);
+    Vector<Ref<const StyleRule>> styleRulesForElement(const Element*, unsigned rulesToInclude = AllButEmptyCSSRules);
+    Vector<Ref<const StyleRule>> pseudoStyleRulesForElement(const Element*, const std::optional<Style::PseudoElementRequest>&, unsigned rulesToInclude = AllButEmptyCSSRules);
 
     bool hasSelectorForId(const AtomString&) const;
     bool hasSelectorForAttribute(const Element&, const AtomString&) const;

--- a/Source/WebCore/style/StyleScope.h
+++ b/Source/WebCore/style/StyleScope.h
@@ -86,7 +86,7 @@ public:
 
     const Vector<Ref<CSSStyleSheet>>& activeStyleSheets() const { return m_activeStyleSheets; }
 
-    const Vector<RefPtr<StyleSheet>>& styleSheetsForStyleSheetList();
+    const Vector<Ref<StyleSheet>>& styleSheetsForStyleSheetList();
     const Vector<Ref<CSSStyleSheet>> activeStyleSheetsForInspector();
 
     void addStyleSheetCandidateNode(Node&, bool createdByParser);
@@ -201,8 +201,8 @@ private:
     WEBCORE_EXPORT void flushPendingDescendantUpdates();
 
     struct ActiveStyleSheetCollection {
-        Vector<RefPtr<StyleSheet>> activeStyleSheets;
-        Vector<RefPtr<StyleSheet>> styleSheetsForStyleSheetList;
+        Vector<Ref<StyleSheet>> activeStyleSheets;
+        Vector<Ref<StyleSheet>> styleSheetsForStyleSheetList;
     };
 
     ActiveStyleSheetCollection collectActiveStyleSheets();
@@ -243,7 +243,7 @@ private:
 
     RefPtr<Resolver> m_resolver;
 
-    Vector<RefPtr<StyleSheet>> m_styleSheetsForStyleSheetList;
+    Vector<Ref<StyleSheet>> m_styleSheetsForStyleSheetList;
     Vector<Ref<CSSStyleSheet>> m_activeStyleSheets;
 
     mutable RefPtr<RuleSet> m_dynamicViewTransitionsStyle;

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -1932,9 +1932,9 @@ static Vector<Function<void ()>>& postResolutionCallbackQueue()
     return vector;
 }
 
-static Vector<RefPtr<Frame>>& memoryCacheClientCallsResumeQueue()
+static Vector<Ref<Frame>>& memoryCacheClientCallsResumeQueue()
 {
-    static NeverDestroyed<Vector<RefPtr<Frame>>> vector;
+    static NeverDestroyed<Vector<Ref<Frame>>> vector;
     return vector;
 }
 
@@ -1952,7 +1952,7 @@ static void suspendMemoryCacheClientCalls(Document& document)
     page->setMemoryCacheClientCallsEnabled(false);
 
     if (RefPtr mainFrame = page->mainFrame())
-        memoryCacheClientCallsResumeQueue().append(mainFrame);
+        memoryCacheClientCallsResumeQueue().append(mainFrame.releaseNonNull());
 }
 
 static unsigned resolutionNestingDepth;


### PR DESCRIPTION
#### 128955a8f93b8d4373f2f74a3cfe3fdab1ff47a2
<pre>
Reduce usage of RefPtr in favor of Ref in WebCore/style
<a href="https://bugs.webkit.org/show_bug.cgi?id=305263">https://bugs.webkit.org/show_bug.cgi?id=305263</a>

Reviewed by Darin Adler.

Improves code clarity.

Canonical link: <a href="https://commits.webkit.org/305445@main">https://commits.webkit.org/305445@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca346464cdac04d468ac080126f3e281568f0a2e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138450 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10815 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49860 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146534 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91425 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140324 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11519 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10970 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105934 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77285 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3d65155f-68c4-488a-a7b7-dbaf61f3b6e0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141397 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8651 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124118 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86781 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5d1f151b-8d1d-4750-a436-2d74bfd50f3d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8238 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6008 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6826 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117658 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42317 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149254 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10497 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42874 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114333 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10514 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8876 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114674 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8329 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120404 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65383 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21322 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10545 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38337 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10280 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74149 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10484 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10335 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->