### PR TITLE
Replace RefPtr usage in Vector with Ref in WebCore/page

### DIFF
--- a/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
@@ -127,7 +127,7 @@ const Vector<Ref<SpeechSynthesisVoice>>& SpeechSynthesis::getVoices()
     RefPtr speechSynthesisClient = m_speechSynthesisClient.get();
     auto& voiceList = speechSynthesisClient ? speechSynthesisClient->voiceList() : ensureProtectedPlatformSpeechSynthesizer()->voiceList();
     m_voiceList = voiceList.map([](auto& voice) {
-        return SpeechSynthesisVoice::create(Ref { *voice }.get());
+        return SpeechSynthesisVoice::create(Ref { voice });
     });
 
     return *m_voiceList;

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -956,7 +956,7 @@ struct AwaitingPromiseData : public RefCounted<AwaitingPromiseData> {
 };
 
 // https://webidl.spec.whatwg.org/#wait-for-all
-static void waitForAllPromises(Document& document, const Vector<RefPtr<DOMPromise>>& promises, Function<void()>&& fulfilledCallback, Function<void(JSC::JSValue)>&& rejectionCallback)
+static void waitForAllPromises(Document& document, const Vector<Ref<DOMPromise>>& promises, Function<void()>&& fulfilledCallback, Function<void(JSC::JSValue)>&& rejectionCallback)
 {
     if (promises.isEmpty()) {
         document.checkedEventLoop()->queueMicrotask(WTF::move(fulfilledCallback));
@@ -1162,12 +1162,12 @@ Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavi
     }
 
     if (endResultIsSameDocument) {
-        Vector<RefPtr<DOMPromise>> promiseList;
+        Vector<Ref<DOMPromise>> promiseList;
 
         for (auto& handler : event->handlers()) {
             auto callbackResult = handler->invoke();
             if (callbackResult.type() != CallbackResultType::UnableToExecute) {
-                auto promise = callbackResult.releaseReturnValue();
+                Ref promise = callbackResult.releaseReturnValue().releaseNonNull();
                 // Because rejection is reported as `navigateerror` event, we can mark this as handled.
                 if (!promise->isSuspended())
                     promise->markAsHandled();

--- a/Source/WebCore/page/PageGroupLoadDeferrer.cpp
+++ b/Source/WebCore/page/PageGroupLoadDeferrer.cpp
@@ -42,7 +42,7 @@ PageGroupLoadDeferrer::PageGroupLoadDeferrer(Page& page, bool deferSelf)
         auto* localMainFrame = dynamicDowncast<LocalFrame>(otherPage.mainFrame());
         if (!localMainFrame)
             continue;
-        m_deferredFrames.append(localMainFrame);
+        m_deferredFrames.append(*localMainFrame);
 
         // This code is not logically part of load deferring, but we do not want JS code executed beneath modal
         // windows or sheets, which is exactly when PageGroupLoadDeferrer is used.

--- a/Source/WebCore/page/PageGroupLoadDeferrer.h
+++ b/Source/WebCore/page/PageGroupLoadDeferrer.h
@@ -34,7 +34,7 @@ public:
     ~PageGroupLoadDeferrer();
 
 private:
-    Vector<RefPtr<LocalFrame>, 16> m_deferredFrames;
+    Vector<Ref<LocalFrame>, 16> m_deferredFrames;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/PageOverlayController.cpp
+++ b/Source/WebCore/page/PageOverlayController.cpp
@@ -201,7 +201,7 @@ void PageOverlayController::installPageOverlay(PageOverlay& overlay, PageOverlay
     if (m_pageOverlays.contains(&overlay))
         return;
 
-    m_pageOverlays.append(&overlay);
+    m_pageOverlays.append(overlay);
 
     auto layerType = (overlay.alwaysTileOverlayLayer() == PageOverlay::AlwaysTileOverlayLayer::Yes) ? GraphicsLayer::Type::TiledBacking : GraphicsLayer::Type::Normal;
     Ref layer = GraphicsLayer::create(protectedPage()->chrome().client().graphicsLayerFactory(), *this, layerType);
@@ -364,7 +364,7 @@ bool PageOverlayController::handleMouseEvent(const PlatformMouseEvent& mouseEven
         return false;
 
     for (auto it = m_pageOverlays.rbegin(), end = m_pageOverlays.rend(); it != end; ++it) {
-        if (RefPtr { *it }->mouseEvent(mouseEvent))
+        if (Ref { *it }->mouseEvent(mouseEvent))
             return true;
     }
 
@@ -377,7 +377,7 @@ bool PageOverlayController::copyAccessibilityAttributeStringValueForPoint(String
         return false;
 
     for (auto it = m_pageOverlays.rbegin(), end = m_pageOverlays.rend(); it != end; ++it) {
-        if (RefPtr { *it }->copyAccessibilityAttributeStringValueForPoint(attribute, parameter, value))
+        if (Ref { *it }->copyAccessibilityAttributeStringValueForPoint(attribute, parameter, value))
             return true;
     }
 
@@ -390,10 +390,10 @@ bool PageOverlayController::copyAccessibilityAttributeBoolValueForPoint(String a
         return false;
 
     for (auto it = m_pageOverlays.rbegin(), end = m_pageOverlays.rend(); it != end; ++it) {
-        if (RefPtr { *it }->copyAccessibilityAttributeBoolValueForPoint(attribute, parameter, value))
+        if (Ref { *it }->copyAccessibilityAttributeBoolValueForPoint(attribute, parameter, value))
             return true;
     }
-    
+
     return false;
 }
 
@@ -403,7 +403,7 @@ Vector<String> PageOverlayController::copyAccessibilityAttributesNames(bool para
         return { };
 
     for (auto it = m_pageOverlays.rbegin(), end = m_pageOverlays.rend(); it != end; ++it) {
-        Vector<String> names = RefPtr { *it }->copyAccessibilityAttributeNames(parameterizedNames);
+        Vector<String> names = Ref { *it }->copyAccessibilityAttributeNames(parameterizedNames);
         if (!names.isEmpty())
             return names;
     }

--- a/Source/WebCore/page/PageOverlayController.h
+++ b/Source/WebCore/page/PageOverlayController.h
@@ -53,7 +53,7 @@ public:
     GraphicsLayer& layerWithViewOverlays();
     Ref<GraphicsLayer> protectedLayerWithViewOverlays();
 
-    const Vector<RefPtr<PageOverlay>>& pageOverlays() const { return m_pageOverlays; }
+    const Vector<Ref<PageOverlay>>& pageOverlays() const { return m_pageOverlays; }
 
     WEBCORE_EXPORT void installPageOverlay(PageOverlay&, PageOverlay::FadeMode);
     WEBCORE_EXPORT void uninstallPageOverlay(PageOverlay&, PageOverlay::FadeMode);
@@ -112,7 +112,7 @@ private:
     RefPtr<GraphicsLayer> m_viewOverlayRootLayer;
 
     WeakHashMap<PageOverlay, Ref<GraphicsLayer>> m_overlayGraphicsLayers;
-    Vector<RefPtr<PageOverlay>> m_pageOverlays;
+    Vector<Ref<PageOverlay>> m_pageOverlays;
     bool m_initialized { false };
 };
 

--- a/Source/WebCore/page/SpeechSynthesisClient.h
+++ b/Source/WebCore/page/SpeechSynthesisClient.h
@@ -42,7 +42,7 @@ public:
     virtual void setObserver(WeakPtr<SpeechSynthesisClientObserver>) = 0;
     virtual WeakPtr<SpeechSynthesisClientObserver> observer() const = 0;
     
-    virtual const Vector<RefPtr<PlatformSpeechSynthesisVoice>>& voiceList() = 0;
+    virtual const Vector<Ref<PlatformSpeechSynthesisVoice>>& voiceList() = 0;
     virtual void speak(RefPtr<PlatformSpeechSynthesisUtterance>) = 0;
     virtual void cancel() = 0;
     virtual void pause() = 0;

--- a/Source/WebCore/platform/PlatformSpeechSynthesizer.cpp
+++ b/Source/WebCore/platform/PlatformSpeechSynthesizer.cpp
@@ -33,7 +33,7 @@ namespace WebCore {
     
 WTF_MAKE_TZONE_ALLOCATED_IMPL(PlatformSpeechSynthesizer);
 
-const Vector<RefPtr<PlatformSpeechSynthesisVoice>>& PlatformSpeechSynthesizer::voiceList() const
+const Vector<Ref<PlatformSpeechSynthesisVoice>>& PlatformSpeechSynthesizer::voiceList() const
 {
     if (!m_voiceListIsInitialized) {
         ASSERT(m_voiceList.isEmpty());

--- a/Source/WebCore/platform/PlatformSpeechSynthesizer.h
+++ b/Source/WebCore/platform/PlatformSpeechSynthesizer.h
@@ -77,7 +77,7 @@ public:
     // Seems wasteful. Would be nice to find a better way.
     WEBCORE_EXPORT virtual ~PlatformSpeechSynthesizer();
 
-    const Vector<RefPtr<PlatformSpeechSynthesisVoice>>& voiceList() const;
+    const Vector<Ref<PlatformSpeechSynthesisVoice>>& voiceList() const;
     virtual void speak(RefPtr<PlatformSpeechSynthesisUtterance>&&);
     virtual void pause();
     virtual void resume();
@@ -89,7 +89,7 @@ public:
 
 protected:
     explicit PlatformSpeechSynthesizer(PlatformSpeechSynthesizerClient&);
-    Vector<RefPtr<PlatformSpeechSynthesisVoice>> m_voiceList;
+    Vector<Ref<PlatformSpeechSynthesisVoice>> m_voiceList;
 
 private:
     virtual void initializeVoiceList();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechSynthesisClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechSynthesisClient.cpp
@@ -44,7 +44,7 @@ WebSpeechSynthesisClient::WebSpeechSynthesisClient(WebPage& page)
 {
 }
 
-const Vector<RefPtr<WebCore::PlatformSpeechSynthesisVoice>>& WebSpeechSynthesisClient::voiceList()
+const Vector<Ref<WebCore::PlatformSpeechSynthesisVoice>>& WebSpeechSynthesisClient::voiceList()
 {
     RefPtr page = m_page.get();
     if (!page) {
@@ -58,7 +58,7 @@ const Vector<RefPtr<WebCore::PlatformSpeechSynthesisVoice>>& WebSpeechSynthesisC
     auto sendResult = page->sendSync(Messages::WebPageProxy::SpeechSynthesisVoiceList());
     auto [voiceList] = sendResult.takeReplyOr(Vector<WebSpeechSynthesisVoice> { });
 
-    m_voices = voiceList.map([](auto& voice) -> RefPtr<WebCore::PlatformSpeechSynthesisVoice> {
+    m_voices = voiceList.map([](auto& voice) {
         return WebCore::PlatformSpeechSynthesisVoice::create(voice.voiceURI, voice.name, voice.lang, voice.localService, voice.defaultLang);
     });
     return m_voices;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechSynthesisClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechSynthesisClient.h
@@ -50,7 +50,7 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
-    const Vector<RefPtr<WebCore::PlatformSpeechSynthesisVoice>>& voiceList() override;
+    const Vector<Ref<WebCore::PlatformSpeechSynthesisVoice>>& voiceList() override;
     void speak(RefPtr<WebCore::PlatformSpeechSynthesisUtterance>) override;
     void cancel() override;
     void pause() override;
@@ -67,7 +67,7 @@ private:
     
     WeakPtr<WebPage> m_page;
     WeakPtr<WebCore::SpeechSynthesisClientObserver> m_observer;
-    Vector<RefPtr<WebCore::PlatformSpeechSynthesisVoice>> m_voices;
+    Vector<Ref<WebCore::PlatformSpeechSynthesisVoice>> m_voices;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -795,7 +795,7 @@ void WebPage::performImmediateActionHitTestAtLocation(WebCore::FrameIdentifier f
 
     bool pageOverlayDidOverrideDataDetectors = false;
     for (auto& overlay : corePage()->pageOverlayController().pageOverlays()) {
-        RefPtr webOverlay = WebPageOverlay::fromCoreOverlay(*overlay);
+        RefPtr webOverlay = WebPageOverlay::fromCoreOverlay(overlay);
         if (!webOverlay)
             continue;
 
@@ -895,7 +895,7 @@ void WebPage::dataDetectorsDidPresentUI(PageOverlay::PageOverlayID overlayID)
 {
     for (const auto& overlay : corePage()->pageOverlayController().pageOverlays()) {
         if (overlay->pageOverlayID() == overlayID) {
-            if (RefPtr webOverlay = WebPageOverlay::fromCoreOverlay(*overlay))
+            if (RefPtr webOverlay = WebPageOverlay::fromCoreOverlay(overlay))
                 webOverlay->dataDetectorsDidPresentUI();
             return;
         }
@@ -906,7 +906,7 @@ void WebPage::dataDetectorsDidChangeUI(PageOverlay::PageOverlayID overlayID)
 {
     for (const auto& overlay : corePage()->pageOverlayController().pageOverlays()) {
         if (overlay->pageOverlayID() == overlayID) {
-            if (RefPtr webOverlay = WebPageOverlay::fromCoreOverlay(*overlay))
+            if (RefPtr webOverlay = WebPageOverlay::fromCoreOverlay(overlay))
                 webOverlay->dataDetectorsDidChangeUI();
             return;
         }
@@ -923,7 +923,7 @@ void WebPage::dataDetectorsDidHideUI(PageOverlay::PageOverlayID overlayID)
 
     for (const auto& overlay : corePage()->pageOverlayController().pageOverlays()) {
         if (overlay->pageOverlayID() == overlayID) {
-            if (RefPtr webOverlay = WebPageOverlay::fromCoreOverlay(*overlay))
+            if (RefPtr webOverlay = WebPageOverlay::fromCoreOverlay(overlay))
                 webOverlay->dataDetectorsDidHideUI();
             return;
         }


### PR DESCRIPTION
#### 79f4f7111f93963195bfcf973b2ea16ccffeda89
<pre>
Replace RefPtr usage in Vector with Ref in WebCore/page
<a href="https://bugs.webkit.org/show_bug.cgi?id=305267">https://bugs.webkit.org/show_bug.cgi?id=305267</a>

Reviewed by Darin Adler.

Improves clarity.

Canonical link: <a href="https://commits.webkit.org/305446@main">https://commits.webkit.org/305446@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5545b3dc0fa1610ed2218b152883e309411e2e9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138452 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10817 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49862 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146536 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91427 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d12e53ea-ab97-465b-bed5-e4fff7cf83fa) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140326 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11521 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10972 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105936 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77288 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/369c388e-e0d2-4059-9f11-af12a21cba1b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141399 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8649 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124114 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86783 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/779706e1-53b3-4175-aea6-55a80b948ca8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8236 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6010 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6828 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117656 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42313 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149256 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10499 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42870 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114349 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10516 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8878 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114677 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8330 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120400 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65385 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21323 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10547 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38333 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10282 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74151 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10486 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10337 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->