### PR TITLE
Drop WTF WARN_UNUSED_RETURN and directly use C++17 [[nodiscard]]

### DIFF
--- a/Source/JavaScriptCore/API/JSRetainPtr.h
+++ b/Source/JavaScriptCore/API/JSRetainPtr.h
@@ -55,7 +55,7 @@ public:
     T get() const { return m_ptr; }
     
     void clear();
-    WARN_UNUSED_RETURN T leakRef();
+    [[nodiscard]] T leakRef();
 
     T operator->() const { return m_ptr; }
     

--- a/Source/JavaScriptCore/assembler/AbstractMacroAssembler.h
+++ b/Source/JavaScriptCore/assembler/AbstractMacroAssembler.h
@@ -1171,7 +1171,7 @@ protected:
 
         ALWAYS_INLINE RegisterID registerIDNoInvalidate() { return m_registerID; }
 
-        WARN_UNUSED_RETURN bool value(intptr_t& value)
+        [[nodiscard]] bool value(intptr_t& value)
         {
             value = m_value;
             return m_masm->isTempRegisterValid(m_validBit);

--- a/Source/JavaScriptCore/bytecode/ArrayAllocationProfile.h
+++ b/Source/JavaScriptCore/bytecode/ArrayAllocationProfile.h
@@ -135,7 +135,7 @@ private:
         IndexingType indexingType() const { return m_bits >> indexingTypeShift; }
         unsigned vectorLength() const { return m_bits & vectorLengthMask; }
 
-        WARN_UNUSED_RETURN IndexingTypeAndVectorLength withIndexingType(IndexingType indexingType)
+        [[nodiscard]] IndexingTypeAndVectorLength withIndexingType(IndexingType indexingType)
         {
             return IndexingTypeAndVectorLength(indexingType, vectorLength());
         }

--- a/Source/JavaScriptCore/heap/Weak.h
+++ b/Source/JavaScriptCore/heap/Weak.h
@@ -81,7 +81,7 @@ public:
 
     inline explicit operator bool() const;
 
-    WARN_UNUSED_RETURN inline WeakImpl* leakImpl();
+    [[nodiscard]] inline WeakImpl* leakImpl();
     WeakImpl* unsafeImpl() const { return impl(); }
     void clear();
 

--- a/Source/JavaScriptCore/jit/RegisterSet.h
+++ b/Source/JavaScriptCore/jit/RegisterSet.h
@@ -136,9 +136,9 @@ public:
         return *this;
     }
 
-    WARN_UNUSED_RETURN inline constexpr RegisterSet buildAndValidate() const;
-    WARN_UNUSED_RETURN inline constexpr RegisterSet buildWithLowerBits() const;
-    WARN_UNUSED_RETURN inline constexpr ScalarRegisterSet buildScalarRegisterSet() const;
+    [[nodiscard]] inline constexpr RegisterSet buildAndValidate() const;
+    [[nodiscard]] inline constexpr RegisterSet buildWithLowerBits() const;
+    [[nodiscard]] inline constexpr ScalarRegisterSet buildScalarRegisterSet() const;
     inline constexpr size_t numberOfSetRegisters() const;
     inline size_t numberOfSetGPRs() const;
     inline size_t numberOfSetFPRs() const;
@@ -314,7 +314,7 @@ public:
         return *this;
     }
 
-    WARN_UNUSED_RETURN inline constexpr ScalarRegisterSet buildScalarRegisterSet() const;
+    [[nodiscard]] inline constexpr ScalarRegisterSet buildScalarRegisterSet() const;
 
     template<typename Func>
     inline constexpr void forEach(const Func& func) const
@@ -478,7 +478,7 @@ public:
     inline uint64_t bitsForDebugging() const { return m_bits.storage()[0]; }
     friend constexpr bool operator==(const ScalarRegisterSet&, const ScalarRegisterSet&) = default;
 
-    WARN_UNUSED_RETURN inline constexpr RegisterSet toRegisterSet() const
+    [[nodiscard]] inline constexpr RegisterSet toRegisterSet() const
     {
         RegisterSet result;
         m_bits.forEachSetBit(

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.cpp
@@ -105,7 +105,7 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayConstructorFromBase64, (JSGlobalObject* globa
 }
 
 template<typename CharacterType>
-WARN_UNUSED_RETURN inline static size_t decodeHexImpl(std::span<CharacterType> span, std::span<uint8_t> result)
+[[nodiscard]] inline static size_t decodeHexImpl(std::span<CharacterType> span, std::span<uint8_t> result)
 {
     ASSERT(span.size() == result.size() * 2);
 
@@ -200,12 +200,12 @@ WARN_UNUSED_RETURN inline static size_t decodeHexImpl(std::span<CharacterType> s
     return WTF::notFound;
 }
 
-WARN_UNUSED_RETURN size_t decodeHex(std::span<const Latin1Character> span, std::span<uint8_t> result)
+[[nodiscard]] size_t decodeHex(std::span<const Latin1Character> span, std::span<uint8_t> result)
 {
     return decodeHexImpl(span, result);
 }
 
-WARN_UNUSED_RETURN size_t decodeHex(std::span<const char16_t> span, std::span<uint8_t> result)
+[[nodiscard]] size_t decodeHex(std::span<const char16_t> span, std::span<uint8_t> result)
 {
     return decodeHexImpl(span, result);
 }

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.h
@@ -150,7 +150,7 @@ private:
 JSC_DECLARE_HOST_FUNCTION(uint8ArrayConstructorFromBase64);
 JSC_DECLARE_HOST_FUNCTION(uint8ArrayConstructorFromHex);
 
-WARN_UNUSED_RETURN size_t decodeHex(std::span<const Latin1Character>, std::span<uint8_t> result);
-WARN_UNUSED_RETURN size_t decodeHex(std::span<const char16_t>, std::span<uint8_t> result);
+[[nodiscard]] size_t decodeHex(std::span<const Latin1Character>, std::span<uint8_t> result);
+[[nodiscard]] size_t decodeHex(std::span<const char16_t>, std::span<uint8_t> result);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSObject.h
+++ b/Source/JavaScriptCore/runtime/JSObject.h
@@ -1028,7 +1028,7 @@ protected:
         
     // Call this if you want setIndexQuickly to succeed and you're sure that
     // the array is contiguous.
-    WARN_UNUSED_RETURN bool ensureLength(VM& vm, unsigned length)
+    [[nodiscard]] bool ensureLength(VM& vm, unsigned length)
     {
         RELEASE_ASSERT(length <= MAX_STORAGE_VECTOR_LENGTH);
         ASSERT(hasContiguous(indexingType()) || hasInt32(indexingType()) || hasDouble(indexingType()) || hasUndecided(indexingType()));

--- a/Source/JavaScriptCore/runtime/PropertyTable.h
+++ b/Source/JavaScriptCore/runtime/PropertyTable.h
@@ -115,7 +115,7 @@ public:
     // Find a value in the table.
     std::tuple<PropertyOffset, unsigned> get(const KeyType&);
     // Add a value to the table
-    WARN_UNUSED_RETURN std::tuple<PropertyOffset, unsigned, bool> add(VM&, const ValueType& entry);
+    [[nodiscard]] std::tuple<PropertyOffset, unsigned, bool> add(VM&, const ValueType& entry);
     // Remove a value from the table.
     std::tuple<PropertyOffset, unsigned> take(VM&, const KeyType&);
     PropertyOffset updateAttributeIfExists(const KeyType&, unsigned attributes);
@@ -355,7 +355,7 @@ inline std::tuple<PropertyOffset, unsigned> PropertyTable::get(const KeyType& ke
     return std::tuple { result.offset, result.attributes };
 }
 
-WARN_UNUSED_RETURN inline std::tuple<PropertyOffset, unsigned, bool> PropertyTable::add(VM& vm, const ValueType& entry)
+[[nodiscard]] inline std::tuple<PropertyOffset, unsigned, bool> PropertyTable::add(VM& vm, const ValueType& entry)
 {
     ASSERT(!m_deletedOffsets || !m_deletedOffsets->contains(entry.offset()));
 

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -836,7 +836,7 @@ PartialResult BBQJIT::addLocal(Type type, uint32_t numberOfLocals)
 
 // Tables
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addTableSet(unsigned tableIndex, Value index, Value value)
+[[nodiscard]] PartialResult BBQJIT::addTableSet(unsigned tableIndex, Value index, Value value)
 {
     // FIXME: Emit this inline <https://bugs.webkit.org/show_bug.cgi?id=198506>.
     ASSERT(index.type() == TypeKind::I32);
@@ -861,7 +861,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addTableSet(unsigned tableIndex, Value 
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addTableInit(unsigned elementIndex, unsigned tableIndex, ExpressionType dstOffset, ExpressionType srcOffset, ExpressionType length)
+[[nodiscard]] PartialResult BBQJIT::addTableInit(unsigned elementIndex, unsigned tableIndex, ExpressionType dstOffset, ExpressionType srcOffset, ExpressionType length)
 {
     ASSERT(dstOffset.type() == TypeKind::I32);
     ASSERT(srcOffset.type() == TypeKind::I32);
@@ -888,7 +888,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addTableInit(unsigned elementIndex, uns
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addElemDrop(unsigned elementIndex)
+[[nodiscard]] PartialResult BBQJIT::addElemDrop(unsigned elementIndex)
 {
     Vector<Value, 8> arguments = {
         instanceValue(),
@@ -900,7 +900,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addElemDrop(unsigned elementIndex)
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addTableSize(unsigned tableIndex, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addTableSize(unsigned tableIndex, Value& result)
 {
     Vector<Value, 8> arguments = {
         instanceValue(),
@@ -913,7 +913,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addTableSize(unsigned tableIndex, Value
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addTableGrow(unsigned tableIndex, Value fill, Value delta, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addTableGrow(unsigned tableIndex, Value fill, Value delta, Value& result)
 {
     ASSERT(delta.type() == TypeKind::I32);
 
@@ -929,7 +929,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addTableGrow(unsigned tableIndex, Value
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addTableFill(unsigned tableIndex, Value offset, Value fill, Value count)
+[[nodiscard]] PartialResult BBQJIT::addTableFill(unsigned tableIndex, Value offset, Value fill, Value count)
 {
     ASSERT(offset.type() == TypeKind::I32);
     ASSERT(count.type() == TypeKind::I32);
@@ -952,7 +952,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addTableFill(unsigned tableIndex, Value
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addTableCopy(unsigned dstTableIndex, unsigned srcTableIndex, Value dstOffset, Value srcOffset, Value length)
+[[nodiscard]] PartialResult BBQJIT::addTableCopy(unsigned dstTableIndex, unsigned srcTableIndex, Value dstOffset, Value srcOffset, Value length)
 {
     ASSERT(dstOffset.type() == TypeKind::I32);
     ASSERT(srcOffset.type() == TypeKind::I32);
@@ -979,7 +979,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addTableCopy(unsigned dstTableIndex, un
 
 // Locals
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::getLocal(uint32_t localIndex, Value& result)
+[[nodiscard]] PartialResult BBQJIT::getLocal(uint32_t localIndex, Value& result)
 {
     // Currently, we load locals as temps, which basically prevents register allocation of locals.
     // This is probably not ideal, we have infrastructure to support binding locals to registers, but
@@ -992,7 +992,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::getLocal(uint32_t localIndex, Value& re
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::setLocal(uint32_t localIndex, Value value)
+[[nodiscard]] PartialResult BBQJIT::setLocal(uint32_t localIndex, Value value)
 {
     if (!value.isConst())
         loadIfNecessary(value);
@@ -1004,7 +1004,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::setLocal(uint32_t localIndex, Value val
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::teeLocal(uint32_t localIndex, Value value, Value& result)
+[[nodiscard]] PartialResult BBQJIT::teeLocal(uint32_t localIndex, Value value, Value& result)
 {
     auto type = m_parser->typeOfLocal(localIndex);
     Value local = Value::fromLocal(type.kind, localIndex);
@@ -1098,7 +1098,7 @@ Address BBQJIT::materializePointer(Location pointerLocation, uint32_t uoffset)
     return Address(pointerLocation.asGPR(), static_cast<int32_t>(uoffset));
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addGrowMemory(Value delta, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addGrowMemory(Value delta, Value& result)
 {
     Vector<Value, 8> arguments = { instanceValue(), delta };
     result = topValue(TypeKind::I32);
@@ -1110,7 +1110,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addGrowMemory(Value delta, Value& resul
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addCurrentMemory(Value& result)
+[[nodiscard]] PartialResult BBQJIT::addCurrentMemory(Value& result)
 {
     result = topValue(TypeKind::I32);
     Location resultLocation = allocate(result);
@@ -1126,7 +1126,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addCurrentMemory(Value& result)
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addMemoryFill(Value dstAddress, Value targetValue, Value count)
+[[nodiscard]] PartialResult BBQJIT::addMemoryFill(Value dstAddress, Value targetValue, Value count)
 {
     ASSERT(dstAddress.type() == TypeKind::I32);
     ASSERT(targetValue.type() == TypeKind::I32);
@@ -1149,7 +1149,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addMemoryFill(Value dstAddress, Value t
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addMemoryCopy(Value dstAddress, Value srcAddress, Value count)
+[[nodiscard]] PartialResult BBQJIT::addMemoryCopy(Value dstAddress, Value srcAddress, Value count)
 {
     ASSERT(dstAddress.type() == TypeKind::I32);
     ASSERT(srcAddress.type() == TypeKind::I32);
@@ -1172,7 +1172,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addMemoryCopy(Value dstAddress, Value s
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addMemoryInit(unsigned dataSegmentIndex, Value dstAddress, Value srcAddress, Value length)
+[[nodiscard]] PartialResult BBQJIT::addMemoryInit(unsigned dataSegmentIndex, Value dstAddress, Value srcAddress, Value length)
 {
     ASSERT(dstAddress.type() == TypeKind::I32);
     ASSERT(srcAddress.type() == TypeKind::I32);
@@ -1196,7 +1196,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addMemoryInit(unsigned dataSegmentIndex
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addDataDrop(unsigned dataSegmentIndex)
+[[nodiscard]] PartialResult BBQJIT::addDataDrop(unsigned dataSegmentIndex)
 {
     Vector<Value, 8> arguments = { instanceValue(), Value::fromI32(dataSegmentIndex) };
     emitCCall(&operationWasmDataDrop, arguments);
@@ -1207,7 +1207,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addDataDrop(unsigned dataSegmentIndex)
 
 // Atomics
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::atomicLoad(ExtAtomicOpType loadOp, Type valueType, ExpressionType pointer, ExpressionType& result, uint32_t uoffset)
+[[nodiscard]] PartialResult BBQJIT::atomicLoad(ExtAtomicOpType loadOp, Type valueType, ExpressionType pointer, ExpressionType& result, uint32_t uoffset)
 {
     if (sumOverflows<uint32_t>(uoffset, sizeOfAtomicOpMemoryAccess(loadOp))) [[unlikely]] {
         // FIXME: Same issue as in AirIRGenerator::load(): https://bugs.webkit.org/show_bug.cgi?id=166435
@@ -1222,7 +1222,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::atomicLoad(ExtAtomicOpType loadOp, Type
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::atomicStore(ExtAtomicOpType storeOp, Type valueType, ExpressionType pointer, ExpressionType value, uint32_t uoffset)
+[[nodiscard]] PartialResult BBQJIT::atomicStore(ExtAtomicOpType storeOp, Type valueType, ExpressionType pointer, ExpressionType value, uint32_t uoffset)
 {
     Location valueLocation = locationOf(value);
     if (sumOverflows<uint32_t>(uoffset, sizeOfAtomicOpMemoryAccess(storeOp))) [[unlikely]] {
@@ -1238,7 +1238,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::atomicStore(ExtAtomicOpType storeOp, Ty
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::atomicBinaryRMW(ExtAtomicOpType op, Type valueType, ExpressionType pointer, ExpressionType value, ExpressionType& result, uint32_t uoffset)
+[[nodiscard]] PartialResult BBQJIT::atomicBinaryRMW(ExtAtomicOpType op, Type valueType, ExpressionType pointer, ExpressionType value, ExpressionType& result, uint32_t uoffset)
 {
     Location valueLocation = locationOf(value);
     if (sumOverflows<uint32_t>(uoffset, sizeOfAtomicOpMemoryAccess(op))) [[unlikely]] {
@@ -1256,7 +1256,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::atomicBinaryRMW(ExtAtomicOpType op, Typ
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::atomicCompareExchange(ExtAtomicOpType op, Type valueType, ExpressionType pointer, ExpressionType expected, ExpressionType value, ExpressionType& result, uint32_t uoffset)
+[[nodiscard]] PartialResult BBQJIT::atomicCompareExchange(ExtAtomicOpType op, Type valueType, ExpressionType pointer, ExpressionType expected, ExpressionType value, ExpressionType& result, uint32_t uoffset)
 {
     Location valueLocation = locationOf(value);
     if (sumOverflows<uint32_t>(uoffset, sizeOfAtomicOpMemoryAccess(op))) [[unlikely]] {
@@ -1275,7 +1275,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::atomicCompareExchange(ExtAtomicOpType o
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::atomicWait(ExtAtomicOpType op, ExpressionType pointer, ExpressionType value, ExpressionType timeout, ExpressionType& result, uint32_t uoffset)
+[[nodiscard]] PartialResult BBQJIT::atomicWait(ExtAtomicOpType op, ExpressionType pointer, ExpressionType value, ExpressionType timeout, ExpressionType& result, uint32_t uoffset)
 {
     Vector<Value, 8> arguments = {
         instanceValue(),
@@ -1298,7 +1298,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::atomicWait(ExtAtomicOpType op, Expressi
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::atomicNotify(ExtAtomicOpType op, ExpressionType pointer, ExpressionType count, ExpressionType& result, uint32_t uoffset)
+[[nodiscard]] PartialResult BBQJIT::atomicNotify(ExtAtomicOpType op, ExpressionType pointer, ExpressionType count, ExpressionType& result, uint32_t uoffset)
 {
     Vector<Value, 8> arguments = {
         instanceValue(),
@@ -1316,7 +1316,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::atomicNotify(ExtAtomicOpType op, Expres
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::atomicFence(ExtAtomicOpType, uint8_t)
+[[nodiscard]] PartialResult BBQJIT::atomicFence(ExtAtomicOpType, uint8_t)
 {
     m_jit.memoryFence();
     return { };
@@ -1419,7 +1419,7 @@ FloatingPointRange BBQJIT::lookupTruncationRange(TruncationKind truncationKind)
     return FloatingPointRange { min, max, closedLowerEndpoint };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::truncTrapping(OpType truncationOp, Value operand, Value& result, Type returnType, Type operandType)
+[[nodiscard]] PartialResult BBQJIT::truncTrapping(OpType truncationOp, Value operand, Value& result, Type returnType, Type operandType)
 {
     ScratchScope<0, 2> scratches(*this);
 
@@ -1465,7 +1465,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::truncTrapping(OpType truncationOp, Valu
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::truncSaturated(Ext1OpType truncationOp, Value operand, Value& result, Type returnType, Type operandType)
+[[nodiscard]] PartialResult BBQJIT::truncSaturated(Ext1OpType truncationOp, Value operand, Value& result, Type returnType, Type operandType)
 {
     ScratchScope<0, 2> scratches(*this);
 
@@ -1605,21 +1605,21 @@ void BBQJIT::pushArrayNewFromSegment(ArraySegmentOperation operation, uint32_t t
     emitThrowOnNullReference(exceptionType, resultLocation);
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayNewData(uint32_t typeIndex, uint32_t dataIndex, ExpressionType arraySize, ExpressionType offset, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addArrayNewData(uint32_t typeIndex, uint32_t dataIndex, ExpressionType arraySize, ExpressionType offset, ExpressionType& result)
 {
     pushArrayNewFromSegment(operationWasmArrayNewData, typeIndex, dataIndex, arraySize, offset, ExceptionType::BadArrayNewInitData, result);
     LOG_INSTRUCTION("ArrayNewData", typeIndex, dataIndex, arraySize, offset, RESULT(result));
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayNewElem(uint32_t typeIndex, uint32_t elemSegmentIndex, ExpressionType arraySize, ExpressionType offset, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addArrayNewElem(uint32_t typeIndex, uint32_t elemSegmentIndex, ExpressionType arraySize, ExpressionType offset, ExpressionType& result)
 {
     pushArrayNewFromSegment(operationWasmArrayNewElem, typeIndex, elemSegmentIndex, arraySize, offset, ExceptionType::BadArrayNewInitElem, result);
     LOG_INSTRUCTION("ArrayNewElem", typeIndex, elemSegmentIndex, arraySize, offset, RESULT(result));
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayCopy(uint32_t dstTypeIndex, TypedExpression typedDst, ExpressionType dstOffset, uint32_t srcTypeIndex, TypedExpression typedSrc, ExpressionType srcOffset, ExpressionType size)
+[[nodiscard]] PartialResult BBQJIT::addArrayCopy(uint32_t dstTypeIndex, TypedExpression typedDst, ExpressionType dstOffset, uint32_t srcTypeIndex, TypedExpression typedSrc, ExpressionType srcOffset, ExpressionType size)
 {
     auto dst = typedDst.value();
     auto src = typedSrc.value();
@@ -1664,7 +1664,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayCopy(uint32_t dstTypeIndex, Typ
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayInitElem(uint32_t dstTypeIndex, TypedExpression typedDst, ExpressionType dstOffset, uint32_t srcElementIndex, ExpressionType srcOffset, ExpressionType size)
+[[nodiscard]] PartialResult BBQJIT::addArrayInitElem(uint32_t dstTypeIndex, TypedExpression typedDst, ExpressionType dstOffset, uint32_t srcElementIndex, ExpressionType srcOffset, ExpressionType size)
 {
     auto dst = typedDst.value();
     if (dst.isConst()) {
@@ -1703,7 +1703,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayInitElem(uint32_t dstTypeIndex,
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayInitData(uint32_t dstTypeIndex, TypedExpression typedDst, ExpressionType dstOffset, uint32_t srcDataIndex, ExpressionType srcOffset, ExpressionType size)
+[[nodiscard]] PartialResult BBQJIT::addArrayInitData(uint32_t dstTypeIndex, TypedExpression typedDst, ExpressionType dstOffset, uint32_t srcDataIndex, ExpressionType srcOffset, ExpressionType size)
 {
     auto dst = typedDst.value();
     if (dst.isConst()) {
@@ -1742,7 +1742,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayInitData(uint32_t dstTypeIndex,
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addAnyConvertExtern(ExpressionType reference, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addAnyConvertExtern(ExpressionType reference, ExpressionType& result)
 {
     Vector<Value, 8> arguments = {
         reference
@@ -1754,7 +1754,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addAnyConvertExtern(ExpressionType refe
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addExternConvertAny(ExpressionType reference, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addExternConvertAny(ExpressionType reference, ExpressionType& result)
 {
     auto referenceLocation = reference.isConst() ? Location::none() : loadIfNecessary(reference);
     consume(reference);
@@ -1771,7 +1771,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addExternConvertAny(ExpressionType refe
 }
 
 // Basic operators
-WARN_UNUSED_RETURN PartialResult BBQJIT::addSelect(Value condition, Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addSelect(Value condition, Value lhs, Value rhs, Value& result)
 {
     if (condition.isConst()) {
         Value src = condition.asI32() ? lhs : rhs;
@@ -1845,7 +1845,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addSelect(Value condition, Value lhs, V
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI32Add(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI32Add(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "I32Add", TypeKind::I32,
@@ -1859,7 +1859,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI32Add(Value lhs, Value rhs, Value& 
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Add(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF32Add(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "F32Add", TypeKind::F32,
@@ -1875,7 +1875,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Add(Value lhs, Value rhs, Value& 
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Add(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF64Add(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "F64Add", TypeKind::F64,
@@ -1891,7 +1891,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Add(Value lhs, Value rhs, Value& 
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI32Sub(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI32Sub(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "I32Sub", TypeKind::I32,
@@ -1910,7 +1910,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI32Sub(Value lhs, Value rhs, Value& 
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Sub(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF32Sub(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "F32Sub", TypeKind::F32,
@@ -1933,7 +1933,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Sub(Value lhs, Value rhs, Value& 
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Sub(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF64Sub(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "F64Sub", TypeKind::F64,
@@ -1956,7 +1956,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Sub(Value lhs, Value rhs, Value& 
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI32Mul(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI32Mul(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "I32Mul", TypeKind::I32,
@@ -1974,7 +1974,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI32Mul(Value lhs, Value rhs, Value& 
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Mul(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF32Mul(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "F32Mul", TypeKind::F32,
@@ -1990,7 +1990,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Mul(Value lhs, Value rhs, Value& 
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Mul(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF64Mul(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "F64Mul", TypeKind::F64,
@@ -2045,7 +2045,7 @@ Value BBQJIT::checkConstantDivision(const Value& lhs, const Value& rhs)
     return rhs;
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI32DivS(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI32DivS(Value lhs, Value rhs, Value& result)
 {
     PREPARE_FOR_MOD_OR_DIV;
     EMIT_BINARY(
@@ -2062,7 +2062,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI32DivS(Value lhs, Value rhs, Value&
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64DivS(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64DivS(Value lhs, Value rhs, Value& result)
 {
     PREPARE_FOR_MOD_OR_DIV;
     EMIT_BINARY(
@@ -2079,7 +2079,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI64DivS(Value lhs, Value rhs, Value&
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI32DivU(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI32DivU(Value lhs, Value rhs, Value& result)
 {
     PREPARE_FOR_MOD_OR_DIV;
     EMIT_BINARY(
@@ -2096,7 +2096,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI32DivU(Value lhs, Value rhs, Value&
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64DivU(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64DivU(Value lhs, Value rhs, Value& result)
 {
     PREPARE_FOR_MOD_OR_DIV;
     EMIT_BINARY(
@@ -2113,7 +2113,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI64DivU(Value lhs, Value rhs, Value&
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI32RemS(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI32RemS(Value lhs, Value rhs, Value& result)
 {
     PREPARE_FOR_MOD_OR_DIV;
     EMIT_BINARY(
@@ -2130,7 +2130,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI32RemS(Value lhs, Value rhs, Value&
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64RemS(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64RemS(Value lhs, Value rhs, Value& result)
 {
     PREPARE_FOR_MOD_OR_DIV;
     EMIT_BINARY(
@@ -2147,7 +2147,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI64RemS(Value lhs, Value rhs, Value&
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI32RemU(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI32RemU(Value lhs, Value rhs, Value& result)
 {
     PREPARE_FOR_MOD_OR_DIV;
     EMIT_BINARY(
@@ -2164,7 +2164,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI32RemU(Value lhs, Value rhs, Value&
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64RemU(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64RemU(Value lhs, Value rhs, Value& result)
 {
     PREPARE_FOR_MOD_OR_DIV;
     EMIT_BINARY(
@@ -2181,7 +2181,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI64RemU(Value lhs, Value rhs, Value&
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Div(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF32Div(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "F32Div", TypeKind::F32,
@@ -2197,7 +2197,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Div(Value lhs, Value rhs, Value& 
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Div(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF64Div(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "F64Div", TypeKind::F64,
@@ -2281,7 +2281,7 @@ void BBQJIT::emitFloatingPointMinOrMax(FPRReg left, FPRReg right, FPRReg result)
 #endif
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Min(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF32Min(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "F32Min", TypeKind::F32,
@@ -2297,7 +2297,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Min(Value lhs, Value rhs, Value& 
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Min(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF64Min(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "F64Min", TypeKind::F64,
@@ -2313,7 +2313,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Min(Value lhs, Value rhs, Value& 
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Max(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF32Max(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "F32Max", TypeKind::F32,
@@ -2329,7 +2329,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Max(Value lhs, Value rhs, Value& 
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Max(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF64Max(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "F64Max", TypeKind::F64,
@@ -2345,7 +2345,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Max(Value lhs, Value rhs, Value& 
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI32And(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI32And(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "I32And", TypeKind::I32,
@@ -2359,7 +2359,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI32And(Value lhs, Value rhs, Value& 
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI32Xor(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI32Xor(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "I32Xor", TypeKind::I32,
@@ -2373,7 +2373,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI32Xor(Value lhs, Value rhs, Value& 
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI32Or(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI32Or(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "I32Or", TypeKind::I32,
@@ -2395,7 +2395,7 @@ void BBQJIT::moveShiftAmountIfNecessary(Location& rhsLocation)
     }
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI32Shl(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI32Shl(Value lhs, Value rhs, Value& result)
 {
     PREPARE_FOR_SHIFT;
     EMIT_BINARY(
@@ -2417,7 +2417,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI32Shl(Value lhs, Value rhs, Value& 
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI32ShrS(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI32ShrS(Value lhs, Value rhs, Value& result)
 {
     PREPARE_FOR_SHIFT;
     EMIT_BINARY(
@@ -2439,7 +2439,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI32ShrS(Value lhs, Value rhs, Value&
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI32ShrU(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI32ShrU(Value lhs, Value rhs, Value& result)
 {
     PREPARE_FOR_SHIFT;
     EMIT_BINARY(
@@ -2461,7 +2461,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI32ShrU(Value lhs, Value rhs, Value&
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI32Rotl(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI32Rotl(Value lhs, Value rhs, Value& result)
 {
     PREPARE_FOR_SHIFT;
     EMIT_BINARY(
@@ -2501,7 +2501,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI32Rotl(Value lhs, Value rhs, Value&
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI32Rotr(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI32Rotr(Value lhs, Value rhs, Value& result)
 {
     PREPARE_FOR_SHIFT;
     EMIT_BINARY(
@@ -2523,7 +2523,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI32Rotr(Value lhs, Value rhs, Value&
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI32Clz(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI32Clz(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I32Clz", TypeKind::I32,
@@ -2534,7 +2534,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI32Clz(Value operand, Value& result)
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI32Ctz(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI32Ctz(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I32Ctz", TypeKind::I32,
@@ -2565,102 +2565,102 @@ PartialResult BBQJIT::emitCompareI32(const char* opcode, Value& lhs, Value& rhs,
 #define RELOP_AS_LAMBDA(op) [](auto lhs, auto rhs) -> auto { return lhs op rhs; }
 #define TYPED_RELOP_AS_LAMBDA(type, op) [](auto lhs, auto rhs) -> auto { return static_cast<type>(lhs) op static_cast<type>(rhs); }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI32Eq(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI32Eq(Value lhs, Value rhs, Value& result)
 {
     return emitCompareI32("I32Eq", lhs, rhs, result, RelationalCondition::Equal, RELOP_AS_LAMBDA( == ));
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Eq(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64Eq(Value lhs, Value rhs, Value& result)
 {
     return emitCompareI64("I64Eq", lhs, rhs, result, RelationalCondition::Equal, RELOP_AS_LAMBDA( == ));
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI32Ne(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI32Ne(Value lhs, Value rhs, Value& result)
 {
     return emitCompareI32("I32Ne", lhs, rhs, result, RelationalCondition::NotEqual, RELOP_AS_LAMBDA( != ));
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Ne(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64Ne(Value lhs, Value rhs, Value& result)
 {
     return emitCompareI64("I64Ne", lhs, rhs, result, RelationalCondition::NotEqual, RELOP_AS_LAMBDA( != ));
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI32LtS(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI32LtS(Value lhs, Value rhs, Value& result)
 {
     return emitCompareI32("I32LtS", lhs, rhs, result, RelationalCondition::LessThan, RELOP_AS_LAMBDA( < ));
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64LtS(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64LtS(Value lhs, Value rhs, Value& result)
 {
     return emitCompareI64("I64LtS", lhs, rhs, result, RelationalCondition::LessThan, RELOP_AS_LAMBDA( < ));
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI32LeS(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI32LeS(Value lhs, Value rhs, Value& result)
 {
     return emitCompareI32("I32LeS", lhs, rhs, result, RelationalCondition::LessThanOrEqual, RELOP_AS_LAMBDA( <= ));
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64LeS(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64LeS(Value lhs, Value rhs, Value& result)
 {
     return emitCompareI64("I64LeS", lhs, rhs, result, RelationalCondition::LessThanOrEqual, RELOP_AS_LAMBDA( <= ));
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI32GtS(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI32GtS(Value lhs, Value rhs, Value& result)
 {
     return emitCompareI32("I32GtS", lhs, rhs, result, RelationalCondition::GreaterThan, RELOP_AS_LAMBDA( > ));
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64GtS(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64GtS(Value lhs, Value rhs, Value& result)
 {
     return emitCompareI64("I64GtS", lhs, rhs, result, RelationalCondition::GreaterThan, RELOP_AS_LAMBDA( > ));
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI32GeS(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI32GeS(Value lhs, Value rhs, Value& result)
 {
     return emitCompareI32("I32GeS", lhs, rhs, result, RelationalCondition::GreaterThanOrEqual, RELOP_AS_LAMBDA( >= ));
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64GeS(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64GeS(Value lhs, Value rhs, Value& result)
 {
     return emitCompareI64("I64GeS", lhs, rhs, result, RelationalCondition::GreaterThanOrEqual, RELOP_AS_LAMBDA( >= ));
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI32LtU(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI32LtU(Value lhs, Value rhs, Value& result)
 {
     return emitCompareI32("I32LtU", lhs, rhs, result, RelationalCondition::Below, TYPED_RELOP_AS_LAMBDA(uint32_t, <));
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64LtU(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64LtU(Value lhs, Value rhs, Value& result)
 {
     return emitCompareI64("I64LtU", lhs, rhs, result, RelationalCondition::Below, TYPED_RELOP_AS_LAMBDA(uint64_t, <));
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI32LeU(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI32LeU(Value lhs, Value rhs, Value& result)
 {
     return emitCompareI32("I32LeU", lhs, rhs, result, RelationalCondition::BelowOrEqual, TYPED_RELOP_AS_LAMBDA(uint32_t, <=));
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64LeU(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64LeU(Value lhs, Value rhs, Value& result)
 {
     return emitCompareI64("I64LeU", lhs, rhs, result, RelationalCondition::BelowOrEqual, TYPED_RELOP_AS_LAMBDA(uint64_t, <=));
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI32GtU(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI32GtU(Value lhs, Value rhs, Value& result)
 {
     return emitCompareI32("I32GtU", lhs, rhs, result, RelationalCondition::Above, TYPED_RELOP_AS_LAMBDA(uint32_t, >));
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64GtU(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64GtU(Value lhs, Value rhs, Value& result)
 {
     return emitCompareI64("I64GtU", lhs, rhs, result, RelationalCondition::Above, TYPED_RELOP_AS_LAMBDA(uint64_t, >));
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI32GeU(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI32GeU(Value lhs, Value rhs, Value& result)
 {
     return emitCompareI32("I32GeU", lhs, rhs, result, RelationalCondition::AboveOrEqual, TYPED_RELOP_AS_LAMBDA(uint32_t, >=));
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64GeU(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64GeU(Value lhs, Value rhs, Value& result)
 {
     return emitCompareI64("I64GeU", lhs, rhs, result, RelationalCondition::AboveOrEqual, TYPED_RELOP_AS_LAMBDA(uint64_t, >=));
 }
@@ -2697,62 +2697,62 @@ PartialResult BBQJIT::emitCompareF64(const char* opcode, Value& lhs, Value& rhs,
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Eq(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF32Eq(Value lhs, Value rhs, Value& result)
 {
     return emitCompareF32("F32Eq", lhs, rhs, result, DoubleCondition::DoubleEqualAndOrdered, RELOP_AS_LAMBDA( == ));
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Eq(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF64Eq(Value lhs, Value rhs, Value& result)
 {
     return emitCompareF64("F64Eq", lhs, rhs, result, DoubleCondition::DoubleEqualAndOrdered, RELOP_AS_LAMBDA( == ));
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Ne(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF32Ne(Value lhs, Value rhs, Value& result)
 {
     return emitCompareF32("F32Ne", lhs, rhs, result, DoubleCondition::DoubleNotEqualOrUnordered, RELOP_AS_LAMBDA( != ));
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Ne(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF64Ne(Value lhs, Value rhs, Value& result)
 {
     return emitCompareF64("F64Ne", lhs, rhs, result, DoubleCondition::DoubleNotEqualOrUnordered, RELOP_AS_LAMBDA( != ));
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Lt(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF32Lt(Value lhs, Value rhs, Value& result)
 {
     return emitCompareF32("F32Lt", lhs, rhs, result, DoubleCondition::DoubleLessThanAndOrdered, RELOP_AS_LAMBDA( < ));
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Lt(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF64Lt(Value lhs, Value rhs, Value& result)
 {
     return emitCompareF64("F64Lt", lhs, rhs, result, DoubleCondition::DoubleLessThanAndOrdered, RELOP_AS_LAMBDA( < ));
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Le(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF32Le(Value lhs, Value rhs, Value& result)
 {
     return emitCompareF32("F32Le", lhs, rhs, result, DoubleCondition::DoubleLessThanOrEqualAndOrdered, RELOP_AS_LAMBDA( <= ));
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Le(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF64Le(Value lhs, Value rhs, Value& result)
 {
     return emitCompareF64("F64Le", lhs, rhs, result, DoubleCondition::DoubleLessThanOrEqualAndOrdered, RELOP_AS_LAMBDA( <= ));
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Gt(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF32Gt(Value lhs, Value rhs, Value& result)
 {
     return emitCompareF32("F32Gt", lhs, rhs, result, DoubleCondition::DoubleGreaterThanAndOrdered, RELOP_AS_LAMBDA( > ));
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Gt(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF64Gt(Value lhs, Value rhs, Value& result)
 {
     return emitCompareF64("F64Gt", lhs, rhs, result, DoubleCondition::DoubleGreaterThanAndOrdered, RELOP_AS_LAMBDA( > ));
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Ge(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF32Ge(Value lhs, Value rhs, Value& result)
 {
     return emitCompareF32("F32Ge", lhs, rhs, result, DoubleCondition::DoubleGreaterThanOrEqualAndOrdered, RELOP_AS_LAMBDA( >= ));
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Ge(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF64Ge(Value lhs, Value rhs, Value& result)
 {
     return emitCompareF64("F64Ge", lhs, rhs, result, DoubleCondition::DoubleGreaterThanOrEqualAndOrdered, RELOP_AS_LAMBDA( >= ));
 }
@@ -2771,7 +2771,7 @@ PartialResult BBQJIT::addI32Extend8S(Value operand, Value& result)
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI32Extend16S(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI32Extend16S(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I32Extend16S", TypeKind::I32,
@@ -2782,7 +2782,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI32Extend16S(Value operand, Value& r
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI32Eqz(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI32Eqz(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I32Eqz", TypeKind::I32,
@@ -2793,7 +2793,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI32Eqz(Value operand, Value& result)
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI32Popcnt(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI32Popcnt(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I32Popcnt", TypeKind::I32,
@@ -2818,7 +2818,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI32Popcnt(Value operand, Value& resu
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Popcnt(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64Popcnt(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I64Popcnt", TypeKind::I64,
@@ -2843,7 +2843,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Popcnt(Value operand, Value& resu
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI32ReinterpretF32(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI32ReinterpretF32(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I32ReinterpretF32", TypeKind::I32,
@@ -2854,7 +2854,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI32ReinterpretF32(Value operand, Val
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF32ReinterpretI32(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF32ReinterpretI32(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F32ReinterpretI32", TypeKind::F32,
@@ -2865,7 +2865,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF32ReinterpretI32(Value operand, Val
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF32DemoteF64(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF32DemoteF64(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F32DemoteF64", TypeKind::F32,
@@ -2876,7 +2876,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF32DemoteF64(Value operand, Value& r
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF64PromoteF32(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF64PromoteF32(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F64PromoteF32", TypeKind::F64,
@@ -2887,7 +2887,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF64PromoteF32(Value operand, Value& 
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Copysign(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF64Copysign(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "F64Copysign", TypeKind::F64,
@@ -2914,7 +2914,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Copysign(Value lhs, Value rhs, Va
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF32ConvertSI32(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF32ConvertSI32(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F32ConvertSI32", TypeKind::F32,
@@ -2925,7 +2925,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF32ConvertSI32(Value operand, Value&
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF64ConvertSI32(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF64ConvertSI32(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F64ConvertSI32", TypeKind::F64,
@@ -2936,7 +2936,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF64ConvertSI32(Value operand, Value&
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Copysign(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF32Copysign(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "F32Copysign", TypeKind::F32,
@@ -2963,7 +2963,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Copysign(Value lhs, Value rhs, Va
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Abs(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF32Abs(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F32Abs", TypeKind::F32,
@@ -2979,7 +2979,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Abs(Value operand, Value& result)
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Abs(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF64Abs(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F64Abs", TypeKind::F64,
@@ -2995,7 +2995,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Abs(Value operand, Value& result)
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Sqrt(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF32Sqrt(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F32Sqrt", TypeKind::F32,
@@ -3006,7 +3006,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Sqrt(Value operand, Value& result
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Sqrt(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF64Sqrt(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F64Sqrt", TypeKind::F64,
@@ -3017,7 +3017,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Sqrt(Value operand, Value& result
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Neg(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF32Neg(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F32Neg", TypeKind::F32,
@@ -3028,7 +3028,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Neg(Value operand, Value& result)
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Neg(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF64Neg(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F64Neg", TypeKind::F64,
@@ -3039,54 +3039,54 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Neg(Value operand, Value& result)
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI32TruncSF32(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI32TruncSF32(Value operand, Value& result)
 {
     return truncTrapping(OpType::I32TruncSF32, operand, result, Types::I32, Types::F32);
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI32TruncSF64(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI32TruncSF64(Value operand, Value& result)
 {
     return truncTrapping(OpType::I32TruncSF64, operand, result, Types::I32, Types::F64);
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI32TruncUF32(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI32TruncUF32(Value operand, Value& result)
 {
     return truncTrapping(OpType::I32TruncUF32, operand, result, Types::I32, Types::F32);
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI32TruncUF64(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI32TruncUF64(Value operand, Value& result)
 {
     return truncTrapping(OpType::I32TruncUF64, operand, result, Types::I32, Types::F64);
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64TruncSF32(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64TruncSF32(Value operand, Value& result)
 {
     return truncTrapping(OpType::I64TruncSF32, operand, result, Types::I64, Types::F32);
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64TruncSF64(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64TruncSF64(Value operand, Value& result)
 {
     return truncTrapping(OpType::I64TruncSF64, operand, result, Types::I64, Types::F64);
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64TruncUF32(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64TruncUF32(Value operand, Value& result)
 {
     return truncTrapping(OpType::I64TruncUF32, operand, result, Types::I64, Types::F32);
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64TruncUF64(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64TruncUF64(Value operand, Value& result)
 {
     return truncTrapping(OpType::I64TruncUF64, operand, result, Types::I64, Types::F64);
 }
 
 // References
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addRefEq(Value ref0, Value ref1, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addRefEq(Value ref0, Value ref1, Value& result)
 {
     return addI64Eq(ref0, ref1, result);
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addRefFunc(FunctionSpaceIndex index, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addRefFunc(FunctionSpaceIndex index, Value& result)
 {
     // FIXME: Emit this inline <https://bugs.webkit.org/show_bug.cgi?id=198506>.
     TypeKind returnType = TypeKind::Ref;
@@ -3123,7 +3123,7 @@ void BBQJIT::emitEntryTierUpCheck()
 }
 
 // Control flow
-WARN_UNUSED_RETURN ControlData BBQJIT::addTopLevel(BlockSignature signature)
+[[nodiscard]] ControlData BBQJIT::addTopLevel(BlockSignature signature)
 {
     if (Options::verboseBBQJITInstructions()) [[unlikely]] {
         auto nameSection = m_info.nameSection;
@@ -3364,7 +3364,7 @@ MacroAssembler::Label BBQJIT::addLoopOSREntrypoint()
     return label;
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addBlock(BlockSignature signature, Stack& enclosingStack, ControlType& result, Stack& newStack)
+[[nodiscard]] PartialResult BBQJIT::addBlock(BlockSignature signature, Stack& enclosingStack, ControlType& result, Stack& newStack)
 {
     result = ControlData(*this, BlockType::Block, signature, currentControlData().enclosedHeight() + currentControlData().implicitSlots() + enclosingStack.size() - signature.m_signature->argumentCount());
     currentControlData().flushAndSingleExit(*this, result, enclosingStack, true, false);
@@ -3520,7 +3520,7 @@ void BBQJIT::emitLoopTierUpCheckAndOSREntryData(const ControlData& data, Stack& 
 #endif
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addLoop(BlockSignature signature, Stack& enclosingStack, ControlType& result, Stack& newStack, uint32_t loopIndex)
+[[nodiscard]] PartialResult BBQJIT::addLoop(BlockSignature signature, Stack& enclosingStack, ControlType& result, Stack& newStack, uint32_t loopIndex)
 {
     result = ControlData(*this, BlockType::Loop, signature, currentControlData().enclosedHeight() + currentControlData().implicitSlots() + enclosingStack.size() - signature.m_signature->argumentCount());
     currentControlData().flushAndSingleExit(*this, result, enclosingStack, true, false);
@@ -3538,7 +3538,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addLoop(BlockSignature signature, Stack
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addIf(Value condition, BlockSignature signature, Stack& enclosingStack, ControlData& result, Stack& newStack)
+[[nodiscard]] PartialResult BBQJIT::addIf(Value condition, BlockSignature signature, Stack& enclosingStack, ControlData& result, Stack& newStack)
 {
     RegisterSet liveScratchGPRs;
     Location conditionLocation;
@@ -3565,7 +3565,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addIf(Value condition, BlockSignature s
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addElse(ControlData& data, Stack& expressionStack)
+[[nodiscard]] PartialResult BBQJIT::addElse(ControlData& data, Stack& expressionStack)
 {
     data.flushAndSingleExit(*this, data, expressionStack, false, true);
     ControlData dataElse(ControlData::UseBlockCallingConventionOfOtherBranch, BlockType::Else, data);
@@ -3590,7 +3590,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addElse(ControlData& data, Stack& expre
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addElseToUnreachable(ControlData& data)
+[[nodiscard]] PartialResult BBQJIT::addElseToUnreachable(ControlData& data)
 {
     // We want to flush or consume all values on the stack to reset the allocator
     // state entering the else block.
@@ -3615,7 +3615,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addElseToUnreachable(ControlData& data)
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addTry(BlockSignature signature, Stack& enclosingStack, ControlType& result, Stack& newStack)
+[[nodiscard]] PartialResult BBQJIT::addTry(BlockSignature signature, Stack& enclosingStack, ControlType& result, Stack& newStack)
 {
     m_usesExceptions = true;
     ++m_tryCatchDepth;
@@ -3631,7 +3631,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addTry(BlockSignature signature, Stack&
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addTryTable(BlockSignature signature, Stack& enclosingStack, const Vector<CatchHandler>& targets, ControlType& result, Stack& newStack)
+[[nodiscard]] PartialResult BBQJIT::addTryTable(BlockSignature signature, Stack& enclosingStack, const Vector<CatchHandler>& targets, ControlType& result, Stack& newStack)
 {
     m_usesExceptions = true;
     ++m_tryCatchDepth;
@@ -3660,7 +3660,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addTryTable(BlockSignature signature, S
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addCatch(unsigned exceptionIndex, const TypeDefinition& exceptionSignature, Stack& expressionStack, ControlType& data, ResultList& results)
+[[nodiscard]] PartialResult BBQJIT::addCatch(unsigned exceptionIndex, const TypeDefinition& exceptionSignature, Stack& expressionStack, ControlType& data, ResultList& results)
 {
     m_usesExceptions = true;
     data.flushAndSingleExit(*this, data, expressionStack, false, true);
@@ -3684,7 +3684,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addCatch(unsigned exceptionIndex, const
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addCatchToUnreachable(unsigned exceptionIndex, const TypeDefinition& exceptionSignature, ControlType& data, ResultList& results)
+[[nodiscard]] PartialResult BBQJIT::addCatchToUnreachable(unsigned exceptionIndex, const TypeDefinition& exceptionSignature, ControlType& data, ResultList& results)
 {
     m_usesExceptions = true;
     unbindAllRegisters();
@@ -3706,7 +3706,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addCatchToUnreachable(unsigned exceptio
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addCatchAll(Stack& expressionStack, ControlType& data)
+[[nodiscard]] PartialResult BBQJIT::addCatchAll(Stack& expressionStack, ControlType& data)
 {
     m_usesExceptions = true;
     data.flushAndSingleExit(*this, data, expressionStack, false, true);
@@ -3730,7 +3730,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addCatchAll(Stack& expressionStack, Con
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addCatchAllToUnreachable(ControlType& data)
+[[nodiscard]] PartialResult BBQJIT::addCatchAllToUnreachable(ControlType& data)
 {
     m_usesExceptions = true;
     unbindAllRegisters();
@@ -3752,12 +3752,12 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addCatchAllToUnreachable(ControlType& d
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addDelegate(ControlType& target, ControlType& data)
+[[nodiscard]] PartialResult BBQJIT::addDelegate(ControlType& target, ControlType& data)
 {
     return addDelegateToUnreachable(target, data);
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addDelegateToUnreachable(ControlType& target, ControlType& data)
+[[nodiscard]] PartialResult BBQJIT::addDelegateToUnreachable(ControlType& target, ControlType& data)
 {
     unsigned depth = 0;
     if (ControlType::isTry(target))
@@ -3771,7 +3771,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addDelegateToUnreachable(ControlType& t
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addThrow(unsigned exceptionIndex, ArgumentList& arguments, Stack&)
+[[nodiscard]] PartialResult BBQJIT::addThrow(unsigned exceptionIndex, ArgumentList& arguments, Stack&)
 {
 
     LOG_INSTRUCTION("Throw", arguments);
@@ -3806,7 +3806,7 @@ void BBQJIT::prepareForExceptions()
     }
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addReturn(const ControlData& data, const Stack& returnValues)
+[[nodiscard]] PartialResult BBQJIT::addReturn(const ControlData& data, const Stack& returnValues)
 {
     CallInformation wasmCallInfo = wasmCallingConvention().callInformationFor(*data.signature().m_signature, CallRole::Callee);
 
@@ -3843,7 +3843,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addReturn(const ControlData& data, cons
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addBranch(ControlData& target, Value condition, Stack& results)
+[[nodiscard]] PartialResult BBQJIT::addBranch(ControlData& target, Value condition, Stack& results)
 {
     if (condition.isConst() && !condition.asI32()) // If condition is known to be false, this is a no-op.
         return { };
@@ -3880,7 +3880,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addBranch(ControlData& target, Value co
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addSwitch(Value condition, const Vector<ControlData*>& targets, ControlData& defaultTarget, Stack& results)
+[[nodiscard]] PartialResult BBQJIT::addSwitch(Value condition, const Vector<ControlData*>& targets, ControlData& defaultTarget, Stack& results)
 {
     ASSERT(condition.type() == TypeKind::I32);
 
@@ -3960,12 +3960,12 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addSwitch(Value condition, const Vector
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::endBlock(ControlEntry& entry, Stack& stack)
+[[nodiscard]] PartialResult BBQJIT::endBlock(ControlEntry& entry, Stack& stack)
 {
     return addEndToUnreachable(entry, stack, false);
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addEndToUnreachable(ControlEntry& entry, Stack& stack, bool unreachable)
+[[nodiscard]] PartialResult BBQJIT::addEndToUnreachable(ControlEntry& entry, Stack& stack, bool unreachable)
 {
     ControlData& entryData = entry.controlData;
 
@@ -4044,7 +4044,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addEndToUnreachable(ControlEntry& entry
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::endTopLevel(BlockSignature, const Stack&)
+[[nodiscard]] PartialResult BBQJIT::endTopLevel(BlockSignature, const Stack&)
 {
     int frameSize = stackCheckSize();
     CCallHelpers& jit = m_jit;
@@ -4418,7 +4418,7 @@ void BBQJIT::emitTailCall(FunctionSpaceIndex functionIndexSpace, const TypeDefin
 }
 
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addCall(unsigned callProfileIndex, FunctionSpaceIndex functionIndexSpace, const TypeDefinition& signature, ArgumentList& arguments, ResultList& results, CallType callType)
+[[nodiscard]] PartialResult BBQJIT::addCall(unsigned callProfileIndex, FunctionSpaceIndex functionIndexSpace, const TypeDefinition& signature, ArgumentList& arguments, ResultList& results, CallType callType)
 {
     emitIncrementCallProfileCount(callProfileIndex);
     JIT_COMMENT(m_jit, "calling functionIndexSpace: ", functionIndexSpace, ConditionalDump(!m_info.isImportedFunctionFromFunctionIndexSpace(functionIndexSpace), " functionIndex: ", functionIndexSpace - m_info.importFunctionCount()));
@@ -4684,7 +4684,7 @@ void BBQJIT::emitIndirectTailCall(const char* opcode, const Value& callee, GPRRe
         consume(value);
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addCallIndirect(unsigned callProfileIndex, unsigned tableIndex, const TypeDefinition& originalSignature, ArgumentList& args, ResultList& results, CallType callType)
+[[nodiscard]] PartialResult BBQJIT::addCallIndirect(unsigned callProfileIndex, unsigned tableIndex, const TypeDefinition& originalSignature, ArgumentList& args, ResultList& results, CallType callType)
 {
     emitIncrementCallProfileCount(callProfileIndex);
     Value calleeIndex = args.takeLast();
@@ -4798,14 +4798,14 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addCallIndirect(unsigned callProfileInd
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addUnreachable()
+[[nodiscard]] PartialResult BBQJIT::addUnreachable()
 {
     LOG_INSTRUCTION("Unreachable");
     emitThrowException(ExceptionType::Unreachable);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addCrash()
+[[nodiscard]] PartialResult BBQJIT::addCrash()
 {
     m_jit.breakpoint();
     return { };
@@ -4953,7 +4953,7 @@ PartialResult BBQJIT::addFusedBranchCompare(OpType opType, ControlType& target, 
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addFusedIfCompare(OpType op, ExpressionType operand, BlockSignature signature, Stack& enclosingStack, ControlData& result, Stack& newStack)
+[[nodiscard]] PartialResult BBQJIT::addFusedIfCompare(OpType op, ExpressionType operand, BlockSignature signature, Stack& enclosingStack, ControlData& result, Stack& newStack)
 {
     BranchFoldResult foldResult = tryFoldFusedBranchCompare(op, operand);
 
@@ -5222,7 +5222,7 @@ PartialResult BBQJIT::addFusedBranchCompare(OpType opType, ControlType& target, 
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addFusedIfCompare(OpType op, ExpressionType left, ExpressionType right, BlockSignature signature, Stack& enclosingStack, ControlData& result, Stack& newStack)
+[[nodiscard]] PartialResult BBQJIT::addFusedIfCompare(OpType op, ExpressionType left, ExpressionType right, BlockSignature signature, Stack& enclosingStack, ControlData& result, Stack& newStack)
 {
     BranchFoldResult foldResult = tryFoldFusedBranchCompare(op, left, right);
 

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -1105,29 +1105,29 @@ public:
     Value instanceValue();
 
     // Tables
-    WARN_UNUSED_RETURN PartialResult addTableGet(unsigned tableIndex, Value index, Value& result);
+    [[nodiscard]] PartialResult addTableGet(unsigned tableIndex, Value index, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addTableSet(unsigned tableIndex, Value index, Value value);
+    [[nodiscard]] PartialResult addTableSet(unsigned tableIndex, Value index, Value value);
 
-    WARN_UNUSED_RETURN PartialResult addTableInit(unsigned elementIndex, unsigned tableIndex, ExpressionType dstOffset, ExpressionType srcOffset, ExpressionType length);
+    [[nodiscard]] PartialResult addTableInit(unsigned elementIndex, unsigned tableIndex, ExpressionType dstOffset, ExpressionType srcOffset, ExpressionType length);
 
-    WARN_UNUSED_RETURN PartialResult addElemDrop(unsigned elementIndex);
+    [[nodiscard]] PartialResult addElemDrop(unsigned elementIndex);
 
-    WARN_UNUSED_RETURN PartialResult addTableSize(unsigned tableIndex, Value& result);
+    [[nodiscard]] PartialResult addTableSize(unsigned tableIndex, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addTableGrow(unsigned tableIndex, Value fill, Value delta, Value& result);
+    [[nodiscard]] PartialResult addTableGrow(unsigned tableIndex, Value fill, Value delta, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addTableFill(unsigned tableIndex, Value offset, Value fill, Value count);
+    [[nodiscard]] PartialResult addTableFill(unsigned tableIndex, Value offset, Value fill, Value count);
 
-    WARN_UNUSED_RETURN PartialResult addTableCopy(unsigned dstTableIndex, unsigned srcTableIndex, Value dstOffset, Value srcOffset, Value length);
+    [[nodiscard]] PartialResult addTableCopy(unsigned dstTableIndex, unsigned srcTableIndex, Value dstOffset, Value srcOffset, Value length);
 
     // Locals
 
-    WARN_UNUSED_RETURN PartialResult getLocal(uint32_t localIndex, Value& result);
+    [[nodiscard]] PartialResult getLocal(uint32_t localIndex, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult setLocal(uint32_t localIndex, Value value);
+    [[nodiscard]] PartialResult setLocal(uint32_t localIndex, Value value);
 
-    WARN_UNUSED_RETURN PartialResult teeLocal(uint32_t localIndex, Value, Value& result);
+    [[nodiscard]] PartialResult teeLocal(uint32_t localIndex, Value, Value& result);
 
     // Globals
 
@@ -1135,12 +1135,12 @@ public:
 
     Value exception(const ControlData& control);
 
-    WARN_UNUSED_RETURN PartialResult getGlobal(uint32_t index, Value& result);
+    [[nodiscard]] PartialResult getGlobal(uint32_t index, Value& result);
 
     void emitWriteBarrier(GPRReg cellGPR);
     void emitMutatorFence();
 
-    WARN_UNUSED_RETURN PartialResult setGlobal(uint32_t index, Value value);
+    [[nodiscard]] PartialResult setGlobal(uint32_t index, Value value);
 
     // Memory
 
@@ -1268,7 +1268,7 @@ public:
         "I64Load8S", "I64Load8U", "I64Load16S", "I64Load16U", "I64Load32S", "I64Load32U"
     };
 
-    WARN_UNUSED_RETURN PartialResult load(LoadOpType loadOp, Value pointer, Value& result, uint32_t uoffset);
+    [[nodiscard]] PartialResult load(LoadOpType loadOp, Value pointer, Value& result, uint32_t uoffset);
 
     inline uint32_t sizeOfStoreOp(StoreOpType op)
     {
@@ -1296,19 +1296,19 @@ public:
         "I64Store8", "I64Store16", "I64Store32",
     };
 
-    WARN_UNUSED_RETURN PartialResult store(StoreOpType storeOp, Value pointer, Value value, uint32_t uoffset);
+    [[nodiscard]] PartialResult store(StoreOpType storeOp, Value pointer, Value value, uint32_t uoffset);
 
-    WARN_UNUSED_RETURN PartialResult addGrowMemory(Value delta, Value& result);
+    [[nodiscard]] PartialResult addGrowMemory(Value delta, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addCurrentMemory(Value& result);
+    [[nodiscard]] PartialResult addCurrentMemory(Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addMemoryFill(Value dstAddress, Value targetValue, Value count);
+    [[nodiscard]] PartialResult addMemoryFill(Value dstAddress, Value targetValue, Value count);
 
-    WARN_UNUSED_RETURN PartialResult addMemoryCopy(Value dstAddress, Value srcAddress, Value count);
+    [[nodiscard]] PartialResult addMemoryCopy(Value dstAddress, Value srcAddress, Value count);
 
-    WARN_UNUSED_RETURN PartialResult addMemoryInit(unsigned dataSegmentIndex, Value dstAddress, Value srcAddress, Value length);
+    [[nodiscard]] PartialResult addMemoryInit(unsigned dataSegmentIndex, Value dstAddress, Value srcAddress, Value length);
 
-    WARN_UNUSED_RETURN PartialResult addDataDrop(unsigned dataSegmentIndex);
+    [[nodiscard]] PartialResult addDataDrop(unsigned dataSegmentIndex);
 
     // Atomics
 
@@ -1335,27 +1335,27 @@ public:
     template<typename Functor>
     void emitAtomicOpGeneric(ExtAtomicOpType op, Address address, Location old, Location cur, const Functor& functor);
 
-    WARN_UNUSED_RETURN Value emitAtomicLoadOp(ExtAtomicOpType loadOp, Type valueType, Location pointer, uint32_t uoffset);
+    [[nodiscard]] Value emitAtomicLoadOp(ExtAtomicOpType loadOp, Type valueType, Location pointer, uint32_t uoffset);
 
-    WARN_UNUSED_RETURN PartialResult atomicLoad(ExtAtomicOpType loadOp, Type valueType, ExpressionType pointer, ExpressionType& result, uint32_t uoffset);
+    [[nodiscard]] PartialResult atomicLoad(ExtAtomicOpType loadOp, Type valueType, ExpressionType pointer, ExpressionType& result, uint32_t uoffset);
 
     void emitAtomicStoreOp(ExtAtomicOpType storeOp, Type, Location pointer, Value value, uint32_t uoffset);
 
-    WARN_UNUSED_RETURN PartialResult atomicStore(ExtAtomicOpType storeOp, Type valueType, ExpressionType pointer, ExpressionType value, uint32_t uoffset);
+    [[nodiscard]] PartialResult atomicStore(ExtAtomicOpType storeOp, Type valueType, ExpressionType pointer, ExpressionType value, uint32_t uoffset);
 
     Value emitAtomicBinaryRMWOp(ExtAtomicOpType op, Type valueType, Location pointer, Value value, uint32_t uoffset);
 
-    WARN_UNUSED_RETURN PartialResult atomicBinaryRMW(ExtAtomicOpType op, Type valueType, ExpressionType pointer, ExpressionType value, ExpressionType& result, uint32_t uoffset);
+    [[nodiscard]] PartialResult atomicBinaryRMW(ExtAtomicOpType op, Type valueType, ExpressionType pointer, ExpressionType value, ExpressionType& result, uint32_t uoffset);
 
-    WARN_UNUSED_RETURN Value emitAtomicCompareExchange(ExtAtomicOpType op, Type, Location pointer, Value expected, Value value, uint32_t uoffset);
+    [[nodiscard]] Value emitAtomicCompareExchange(ExtAtomicOpType op, Type, Location pointer, Value expected, Value value, uint32_t uoffset);
 
-    WARN_UNUSED_RETURN PartialResult atomicCompareExchange(ExtAtomicOpType op, Type valueType, ExpressionType pointer, ExpressionType expected, ExpressionType value, ExpressionType& result, uint32_t uoffset);
+    [[nodiscard]] PartialResult atomicCompareExchange(ExtAtomicOpType op, Type valueType, ExpressionType pointer, ExpressionType expected, ExpressionType value, ExpressionType& result, uint32_t uoffset);
 
-    WARN_UNUSED_RETURN PartialResult atomicWait(ExtAtomicOpType op, ExpressionType pointer, ExpressionType value, ExpressionType timeout, ExpressionType& result, uint32_t uoffset);
+    [[nodiscard]] PartialResult atomicWait(ExtAtomicOpType op, ExpressionType pointer, ExpressionType value, ExpressionType timeout, ExpressionType& result, uint32_t uoffset);
 
-    WARN_UNUSED_RETURN PartialResult atomicNotify(ExtAtomicOpType op, ExpressionType pointer, ExpressionType count, ExpressionType& result, uint32_t uoffset);
+    [[nodiscard]] PartialResult atomicNotify(ExtAtomicOpType op, ExpressionType pointer, ExpressionType count, ExpressionType& result, uint32_t uoffset);
 
-    WARN_UNUSED_RETURN PartialResult atomicFence(ExtAtomicOpType, uint8_t);
+    [[nodiscard]] PartialResult atomicFence(ExtAtomicOpType, uint8_t);
 
     // Saturated truncation.
 
@@ -1383,16 +1383,16 @@ public:
 
     void truncInBounds(TruncationKind truncationKind, Location operandLocation, Location resultLocation, FPRReg scratch1FPR, FPRReg scratch2FPR);
 
-    WARN_UNUSED_RETURN PartialResult truncTrapping(OpType truncationOp, Value operand, Value& result, Type returnType, Type operandType);
-    WARN_UNUSED_RETURN PartialResult truncSaturated(Ext1OpType truncationOp, Value operand, Value& result, Type returnType, Type operandType);
+    [[nodiscard]] PartialResult truncTrapping(OpType truncationOp, Value operand, Value& result, Type returnType, Type operandType);
+    [[nodiscard]] PartialResult truncSaturated(Ext1OpType truncationOp, Value operand, Value& result, Type returnType, Type operandType);
 
 
     // GC
-    WARN_UNUSED_RETURN PartialResult addRefI31(ExpressionType value, ExpressionType& result);
+    [[nodiscard]] PartialResult addRefI31(ExpressionType value, ExpressionType& result);
 
-    WARN_UNUSED_RETURN PartialResult addI31GetS(TypedExpression value, ExpressionType& result);
+    [[nodiscard]] PartialResult addI31GetS(TypedExpression value, ExpressionType& result);
 
-    WARN_UNUSED_RETURN PartialResult addI31GetU(TypedExpression value, ExpressionType& result);
+    [[nodiscard]] PartialResult addI31GetU(TypedExpression value, ExpressionType& result);
 
     const Ref<TypeDefinition> getTypeDefinition(uint32_t typeIndex);
 
@@ -1407,62 +1407,62 @@ public:
     Value marshallToI64(Value value);
 
     void emitAllocateGCArrayUninitialized(GPRReg result, uint32_t typeIndex, ExpressionType size, GPRReg scratchGPR, GPRReg scratchGPR2);
-    WARN_UNUSED_RETURN PartialResult addArrayNew(uint32_t typeIndex, ExpressionType size, ExpressionType initValue, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addArrayNewDefault(uint32_t typeIndex, ExpressionType size, ExpressionType& result);
+    [[nodiscard]] PartialResult addArrayNew(uint32_t typeIndex, ExpressionType size, ExpressionType initValue, ExpressionType& result);
+    [[nodiscard]] PartialResult addArrayNewDefault(uint32_t typeIndex, ExpressionType size, ExpressionType& result);
 
     using ArraySegmentOperation = EncodedJSValue SYSV_ABI (&)(JSC::JSWebAssemblyInstance*, uint32_t, uint32_t, uint32_t, uint32_t);
     void pushArrayNewFromSegment(ArraySegmentOperation operation, uint32_t typeIndex, uint32_t segmentIndex, ExpressionType arraySize, ExpressionType offset, ExceptionType exceptionType, ExpressionType& result);
 
-    WARN_UNUSED_RETURN PartialResult addArrayNewData(uint32_t typeIndex, uint32_t dataIndex, ExpressionType arraySize, ExpressionType offset, ExpressionType& result);
+    [[nodiscard]] PartialResult addArrayNewData(uint32_t typeIndex, uint32_t dataIndex, ExpressionType arraySize, ExpressionType offset, ExpressionType& result);
 
-    WARN_UNUSED_RETURN PartialResult addArrayNewElem(uint32_t typeIndex, uint32_t elemSegmentIndex, ExpressionType arraySize, ExpressionType offset, ExpressionType& result);
+    [[nodiscard]] PartialResult addArrayNewElem(uint32_t typeIndex, uint32_t elemSegmentIndex, ExpressionType arraySize, ExpressionType offset, ExpressionType& result);
 
     void emitArrayStoreElementUnchecked(StorageType elementType, GPRReg payloadGPR, Location index, Value value, bool preserveIndex = false);
     void emitArrayStoreElementUnchecked(StorageType elementType, GPRReg payloadGPR, Value index, Value value);
     void emitArraySetUnchecked(uint32_t typeIndex, Value arrayref, Value index, Value value);
 
-    WARN_UNUSED_RETURN PartialResult addArrayNewFixed(uint32_t typeIndex, ArgumentList& args, ExpressionType& result);
+    [[nodiscard]] PartialResult addArrayNewFixed(uint32_t typeIndex, ArgumentList& args, ExpressionType& result);
 
     void emitArrayGetPayload(StorageType, GPRReg arrayGPR, GPRReg payloadGPR);
 
-    WARN_UNUSED_RETURN PartialResult addArrayGet(ExtGCOpType arrayGetKind, uint32_t typeIndex, TypedExpression arrayref, ExpressionType index, ExpressionType& result);
+    [[nodiscard]] PartialResult addArrayGet(ExtGCOpType arrayGetKind, uint32_t typeIndex, TypedExpression arrayref, ExpressionType index, ExpressionType& result);
 
-    WARN_UNUSED_RETURN PartialResult addArraySet(uint32_t typeIndex, TypedExpression arrayref, ExpressionType index, ExpressionType value);
+    [[nodiscard]] PartialResult addArraySet(uint32_t typeIndex, TypedExpression arrayref, ExpressionType index, ExpressionType value);
 
-    WARN_UNUSED_RETURN PartialResult addArrayLen(TypedExpression arrayref, ExpressionType& result);
+    [[nodiscard]] PartialResult addArrayLen(TypedExpression arrayref, ExpressionType& result);
 
-    WARN_UNUSED_RETURN PartialResult addArrayFill(uint32_t typeIndex, TypedExpression arrayref, ExpressionType offset, ExpressionType value, ExpressionType size);
+    [[nodiscard]] PartialResult addArrayFill(uint32_t typeIndex, TypedExpression arrayref, ExpressionType offset, ExpressionType value, ExpressionType size);
 
-    WARN_UNUSED_RETURN PartialResult addArrayCopy(uint32_t dstTypeIndex, TypedExpression dst, ExpressionType dstOffset, uint32_t srcTypeIndex, TypedExpression src, ExpressionType srcOffset, ExpressionType size);
+    [[nodiscard]] PartialResult addArrayCopy(uint32_t dstTypeIndex, TypedExpression dst, ExpressionType dstOffset, uint32_t srcTypeIndex, TypedExpression src, ExpressionType srcOffset, ExpressionType size);
 
-    WARN_UNUSED_RETURN PartialResult addArrayInitElem(uint32_t dstTypeIndex, TypedExpression dst, ExpressionType dstOffset, uint32_t srcElementIndex, ExpressionType srcOffset, ExpressionType size);
+    [[nodiscard]] PartialResult addArrayInitElem(uint32_t dstTypeIndex, TypedExpression dst, ExpressionType dstOffset, uint32_t srcElementIndex, ExpressionType srcOffset, ExpressionType size);
 
-    WARN_UNUSED_RETURN PartialResult addArrayInitData(uint32_t dstTypeIndex, TypedExpression dst, ExpressionType dstOffset, uint32_t srcDataIndex, ExpressionType srcOffset, ExpressionType size);
+    [[nodiscard]] PartialResult addArrayInitData(uint32_t dstTypeIndex, TypedExpression dst, ExpressionType dstOffset, uint32_t srcDataIndex, ExpressionType srcOffset, ExpressionType size);
 
     // Returns true if a writeBarrier/mutatorFence is needed.
-    WARN_UNUSED_RETURN bool emitStructSet(GPRReg structGPR, const StructType& structType, uint32_t fieldIndex, Value value);
+    [[nodiscard]] bool emitStructSet(GPRReg structGPR, const StructType& structType, uint32_t fieldIndex, Value value);
 
     void emitAllocateGCStructUninitialized(GPRReg resultGPR, uint32_t typeIndex, GPRReg scratchGPR, GPRReg scratchGPR2);
-    WARN_UNUSED_RETURN PartialResult addStructNewDefault(uint32_t typeIndex, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addStructNew(uint32_t typeIndex, ArgumentList& args, Value& result);
+    [[nodiscard]] PartialResult addStructNewDefault(uint32_t typeIndex, ExpressionType& result);
+    [[nodiscard]] PartialResult addStructNew(uint32_t typeIndex, ArgumentList& args, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addStructGet(ExtGCOpType structGetKind, TypedExpression structValue, const StructType& structType, uint32_t fieldIndex, Value& result);
+    [[nodiscard]] PartialResult addStructGet(ExtGCOpType structGetKind, TypedExpression structValue, const StructType& structType, uint32_t fieldIndex, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addStructSet(TypedExpression structValue, const StructType& structType, uint32_t fieldIndex, Value value);
+    [[nodiscard]] PartialResult addStructSet(TypedExpression structValue, const StructType& structType, uint32_t fieldIndex, Value value);
 
     enum class CastKind { Test, Cast };
     void emitRefTestOrCast(CastKind, const TypedExpression&, GPRReg, bool allowNull, int32_t toHeapType, JumpList& failureCases);
 
-    WARN_UNUSED_RETURN PartialResult addRefTest(TypedExpression reference, bool allowNull, int32_t heapType, bool shouldNegate, ExpressionType& result);
+    [[nodiscard]] PartialResult addRefTest(TypedExpression reference, bool allowNull, int32_t heapType, bool shouldNegate, ExpressionType& result);
 
-    WARN_UNUSED_RETURN PartialResult addRefCast(TypedExpression reference, bool allowNull, int32_t heapType, ExpressionType& result);
+    [[nodiscard]] PartialResult addRefCast(TypedExpression reference, bool allowNull, int32_t heapType, ExpressionType& result);
 
-    WARN_UNUSED_RETURN PartialResult addAnyConvertExtern(ExpressionType reference, ExpressionType& result);
+    [[nodiscard]] PartialResult addAnyConvertExtern(ExpressionType reference, ExpressionType& result);
 
-    WARN_UNUSED_RETURN PartialResult addExternConvertAny(ExpressionType reference, ExpressionType& result);
+    [[nodiscard]] PartialResult addExternConvertAny(ExpressionType reference, ExpressionType& result);
 
     // Basic operators
-    WARN_UNUSED_RETURN PartialResult addSelect(Value condition, Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addSelect(Value condition, Value lhs, Value rhs, Value& result);
 
     template<typename Fold, typename RegReg, typename RegImm>
     inline PartialResult binary(const char* opcode, TypeKind resultType, Value& lhs, Value& rhs, Value& result, Fold fold, RegReg regReg, RegImm regImm)
@@ -1588,29 +1588,29 @@ public:
                 regStatement /* Lambda to be called when both operands are registers. */ \
             });
 
-    WARN_UNUSED_RETURN PartialResult addI32Add(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI32Add(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI64Add(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI64Add(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF32Add(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addF32Add(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF64Add(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addF64Add(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI32Sub(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI32Sub(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI64Sub(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI64Sub(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF32Sub(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addF32Sub(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF64Sub(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addF64Sub(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI32Mul(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI32Mul(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI64Mul(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI64Mul(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF32Mul(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addF32Mul(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF64Mul(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addF64Mul(Value lhs, Value rhs, Value& result);
 
     template<typename Func>
     void addLatePath(WasmOrigin, Func&&);
@@ -1629,25 +1629,25 @@ public:
     template<typename IntType>
     Value checkConstantDivision(const Value& lhs, const Value& rhs);
 
-    WARN_UNUSED_RETURN PartialResult addI32DivS(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI32DivS(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI64DivS(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI64DivS(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI32DivU(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI32DivU(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI64DivU(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI64DivU(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI32RemS(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI32RemS(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI64RemS(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI64RemS(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI32RemU(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI32RemU(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI64RemU(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI64RemU(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF32Div(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addF32Div(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF64Div(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addF64Div(Value lhs, Value rhs, Value& result);
 
     enum class MinOrMax { Min, Max };
 
@@ -1668,13 +1668,13 @@ public:
             return std::max<FloatType>(left, right);
     }
 
-    WARN_UNUSED_RETURN PartialResult addF32Min(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addF32Min(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF64Min(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addF64Min(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF32Max(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addF32Max(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF64Max(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addF64Max(Value lhs, Value rhs, Value& result);
 
     inline float floatCopySign(float lhs, float rhs)
     {
@@ -1696,241 +1696,241 @@ public:
         return std::bit_cast<double>(lhsAsInt64);
     }
 
-    WARN_UNUSED_RETURN PartialResult addI32And(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI32And(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI64And(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI64And(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI32Xor(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI32Xor(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI64Xor(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI64Xor(Value lhs, Value rhs, Value& result);
 
 
-    WARN_UNUSED_RETURN PartialResult addI32Or(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI32Or(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI64Or(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI64Or(Value lhs, Value rhs, Value& result);
 
     void moveShiftAmountIfNecessary(Location& rhsLocation);
 
-    WARN_UNUSED_RETURN PartialResult addI32Shl(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI32Shl(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI64Shl(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI64Shl(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI32ShrS(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI32ShrS(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI64ShrS(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI64ShrS(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI32ShrU(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI32ShrU(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI64ShrU(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI64ShrU(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI32Rotl(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI32Rotl(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI64Rotl(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI64Rotl(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI32Rotr(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI32Rotr(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI64Rotr(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI64Rotr(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI32Clz(Value operand, Value& result);
+    [[nodiscard]] PartialResult addI32Clz(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI64Clz(Value operand, Value& result);
+    [[nodiscard]] PartialResult addI64Clz(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI32Ctz(Value operand, Value& result);
+    [[nodiscard]] PartialResult addI32Ctz(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI64Ctz(Value operand, Value& result);
+    [[nodiscard]] PartialResult addI64Ctz(Value operand, Value& result);
 
     PartialResult emitCompareI32(const char* opcode, Value& lhs, Value& rhs, Value& result, RelationalCondition condition, bool (*comparator)(int32_t lhs, int32_t rhs));
 
     PartialResult emitCompareI64(const char* opcode, Value& lhs, Value& rhs, Value& result, RelationalCondition condition, bool (*comparator)(int64_t lhs, int64_t rhs));
 
-    WARN_UNUSED_RETURN PartialResult addI32Eq(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI32Eq(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI64Eq(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI64Eq(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI32Ne(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI32Ne(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI64Ne(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI64Ne(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI32LtS(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI32LtS(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI64LtS(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI64LtS(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI32LeS(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI32LeS(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI64LeS(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI64LeS(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI32GtS(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI32GtS(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI64GtS(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI64GtS(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI32GeS(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI32GeS(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI64GeS(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI64GeS(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI32LtU(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI32LtU(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI64LtU(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI64LtU(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI32LeU(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI32LeU(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI64LeU(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI64LeU(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI32GtU(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI32GtU(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI64GtU(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI64GtU(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI32GeU(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI32GeU(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI64GeU(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addI64GeU(Value lhs, Value rhs, Value& result);
 
     PartialResult emitCompareF32(const char* opcode, Value& lhs, Value& rhs, Value& result, DoubleCondition condition, bool (*comparator)(float lhs, float rhs));
 
     PartialResult emitCompareF64(const char* opcode, Value& lhs, Value& rhs, Value& result, DoubleCondition condition, bool (*comparator)(double lhs, double rhs));
 
-    WARN_UNUSED_RETURN PartialResult addF32Eq(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addF32Eq(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF64Eq(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addF64Eq(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF32Ne(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addF32Ne(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF64Ne(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addF64Ne(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF32Lt(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addF32Lt(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF64Lt(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addF64Lt(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF32Le(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addF32Le(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF64Le(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addF64Le(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF32Gt(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addF32Gt(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF64Gt(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addF64Gt(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF32Ge(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addF32Ge(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF64Ge(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addF64Ge(Value lhs, Value rhs, Value& result);
 
     PartialResult addI32WrapI64(Value operand, Value& result);
 
     PartialResult addI32Extend8S(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI32Extend16S(Value operand, Value& result);
+    [[nodiscard]] PartialResult addI32Extend16S(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI64Extend8S(Value operand, Value& result);
+    [[nodiscard]] PartialResult addI64Extend8S(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI64Extend16S(Value operand, Value& result);
+    [[nodiscard]] PartialResult addI64Extend16S(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI64Extend32S(Value operand, Value& result);
+    [[nodiscard]] PartialResult addI64Extend32S(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI64ExtendSI32(Value operand, Value& result);
+    [[nodiscard]] PartialResult addI64ExtendSI32(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI64ExtendUI32(Value operand, Value& result);
+    [[nodiscard]] PartialResult addI64ExtendUI32(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI32Eqz(Value operand, Value& result);
+    [[nodiscard]] PartialResult addI32Eqz(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI64Eqz(Value operand, Value& result);
+    [[nodiscard]] PartialResult addI64Eqz(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI32Popcnt(Value operand, Value& result);
+    [[nodiscard]] PartialResult addI32Popcnt(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI64Popcnt(Value operand, Value& result);
+    [[nodiscard]] PartialResult addI64Popcnt(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI32ReinterpretF32(Value operand, Value& result);
+    [[nodiscard]] PartialResult addI32ReinterpretF32(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI64ReinterpretF64(Value operand, Value& result);
+    [[nodiscard]] PartialResult addI64ReinterpretF64(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF32ReinterpretI32(Value operand, Value& result);
+    [[nodiscard]] PartialResult addF32ReinterpretI32(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF64ReinterpretI64(Value operand, Value& result);
+    [[nodiscard]] PartialResult addF64ReinterpretI64(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF32DemoteF64(Value operand, Value& result);
+    [[nodiscard]] PartialResult addF32DemoteF64(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF64PromoteF32(Value operand, Value& result);
+    [[nodiscard]] PartialResult addF64PromoteF32(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF32ConvertSI32(Value operand, Value& result);
+    [[nodiscard]] PartialResult addF32ConvertSI32(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF32ConvertUI32(Value operand, Value& result);
+    [[nodiscard]] PartialResult addF32ConvertUI32(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF32ConvertSI64(Value operand, Value& result);
+    [[nodiscard]] PartialResult addF32ConvertSI64(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF32ConvertUI64(Value operand, Value& result);
+    [[nodiscard]] PartialResult addF32ConvertUI64(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF64ConvertSI32(Value operand, Value& result);
+    [[nodiscard]] PartialResult addF64ConvertSI32(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF64ConvertUI32(Value operand, Value& result);
+    [[nodiscard]] PartialResult addF64ConvertUI32(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF64ConvertSI64(Value operand, Value& result);
+    [[nodiscard]] PartialResult addF64ConvertSI64(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF64ConvertUI64(Value operand, Value& result);
+    [[nodiscard]] PartialResult addF64ConvertUI64(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF32Copysign(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addF32Copysign(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF64Copysign(Value lhs, Value rhs, Value& result);
+    [[nodiscard]] PartialResult addF64Copysign(Value lhs, Value rhs, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF32Floor(Value operand, Value& result);
+    [[nodiscard]] PartialResult addF32Floor(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF64Floor(Value operand, Value& result);
+    [[nodiscard]] PartialResult addF64Floor(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF32Ceil(Value operand, Value& result);
+    [[nodiscard]] PartialResult addF32Ceil(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF64Ceil(Value operand, Value& result);
+    [[nodiscard]] PartialResult addF64Ceil(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF32Abs(Value operand, Value& result);
+    [[nodiscard]] PartialResult addF32Abs(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF64Abs(Value operand, Value& result);
+    [[nodiscard]] PartialResult addF64Abs(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF32Sqrt(Value operand, Value& result);
+    [[nodiscard]] PartialResult addF32Sqrt(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF64Sqrt(Value operand, Value& result);
+    [[nodiscard]] PartialResult addF64Sqrt(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF32Neg(Value operand, Value& result);
+    [[nodiscard]] PartialResult addF32Neg(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF64Neg(Value operand, Value& result);
+    [[nodiscard]] PartialResult addF64Neg(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF32Nearest(Value operand, Value& result);
+    [[nodiscard]] PartialResult addF32Nearest(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF64Nearest(Value operand, Value& result);
+    [[nodiscard]] PartialResult addF64Nearest(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF32Trunc(Value operand, Value& result);
+    [[nodiscard]] PartialResult addF32Trunc(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addF64Trunc(Value operand, Value& result);
+    [[nodiscard]] PartialResult addF64Trunc(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI32TruncSF32(Value operand, Value& result);
+    [[nodiscard]] PartialResult addI32TruncSF32(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI32TruncSF64(Value operand, Value& result);
+    [[nodiscard]] PartialResult addI32TruncSF64(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI32TruncUF32(Value operand, Value& result);
+    [[nodiscard]] PartialResult addI32TruncUF32(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI32TruncUF64(Value operand, Value& result);
+    [[nodiscard]] PartialResult addI32TruncUF64(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI64TruncSF32(Value operand, Value& result);
+    [[nodiscard]] PartialResult addI64TruncSF32(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI64TruncSF64(Value operand, Value& result);
+    [[nodiscard]] PartialResult addI64TruncSF64(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI64TruncUF32(Value operand, Value& result);
+    [[nodiscard]] PartialResult addI64TruncUF32(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addI64TruncUF64(Value operand, Value& result);
+    [[nodiscard]] PartialResult addI64TruncUF64(Value operand, Value& result);
 
     // References
 
-    WARN_UNUSED_RETURN PartialResult addRefIsNull(Value operand, Value& result);
+    [[nodiscard]] PartialResult addRefIsNull(Value operand, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addRefAsNonNull(Value value, Value& result);
+    [[nodiscard]] PartialResult addRefAsNonNull(Value value, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addRefEq(Value ref0, Value ref1, Value& result);
+    [[nodiscard]] PartialResult addRefEq(Value ref0, Value ref1, Value& result);
 
-    WARN_UNUSED_RETURN PartialResult addRefFunc(FunctionSpaceIndex index, Value& result);
+    [[nodiscard]] PartialResult addRefFunc(FunctionSpaceIndex index, Value& result);
 
     void emitEntryTierUpCheck();
 
     // Control flow
-    WARN_UNUSED_RETURN ControlData addTopLevel(BlockSignature signature);
+    [[nodiscard]] ControlData addTopLevel(BlockSignature signature);
 
     bool hasLoops() const;
 
     MacroAssembler::Label addLoopOSREntrypoint();
 
-    WARN_UNUSED_RETURN PartialResult addBlock(BlockSignature signature, Stack& enclosingStack, ControlType& result, Stack& newStack);
+    [[nodiscard]] PartialResult addBlock(BlockSignature signature, Stack& enclosingStack, ControlType& result, Stack& newStack);
 
     B3::Type toB3Type(Type type);
 
@@ -1942,16 +1942,16 @@ public:
 
     void emitLoopTierUpCheckAndOSREntryData(const ControlData&, Stack& enclosingStack, unsigned loopIndex);
 
-    WARN_UNUSED_RETURN PartialResult addLoop(BlockSignature signature, Stack& enclosingStack, ControlType& result, Stack& newStack, uint32_t loopIndex);
+    [[nodiscard]] PartialResult addLoop(BlockSignature signature, Stack& enclosingStack, ControlType& result, Stack& newStack, uint32_t loopIndex);
 
-    WARN_UNUSED_RETURN PartialResult addIf(Value condition, BlockSignature signature, Stack& enclosingStack, ControlData& result, Stack& newStack);
+    [[nodiscard]] PartialResult addIf(Value condition, BlockSignature signature, Stack& enclosingStack, ControlData& result, Stack& newStack);
 
-    WARN_UNUSED_RETURN PartialResult addElse(ControlData& data, Stack& expressionStack);
+    [[nodiscard]] PartialResult addElse(ControlData& data, Stack& expressionStack);
 
-    WARN_UNUSED_RETURN PartialResult addElseToUnreachable(ControlData& data);
+    [[nodiscard]] PartialResult addElseToUnreachable(ControlData& data);
 
-    WARN_UNUSED_RETURN PartialResult addTry(BlockSignature signature, Stack& enclosingStack, ControlType& result, Stack& newStack);
-    WARN_UNUSED_RETURN PartialResult addTryTable(BlockSignature, Stack& enclosingStack, const Vector<CatchHandler>& targets, ControlType& result, Stack& newStack);
+    [[nodiscard]] PartialResult addTry(BlockSignature signature, Stack& enclosingStack, ControlType& result, Stack& newStack);
+    [[nodiscard]] PartialResult addTryTable(BlockSignature, Stack& enclosingStack, const Vector<CatchHandler>& targets, ControlType& result, Stack& newStack);
 
     void emitCatchPrologue();
 
@@ -1960,43 +1960,43 @@ public:
     void emitCatchImpl(ControlData& dataCatch, const TypeDefinition& exceptionSignature, ResultList& results);
     void emitCatchTableImpl(ControlData& entryData, ControlType::TryTableTarget&);
 
-    WARN_UNUSED_RETURN PartialResult addCatch(unsigned exceptionIndex, const TypeDefinition& exceptionSignature, Stack& expressionStack, ControlType& data, ResultList& results);
+    [[nodiscard]] PartialResult addCatch(unsigned exceptionIndex, const TypeDefinition& exceptionSignature, Stack& expressionStack, ControlType& data, ResultList& results);
 
-    WARN_UNUSED_RETURN PartialResult addCatchToUnreachable(unsigned exceptionIndex, const TypeDefinition& exceptionSignature, ControlType& data, ResultList& results);
+    [[nodiscard]] PartialResult addCatchToUnreachable(unsigned exceptionIndex, const TypeDefinition& exceptionSignature, ControlType& data, ResultList& results);
 
-    WARN_UNUSED_RETURN PartialResult addCatchAll(Stack& expressionStack, ControlType& data);
+    [[nodiscard]] PartialResult addCatchAll(Stack& expressionStack, ControlType& data);
 
-    WARN_UNUSED_RETURN PartialResult addCatchAllToUnreachable(ControlType& data);
+    [[nodiscard]] PartialResult addCatchAllToUnreachable(ControlType& data);
 
-    WARN_UNUSED_RETURN PartialResult addDelegate(ControlType& target, ControlType& data);
+    [[nodiscard]] PartialResult addDelegate(ControlType& target, ControlType& data);
 
-    WARN_UNUSED_RETURN PartialResult addDelegateToUnreachable(ControlType& target, ControlType& data);
+    [[nodiscard]] PartialResult addDelegateToUnreachable(ControlType& target, ControlType& data);
 
-    WARN_UNUSED_RETURN PartialResult addThrow(unsigned exceptionIndex, ArgumentList& arguments, Stack&);
+    [[nodiscard]] PartialResult addThrow(unsigned exceptionIndex, ArgumentList& arguments, Stack&);
 
-    WARN_UNUSED_RETURN PartialResult addRethrow(unsigned, ControlType& data);
+    [[nodiscard]] PartialResult addRethrow(unsigned, ControlType& data);
 
-    WARN_UNUSED_RETURN PartialResult addThrowRef(ExpressionType exception, Stack&);
+    [[nodiscard]] PartialResult addThrowRef(ExpressionType exception, Stack&);
 
     void prepareForExceptions();
 
-    WARN_UNUSED_RETURN PartialResult addReturn(const ControlData& data, const Stack& returnValues);
+    [[nodiscard]] PartialResult addReturn(const ControlData& data, const Stack& returnValues);
 
-    WARN_UNUSED_RETURN PartialResult addBranch(ControlData& target, Value condition, Stack& results);
+    [[nodiscard]] PartialResult addBranch(ControlData& target, Value condition, Stack& results);
 
-    WARN_UNUSED_RETURN PartialResult addBranchNull(ControlData& data, ExpressionType reference, Stack& returnValues, bool shouldNegate, ExpressionType& result);
+    [[nodiscard]] PartialResult addBranchNull(ControlData& data, ExpressionType reference, Stack& returnValues, bool shouldNegate, ExpressionType& result);
 
-    WARN_UNUSED_RETURN PartialResult addBranchCast(ControlData& data, ExpressionType reference, Stack& returnValues, bool allowNull, int32_t heapType, bool shouldNegate);
+    [[nodiscard]] PartialResult addBranchCast(ControlData& data, ExpressionType reference, Stack& returnValues, bool allowNull, int32_t heapType, bool shouldNegate);
 
-    WARN_UNUSED_RETURN PartialResult addSwitch(Value condition, const Vector<ControlData*>& targets, ControlData& defaultTarget, Stack& results);
+    [[nodiscard]] PartialResult addSwitch(Value condition, const Vector<ControlData*>& targets, ControlData& defaultTarget, Stack& results);
 
-    WARN_UNUSED_RETURN PartialResult endBlock(ControlEntry& entry, Stack& stack);
+    [[nodiscard]] PartialResult endBlock(ControlEntry& entry, Stack& stack);
 
-    WARN_UNUSED_RETURN PartialResult addEndToUnreachable(ControlEntry& entry, Stack& stack, bool unreachable = true);
+    [[nodiscard]] PartialResult addEndToUnreachable(ControlEntry& entry, Stack& stack, bool unreachable = true);
 
     int alignedFrameSize(int frameSize) const;
 
-    WARN_UNUSED_RETURN PartialResult endTopLevel(BlockSignature, const Stack&);
+    [[nodiscard]] PartialResult endTopLevel(BlockSignature, const Stack&);
 
     enum BranchFoldResult {
         BranchAlwaysTaken,
@@ -2004,15 +2004,15 @@ public:
         BranchNotFolded
     };
 
-    WARN_UNUSED_RETURN BranchFoldResult tryFoldFusedBranchCompare(OpType, ExpressionType);
-    WARN_UNUSED_RETURN Jump emitFusedBranchCompareBranch(OpType, ExpressionType, Location);
-    WARN_UNUSED_RETURN BranchFoldResult tryFoldFusedBranchCompare(OpType, ExpressionType, ExpressionType);
-    WARN_UNUSED_RETURN Jump emitFusedBranchCompareBranch(OpType, ExpressionType, Location, ExpressionType, Location);
+    [[nodiscard]] BranchFoldResult tryFoldFusedBranchCompare(OpType, ExpressionType);
+    [[nodiscard]] Jump emitFusedBranchCompareBranch(OpType, ExpressionType, Location);
+    [[nodiscard]] BranchFoldResult tryFoldFusedBranchCompare(OpType, ExpressionType, ExpressionType);
+    [[nodiscard]] Jump emitFusedBranchCompareBranch(OpType, ExpressionType, Location, ExpressionType, Location);
 
-    WARN_UNUSED_RETURN PartialResult addFusedBranchCompare(OpType, ControlType& target, ExpressionType, Stack&);
-    WARN_UNUSED_RETURN PartialResult addFusedBranchCompare(OpType, ControlType& target, ExpressionType, ExpressionType, Stack&);
-    WARN_UNUSED_RETURN PartialResult addFusedIfCompare(OpType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&);
-    WARN_UNUSED_RETURN PartialResult addFusedIfCompare(OpType, ExpressionType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&);
+    [[nodiscard]] PartialResult addFusedBranchCompare(OpType, ControlType& target, ExpressionType, Stack&);
+    [[nodiscard]] PartialResult addFusedBranchCompare(OpType, ControlType& target, ExpressionType, ExpressionType, Stack&);
+    [[nodiscard]] PartialResult addFusedIfCompare(OpType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&);
+    [[nodiscard]] PartialResult addFusedIfCompare(OpType, ExpressionType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&);
 
     // Flush a value to its canonical slot.
     void flushValue(Value value);
@@ -2046,18 +2046,18 @@ public:
     void emitCCall(Func function, const Vector<Value, N>& arguments, Value& result);
 
     void emitTailCall(FunctionSpaceIndex, const TypeDefinition& signature, ArgumentList& arguments);
-    WARN_UNUSED_RETURN PartialResult addCall(unsigned, FunctionSpaceIndex, const TypeDefinition& signature, ArgumentList& arguments, ResultList& results, CallType = CallType::Call);
+    [[nodiscard]] PartialResult addCall(unsigned, FunctionSpaceIndex, const TypeDefinition& signature, ArgumentList& arguments, ResultList& results, CallType = CallType::Call);
 
     void emitIndirectCall(const char* opcode, unsigned callProfileIndex, const Value& callee, GPRReg importableFunction, const TypeDefinition& signature, ArgumentList& arguments, ResultList& results);
     void emitIndirectTailCall(const char* opcode, const Value& callee, GPRReg importableFunction, const TypeDefinition& signature, ArgumentList& arguments);
 
-    WARN_UNUSED_RETURN PartialResult addCallIndirect(unsigned, unsigned tableIndex, const TypeDefinition& originalSignature, ArgumentList& args, ResultList& results, CallType = CallType::Call);
+    [[nodiscard]] PartialResult addCallIndirect(unsigned, unsigned tableIndex, const TypeDefinition& originalSignature, ArgumentList& args, ResultList& results, CallType = CallType::Call);
 
-    WARN_UNUSED_RETURN PartialResult addCallRef(unsigned, const TypeDefinition& originalSignature, ArgumentList& args, ResultList& results, CallType = CallType::Call);
+    [[nodiscard]] PartialResult addCallRef(unsigned, const TypeDefinition& originalSignature, ArgumentList& args, ResultList& results, CallType = CallType::Call);
 
-    WARN_UNUSED_RETURN PartialResult addUnreachable();
+    [[nodiscard]] PartialResult addUnreachable();
 
-    WARN_UNUSED_RETURN PartialResult addCrash();
+    [[nodiscard]] PartialResult addCrash();
 
     ALWAYS_INLINE void willParseOpcode();
 
@@ -2111,7 +2111,7 @@ public:
 
     void emitVectorMul(SIMDInfo info, Location left, Location right, Location result);
 
-    WARN_UNUSED_RETURN PartialResult fixupOutOfBoundsIndicesForSwizzle(Location a, Location b, Location result);
+    [[nodiscard]] PartialResult fixupOutOfBoundsIndicesForSwizzle(Location a, Location b, Location result);
 
     PartialResult addSIMDV_VV(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&);
 

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT32_64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT32_64.cpp
@@ -209,7 +209,7 @@ Value BBQJIT::instanceValue()
 }
 
 // Tables
-WARN_UNUSED_RETURN PartialResult BBQJIT::addTableGet(unsigned tableIndex, Value index, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addTableGet(unsigned tableIndex, Value index, Value& result)
 {
     // FIXME: Emit this inline <https://bugs.webkit.org/show_bug.cgi?id=198506>.
     ASSERT(index.type() == TypeKind::I32);
@@ -233,7 +233,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addTableGet(unsigned tableIndex, Value 
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::getGlobal(uint32_t index, Value& result)
+[[nodiscard]] PartialResult BBQJIT::getGlobal(uint32_t index, Value& result)
 {
     const Wasm::GlobalInformation& global = m_info.globals[index];
     Type type = global.type;
@@ -303,7 +303,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::getGlobal(uint32_t index, Value& result
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::setGlobal(uint32_t index, Value value)
+[[nodiscard]] PartialResult BBQJIT::setGlobal(uint32_t index, Value value)
 {
     const Wasm::GlobalInformation& global = m_info.globals[index];
     Type type = global.type;
@@ -398,7 +398,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::setGlobal(uint32_t index, Value value)
 
 // Memory
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::load(LoadOpType loadOp, Value pointer, Value& result, uint32_t uoffset)
+[[nodiscard]] PartialResult BBQJIT::load(LoadOpType loadOp, Value pointer, Value& result, uint32_t uoffset)
 {
     if (sumOverflows<uint32_t>(uoffset, sizeOfLoadOp(loadOp))) [[unlikely]] {
         // FIXME: Same issue as in AirIRGenerator::load(): https://bugs.webkit.org/show_bug.cgi?id=166435
@@ -498,7 +498,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::load(LoadOpType loadOp, Value pointer, 
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::store(StoreOpType storeOp, Value pointer, Value value, uint32_t uoffset)
+[[nodiscard]] PartialResult BBQJIT::store(StoreOpType storeOp, Value pointer, Value value, uint32_t uoffset)
 {
     Location valueLocation = locationOf(value);
     if (sumOverflows<uint32_t>(uoffset, sizeOfStoreOp(storeOp))) [[unlikely]] {
@@ -776,7 +776,7 @@ void BBQJIT::emitAtomicOpGeneric(ExtAtomicOpType op, Address address, Location o
     m_jit.branchTest32(ResultCondition::NonZero, wasmScratchGPR2).linkTo(reloopLabel, &m_jit);
 }
 
-WARN_UNUSED_RETURN Value BBQJIT::emitAtomicLoadOp(ExtAtomicOpType loadOp, Type valueType, Location pointer, uint32_t uoffset)
+[[nodiscard]] Value BBQJIT::emitAtomicLoadOp(ExtAtomicOpType loadOp, Type valueType, Location pointer, uint32_t uoffset)
 {
     ASSERT(pointer.isGPR());
 
@@ -1065,7 +1065,7 @@ Value BBQJIT::emitAtomicBinaryRMWOp(ExtAtomicOpType op, Type valueType, Location
     return result;
 }
 
-WARN_UNUSED_RETURN Value BBQJIT::emitAtomicCompareExchange(ExtAtomicOpType op, Type valueType, Location pointer, Value expected, Value value, uint32_t uoffset)
+[[nodiscard]] Value BBQJIT::emitAtomicCompareExchange(ExtAtomicOpType op, Type valueType, Location pointer, Value expected, Value value, uint32_t uoffset)
 {
     ASSERT(pointer.isGPR());
 
@@ -1211,7 +1211,7 @@ void BBQJIT::truncInBounds(TruncationKind truncationKind, Location operandLocati
 }
 
 // GC
-WARN_UNUSED_RETURN PartialResult BBQJIT::addRefI31(ExpressionType value, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addRefI31(ExpressionType value, ExpressionType& result)
 {
     if (value.isConst()) {
         uint32_t lo32 = (value.asI32() << 1) >> 1;
@@ -1234,7 +1234,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addRefI31(ExpressionType value, Express
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI31GetS(TypedExpression typedValue, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addI31GetS(TypedExpression typedValue, ExpressionType& result)
 {
     auto value = typedValue.value();
     if (value.isConst()) {
@@ -1266,7 +1266,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI31GetS(TypedExpression typedValue, 
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI31GetU(TypedExpression typedValue, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addI31GetU(TypedExpression typedValue, ExpressionType& result)
 {
     auto value = typedValue.value();
     if (value.isConst()) {
@@ -1329,7 +1329,7 @@ Value BBQJIT::marshallToI64(Value value)
     }
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayNew(uint32_t typeIndex, ExpressionType size, ExpressionType initValue, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addArrayNew(uint32_t typeIndex, ExpressionType size, ExpressionType initValue, ExpressionType& result)
 {
     result = topValue(TypeKind::Arrayref);
 
@@ -1350,7 +1350,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayNew(uint32_t typeIndex, Express
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayNewFixed(uint32_t typeIndex, ArgumentList& args, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addArrayNewFixed(uint32_t typeIndex, ArgumentList& args, ExpressionType& result)
 {
     // Allocate an uninitialized array whose length matches the argument count
     // FIXME: inline the allocation.
@@ -1394,7 +1394,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayNewFixed(uint32_t typeIndex, Ar
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayNewDefault(uint32_t typeIndex, ExpressionType size, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addArrayNewDefault(uint32_t typeIndex, ExpressionType size, ExpressionType& result)
 {
     Vector<Value, 8> arguments = {
         instanceValue(),
@@ -1411,7 +1411,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayNewDefault(uint32_t typeIndex, 
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayGet(ExtGCOpType arrayGetKind, uint32_t typeIndex, TypedExpression typedArray, ExpressionType index, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addArrayGet(ExtGCOpType arrayGetKind, uint32_t typeIndex, TypedExpression typedArray, ExpressionType index, ExpressionType& result)
 {
     auto arrayref = typedArray.value();
     StorageType elementType = getArrayElementType(typeIndex);
@@ -1664,7 +1664,7 @@ void BBQJIT::emitArraySetUnchecked(uint32_t typeIndex, Value arrayref, Value ind
     consume(value);
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addArraySet(uint32_t typeIndex, TypedExpression typedArray, ExpressionType index, ExpressionType value)
+[[nodiscard]] PartialResult BBQJIT::addArraySet(uint32_t typeIndex, TypedExpression typedArray, ExpressionType index, ExpressionType value)
 {
     auto arrayref = typedArray.value();
     if (arrayref.isConst()) {
@@ -1700,7 +1700,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addArraySet(uint32_t typeIndex, TypedEx
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayLen(TypedExpression typedArray, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addArrayLen(TypedExpression typedArray, ExpressionType& result)
 {
     auto arrayref = typedArray.value();
     if (arrayref.isConst()) {
@@ -1724,7 +1724,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayLen(TypedExpression typedArray,
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayFill(uint32_t typeIndex, TypedExpression typedArray, ExpressionType offset, ExpressionType value, ExpressionType size)
+[[nodiscard]] PartialResult BBQJIT::addArrayFill(uint32_t typeIndex, TypedExpression typedArray, ExpressionType offset, ExpressionType value, ExpressionType size)
 {
     auto arrayref = typedArray.value();
     if (arrayref.isConst()) {
@@ -1838,7 +1838,7 @@ bool BBQJIT::emitStructSet(GPRReg structGPR, const StructType& structType, uint3
     return isRefType(storageType.unpacked());
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addStructNewDefault(uint32_t typeIndex, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addStructNewDefault(uint32_t typeIndex, ExpressionType& result)
 {
 
     Vector<Value, 8> arguments = {
@@ -1867,7 +1867,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addStructNewDefault(uint32_t typeIndex,
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addStructNew(uint32_t typeIndex, ArgumentList& args, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addStructNew(uint32_t typeIndex, ArgumentList& args, Value& result)
 {
     Vector<Value, 8> arguments = {
         instanceValue(),
@@ -1904,7 +1904,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addStructNew(uint32_t typeIndex, Argume
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addStructGet(ExtGCOpType structGetKind, TypedExpression typedStruct, const StructType& structType, uint32_t fieldIndex, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addStructGet(ExtGCOpType structGetKind, TypedExpression typedStruct, const StructType& structType, uint32_t fieldIndex, Value& result)
 {
     auto structValue = typedStruct.value();
     TypeKind resultKind = structType.field(fieldIndex).type.unpacked().kind;
@@ -1975,7 +1975,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addStructGet(ExtGCOpType structGetKind,
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addStructSet(TypedExpression typedStruct, const StructType& structType, uint32_t fieldIndex, Value value)
+[[nodiscard]] PartialResult BBQJIT::addStructSet(TypedExpression typedStruct, const StructType& structType, uint32_t fieldIndex, Value value)
 {
     auto structValue = typedStruct.value();
     if (structValue.isConst()) {
@@ -2003,7 +2003,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addStructSet(TypedExpression typedStruc
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addRefCast(TypedExpression reference, bool allowNull, int32_t heapType, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addRefCast(TypedExpression reference, bool allowNull, int32_t heapType, ExpressionType& result)
 {
     Vector<Value, 8> arguments = {
         instanceValue(),
@@ -2023,7 +2023,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addRefCast(TypedExpression reference, b
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addRefTest(TypedExpression reference, bool allowNull, int32_t heapType, bool shouldNegate, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addRefTest(TypedExpression reference, bool allowNull, int32_t heapType, bool shouldNegate, ExpressionType& result)
 {
     Vector<Value, 8> arguments = {
         instanceValue(),
@@ -2040,7 +2040,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addRefTest(TypedExpression reference, b
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Add(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64Add(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "I64Add", TypeKind::I64,
@@ -2056,7 +2056,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Add(Value lhs, Value rhs, Value& 
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Sub(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64Sub(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "I64Sub", TypeKind::I64,
@@ -2080,7 +2080,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Sub(Value lhs, Value rhs, Value& 
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Mul(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64Mul(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "I64Mul", TypeKind::I64,
@@ -2101,7 +2101,7 @@ void BBQJIT::emitThrowOnNullReference(ExceptionType type, Location ref)
     recordJumpToThrowException(type, m_jit.branch32(MacroAssembler::Equal, ref.asGPRhi(), TrustedImm32(JSValue::NullTag)));
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64And(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64And(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "I64And", TypeKind::I64,
@@ -2118,7 +2118,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI64And(Value lhs, Value rhs, Value& 
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Xor(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64Xor(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "I64Xor", TypeKind::I64,
@@ -2135,7 +2135,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Xor(Value lhs, Value rhs, Value& 
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Or(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64Or(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "I64Or", TypeKind::I64,
@@ -2152,7 +2152,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Or(Value lhs, Value rhs, Value& r
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Shl(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64Shl(Value lhs, Value rhs, Value& result)
 {
     auto emitI64Shl = [&](Location lhsLocation, Location rhsLocation, Location resultLocation) {
         ScratchScope<2, 0> scratches(*this, lhsLocation, rhsLocation, resultLocation);
@@ -2193,7 +2193,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Shl(Value lhs, Value rhs, Value& 
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64ShrS(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64ShrS(Value lhs, Value rhs, Value& result)
 {
     auto emitI64ShrS = [&](Location lhsLocation, Location rhsLocation, Location resultLocation) {
         ScratchScope<2, 0> scratches(*this, lhsLocation, rhsLocation, resultLocation);
@@ -2237,7 +2237,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI64ShrS(Value lhs, Value rhs, Value&
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64ShrU(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64ShrU(Value lhs, Value rhs, Value& result)
 {
     auto emitI64ShrU = [&](Location lhsLocation, Location rhsLocation, Location resultLocation) {
         ScratchScope<2, 0> scratches(*this, lhsLocation, rhsLocation, resultLocation);
@@ -2280,7 +2280,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI64ShrU(Value lhs, Value rhs, Value&
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Rotl(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64Rotl(Value lhs, Value rhs, Value& result)
 {
     PREPARE_FOR_SHIFT;
     EMIT_BINARY(
@@ -2297,7 +2297,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Rotl(Value lhs, Value rhs, Value&
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Rotr(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64Rotr(Value lhs, Value rhs, Value& result)
 {
     PREPARE_FOR_SHIFT;
     EMIT_BINARY(
@@ -2350,7 +2350,7 @@ void BBQJIT::rotI64Helper(RotI64HelperOp op, Location lhsLocation, Location rhsL
     zero.link(&m_jit);
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Clz(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64Clz(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I64Clz", TypeKind::I64,
@@ -2361,7 +2361,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Clz(Value operand, Value& result)
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Ctz(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64Ctz(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I64Ctz", TypeKind::I64,
@@ -2399,7 +2399,7 @@ PartialResult BBQJIT::addI32WrapI64(Value operand, Value& result)
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Extend8S(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64Extend8S(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I64Extend8S", TypeKind::I64,
@@ -2412,7 +2412,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Extend8S(Value operand, Value& re
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Extend16S(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64Extend16S(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I64Extend16S", TypeKind::I64,
@@ -2425,7 +2425,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Extend16S(Value operand, Value& r
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Extend32S(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64Extend32S(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I64Extend32S", TypeKind::I64,
@@ -2438,7 +2438,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Extend32S(Value operand, Value& r
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64ExtendSI32(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64ExtendSI32(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I64ExtendSI32", TypeKind::I64,
@@ -2451,7 +2451,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI64ExtendSI32(Value operand, Value& 
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64ExtendUI32(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64ExtendUI32(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I64ExtendUI32", TypeKind::I64,
@@ -2464,7 +2464,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI64ExtendUI32(Value operand, Value& 
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Eqz(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64Eqz(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I64Eqz", TypeKind::I32,
@@ -2476,7 +2476,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Eqz(Value operand, Value& result)
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64ReinterpretF64(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64ReinterpretF64(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I64ReinterpretF64", TypeKind::I64,
@@ -2487,7 +2487,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI64ReinterpretF64(Value operand, Val
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF64ReinterpretI64(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF64ReinterpretI64(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F64ReinterpretI64", TypeKind::F64,
@@ -2498,7 +2498,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF64ReinterpretI64(Value operand, Val
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF32ConvertUI32(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF32ConvertUI32(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F32ConvertUI32", TypeKind::F32,
@@ -2509,7 +2509,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF32ConvertUI32(Value operand, Value&
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF32ConvertSI64(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF32ConvertSI64(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F32ConvertSI64", TypeKind::F32,
@@ -2522,7 +2522,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF32ConvertSI64(Value operand, Value&
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF32ConvertUI64(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF32ConvertUI64(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F32ConvertUI64", TypeKind::F32,
@@ -2535,7 +2535,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF32ConvertUI64(Value operand, Value&
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF64ConvertUI32(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF64ConvertUI32(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F64ConvertUI32", TypeKind::F64,
@@ -2546,7 +2546,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF64ConvertUI32(Value operand, Value&
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF64ConvertSI64(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF64ConvertSI64(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F64ConvertSI64", TypeKind::F64,
@@ -2559,7 +2559,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF64ConvertSI64(Value operand, Value&
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF64ConvertUI64(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF64ConvertUI64(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F64ConvertUI64", TypeKind::F64,
@@ -2572,7 +2572,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF64ConvertUI64(Value operand, Value&
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Floor(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF32Floor(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F32Floor", TypeKind::F32,
@@ -2585,7 +2585,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Floor(Value operand, Value& resul
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Floor(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF64Floor(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F64Floor", TypeKind::F64,
@@ -2598,7 +2598,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Floor(Value operand, Value& resul
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Ceil(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF32Ceil(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F32Ceil", TypeKind::F32,
@@ -2611,7 +2611,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Ceil(Value operand, Value& result
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Ceil(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF64Ceil(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F64Ceil", TypeKind::F64,
@@ -2624,7 +2624,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Ceil(Value operand, Value& result
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Nearest(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF32Nearest(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F32Nearest", TypeKind::F32,
@@ -2637,7 +2637,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Nearest(Value operand, Value& res
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Nearest(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF64Nearest(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F64Nearest", TypeKind::F64,
@@ -2650,7 +2650,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Nearest(Value operand, Value& res
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Trunc(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF32Trunc(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F32Trunc", TypeKind::F32,
@@ -2663,7 +2663,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Trunc(Value operand, Value& resul
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Trunc(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF64Trunc(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F64Trunc", TypeKind::F64,
@@ -2678,7 +2678,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Trunc(Value operand, Value& resul
 
 // References
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addRefIsNull(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addRefIsNull(Value operand, Value& result)
 {
     EMIT_UNARY(
         "RefIsNull", TypeKind::I32,
@@ -2690,7 +2690,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addRefIsNull(Value operand, Value& resu
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addRefAsNonNull(Value value, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addRefAsNonNull(Value value, Value& result)
 {
     Location valueLocation;
     if (value.isConst()) {
@@ -2909,7 +2909,7 @@ void BBQJIT::emitCatchTableImpl(ControlData& entryData, ControlType::TryTableTar
     targetControl.addBranch(m_jit.jump());
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addThrowRef(Value exception, Stack&)
+[[nodiscard]] PartialResult BBQJIT::addThrowRef(Value exception, Stack&)
 {
     LOG_INSTRUCTION("ThrowRef", exception);
 
@@ -2935,7 +2935,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addThrowRef(Value exception, Stack&)
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addRethrow(unsigned, ControlType& data)
+[[nodiscard]] PartialResult BBQJIT::addRethrow(unsigned, ControlType& data)
 {
     LOG_INSTRUCTION("Rethrow", exception(data));
 
@@ -2950,7 +2950,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addRethrow(unsigned, ControlType& data)
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addBranchNull(ControlData& data, ExpressionType reference, Stack& returnValues, bool shouldNegate, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addBranchNull(ControlData& data, ExpressionType reference, Stack& returnValues, bool shouldNegate, ExpressionType& result)
 {
     if (reference.isConst() && (reference.asRef() == JSValue::encode(jsNull())) == shouldNegate) {
         // If branch is known to be not-taken, exit early.
@@ -3014,7 +3014,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addBranchNull(ControlData& data, Expres
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addBranchCast(ControlData& data, ExpressionType reference, Stack& returnValues, bool allowNull, int32_t heapType, bool shouldNegate)
+[[nodiscard]] PartialResult BBQJIT::addBranchCast(ControlData& data, ExpressionType reference, Stack& returnValues, bool allowNull, int32_t heapType, bool shouldNegate)
 {
     Value condition;
     if (reference.isConst()) {
@@ -3073,67 +3073,67 @@ void BBQJIT::notifyFunctionUsesSIMD()
     m_usesSIMD = false;
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDLoad(ExpressionType, uint32_t, ExpressionType&)
+[[nodiscard]] PartialResult BBQJIT::addSIMDLoad(ExpressionType, uint32_t, ExpressionType&)
 {
     UNREACHABLE_FOR_PLATFORM();
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDStore(ExpressionType, ExpressionType, uint32_t)
+[[nodiscard]] PartialResult BBQJIT::addSIMDStore(ExpressionType, ExpressionType, uint32_t)
 {
     UNREACHABLE_FOR_PLATFORM();
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDSplat(SIMDLane, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult BBQJIT::addSIMDSplat(SIMDLane, ExpressionType, ExpressionType&)
 {
     UNREACHABLE_FOR_PLATFORM();
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDShuffle(v128_t, ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult BBQJIT::addSIMDShuffle(v128_t, ExpressionType, ExpressionType, ExpressionType&)
 {
     UNREACHABLE_FOR_PLATFORM();
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDShift(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult BBQJIT::addSIMDShift(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&)
 {
     UNREACHABLE_FOR_PLATFORM();
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDExtmul(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult BBQJIT::addSIMDExtmul(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&)
 {
     UNREACHABLE_FOR_PLATFORM();
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDLoadSplat(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&)
+[[nodiscard]] PartialResult BBQJIT::addSIMDLoadSplat(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&)
 {
     UNREACHABLE_FOR_PLATFORM();
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDLoadLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t, uint8_t, ExpressionType&)
+[[nodiscard]] PartialResult BBQJIT::addSIMDLoadLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t, uint8_t, ExpressionType&)
 {
     UNREACHABLE_FOR_PLATFORM();
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDStoreLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t, uint8_t)
+[[nodiscard]] PartialResult BBQJIT::addSIMDStoreLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t, uint8_t)
 {
     UNREACHABLE_FOR_PLATFORM();
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDLoadExtend(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&)
+[[nodiscard]] PartialResult BBQJIT::addSIMDLoadExtend(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&)
 {
     UNREACHABLE_FOR_PLATFORM();
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDLoadPad(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&)
+[[nodiscard]] PartialResult BBQJIT::addSIMDLoadPad(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&)
 {
     UNREACHABLE_FOR_PLATFORM();
     return { };
@@ -3150,49 +3150,49 @@ ExpressionType BBQJIT::addConstant(v128_t)
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addExtractLane(SIMDInfo, uint8_t, Value, Value&)
+[[nodiscard]] PartialResult BBQJIT::addExtractLane(SIMDInfo, uint8_t, Value, Value&)
 {
     UNREACHABLE_FOR_PLATFORM();
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addReplaceLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult BBQJIT::addReplaceLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType, ExpressionType&)
 {
     UNREACHABLE_FOR_PLATFORM();
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDI_V(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult BBQJIT::addSIMDI_V(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType&)
 {
     UNREACHABLE_FOR_PLATFORM();
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDV_V(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult BBQJIT::addSIMDV_V(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType&)
 {
     UNREACHABLE_FOR_PLATFORM();
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDBitwiseSelect(ExpressionType, ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult BBQJIT::addSIMDBitwiseSelect(ExpressionType, ExpressionType, ExpressionType, ExpressionType&)
 {
     UNREACHABLE_FOR_PLATFORM();
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDRelOp(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, B3::Air::Arg, ExpressionType&)
+[[nodiscard]] PartialResult BBQJIT::addSIMDRelOp(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, B3::Air::Arg, ExpressionType&)
 {
     UNREACHABLE_FOR_PLATFORM();
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDV_VV(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult BBQJIT::addSIMDV_VV(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&)
 {
     UNREACHABLE_FOR_PLATFORM();
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDRelaxedFMA(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult BBQJIT::addSIMDRelaxedFMA(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType, ExpressionType&)
 {
     UNREACHABLE_FOR_PLATFORM();
     return { };
@@ -3470,7 +3470,7 @@ void BBQJIT::emitLoad(TypeKind type, Location src, Location dst)
     }
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addCallRef(unsigned callProfileIndex, const TypeDefinition& originalSignature, ArgumentList& args, ResultList& results, CallType callType)
+[[nodiscard]] PartialResult BBQJIT::addCallRef(unsigned callProfileIndex, const TypeDefinition& originalSignature, ArgumentList& args, ResultList& results, CallType callType)
 {
     emitIncrementCallProfileCount(callProfileIndex);
     Value callee = args.takeLast();

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -161,7 +161,7 @@ Value BBQJIT::instanceValue()
 }
 
 // Tables
-WARN_UNUSED_RETURN PartialResult BBQJIT::addTableGet(unsigned tableIndex, Value index, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addTableGet(unsigned tableIndex, Value index, Value& result)
 {
     // FIXME: Emit this inline <https://bugs.webkit.org/show_bug.cgi?id=198506>.
     ASSERT(index.type() == TypeKind::I32);
@@ -183,7 +183,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addTableGet(unsigned tableIndex, Value 
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::getGlobal(uint32_t index, Value& result)
+[[nodiscard]] PartialResult BBQJIT::getGlobal(uint32_t index, Value& result)
 {
     const Wasm::GlobalInformation& global = m_info.globals[index];
     Type type = global.type;
@@ -250,7 +250,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::getGlobal(uint32_t index, Value& result
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::setGlobal(uint32_t index, Value value)
+[[nodiscard]] PartialResult BBQJIT::setGlobal(uint32_t index, Value value)
 {
     const Wasm::GlobalInformation& global = m_info.globals[index];
     Type type = global.type;
@@ -340,7 +340,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::setGlobal(uint32_t index, Value value)
 
 // Memory
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::load(LoadOpType loadOp, Value pointer, Value& result, uint32_t uoffset)
+[[nodiscard]] PartialResult BBQJIT::load(LoadOpType loadOp, Value pointer, Value& result, uint32_t uoffset)
 {
     if (sumOverflows<uint32_t>(uoffset, sizeOfLoadOp(loadOp))) [[unlikely]] {
         // FIXME: Same issue as in AirIRGenerator::load(): https://bugs.webkit.org/show_bug.cgi?id=166435
@@ -432,7 +432,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::load(LoadOpType loadOp, Value pointer, 
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::store(StoreOpType storeOp, Value pointer, Value value, uint32_t uoffset)
+[[nodiscard]] PartialResult BBQJIT::store(StoreOpType storeOp, Value pointer, Value value, uint32_t uoffset)
 {
     Location valueLocation = locationOf(value);
     if (sumOverflows<uint32_t>(uoffset, sizeOfStoreOp(storeOp))) [[unlikely]] {
@@ -631,7 +631,7 @@ void BBQJIT::emitAtomicOpGeneric(ExtAtomicOpType op, Address address, GPRReg old
 #endif
 }
 
-WARN_UNUSED_RETURN Value BBQJIT::emitAtomicLoadOp(ExtAtomicOpType loadOp, Type valueType, Location pointer, uint32_t uoffset)
+[[nodiscard]] Value BBQJIT::emitAtomicLoadOp(ExtAtomicOpType loadOp, Type valueType, Location pointer, uint32_t uoffset)
 {
     ASSERT(pointer.isGPR());
 
@@ -1187,7 +1187,7 @@ Value BBQJIT::emitAtomicBinaryRMWOp(ExtAtomicOpType op, Type valueType, Location
     return result;
 }
 
-WARN_UNUSED_RETURN Value BBQJIT::emitAtomicCompareExchange(ExtAtomicOpType op, Type, Location pointer, Value expected, Value value, uint32_t uoffset)
+[[nodiscard]] Value BBQJIT::emitAtomicCompareExchange(ExtAtomicOpType op, Type, Location pointer, Value expected, Value value, uint32_t uoffset)
 {
     ASSERT(pointer.isGPR());
 
@@ -1337,7 +1337,7 @@ void BBQJIT::truncInBounds(TruncationKind truncationKind, Location operandLocati
 }
 
 // GC
-WARN_UNUSED_RETURN PartialResult BBQJIT::addRefI31(ExpressionType value, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addRefI31(ExpressionType value, ExpressionType& result)
 {
     if (value.isConst()) {
         uint32_t lo32 = (value.asI32() << 1) >> 1;
@@ -1360,7 +1360,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addRefI31(ExpressionType value, Express
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI31GetS(TypedExpression typedValue, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addI31GetS(TypedExpression typedValue, ExpressionType& result)
 {
     auto value = typedValue.value();
     if (value.isConst()) {
@@ -1392,7 +1392,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI31GetS(TypedExpression typedValue, 
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI31GetU(TypedExpression typedValue, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addI31GetU(TypedExpression typedValue, ExpressionType& result)
 {
     auto value = typedValue.value();
     if (value.isConst()) {
@@ -1501,7 +1501,7 @@ void BBQJIT::emitAllocateGCArrayUninitialized(GPRReg resultGPR, uint32_t typeInd
     } });
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayNew(uint32_t typeIndex, ExpressionType size, ExpressionType initValue, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addArrayNew(uint32_t typeIndex, ExpressionType size, ExpressionType initValue, ExpressionType& result)
 {
     GPRReg resultGPR;
     {
@@ -1553,7 +1553,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayNew(uint32_t typeIndex, Express
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayNewFixed(uint32_t typeIndex, ArgumentList& args, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addArrayNewFixed(uint32_t typeIndex, ArgumentList& args, ExpressionType& result)
 {
     GPRReg resultGPR;
     {
@@ -1585,7 +1585,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayNewFixed(uint32_t typeIndex, Ar
 }
 
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayNewDefault(uint32_t typeIndex, ExpressionType size, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addArrayNewDefault(uint32_t typeIndex, ExpressionType size, ExpressionType& result)
 {
     StorageType elementType = getArrayElementType(typeIndex);
     // FIXME: We don't have a good way to fill V128s yet so just make a call.
@@ -1641,7 +1641,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayNewDefault(uint32_t typeIndex, 
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayGet(ExtGCOpType arrayGetKind, uint32_t typeIndex, TypedExpression typedArray, ExpressionType index, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addArrayGet(ExtGCOpType arrayGetKind, uint32_t typeIndex, TypedExpression typedArray, ExpressionType index, ExpressionType& result)
 {
     auto arrayref = typedArray.value();
     StorageType elementType = getArrayElementType(typeIndex);
@@ -1830,7 +1830,7 @@ void BBQJIT::emitArraySetUnchecked(uint32_t typeIndex, Value arrayref, Value ind
     consume(value);
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addArraySet(uint32_t typeIndex, TypedExpression typedArray, ExpressionType index, ExpressionType value)
+[[nodiscard]] PartialResult BBQJIT::addArraySet(uint32_t typeIndex, TypedExpression typedArray, ExpressionType index, ExpressionType value)
 {
     auto arrayref = typedArray.value();
     if (arrayref.isConst()) {
@@ -1869,7 +1869,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addArraySet(uint32_t typeIndex, TypedEx
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayLen(TypedExpression typedArray, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addArrayLen(TypedExpression typedArray, ExpressionType& result)
 {
     auto arrayref = typedArray.value();
     if (arrayref.isConst()) {
@@ -1893,7 +1893,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayLen(TypedExpression typedArray,
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayFill(uint32_t typeIndex, TypedExpression typedArray, ExpressionType offset, ExpressionType value, ExpressionType size)
+[[nodiscard]] PartialResult BBQJIT::addArrayFill(uint32_t typeIndex, TypedExpression typedArray, ExpressionType offset, ExpressionType value, ExpressionType size)
 {
     auto arrayref = typedArray.value();
     if (arrayref.isConst()) {
@@ -2015,7 +2015,7 @@ void BBQJIT::emitAllocateGCStructUninitialized(GPRReg resultGPR, uint32_t typeIn
     }});
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addStructNewDefault(uint32_t typeIndex, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addStructNewDefault(uint32_t typeIndex, ExpressionType& result)
 {
     const auto& structType = *m_info.typeSignatures[typeIndex]->expand().template as<StructType>();
     GPRReg resultGPR;
@@ -2061,7 +2061,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addStructNewDefault(uint32_t typeIndex,
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addStructNew(uint32_t typeIndex, ArgumentList& args, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addStructNew(uint32_t typeIndex, ArgumentList& args, Value& result)
 {
     const auto& structType = *m_info.typeSignatures[typeIndex]->expand().template as<StructType>();
     GPRReg resultGPR;
@@ -2101,7 +2101,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addStructNew(uint32_t typeIndex, Argume
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addStructGet(ExtGCOpType structGetKind, TypedExpression typedStruct, const StructType& structType, uint32_t fieldIndex, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addStructGet(ExtGCOpType structGetKind, TypedExpression typedStruct, const StructType& structType, uint32_t fieldIndex, Value& result)
 {
     auto structValue = typedStruct.value();
     TypeKind resultKind = structType.field(fieldIndex).type.unpacked().kind;
@@ -2188,7 +2188,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addStructGet(ExtGCOpType structGetKind,
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addStructSet(TypedExpression typedStruct, const StructType& structType, uint32_t fieldIndex, Value value)
+[[nodiscard]] PartialResult BBQJIT::addStructSet(TypedExpression typedStruct, const StructType& structType, uint32_t fieldIndex, Value value)
 {
     auto structValue = typedStruct.value();
     if (structValue.isConst()) {
@@ -2339,7 +2339,7 @@ void BBQJIT::emitRefTestOrCast(CastKind castKind, const TypedExpression& typedVa
     doneCases.link(m_jit);
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addRefCast(TypedExpression typedValue, bool allowNull, int32_t toHeapType, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addRefCast(TypedExpression typedValue, bool allowNull, int32_t toHeapType, ExpressionType& result)
 {
     auto value = typedValue.value();
     Location valueLocation;
@@ -2363,7 +2363,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addRefCast(TypedExpression typedValue, 
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addRefTest(TypedExpression typedValue, bool allowNull, int32_t toHeapType, bool shouldNegate, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addRefTest(TypedExpression typedValue, bool allowNull, int32_t toHeapType, bool shouldNegate, ExpressionType& result)
 {
     auto value = typedValue.value();
     Location valueLocation;
@@ -2394,7 +2394,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addRefTest(TypedExpression typedValue, 
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Add(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64Add(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "I64Add", TypeKind::I64,
@@ -2413,7 +2413,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Add(Value lhs, Value rhs, Value& 
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Sub(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64Sub(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "I64Sub", TypeKind::I64,
@@ -2432,7 +2432,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Sub(Value lhs, Value rhs, Value& 
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Mul(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64Mul(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "I64Mul", TypeKind::I64,
@@ -2462,7 +2462,7 @@ void BBQJIT::emitThrowOnNullReferenceBeforeAccess(Location ref, ptrdiff_t offset
     emitThrowOnNullReference(ExceptionType::NullAccess, ref);
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64And(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64And(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "I64And", TypeKind::I64,
@@ -2476,7 +2476,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI64And(Value lhs, Value rhs, Value& 
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Xor(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64Xor(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "I64Xor", TypeKind::I64,
@@ -2490,7 +2490,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Xor(Value lhs, Value rhs, Value& 
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Or(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64Or(Value lhs, Value rhs, Value& result)
 {
     EMIT_BINARY(
         "I64Or", TypeKind::I64,
@@ -2504,7 +2504,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Or(Value lhs, Value rhs, Value& r
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Shl(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64Shl(Value lhs, Value rhs, Value& result)
 {
     PREPARE_FOR_SHIFT;
     EMIT_BINARY(
@@ -2526,7 +2526,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Shl(Value lhs, Value rhs, Value& 
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64ShrS(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64ShrS(Value lhs, Value rhs, Value& result)
 {
     PREPARE_FOR_SHIFT;
     EMIT_BINARY(
@@ -2548,7 +2548,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI64ShrS(Value lhs, Value rhs, Value&
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64ShrU(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64ShrU(Value lhs, Value rhs, Value& result)
 {
     PREPARE_FOR_SHIFT;
     EMIT_BINARY(
@@ -2570,7 +2570,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI64ShrU(Value lhs, Value rhs, Value&
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Rotl(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64Rotl(Value lhs, Value rhs, Value& result)
 {
     PREPARE_FOR_SHIFT;
     EMIT_BINARY(
@@ -2610,7 +2610,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Rotl(Value lhs, Value rhs, Value&
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Rotr(Value lhs, Value rhs, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64Rotr(Value lhs, Value rhs, Value& result)
 {
     PREPARE_FOR_SHIFT;
     EMIT_BINARY(
@@ -2632,7 +2632,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Rotr(Value lhs, Value rhs, Value&
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Clz(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64Clz(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I64Clz", TypeKind::I64,
@@ -2643,7 +2643,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Clz(Value operand, Value& result)
     );
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Ctz(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64Ctz(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I64Ctz", TypeKind::I64,
@@ -2682,7 +2682,7 @@ PartialResult BBQJIT::addI32WrapI64(Value operand, Value& result)
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Extend8S(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64Extend8S(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I64Extend8S", TypeKind::I64,
@@ -2693,7 +2693,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Extend8S(Value operand, Value& re
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Extend16S(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64Extend16S(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I64Extend16S", TypeKind::I64,
@@ -2704,7 +2704,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Extend16S(Value operand, Value& r
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Extend32S(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64Extend32S(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I64Extend32S", TypeKind::I64,
@@ -2715,7 +2715,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Extend32S(Value operand, Value& r
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64ExtendSI32(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64ExtendSI32(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I64ExtendSI32", TypeKind::I64,
@@ -2726,7 +2726,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI64ExtendSI32(Value operand, Value& 
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64ExtendUI32(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64ExtendUI32(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I64ExtendUI32", TypeKind::I64,
@@ -2737,7 +2737,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI64ExtendUI32(Value operand, Value& 
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Eqz(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64Eqz(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I64Eqz", TypeKind::I32,
@@ -2748,7 +2748,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Eqz(Value operand, Value& result)
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addI64ReinterpretF64(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addI64ReinterpretF64(Value operand, Value& result)
 {
     EMIT_UNARY(
         "I64ReinterpretF64", TypeKind::I64,
@@ -2759,7 +2759,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addI64ReinterpretF64(Value operand, Val
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF64ReinterpretI64(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF64ReinterpretI64(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F64ReinterpretI64", TypeKind::F64,
@@ -2770,7 +2770,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF64ReinterpretI64(Value operand, Val
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF32ConvertUI32(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF32ConvertUI32(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F32ConvertUI32", TypeKind::F32,
@@ -2781,7 +2781,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF32ConvertUI32(Value operand, Value&
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF32ConvertSI64(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF32ConvertSI64(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F32ConvertSI64", TypeKind::F32,
@@ -2792,7 +2792,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF32ConvertSI64(Value operand, Value&
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF32ConvertUI64(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF32ConvertUI64(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F32ConvertUI64", TypeKind::F32,
@@ -2807,7 +2807,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF32ConvertUI64(Value operand, Value&
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF64ConvertUI32(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF64ConvertUI32(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F64ConvertUI32", TypeKind::F64,
@@ -2818,7 +2818,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF64ConvertUI32(Value operand, Value&
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF64ConvertSI64(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF64ConvertSI64(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F64ConvertSI64", TypeKind::F64,
@@ -2829,7 +2829,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF64ConvertSI64(Value operand, Value&
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF64ConvertUI64(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF64ConvertUI64(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F64ConvertUI64", TypeKind::F64,
@@ -2844,7 +2844,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF64ConvertUI64(Value operand, Value&
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Floor(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF32Floor(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F32Floor", TypeKind::F32,
@@ -2855,7 +2855,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Floor(Value operand, Value& resul
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Floor(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF64Floor(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F64Floor", TypeKind::F64,
@@ -2866,7 +2866,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Floor(Value operand, Value& resul
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Ceil(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF32Ceil(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F32Ceil", TypeKind::F32,
@@ -2877,7 +2877,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Ceil(Value operand, Value& result
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Ceil(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF64Ceil(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F64Ceil", TypeKind::F64,
@@ -2888,7 +2888,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Ceil(Value operand, Value& result
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Nearest(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF32Nearest(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F32Nearest", TypeKind::F32,
@@ -2899,7 +2899,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Nearest(Value operand, Value& res
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Nearest(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF64Nearest(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F64Nearest", TypeKind::F64,
@@ -2910,7 +2910,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Nearest(Value operand, Value& res
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Trunc(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF32Trunc(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F32Trunc", TypeKind::F32,
@@ -2921,7 +2921,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Trunc(Value operand, Value& resul
     )
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Trunc(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addF64Trunc(Value operand, Value& result)
 {
     EMIT_UNARY(
         "F64Trunc", TypeKind::F64,
@@ -2934,7 +2934,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Trunc(Value operand, Value& resul
 
 // References
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addRefIsNull(Value operand, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addRefIsNull(Value operand, Value& result)
 {
     EMIT_UNARY(
         "RefIsNull", TypeKind::I32,
@@ -2947,7 +2947,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addRefIsNull(Value operand, Value& resu
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addRefAsNonNull(Value value, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addRefAsNonNull(Value value, Value& result)
 {
     Location valueLocation;
     if (value.isConst()) {
@@ -3155,7 +3155,7 @@ void BBQJIT::emitCatchTableImpl(ControlData& entryData, ControlType::TryTableTar
     targetControl.addBranch(m_jit.jump());
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addThrowRef(Value exception, Stack&)
+[[nodiscard]] PartialResult BBQJIT::addThrowRef(Value exception, Stack&)
 {
     LOG_INSTRUCTION("ThrowRef", exception);
 
@@ -3182,7 +3182,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addThrowRef(Value exception, Stack&)
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addRethrow(unsigned, ControlType& data)
+[[nodiscard]] PartialResult BBQJIT::addRethrow(unsigned, ControlType& data)
 {
     LOG_INSTRUCTION("Rethrow", exception(data));
 
@@ -3197,7 +3197,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addRethrow(unsigned, ControlType& data)
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addBranchNull(ControlData& data, ExpressionType reference, Stack& returnValues, bool shouldNegate, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addBranchNull(ControlData& data, ExpressionType reference, Stack& returnValues, bool shouldNegate, ExpressionType& result)
 {
     if (reference.isConst() && (reference.asRef() == JSValue::encode(jsNull())) == shouldNegate) {
         // If branch is known to be not-taken, exit early.
@@ -3262,7 +3262,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addBranchNull(ControlData& data, Expres
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addBranchCast(ControlData& data, ExpressionType reference, Stack& returnValues, bool allowNull, int32_t heapType, bool shouldNegate)
+[[nodiscard]] PartialResult BBQJIT::addBranchCast(ControlData& data, ExpressionType reference, Stack& returnValues, bool allowNull, int32_t heapType, bool shouldNegate)
 {
     Value condition;
     if (reference.isConst()) {
@@ -3333,7 +3333,7 @@ void BBQJIT::notifyFunctionUsesSIMD()
     m_usesSIMD = true;
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDLoad(ExpressionType pointer, uint32_t uoffset, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addSIMDLoad(ExpressionType pointer, uint32_t uoffset, ExpressionType& result)
 {
     result = emitCheckAndPrepareAndMaterializePointerApply(pointer, uoffset, bytesForWidth(Width::Width128), [&](auto location) -> Value {
         consume(pointer);
@@ -3346,7 +3346,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDLoad(ExpressionType pointer, uin
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDStore(ExpressionType value, ExpressionType pointer, uint32_t uoffset)
+[[nodiscard]] PartialResult BBQJIT::addSIMDStore(ExpressionType value, ExpressionType pointer, uint32_t uoffset)
 {
     emitCheckAndPrepareAndMaterializePointerApply(pointer, uoffset, bytesForWidth(Width::Width128), [&](auto location) -> void {
         Location valueLocation = loadIfNecessary(value);
@@ -3358,7 +3358,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDStore(ExpressionType value, Expr
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDSplat(SIMDLane lane, ExpressionType value, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addSIMDSplat(SIMDLane lane, ExpressionType value, ExpressionType& result)
 {
     Location valueLocation;
     if (value.isConst()) {
@@ -3433,7 +3433,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDSplat(SIMDLane lane, ExpressionT
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDShuffle(v128_t imm, ExpressionType a, ExpressionType b, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addSIMDShuffle(v128_t imm, ExpressionType a, ExpressionType b, ExpressionType& result)
 {
 #if CPU(X86_64)
     ScratchScope<0, 1> scratches(*this);
@@ -3491,7 +3491,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDShuffle(v128_t imm, ExpressionTy
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDShift(SIMDLaneOperation op, SIMDInfo info, ExpressionType src, ExpressionType shift, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addSIMDShift(SIMDLaneOperation op, SIMDInfo info, ExpressionType src, ExpressionType shift, ExpressionType& result)
 {
 #if CPU(X86_64)
     // Clobber and preserve RCX on x86, since we need it to do shifts.
@@ -3571,7 +3571,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDShift(SIMDLaneOperation op, SIMD
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDExtmul(SIMDLaneOperation op, SIMDInfo info, ExpressionType left, ExpressionType right, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addSIMDExtmul(SIMDLaneOperation op, SIMDInfo info, ExpressionType left, ExpressionType right, ExpressionType& result)
 {
     ASSERT(info.signMode != SIMDSignMode::None);
 
@@ -3592,7 +3592,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDExtmul(SIMDLaneOperation op, SIM
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDLoadSplat(SIMDLaneOperation op, ExpressionType pointer, uint32_t uoffset, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addSIMDLoadSplat(SIMDLaneOperation op, ExpressionType pointer, uint32_t uoffset, ExpressionType& result)
 {
     Width width;
     switch (op) {
@@ -3645,7 +3645,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDLoadSplat(SIMDLaneOperation op, 
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDLoadLane(SIMDLaneOperation op, ExpressionType pointer, ExpressionType vector, uint32_t uoffset, uint8_t lane, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addSIMDLoadLane(SIMDLaneOperation op, ExpressionType pointer, ExpressionType vector, uint32_t uoffset, uint8_t lane, ExpressionType& result)
 {
     Width width;
     switch (op) {
@@ -3696,7 +3696,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDLoadLane(SIMDLaneOperation op, E
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDStoreLane(SIMDLaneOperation op, ExpressionType pointer, ExpressionType vector, uint32_t uoffset, uint8_t lane)
+[[nodiscard]] PartialResult BBQJIT::addSIMDStoreLane(SIMDLaneOperation op, ExpressionType pointer, ExpressionType vector, uint32_t uoffset, uint8_t lane)
 {
     Width width;
     switch (op) {
@@ -3743,7 +3743,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDStoreLane(SIMDLaneOperation op, 
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDLoadExtend(SIMDLaneOperation op, ExpressionType pointer, uint32_t uoffset, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addSIMDLoadExtend(SIMDLaneOperation op, ExpressionType pointer, uint32_t uoffset, ExpressionType& result)
 {
     SIMDLane lane;
     SIMDSignMode signMode;
@@ -3792,7 +3792,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDLoadExtend(SIMDLaneOperation op,
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDLoadPad(SIMDLaneOperation op, ExpressionType pointer, uint32_t uoffset, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addSIMDLoadPad(SIMDLaneOperation op, ExpressionType pointer, uint32_t uoffset, ExpressionType& result)
 {
     result = emitCheckAndPrepareAndMaterializePointerApply(pointer, uoffset, op == SIMDLaneOperation::LoadPad32 ? sizeof(float) : sizeof(double), [&](auto location) -> Value {
         consume(pointer);
@@ -3826,7 +3826,7 @@ void BBQJIT::materializeVectorConstant(v128_t value, Location result)
         m_jit.materializeVector(value, result.asFPR());
 }
 
-WARN_UNUSED_RETURN ExpressionType BBQJIT::addConstant(v128_t value)
+[[nodiscard]] ExpressionType BBQJIT::addConstant(v128_t value)
 {
     // We currently don't track constant Values for V128s, since folding them seems like a lot of work that might not be worth it.
     // Maybe we can look into this eventually?
@@ -3839,7 +3839,7 @@ WARN_UNUSED_RETURN ExpressionType BBQJIT::addConstant(v128_t value)
 
 // SIMD generated
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addExtractLane(SIMDInfo info, uint8_t lane, Value value, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addExtractLane(SIMDInfo info, uint8_t lane, Value value, Value& result)
 {
     Location valueLocation = loadIfNecessary(value);
     consume(value);
@@ -3855,7 +3855,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addExtractLane(SIMDInfo info, uint8_t l
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addReplaceLane(SIMDInfo info, uint8_t lane, ExpressionType vector, ExpressionType scalar, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addReplaceLane(SIMDInfo info, uint8_t lane, ExpressionType vector, ExpressionType scalar, ExpressionType& result)
 {
     Location vectorLocation = loadIfNecessary(vector);
     Location scalarLocation;
@@ -3885,7 +3885,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addReplaceLane(SIMDInfo info, uint8_t l
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDI_V(SIMDLaneOperation op, SIMDInfo info, ExpressionType value, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addSIMDI_V(SIMDLaneOperation op, SIMDInfo info, ExpressionType value, ExpressionType& result)
 {
     Location valueLocation = loadIfNecessary(value);
     consume(value);
@@ -3992,7 +3992,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDI_V(SIMDLaneOperation op, SIMDIn
     }
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDV_V(SIMDLaneOperation op, SIMDInfo info, ExpressionType value, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addSIMDV_V(SIMDLaneOperation op, SIMDInfo info, ExpressionType value, ExpressionType& result)
 {
     Location valueLocation = loadIfNecessary(value);
     consume(value);
@@ -4180,7 +4180,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDV_V(SIMDLaneOperation op, SIMDIn
     }
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDBitwiseSelect(ExpressionType left, ExpressionType right, ExpressionType selector, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addSIMDBitwiseSelect(ExpressionType left, ExpressionType right, ExpressionType selector, ExpressionType& result)
 {
     Location leftLocation = loadIfNecessary(left);
     Location rightLocation = loadIfNecessary(right);
@@ -4206,7 +4206,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDBitwiseSelect(ExpressionType lef
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDRelOp(SIMDLaneOperation op, SIMDInfo info, ExpressionType left, ExpressionType right, B3::Air::Arg relOp, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addSIMDRelOp(SIMDLaneOperation op, SIMDInfo info, ExpressionType left, ExpressionType right, B3::Air::Arg relOp, ExpressionType& result)
 {
     Location leftLocation = loadIfNecessary(left);
     Location rightLocation = loadIfNecessary(right);
@@ -4299,7 +4299,7 @@ void BBQJIT::emitVectorMul(SIMDInfo info, Location left, Location right, Locatio
         m_jit.vectorMul(info, left.asFPR(), right.asFPR(), result.asFPR());
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::fixupOutOfBoundsIndicesForSwizzle(Location a, Location b, Location result)
+[[nodiscard]] PartialResult BBQJIT::fixupOutOfBoundsIndicesForSwizzle(Location a, Location b, Location result)
 {
     ASSERT(isX86());
     // Let each byte mask be 112 (0x70) then after VectorAddSat
@@ -4315,7 +4315,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::fixupOutOfBoundsIndicesForSwizzle(Locat
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDV_VV(SIMDLaneOperation op, SIMDInfo info, ExpressionType left, ExpressionType right, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addSIMDV_VV(SIMDLaneOperation op, SIMDInfo info, ExpressionType left, ExpressionType right, ExpressionType& result)
 {
     Location leftLocation = loadIfNecessary(left);
     Location rightLocation = loadIfNecessary(right);
@@ -4465,7 +4465,7 @@ WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDV_VV(SIMDLaneOperation op, SIMDI
     }
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDRelaxedFMA(SIMDLaneOperation op, SIMDInfo info, ExpressionType mul1, ExpressionType mul2, ExpressionType addend, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addSIMDRelaxedFMA(SIMDLaneOperation op, SIMDInfo info, ExpressionType mul1, ExpressionType mul2, ExpressionType addend, ExpressionType& result)
 {
     Location mul1Location = loadIfNecessary(mul1);
     Location mul2Location = loadIfNecessary(mul2);
@@ -4901,7 +4901,7 @@ void BBQJIT::emitMove(StorageType type, Value src, Address dst)
         emitStore(type, srcLocation, dst);
 }
 
-WARN_UNUSED_RETURN PartialResult BBQJIT::addCallRef(unsigned callProfileIndex, const TypeDefinition& originalSignature, ArgumentList& args, ResultList& results, CallType callType)
+[[nodiscard]] PartialResult BBQJIT::addCallRef(unsigned callProfileIndex, const TypeDefinition& originalSignature, ArgumentList& args, ResultList& results, CallType callType)
 {
     emitIncrementCallProfileCount(callProfileIndex);
     Value callee = args.takeLast();

--- a/Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp
@@ -184,7 +184,7 @@ public:
 
 protected:
     template <typename ...Args>
-    WARN_UNUSED_RETURN NEVER_INLINE UnexpectedResult fail(Args... args) const
+    [[nodiscard]] NEVER_INLINE UnexpectedResult fail(Args... args) const
     {
         using namespace FailureHelper; // See ADL comment in WasmParser.h.
         return UnexpectedResult(makeString("WebAssembly.Module doesn't parse at byte "_s, String::number(m_parser->offset() + m_offsetInSource), ": "_s, makeString(args)...));
@@ -248,19 +248,19 @@ public:
 
     PartialResult addDrop(ExpressionType) CONST_EXPR_STUB
     PartialResult addLocal(Type, uint32_t) { RELEASE_ASSERT_NOT_REACHED(); }
-    WARN_UNUSED_RETURN PartialResult addTableGet(unsigned, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addTableSet(unsigned, ExpressionType, ExpressionType) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addTableInit(unsigned, unsigned, ExpressionType, ExpressionType, ExpressionType) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addElemDrop(unsigned) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addTableSize(unsigned, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addTableGrow(unsigned, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addTableFill(unsigned, ExpressionType, ExpressionType, ExpressionType) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addTableCopy(unsigned, unsigned, ExpressionType, ExpressionType, ExpressionType) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult getLocal(uint32_t, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult setLocal(uint32_t, ExpressionType) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult teeLocal(uint32_t, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addTableGet(unsigned, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addTableSet(unsigned, ExpressionType, ExpressionType) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addTableInit(unsigned, unsigned, ExpressionType, ExpressionType, ExpressionType) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addElemDrop(unsigned) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addTableSize(unsigned, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addTableGrow(unsigned, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addTableFill(unsigned, ExpressionType, ExpressionType, ExpressionType) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addTableCopy(unsigned, unsigned, ExpressionType, ExpressionType, ExpressionType) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult getLocal(uint32_t, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult setLocal(uint32_t, ExpressionType) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult teeLocal(uint32_t, ExpressionType, ExpressionType&) CONST_EXPR_STUB
 
-    WARN_UNUSED_RETURN PartialResult getGlobal(uint32_t index, ExpressionType& result)
+    [[nodiscard]] PartialResult getGlobal(uint32_t index, ExpressionType& result)
     {
         // Note that this check works for table initializers too, because no globals are registered when the table section is read and the count is 0.
         WASM_COMPILE_FAIL_IF(index >= m_info.globals.size(), "get_global's index ", index, " exceeds the number of globals ", m_info.globals.size());
@@ -276,26 +276,26 @@ public:
         return { };
     }
 
-    WARN_UNUSED_RETURN PartialResult setGlobal(uint32_t, ExpressionType) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult load(LoadOpType, ExpressionType, ExpressionType&, uint32_t) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult store(StoreOpType, ExpressionType, ExpressionType, uint32_t) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addGrowMemory(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addCurrentMemory(ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addMemoryFill(ExpressionType, ExpressionType, ExpressionType) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addMemoryCopy(ExpressionType, ExpressionType, ExpressionType) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addMemoryInit(unsigned, ExpressionType, ExpressionType, ExpressionType) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addDataDrop(unsigned) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult atomicLoad(ExtAtomicOpType, Type, ExpressionType, ExpressionType&, uint32_t) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult atomicStore(ExtAtomicOpType, Type, ExpressionType, ExpressionType, uint32_t) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult atomicBinaryRMW(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType&, uint32_t) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult atomicCompareExchange(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint32_t) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult atomicWait(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint32_t) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult atomicNotify(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType&, uint32_t) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult atomicFence(ExtAtomicOpType, uint8_t) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult truncTrapping(OpType, ExpressionType, ExpressionType&, Type, Type) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult truncSaturated(Ext1OpType, ExpressionType, ExpressionType&, Type, Type) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult setGlobal(uint32_t, ExpressionType) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult load(LoadOpType, ExpressionType, ExpressionType&, uint32_t) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult store(StoreOpType, ExpressionType, ExpressionType, uint32_t) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addGrowMemory(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addCurrentMemory(ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addMemoryFill(ExpressionType, ExpressionType, ExpressionType) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addMemoryCopy(ExpressionType, ExpressionType, ExpressionType) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addMemoryInit(unsigned, ExpressionType, ExpressionType, ExpressionType) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addDataDrop(unsigned) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult atomicLoad(ExtAtomicOpType, Type, ExpressionType, ExpressionType&, uint32_t) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult atomicStore(ExtAtomicOpType, Type, ExpressionType, ExpressionType, uint32_t) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult atomicBinaryRMW(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType&, uint32_t) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult atomicCompareExchange(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint32_t) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult atomicWait(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint32_t) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult atomicNotify(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType&, uint32_t) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult atomicFence(ExtAtomicOpType, uint8_t) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult truncTrapping(OpType, ExpressionType, ExpressionType&, Type, Type) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult truncSaturated(Ext1OpType, ExpressionType, ExpressionType&, Type, Type) CONST_EXPR_STUB
 
-    WARN_UNUSED_RETURN PartialResult addRefI31(ExpressionType value, ExpressionType& result)
+    [[nodiscard]] PartialResult addRefI31(ExpressionType value, ExpressionType& result)
     {
         if (m_mode == Mode::Evaluate) {
             JSValue i31 = JSValue((((static_cast<int32_t>(value.getValue()) & 0x7fffffff) << 1) >> 1));
@@ -305,8 +305,8 @@ public:
         return { };
     }
 
-    WARN_UNUSED_RETURN PartialResult addI31GetS(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI31GetU(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI31GetS(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI31GetU(ExpressionType, ExpressionType&) CONST_EXPR_STUB
 
     ExpressionType createNewArray(WebAssemblyGCStructure* structure, uint32_t size, ExpressionType value)
     {
@@ -321,7 +321,7 @@ public:
         return ConstExprValue(result);
     }
 
-    WARN_UNUSED_RETURN PartialResult addArrayNew(uint32_t typeIndex, ExpressionType size, ExpressionType value, ExpressionType& result)
+    [[nodiscard]] PartialResult addArrayNew(uint32_t typeIndex, ExpressionType size, ExpressionType value, ExpressionType& result)
     {
         if (m_mode == Mode::Evaluate) {
             auto* structure = m_instance->gcObjectStructure(typeIndex);
@@ -331,7 +331,7 @@ public:
         return { };
     }
 
-    WARN_UNUSED_RETURN PartialResult addArrayNewDefault(uint32_t typeIndex, ExpressionType size, ExpressionType& result)
+    [[nodiscard]] PartialResult addArrayNewDefault(uint32_t typeIndex, ExpressionType size, ExpressionType& result)
     {
         if (m_mode == Mode::Evaluate) {
             auto* structure = m_instance->gcObjectStructure(typeIndex);
@@ -349,7 +349,7 @@ public:
         return { };
     }
 
-    WARN_UNUSED_RETURN PartialResult addArrayNewFixed(uint32_t typeIndex, ArgumentList& args, ExpressionType& result)
+    [[nodiscard]] PartialResult addArrayNewFixed(uint32_t typeIndex, ArgumentList& args, ExpressionType& result)
     {
         if (m_mode == Mode::Evaluate) {
             auto* structure = m_instance->gcObjectStructure(typeIndex);
@@ -372,15 +372,15 @@ public:
         return { };
     }
 
-    WARN_UNUSED_RETURN PartialResult addArrayNewData(uint32_t, uint32_t, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addArrayNewElem(uint32_t, uint32_t, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addArrayGet(ExtGCOpType, uint32_t, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addArraySet(uint32_t, ExpressionType, ExpressionType, ExpressionType) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addArrayLen(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addArrayFill(uint32_t, ExpressionType, ExpressionType, ExpressionType, ExpressionType) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addArrayCopy(uint32_t, ExpressionType, ExpressionType, uint32_t, ExpressionType, ExpressionType, ExpressionType) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addArrayInitElem(uint32_t, ExpressionType, ExpressionType, uint32_t, ExpressionType, ExpressionType) CONST_EXPR_STUB;
-    WARN_UNUSED_RETURN PartialResult addArrayInitData(uint32_t, ExpressionType, ExpressionType, uint32_t, ExpressionType, ExpressionType) CONST_EXPR_STUB;
+    [[nodiscard]] PartialResult addArrayNewData(uint32_t, uint32_t, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addArrayNewElem(uint32_t, uint32_t, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addArrayGet(ExtGCOpType, uint32_t, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addArraySet(uint32_t, ExpressionType, ExpressionType, ExpressionType) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addArrayLen(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addArrayFill(uint32_t, ExpressionType, ExpressionType, ExpressionType, ExpressionType) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addArrayCopy(uint32_t, ExpressionType, ExpressionType, uint32_t, ExpressionType, ExpressionType, ExpressionType) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addArrayInitElem(uint32_t, ExpressionType, ExpressionType, uint32_t, ExpressionType, ExpressionType) CONST_EXPR_STUB;
+    [[nodiscard]] PartialResult addArrayInitData(uint32_t, ExpressionType, ExpressionType, uint32_t, ExpressionType, ExpressionType) CONST_EXPR_STUB;
 
     ExpressionType createNewStruct(uint32_t typeIndex)
     {
@@ -392,7 +392,7 @@ public:
         return ConstExprValue(result);
     }
 
-    WARN_UNUSED_RETURN PartialResult addStructNewDefault(uint32_t typeIndex, ExpressionType& result)
+    [[nodiscard]] PartialResult addStructNewDefault(uint32_t typeIndex, ExpressionType& result)
     {
         if (m_mode == Mode::Evaluate) {
             result = createNewStruct(typeIndex);
@@ -402,7 +402,7 @@ public:
         return { };
     }
 
-    WARN_UNUSED_RETURN PartialResult addStructNew(uint32_t typeIndex, ArgumentList& args, ExpressionType& result)
+    [[nodiscard]] PartialResult addStructNew(uint32_t typeIndex, ArgumentList& args, ExpressionType& result)
     {
         if (m_mode == Mode::Evaluate) {
             result = createNewStruct(typeIndex);
@@ -419,12 +419,12 @@ public:
         return { };
     }
 
-    WARN_UNUSED_RETURN PartialResult addStructGet(ExtGCOpType, ExpressionType, const StructType&, uint32_t, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addStructSet(ExpressionType, const StructType&, uint32_t, ExpressionType) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addRefTest(ExpressionType, bool, int32_t, bool, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addRefCast(ExpressionType, bool, int32_t, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addStructGet(ExtGCOpType, ExpressionType, const StructType&, uint32_t, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addStructSet(ExpressionType, const StructType&, uint32_t, ExpressionType) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addRefTest(ExpressionType, bool, int32_t, bool, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addRefCast(ExpressionType, bool, int32_t, ExpressionType&) CONST_EXPR_STUB
 
-    WARN_UNUSED_RETURN PartialResult addAnyConvertExtern(ExpressionType reference, ExpressionType& result)
+    [[nodiscard]] PartialResult addAnyConvertExtern(ExpressionType reference, ExpressionType& result)
     {
         if (m_mode == Mode::Evaluate) {
             if (reference.type() == ConstExprValue::Numeric)
@@ -438,184 +438,184 @@ public:
         return { };
     }
 
-    WARN_UNUSED_RETURN PartialResult addExternConvertAny(ExpressionType reference, ExpressionType& result)
+    [[nodiscard]] PartialResult addExternConvertAny(ExpressionType reference, ExpressionType& result)
     {
         result = reference;
         return { };
     }
 
-    WARN_UNUSED_RETURN PartialResult addSelect(ExpressionType, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addSelect(ExpressionType, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
 
-    WARN_UNUSED_RETURN PartialResult addI32Add(ExpressionType lhs, ExpressionType rhs, ExpressionType& result)
+    [[nodiscard]] PartialResult addI32Add(ExpressionType lhs, ExpressionType rhs, ExpressionType& result)
     {
         if (m_mode == Mode::Evaluate)
             result = lhs + rhs;
         return { };
     }
-    WARN_UNUSED_RETURN PartialResult addI64Add(ExpressionType lhs, ExpressionType rhs, ExpressionType& result)
+    [[nodiscard]] PartialResult addI64Add(ExpressionType lhs, ExpressionType rhs, ExpressionType& result)
     {
         if (m_mode == Mode::Evaluate)
             result = lhs + rhs;
         return { };
     }
 
-    WARN_UNUSED_RETURN PartialResult addF32Add(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF64Add(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF32Add(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF64Add(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
 
-    WARN_UNUSED_RETURN PartialResult addI32Sub(ExpressionType lhs, ExpressionType rhs, ExpressionType& result)
+    [[nodiscard]] PartialResult addI32Sub(ExpressionType lhs, ExpressionType rhs, ExpressionType& result)
     {
         if (m_mode == Mode::Evaluate)
             result = lhs - rhs;
         return { };
     }
 
-    WARN_UNUSED_RETURN PartialResult addI64Sub(ExpressionType lhs, ExpressionType rhs, ExpressionType& result)
+    [[nodiscard]] PartialResult addI64Sub(ExpressionType lhs, ExpressionType rhs, ExpressionType& result)
     {
         if (m_mode == Mode::Evaluate)
             result = lhs - rhs;
         return { };
     }
 
-    WARN_UNUSED_RETURN PartialResult addF32Sub(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF64Sub(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF32Sub(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF64Sub(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
 
-    WARN_UNUSED_RETURN PartialResult addI32Mul(ExpressionType lhs, ExpressionType rhs, ExpressionType& result)
+    [[nodiscard]] PartialResult addI32Mul(ExpressionType lhs, ExpressionType rhs, ExpressionType& result)
     {
         if (m_mode == Mode::Evaluate)
             result = lhs * rhs;
         return { };
     }
 
-    WARN_UNUSED_RETURN PartialResult addI64Mul(ExpressionType lhs, ExpressionType rhs, ExpressionType& result)
+    [[nodiscard]] PartialResult addI64Mul(ExpressionType lhs, ExpressionType rhs, ExpressionType& result)
     {
         if (m_mode == Mode::Evaluate)
             result = lhs * rhs;
         return { };
     }
 
-    WARN_UNUSED_RETURN PartialResult addF32Mul(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF64Mul(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI32DivS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI64DivS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI32DivU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI64DivU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI32RemS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI64RemS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI32RemU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI64RemU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF32Div(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF64Div(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF32Min(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF64Min(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF32Max(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF64Max(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI32And(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI64And(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI32Xor(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI64Xor(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI32Or(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI64Or(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI32Shl(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI64Shl(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI32ShrS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI64ShrS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI32ShrU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI64ShrU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI32Rotl(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI64Rotl(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI32Rotr(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI64Rotr(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI32Clz(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI64Clz(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI32Ctz(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI64Ctz(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI32Eq(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI64Eq(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI32Ne(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI64Ne(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI32LtS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI64LtS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI32LeS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI64LeS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI32GtS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI64GtS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI32GeS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI64GeS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI32LtU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI64LtU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI32LeU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI64LeU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI32GtU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI64GtU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI32GeU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI64GeU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF32Eq(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF64Eq(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF32Ne(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF64Ne(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF32Lt(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF64Lt(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF32Le(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF64Le(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF32Gt(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF64Gt(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF32Ge(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF64Ge(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF32Mul(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF64Mul(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI32DivS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI64DivS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI32DivU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI64DivU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI32RemS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI64RemS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI32RemU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI64RemU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF32Div(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF64Div(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF32Min(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF64Min(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF32Max(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF64Max(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI32And(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI64And(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI32Xor(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI64Xor(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI32Or(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI64Or(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI32Shl(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI64Shl(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI32ShrS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI64ShrS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI32ShrU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI64ShrU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI32Rotl(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI64Rotl(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI32Rotr(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI64Rotr(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI32Clz(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI64Clz(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI32Ctz(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI64Ctz(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI32Eq(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI64Eq(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI32Ne(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI64Ne(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI32LtS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI64LtS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI32LeS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI64LeS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI32GtS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI64GtS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI32GeS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI64GeS(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI32LtU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI64LtU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI32LeU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI64LeU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI32GtU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI64GtU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI32GeU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI64GeU(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF32Eq(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF64Eq(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF32Ne(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF64Ne(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF32Lt(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF64Lt(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF32Le(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF64Le(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF32Gt(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF64Gt(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF32Ge(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF64Ge(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
     PartialResult addI32WrapI64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
     PartialResult addI32Extend8S(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI32Extend16S(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI64Extend8S(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI64Extend16S(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI64Extend32S(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI64ExtendSI32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI64ExtendUI32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI32Eqz(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI64Eqz(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI32Popcnt(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI64Popcnt(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI32ReinterpretF32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI64ReinterpretF64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF32ReinterpretI32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF64ReinterpretI64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF32DemoteF64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF64PromoteF32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF32ConvertSI32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF32ConvertUI32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF32ConvertSI64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF32ConvertUI64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF64ConvertSI32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF64ConvertUI32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF64ConvertSI64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF64ConvertUI64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF32Copysign(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF64Copysign(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF32Floor(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF64Floor(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF32Ceil(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF64Ceil(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF32Abs(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF64Abs(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF32Sqrt(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF64Sqrt(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF32Neg(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF64Neg(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF32Nearest(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF64Nearest(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF32Trunc(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addF64Trunc(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI32TruncSF32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI32TruncSF64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI32TruncUF32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI32TruncUF64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI64TruncSF32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI64TruncSF64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI64TruncUF32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addI64TruncUF64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addRefIsNull(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addRefAsNonNull(ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addRefEq(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI32Extend16S(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI64Extend8S(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI64Extend16S(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI64Extend32S(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI64ExtendSI32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI64ExtendUI32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI32Eqz(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI64Eqz(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI32Popcnt(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI64Popcnt(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI32ReinterpretF32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI64ReinterpretF64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF32ReinterpretI32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF64ReinterpretI64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF32DemoteF64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF64PromoteF32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF32ConvertSI32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF32ConvertUI32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF32ConvertSI64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF32ConvertUI64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF64ConvertSI32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF64ConvertUI32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF64ConvertSI64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF64ConvertUI64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF32Copysign(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF64Copysign(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF32Floor(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF64Floor(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF32Ceil(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF64Ceil(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF32Abs(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF64Abs(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF32Sqrt(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF64Sqrt(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF32Neg(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF64Neg(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF32Nearest(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF64Nearest(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF32Trunc(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addF64Trunc(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI32TruncSF32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI32TruncSF64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI32TruncUF32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI32TruncUF64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI64TruncSF32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI64TruncSF64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI64TruncUF32(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addI64TruncUF64(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addRefIsNull(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addRefAsNonNull(ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addRefEq(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
 
-    WARN_UNUSED_RETURN PartialResult addRefFunc(FunctionSpaceIndex index, ExpressionType& result)
+    [[nodiscard]] PartialResult addRefFunc(FunctionSpaceIndex index, ExpressionType& result)
     {
         if (m_mode == Mode::Evaluate) {
             JSValue wrapper = m_instance->getFunctionWrapper(index);
@@ -634,33 +634,33 @@ public:
         return ControlData(signature);
     }
 
-    WARN_UNUSED_RETURN PartialResult addBlock(BlockSignature, Stack&, ControlType&, Stack&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addLoop(BlockSignature, Stack&, ControlType&, Stack&, uint32_t) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addIf(ExpressionType, BlockSignature, Stack&, ControlData&, Stack&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addElse(ControlData&, Stack&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addElseToUnreachable(ControlData&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addTry(BlockSignature, Stack&, ControlType&, Stack&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addTryTable(BlockSignature, Stack&, const Vector<CatchHandler>&, ControlType&, Stack&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addCatch(unsigned, const TypeDefinition&, Stack&, ControlType&, ResultList&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addCatchToUnreachable(unsigned, const TypeDefinition&, ControlType&, ResultList&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addCatchAll(Stack&, ControlType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addCatchAllToUnreachable(ControlType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addDelegate(ControlType&, ControlType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addDelegateToUnreachable(ControlType&, ControlType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addThrow(unsigned, ArgumentList&, Stack&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addRethrow(unsigned, ControlType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addThrowRef(ExpressionType, Stack&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addReturn(const ControlData&, const Stack&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addBranch(ControlData&, ExpressionType, Stack&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addBranchNull(ControlType&, ExpressionType, Stack&, bool, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addBranchCast(ControlType&, ExpressionType, Stack&, bool, int32_t, bool) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addSwitch(ExpressionType, const Vector<ControlData*>&, ControlData&, Stack&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addFusedBranchCompare(OpType, ControlType&, ExpressionType, const Stack&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addFusedBranchCompare(OpType, ControlType&, ExpressionType, ExpressionType, const Stack&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addFusedIfCompare(OpType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addFusedIfCompare(OpType, ExpressionType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addBlock(BlockSignature, Stack&, ControlType&, Stack&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addLoop(BlockSignature, Stack&, ControlType&, Stack&, uint32_t) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addIf(ExpressionType, BlockSignature, Stack&, ControlData&, Stack&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addElse(ControlData&, Stack&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addElseToUnreachable(ControlData&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addTry(BlockSignature, Stack&, ControlType&, Stack&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addTryTable(BlockSignature, Stack&, const Vector<CatchHandler>&, ControlType&, Stack&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addCatch(unsigned, const TypeDefinition&, Stack&, ControlType&, ResultList&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addCatchToUnreachable(unsigned, const TypeDefinition&, ControlType&, ResultList&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addCatchAll(Stack&, ControlType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addCatchAllToUnreachable(ControlType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addDelegate(ControlType&, ControlType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addDelegateToUnreachable(ControlType&, ControlType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addThrow(unsigned, ArgumentList&, Stack&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addRethrow(unsigned, ControlType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addThrowRef(ExpressionType, Stack&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addReturn(const ControlData&, const Stack&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addBranch(ControlData&, ExpressionType, Stack&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addBranchNull(ControlType&, ExpressionType, Stack&, bool, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addBranchCast(ControlType&, ExpressionType, Stack&, bool, int32_t, bool) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addSwitch(ExpressionType, const Vector<ControlData*>&, ControlData&, Stack&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addFusedBranchCompare(OpType, ControlType&, ExpressionType, const Stack&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addFusedBranchCompare(OpType, ControlType&, ExpressionType, ExpressionType, const Stack&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addFusedIfCompare(OpType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addFusedIfCompare(OpType, ExpressionType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&) CONST_EXPR_STUB
 
-    WARN_UNUSED_RETURN PartialResult endBlock(ControlEntry& entry, Stack& expressionStack)
+    [[nodiscard]] PartialResult endBlock(ControlEntry& entry, Stack& expressionStack)
     {
         ASSERT(expressionStack.size() == 1);
         ASSERT_UNUSED(entry, ControlType::isTopLevel(entry.controlData));
@@ -668,9 +668,9 @@ public:
         return { };
     }
 
-    WARN_UNUSED_RETURN PartialResult addEndToUnreachable(ControlEntry&, Stack&, bool = true) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addEndToUnreachable(ControlEntry&, Stack&, bool = true) CONST_EXPR_STUB
 
-    WARN_UNUSED_RETURN PartialResult endTopLevel(BlockSignature, const Stack&)
+    [[nodiscard]] PartialResult endTopLevel(BlockSignature, const Stack&)
     {
         // Some opcodes like "nop" are not detectable by an error stub because the context
         // doesn't get called by the parser. This flag is set by didParseOpcode() to signal
@@ -679,41 +679,41 @@ public:
         return { };
     }
 
-    WARN_UNUSED_RETURN PartialResult addCall(unsigned, FunctionSpaceIndex, const TypeDefinition&, ArgumentList&, ResultList&, CallType = CallType::Call) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addCallIndirect(unsigned, unsigned, const TypeDefinition&, ArgumentList&, ResultList&, CallType = CallType::Call) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addCallRef(unsigned, const TypeDefinition&, ArgumentList&, ResultList&, CallType = CallType::Call) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addUnreachable() CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addCrash() CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addCall(unsigned, FunctionSpaceIndex, const TypeDefinition&, ArgumentList&, ResultList&, CallType = CallType::Call) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addCallIndirect(unsigned, unsigned, const TypeDefinition&, ArgumentList&, ResultList&, CallType = CallType::Call) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addCallRef(unsigned, const TypeDefinition&, ArgumentList&, ResultList&, CallType = CallType::Call) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addUnreachable() CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addCrash() CONST_EXPR_STUB
     bool usesSIMD() { return false; }
     void notifyFunctionUsesSIMD() { }
-    WARN_UNUSED_RETURN PartialResult addSIMDLoad(ExpressionType, uint32_t, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addSIMDStore(ExpressionType, ExpressionType, uint32_t) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addSIMDSplat(SIMDLane, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addSIMDShuffle(v128_t, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addSIMDShift(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addSIMDExtmul(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addSIMDLoadSplat(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addSIMDLoadLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t, uint8_t, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addSIMDStoreLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t, uint8_t) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addSIMDLoadExtend(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addSIMDLoadPad(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN ExpressionType addConstant(v128_t vector)
+    [[nodiscard]] PartialResult addSIMDLoad(ExpressionType, uint32_t, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addSIMDStore(ExpressionType, ExpressionType, uint32_t) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addSIMDSplat(SIMDLane, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addSIMDShuffle(v128_t, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addSIMDShift(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addSIMDExtmul(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addSIMDLoadSplat(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addSIMDLoadLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t, uint8_t, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addSIMDStoreLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t, uint8_t) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addSIMDLoadExtend(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addSIMDLoadPad(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] ExpressionType addConstant(v128_t vector)
     {
         RELEASE_ASSERT(Options::useWasmSIMD());
         if (m_mode == Mode::Evaluate)
             return ConstExprValue(vector);
         return { };
     }
-    WARN_UNUSED_RETURN PartialResult addExtractLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addReplaceLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addSIMDI_V(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addSIMDV_V(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addSIMDBitwiseSelect(ExpressionType, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addExtractLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addReplaceLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addSIMDI_V(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addSIMDV_V(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addSIMDBitwiseSelect(ExpressionType, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
 #if ENABLE(B3_JIT)
-    WARN_UNUSED_RETURN PartialResult addSIMDRelOp(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, B3::Air::Arg, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addSIMDRelOp(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, B3::Air::Arg, ExpressionType&) CONST_EXPR_STUB
 #endif
-    WARN_UNUSED_RETURN PartialResult addSIMDV_VV(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    WARN_UNUSED_RETURN PartialResult addSIMDRelaxedFMA(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addSIMDV_VV(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addSIMDRelaxedFMA(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
 
     void dump(const ControlStack&, const Stack*) { }
     ALWAYS_INLINE void willParseOpcode() { }

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -155,8 +155,8 @@ public:
 
     FunctionParser(Context&, std::span<const uint8_t> function, const TypeDefinition&, const ModuleInformation&);
 
-    WARN_UNUSED_RETURN Result parse();
-    WARN_UNUSED_RETURN Result parseConstantExpression();
+    [[nodiscard]] Result parse();
+    [[nodiscard]] Result parseConstantExpression();
 
     OpType currentOpcode() const { return m_currentOpcode; }
     uint32_t currentExtendedOpcode() const { return m_currentExtOp; }
@@ -207,25 +207,25 @@ public:
 private:
     static constexpr bool verbose = false;
 
-    WARN_UNUSED_RETURN PartialResult parseBody();
-    WARN_UNUSED_RETURN PartialResult parseExpression();
-    WARN_UNUSED_RETURN PartialResult parseUnreachableExpression();
-    WARN_UNUSED_RETURN PartialResult unifyControl(ArgumentList&, unsigned level);
-    WARN_UNUSED_RETURN PartialResult checkLocalInitialized(uint32_t);
-    WARN_UNUSED_RETURN PartialResult checkExpressionStack(const ControlType&, bool forceSignature = false);
+    [[nodiscard]] PartialResult parseBody();
+    [[nodiscard]] PartialResult parseExpression();
+    [[nodiscard]] PartialResult parseUnreachableExpression();
+    [[nodiscard]] PartialResult unifyControl(ArgumentList&, unsigned level);
+    [[nodiscard]] PartialResult checkLocalInitialized(uint32_t);
+    [[nodiscard]] PartialResult checkExpressionStack(const ControlType&, bool forceSignature = false);
 
     enum BranchConditionalityTag {
         Unconditional,
         Conditional
     };
 
-    WARN_UNUSED_RETURN PartialResult checkBranchTarget(const ControlType&, BranchConditionalityTag);
+    [[nodiscard]] PartialResult checkBranchTarget(const ControlType&, BranchConditionalityTag);
 
-    WARN_UNUSED_RETURN PartialResult parseImmLaneIdx(uint8_t laneCount, uint8_t&);
-    WARN_UNUSED_RETURN PartialResult parseBlockSignature(const ModuleInformation&, BlockSignature&);
-    WARN_UNUSED_RETURN PartialResult parseReftypeSignature(const ModuleInformation&, BlockSignature&);
+    [[nodiscard]] PartialResult parseImmLaneIdx(uint8_t laneCount, uint8_t&);
+    [[nodiscard]] PartialResult parseBlockSignature(const ModuleInformation&, BlockSignature&);
+    [[nodiscard]] PartialResult parseReftypeSignature(const ModuleInformation&, BlockSignature&);
 
-    WARN_UNUSED_RETURN PartialResult parseNestedBlocksEagerly(bool&);
+    [[nodiscard]] PartialResult parseNestedBlocksEagerly(bool&);
     void switchToBlock(ControlType&&, Stack&&);
 
 #define WASM_TRY_POP_EXPRESSION_STACK_INTO(result, what) do { \
@@ -235,88 +235,88 @@ private:
     } while (0)
 
     using UnaryOperationHandler = PartialResult (Context::*)(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult unaryCase(OpType, UnaryOperationHandler, Type returnType, Type operandType);
-    WARN_UNUSED_RETURN PartialResult unaryCompareCase(OpType, UnaryOperationHandler, Type returnType, Type operandType);
+    [[nodiscard]] PartialResult unaryCase(OpType, UnaryOperationHandler, Type returnType, Type operandType);
+    [[nodiscard]] PartialResult unaryCompareCase(OpType, UnaryOperationHandler, Type returnType, Type operandType);
     using BinaryOperationHandler = PartialResult (Context::*)(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult binaryCase(OpType, BinaryOperationHandler, Type returnType, Type lhsType, Type rhsType);
-    WARN_UNUSED_RETURN PartialResult binaryCompareCase(OpType, BinaryOperationHandler, Type returnType, Type lhsType, Type rhsType);
+    [[nodiscard]] PartialResult binaryCase(OpType, BinaryOperationHandler, Type returnType, Type lhsType, Type rhsType);
+    [[nodiscard]] PartialResult binaryCompareCase(OpType, BinaryOperationHandler, Type returnType, Type lhsType, Type rhsType);
 
-    WARN_UNUSED_RETURN PartialResult store(Type memoryType);
-    WARN_UNUSED_RETURN PartialResult load(Type memoryType);
+    [[nodiscard]] PartialResult store(Type memoryType);
+    [[nodiscard]] PartialResult load(Type memoryType);
 
-    WARN_UNUSED_RETURN PartialResult truncSaturated(Ext1OpType, Type returnType, Type operandType);
+    [[nodiscard]] PartialResult truncSaturated(Ext1OpType, Type returnType, Type operandType);
 
-    WARN_UNUSED_RETURN PartialResult atomicLoad(ExtAtomicOpType, Type memoryType);
-    WARN_UNUSED_RETURN PartialResult atomicStore(ExtAtomicOpType, Type memoryType);
-    WARN_UNUSED_RETURN PartialResult atomicBinaryRMW(ExtAtomicOpType, Type memoryType);
-    WARN_UNUSED_RETURN PartialResult atomicCompareExchange(ExtAtomicOpType, Type memoryType);
-    WARN_UNUSED_RETURN PartialResult atomicWait(ExtAtomicOpType, Type memoryType);
-    WARN_UNUSED_RETURN PartialResult atomicNotify(ExtAtomicOpType);
-    WARN_UNUSED_RETURN PartialResult atomicFence(ExtAtomicOpType);
+    [[nodiscard]] PartialResult atomicLoad(ExtAtomicOpType, Type memoryType);
+    [[nodiscard]] PartialResult atomicStore(ExtAtomicOpType, Type memoryType);
+    [[nodiscard]] PartialResult atomicBinaryRMW(ExtAtomicOpType, Type memoryType);
+    [[nodiscard]] PartialResult atomicCompareExchange(ExtAtomicOpType, Type memoryType);
+    [[nodiscard]] PartialResult atomicWait(ExtAtomicOpType, Type memoryType);
+    [[nodiscard]] PartialResult atomicNotify(ExtAtomicOpType);
+    [[nodiscard]] PartialResult atomicFence(ExtAtomicOpType);
 
 #if ENABLE(B3_JIT)
     template<bool isReachable, typename = void>
-    WARN_UNUSED_RETURN PartialResult simd(SIMDLaneOperation, SIMDLane, SIMDSignMode, B3::Air::Arg optionalRelation = { });
+    [[nodiscard]] PartialResult simd(SIMDLaneOperation, SIMDLane, SIMDSignMode, B3::Air::Arg optionalRelation = { });
 #endif
 
-    WARN_UNUSED_RETURN PartialResult parseTableIndex(unsigned&);
-    WARN_UNUSED_RETURN PartialResult parseElementIndex(unsigned&);
-    WARN_UNUSED_RETURN PartialResult parseDataSegmentIndex(unsigned&);
+    [[nodiscard]] PartialResult parseTableIndex(unsigned&);
+    [[nodiscard]] PartialResult parseElementIndex(unsigned&);
+    [[nodiscard]] PartialResult parseDataSegmentIndex(unsigned&);
 
-    WARN_UNUSED_RETURN PartialResult parseIndexForLocal(uint32_t&);
-    WARN_UNUSED_RETURN PartialResult parseIndexForGlobal(uint32_t&);
-    WARN_UNUSED_RETURN PartialResult parseFunctionIndex(FunctionSpaceIndex&);
-    WARN_UNUSED_RETURN PartialResult parseExceptionIndex(uint32_t&);
-    WARN_UNUSED_RETURN PartialResult parseBranchTarget(uint32_t&, uint32_t = 0);
-    WARN_UNUSED_RETURN PartialResult parseDelegateTarget(uint32_t&, uint32_t);
+    [[nodiscard]] PartialResult parseIndexForLocal(uint32_t&);
+    [[nodiscard]] PartialResult parseIndexForGlobal(uint32_t&);
+    [[nodiscard]] PartialResult parseFunctionIndex(FunctionSpaceIndex&);
+    [[nodiscard]] PartialResult parseExceptionIndex(uint32_t&);
+    [[nodiscard]] PartialResult parseBranchTarget(uint32_t&, uint32_t = 0);
+    [[nodiscard]] PartialResult parseDelegateTarget(uint32_t&, uint32_t);
 
     struct TableInitImmediates {
         unsigned elementIndex;
         unsigned tableIndex;
     };
-    WARN_UNUSED_RETURN PartialResult parseTableInitImmediates(TableInitImmediates&);
+    [[nodiscard]] PartialResult parseTableInitImmediates(TableInitImmediates&);
 
     struct TableCopyImmediates {
         unsigned srcTableIndex;
         unsigned dstTableIndex;
     };
-    WARN_UNUSED_RETURN PartialResult parseTableCopyImmediates(TableCopyImmediates&);
+    [[nodiscard]] PartialResult parseTableCopyImmediates(TableCopyImmediates&);
 
     struct AnnotatedSelectImmediates {
         unsigned sizeOfAnnotationVector;
         Type targetType;
     };
-    WARN_UNUSED_RETURN PartialResult parseAnnotatedSelectImmediates(AnnotatedSelectImmediates&);
+    [[nodiscard]] PartialResult parseAnnotatedSelectImmediates(AnnotatedSelectImmediates&);
 
-    WARN_UNUSED_RETURN PartialResult parseMemoryFillImmediate();
-    WARN_UNUSED_RETURN PartialResult parseMemoryCopyImmediates();
+    [[nodiscard]] PartialResult parseMemoryFillImmediate();
+    [[nodiscard]] PartialResult parseMemoryCopyImmediates();
 
     struct MemoryInitImmediates {
         unsigned dataSegmentIndex;
         unsigned unused;
     };
-    WARN_UNUSED_RETURN PartialResult parseMemoryInitImmediates(MemoryInitImmediates&);
+    [[nodiscard]] PartialResult parseMemoryInitImmediates(MemoryInitImmediates&);
 
-    WARN_UNUSED_RETURN PartialResult parseStructTypeIndex(uint32_t& structTypeIndex, ASCIILiteral operation);
-    WARN_UNUSED_RETURN PartialResult parseStructFieldIndex(uint32_t& structFieldIndex, const StructType&, ASCIILiteral operation);
+    [[nodiscard]] PartialResult parseStructTypeIndex(uint32_t& structTypeIndex, ASCIILiteral operation);
+    [[nodiscard]] PartialResult parseStructFieldIndex(uint32_t& structFieldIndex, const StructType&, ASCIILiteral operation);
 
     struct StructTypeIndexAndFieldIndex {
         uint32_t structTypeIndex;
         uint32_t fieldIndex;
     };
-    WARN_UNUSED_RETURN PartialResult parseStructTypeIndexAndFieldIndex(StructTypeIndexAndFieldIndex& result, ASCIILiteral operation);
+    [[nodiscard]] PartialResult parseStructTypeIndexAndFieldIndex(StructTypeIndexAndFieldIndex& result, ASCIILiteral operation);
 
     struct StructFieldManipulation {
         StructTypeIndexAndFieldIndex indices;
         TypedExpression structReference;
         FieldType field;
     };
-    WARN_UNUSED_RETURN PartialResult parseStructFieldManipulation(StructFieldManipulation& result, ASCIILiteral operation);
+    [[nodiscard]] PartialResult parseStructFieldManipulation(StructFieldManipulation& result, ASCIILiteral operation);
 
 #define WASM_TRY_ADD_TO_CONTEXT(add_expression) WASM_FAIL_IF_HELPER_FAILS(m_context.add_expression)
 
     template <typename ...Args>
-    WARN_UNUSED_RETURN NEVER_INLINE UnexpectedResult validationFail(const Args&... args) const
+    [[nodiscard]] NEVER_INLINE UnexpectedResult validationFail(const Args&... args) const
     {
         using namespace FailureHelper; // See ADL comment in WasmParser.h.
         if (ASSERT_ENABLED && Options::crashOnFailedWasmValidate())
@@ -328,7 +328,7 @@ private:
     }
 
     template <typename Arg>
-    WARN_UNUSED_RETURN String validationFailHelper(const Arg& arg) const
+    [[nodiscard]] String validationFailHelper(const Arg& arg) const
     {
         if constexpr (std::is_same<Arg, Type>())
             return typeToStringModuleRelative(arg);
@@ -378,8 +378,8 @@ private:
     // FIXME add a macro as above for WASM_TRY_APPEND_TO_CONTROL_STACK https://bugs.webkit.org/show_bug.cgi?id=165862
 
     void addReferencedFunctions(const Element&);
-    WARN_UNUSED_RETURN PartialResult parseArrayTypeDefinition(ASCIILiteral, bool, uint32_t&, FieldType&, Type&);
-    WARN_UNUSED_RETURN PartialResult parseBlockSignatureAndNotifySIMDUseIfNeeded(BlockSignature&);
+    [[nodiscard]] PartialResult parseArrayTypeDefinition(ASCIILiteral, bool, uint32_t&, FieldType&, Type&);
+    [[nodiscard]] PartialResult parseBlockSignatureAndNotifySIMDUseIfNeeded(BlockSignature&);
 
     Context& m_context;
     Stack m_expressionStack;

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
@@ -219,10 +219,10 @@ public:
     using ArgumentList = FunctionParser<IPIntGenerator>::ArgumentList;
 
     static ExpressionType emptyExpression() { return { }; };
-    WARN_UNUSED_RETURN PartialResult addDrop(ExpressionType);
+    [[nodiscard]] PartialResult addDrop(ExpressionType);
 
     template <typename ...Args>
-    WARN_UNUSED_RETURN NEVER_INLINE UnexpectedResult fail(Args... args) const
+    [[nodiscard]] NEVER_INLINE UnexpectedResult fail(Args... args) const
     {
         using namespace FailureHelper; // See ADL comment in WasmParser.h.
         return UnexpectedResult(makeString("WebAssembly.Module failed compiling: "_s, makeString(args)...));
@@ -234,299 +234,299 @@ public:
 
     std::unique_ptr<FunctionIPIntMetadataGenerator> finalize();
 
-    WARN_UNUSED_RETURN PartialResult addArguments(const TypeDefinition&);
-    WARN_UNUSED_RETURN PartialResult addLocal(Type, uint32_t);
+    [[nodiscard]] PartialResult addArguments(const TypeDefinition&);
+    [[nodiscard]] PartialResult addLocal(Type, uint32_t);
     Value addConstant(Type, uint64_t);
 
     // SIMD
 
     bool usesSIMD() { return m_usesSIMD; }
     void notifyFunctionUsesSIMD() { ASSERT(Options::useWasmSIMD()); m_usesSIMD = true; }
-    WARN_UNUSED_RETURN PartialResult addSIMDLoad(ExpressionType, uint32_t, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addSIMDStore(ExpressionType, ExpressionType, uint32_t);
-    WARN_UNUSED_RETURN PartialResult addSIMDSplat(SIMDLane, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addSIMDShuffle(v128_t, ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addSIMDShift(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addSIMDExtmul(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addSIMDLoadSplat(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addSIMDLoadLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t, uint8_t, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addSIMDStoreLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t, uint8_t);
-    WARN_UNUSED_RETURN PartialResult addSIMDLoadExtend(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addSIMDLoadPad(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&);
+    [[nodiscard]] PartialResult addSIMDLoad(ExpressionType, uint32_t, ExpressionType&);
+    [[nodiscard]] PartialResult addSIMDStore(ExpressionType, ExpressionType, uint32_t);
+    [[nodiscard]] PartialResult addSIMDSplat(SIMDLane, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addSIMDShuffle(v128_t, ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addSIMDShift(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addSIMDExtmul(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addSIMDLoadSplat(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&);
+    [[nodiscard]] PartialResult addSIMDLoadLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t, uint8_t, ExpressionType&);
+    [[nodiscard]] PartialResult addSIMDStoreLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t, uint8_t);
+    [[nodiscard]] PartialResult addSIMDLoadExtend(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&);
+    [[nodiscard]] PartialResult addSIMDLoadPad(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&);
 
     ExpressionType addConstant(v128_t);
 
     // SIMD generated
 
-    WARN_UNUSED_RETURN PartialResult addExtractLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addReplaceLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addSIMDI_V(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addSIMDV_V(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addSIMDBitwiseSelect(ExpressionType, ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addExtractLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addReplaceLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addSIMDI_V(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addSIMDV_V(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addSIMDBitwiseSelect(ExpressionType, ExpressionType, ExpressionType, ExpressionType&);
 #if ENABLE(B3_JIT)
-    WARN_UNUSED_RETURN PartialResult addSIMDRelOp(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, B3::Air::Arg, ExpressionType&);
+    [[nodiscard]] PartialResult addSIMDRelOp(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, B3::Air::Arg, ExpressionType&);
 #endif
-    WARN_UNUSED_RETURN PartialResult addSIMDV_VV(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addSIMDRelaxedFMA(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addSIMDV_VV(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addSIMDRelaxedFMA(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType, ExpressionType&);
 
     // References
 
-    WARN_UNUSED_RETURN PartialResult addRefIsNull(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addRefFunc(FunctionSpaceIndex, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addRefAsNonNull(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addRefEq(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addRefIsNull(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addRefFunc(FunctionSpaceIndex, ExpressionType&);
+    [[nodiscard]] PartialResult addRefAsNonNull(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addRefEq(ExpressionType, ExpressionType, ExpressionType&);
 
     // Tables
 
-    WARN_UNUSED_RETURN PartialResult addTableGet(unsigned, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addTableSet(unsigned, ExpressionType, ExpressionType);
-    WARN_UNUSED_RETURN PartialResult addTableInit(unsigned, unsigned, ExpressionType, ExpressionType, ExpressionType);
-    WARN_UNUSED_RETURN PartialResult addElemDrop(unsigned);
-    WARN_UNUSED_RETURN PartialResult addTableSize(unsigned, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addTableGrow(unsigned, ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addTableFill(unsigned, ExpressionType, ExpressionType, ExpressionType);
-    WARN_UNUSED_RETURN PartialResult addTableCopy(unsigned, unsigned, ExpressionType, ExpressionType, ExpressionType);
+    [[nodiscard]] PartialResult addTableGet(unsigned, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addTableSet(unsigned, ExpressionType, ExpressionType);
+    [[nodiscard]] PartialResult addTableInit(unsigned, unsigned, ExpressionType, ExpressionType, ExpressionType);
+    [[nodiscard]] PartialResult addElemDrop(unsigned);
+    [[nodiscard]] PartialResult addTableSize(unsigned, ExpressionType&);
+    [[nodiscard]] PartialResult addTableGrow(unsigned, ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addTableFill(unsigned, ExpressionType, ExpressionType, ExpressionType);
+    [[nodiscard]] PartialResult addTableCopy(unsigned, unsigned, ExpressionType, ExpressionType, ExpressionType);
 
     // Locals
 
-    WARN_UNUSED_RETURN PartialResult getLocal(uint32_t index, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult setLocal(uint32_t, ExpressionType);
-    WARN_UNUSED_RETURN PartialResult teeLocal(uint32_t, ExpressionType, ExpressionType& result);
+    [[nodiscard]] PartialResult getLocal(uint32_t index, ExpressionType&);
+    [[nodiscard]] PartialResult setLocal(uint32_t, ExpressionType);
+    [[nodiscard]] PartialResult teeLocal(uint32_t, ExpressionType, ExpressionType& result);
 
     // Globals
 
-    WARN_UNUSED_RETURN PartialResult getGlobal(uint32_t, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult setGlobal(uint32_t, ExpressionType);
+    [[nodiscard]] PartialResult getGlobal(uint32_t, ExpressionType&);
+    [[nodiscard]] PartialResult setGlobal(uint32_t, ExpressionType);
 
     // Memory
 
-    WARN_UNUSED_RETURN PartialResult load(LoadOpType, ExpressionType, ExpressionType&, uint64_t);
-    WARN_UNUSED_RETURN PartialResult store(StoreOpType, ExpressionType, ExpressionType, uint64_t);
-    WARN_UNUSED_RETURN PartialResult addGrowMemory(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addCurrentMemory(ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addMemoryFill(ExpressionType, ExpressionType, ExpressionType);
-    WARN_UNUSED_RETURN PartialResult addMemoryCopy(ExpressionType, ExpressionType, ExpressionType);
-    WARN_UNUSED_RETURN PartialResult addMemoryInit(unsigned, ExpressionType, ExpressionType, ExpressionType);
-    WARN_UNUSED_RETURN PartialResult addDataDrop(unsigned);
+    [[nodiscard]] PartialResult load(LoadOpType, ExpressionType, ExpressionType&, uint64_t);
+    [[nodiscard]] PartialResult store(StoreOpType, ExpressionType, ExpressionType, uint64_t);
+    [[nodiscard]] PartialResult addGrowMemory(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addCurrentMemory(ExpressionType&);
+    [[nodiscard]] PartialResult addMemoryFill(ExpressionType, ExpressionType, ExpressionType);
+    [[nodiscard]] PartialResult addMemoryCopy(ExpressionType, ExpressionType, ExpressionType);
+    [[nodiscard]] PartialResult addMemoryInit(unsigned, ExpressionType, ExpressionType, ExpressionType);
+    [[nodiscard]] PartialResult addDataDrop(unsigned);
 
     // Atomics
 
-    WARN_UNUSED_RETURN PartialResult atomicLoad(ExtAtomicOpType, Type, ExpressionType, ExpressionType&, uint32_t);
-    WARN_UNUSED_RETURN PartialResult atomicStore(ExtAtomicOpType, Type, ExpressionType, ExpressionType, uint32_t);
-    WARN_UNUSED_RETURN PartialResult atomicBinaryRMW(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType&, uint32_t);
-    WARN_UNUSED_RETURN PartialResult atomicCompareExchange(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint32_t);
+    [[nodiscard]] PartialResult atomicLoad(ExtAtomicOpType, Type, ExpressionType, ExpressionType&, uint32_t);
+    [[nodiscard]] PartialResult atomicStore(ExtAtomicOpType, Type, ExpressionType, ExpressionType, uint32_t);
+    [[nodiscard]] PartialResult atomicBinaryRMW(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType&, uint32_t);
+    [[nodiscard]] PartialResult atomicCompareExchange(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint32_t);
 
-    WARN_UNUSED_RETURN PartialResult atomicWait(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint32_t);
-    WARN_UNUSED_RETURN PartialResult atomicNotify(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType&, uint32_t);
-    WARN_UNUSED_RETURN PartialResult atomicFence(ExtAtomicOpType, uint8_t);
+    [[nodiscard]] PartialResult atomicWait(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint32_t);
+    [[nodiscard]] PartialResult atomicNotify(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType&, uint32_t);
+    [[nodiscard]] PartialResult atomicFence(ExtAtomicOpType, uint8_t);
 
     // Saturated truncation
 
-    WARN_UNUSED_RETURN PartialResult truncSaturated(Ext1OpType, ExpressionType, ExpressionType&, Type, Type);
+    [[nodiscard]] PartialResult truncSaturated(Ext1OpType, ExpressionType, ExpressionType&, Type, Type);
 
     // GC
 
-    WARN_UNUSED_RETURN PartialResult addRefI31(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI31GetS(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI31GetU(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addArrayNew(uint32_t, ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addArrayNewDefault(uint32_t, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addArrayNewData(uint32_t, uint32_t, ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addArrayNewElem(uint32_t, uint32_t, ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addArrayNewFixed(uint32_t, ArgumentList&, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addArrayGet(ExtGCOpType, uint32_t, ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addArraySet(uint32_t, ExpressionType, ExpressionType, ExpressionType);
-    WARN_UNUSED_RETURN PartialResult addArrayLen(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addArrayFill(uint32_t, ExpressionType, ExpressionType, ExpressionType, ExpressionType);
-    WARN_UNUSED_RETURN PartialResult addArrayCopy(uint32_t, ExpressionType, ExpressionType, uint32_t, ExpressionType, ExpressionType, ExpressionType);
-    WARN_UNUSED_RETURN PartialResult addArrayInitElem(uint32_t, ExpressionType, ExpressionType, uint32_t, ExpressionType, ExpressionType);
-    WARN_UNUSED_RETURN PartialResult addArrayInitData(uint32_t, ExpressionType, ExpressionType, uint32_t, ExpressionType, ExpressionType);
-    WARN_UNUSED_RETURN PartialResult addStructNew(uint32_t, ArgumentList&, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addStructNewDefault(uint32_t, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addStructGet(ExtGCOpType, ExpressionType, const StructType&, uint32_t, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addStructSet(ExpressionType, const StructType&, uint32_t, ExpressionType);
-    WARN_UNUSED_RETURN PartialResult addRefTest(ExpressionType, bool, int32_t, bool, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addRefCast(ExpressionType, bool, int32_t, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addAnyConvertExtern(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addExternConvertAny(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addRefI31(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI31GetS(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI31GetU(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addArrayNew(uint32_t, ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addArrayNewDefault(uint32_t, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addArrayNewData(uint32_t, uint32_t, ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addArrayNewElem(uint32_t, uint32_t, ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addArrayNewFixed(uint32_t, ArgumentList&, ExpressionType&);
+    [[nodiscard]] PartialResult addArrayGet(ExtGCOpType, uint32_t, ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addArraySet(uint32_t, ExpressionType, ExpressionType, ExpressionType);
+    [[nodiscard]] PartialResult addArrayLen(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addArrayFill(uint32_t, ExpressionType, ExpressionType, ExpressionType, ExpressionType);
+    [[nodiscard]] PartialResult addArrayCopy(uint32_t, ExpressionType, ExpressionType, uint32_t, ExpressionType, ExpressionType, ExpressionType);
+    [[nodiscard]] PartialResult addArrayInitElem(uint32_t, ExpressionType, ExpressionType, uint32_t, ExpressionType, ExpressionType);
+    [[nodiscard]] PartialResult addArrayInitData(uint32_t, ExpressionType, ExpressionType, uint32_t, ExpressionType, ExpressionType);
+    [[nodiscard]] PartialResult addStructNew(uint32_t, ArgumentList&, ExpressionType&);
+    [[nodiscard]] PartialResult addStructNewDefault(uint32_t, ExpressionType&);
+    [[nodiscard]] PartialResult addStructGet(ExtGCOpType, ExpressionType, const StructType&, uint32_t, ExpressionType&);
+    [[nodiscard]] PartialResult addStructSet(ExpressionType, const StructType&, uint32_t, ExpressionType);
+    [[nodiscard]] PartialResult addRefTest(ExpressionType, bool, int32_t, bool, ExpressionType&);
+    [[nodiscard]] PartialResult addRefCast(ExpressionType, bool, int32_t, ExpressionType&);
+    [[nodiscard]] PartialResult addAnyConvertExtern(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addExternConvertAny(ExpressionType, ExpressionType&);
 
     // Basic operators
 
-    WARN_UNUSED_RETURN PartialResult addI32DivS(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI32RemS(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI32DivU(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI32RemU(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI64DivS(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI64RemS(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI64DivU(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI64RemU(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI32Ctz(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI32Popcnt(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI64Popcnt(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF64Nearest(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF32Nearest(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF64Trunc(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF32Trunc(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI32TruncSF64(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI32TruncSF32(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI32TruncUF64(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI32TruncUF32(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI64TruncSF64(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI64TruncSF32(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI64TruncUF64(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI64TruncUF32(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF32Ceil(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI32Mul(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI32Sub(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF64Le(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF32DemoteF64(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF64Ne(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF64Lt(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF32Min(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF32Max(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF64Min(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF64Max(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF64Mul(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF32Div(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI32Clz(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF32Copysign(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF32ReinterpretI32(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF32Ne(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF64Gt(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF32Sqrt(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF64Ge(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI64GtS(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI64GtU(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF64Div(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF32Add(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI32LeU(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI32LeS(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI64Ne(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI64Clz(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF32Neg(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI32And(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI32LtU(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI64Rotr(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF64Abs(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI32LtS(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI32Eq(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF64Copysign(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF32ConvertSI64(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI64Rotl(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF32Lt(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF64ConvertSI32(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF64Eq(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF32Le(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF32Ge(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI32ShrU(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF32ConvertUI32(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI32ShrS(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI32GeU(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF64Ceil(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI32GeS(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI32Shl(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF64Floor(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI32Xor(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF32Abs(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF32Mul(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI64Sub(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI32ReinterpretF32(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI32Add(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF64Sub(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI32Or(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI64LtU(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI64LtS(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF64ConvertSI64(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI64Xor(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI64GeU(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI64Mul(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF32Sub(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF64PromoteF32(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF64Add(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI64GeS(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI64ExtendUI32(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI32Ne(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF64ReinterpretI64(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF32Eq(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI64Eq(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF32Floor(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF32ConvertSI32(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI64And(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI64Or(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI64Ctz(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI32Eqz(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI64Eqz(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI64ReinterpretF64(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF64ConvertUI32(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF32ConvertUI64(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF64ConvertUI64(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI64ShrS(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI64ShrU(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF64Sqrt(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI64Shl(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF32Gt(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI32WrapI64(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI32Rotl(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI32Rotr(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI32GtU(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI64ExtendSI32(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI32Extend8S(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI32Extend16S(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI64Extend8S(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI64Extend16S(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI64Extend32S(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI32GtS(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addF64Neg(ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI64LeU(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI64LeS(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addI64Add(ExpressionType, ExpressionType, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addSelect(ExpressionType, ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI32DivS(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI32RemS(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI32DivU(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI32RemU(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI64DivS(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI64RemS(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI64DivU(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI64RemU(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI32Ctz(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI32Popcnt(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI64Popcnt(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF64Nearest(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF32Nearest(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF64Trunc(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF32Trunc(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI32TruncSF64(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI32TruncSF32(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI32TruncUF64(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI32TruncUF32(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI64TruncSF64(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI64TruncSF32(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI64TruncUF64(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI64TruncUF32(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF32Ceil(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI32Mul(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI32Sub(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF64Le(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF32DemoteF64(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF64Ne(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF64Lt(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF32Min(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF32Max(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF64Min(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF64Max(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF64Mul(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF32Div(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI32Clz(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF32Copysign(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF32ReinterpretI32(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF32Ne(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF64Gt(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF32Sqrt(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF64Ge(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI64GtS(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI64GtU(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF64Div(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF32Add(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI32LeU(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI32LeS(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI64Ne(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI64Clz(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF32Neg(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI32And(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI32LtU(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI64Rotr(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF64Abs(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI32LtS(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI32Eq(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF64Copysign(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF32ConvertSI64(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI64Rotl(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF32Lt(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF64ConvertSI32(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF64Eq(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF32Le(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF32Ge(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI32ShrU(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF32ConvertUI32(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI32ShrS(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI32GeU(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF64Ceil(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI32GeS(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI32Shl(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF64Floor(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI32Xor(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF32Abs(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF32Mul(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI64Sub(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI32ReinterpretF32(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI32Add(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF64Sub(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI32Or(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI64LtU(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI64LtS(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF64ConvertSI64(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI64Xor(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI64GeU(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI64Mul(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF32Sub(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF64PromoteF32(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF64Add(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI64GeS(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI64ExtendUI32(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI32Ne(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF64ReinterpretI64(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF32Eq(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI64Eq(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF32Floor(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF32ConvertSI32(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI64And(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI64Or(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI64Ctz(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI32Eqz(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI64Eqz(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI64ReinterpretF64(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF64ConvertUI32(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF32ConvertUI64(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF64ConvertUI64(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI64ShrS(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI64ShrU(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF64Sqrt(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI64Shl(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF32Gt(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI32WrapI64(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI32Rotl(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI32Rotr(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI32GtU(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI64ExtendSI32(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI32Extend8S(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI32Extend16S(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI64Extend8S(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI64Extend16S(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI64Extend32S(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI32GtS(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addF64Neg(ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI64LeU(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI64LeS(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addI64Add(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addSelect(ExpressionType, ExpressionType, ExpressionType, ExpressionType&);
 
     // Control flow
 
-    WARN_UNUSED_RETURN ControlType addTopLevel(BlockSignature);
-    WARN_UNUSED_RETURN PartialResult addBlock(BlockSignature, Stack&, ControlType&, Stack&);
-    WARN_UNUSED_RETURN PartialResult addLoop(BlockSignature, Stack&, ControlType&, Stack&, uint32_t);
-    WARN_UNUSED_RETURN PartialResult addIf(ExpressionType, BlockSignature, Stack&, ControlType&, Stack&);
-    WARN_UNUSED_RETURN PartialResult addElse(ControlType&, Stack&);
-    WARN_UNUSED_RETURN PartialResult addElseToUnreachable(ControlType&);
+    [[nodiscard]] ControlType addTopLevel(BlockSignature);
+    [[nodiscard]] PartialResult addBlock(BlockSignature, Stack&, ControlType&, Stack&);
+    [[nodiscard]] PartialResult addLoop(BlockSignature, Stack&, ControlType&, Stack&, uint32_t);
+    [[nodiscard]] PartialResult addIf(ExpressionType, BlockSignature, Stack&, ControlType&, Stack&);
+    [[nodiscard]] PartialResult addElse(ControlType&, Stack&);
+    [[nodiscard]] PartialResult addElseToUnreachable(ControlType&);
 
-    WARN_UNUSED_RETURN PartialResult addTry(BlockSignature, Stack&, ControlType&, Stack&);
-    WARN_UNUSED_RETURN PartialResult addTryTable(BlockSignature, Stack& enclosingStack, const Vector<CatchHandler>& targets, ControlType& result, Stack& newStack);
-    WARN_UNUSED_RETURN PartialResult addCatch(unsigned, const TypeDefinition&, Stack&, ControlType&, ResultList&);
-    WARN_UNUSED_RETURN PartialResult addCatchToUnreachable(unsigned, const TypeDefinition&, ControlType&, ResultList&);
-    WARN_UNUSED_RETURN PartialResult addCatchAll(Stack&, ControlType&);
-    WARN_UNUSED_RETURN PartialResult addCatchAllToUnreachable(ControlType&);
-    WARN_UNUSED_RETURN PartialResult addDelegate(ControlType&, ControlType&);
-    WARN_UNUSED_RETURN PartialResult addDelegateToUnreachable(ControlType&, ControlType&);
-    WARN_UNUSED_RETURN PartialResult addThrow(unsigned, ArgumentList&, Stack&);
-    WARN_UNUSED_RETURN PartialResult addRethrow(unsigned, ControlType&);
-    WARN_UNUSED_RETURN PartialResult addThrowRef(ExpressionType, Stack&);
+    [[nodiscard]] PartialResult addTry(BlockSignature, Stack&, ControlType&, Stack&);
+    [[nodiscard]] PartialResult addTryTable(BlockSignature, Stack& enclosingStack, const Vector<CatchHandler>& targets, ControlType& result, Stack& newStack);
+    [[nodiscard]] PartialResult addCatch(unsigned, const TypeDefinition&, Stack&, ControlType&, ResultList&);
+    [[nodiscard]] PartialResult addCatchToUnreachable(unsigned, const TypeDefinition&, ControlType&, ResultList&);
+    [[nodiscard]] PartialResult addCatchAll(Stack&, ControlType&);
+    [[nodiscard]] PartialResult addCatchAllToUnreachable(ControlType&);
+    [[nodiscard]] PartialResult addDelegate(ControlType&, ControlType&);
+    [[nodiscard]] PartialResult addDelegateToUnreachable(ControlType&, ControlType&);
+    [[nodiscard]] PartialResult addThrow(unsigned, ArgumentList&, Stack&);
+    [[nodiscard]] PartialResult addRethrow(unsigned, ControlType&);
+    [[nodiscard]] PartialResult addThrowRef(ExpressionType, Stack&);
 
-    WARN_UNUSED_RETURN PartialResult addReturn(const ControlType&, const Stack&);
-    WARN_UNUSED_RETURN PartialResult addBranch(ControlType&, ExpressionType, const Stack&);
-    WARN_UNUSED_RETURN PartialResult addBranchNull(ControlType&, ExpressionType, Stack&, bool, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addBranchCast(ControlType&, ExpressionType, Stack&, bool, int32_t, bool);
-    WARN_UNUSED_RETURN PartialResult addSwitch(ExpressionType, const Vector<ControlType*>&, ControlType&, const Stack&);
-    WARN_UNUSED_RETURN PartialResult endBlock(ControlEntry&, Stack&);
+    [[nodiscard]] PartialResult addReturn(const ControlType&, const Stack&);
+    [[nodiscard]] PartialResult addBranch(ControlType&, ExpressionType, const Stack&);
+    [[nodiscard]] PartialResult addBranchNull(ControlType&, ExpressionType, Stack&, bool, ExpressionType&);
+    [[nodiscard]] PartialResult addBranchCast(ControlType&, ExpressionType, Stack&, bool, int32_t, bool);
+    [[nodiscard]] PartialResult addSwitch(ExpressionType, const Vector<ControlType*>&, ControlType&, const Stack&);
+    [[nodiscard]] PartialResult endBlock(ControlEntry&, Stack&);
     void endTryTable(ControlType& data);
-    WARN_UNUSED_RETURN PartialResult addEndToUnreachable(ControlEntry&, Stack&);
+    [[nodiscard]] PartialResult addEndToUnreachable(ControlEntry&, Stack&);
 
-    WARN_UNUSED_RETURN PartialResult endTopLevel(BlockSignature, const Stack&);
+    [[nodiscard]] PartialResult endTopLevel(BlockSignature, const Stack&);
 
     // Fused comparison stubs (TODO: make use of these for better codegen)
-    WARN_UNUSED_RETURN PartialResult addFusedBranchCompare(OpType, ControlType&, ExpressionType, const Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
-    WARN_UNUSED_RETURN PartialResult addFusedBranchCompare(OpType, ControlType&, ExpressionType, ExpressionType, const Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
-    WARN_UNUSED_RETURN PartialResult addFusedIfCompare(OpType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
-    WARN_UNUSED_RETURN PartialResult addFusedIfCompare(OpType, ExpressionType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
+    [[nodiscard]] PartialResult addFusedBranchCompare(OpType, ControlType&, ExpressionType, const Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
+    [[nodiscard]] PartialResult addFusedBranchCompare(OpType, ControlType&, ExpressionType, ExpressionType, const Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
+    [[nodiscard]] PartialResult addFusedIfCompare(OpType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
+    [[nodiscard]] PartialResult addFusedIfCompare(OpType, ExpressionType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
 
     // Calls
 
-    WARN_UNUSED_RETURN PartialResult addCall(unsigned, FunctionSpaceIndex, const TypeDefinition&, ArgumentList&, ResultList&, CallType = CallType::Call);
-    WARN_UNUSED_RETURN PartialResult addCallIndirect(unsigned, unsigned, const TypeDefinition&, ArgumentList&, ResultList&, CallType = CallType::Call);
-    WARN_UNUSED_RETURN PartialResult addCallRef(unsigned, const TypeDefinition&, ArgumentList&, ResultList&, CallType = CallType::Call);
-    WARN_UNUSED_RETURN PartialResult addUnreachable();
-    WARN_UNUSED_RETURN PartialResult addCrash();
+    [[nodiscard]] PartialResult addCall(unsigned, FunctionSpaceIndex, const TypeDefinition&, ArgumentList&, ResultList&, CallType = CallType::Call);
+    [[nodiscard]] PartialResult addCallIndirect(unsigned, unsigned, const TypeDefinition&, ArgumentList&, ResultList&, CallType = CallType::Call);
+    [[nodiscard]] PartialResult addCallRef(unsigned, const TypeDefinition&, ArgumentList&, ResultList&, CallType = CallType::Call);
+    [[nodiscard]] PartialResult addUnreachable();
+    [[nodiscard]] PartialResult addCrash();
 
     void setParser(FunctionParser<IPIntGenerator>* parser) { m_parser = parser; };
     size_t getCurrentInstructionLength()
@@ -684,7 +684,7 @@ IPIntGenerator::IPIntGenerator(ModuleInformation& info, FunctionCodeIndex functi
 {
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addDrop(ExpressionType)
+[[nodiscard]] PartialResult IPIntGenerator::addDrop(ExpressionType)
 {
     changeStackSize(-1);
     return { };
@@ -699,68 +699,68 @@ Value IPIntGenerator::addConstant(Type type, uint64_t value)
 
 // SIMD
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addSIMDLoad(ExpressionType, uint32_t offset, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addSIMDLoad(ExpressionType, uint32_t offset, ExpressionType&)
 {
     changeStackSize(0); // Pop address, push v128 value (net change = 0)
     m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addSIMDStore(ExpressionType, ExpressionType, uint32_t offset)
+[[nodiscard]] PartialResult IPIntGenerator::addSIMDStore(ExpressionType, ExpressionType, uint32_t offset)
 {
     changeStackSize(-2); // Pop address and v128 value
     m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addSIMDSplat(SIMDLane, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addSIMDSplat(SIMDLane, ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addSIMDShuffle(v128_t, ExpressionType, ExpressionType, ExpressionType&)
-{
-    changeStackSize(-1);
-    return { };
-}
-
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addSIMDShift(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addSIMDShuffle(v128_t, ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addSIMDExtmul(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addSIMDShift(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addSIMDLoadSplat(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result)
+[[nodiscard]] PartialResult IPIntGenerator::addSIMDExtmul(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&)
+{
+    changeStackSize(-1);
+    return { };
+}
+
+[[nodiscard]] PartialResult IPIntGenerator::addSIMDLoadSplat(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result)
 {
     return addSIMDLoad(pointer, offset, result);
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addSIMDLoadLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t offset, uint8_t, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addSIMDLoadLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t offset, uint8_t, ExpressionType&)
 {
     changeStackSize(-1);
     m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addSIMDStoreLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t offset, uint8_t)
+[[nodiscard]] PartialResult IPIntGenerator::addSIMDStoreLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t offset, uint8_t)
 {
     changeStackSize(-2);
     m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addSIMDLoadExtend(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result)
+[[nodiscard]] PartialResult IPIntGenerator::addSIMDLoadExtend(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result)
 {
     return addSIMDLoad(pointer, offset, result);
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addSIMDLoadPad(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result)
+[[nodiscard]] PartialResult IPIntGenerator::addSIMDLoadPad(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result)
 {
     return addSIMDLoad(pointer, offset, result);
 }
@@ -771,48 +771,48 @@ IPIntGenerator::ExpressionType IPIntGenerator::addConstant(v128_t)
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addExtractLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addExtractLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addReplaceLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addReplaceLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addSIMDI_V(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addSIMDI_V(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addSIMDV_V(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addSIMDV_V(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addSIMDBitwiseSelect(ExpressionType, ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addSIMDBitwiseSelect(ExpressionType, ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-2); // 3 operands, 1 result
     return { };
 }
 
 #if ENABLE(B3_JIT)
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addSIMDRelOp(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, B3::Air::Arg, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addSIMDRelOp(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, B3::Air::Arg, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 #endif
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addSIMDV_VV(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addSIMDV_VV(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1); // Pop two v128 values, push one v128 value
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addSIMDRelaxedFMA(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addSIMDRelaxedFMA(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-2); // Pop three v128 values, push one v128 value
     return { };
@@ -820,24 +820,24 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addSIMDRelaxedFMA(SIMDLaneOpera
 
 // References
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addRefIsNull(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addRefIsNull(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addRefFunc(FunctionSpaceIndex index, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addRefFunc(FunctionSpaceIndex index, ExpressionType&)
 {
     changeStackSize(1);
     m_metadata->addLEB128ConstantInt32AndLength(index, getCurrentInstructionLength());
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addRefAsNonNull(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addRefAsNonNull(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addRefEq(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addRefEq(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
@@ -845,20 +845,20 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addRefEq(ExpressionType, Expres
 
 // Tables
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addTableGet(unsigned index, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addTableGet(unsigned index, ExpressionType, ExpressionType&)
 {
     m_metadata->addLEB128ConstantInt32AndLength(index, getCurrentInstructionLength());
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addTableSet(unsigned index, ExpressionType, ExpressionType)
+[[nodiscard]] PartialResult IPIntGenerator::addTableSet(unsigned index, ExpressionType, ExpressionType)
 {
     changeStackSize(-2);
     m_metadata->addLEB128ConstantInt32AndLength(index, getCurrentInstructionLength());
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addTableInit(unsigned elementIndex, unsigned tableIndex, ExpressionType, ExpressionType, ExpressionType)
+[[nodiscard]] PartialResult IPIntGenerator::addTableInit(unsigned elementIndex, unsigned tableIndex, ExpressionType, ExpressionType, ExpressionType)
 {
     changeStackSize(-3);
     IPInt::TableInitMetadata table {
@@ -870,20 +870,20 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addTableInit(unsigned elementIn
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addElemDrop(unsigned elementIndex)
+[[nodiscard]] PartialResult IPIntGenerator::addElemDrop(unsigned elementIndex)
 {
     m_metadata->addLEB128ConstantInt32AndLength(elementIndex, getCurrentInstructionLength());
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addTableSize(unsigned tableIndex, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addTableSize(unsigned tableIndex, ExpressionType&)
 {
     changeStackSize(1);
     m_metadata->addLEB128ConstantInt32AndLength(tableIndex, getCurrentInstructionLength());
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addTableGrow(unsigned tableIndex, ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addTableGrow(unsigned tableIndex, ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     IPInt::TableGrowMetadata table {
@@ -894,7 +894,7 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addTableGrow(unsigned tableInde
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addTableFill(unsigned tableIndex, ExpressionType, ExpressionType, ExpressionType)
+[[nodiscard]] PartialResult IPIntGenerator::addTableFill(unsigned tableIndex, ExpressionType, ExpressionType, ExpressionType)
 {
     changeStackSize(-3);
     IPInt::TableFillMetadata table {
@@ -905,7 +905,7 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addTableFill(unsigned tableInde
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addTableCopy(unsigned dstTableIndex, unsigned srcTableIndex, ExpressionType, ExpressionType, ExpressionType)
+[[nodiscard]] PartialResult IPIntGenerator::addTableCopy(unsigned dstTableIndex, unsigned srcTableIndex, ExpressionType, ExpressionType, ExpressionType)
 {
     changeStackSize(-3);
     IPInt::TableCopyMetadata table {
@@ -919,7 +919,7 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addTableCopy(unsigned dstTableI
 
 // Locals and Globals
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addArguments(const TypeDefinition &signature)
+[[nodiscard]] PartialResult IPIntGenerator::addArguments(const TypeDefinition &signature)
 {
     auto sig = signature.as<FunctionSignature>();
     const CallInformation callCC = wasmCallingConvention().callInformationFor(*sig, CallRole::Callee);
@@ -989,7 +989,7 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addArguments(const TypeDefiniti
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addLocal(Type localType, uint32_t count)
+[[nodiscard]] PartialResult IPIntGenerator::addLocal(Type localType, uint32_t count)
 {
     // push 0x00 or 0xff (for bit hacks) to the metadata depending on if we have a primitive or a reference
     if (isRefType(localType)) {
@@ -1012,7 +1012,7 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addLocal(Type localType, uint32
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::getLocal(uint32_t, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::getLocal(uint32_t, ExpressionType&)
 {
     // Local indices are usually very small, so we decode them on the fly
     // instead of generating metadata.
@@ -1020,7 +1020,7 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::getLocal(uint32_t, ExpressionTy
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::setLocal(uint32_t, ExpressionType)
+[[nodiscard]] PartialResult IPIntGenerator::setLocal(uint32_t, ExpressionType)
 {
     // Local indices are usually very small, so we decode them on the fly
     // instead of generating metadata.
@@ -1028,12 +1028,12 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::setLocal(uint32_t, ExpressionTy
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::teeLocal(uint32_t, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::teeLocal(uint32_t, ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::getGlobal(uint32_t index, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::getGlobal(uint32_t index, ExpressionType&)
 {
     changeStackSize(1);
     const Wasm::GlobalInformation& global = m_info.globals[index];
@@ -1047,7 +1047,7 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::getGlobal(uint32_t index, Expre
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::setGlobal(uint32_t index, ExpressionType)
+[[nodiscard]] PartialResult IPIntGenerator::setGlobal(uint32_t index, ExpressionType)
 {
     changeStackSize(-1);
     const Wasm::GlobalInformation& global = m_info.globals[index];
@@ -1063,7 +1063,7 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::setGlobal(uint32_t index, Expre
 
 // Loads and Stores
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::load(LoadOpType, ExpressionType, ExpressionType&, uint64_t offset)
+[[nodiscard]] PartialResult IPIntGenerator::load(LoadOpType, ExpressionType, ExpressionType&, uint64_t offset)
 {
     if (m_info.memory.isMemory64())
         m_metadata->addLEB128ConstantInt64AndLength(offset, getCurrentInstructionLength());
@@ -1072,7 +1072,7 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::load(LoadOpType, ExpressionType
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::store(StoreOpType, ExpressionType, ExpressionType, uint64_t offset)
+[[nodiscard]] PartialResult IPIntGenerator::store(StoreOpType, ExpressionType, ExpressionType, uint64_t offset)
 {
     changeStackSize(-2);
     if (m_info.memory.isMemory64())
@@ -1084,39 +1084,39 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::store(StoreOpType, ExpressionTy
 
 // Memories
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addGrowMemory(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addGrowMemory(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addCurrentMemory(ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addCurrentMemory(ExpressionType&)
 {
     changeStackSize(1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addMemoryFill(ExpressionType, ExpressionType, ExpressionType)
+[[nodiscard]] PartialResult IPIntGenerator::addMemoryFill(ExpressionType, ExpressionType, ExpressionType)
 {
     changeStackSize(-3);
     m_metadata->addLength(getCurrentInstructionLength());
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addMemoryCopy(ExpressionType, ExpressionType, ExpressionType)
+[[nodiscard]] PartialResult IPIntGenerator::addMemoryCopy(ExpressionType, ExpressionType, ExpressionType)
 {
     changeStackSize(-3);
     m_metadata->addLength(getCurrentInstructionLength());
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addMemoryInit(unsigned dataIndex, ExpressionType, ExpressionType, ExpressionType)
+[[nodiscard]] PartialResult IPIntGenerator::addMemoryInit(unsigned dataIndex, ExpressionType, ExpressionType, ExpressionType)
 {
     changeStackSize(-3);
     m_metadata->addLEB128ConstantInt32AndLength(dataIndex, getCurrentInstructionLength());
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addDataDrop(unsigned dataIndex)
+[[nodiscard]] PartialResult IPIntGenerator::addDataDrop(unsigned dataIndex)
 {
     m_metadata->addLEB128ConstantInt32AndLength(dataIndex, getCurrentInstructionLength());
     return { };
@@ -1124,48 +1124,48 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addDataDrop(unsigned dataIndex)
 
 // Atomics
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::atomicLoad(ExtAtomicOpType, Type, ExpressionType, ExpressionType&, uint32_t offset)
+[[nodiscard]] PartialResult IPIntGenerator::atomicLoad(ExtAtomicOpType, Type, ExpressionType, ExpressionType&, uint32_t offset)
 {
     m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::atomicStore(ExtAtomicOpType, Type, ExpressionType, ExpressionType, uint32_t offset)
+[[nodiscard]] PartialResult IPIntGenerator::atomicStore(ExtAtomicOpType, Type, ExpressionType, ExpressionType, uint32_t offset)
 {
     changeStackSize(-2);
     m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::atomicBinaryRMW(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType&, uint32_t offset)
+[[nodiscard]] PartialResult IPIntGenerator::atomicBinaryRMW(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType&, uint32_t offset)
 {
     changeStackSize(-1);
     m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::atomicCompareExchange(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint32_t offset)
+[[nodiscard]] PartialResult IPIntGenerator::atomicCompareExchange(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint32_t offset)
 {
     changeStackSize(-2);
     m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::atomicWait(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint32_t offset)
+[[nodiscard]] PartialResult IPIntGenerator::atomicWait(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint32_t offset)
 {
     changeStackSize(-2);
     m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::atomicNotify(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType&, uint32_t offset)
+[[nodiscard]] PartialResult IPIntGenerator::atomicNotify(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType&, uint32_t offset)
 {
     changeStackSize(-1);
     m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::atomicFence(ExtAtomicOpType, uint8_t)
+[[nodiscard]] PartialResult IPIntGenerator::atomicFence(ExtAtomicOpType, uint8_t)
 {
     m_metadata->addLength(getCurrentInstructionLength());
     return { };
@@ -1173,22 +1173,22 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::atomicFence(ExtAtomicOpType, ui
 
 // GC
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addRefI31(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addRefI31(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI31GetS(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI31GetS(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI31GetU(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI31GetU(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addArrayNew(uint32_t index, ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addArrayNew(uint32_t index, ExpressionType, ExpressionType, ExpressionType&)
 {
     m_metadata->appendMetadata<IPInt::ArrayNewMetadata>({
         index,
@@ -1198,7 +1198,7 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addArrayNew(uint32_t index, Exp
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addArrayNewData(uint32_t index, uint32_t dataSegmentIndex, ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addArrayNewData(uint32_t index, uint32_t dataSegmentIndex, ExpressionType, ExpressionType, ExpressionType&)
 {
     m_metadata->appendMetadata<IPInt::ArrayNewDataMetadata>({
         index,
@@ -1209,7 +1209,7 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addArrayNewData(uint32_t index,
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addArrayNewElem(uint32_t index, uint32_t elemSegmentIndex, ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addArrayNewElem(uint32_t index, uint32_t elemSegmentIndex, ExpressionType, ExpressionType, ExpressionType&)
 {
     m_metadata->appendMetadata<IPInt::ArrayNewElemMetadata>({
         index,
@@ -1220,7 +1220,7 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addArrayNewElem(uint32_t index,
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addArrayNewFixed(uint32_t index, ArgumentList& args, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addArrayNewFixed(uint32_t index, ArgumentList& args, ExpressionType&)
 {
     m_metadata->appendMetadata<IPInt::ArrayNewFixedMetadata>({
         index,
@@ -1231,7 +1231,7 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addArrayNewFixed(uint32_t index
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addArrayNewDefault(uint32_t index, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addArrayNewDefault(uint32_t index, ExpressionType, ExpressionType&)
 {
     m_metadata->appendMetadata<IPInt::ArrayNewMetadata>({
         index,
@@ -1240,7 +1240,7 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addArrayNewDefault(uint32_t ind
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addArrayGet(ExtGCOpType, uint32_t index, ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addArrayGet(ExtGCOpType, uint32_t index, ExpressionType, ExpressionType, ExpressionType&)
 {
     m_metadata->appendMetadata<IPInt::ArrayGetSetMetadata>({
         index,
@@ -1250,7 +1250,7 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addArrayGet(ExtGCOpType, uint32
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addArraySet(uint32_t index, ExpressionType, ExpressionType, ExpressionType)
+[[nodiscard]] PartialResult IPIntGenerator::addArraySet(uint32_t index, ExpressionType, ExpressionType, ExpressionType)
 {
     m_metadata->appendMetadata<IPInt::ArrayGetSetMetadata>({
         index,
@@ -1260,13 +1260,13 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addArraySet(uint32_t index, Exp
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addArrayLen(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addArrayLen(ExpressionType, ExpressionType&)
 {
     // no metadata
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addArrayFill(uint32_t, ExpressionType, ExpressionType, ExpressionType, ExpressionType)
+[[nodiscard]] PartialResult IPIntGenerator::addArrayFill(uint32_t, ExpressionType, ExpressionType, ExpressionType, ExpressionType)
 {
     changeStackSize(-4);
     m_metadata->appendMetadata<IPInt::ArrayFillMetadata>({
@@ -1275,7 +1275,7 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addArrayFill(uint32_t, Expressi
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addArrayCopy(uint32_t, ExpressionType, ExpressionType, uint32_t, ExpressionType, ExpressionType, ExpressionType)
+[[nodiscard]] PartialResult IPIntGenerator::addArrayCopy(uint32_t, ExpressionType, ExpressionType, uint32_t, ExpressionType, ExpressionType, ExpressionType)
 {
     changeStackSize(-5);
     m_metadata->appendMetadata<IPInt::ArrayCopyMetadata>({
@@ -1284,7 +1284,7 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addArrayCopy(uint32_t, Expressi
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addArrayInitElem(uint32_t, ExpressionType, ExpressionType, uint32_t elemSegmentIndex, ExpressionType, ExpressionType)
+[[nodiscard]] PartialResult IPIntGenerator::addArrayInitElem(uint32_t, ExpressionType, ExpressionType, uint32_t elemSegmentIndex, ExpressionType, ExpressionType)
 {
     changeStackSize(-4);
     m_metadata->appendMetadata<IPInt::ArrayInitDataMetadata>({
@@ -1294,7 +1294,7 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addArrayInitElem(uint32_t, Expr
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addArrayInitData(uint32_t, ExpressionType, ExpressionType, uint32_t dataSegmentIndex, ExpressionType, ExpressionType)
+[[nodiscard]] PartialResult IPIntGenerator::addArrayInitData(uint32_t, ExpressionType, ExpressionType, uint32_t dataSegmentIndex, ExpressionType, ExpressionType)
 {
     changeStackSize(-4);
     m_metadata->appendMetadata<IPInt::ArrayInitDataMetadata>({
@@ -1304,7 +1304,7 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addArrayInitData(uint32_t, Expr
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addStructNew(uint32_t index, ArgumentList&, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addStructNew(uint32_t index, ArgumentList&, ExpressionType&)
 {
     const StructType& type = *m_info.typeSignatures[index]->expand().as<StructType>();
     m_metadata->appendMetadata<IPInt::StructNewMetadata>({
@@ -1316,7 +1316,7 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addStructNew(uint32_t index, Ar
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addStructNewDefault(uint32_t index, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addStructNewDefault(uint32_t index, ExpressionType&)
 {
     m_metadata->appendMetadata<IPInt::StructNewDefaultMetadata>({
         index,
@@ -1326,7 +1326,7 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addStructNewDefault(uint32_t in
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addStructGet(ExtGCOpType, ExpressionType, const StructType&, uint32_t fieldIndex, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addStructGet(ExtGCOpType, ExpressionType, const StructType&, uint32_t fieldIndex, ExpressionType&)
 {
     m_metadata->appendMetadata<IPInt::StructGetSetMetadata>({
         fieldIndex,
@@ -1335,7 +1335,7 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addStructGet(ExtGCOpType, Expre
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addStructSet(ExpressionType, const StructType&, uint32_t fieldIndex, ExpressionType)
+[[nodiscard]] PartialResult IPIntGenerator::addStructSet(ExpressionType, const StructType&, uint32_t fieldIndex, ExpressionType)
 {
     m_metadata->appendMetadata<IPInt::StructGetSetMetadata>({
         fieldIndex,
@@ -1345,7 +1345,7 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addStructSet(ExpressionType, co
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addRefTest(ExpressionType, bool, int32_t heapType, bool, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addRefTest(ExpressionType, bool, int32_t heapType, bool, ExpressionType&)
 {
     m_metadata->appendMetadata<IPInt::RefTestCastMetadata>({
         heapType,
@@ -1354,7 +1354,7 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addRefTest(ExpressionType, bool
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addRefCast(ExpressionType, bool, int32_t heapType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addRefCast(ExpressionType, bool, int32_t heapType, ExpressionType&)
 {
     m_metadata->appendMetadata<IPInt::RefTestCastMetadata>({
         heapType,
@@ -1363,97 +1363,97 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addRefCast(ExpressionType, bool
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addAnyConvertExtern(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addAnyConvertExtern(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addExternConvertAny(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addExternConvertAny(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
 // Integer Arithmetic
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32Add(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI32Add(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64Add(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI64Add(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32Sub(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI32Sub(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64Sub(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI64Sub(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32Mul(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI32Mul(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64Mul(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI64Mul(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32DivS(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI32DivS(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32DivU(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI32DivU(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64DivS(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI64DivS(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64DivU(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI64DivU(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32RemS(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI32RemS(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32RemU(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI32RemU(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64RemS(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI64RemS(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64RemU(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI64RemU(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
@@ -1461,177 +1461,177 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64RemU(ExpressionType, Expr
 
 // Bitwise Operations
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32And(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI32And(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64And(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI64And(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32Xor(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI32Xor(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64Xor(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI64Xor(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32Or(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI32Or(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64Or(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI64Or(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32Shl(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI32Shl(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32ShrU(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI32ShrU(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32ShrS(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI32ShrS(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64Shl(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI64Shl(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64ShrU(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI64ShrU(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64ShrS(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI64ShrS(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32Rotl(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI32Rotl(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64Rotl(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI64Rotl(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32Rotr(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI32Rotr(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64Rotr(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI64Rotr(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32Popcnt(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI32Popcnt(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64Popcnt(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI64Popcnt(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32Clz(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI32Clz(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64Clz(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI64Clz(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32Ctz(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI32Ctz(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64Ctz(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI64Ctz(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
 // Floating-Point Arithmetic
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32Add(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF32Add(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64Add(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF64Add(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32Sub(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF32Sub(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64Sub(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF64Sub(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32Mul(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF32Mul(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64Mul(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF64Mul(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32Div(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF32Div(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64Div(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF64Div(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
@@ -1639,303 +1639,303 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64Div(ExpressionType, Expre
 
 // Other Floating-Point Instructions
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32Min(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF32Min(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32Max(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF32Max(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64Min(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF64Min(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64Max(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF64Max(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32Nearest(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF32Nearest(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64Nearest(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF64Nearest(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32Floor(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF32Floor(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64Floor(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF64Floor(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32Ceil(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF32Ceil(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64Ceil(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF64Ceil(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32Copysign(ExpressionType, ExpressionType, ExpressionType&)
-{
-    changeStackSize(-1);
-    return { };
-}
-
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64Copysign(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF32Copysign(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32Sqrt(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF64Copysign(ExpressionType, ExpressionType, ExpressionType&)
+{
+    changeStackSize(-1);
+    return { };
+}
+
+[[nodiscard]] PartialResult IPIntGenerator::addF32Sqrt(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64Sqrt(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF64Sqrt(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32Neg(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF32Neg(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64Neg(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF64Neg(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32Abs(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF32Abs(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64Abs(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF64Abs(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
 // Integer Comparisons
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32Eq(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI32Eq(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32Ne(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI32Ne(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32LtS(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI32LtS(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32LtU(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI32LtU(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32LeS(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI32LeS(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32LeU(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI32LeU(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32GtS(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI32GtS(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32GtU(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI32GtU(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32GeU(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI32GeU(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32GeS(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI32GeS(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32Eqz(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI32Eqz(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64Eq(ExpressionType, ExpressionType, ExpressionType&)
-{
-    changeStackSize(-1);
-    return { };
-}
-
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64Ne(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI64Eq(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64GtS(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI64Ne(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64GtU(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI64GtS(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64GeS(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI64GtU(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64GeU(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI64GeS(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64LtS(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI64GeU(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64LtU(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI64LtS(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64LeS(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI64LtU(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64LeU(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI64LeS(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64Eqz(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI64LeU(ExpressionType, ExpressionType, ExpressionType&)
+{
+    changeStackSize(-1);
+    return { };
+}
+
+[[nodiscard]] PartialResult IPIntGenerator::addI64Eqz(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
 // Floating-Point Comparisons
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32Eq(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF32Eq(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32Ne(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF32Ne(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32Lt(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF32Lt(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32Le(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF32Le(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32Gt(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF32Gt(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32Ge(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF32Ge(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64Eq(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF64Eq(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64Ne(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF64Ne(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64Lt(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF64Lt(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64Le(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF64Le(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64Gt(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF64Gt(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64Ge(ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF64Ge(ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
     return { };
@@ -1943,94 +1943,94 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64Ge(ExpressionType, Expres
 
 // Integer Extension
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64ExtendSI32(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI64ExtendSI32(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64ExtendUI32(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI64ExtendUI32(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32Extend8S(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI32Extend8S(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32Extend16S(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI32Extend16S(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64Extend8S(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI64Extend8S(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64Extend16S(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI64Extend16S(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64Extend32S(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI64Extend32S(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
 // Truncation
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64Trunc(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF64Trunc(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32Trunc(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF32Trunc(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32TruncSF64(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI32TruncSF64(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32TruncSF32(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI32TruncSF32(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32TruncUF64(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI32TruncUF64(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32TruncUF32(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI32TruncUF32(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64TruncSF64(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI64TruncSF64(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64TruncSF32(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI64TruncSF32(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64TruncUF64(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI64TruncUF64(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64TruncUF32(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI64TruncUF32(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::truncSaturated(Ext1OpType, ExpressionType, ExpressionType&, Type, Type)
+[[nodiscard]] PartialResult IPIntGenerator::truncSaturated(Ext1OpType, ExpressionType, ExpressionType&, Type, Type)
 {
     m_metadata->addLength(getCurrentInstructionLength());
     return { };
@@ -2038,77 +2038,77 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::truncSaturated(Ext1OpType, Expr
 
 // Conversions
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32WrapI64(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI32WrapI64(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32DemoteF64(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF32DemoteF64(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64PromoteF32(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF64PromoteF32(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32ReinterpretI32(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF32ReinterpretI32(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI32ReinterpretF32(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI32ReinterpretF32(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64ReinterpretI64(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF64ReinterpretI64(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addI64ReinterpretF64(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addI64ReinterpretF64(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32ConvertSI32(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF32ConvertSI32(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32ConvertUI32(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF32ConvertUI32(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32ConvertSI64(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF32ConvertSI64(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF32ConvertUI64(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF32ConvertUI64(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64ConvertSI32(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF64ConvertSI32(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64ConvertUI32(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF64ConvertUI32(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64ConvertSI64(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF64ConvertSI64(ExpressionType, ExpressionType&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addF64ConvertUI64(ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addF64ConvertUI64(ExpressionType, ExpressionType&)
 {
     return { };
 }
@@ -2195,19 +2195,19 @@ void IPIntGenerator::resolveExitTarget(unsigned index, IPIntLocation loc)
     control.m_exitTarget = loc;
 }
 
-WARN_UNUSED_RETURN IPIntGenerator::ControlType IPIntGenerator::addTopLevel(BlockSignature signature)
+[[nodiscard]] IPIntGenerator::ControlType IPIntGenerator::addTopLevel(BlockSignature signature)
 {
     return ControlType(signature, 0, BlockType::TopLevel);
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addSelect(ExpressionType, ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addSelect(ExpressionType, ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-2);
     m_metadata->addLength(getCurrentInstructionLength());
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addBlock(BlockSignature signature, Stack& oldStack, ControlType& block, Stack& newStack)
+[[nodiscard]] PartialResult IPIntGenerator::addBlock(BlockSignature signature, Stack& oldStack, ControlType& block, Stack& newStack)
 {
     splitStack(signature, oldStack, newStack);
     block = ControlType(signature, m_stackSize.value() - newStack.size(), BlockType::Block);
@@ -2234,7 +2234,7 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addBlock(BlockSignature signatu
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addLoop(BlockSignature signature, Stack& oldStack, ControlType& block, Stack& newStack, uint32_t loopIndex)
+[[nodiscard]] PartialResult IPIntGenerator::addLoop(BlockSignature signature, Stack& oldStack, ControlType& block, Stack& newStack, uint32_t loopIndex)
 {
     splitStack(signature, oldStack, newStack);
     block = ControlType(signature, m_stackSize.value() - newStack.size(), BlockType::Loop);
@@ -2265,7 +2265,7 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addLoop(BlockSignature signatur
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addIf(ExpressionType, BlockSignature signature, Stack& oldStack, ControlType& block, Stack& newStack)
+[[nodiscard]] PartialResult IPIntGenerator::addIf(ExpressionType, BlockSignature signature, Stack& oldStack, ControlType& block, Stack& newStack)
 {
     splitStack(signature, oldStack, newStack);
     changeStackSize(-1);
@@ -2292,12 +2292,12 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addIf(ExpressionType, BlockSign
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addElse(ControlType& block, Stack&)
+[[nodiscard]] PartialResult IPIntGenerator::addElse(ControlType& block, Stack&)
 {
     return addElseToUnreachable(block);
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addElseToUnreachable(ControlType& block)
+[[nodiscard]] PartialResult IPIntGenerator::addElseToUnreachable(ControlType& block)
 {
     auto blockSignature = block.signature();
     const FunctionSignature& signature = *blockSignature.m_signature;
@@ -2335,7 +2335,7 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addElseToUnreachable(ControlTyp
 
 // Exception Handling
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addTry(BlockSignature signature, Stack& oldStack, ControlType& block, Stack& newStack)
+[[nodiscard]] PartialResult IPIntGenerator::addTry(BlockSignature signature, Stack& oldStack, ControlType& block, Stack& newStack)
 {
     m_tryDepth++;
     m_maxTryDepth = std::max(m_maxTryDepth, m_tryDepth.value());
@@ -2366,7 +2366,7 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addTry(BlockSignature signature
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addTryTable(BlockSignature signature, Stack& enclosingStack, const Vector<CatchHandler>& targets, ControlType& result, Stack& newStack)
+[[nodiscard]] PartialResult IPIntGenerator::addTryTable(BlockSignature signature, Stack& enclosingStack, const Vector<CatchHandler>& targets, ControlType& result, Stack& newStack)
 {
     splitStack(signature, enclosingStack, newStack);
     result = ControlType(signature, m_stackSize.value() - newStack.size(), BlockType::TryTable);
@@ -2434,13 +2434,13 @@ void IPIntGenerator::convertTryToCatch(ControlType& tryBlock, CatchKind catchKin
     tryBlock = WTF::move(catchBlock);
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addCatch(unsigned exceptionIndex, const TypeDefinition& exceptionSignature, Stack&, ControlType& block, ResultList& results)
+[[nodiscard]] PartialResult IPIntGenerator::addCatch(unsigned exceptionIndex, const TypeDefinition& exceptionSignature, Stack&, ControlType& block, ResultList& results)
 {
 
     return addCatchToUnreachable(exceptionIndex, exceptionSignature, block, results);
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addCatchToUnreachable(unsigned exceptionIndex, const TypeDefinition& exceptionSignature, ControlType& block, ResultList& results)
+[[nodiscard]] PartialResult IPIntGenerator::addCatchToUnreachable(unsigned exceptionIndex, const TypeDefinition& exceptionSignature, ControlType& block, ResultList& results)
 {
     if (ControlType::isTry(block))
         convertTryToCatch(block, CatchKind::Catch);
@@ -2476,12 +2476,12 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addCatchToUnreachable(unsigned 
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addCatchAll(Stack&, ControlType& block)
+[[nodiscard]] PartialResult IPIntGenerator::addCatchAll(Stack&, ControlType& block)
 {
     return addCatchAllToUnreachable(block);
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addCatchAllToUnreachable(ControlType& block)
+[[nodiscard]] PartialResult IPIntGenerator::addCatchAllToUnreachable(ControlType& block)
 {
     UNUSED_PARAM(block);
     if (ControlType::isTry(block))
@@ -2515,12 +2515,12 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addCatchAllToUnreachable(Contro
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addDelegate(ControlType& target, ControlType& data)
+[[nodiscard]] PartialResult IPIntGenerator::addDelegate(ControlType& target, ControlType& data)
 {
     return addDelegateToUnreachable(target, data);
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addDelegateToUnreachable(ControlType& target, ControlType& data)
+[[nodiscard]] PartialResult IPIntGenerator::addDelegateToUnreachable(ControlType& target, ControlType& data)
 {
     UNUSED_PARAM(target);
     UNUSED_PARAM(data);
@@ -2547,7 +2547,7 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addDelegateToUnreachable(Contro
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addThrow(unsigned exceptionIndex, ArgumentList&, Stack&)
+[[nodiscard]] PartialResult IPIntGenerator::addThrow(unsigned exceptionIndex, ArgumentList&, Stack&)
 {
     IPInt::ThrowMetadata mdThrow {
         .exceptionIndex = safeCast<uint32_t>(exceptionIndex)
@@ -2557,7 +2557,7 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addThrow(unsigned exceptionInde
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addRethrow(unsigned, ControlType& catchBlock)
+[[nodiscard]] PartialResult IPIntGenerator::addRethrow(unsigned, ControlType& catchBlock)
 {
     m_usesRethrow = true;
 
@@ -2571,7 +2571,7 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addRethrow(unsigned, ControlTyp
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addThrowRef(ExpressionType, Stack&)
+[[nodiscard]] PartialResult IPIntGenerator::addThrowRef(ExpressionType, Stack&)
 {
     changeStackSize(-1);
     return { };
@@ -2579,12 +2579,12 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addThrowRef(ExpressionType, Sta
 
 // Control Flow Branches
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addReturn(const ControlType&, const Stack&)
+[[nodiscard]] PartialResult IPIntGenerator::addReturn(const ControlType&, const Stack&)
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addBranch(ControlType& block, ExpressionType, const Stack&)
+[[nodiscard]] PartialResult IPIntGenerator::addBranch(ControlType& block, ExpressionType, const Stack&)
 {
     bool isBrIf = (m_parser->currentOpcode() == OpType::BrIf);
     if (isBrIf)
@@ -2608,7 +2608,7 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addBranch(ControlType& block, E
 
     return { };
 }
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addBranchNull(ControlType& block, ExpressionType, Stack&, bool shouldNegate, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addBranchNull(ControlType& block, ExpressionType, Stack&, bool shouldNegate, ExpressionType&)
 {
     // We don't need shouldNegate in the metadata since it's in the opcode
 
@@ -2636,7 +2636,7 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addBranchNull(ControlType& bloc
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addBranchCast(ControlType& block, ExpressionType, Stack&, bool, int32_t heapType, bool)
+[[nodiscard]] PartialResult IPIntGenerator::addBranchCast(ControlType& block, ExpressionType, Stack&, bool, int32_t heapType, bool)
 {
     m_metadata->appendMetadata<IPInt::RefTestCastMetadata>({
         heapType,
@@ -2659,7 +2659,7 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addBranchCast(ControlType& bloc
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addSwitch(ExpressionType, const Vector<ControlType*>& jumps, ControlType& defaultJump, const Stack&)
+[[nodiscard]] PartialResult IPIntGenerator::addSwitch(ExpressionType, const Vector<ControlType*>& jumps, ControlType& defaultJump, const Stack&)
 {
     changeStackSize(-1);
     IPInt::SwitchMetadata mdSwitch {
@@ -2690,7 +2690,7 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addSwitch(ExpressionType, const
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::endBlock(ControlEntry& entry, Stack& stack)
+[[nodiscard]] PartialResult IPIntGenerator::endBlock(ControlEntry& entry, Stack& stack)
 {
     return addEndToUnreachable(entry, stack);
 }
@@ -2734,7 +2734,7 @@ void IPIntGenerator::endTryTable(ControlType& data)
     }
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addEndToUnreachable(ControlEntry& entry, Stack&)
+[[nodiscard]] PartialResult IPIntGenerator::addEndToUnreachable(ControlEntry& entry, Stack&)
 {
     auto blockSignature = entry.controlData.signature();
     const auto& signature = *blockSignature.m_signature;
@@ -3004,7 +3004,7 @@ void IPIntGenerator::addTailCallCommonData(const FunctionSignature&, const CallI
     m_metadata->appendMetadata(stackArgumentsAndResultsInBytes);
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addCall(unsigned callProfileIndex, FunctionSpaceIndex index, const TypeDefinition& type, ArgumentList&, ResultList& results, CallType callType)
+[[nodiscard]] PartialResult IPIntGenerator::addCall(unsigned callProfileIndex, FunctionSpaceIndex index, const TypeDefinition& type, ArgumentList&, ResultList& results, CallType callType)
 {
     const FunctionSignature& signature = *type.as<FunctionSignature>();
     const CallInformation& callConvention = cachedCallInformationFor(signature);
@@ -3050,7 +3050,7 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addCall(unsigned callProfileInd
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addCallIndirect(unsigned callProfileIndex, unsigned tableIndex, const TypeDefinition& originalSignature, ArgumentList&, ResultList& results, CallType callType)
+[[nodiscard]] PartialResult IPIntGenerator::addCallIndirect(unsigned callProfileIndex, unsigned tableIndex, const TypeDefinition& originalSignature, ArgumentList&, ResultList& results, CallType callType)
 {
     const FunctionSignature& signature = *originalSignature.expand().as<FunctionSignature>();
     const CallInformation& callConvention = cachedCallInformationFor(signature);
@@ -3101,7 +3101,7 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addCallIndirect(unsigned callPr
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addCallRef(unsigned callProfileIndex, const TypeDefinition& originalSignature, ArgumentList&, ResultList& results, CallType callType)
+[[nodiscard]] PartialResult IPIntGenerator::addCallRef(unsigned callProfileIndex, const TypeDefinition& originalSignature, ArgumentList&, ResultList& results, CallType callType)
 {
     const FunctionSignature& signature = *originalSignature.expand().as<FunctionSignature>();
     const CallInformation& callConvention = cachedCallInformationFor(signature);
@@ -3150,12 +3150,12 @@ WARN_UNUSED_RETURN PartialResult IPIntGenerator::addCallRef(unsigned callProfile
 
 // Traps
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addUnreachable()
+[[nodiscard]] PartialResult IPIntGenerator::addUnreachable()
 {
     return { };
 }
 
-WARN_UNUSED_RETURN PartialResult IPIntGenerator::addCrash()
+[[nodiscard]] PartialResult IPIntGenerator::addCrash()
 {
     return { };
 }

--- a/Source/JavaScriptCore/wasm/WasmNameSectionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmNameSectionParser.h
@@ -41,7 +41,7 @@ public:
     {
     }
 
-    WARN_UNUSED_RETURN Result parse();
+    [[nodiscard]] Result parse();
     
 private:
     const ModuleInformation& m_info;

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -425,7 +425,7 @@ public:
     enum class CastKind { Cast, Test };
 
     template <typename ...Args>
-    WARN_UNUSED_RETURN NEVER_INLINE UnexpectedResult fail(Args... args) const
+    [[nodiscard]] NEVER_INLINE UnexpectedResult fail(Args... args) const
     {
         using namespace FailureHelper; // See ADL comment in WasmParser.h.
         return UnexpectedResult(makeString("WebAssembly.Module failed compiling: "_s, makeString(args)...));
@@ -477,19 +477,19 @@ public:
     // SIMD
     bool usesSIMD() { return m_info.usesSIMD(m_functionIndex); }
     void notifyFunctionUsesSIMD() { ASSERT(m_info.usesSIMD(m_functionIndex)); }
-    WARN_UNUSED_RETURN PartialResult addSIMDLoad(ExpressionType pointer, uint32_t offset, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addSIMDStore(ExpressionType value, ExpressionType pointer, uint32_t offset);
-    WARN_UNUSED_RETURN PartialResult addSIMDSplat(SIMDLane, ExpressionType scalar, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addSIMDShuffle(v128_t imm, ExpressionType a, ExpressionType b, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addSIMDShift(SIMDLaneOperation, SIMDInfo, ExpressionType v, ExpressionType shift, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addSIMDExtmul(SIMDLaneOperation, SIMDInfo, ExpressionType lhs, ExpressionType rhs, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addSIMDLoadSplat(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addSIMDLoadLane(SIMDLaneOperation, ExpressionType pointer, ExpressionType vector, uint32_t offset, uint8_t laneIndex, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addSIMDStoreLane(SIMDLaneOperation, ExpressionType pointer, ExpressionType vector, uint32_t offset, uint8_t laneIndex);
-    WARN_UNUSED_RETURN PartialResult addSIMDLoadExtend(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addSIMDLoadPad(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result);
+    [[nodiscard]] PartialResult addSIMDLoad(ExpressionType pointer, uint32_t offset, ExpressionType& result);
+    [[nodiscard]] PartialResult addSIMDStore(ExpressionType value, ExpressionType pointer, uint32_t offset);
+    [[nodiscard]] PartialResult addSIMDSplat(SIMDLane, ExpressionType scalar, ExpressionType& result);
+    [[nodiscard]] PartialResult addSIMDShuffle(v128_t imm, ExpressionType a, ExpressionType b, ExpressionType& result);
+    [[nodiscard]] PartialResult addSIMDShift(SIMDLaneOperation, SIMDInfo, ExpressionType v, ExpressionType shift, ExpressionType& result);
+    [[nodiscard]] PartialResult addSIMDExtmul(SIMDLaneOperation, SIMDInfo, ExpressionType lhs, ExpressionType rhs, ExpressionType& result);
+    [[nodiscard]] PartialResult addSIMDLoadSplat(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result);
+    [[nodiscard]] PartialResult addSIMDLoadLane(SIMDLaneOperation, ExpressionType pointer, ExpressionType vector, uint32_t offset, uint8_t laneIndex, ExpressionType& result);
+    [[nodiscard]] PartialResult addSIMDStoreLane(SIMDLaneOperation, ExpressionType pointer, ExpressionType vector, uint32_t offset, uint8_t laneIndex);
+    [[nodiscard]] PartialResult addSIMDLoadExtend(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result);
+    [[nodiscard]] PartialResult addSIMDLoadPad(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result);
 
-    WARN_UNUSED_RETURN ExpressionType addConstant(v128_t value)
+    [[nodiscard]] ExpressionType addConstant(v128_t value)
     {
         return push(constant(B3::V128, value));
     }
@@ -695,153 +695,153 @@ public:
         return { };
     }
 
-    WARN_UNUSED_RETURN PartialResult addDrop(ExpressionType);
-    WARN_UNUSED_RETURN PartialResult addInlinedArguments(const TypeDefinition&);
-    WARN_UNUSED_RETURN PartialResult addArguments(const TypeDefinition&);
-    WARN_UNUSED_RETURN PartialResult addLocal(Type, uint32_t);
+    [[nodiscard]] PartialResult addDrop(ExpressionType);
+    [[nodiscard]] PartialResult addInlinedArguments(const TypeDefinition&);
+    [[nodiscard]] PartialResult addArguments(const TypeDefinition&);
+    [[nodiscard]] PartialResult addLocal(Type, uint32_t);
     ExpressionType addConstant(Type, uint64_t);
 
     // References
-    WARN_UNUSED_RETURN PartialResult addRefIsNull(ExpressionType value, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addRefFunc(FunctionSpaceIndex index, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addRefAsNonNull(TypedExpression, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addRefEq(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addRefIsNull(ExpressionType value, ExpressionType& result);
+    [[nodiscard]] PartialResult addRefFunc(FunctionSpaceIndex index, ExpressionType& result);
+    [[nodiscard]] PartialResult addRefAsNonNull(TypedExpression, ExpressionType&);
+    [[nodiscard]] PartialResult addRefEq(ExpressionType, ExpressionType, ExpressionType&);
 
     // Tables
-    WARN_UNUSED_RETURN PartialResult addTableGet(unsigned, ExpressionType index, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addTableSet(unsigned, ExpressionType index, ExpressionType value);
-    WARN_UNUSED_RETURN PartialResult addTableInit(unsigned, unsigned, ExpressionType dstOffset, ExpressionType srcOffset, ExpressionType length);
-    WARN_UNUSED_RETURN PartialResult addElemDrop(unsigned);
-    WARN_UNUSED_RETURN PartialResult addTableSize(unsigned, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addTableGrow(unsigned, ExpressionType fill, ExpressionType delta, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addTableFill(unsigned, ExpressionType offset, ExpressionType fill, ExpressionType count);
-    WARN_UNUSED_RETURN PartialResult addTableCopy(unsigned, unsigned, ExpressionType dstOffset, ExpressionType srcOffset, ExpressionType length);
+    [[nodiscard]] PartialResult addTableGet(unsigned, ExpressionType index, ExpressionType& result);
+    [[nodiscard]] PartialResult addTableSet(unsigned, ExpressionType index, ExpressionType value);
+    [[nodiscard]] PartialResult addTableInit(unsigned, unsigned, ExpressionType dstOffset, ExpressionType srcOffset, ExpressionType length);
+    [[nodiscard]] PartialResult addElemDrop(unsigned);
+    [[nodiscard]] PartialResult addTableSize(unsigned, ExpressionType& result);
+    [[nodiscard]] PartialResult addTableGrow(unsigned, ExpressionType fill, ExpressionType delta, ExpressionType& result);
+    [[nodiscard]] PartialResult addTableFill(unsigned, ExpressionType offset, ExpressionType fill, ExpressionType count);
+    [[nodiscard]] PartialResult addTableCopy(unsigned, unsigned, ExpressionType dstOffset, ExpressionType srcOffset, ExpressionType length);
 
     // Locals
-    WARN_UNUSED_RETURN PartialResult getLocal(uint32_t index, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult setLocal(uint32_t index, ExpressionType value);
-    WARN_UNUSED_RETURN PartialResult teeLocal(uint32_t, ExpressionType, ExpressionType& result);
+    [[nodiscard]] PartialResult getLocal(uint32_t index, ExpressionType& result);
+    [[nodiscard]] PartialResult setLocal(uint32_t index, ExpressionType value);
+    [[nodiscard]] PartialResult teeLocal(uint32_t, ExpressionType, ExpressionType& result);
 
     // Globals
-    WARN_UNUSED_RETURN PartialResult getGlobal(uint32_t index, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult setGlobal(uint32_t index, ExpressionType value);
+    [[nodiscard]] PartialResult getGlobal(uint32_t index, ExpressionType& result);
+    [[nodiscard]] PartialResult setGlobal(uint32_t index, ExpressionType value);
 
     // Memory
-    WARN_UNUSED_RETURN PartialResult load(LoadOpType, ExpressionType pointer, ExpressionType& result, uint32_t offset);
-    WARN_UNUSED_RETURN PartialResult store(StoreOpType, ExpressionType pointer, ExpressionType value, uint32_t offset);
-    WARN_UNUSED_RETURN PartialResult addGrowMemory(ExpressionType delta, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addCurrentMemory(ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addMemoryFill(ExpressionType dstAddress, ExpressionType targetValue, ExpressionType count);
-    WARN_UNUSED_RETURN PartialResult addMemoryCopy(ExpressionType dstAddress, ExpressionType srcAddress, ExpressionType count);
-    WARN_UNUSED_RETURN PartialResult addMemoryInit(unsigned, ExpressionType dstAddress, ExpressionType srcAddress, ExpressionType length);
-    WARN_UNUSED_RETURN PartialResult addDataDrop(unsigned);
+    [[nodiscard]] PartialResult load(LoadOpType, ExpressionType pointer, ExpressionType& result, uint32_t offset);
+    [[nodiscard]] PartialResult store(StoreOpType, ExpressionType pointer, ExpressionType value, uint32_t offset);
+    [[nodiscard]] PartialResult addGrowMemory(ExpressionType delta, ExpressionType& result);
+    [[nodiscard]] PartialResult addCurrentMemory(ExpressionType& result);
+    [[nodiscard]] PartialResult addMemoryFill(ExpressionType dstAddress, ExpressionType targetValue, ExpressionType count);
+    [[nodiscard]] PartialResult addMemoryCopy(ExpressionType dstAddress, ExpressionType srcAddress, ExpressionType count);
+    [[nodiscard]] PartialResult addMemoryInit(unsigned, ExpressionType dstAddress, ExpressionType srcAddress, ExpressionType length);
+    [[nodiscard]] PartialResult addDataDrop(unsigned);
 
     // Atomics
-    WARN_UNUSED_RETURN PartialResult atomicLoad(ExtAtomicOpType, Type, ExpressionType pointer, ExpressionType& result, uint32_t offset);
-    WARN_UNUSED_RETURN PartialResult atomicStore(ExtAtomicOpType, Type, ExpressionType pointer, ExpressionType value, uint32_t offset);
-    WARN_UNUSED_RETURN PartialResult atomicBinaryRMW(ExtAtomicOpType, Type, ExpressionType pointer, ExpressionType value, ExpressionType& result, uint32_t offset);
-    WARN_UNUSED_RETURN PartialResult atomicCompareExchange(ExtAtomicOpType, Type, ExpressionType pointer, ExpressionType expected, ExpressionType value, ExpressionType& result, uint32_t offset);
+    [[nodiscard]] PartialResult atomicLoad(ExtAtomicOpType, Type, ExpressionType pointer, ExpressionType& result, uint32_t offset);
+    [[nodiscard]] PartialResult atomicStore(ExtAtomicOpType, Type, ExpressionType pointer, ExpressionType value, uint32_t offset);
+    [[nodiscard]] PartialResult atomicBinaryRMW(ExtAtomicOpType, Type, ExpressionType pointer, ExpressionType value, ExpressionType& result, uint32_t offset);
+    [[nodiscard]] PartialResult atomicCompareExchange(ExtAtomicOpType, Type, ExpressionType pointer, ExpressionType expected, ExpressionType value, ExpressionType& result, uint32_t offset);
 
-    WARN_UNUSED_RETURN PartialResult atomicWait(ExtAtomicOpType, ExpressionType pointer, ExpressionType value, ExpressionType timeout, ExpressionType& result, uint32_t offset);
-    WARN_UNUSED_RETURN PartialResult atomicNotify(ExtAtomicOpType, ExpressionType pointer, ExpressionType value, ExpressionType& result, uint32_t offset);
-    WARN_UNUSED_RETURN PartialResult atomicFence(ExtAtomicOpType, uint8_t flags);
+    [[nodiscard]] PartialResult atomicWait(ExtAtomicOpType, ExpressionType pointer, ExpressionType value, ExpressionType timeout, ExpressionType& result, uint32_t offset);
+    [[nodiscard]] PartialResult atomicNotify(ExtAtomicOpType, ExpressionType pointer, ExpressionType value, ExpressionType& result, uint32_t offset);
+    [[nodiscard]] PartialResult atomicFence(ExtAtomicOpType, uint8_t flags);
 
     // Saturated truncation.
-    WARN_UNUSED_RETURN PartialResult truncSaturated(Ext1OpType, ExpressionType operand, ExpressionType& result, Type returnType, Type operandType);
+    [[nodiscard]] PartialResult truncSaturated(Ext1OpType, ExpressionType operand, ExpressionType& result, Type returnType, Type operandType);
 
     // GC
-    WARN_UNUSED_RETURN PartialResult addRefI31(ExpressionType value, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addI31GetS(TypedExpression ref, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addI31GetU(TypedExpression ref, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addArrayNew(uint32_t index, ExpressionType size, ExpressionType value, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addArrayNewDefault(uint32_t index, ExpressionType size, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addArrayNewFixed(uint32_t typeIndex, ArgumentList& args, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addArrayGet(ExtGCOpType arrayGetKind, uint32_t typeIndex, TypedExpression arrayref, ExpressionType index, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addArrayNewData(uint32_t typeIndex, uint32_t dataIndex, ExpressionType size, ExpressionType offset, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addArrayNewElem(uint32_t typeIndex, uint32_t elemSegmentIndex, ExpressionType size, ExpressionType offset, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addArraySet(uint32_t typeIndex, TypedExpression arrayref, ExpressionType index, ExpressionType value);
-    WARN_UNUSED_RETURN PartialResult addArrayLen(TypedExpression arrayref, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addArrayFill(uint32_t, TypedExpression, ExpressionType, ExpressionType, ExpressionType);
-    WARN_UNUSED_RETURN PartialResult addArrayCopy(uint32_t, TypedExpression, ExpressionType, uint32_t, TypedExpression, ExpressionType, ExpressionType);
-    WARN_UNUSED_RETURN PartialResult addArrayInitElem(uint32_t, TypedExpression, ExpressionType, uint32_t, ExpressionType, ExpressionType);
-    WARN_UNUSED_RETURN PartialResult addArrayInitData(uint32_t, TypedExpression, ExpressionType, uint32_t, ExpressionType, ExpressionType);
-    WARN_UNUSED_RETURN PartialResult addStructNew(uint32_t typeIndex, ArgumentList& args, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addStructNewDefault(uint32_t index, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addStructGet(ExtGCOpType structGetKind, TypedExpression structReference, const StructType&, uint32_t fieldIndex, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addStructSet(TypedExpression structReference, const StructType&, uint32_t fieldIndex, ExpressionType value);
-    WARN_UNUSED_RETURN PartialResult addRefTest(TypedExpression reference, bool allowNull, int32_t heapType, bool shouldNegate, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addRefCast(TypedExpression reference, bool allowNull, int32_t heapType, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addAnyConvertExtern(ExpressionType reference, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addExternConvertAny(ExpressionType reference, ExpressionType& result);
+    [[nodiscard]] PartialResult addRefI31(ExpressionType value, ExpressionType& result);
+    [[nodiscard]] PartialResult addI31GetS(TypedExpression ref, ExpressionType& result);
+    [[nodiscard]] PartialResult addI31GetU(TypedExpression ref, ExpressionType& result);
+    [[nodiscard]] PartialResult addArrayNew(uint32_t index, ExpressionType size, ExpressionType value, ExpressionType& result);
+    [[nodiscard]] PartialResult addArrayNewDefault(uint32_t index, ExpressionType size, ExpressionType& result);
+    [[nodiscard]] PartialResult addArrayNewFixed(uint32_t typeIndex, ArgumentList& args, ExpressionType& result);
+    [[nodiscard]] PartialResult addArrayGet(ExtGCOpType arrayGetKind, uint32_t typeIndex, TypedExpression arrayref, ExpressionType index, ExpressionType& result);
+    [[nodiscard]] PartialResult addArrayNewData(uint32_t typeIndex, uint32_t dataIndex, ExpressionType size, ExpressionType offset, ExpressionType& result);
+    [[nodiscard]] PartialResult addArrayNewElem(uint32_t typeIndex, uint32_t elemSegmentIndex, ExpressionType size, ExpressionType offset, ExpressionType& result);
+    [[nodiscard]] PartialResult addArraySet(uint32_t typeIndex, TypedExpression arrayref, ExpressionType index, ExpressionType value);
+    [[nodiscard]] PartialResult addArrayLen(TypedExpression arrayref, ExpressionType& result);
+    [[nodiscard]] PartialResult addArrayFill(uint32_t, TypedExpression, ExpressionType, ExpressionType, ExpressionType);
+    [[nodiscard]] PartialResult addArrayCopy(uint32_t, TypedExpression, ExpressionType, uint32_t, TypedExpression, ExpressionType, ExpressionType);
+    [[nodiscard]] PartialResult addArrayInitElem(uint32_t, TypedExpression, ExpressionType, uint32_t, ExpressionType, ExpressionType);
+    [[nodiscard]] PartialResult addArrayInitData(uint32_t, TypedExpression, ExpressionType, uint32_t, ExpressionType, ExpressionType);
+    [[nodiscard]] PartialResult addStructNew(uint32_t typeIndex, ArgumentList& args, ExpressionType& result);
+    [[nodiscard]] PartialResult addStructNewDefault(uint32_t index, ExpressionType& result);
+    [[nodiscard]] PartialResult addStructGet(ExtGCOpType structGetKind, TypedExpression structReference, const StructType&, uint32_t fieldIndex, ExpressionType& result);
+    [[nodiscard]] PartialResult addStructSet(TypedExpression structReference, const StructType&, uint32_t fieldIndex, ExpressionType value);
+    [[nodiscard]] PartialResult addRefTest(TypedExpression reference, bool allowNull, int32_t heapType, bool shouldNegate, ExpressionType& result);
+    [[nodiscard]] PartialResult addRefCast(TypedExpression reference, bool allowNull, int32_t heapType, ExpressionType& result);
+    [[nodiscard]] PartialResult addAnyConvertExtern(ExpressionType reference, ExpressionType& result);
+    [[nodiscard]] PartialResult addExternConvertAny(ExpressionType reference, ExpressionType& result);
 
     // Basic operators
 #define X(name, opcode, short, idx, ...) \
-    WARN_UNUSED_RETURN PartialResult add##name(ExpressionType arg, ExpressionType& result);
+    [[nodiscard]] PartialResult add##name(ExpressionType arg, ExpressionType& result);
     FOR_EACH_WASM_UNARY_OP(X)
 #undef X
 #define X(name, opcode, short, idx, ...) \
-    WARN_UNUSED_RETURN PartialResult add##name(ExpressionType left, ExpressionType right, ExpressionType& result);
+    [[nodiscard]] PartialResult add##name(ExpressionType left, ExpressionType right, ExpressionType& result);
     FOR_EACH_WASM_BINARY_OP(X)
 #undef X
 
-    WARN_UNUSED_RETURN PartialResult addSelect(ExpressionType condition, ExpressionType nonZero, ExpressionType zero, ExpressionType& result);
+    [[nodiscard]] PartialResult addSelect(ExpressionType condition, ExpressionType nonZero, ExpressionType zero, ExpressionType& result);
 
     // Control flow
-    WARN_UNUSED_RETURN ControlData addTopLevel(BlockSignature);
-    WARN_UNUSED_RETURN PartialResult addBlock(BlockSignature, Stack& enclosingStack, ControlType& newBlock, Stack& newStack);
-    WARN_UNUSED_RETURN PartialResult addLoop(BlockSignature, Stack& enclosingStack, ControlType& block, Stack& newStack, uint32_t loopIndex);
-    WARN_UNUSED_RETURN PartialResult addIf(ExpressionType condition, BlockSignature, Stack& enclosingStack, ControlType& result, Stack& newStack);
-    WARN_UNUSED_RETURN PartialResult addElse(ControlData&, const Stack&);
-    WARN_UNUSED_RETURN PartialResult addElseToUnreachable(ControlData&);
+    [[nodiscard]] ControlData addTopLevel(BlockSignature);
+    [[nodiscard]] PartialResult addBlock(BlockSignature, Stack& enclosingStack, ControlType& newBlock, Stack& newStack);
+    [[nodiscard]] PartialResult addLoop(BlockSignature, Stack& enclosingStack, ControlType& block, Stack& newStack, uint32_t loopIndex);
+    [[nodiscard]] PartialResult addIf(ExpressionType condition, BlockSignature, Stack& enclosingStack, ControlType& result, Stack& newStack);
+    [[nodiscard]] PartialResult addElse(ControlData&, const Stack&);
+    [[nodiscard]] PartialResult addElseToUnreachable(ControlData&);
 
-    WARN_UNUSED_RETURN PartialResult addTry(BlockSignature, Stack& enclosingStack, ControlType& result, Stack& newStack);
-    WARN_UNUSED_RETURN PartialResult addTryTable(BlockSignature, Stack& enclosingStack, const Vector<CatchHandler>& targets, ControlType& result, Stack& newStack);
-    WARN_UNUSED_RETURN PartialResult addCatch(unsigned exceptionIndex, const TypeDefinition&, Stack&, ControlType&, ResultList&);
-    WARN_UNUSED_RETURN PartialResult addCatchToUnreachable(unsigned exceptionIndex, const TypeDefinition&, ControlType&, ResultList&);
-    WARN_UNUSED_RETURN PartialResult addCatchAll(Stack&, ControlType&);
-    WARN_UNUSED_RETURN PartialResult addCatchAllToUnreachable(ControlType&);
-    WARN_UNUSED_RETURN PartialResult addDelegate(ControlType&, ControlType&);
-    WARN_UNUSED_RETURN PartialResult addDelegateToUnreachable(ControlType&, ControlType&);
-    WARN_UNUSED_RETURN PartialResult addThrow(unsigned exceptionIndex, ArgumentList& args, Stack&);
-    WARN_UNUSED_RETURN PartialResult addRethrow(unsigned, ControlType&);
-    WARN_UNUSED_RETURN PartialResult addThrowRef(TypedExpression exception, Stack&);
+    [[nodiscard]] PartialResult addTry(BlockSignature, Stack& enclosingStack, ControlType& result, Stack& newStack);
+    [[nodiscard]] PartialResult addTryTable(BlockSignature, Stack& enclosingStack, const Vector<CatchHandler>& targets, ControlType& result, Stack& newStack);
+    [[nodiscard]] PartialResult addCatch(unsigned exceptionIndex, const TypeDefinition&, Stack&, ControlType&, ResultList&);
+    [[nodiscard]] PartialResult addCatchToUnreachable(unsigned exceptionIndex, const TypeDefinition&, ControlType&, ResultList&);
+    [[nodiscard]] PartialResult addCatchAll(Stack&, ControlType&);
+    [[nodiscard]] PartialResult addCatchAllToUnreachable(ControlType&);
+    [[nodiscard]] PartialResult addDelegate(ControlType&, ControlType&);
+    [[nodiscard]] PartialResult addDelegateToUnreachable(ControlType&, ControlType&);
+    [[nodiscard]] PartialResult addThrow(unsigned exceptionIndex, ArgumentList& args, Stack&);
+    [[nodiscard]] PartialResult addRethrow(unsigned, ControlType&);
+    [[nodiscard]] PartialResult addThrowRef(TypedExpression exception, Stack&);
 
-    WARN_UNUSED_RETURN PartialResult addInlinedReturn(const auto& returnValues);
+    [[nodiscard]] PartialResult addInlinedReturn(const auto& returnValues);
 
-    WARN_UNUSED_RETURN PartialResult addReturn(const ControlData&, const Stack& returnValues);
-    WARN_UNUSED_RETURN PartialResult addBranch(ControlData&, ExpressionType condition, const Stack& returnValues);
-    WARN_UNUSED_RETURN PartialResult addBranchNull(ControlType&, ExpressionType, const Stack&, bool, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addBranchCast(ControlType&, TypedExpression, const Stack&, bool, int32_t, bool);
-    WARN_UNUSED_RETURN PartialResult addSwitch(ExpressionType condition, const Vector<ControlData*>& targets, ControlData& defaultTargets, const Stack& expressionStack);
-    WARN_UNUSED_RETURN PartialResult endBlock(ControlEntry&, Stack& expressionStack);
-    WARN_UNUSED_RETURN PartialResult addEndToUnreachable(ControlEntry&, const Stack& = { });
+    [[nodiscard]] PartialResult addReturn(const ControlData&, const Stack& returnValues);
+    [[nodiscard]] PartialResult addBranch(ControlData&, ExpressionType condition, const Stack& returnValues);
+    [[nodiscard]] PartialResult addBranchNull(ControlType&, ExpressionType, const Stack&, bool, ExpressionType&);
+    [[nodiscard]] PartialResult addBranchCast(ControlType&, TypedExpression, const Stack&, bool, int32_t, bool);
+    [[nodiscard]] PartialResult addSwitch(ExpressionType condition, const Vector<ControlData*>& targets, ControlData& defaultTargets, const Stack& expressionStack);
+    [[nodiscard]] PartialResult endBlock(ControlEntry&, Stack& expressionStack);
+    [[nodiscard]] PartialResult addEndToUnreachable(ControlEntry&, const Stack& = { });
 
-    WARN_UNUSED_RETURN PartialResult endTopLevel(BlockSignature, const Stack&) { return { }; }
+    [[nodiscard]] PartialResult endTopLevel(BlockSignature, const Stack&) { return { }; }
 
     // Fused comparison stubs (B3 will do this for us later).
-    WARN_UNUSED_RETURN PartialResult addFusedBranchCompare(OpType, ControlType&, ExpressionType, const Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
-    WARN_UNUSED_RETURN PartialResult addFusedBranchCompare(OpType, ControlType&, ExpressionType, ExpressionType, const Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
-    WARN_UNUSED_RETURN PartialResult addFusedIfCompare(OpType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
-    WARN_UNUSED_RETURN PartialResult addFusedIfCompare(OpType, ExpressionType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
+    [[nodiscard]] PartialResult addFusedBranchCompare(OpType, ControlType&, ExpressionType, const Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
+    [[nodiscard]] PartialResult addFusedBranchCompare(OpType, ControlType&, ExpressionType, ExpressionType, const Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
+    [[nodiscard]] PartialResult addFusedIfCompare(OpType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
+    [[nodiscard]] PartialResult addFusedIfCompare(OpType, ExpressionType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
 
     // Calls
-    WARN_UNUSED_RETURN PartialResult addCall(unsigned, FunctionSpaceIndex functionIndexSpace, const TypeDefinition&, ArgumentList& args, ResultList& results, CallType = CallType::Call);
-    WARN_UNUSED_RETURN PartialResult addCallIndirect(unsigned, unsigned tableIndex, const TypeDefinition&, ArgumentList& args, ResultList& results, CallType = CallType::Call);
-    WARN_UNUSED_RETURN PartialResult addCallRef(unsigned, const TypeDefinition&, ArgumentList& args, ResultList& results, CallType = CallType::Call);
-    WARN_UNUSED_RETURN PartialResult addUnreachable();
-    WARN_UNUSED_RETURN PartialResult addCrash();
+    [[nodiscard]] PartialResult addCall(unsigned, FunctionSpaceIndex functionIndexSpace, const TypeDefinition&, ArgumentList& args, ResultList& results, CallType = CallType::Call);
+    [[nodiscard]] PartialResult addCallIndirect(unsigned, unsigned tableIndex, const TypeDefinition&, ArgumentList& args, ResultList& results, CallType = CallType::Call);
+    [[nodiscard]] PartialResult addCallRef(unsigned, const TypeDefinition&, ArgumentList& args, ResultList& results, CallType = CallType::Call);
+    [[nodiscard]] PartialResult addUnreachable();
+    [[nodiscard]] PartialResult addCrash();
 
     using ValueResults = Vector<Value*, 16>;
     void fillCallResults(Value* callResult, const TypeDefinition& signature, ValueResults&);
-    WARN_UNUSED_RETURN PartialResult emitDirectCall(unsigned, FunctionSpaceIndex functionIndexSpace, const TypeDefinition&, const ArgumentList& args, ValueResults&, CallType = CallType::Call);
-    WARN_UNUSED_RETURN PartialResult emitIndirectCall(Value* calleeInstance, Value* calleeCode, Value* boxedCalleeCallee, const TypeDefinition&, const ArgumentList& args, ValueResults&, CallType = CallType::Call);
+    [[nodiscard]] PartialResult emitDirectCall(unsigned, FunctionSpaceIndex functionIndexSpace, const TypeDefinition&, const ArgumentList& args, ValueResults&, CallType = CallType::Call);
+    [[nodiscard]] PartialResult emitIndirectCall(Value* calleeInstance, Value* calleeCode, Value* boxedCalleeCallee, const TypeDefinition&, const ArgumentList& args, ValueResults&, CallType = CallType::Call);
 
     Vector<ConstrainedValue> createCallConstrainedArgs(BasicBlock*, const CallInformation& wasmCalleeInfo, const ArgumentList&);
     auto createCallPatchpoint(BasicBlock*, const TypeDefinition&, const CallInformation&, const ArgumentList& tmpArgs) -> CallPatchpointData;
     auto createTailCallPatchpoint(BasicBlock*, const TypeDefinition&, const CallInformation& wasmCallerInfoAsCallee, const CallInformation& wasmCalleeInfoAsCallee, const ArgumentList& tmpArgSourceLocations, Vector<B3::ConstrainedValue> patchArgs) -> CallPatchpointData;
 
     InliningNode* canInline(FunctionSpaceIndex functionIndexSpace, unsigned callProfileIndex) const;
-    WARN_UNUSED_RETURN PartialResult emitInlineDirectCall(InliningNode*, FunctionCodeIndex calleeIndex, const TypeDefinition&, const ArgumentList& args, ValueResults&);
+    [[nodiscard]] PartialResult emitInlineDirectCall(InliningNode*, FunctionCodeIndex calleeIndex, const TypeDefinition&, const ArgumentList& args, ValueResults&);
 
     void dump(const ControlStack&, const Stack* expressionStack);
     void setParser(FunctionParser<OMGIRGenerator>* parser) { m_parser = parser; };
@@ -940,10 +940,10 @@ private:
     void emitArraySetUnchecked(uint32_t, Value*, Value*, Value*);
     bool emitArraySetUncheckedWithoutWriteBarrier(uint32_t, Value*, Value*, Value*);
     // Returns true if a writeBarrier/mutatorFence is needed.
-    WARN_UNUSED_RETURN bool emitStructSet(bool canTrap, Value*, uint32_t, const StructType&, Value*);
-    WARN_UNUSED_RETURN Value* allocateWasmGCArray(uint32_t typeIndex, Value* initValue, Value* size);
+    [[nodiscard]] bool emitStructSet(bool canTrap, Value*, uint32_t, const StructType&, Value*);
+    [[nodiscard]] Value* allocateWasmGCArray(uint32_t typeIndex, Value* initValue, Value* size);
     using ArraySegmentOperation = EncodedJSValue SYSV_ABI (&)(JSC::JSWebAssemblyInstance*, uint32_t, uint32_t, uint32_t, uint32_t);
-    WARN_UNUSED_RETURN ExpressionType pushArrayNewFromSegment(ArraySegmentOperation, uint32_t typeIndex, uint32_t segmentIndex, ExpressionType arraySize, ExpressionType offset, ExceptionType);
+    [[nodiscard]] ExpressionType pushArrayNewFromSegment(ArraySegmentOperation, uint32_t typeIndex, uint32_t segmentIndex, ExpressionType arraySize, ExpressionType offset, ExceptionType);
     void emitRefTestOrCast(CastKind, TypedExpression, bool, int32_t, bool, ExpressionType&);
     template <typename Generator>
     void emitCheckOrBranchForCast(CastKind, Value*, const Generator&, BasicBlock*);
@@ -954,8 +954,8 @@ private:
 
     void emitChecksForModOrDiv(B3::Opcode, Value* left, Value* right);
 
-    WARN_UNUSED_RETURN int32_t fixupPointerPlusOffset(Value*&, uint32_t);
-    WARN_UNUSED_RETURN Value* fixupPointerPlusOffsetForAtomicOps(ExtAtomicOpType, Value*, uint32_t);
+    [[nodiscard]] int32_t fixupPointerPlusOffset(Value*&, uint32_t);
+    [[nodiscard]] Value* fixupPointerPlusOffsetForAtomicOps(ExtAtomicOpType, Value*, uint32_t);
 
     void restoreWasmContextInstance(BasicBlock*, Value*);
     void restoreWebAssemblyGlobalState(const MemoryInformation&, Value* instance, BasicBlock*);
@@ -2935,7 +2935,7 @@ Value* OMGIRGenerator::emitAtomicCompareExchange(ExtAtomicOpType op, Type valueT
     return sanitizeAtomicResult(op, valueType, atomic);
 }
 
-WARN_UNUSED_RETURN bool OMGIRGenerator::emitStructSet(bool canTrap, Value* structValue, uint32_t fieldIndex, const StructType& structType, Value* argument)
+[[nodiscard]] bool OMGIRGenerator::emitStructSet(bool canTrap, Value* structValue, uint32_t fieldIndex, const StructType& structType, Value* argument)
 {
     structValue = pointerOfWasmRef(structValue);
     auto fieldType = structType.field(fieldIndex).type;
@@ -5333,7 +5333,7 @@ auto OMGIRGenerator::addThrow(unsigned exceptionIndex, ArgumentList& args, Stack
     return { };
 }
 
-WARN_UNUSED_RETURN auto OMGIRGenerator::addThrowRef(TypedExpression exnref, Stack&) -> PartialResult
+[[nodiscard]] auto OMGIRGenerator::addThrowRef(TypedExpression exnref, Stack&) -> PartialResult
 {
     TRACE_CF("THROW_REF");
 

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
@@ -361,7 +361,7 @@ public:
     enum class CastKind { Cast, Test };
 
     template <typename ...Args>
-    WARN_UNUSED_RETURN NEVER_INLINE UnexpectedResult fail(Args... args) const
+    [[nodiscard]] NEVER_INLINE UnexpectedResult fail(Args... args) const
     {
         using namespace FailureHelper; // See ADL comment in WasmParser.h.
         return UnexpectedResult(makeString("WebAssembly.Module failed compiling: "_s, makeString(args)...));
@@ -418,19 +418,19 @@ public:
     // SIMD
     bool usesSIMD() { return m_info.usesSIMD(m_functionIndex); }
     void notifyFunctionUsesSIMD() { ASSERT(m_info.usesSIMD(m_functionIndex)); }
-    WARN_UNUSED_RETURN PartialResult addSIMDLoad(ExpressionType pointer, uint32_t offset, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addSIMDStore(ExpressionType value, ExpressionType pointer, uint32_t offset);
-    WARN_UNUSED_RETURN PartialResult addSIMDSplat(SIMDLane, ExpressionType scalar, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addSIMDShuffle(v128_t imm, ExpressionType a, ExpressionType b, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addSIMDShift(SIMDLaneOperation, SIMDInfo, ExpressionType v, ExpressionType shift, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addSIMDExtmul(SIMDLaneOperation, SIMDInfo, ExpressionType lhs, ExpressionType rhs, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addSIMDLoadSplat(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addSIMDLoadLane(SIMDLaneOperation, ExpressionType pointer, ExpressionType vector, uint32_t offset, uint8_t laneIndex, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addSIMDStoreLane(SIMDLaneOperation, ExpressionType pointer, ExpressionType vector, uint32_t offset, uint8_t laneIndex);
-    WARN_UNUSED_RETURN PartialResult addSIMDLoadExtend(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addSIMDLoadPad(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result);
+    [[nodiscard]] PartialResult addSIMDLoad(ExpressionType pointer, uint32_t offset, ExpressionType& result);
+    [[nodiscard]] PartialResult addSIMDStore(ExpressionType value, ExpressionType pointer, uint32_t offset);
+    [[nodiscard]] PartialResult addSIMDSplat(SIMDLane, ExpressionType scalar, ExpressionType& result);
+    [[nodiscard]] PartialResult addSIMDShuffle(v128_t imm, ExpressionType a, ExpressionType b, ExpressionType& result);
+    [[nodiscard]] PartialResult addSIMDShift(SIMDLaneOperation, SIMDInfo, ExpressionType v, ExpressionType shift, ExpressionType& result);
+    [[nodiscard]] PartialResult addSIMDExtmul(SIMDLaneOperation, SIMDInfo, ExpressionType lhs, ExpressionType rhs, ExpressionType& result);
+    [[nodiscard]] PartialResult addSIMDLoadSplat(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result);
+    [[nodiscard]] PartialResult addSIMDLoadLane(SIMDLaneOperation, ExpressionType pointer, ExpressionType vector, uint32_t offset, uint8_t laneIndex, ExpressionType& result);
+    [[nodiscard]] PartialResult addSIMDStoreLane(SIMDLaneOperation, ExpressionType pointer, ExpressionType vector, uint32_t offset, uint8_t laneIndex);
+    [[nodiscard]] PartialResult addSIMDLoadExtend(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result);
+    [[nodiscard]] PartialResult addSIMDLoadPad(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result);
 
-    WARN_UNUSED_RETURN ExpressionType addConstant(v128_t value)
+    [[nodiscard]] ExpressionType addConstant(v128_t value)
     {
         return push(m_currentBlock->appendNew<Const128Value>(m_proc, origin(), value));
     }
@@ -636,153 +636,153 @@ public:
         return { };
     }
 
-    WARN_UNUSED_RETURN PartialResult addDrop(ExpressionType);
-    WARN_UNUSED_RETURN PartialResult addInlinedArguments(const TypeDefinition&);
-    WARN_UNUSED_RETURN PartialResult addArguments(const TypeDefinition&);
-    WARN_UNUSED_RETURN PartialResult addLocal(Type, uint32_t);
+    [[nodiscard]] PartialResult addDrop(ExpressionType);
+    [[nodiscard]] PartialResult addInlinedArguments(const TypeDefinition&);
+    [[nodiscard]] PartialResult addArguments(const TypeDefinition&);
+    [[nodiscard]] PartialResult addLocal(Type, uint32_t);
     ExpressionType addConstant(Type, uint64_t);
 
     // References
-    WARN_UNUSED_RETURN PartialResult addRefIsNull(ExpressionType value, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addRefFunc(FunctionSpaceIndex index, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addRefAsNonNull(TypedExpression, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addRefEq(ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addRefIsNull(ExpressionType value, ExpressionType& result);
+    [[nodiscard]] PartialResult addRefFunc(FunctionSpaceIndex index, ExpressionType& result);
+    [[nodiscard]] PartialResult addRefAsNonNull(TypedExpression, ExpressionType&);
+    [[nodiscard]] PartialResult addRefEq(ExpressionType, ExpressionType, ExpressionType&);
 
     // Tables
-    WARN_UNUSED_RETURN PartialResult addTableGet(unsigned, ExpressionType index, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addTableSet(unsigned, ExpressionType index, ExpressionType value);
-    WARN_UNUSED_RETURN PartialResult addTableInit(unsigned, unsigned, ExpressionType dstOffset, ExpressionType srcOffset, ExpressionType length);
-    WARN_UNUSED_RETURN PartialResult addElemDrop(unsigned);
-    WARN_UNUSED_RETURN PartialResult addTableSize(unsigned, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addTableGrow(unsigned, ExpressionType fill, ExpressionType delta, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addTableFill(unsigned, ExpressionType offset, ExpressionType fill, ExpressionType count);
-    WARN_UNUSED_RETURN PartialResult addTableCopy(unsigned, unsigned, ExpressionType dstOffset, ExpressionType srcOffset, ExpressionType length);
+    [[nodiscard]] PartialResult addTableGet(unsigned, ExpressionType index, ExpressionType& result);
+    [[nodiscard]] PartialResult addTableSet(unsigned, ExpressionType index, ExpressionType value);
+    [[nodiscard]] PartialResult addTableInit(unsigned, unsigned, ExpressionType dstOffset, ExpressionType srcOffset, ExpressionType length);
+    [[nodiscard]] PartialResult addElemDrop(unsigned);
+    [[nodiscard]] PartialResult addTableSize(unsigned, ExpressionType& result);
+    [[nodiscard]] PartialResult addTableGrow(unsigned, ExpressionType fill, ExpressionType delta, ExpressionType& result);
+    [[nodiscard]] PartialResult addTableFill(unsigned, ExpressionType offset, ExpressionType fill, ExpressionType count);
+    [[nodiscard]] PartialResult addTableCopy(unsigned, unsigned, ExpressionType dstOffset, ExpressionType srcOffset, ExpressionType length);
 
     // Locals
-    WARN_UNUSED_RETURN PartialResult getLocal(uint32_t index, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult setLocal(uint32_t index, ExpressionType value);
-    WARN_UNUSED_RETURN PartialResult teeLocal(uint32_t, ExpressionType, ExpressionType& result);
+    [[nodiscard]] PartialResult getLocal(uint32_t index, ExpressionType& result);
+    [[nodiscard]] PartialResult setLocal(uint32_t index, ExpressionType value);
+    [[nodiscard]] PartialResult teeLocal(uint32_t, ExpressionType, ExpressionType& result);
 
     // Globals
-    WARN_UNUSED_RETURN PartialResult getGlobal(uint32_t index, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult setGlobal(uint32_t index, ExpressionType value);
+    [[nodiscard]] PartialResult getGlobal(uint32_t index, ExpressionType& result);
+    [[nodiscard]] PartialResult setGlobal(uint32_t index, ExpressionType value);
 
     // Memory
-    WARN_UNUSED_RETURN PartialResult load(LoadOpType, ExpressionType pointer, ExpressionType& result, uint32_t offset);
-    WARN_UNUSED_RETURN PartialResult store(StoreOpType, ExpressionType pointer, ExpressionType value, uint32_t offset);
-    WARN_UNUSED_RETURN PartialResult addGrowMemory(ExpressionType delta, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addCurrentMemory(ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addMemoryFill(ExpressionType dstAddress, ExpressionType targetValue, ExpressionType count);
-    WARN_UNUSED_RETURN PartialResult addMemoryCopy(ExpressionType dstAddress, ExpressionType srcAddress, ExpressionType count);
-    WARN_UNUSED_RETURN PartialResult addMemoryInit(unsigned, ExpressionType dstAddress, ExpressionType srcAddress, ExpressionType length);
-    WARN_UNUSED_RETURN PartialResult addDataDrop(unsigned);
+    [[nodiscard]] PartialResult load(LoadOpType, ExpressionType pointer, ExpressionType& result, uint32_t offset);
+    [[nodiscard]] PartialResult store(StoreOpType, ExpressionType pointer, ExpressionType value, uint32_t offset);
+    [[nodiscard]] PartialResult addGrowMemory(ExpressionType delta, ExpressionType& result);
+    [[nodiscard]] PartialResult addCurrentMemory(ExpressionType& result);
+    [[nodiscard]] PartialResult addMemoryFill(ExpressionType dstAddress, ExpressionType targetValue, ExpressionType count);
+    [[nodiscard]] PartialResult addMemoryCopy(ExpressionType dstAddress, ExpressionType srcAddress, ExpressionType count);
+    [[nodiscard]] PartialResult addMemoryInit(unsigned, ExpressionType dstAddress, ExpressionType srcAddress, ExpressionType length);
+    [[nodiscard]] PartialResult addDataDrop(unsigned);
 
     // Atomics
-    WARN_UNUSED_RETURN PartialResult atomicLoad(ExtAtomicOpType, Type, ExpressionType pointer, ExpressionType& result, uint32_t offset);
-    WARN_UNUSED_RETURN PartialResult atomicStore(ExtAtomicOpType, Type, ExpressionType pointer, ExpressionType value, uint32_t offset);
-    WARN_UNUSED_RETURN PartialResult atomicBinaryRMW(ExtAtomicOpType, Type, ExpressionType pointer, ExpressionType value, ExpressionType& result, uint32_t offset);
-    WARN_UNUSED_RETURN PartialResult atomicCompareExchange(ExtAtomicOpType, Type, ExpressionType pointer, ExpressionType expected, ExpressionType value, ExpressionType& result, uint32_t offset);
+    [[nodiscard]] PartialResult atomicLoad(ExtAtomicOpType, Type, ExpressionType pointer, ExpressionType& result, uint32_t offset);
+    [[nodiscard]] PartialResult atomicStore(ExtAtomicOpType, Type, ExpressionType pointer, ExpressionType value, uint32_t offset);
+    [[nodiscard]] PartialResult atomicBinaryRMW(ExtAtomicOpType, Type, ExpressionType pointer, ExpressionType value, ExpressionType& result, uint32_t offset);
+    [[nodiscard]] PartialResult atomicCompareExchange(ExtAtomicOpType, Type, ExpressionType pointer, ExpressionType expected, ExpressionType value, ExpressionType& result, uint32_t offset);
 
-    WARN_UNUSED_RETURN PartialResult atomicWait(ExtAtomicOpType, ExpressionType pointer, ExpressionType value, ExpressionType timeout, ExpressionType& result, uint32_t offset);
-    WARN_UNUSED_RETURN PartialResult atomicNotify(ExtAtomicOpType, ExpressionType pointer, ExpressionType value, ExpressionType& result, uint32_t offset);
-    WARN_UNUSED_RETURN PartialResult atomicFence(ExtAtomicOpType, uint8_t flags);
+    [[nodiscard]] PartialResult atomicWait(ExtAtomicOpType, ExpressionType pointer, ExpressionType value, ExpressionType timeout, ExpressionType& result, uint32_t offset);
+    [[nodiscard]] PartialResult atomicNotify(ExtAtomicOpType, ExpressionType pointer, ExpressionType value, ExpressionType& result, uint32_t offset);
+    [[nodiscard]] PartialResult atomicFence(ExtAtomicOpType, uint8_t flags);
 
     // Saturated truncation.
-    WARN_UNUSED_RETURN PartialResult truncSaturated(Ext1OpType, ExpressionType operand, ExpressionType& result, Type returnType, Type operandType);
+    [[nodiscard]] PartialResult truncSaturated(Ext1OpType, ExpressionType operand, ExpressionType& result, Type returnType, Type operandType);
 
     // GC
-    WARN_UNUSED_RETURN PartialResult addRefI31(ExpressionType value, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addI31GetS(TypedExpression ref, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addI31GetU(TypedExpression ref, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addArrayNew(uint32_t index, ExpressionType size, ExpressionType value, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addArrayNewDefault(uint32_t index, ExpressionType size, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addArrayNewFixed(uint32_t typeIndex, ArgumentList& args, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addArrayGet(ExtGCOpType arrayGetKind, uint32_t typeIndex, TypedExpression arrayref, ExpressionType index, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addArrayNewData(uint32_t typeIndex, uint32_t dataIndex, ExpressionType size, ExpressionType offset, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addArrayNewElem(uint32_t typeIndex, uint32_t elemSegmentIndex, ExpressionType size, ExpressionType offset, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addArraySet(uint32_t typeIndex, TypedExpression arrayref, ExpressionType index, ExpressionType value);
-    WARN_UNUSED_RETURN PartialResult addArrayLen(TypedExpression arrayref, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addArrayFill(uint32_t, TypedExpression, ExpressionType, ExpressionType, ExpressionType);
-    WARN_UNUSED_RETURN PartialResult addArrayCopy(uint32_t, TypedExpression, ExpressionType, uint32_t, TypedExpression, ExpressionType, ExpressionType);
-    WARN_UNUSED_RETURN PartialResult addArrayInitElem(uint32_t, TypedExpression, ExpressionType, uint32_t, ExpressionType, ExpressionType);
-    WARN_UNUSED_RETURN PartialResult addArrayInitData(uint32_t, TypedExpression, ExpressionType, uint32_t, ExpressionType, ExpressionType);
-    WARN_UNUSED_RETURN PartialResult addStructNew(uint32_t typeIndex, ArgumentList& args, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addStructNewDefault(uint32_t index, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addStructGet(ExtGCOpType structGetKind, TypedExpression structReference, const StructType&, uint32_t fieldIndex, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addStructSet(TypedExpression structReference, const StructType&, uint32_t fieldIndex, ExpressionType value);
-    WARN_UNUSED_RETURN PartialResult addRefTest(TypedExpression reference, bool allowNull, int32_t heapType, bool shouldNegate, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addRefCast(TypedExpression reference, bool allowNull, int32_t heapType, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addAnyConvertExtern(ExpressionType reference, ExpressionType& result);
-    WARN_UNUSED_RETURN PartialResult addExternConvertAny(ExpressionType reference, ExpressionType& result);
+    [[nodiscard]] PartialResult addRefI31(ExpressionType value, ExpressionType& result);
+    [[nodiscard]] PartialResult addI31GetS(TypedExpression ref, ExpressionType& result);
+    [[nodiscard]] PartialResult addI31GetU(TypedExpression ref, ExpressionType& result);
+    [[nodiscard]] PartialResult addArrayNew(uint32_t index, ExpressionType size, ExpressionType value, ExpressionType& result);
+    [[nodiscard]] PartialResult addArrayNewDefault(uint32_t index, ExpressionType size, ExpressionType& result);
+    [[nodiscard]] PartialResult addArrayNewFixed(uint32_t typeIndex, ArgumentList& args, ExpressionType& result);
+    [[nodiscard]] PartialResult addArrayGet(ExtGCOpType arrayGetKind, uint32_t typeIndex, TypedExpression arrayref, ExpressionType index, ExpressionType& result);
+    [[nodiscard]] PartialResult addArrayNewData(uint32_t typeIndex, uint32_t dataIndex, ExpressionType size, ExpressionType offset, ExpressionType& result);
+    [[nodiscard]] PartialResult addArrayNewElem(uint32_t typeIndex, uint32_t elemSegmentIndex, ExpressionType size, ExpressionType offset, ExpressionType& result);
+    [[nodiscard]] PartialResult addArraySet(uint32_t typeIndex, TypedExpression arrayref, ExpressionType index, ExpressionType value);
+    [[nodiscard]] PartialResult addArrayLen(TypedExpression arrayref, ExpressionType& result);
+    [[nodiscard]] PartialResult addArrayFill(uint32_t, TypedExpression, ExpressionType, ExpressionType, ExpressionType);
+    [[nodiscard]] PartialResult addArrayCopy(uint32_t, TypedExpression, ExpressionType, uint32_t, TypedExpression, ExpressionType, ExpressionType);
+    [[nodiscard]] PartialResult addArrayInitElem(uint32_t, TypedExpression, ExpressionType, uint32_t, ExpressionType, ExpressionType);
+    [[nodiscard]] PartialResult addArrayInitData(uint32_t, TypedExpression, ExpressionType, uint32_t, ExpressionType, ExpressionType);
+    [[nodiscard]] PartialResult addStructNew(uint32_t typeIndex, ArgumentList& args, ExpressionType& result);
+    [[nodiscard]] PartialResult addStructNewDefault(uint32_t index, ExpressionType& result);
+    [[nodiscard]] PartialResult addStructGet(ExtGCOpType structGetKind, TypedExpression structReference, const StructType&, uint32_t fieldIndex, ExpressionType& result);
+    [[nodiscard]] PartialResult addStructSet(TypedExpression structReference, const StructType&, uint32_t fieldIndex, ExpressionType value);
+    [[nodiscard]] PartialResult addRefTest(TypedExpression reference, bool allowNull, int32_t heapType, bool shouldNegate, ExpressionType& result);
+    [[nodiscard]] PartialResult addRefCast(TypedExpression reference, bool allowNull, int32_t heapType, ExpressionType& result);
+    [[nodiscard]] PartialResult addAnyConvertExtern(ExpressionType reference, ExpressionType& result);
+    [[nodiscard]] PartialResult addExternConvertAny(ExpressionType reference, ExpressionType& result);
 
     // Basic operators
 #define X(name, opcode, short, idx, ...) \
-    WARN_UNUSED_RETURN PartialResult add##name(ExpressionType arg, ExpressionType& result);
+    [[nodiscard]] PartialResult add##name(ExpressionType arg, ExpressionType& result);
     FOR_EACH_WASM_UNARY_OP(X)
 #undef X
 #define X(name, opcode, short, idx, ...) \
-    WARN_UNUSED_RETURN PartialResult add##name(ExpressionType left, ExpressionType right, ExpressionType& result);
+    [[nodiscard]] PartialResult add##name(ExpressionType left, ExpressionType right, ExpressionType& result);
     FOR_EACH_WASM_BINARY_OP(X)
 #undef X
 
-    WARN_UNUSED_RETURN PartialResult addSelect(ExpressionType condition, ExpressionType nonZero, ExpressionType zero, ExpressionType& result);
+    [[nodiscard]] PartialResult addSelect(ExpressionType condition, ExpressionType nonZero, ExpressionType zero, ExpressionType& result);
 
     // Control flow
-    WARN_UNUSED_RETURN ControlData addTopLevel(BlockSignature);
-    WARN_UNUSED_RETURN PartialResult addBlock(BlockSignature, Stack& enclosingStack, ControlType& newBlock, Stack& newStack);
-    WARN_UNUSED_RETURN PartialResult addLoop(BlockSignature, Stack& enclosingStack, ControlType& block, Stack& newStack, uint32_t loopIndex);
-    WARN_UNUSED_RETURN PartialResult addIf(ExpressionType condition, BlockSignature, Stack& enclosingStack, ControlType& result, Stack& newStack);
-    WARN_UNUSED_RETURN PartialResult addElse(ControlData&, const Stack&);
-    WARN_UNUSED_RETURN PartialResult addElseToUnreachable(ControlData&);
+    [[nodiscard]] ControlData addTopLevel(BlockSignature);
+    [[nodiscard]] PartialResult addBlock(BlockSignature, Stack& enclosingStack, ControlType& newBlock, Stack& newStack);
+    [[nodiscard]] PartialResult addLoop(BlockSignature, Stack& enclosingStack, ControlType& block, Stack& newStack, uint32_t loopIndex);
+    [[nodiscard]] PartialResult addIf(ExpressionType condition, BlockSignature, Stack& enclosingStack, ControlType& result, Stack& newStack);
+    [[nodiscard]] PartialResult addElse(ControlData&, const Stack&);
+    [[nodiscard]] PartialResult addElseToUnreachable(ControlData&);
 
-    WARN_UNUSED_RETURN PartialResult addTry(BlockSignature, Stack& enclosingStack, ControlType& result, Stack& newStack);
-    WARN_UNUSED_RETURN PartialResult addTryTable(BlockSignature, Stack& enclosingStack, const Vector<CatchHandler>& targets, ControlType& result, Stack& newStack);
-    WARN_UNUSED_RETURN PartialResult addCatch(unsigned exceptionIndex, const TypeDefinition&, Stack&, ControlType&, ResultList&);
-    WARN_UNUSED_RETURN PartialResult addCatchToUnreachable(unsigned exceptionIndex, const TypeDefinition&, ControlType&, ResultList&);
-    WARN_UNUSED_RETURN PartialResult addCatchAll(Stack&, ControlType&);
-    WARN_UNUSED_RETURN PartialResult addCatchAllToUnreachable(ControlType&);
-    WARN_UNUSED_RETURN PartialResult addDelegate(ControlType&, ControlType&);
-    WARN_UNUSED_RETURN PartialResult addDelegateToUnreachable(ControlType&, ControlType&);
-    WARN_UNUSED_RETURN PartialResult addThrow(unsigned exceptionIndex, ArgumentList& args, Stack&);
-    WARN_UNUSED_RETURN PartialResult addRethrow(unsigned, ControlType&);
-    WARN_UNUSED_RETURN PartialResult addThrowRef(TypedExpression exception, Stack&);
+    [[nodiscard]] PartialResult addTry(BlockSignature, Stack& enclosingStack, ControlType& result, Stack& newStack);
+    [[nodiscard]] PartialResult addTryTable(BlockSignature, Stack& enclosingStack, const Vector<CatchHandler>& targets, ControlType& result, Stack& newStack);
+    [[nodiscard]] PartialResult addCatch(unsigned exceptionIndex, const TypeDefinition&, Stack&, ControlType&, ResultList&);
+    [[nodiscard]] PartialResult addCatchToUnreachable(unsigned exceptionIndex, const TypeDefinition&, ControlType&, ResultList&);
+    [[nodiscard]] PartialResult addCatchAll(Stack&, ControlType&);
+    [[nodiscard]] PartialResult addCatchAllToUnreachable(ControlType&);
+    [[nodiscard]] PartialResult addDelegate(ControlType&, ControlType&);
+    [[nodiscard]] PartialResult addDelegateToUnreachable(ControlType&, ControlType&);
+    [[nodiscard]] PartialResult addThrow(unsigned exceptionIndex, ArgumentList& args, Stack&);
+    [[nodiscard]] PartialResult addRethrow(unsigned, ControlType&);
+    [[nodiscard]] PartialResult addThrowRef(TypedExpression exception, Stack&);
 
-    WARN_UNUSED_RETURN PartialResult addInlinedReturn(const auto& returnValues);
+    [[nodiscard]] PartialResult addInlinedReturn(const auto& returnValues);
 
-    WARN_UNUSED_RETURN PartialResult addReturn(const ControlData&, const Stack& returnValues);
-    WARN_UNUSED_RETURN PartialResult addBranch(ControlData&, ExpressionType condition, const Stack& returnValues);
-    WARN_UNUSED_RETURN PartialResult addBranchNull(ControlType&, ExpressionType, const Stack&, bool, ExpressionType&);
-    WARN_UNUSED_RETURN PartialResult addBranchCast(ControlType&, TypedExpression, const Stack&, bool, int32_t, bool);
-    WARN_UNUSED_RETURN PartialResult addSwitch(ExpressionType condition, const Vector<ControlData*>& targets, ControlData& defaultTargets, const Stack& expressionStack);
-    WARN_UNUSED_RETURN PartialResult endBlock(ControlEntry&, Stack& expressionStack);
-    WARN_UNUSED_RETURN PartialResult addEndToUnreachable(ControlEntry&, const Stack& = { });
+    [[nodiscard]] PartialResult addReturn(const ControlData&, const Stack& returnValues);
+    [[nodiscard]] PartialResult addBranch(ControlData&, ExpressionType condition, const Stack& returnValues);
+    [[nodiscard]] PartialResult addBranchNull(ControlType&, ExpressionType, const Stack&, bool, ExpressionType&);
+    [[nodiscard]] PartialResult addBranchCast(ControlType&, TypedExpression, const Stack&, bool, int32_t, bool);
+    [[nodiscard]] PartialResult addSwitch(ExpressionType condition, const Vector<ControlData*>& targets, ControlData& defaultTargets, const Stack& expressionStack);
+    [[nodiscard]] PartialResult endBlock(ControlEntry&, Stack& expressionStack);
+    [[nodiscard]] PartialResult addEndToUnreachable(ControlEntry&, const Stack& = { });
 
-    WARN_UNUSED_RETURN PartialResult endTopLevel(BlockSignature, const Stack&) { return { }; }
+    [[nodiscard]] PartialResult endTopLevel(BlockSignature, const Stack&) { return { }; }
 
     // Fused comparison stubs (B3 will do this for us later).
-    WARN_UNUSED_RETURN PartialResult addFusedBranchCompare(OpType, ControlType&, ExpressionType, const Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
-    WARN_UNUSED_RETURN PartialResult addFusedBranchCompare(OpType, ControlType&, ExpressionType, ExpressionType, const Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
-    WARN_UNUSED_RETURN PartialResult addFusedIfCompare(OpType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
-    WARN_UNUSED_RETURN PartialResult addFusedIfCompare(OpType, ExpressionType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
+    [[nodiscard]] PartialResult addFusedBranchCompare(OpType, ControlType&, ExpressionType, const Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
+    [[nodiscard]] PartialResult addFusedBranchCompare(OpType, ControlType&, ExpressionType, ExpressionType, const Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
+    [[nodiscard]] PartialResult addFusedIfCompare(OpType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
+    [[nodiscard]] PartialResult addFusedIfCompare(OpType, ExpressionType, ExpressionType, BlockSignature, Stack&, ControlType&, Stack&) { RELEASE_ASSERT_NOT_REACHED(); }
 
     // Calls
-    WARN_UNUSED_RETURN PartialResult addCall(unsigned, FunctionSpaceIndex functionIndexSpace, const TypeDefinition&, ArgumentList& args, ResultList& results, CallType = CallType::Call);
-    WARN_UNUSED_RETURN PartialResult addCallIndirect(unsigned, unsigned tableIndex, const TypeDefinition&, ArgumentList& args, ResultList& results, CallType = CallType::Call);
-    WARN_UNUSED_RETURN PartialResult addCallRef(unsigned, const TypeDefinition&, ArgumentList& args, ResultList& results, CallType = CallType::Call);
-    WARN_UNUSED_RETURN PartialResult addUnreachable();
-    WARN_UNUSED_RETURN PartialResult addCrash();
+    [[nodiscard]] PartialResult addCall(unsigned, FunctionSpaceIndex functionIndexSpace, const TypeDefinition&, ArgumentList& args, ResultList& results, CallType = CallType::Call);
+    [[nodiscard]] PartialResult addCallIndirect(unsigned, unsigned tableIndex, const TypeDefinition&, ArgumentList& args, ResultList& results, CallType = CallType::Call);
+    [[nodiscard]] PartialResult addCallRef(unsigned, const TypeDefinition&, ArgumentList& args, ResultList& results, CallType = CallType::Call);
+    [[nodiscard]] PartialResult addUnreachable();
+    [[nodiscard]] PartialResult addCrash();
 
     using ValueResults = Vector<Value*, 16>;
     void fillCallResults(Value* callResult, const TypeDefinition& signature, ValueResults&);
-    WARN_UNUSED_RETURN PartialResult emitDirectCall(unsigned, FunctionSpaceIndex functionIndexSpace, const TypeDefinition&, ArgumentList& args, ValueResults&, CallType = CallType::Call);
-    WARN_UNUSED_RETURN PartialResult emitIndirectCall(Value* calleeInstance, Value* calleeCode, Value* boxedCalleeCallee, const TypeDefinition&, const ArgumentList& args, ValueResults&, CallType = CallType::Call);
+    [[nodiscard]] PartialResult emitDirectCall(unsigned, FunctionSpaceIndex functionIndexSpace, const TypeDefinition&, ArgumentList& args, ValueResults&, CallType = CallType::Call);
+    [[nodiscard]] PartialResult emitIndirectCall(Value* calleeInstance, Value* calleeCode, Value* boxedCalleeCallee, const TypeDefinition&, const ArgumentList& args, ValueResults&, CallType = CallType::Call);
 
     Vector<ConstrainedValue> createCallConstrainedArgs(BasicBlock*, const CallInformation& wasmCalleeInfo, const ArgumentList&);
     auto createCallPatchpoint(BasicBlock*, const TypeDefinition&, const CallInformation&, const ArgumentList& tmpArgs) -> CallPatchpointData;
     auto createTailCallPatchpoint(BasicBlock*, const TypeDefinition&, const CallInformation& wasmCallerInfoAsCallee, const CallInformation& wasmCalleeInfoAsCallee, const ArgumentList& tmpArgSourceLocations, Vector<B3::ConstrainedValue> patchArgs) -> CallPatchpointData;
 
     bool canInline(FunctionSpaceIndex functionIndexSpace, unsigned callProfileIndex) const;
-    WARN_UNUSED_RETURN PartialResult emitInlineDirectCall(FunctionCodeIndex calleeIndex, const TypeDefinition&, ArgumentList& args, ValueResults&);
+    [[nodiscard]] PartialResult emitInlineDirectCall(FunctionCodeIndex calleeIndex, const TypeDefinition&, ArgumentList& args, ValueResults&);
 
     void dump(const ControlStack&, const Stack* expressionStack);
     void setParser(FunctionParser<OMGIRGenerator>* parser) { m_parser = parser; };
@@ -881,10 +881,10 @@ private:
     void emitArraySetUnchecked(uint32_t, Value*, Value*, Value*);
     bool emitArraySetUncheckedWithoutWriteBarrier(uint32_t, Value*, Value*, Value*);
     // Returns true if a writeBarrier/mutatorFence is needed.
-    WARN_UNUSED_RETURN bool emitStructSet(bool canTrap, Value*, uint32_t, const StructType&, Value*);
-    WARN_UNUSED_RETURN Value* allocateWasmGCArray(uint32_t typeIndex, Value* initValue, Value* size);
+    [[nodiscard]] bool emitStructSet(bool canTrap, Value*, uint32_t, const StructType&, Value*);
+    [[nodiscard]] Value* allocateWasmGCArray(uint32_t typeIndex, Value* initValue, Value* size);
     using ArraySegmentOperation = EncodedJSValue SYSV_ABI (&)(JSC::JSWebAssemblyInstance*, uint32_t, uint32_t, uint32_t, uint32_t);
-    WARN_UNUSED_RETURN ExpressionType pushArrayNewFromSegment(ArraySegmentOperation, uint32_t typeIndex, uint32_t segmentIndex, ExpressionType arraySize, ExpressionType offset, ExceptionType);
+    [[nodiscard]] ExpressionType pushArrayNewFromSegment(ArraySegmentOperation, uint32_t typeIndex, uint32_t segmentIndex, ExpressionType arraySize, ExpressionType offset, ExceptionType);
     void emitRefTestOrCast(CastKind, TypedExpression, bool, int32_t, bool, ExpressionType&);
     template <typename Generator>
     void emitCheckOrBranchForCast(CastKind, Value*, const Generator&, BasicBlock*);
@@ -895,8 +895,8 @@ private:
 
     void emitChecksForModOrDiv(B3::Opcode, Value* left, Value* right);
 
-    WARN_UNUSED_RETURN int32_t fixupPointerPlusOffset(Value*&, uint32_t);
-    WARN_UNUSED_RETURN Value* fixupPointerPlusOffsetForAtomicOps(ExtAtomicOpType, Value*, uint32_t);
+    [[nodiscard]] int32_t fixupPointerPlusOffset(Value*&, uint32_t);
+    [[nodiscard]] Value* fixupPointerPlusOffsetForAtomicOps(ExtAtomicOpType, Value*, uint32_t);
 
     void restoreWasmContextInstance(BasicBlock*, Value*);
     void restoreWebAssemblyGlobalState(const MemoryInformation&, Value* instance, BasicBlock*);
@@ -3026,7 +3026,7 @@ Value* OMGIRGenerator::emitAtomicCompareExchange(ExtAtomicOpType op, Type valueT
     return sanitizeAtomicResult(op, valueType, atomic);
 }
 
-WARN_UNUSED_RETURN bool OMGIRGenerator::emitStructSet(bool canTrap, Value* structValue, uint32_t fieldIndex, const StructType& structType, Value* argument)
+[[nodiscard]] bool OMGIRGenerator::emitStructSet(bool canTrap, Value* structValue, uint32_t fieldIndex, const StructType& structType, Value* argument)
 {
     structValue = pointerOfWasmRef(structValue);
     auto fieldType = structType.field(fieldIndex).type;
@@ -5320,7 +5320,7 @@ auto OMGIRGenerator::addThrow(unsigned exceptionIndex, ArgumentList& args, Stack
     return { };
 }
 
-WARN_UNUSED_RETURN auto OMGIRGenerator::addThrowRef(TypedExpression exnref, Stack&) -> PartialResult
+[[nodiscard]] auto OMGIRGenerator::addThrowRef(TypedExpression exnref, Stack&) -> PartialResult
 {
     TRACE_CF("THROW_REF");
 

--- a/Source/JavaScriptCore/wasm/WasmParser.h
+++ b/Source/JavaScriptCore/wasm/WasmParser.h
@@ -75,35 +75,35 @@ protected:
 
     explicit ParserBase(std::span<const uint8_t>);
 
-    WARN_UNUSED_RETURN bool consumeCharacter(char);
-    WARN_UNUSED_RETURN bool consumeString(const char*);
-    WARN_UNUSED_RETURN bool consumeUTF8String(Name&, size_t);
+    [[nodiscard]] bool consumeCharacter(char);
+    [[nodiscard]] bool consumeString(const char*);
+    [[nodiscard]] bool consumeUTF8String(Name&, size_t);
 
-    WARN_UNUSED_RETURN bool parseVarUInt1(uint8_t&);
-    WARN_UNUSED_RETURN bool parseInt7(int8_t&);
-    WARN_UNUSED_RETURN bool peekInt7(int8_t&);
-    WARN_UNUSED_RETURN bool parseUInt7(uint8_t&);
-    WARN_UNUSED_RETURN bool peekUInt8(uint8_t&);
-    WARN_UNUSED_RETURN bool parseUInt8(uint8_t&);
-    WARN_UNUSED_RETURN bool parseUInt32(uint32_t&);
-    WARN_UNUSED_RETURN bool parseUInt64(uint64_t&);
-    WARN_UNUSED_RETURN bool parseImmByteArray16(v128_t&);
-    WARN_UNUSED_RETURN bool parseVarUInt32(uint32_t&);
-    WARN_UNUSED_RETURN bool peekVarUInt32(uint32_t&);
-    WARN_UNUSED_RETURN bool parseVarUInt64(uint64_t&);
+    [[nodiscard]] bool parseVarUInt1(uint8_t&);
+    [[nodiscard]] bool parseInt7(int8_t&);
+    [[nodiscard]] bool peekInt7(int8_t&);
+    [[nodiscard]] bool parseUInt7(uint8_t&);
+    [[nodiscard]] bool peekUInt8(uint8_t&);
+    [[nodiscard]] bool parseUInt8(uint8_t&);
+    [[nodiscard]] bool parseUInt32(uint32_t&);
+    [[nodiscard]] bool parseUInt64(uint64_t&);
+    [[nodiscard]] bool parseImmByteArray16(v128_t&);
+    [[nodiscard]] bool parseVarUInt32(uint32_t&);
+    [[nodiscard]] bool peekVarUInt32(uint32_t&);
+    [[nodiscard]] bool parseVarUInt64(uint64_t&);
 
-    WARN_UNUSED_RETURN bool parseVarInt32(int32_t&);
-    WARN_UNUSED_RETURN bool parseVarInt64(int64_t&);
+    [[nodiscard]] bool parseVarInt32(int32_t&);
+    [[nodiscard]] bool parseVarInt64(int64_t&);
 
-    WARN_UNUSED_RETURN bool parseValueType(const ModuleInformation&, Type&);
-    WARN_UNUSED_RETURN bool parseRefType(const ModuleInformation&, Type&);
-    WARN_UNUSED_RETURN bool parseExternalKind(ExternalKind&);
-    WARN_UNUSED_RETURN bool parseHeapType(const ModuleInformation&, int32_t&);
+    [[nodiscard]] bool parseValueType(const ModuleInformation&, Type&);
+    [[nodiscard]] bool parseRefType(const ModuleInformation&, Type&);
+    [[nodiscard]] bool parseExternalKind(ExternalKind&);
+    [[nodiscard]] bool parseHeapType(const ModuleInformation&, int32_t&);
 
     size_t m_offset = 0;
 
     template <typename ...Args>
-    WARN_UNUSED_RETURN NEVER_INLINE UnexpectedResult fail(Args... args) const
+    [[nodiscard]] NEVER_INLINE UnexpectedResult fail(Args... args) const
     {
         using namespace FailureHelper; // See ADL comment in namespace above.
         return UnexpectedResult(makeString("WebAssembly.Module doesn't parse at byte "_s, m_offset, ": "_s, makeString(args)...));

--- a/Source/JavaScriptCore/wasm/WasmPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmPlan.h
@@ -69,7 +69,7 @@ public:
     String errorMessage() const { return crossThreadCopy(m_errorMessage); }
     CompilationError error() const { return m_error; }
 
-    WARN_UNUSED_RETURN bool failed() const { return !m_errorMessage.isNull(); }
+    [[nodiscard]] bool failed() const { return !m_errorMessage.isNull(); }
     virtual bool hasWork() const = 0;
     virtual void work() = 0;
     virtual bool multiThreaded() const = 0;

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.h
@@ -45,15 +45,15 @@ public:
     {
     }
 
-#define WASM_SECTION_DECLARE_PARSER(NAME, ID, ORDERING, DESCRIPTION) WARN_UNUSED_RETURN PartialResult parse ## NAME();
+#define WASM_SECTION_DECLARE_PARSER(NAME, ID, ORDERING, DESCRIPTION) [[nodiscard]] PartialResult parse ## NAME();
     FOR_EACH_KNOWN_WASM_SECTION(WASM_SECTION_DECLARE_PARSER)
 #undef WASM_SECTION_DECLARE_PARSER
 
-    WARN_UNUSED_RETURN PartialResult parseCustom();
+    [[nodiscard]] PartialResult parseCustom();
 
 private:
     template <typename ...Args>
-    WARN_UNUSED_RETURN NEVER_INLINE UnexpectedResult fail(Args... args) const
+    [[nodiscard]] NEVER_INLINE UnexpectedResult fail(Args... args) const
     {
         using namespace FailureHelper; // See ADL comment in namespace above.
         if (ASSERT_ENABLED && Options::crashOnFailedWasmValidate()) [[unlikely]]
@@ -62,34 +62,34 @@ private:
         return UnexpectedResult(makeString("WebAssembly.Module doesn't parse at byte "_s, String::number(m_offset + m_offsetInSource), ": "_s, makeString(args)...));
     }
 
-    WARN_UNUSED_RETURN PartialResult parseGlobalType(GlobalInformation&);
-    WARN_UNUSED_RETURN PartialResult parseMemoryHelper(bool isImport);
-    WARN_UNUSED_RETURN PartialResult parseTableHelper(bool isImport);
+    [[nodiscard]] PartialResult parseGlobalType(GlobalInformation&);
+    [[nodiscard]] PartialResult parseMemoryHelper(bool isImport);
+    [[nodiscard]] PartialResult parseTableHelper(bool isImport);
     enum class LimitsType { Memory, Table };
     template <LimitsType T>
-    WARN_UNUSED_RETURN PartialResult parseResizableLimits(uint64_t& initial, std::optional<uint64_t>& maximum, bool& isShared, bool& is64bit);
-    WARN_UNUSED_RETURN PartialResult parseInitExpr(uint8_t&, bool&, uint64_t&, v128_t&, Type, Type& initExprType);
-    WARN_UNUSED_RETURN PartialResult parseI32InitExpr(std::optional<I32InitExpr>&, ASCIILiteral failMessage);
+    [[nodiscard]] PartialResult parseResizableLimits(uint64_t& initial, std::optional<uint64_t>& maximum, bool& isShared, bool& is64bit);
+    [[nodiscard]] PartialResult parseInitExpr(uint8_t&, bool&, uint64_t&, v128_t&, Type, Type& initExprType);
+    [[nodiscard]] PartialResult parseI32InitExpr(std::optional<I32InitExpr>&, ASCIILiteral failMessage);
 
-    WARN_UNUSED_RETURN PartialResult parseFunctionType(uint32_t position, RefPtr<TypeDefinition>&);
-    WARN_UNUSED_RETURN PartialResult parsePackedType(PackedType&);
-    WARN_UNUSED_RETURN PartialResult parseStorageType(StorageType&);
-    WARN_UNUSED_RETURN PartialResult parseStructType(uint32_t position, RefPtr<TypeDefinition>&);
-    WARN_UNUSED_RETURN PartialResult parseArrayType(uint32_t position, RefPtr<TypeDefinition>&);
-    WARN_UNUSED_RETURN PartialResult parseRecursionGroup(uint32_t position, RefPtr<TypeDefinition>&);
-    WARN_UNUSED_RETURN PartialResult parseSubtype(uint32_t position, RefPtr<TypeDefinition>&, Vector<TypeIndex>&, bool);
+    [[nodiscard]] PartialResult parseFunctionType(uint32_t position, RefPtr<TypeDefinition>&);
+    [[nodiscard]] PartialResult parsePackedType(PackedType&);
+    [[nodiscard]] PartialResult parseStorageType(StorageType&);
+    [[nodiscard]] PartialResult parseStructType(uint32_t position, RefPtr<TypeDefinition>&);
+    [[nodiscard]] PartialResult parseArrayType(uint32_t position, RefPtr<TypeDefinition>&);
+    [[nodiscard]] PartialResult parseRecursionGroup(uint32_t position, RefPtr<TypeDefinition>&);
+    [[nodiscard]] PartialResult parseSubtype(uint32_t position, RefPtr<TypeDefinition>&, Vector<TypeIndex>&, bool);
 
-    WARN_UNUSED_RETURN PartialResult validateElementTableIdx(uint32_t, Type);
-    WARN_UNUSED_RETURN PartialResult parseI32InitExprForElementSection(std::optional<I32InitExpr>&);
-    WARN_UNUSED_RETURN PartialResult parseElementKind(uint8_t& elementKind);
-    WARN_UNUSED_RETURN PartialResult parseIndexCountForElementSection(uint32_t&, const unsigned);
-    WARN_UNUSED_RETURN PartialResult parseElementSegmentVectorOfExpressions(Type, Vector<Element::InitializationType>&, Vector<uint64_t>&, const unsigned, const unsigned);
-    WARN_UNUSED_RETURN PartialResult parseElementSegmentVectorOfIndexes(Vector<Element::InitializationType>&, Vector<uint64_t>&, const unsigned, const unsigned);
+    [[nodiscard]] PartialResult validateElementTableIdx(uint32_t, Type);
+    [[nodiscard]] PartialResult parseI32InitExprForElementSection(std::optional<I32InitExpr>&);
+    [[nodiscard]] PartialResult parseElementKind(uint8_t& elementKind);
+    [[nodiscard]] PartialResult parseIndexCountForElementSection(uint32_t&, const unsigned);
+    [[nodiscard]] PartialResult parseElementSegmentVectorOfExpressions(Type, Vector<Element::InitializationType>&, Vector<uint64_t>&, const unsigned, const unsigned);
+    [[nodiscard]] PartialResult parseElementSegmentVectorOfIndexes(Vector<Element::InitializationType>&, Vector<uint64_t>&, const unsigned, const unsigned);
 
-    WARN_UNUSED_RETURN PartialResult parseI32InitExprForDataSection(std::optional<I32InitExpr>&);
+    [[nodiscard]] PartialResult parseI32InitExprForDataSection(std::optional<I32InitExpr>&);
 
     static bool checkStructuralSubtype(const TypeDefinition&, const TypeDefinition&);
-    WARN_UNUSED_RETURN PartialResult checkSubtypeValidity(const TypeDefinition&);
+    [[nodiscard]] PartialResult checkSubtypeValidity(const TypeDefinition&);
 
     size_t m_offsetInSource;
     const Ref<ModuleInformation> m_info;

--- a/Source/JavaScriptCore/wasm/WasmStreamingParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmStreamingParser.cpp
@@ -71,7 +71,7 @@ ALWAYS_INLINE std::optional<uint8_t> parseUInt7(const uint8_t* data, size_t& off
 }
 
 template <typename ...Args>
-WARN_UNUSED_RETURN NEVER_INLINE auto StreamingParser::fail(Args... args) -> State
+[[nodiscard]] NEVER_INLINE auto StreamingParser::fail(Args... args) -> State
 {
     using namespace FailureHelper; // See ADL comment in namespace above.
     m_errorMessage = makeString("WebAssembly.Module doesn't parse at byte "_s, m_offset, ": "_s, makeString(args)...);

--- a/Source/JavaScriptCore/wasm/WasmStreamingParser.h
+++ b/Source/JavaScriptCore/wasm/WasmStreamingParser.h
@@ -109,7 +109,7 @@ private:
     Expected<uint32_t, State> consumeVarUInt32(std::span<const uint8_t> bytes, size_t&, IsEndOfStream);
 
     void moveToStateIfNotFailed(State);
-    template <typename ...Args> WARN_UNUSED_RETURN NEVER_INLINE State fail(Args...);
+    template <typename ...Args> [[nodiscard]] NEVER_INLINE State fail(Args...);
 
     State failOnState(State);
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.h
@@ -61,7 +61,7 @@ public:
     std::optional<uint32_t> maximum() const { return m_table->maximum(); }
     uint32_t length() const { return m_table->length(); }
     uint32_t allocatedLength() const { return m_table->allocatedLength(length()); }
-    WARN_UNUSED_RETURN std::optional<uint32_t> grow(JSGlobalObject*, uint32_t delta, JSValue defaultValue);
+    [[nodiscard]] std::optional<uint32_t> grow(JSGlobalObject*, uint32_t delta, JSValue defaultValue);
     JSValue get(JSGlobalObject*, uint32_t);
     void set(uint32_t, JSValue);
     void set(JSGlobalObject*, uint32_t, JSValue);

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
@@ -2668,7 +2668,7 @@ public:
         m_currentAlternativeIndex = newAlternativeIndex;
     }
 
-    WARN_UNUSED_RETURN std::optional<ErrorCode> emitDisjunction(PatternDisjunction* disjunction, CheckedUint32 inputCountAlreadyChecked, unsigned parenthesesInputCountAlreadyChecked, MatchDirection matchDirection = Forward)
+    [[nodiscard]] std::optional<ErrorCode> emitDisjunction(PatternDisjunction* disjunction, CheckedUint32 inputCountAlreadyChecked, unsigned parenthesesInputCountAlreadyChecked, MatchDirection matchDirection = Forward)
     {
         if (!isSafeToRecurse()) [[unlikely]]
             return ErrorCode::TooManyDisjunctions;

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -1768,7 +1768,7 @@ public:
         return m_error;
     }
 
-    WARN_UNUSED_RETURN ErrorCode setupAlternativeOffsets(PatternAlternative* alternative, unsigned currentCallFrameSize, unsigned initialInputPosition, unsigned& newCallFrameSize)
+    [[nodiscard]] ErrorCode setupAlternativeOffsets(PatternAlternative* alternative, unsigned currentCallFrameSize, unsigned initialInputPosition, unsigned& newCallFrameSize)
     {
         if (!isSafeToRecurse()) [[unlikely]]
             return ErrorCode::TooManyDisjunctions;

--- a/Source/WTF/wtf/AllocSpanMixin.h
+++ b/Source/WTF/wtf/AllocSpanMixin.h
@@ -49,7 +49,7 @@ public:
 
     std::span<const T> span() const LIFETIME_BOUND { return m_span; }
     std::span<T> mutableSpan() LIFETIME_BOUND { return m_span; }
-    WARN_UNUSED_RETURN std::span<T> leakSpan() { return std::exchange(m_span, std::span<T> { }); }
+    [[nodiscard]] std::span<T> leakSpan() { return std::exchange(m_span, std::span<T> { }); }
 
     T& operator[](size_t i) LIFETIME_BOUND { return m_span[i]; }
     const T& operator[](size_t i) const LIFETIME_BOUND { return m_span[i]; }

--- a/Source/WTF/wtf/CheckedArithmetic.h
+++ b/Source/WTF/wtf/CheckedArithmetic.h
@@ -289,7 +289,7 @@ template<typename LHS, typename RHS, typename ResultType> struct ArithmeticOpera
         return (lhs ^ rhs) >= 0;
     }
 
-    WARN_UNUSED_RETURN static inline bool add(LHS lhs, RHS rhs, ResultType& result)
+    [[nodiscard]] static inline bool add(LHS lhs, RHS rhs, ResultType& result)
     {
 #if !HAVE(INT128_T)
         if constexpr (sizeof(LHS) <= sizeof(uint64_t) || sizeof(RHS) <= sizeof(uint64_t)) {
@@ -316,7 +316,7 @@ template<typename LHS, typename RHS, typename ResultType> struct ArithmeticOpera
         return true;
     }
 
-    WARN_UNUSED_RETURN static inline bool sub(LHS lhs, RHS rhs, ResultType& result)
+    [[nodiscard]] static inline bool sub(LHS lhs, RHS rhs, ResultType& result)
     {
 #if !HAVE(INT128_T)
         if constexpr (sizeof(LHS) <= sizeof(uint64_t) || sizeof(RHS) <= sizeof(uint64_t)) {
@@ -342,7 +342,7 @@ template<typename LHS, typename RHS, typename ResultType> struct ArithmeticOpera
         return true;
     }
 
-    WARN_UNUSED_RETURN static inline bool multiply(LHS lhs, RHS rhs, ResultType& result)
+    [[nodiscard]] static inline bool multiply(LHS lhs, RHS rhs, ResultType& result)
     {
 #if USE(MUL_OVERFLOW)
         // Don't use the builtin if the int128 type is WTF::[U]Int128Impl.
@@ -383,7 +383,7 @@ template<typename LHS, typename RHS, typename ResultType> struct ArithmeticOpera
         return true;
     }
 
-    WARN_UNUSED_RETURN static inline bool divide(LHS lhs, RHS rhs, ResultType& result)
+    [[nodiscard]] static inline bool divide(LHS lhs, RHS rhs, ResultType& result)
     {
         if (!rhs)
             return false;
@@ -398,7 +398,7 @@ template<typename LHS, typename RHS, typename ResultType> struct ArithmeticOpera
 
 template<typename LHS, typename RHS, typename ResultType> struct ArithmeticOperations<LHS, RHS, ResultType, false, false> {
     // LHS and RHS are unsigned types so bounds checks are nice and easy
-    WARN_UNUSED_RETURN static inline bool add(LHS lhs, RHS rhs, ResultType& result)
+    [[nodiscard]] static inline bool add(LHS lhs, RHS rhs, ResultType& result)
     {
         ResultType temp;
 #if !HAVE(INT128_T)
@@ -418,7 +418,7 @@ template<typename LHS, typename RHS, typename ResultType> struct ArithmeticOpera
         return true;
     }
 
-    WARN_UNUSED_RETURN static inline bool sub(LHS lhs, RHS rhs, ResultType& result)
+    [[nodiscard]] static inline bool sub(LHS lhs, RHS rhs, ResultType& result)
     {
         ResultType temp;
 #if !HAVE(INT128_T)
@@ -438,7 +438,7 @@ template<typename LHS, typename RHS, typename ResultType> struct ArithmeticOpera
         return true;
     }
 
-    WARN_UNUSED_RETURN static inline bool multiply(LHS lhs, RHS rhs, ResultType& result)
+    [[nodiscard]] static inline bool multiply(LHS lhs, RHS rhs, ResultType& result)
     {
 #if USE(MUL_OVERFLOW)
         // Don't use the builtin if the int128 type is WTF::Int128Impl.
@@ -466,7 +466,7 @@ template<typename LHS, typename RHS, typename ResultType> struct ArithmeticOpera
         return true;
     }
 
-    WARN_UNUSED_RETURN static inline bool divide(LHS lhs, RHS rhs, ResultType& result)
+    [[nodiscard]] static inline bool divide(LHS lhs, RHS rhs, ResultType& result)
     {
         if (!rhs)
             return false;

--- a/Source/WTF/wtf/Compiler.h
+++ b/Source/WTF/wtf/Compiler.h
@@ -421,12 +421,6 @@
 #define UNUSED_VARIADIC_PARAMS __attribute__((unused))
 #endif
 
-/* WARN_UNUSED_RETURN */
-
-#if !defined(WARN_UNUSED_RETURN)
-#define WARN_UNUSED_RETURN [[nodiscard]] // NOLINT: check-webkit-style does not understand annotations.
-#endif
-
 /* DEBUGGER_ANNOTATION_MARKER */
 
 #if !defined(DEBUGGER_ANNOTATION_MARKER) && COMPILER(GCC)

--- a/Source/WTF/wtf/CompletionHandler.h
+++ b/Source/WTF/wtf/CompletionHandler.h
@@ -85,7 +85,7 @@ public:
 
     explicit operator bool() const { return !!m_function; }
 
-    WARN_UNUSED_RETURN Impl* leak() { return m_function.leak(); }
+    [[nodiscard]] Impl* leak() { return m_function.leak(); }
 
     Out operator()(In... in)
     {

--- a/Source/WTF/wtf/FileSystem.h
+++ b/Source/WTF/wtf/FileSystem.h
@@ -199,7 +199,7 @@ WTF_EXPORT_PRIVATE bool deleteNonEmptyDirectory(const String&);
 WTF_EXPORT_PRIVATE String realPath(const String&);
 
 WTF_EXPORT_PRIVATE bool isSafeToUseMemoryMapForPath(const String&);
-WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE bool makeSafeToUseMemoryMapForPath(const String&);
+[[nodiscard]] WTF_EXPORT_PRIVATE bool makeSafeToUseMemoryMapForPath(const String&);
 
 WTF_EXPORT_PRIVATE std::optional<MappedFileData> mapFile(const String& path, MappedFileMode);
 

--- a/Source/WTF/wtf/Function.h
+++ b/Source/WTF/wtf/Function.h
@@ -127,7 +127,7 @@ public:
         return *this;
     }
 
-    WARN_UNUSED_RETURN Impl* leak()
+    [[nodiscard]] Impl* leak()
     {
         return m_callableWrapper.release();
     }

--- a/Source/WTF/wtf/InlineWeakPtr.h
+++ b/Source/WTF/wtf/InlineWeakPtr.h
@@ -51,7 +51,7 @@ public:
 
     T* get() const LIFETIME_BOUND;
 
-    WARN_UNUSED_RETURN T* leakWeak();
+    [[nodiscard]] T* leakWeak();
 
     T& operator*() const LIFETIME_BOUND { ASSERT(get()); return *get(); }
     ALWAYS_INLINE T* operator->() const LIFETIME_BOUND { return get(); }

--- a/Source/WTF/wtf/InlineWeakRef.h
+++ b/Source/WTF/wtf/InlineWeakRef.h
@@ -76,7 +76,7 @@ public:
 private:
     template<typename X> friend class InlineWeakRef;
 
-    WARN_UNUSED_RETURN T& leakWeak();
+    [[nodiscard]] T& leakWeak();
 
     T* m_ptr;
 } SWIFT_ESCAPABLE;

--- a/Source/WTF/wtf/LEBDecoder.h
+++ b/Source/WTF/wtf/LEBDecoder.h
@@ -53,7 +53,7 @@ constexpr unsigned lastByteMask()
 }
 
 template<typename T>
-WARN_UNUSED_RETURN inline bool decodeUInt(std::span<const uint8_t> bytes, size_t& offset, T& result)
+[[nodiscard]] inline bool decodeUInt(std::span<const uint8_t> bytes, size_t& offset, T& result)
 {
     static_assert(std::is_unsigned_v<T>);
     if (bytes.size() <= offset)
@@ -75,7 +75,7 @@ WARN_UNUSED_RETURN inline bool decodeUInt(std::span<const uint8_t> bytes, size_t
 }
 
 template<typename T>
-WARN_UNUSED_RETURN inline bool decodeInt(std::span<const uint8_t> bytes, size_t& offset, T& result)
+[[nodiscard]] inline bool decodeInt(std::span<const uint8_t> bytes, size_t& offset, T& result)
 {
     static_assert(std::is_signed_v<T>);
     if (bytes.size() <= offset)
@@ -117,22 +117,22 @@ WARN_UNUSED_RETURN inline bool decodeInt(std::span<const uint8_t> bytes, size_t&
     return true;
 }
 
-WARN_UNUSED_RETURN inline bool decodeUInt32(std::span<const uint8_t> bytes, size_t& offset, uint32_t& result)
+[[nodiscard]] inline bool decodeUInt32(std::span<const uint8_t> bytes, size_t& offset, uint32_t& result)
 {
     return decodeUInt<uint32_t>(bytes, offset, result);
 }
 
-WARN_UNUSED_RETURN inline bool decodeUInt64(std::span<const uint8_t> bytes, size_t& offset, uint64_t& result)
+[[nodiscard]] inline bool decodeUInt64(std::span<const uint8_t> bytes, size_t& offset, uint64_t& result)
 {
     return decodeUInt<uint64_t>(bytes, offset, result);
 }
 
-WARN_UNUSED_RETURN inline bool decodeInt32(std::span<const uint8_t> bytes, size_t& offset, int32_t& result)
+[[nodiscard]] inline bool decodeInt32(std::span<const uint8_t> bytes, size_t& offset, int32_t& result)
 {
     return decodeInt<int32_t>(bytes, offset, result);
 }
 
-WARN_UNUSED_RETURN inline bool decodeInt64(std::span<const uint8_t> bytes, size_t& offset, int64_t& result)
+[[nodiscard]] inline bool decodeInt64(std::span<const uint8_t> bytes, size_t& offset, int64_t& result)
 {
     return decodeInt<int64_t>(bytes, offset, result);
 }

--- a/Source/WTF/wtf/MachSendRight.h
+++ b/Source/WTF/wtf/MachSendRight.h
@@ -54,7 +54,7 @@ public:
 
     mach_port_t sendRight() const LIFETIME_BOUND { return m_port; }
 
-    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE mach_port_t leakSendRight();
+    [[nodiscard]] WTF_EXPORT_PRIVATE mach_port_t leakSendRight();
 
 private:
     explicit MachSendRight(mach_port_t);

--- a/Source/WTF/wtf/MallocCommon.h
+++ b/Source/WTF/wtf/MallocCommon.h
@@ -35,7 +35,7 @@ public:
     TryMallocReturnValue(void*);
     TryMallocReturnValue(TryMallocReturnValue&&);
     ~TryMallocReturnValue();
-    template<typename T> WARN_UNUSED_RETURN bool getValue(T*&);
+    template<typename T> [[nodiscard]] bool getValue(T*&);
 private:
     void operator=(TryMallocReturnValue&&) = delete;
     mutable void* m_data;

--- a/Source/WTF/wtf/MallocPtr.h
+++ b/Source/WTF/wtf/MallocPtr.h
@@ -62,7 +62,7 @@ public:
         return m_ptr;
     }
 
-    WARN_UNUSED_RETURN T* leakPtr()
+    [[nodiscard]] T* leakPtr()
     {
         return std::exchange(m_ptr, nullptr);
     }

--- a/Source/WTF/wtf/MappedFileData.h
+++ b/Source/WTF/wtf/MappedFileData.h
@@ -60,7 +60,7 @@ public:
 #if HAVE(MMAP)
     explicit MappedFileData(MmapSpan<uint8_t>&&);
 
-    WARN_UNUSED_RETURN std::span<uint8_t> leakHandle() { return m_fileData.leakSpan(); }
+    [[nodiscard]] std::span<uint8_t> leakHandle() { return m_fileData.leakSpan(); }
     explicit operator bool() const { return !!m_fileData; }
     size_t size() const { return m_fileData.span().size(); }
     std::span<const uint8_t> span() const LIFETIME_BOUND { return m_fileData.span(); }

--- a/Source/WTF/wtf/OSObjectPtr.h
+++ b/Source/WTF/wtf/OSObjectPtr.h
@@ -59,7 +59,7 @@ template<typename T, typename arcEnabled = ARCEnabled> struct DefaultOSObjectRet
     }
 };
 
-template<typename T, typename RetainTraits = DefaultOSObjectRetainTraits<T, ARCEnabled>> WARN_UNUSED_RETURN OSObjectPtr<T, RetainTraits> adoptOSObject(T);
+template<typename T, typename RetainTraits = DefaultOSObjectRetainTraits<T, ARCEnabled>> [[nodiscard]] OSObjectPtr<T, RetainTraits> adoptOSObject(T);
 
 template<typename T, typename RetainTraits> class OSObjectPtr {
 public:
@@ -140,7 +140,7 @@ public:
         std::swap(m_ptr, other.m_ptr);
     }
 
-    WARN_UNUSED_RETURN T leakRef()
+    [[nodiscard]] T leakRef()
     {
         return std::exchange(m_ptr, nullptr);
     }

--- a/Source/WTF/wtf/OptionSet.h
+++ b/Source/WTF/wtf/OptionSet.h
@@ -231,7 +231,7 @@ struct OptionSetValueChecker<T, EnumValues<E>> {
 }
 
 template<typename E, ConcurrencyTag concurrency>
-WARN_UNUSED_RETURN constexpr bool isValidOptionSet(OptionSet<E, concurrency> optionSet)
+[[nodiscard]] constexpr bool isValidOptionSet(OptionSet<E, concurrency> optionSet)
 {
     // FIXME: Remove this when all OptionSet enums are migrated to generated serialization.
     auto allValidBitsValue = IsValidOptionSetHelper::OptionSetValueChecker<std::make_unsigned_t<std::underlying_type_t<E>>, typename EnumTraits<E>::values>::allValidBits();

--- a/Source/WTF/wtf/Ref.h
+++ b/Source/WTF/wtf/Ref.h
@@ -141,13 +141,13 @@ public:
     operator T&() const LIFETIME_BOUND { ASSERT(m_ptr); return *PtrTraits::unwrap(m_ptr); }
     bool operator!() const { ASSERT(m_ptr); return !*m_ptr; }
 
-    template<typename X, typename Y, typename Z> WARN_UNUSED_RETURN Ref<T, PtrTraits, RefDerefTraits> replace(Ref<X, Y, Z>&&);
+    template<typename X, typename Y, typename Z> [[nodiscard]] Ref<T, PtrTraits, RefDerefTraits> replace(Ref<X, Y, Z>&&);
 
     // The following function is deprecated.
     Ref copyRef() && = delete;
-    WARN_UNUSED_RETURN Ref copyRef() const & { return Ref(*m_ptr); }
+    [[nodiscard]] Ref copyRef() const & { return Ref(*m_ptr); }
 
-    WARN_UNUSED_RETURN T& leakRef()
+    [[nodiscard]] T& leakRef()
     {
         ASSERT(m_ptr);
 

--- a/Source/WTF/wtf/RefPtr.h
+++ b/Source/WTF/wtf/RefPtr.h
@@ -70,7 +70,7 @@ public:
 
     Ref<T> releaseNonNull() { ASSERT(m_ptr); Ref<T> tmp(adoptRef(*m_ptr)); m_ptr = nullptr; return tmp; }
 
-    WARN_UNUSED_RETURN T* leakRef();
+    [[nodiscard]] T* leakRef();
 
     ALWAYS_INLINE T& operator*() const LIFETIME_BOUND { ASSERT(m_ptr); return *PtrTraits::unwrap(m_ptr); }
     ALWAYS_INLINE T* operator->() const LIFETIME_BOUND { return &**this; }
@@ -94,7 +94,7 @@ public:
     template<typename X, typename Y, typename Z> void swap(RefPtr<X, Y, Z>&);
 
     RefPtr copyRef() && = delete;
-    WARN_UNUSED_RETURN RefPtr copyRef() const & { return RefPtr(m_ptr); }
+    [[nodiscard]] RefPtr copyRef() const & { return RefPtr(m_ptr); }
 
 private:
     void unspecifiedBoolTypeInstance() const { }

--- a/Source/WTF/wtf/RetainPtr.h
+++ b/Source/WTF/wtf/RetainPtr.h
@@ -73,9 +73,9 @@ template<typename T> class RetainPtr;
 template<typename T> constexpr bool IsNSType = std::is_convertible_v<T, id>;
 template<typename T> using RetainPtrType = std::conditional_t<IsNSType<T> && !std::is_same_v<T, id>, std::remove_pointer_t<T>, T>;
 
-template<typename T> WARN_UNUSED_RETURN constexpr RetainPtr<RetainPtrType<T>> adoptCF(T CF_RELEASES_ARGUMENT);
+template<typename T> [[nodiscard]] constexpr RetainPtr<RetainPtrType<T>> adoptCF(T CF_RELEASES_ARGUMENT);
 
-template<typename T> WARN_UNUSED_RETURN constexpr RetainPtr<RetainPtrType<T>> adoptNS(T NS_RELEASES_ARGUMENT);
+template<typename T> [[nodiscard]] constexpr RetainPtr<RetainPtrType<T>> adoptNS(T NS_RELEASES_ARGUMENT);
 
 template<typename T> class RetainPtr {
 public:
@@ -108,12 +108,12 @@ public:
     void clear();
 
     template<typename U = StorageType>
-    WARN_UNUSED_RETURN std::enable_if_t<IsNSType<U> && std::is_same_v<U, StorageType>, StorageType> leakRef() NS_RETURNS_RETAINED {
+    [[nodiscard]] std::enable_if_t<IsNSType<U> && std::is_same_v<U, StorageType>, StorageType> leakRef() NS_RETURNS_RETAINED {
         return std::exchange(m_ptr, nullptr);
     }
 
     template<typename U = StorageType>
-    WARN_UNUSED_RETURN std::enable_if_t<!IsNSType<U> && std::is_same_v<U, StorageType>, StorageType> leakRef() CF_RETURNS_RETAINED {
+    [[nodiscard]] std::enable_if_t<!IsNSType<U> && std::is_same_v<U, StorageType>, StorageType> leakRef() CF_RETURNS_RETAINED {
         return std::exchange(m_ptr, nullptr);
     }
 
@@ -183,7 +183,7 @@ private:
 template<typename T> RetainPtr(T) -> RetainPtr<RetainPtrType<T>>;
 
 // Helper function for creating a RetainPtr using template argument deduction.
-template<typename T> WARN_UNUSED_RETURN RetainPtr<RetainPtrType<T>> retainPtr(T);
+template<typename T> [[nodiscard]] RetainPtr<RetainPtrType<T>> retainPtr(T);
 
 template<typename T> inline RetainPtr<T>::~RetainPtr()
 {

--- a/Source/WTF/wtf/Scope.h
+++ b/Source/WTF/wtf/Scope.h
@@ -68,7 +68,7 @@ private:
 };
 
 
-template<typename ExitFunction> WARN_UNUSED_RETURN ScopeExit<ExitFunction> makeScopeExit(ExitFunction&&);
+template<typename ExitFunction> [[nodiscard]] ScopeExit<ExitFunction> makeScopeExit(ExitFunction&&);
 template<typename ExitFunction>
 ScopeExit<ExitFunction> makeScopeExit(ExitFunction&& exitFunction)
 {

--- a/Source/WTF/wtf/glib/GMallocString.h
+++ b/Source/WTF/wtf/glib/GMallocString.h
@@ -95,7 +95,7 @@ public:
 
     bool isNull() const { return m_spanWithNullTerminator.span().empty(); }
     const char* utf8() const LIFETIME_BOUND { return byteCast<char>(m_spanWithNullTerminator.span().data()); }
-    WARN_UNUSED_RETURN char* leakUTF8() { return byteCast<char>(m_spanWithNullTerminator.leakSpan().data()); }
+    [[nodiscard]] char* leakUTF8() { return byteCast<char>(m_spanWithNullTerminator.leakSpan().data()); }
     size_t lengthInBytes() const { return !m_spanWithNullTerminator.span().empty() ? m_spanWithNullTerminator.span().size() - 1 : 0; }
     std::span<const char8_t> span() const LIFETIME_BOUND { return m_spanWithNullTerminator.span().first(lengthInBytes()); }
     std::span<const char8_t> spanIncludingNullTerminator() const LIFETIME_BOUND { return m_spanWithNullTerminator.span(); }

--- a/Source/WTF/wtf/glib/GRefPtr.h
+++ b/Source/WTF/wtf/glib/GRefPtr.h
@@ -132,13 +132,14 @@ public:
     }
 
     // Relinquishes the owned reference as a raw pointer. GRefPtr<T> is empty afterwards.
-    WARN_UNUSED_RETURN T* /* (transfer full) */ leakRef()
+    [[nodiscard]] T* /* (transfer full) */ leakRef()
     {
         return std::exchange(m_ptr, nullptr);
     }
 
     // Increments the reference count.
-    WARN_UNUSED_RETURN T* /* (transfer full) */ ref() {
+    [[nodiscard]] T* /* (transfer full) */ ref()
+    {
         return RefDerefTraits::refIfNotNull(m_ptr);
     }
 

--- a/Source/WTF/wtf/glib/GThreadSafeWeakPtr.h
+++ b/Source/WTF/wtf/glib/GThreadSafeWeakPtr.h
@@ -55,7 +55,7 @@ public:
         g_weak_ref_clear(&m_ref);
     }
 
-    WARN_UNUSED_RETURN GRefPtr<T> get()
+    [[nodiscard]] GRefPtr<T> get()
     {
         return adoptGRef(reinterpret_cast<T*>(g_weak_ref_get(&m_ref)));
     }

--- a/Source/WTF/wtf/persistence/PersistentDecoder.h
+++ b/Source/WTF/wtf/persistence/PersistentDecoder.h
@@ -43,11 +43,11 @@ public:
     size_t length() const { return m_buffer.size(); }
     size_t currentOffset() const { return static_cast<size_t>(std::distance(m_buffer.begin(), m_bufferPosition)); }
     
-    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE bool rewind(size_t);
+    [[nodiscard]] WTF_EXPORT_PRIVATE bool rewind(size_t);
 
-    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE bool verifyChecksum();
+    [[nodiscard]] WTF_EXPORT_PRIVATE bool verifyChecksum();
 
-    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE bool decodeFixedLengthData(std::span<uint8_t>);
+    [[nodiscard]] WTF_EXPORT_PRIVATE bool decodeFixedLengthData(std::span<uint8_t>);
 
     WTF_EXPORT_PRIVATE Decoder& operator>>(std::optional<bool>&);
     WTF_EXPORT_PRIVATE Decoder& operator>>(std::optional<uint8_t>&);
@@ -83,17 +83,17 @@ public:
         return *this;
     }
 
-    template<typename T> WARN_UNUSED_RETURN
+    template<typename T> [[nodiscard]]
     bool bufferIsLargeEnoughToContain(size_t numElements) const
     {
         static_assert(std::is_arithmetic<T>::value, "Type T must have a fixed, known encoded size!");
         return numElements <= std::numeric_limits<size_t>::max() / sizeof(T) && bufferIsLargeEnoughToContain(numElements * sizeof(T));
     }
 
-    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE std::span<const uint8_t> bufferPointerForDirectRead(size_t numBytes);
+    [[nodiscard]] WTF_EXPORT_PRIVATE std::span<const uint8_t> bufferPointerForDirectRead(size_t numBytes);
 
 private:
-    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE bool bufferIsLargeEnoughToContain(size_t) const;
+    [[nodiscard]] WTF_EXPORT_PRIVATE bool bufferIsLargeEnoughToContain(size_t) const;
     template<typename Type> Decoder& decodeNumber(std::optional<Type>&);
 
     const std::span<const uint8_t> m_buffer;

--- a/Source/WTF/wtf/text/AtomString.h
+++ b/Source/WTF/wtf/text/AtomString.h
@@ -324,7 +324,7 @@ inline std::strong_ordering codePointCompare(const AtomString& a, const AtomStri
     return codePointCompare(a.string(), b.string());
 }
 
-WARN_UNUSED_RETURN ALWAYS_INLINE String makeStringByReplacingAll(const AtomString& string, char16_t target, char16_t replacement)
+[[nodiscard]] ALWAYS_INLINE String makeStringByReplacingAll(const AtomString& string, char16_t target, char16_t replacement)
 {
     return makeStringByReplacingAll(string.string(), target, replacement);
 }

--- a/Source/WTF/wtf/text/MakeString.h
+++ b/Source/WTF/wtf/text/MakeString.h
@@ -149,7 +149,7 @@ AtomString makeAtomString(StringTypes... strings)
     return result;
 }
 
-WARN_UNUSED_RETURN inline String makeStringByInserting(StringView originalString, StringView stringToInsert, unsigned position)
+[[nodiscard]] inline String makeStringByInserting(StringView originalString, StringView stringToInsert, unsigned position)
 {
     return makeString(originalString.left(position), stringToInsert, originalString.substring(position));
 }

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -1378,31 +1378,31 @@ inline bool String::containsIgnoringASCIICase(StringView string, unsigned start)
     return findIgnoringASCIICase(string, start) != notFound;
 }
 
-WARN_UNUSED_RETURN inline String makeStringByReplacingAll(const String& string, StringView target, StringView replacement)
+[[nodiscard]] inline String makeStringByReplacingAll(const String& string, StringView target, StringView replacement)
 {
     if (auto* impl = string.impl())
         return String { impl->replace(target, replacement) };
     return string;
 }
 
-WARN_UNUSED_RETURN inline String makeStringByReplacing(const String& string, unsigned start, unsigned length, StringView replacement)
+[[nodiscard]] inline String makeStringByReplacing(const String& string, unsigned start, unsigned length, StringView replacement)
 {
     if (auto* impl = string.impl())
         return String { impl->replace(start, length, replacement) };
     return string;
 }
 
-WARN_UNUSED_RETURN inline String makeStringByReplacingAll(const String& string, char16_t target, StringView replacement)
+[[nodiscard]] inline String makeStringByReplacingAll(const String& string, char16_t target, StringView replacement)
 {
     if (auto* impl = string.impl())
         return String { impl->replace(target, replacement) };
     return string;
 }
 
-WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE String makeStringByReplacingAll(StringView, char16_t target, char16_t replacement);
-WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE String makeStringBySimplifyingNewLinesSlowCase(const String&, unsigned firstCarriageReturnOffset);
+[[nodiscard]] WTF_EXPORT_PRIVATE String makeStringByReplacingAll(StringView, char16_t target, char16_t replacement);
+[[nodiscard]] WTF_EXPORT_PRIVATE String makeStringBySimplifyingNewLinesSlowCase(const String&, unsigned firstCarriageReturnOffset);
 
-WARN_UNUSED_RETURN inline String makeStringBySimplifyingNewLines(const String& string)
+[[nodiscard]] inline String makeStringBySimplifyingNewLines(const String& string)
 {
     auto firstCarriageReturn = string.find('\r');
     if (firstCarriageReturn == notFound)

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -191,27 +191,27 @@ public:
     bool endsWith(char character) const { return endsWith(static_cast<char16_t>(character)); }
     bool hasInfixEndingAt(StringView suffix, unsigned end) const;
 
-    WARN_UNUSED_RETURN String substring(unsigned position, unsigned length = MaxLength) const;
-    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE String substringSharingImpl(unsigned position, unsigned length = MaxLength) const;
-    WARN_UNUSED_RETURN String left(unsigned length) const { return substring(0, length); }
-    WARN_UNUSED_RETURN String right(unsigned length) const { return substring(this->length() - length, length); }
+    [[nodiscard]] String substring(unsigned position, unsigned length = MaxLength) const;
+    [[nodiscard]] WTF_EXPORT_PRIVATE String substringSharingImpl(unsigned position, unsigned length = MaxLength) const;
+    [[nodiscard]] String left(unsigned length) const { return substring(0, length); }
+    [[nodiscard]] String right(unsigned length) const { return substring(this->length() - length, length); }
 
-    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE String convertToASCIILowercase() const;
-    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE String convertToASCIIUppercase() const;
-    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE String convertToLowercaseWithoutLocale() const;
-    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE String convertToLowercaseWithoutLocaleStartingAtFailingIndex8Bit(unsigned) const;
-    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE String convertToUppercaseWithoutLocale() const;
-    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE String convertToLowercaseWithLocale(const AtomString& localeIdentifier) const;
-    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE String convertToUppercaseWithLocale(const AtomString& localeIdentifier) const;
+    [[nodiscard]] WTF_EXPORT_PRIVATE String convertToASCIILowercase() const;
+    [[nodiscard]] WTF_EXPORT_PRIVATE String convertToASCIIUppercase() const;
+    [[nodiscard]] WTF_EXPORT_PRIVATE String convertToLowercaseWithoutLocale() const;
+    [[nodiscard]] WTF_EXPORT_PRIVATE String convertToLowercaseWithoutLocaleStartingAtFailingIndex8Bit(unsigned) const;
+    [[nodiscard]] WTF_EXPORT_PRIVATE String convertToUppercaseWithoutLocale() const;
+    [[nodiscard]] WTF_EXPORT_PRIVATE String convertToLowercaseWithLocale(const AtomString& localeIdentifier) const;
+    [[nodiscard]] WTF_EXPORT_PRIVATE String convertToUppercaseWithLocale(const AtomString& localeIdentifier) const;
 
-    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE String simplifyWhiteSpace(CodeUnitMatchFunction) const;
+    [[nodiscard]] WTF_EXPORT_PRIVATE String simplifyWhiteSpace(CodeUnitMatchFunction) const;
 
-    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE String trim(CodeUnitMatchFunction) const;
-    template<typename Predicate> WARN_UNUSED_RETURN String removeCharacters(const Predicate&) const;
+    [[nodiscard]] WTF_EXPORT_PRIVATE String trim(CodeUnitMatchFunction) const;
+    template<typename Predicate> [[nodiscard]] String removeCharacters(const Predicate&) const;
 
     // Returns the string with case folded for case insensitive comparison.
     // Use convertToASCIILowercase instead if ASCII case insensitive comparison is desired.
-    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE String foldCase() const;
+    [[nodiscard]] WTF_EXPORT_PRIVATE String foldCase() const;
 
     // Returns an uninitialized string. The characters needs to be written
     // into the buffer returned in data before the returned string is used.
@@ -221,18 +221,18 @@ public:
     using SplitFunctor = WTF::Function<void(StringView)>;
 
     WTF_EXPORT_PRIVATE void split(char16_t separator, NOESCAPE const SplitFunctor&) const;
-    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE Vector<String> split(char16_t separator) const;
-    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE Vector<String> split(StringView separator) const;
+    [[nodiscard]] WTF_EXPORT_PRIVATE Vector<String> split(char16_t separator) const;
+    [[nodiscard]] WTF_EXPORT_PRIVATE Vector<String> split(StringView separator) const;
 
     WTF_EXPORT_PRIVATE void splitAllowingEmptyEntries(char16_t separator, NOESCAPE const SplitFunctor&) const;
-    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE Vector<String> splitAllowingEmptyEntries(char16_t separator) const;
-    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE Vector<String> splitAllowingEmptyEntries(StringView separator) const;
+    [[nodiscard]] WTF_EXPORT_PRIVATE Vector<String> splitAllowingEmptyEntries(char16_t separator) const;
+    [[nodiscard]] WTF_EXPORT_PRIVATE Vector<String> splitAllowingEmptyEntries(StringView separator) const;
 
     WTF_EXPORT_PRIVATE double toDouble(bool* ok = nullptr) const;
     WTF_EXPORT_PRIVATE float toFloat(bool* ok = nullptr) const;
 
-    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE String isolatedCopy() const &;
-    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE String isolatedCopy() &&;
+    [[nodiscard]] WTF_EXPORT_PRIVATE String isolatedCopy() const &;
+    [[nodiscard]] WTF_EXPORT_PRIVATE String isolatedCopy() &&;
 
     WTF_EXPORT_PRIVATE bool isSafeToSendToAnotherThread() const;
 
@@ -465,21 +465,21 @@ inline char16_t String::characterAt(unsigned index) const
     return m_impl->at(index);
 }
 
-WARN_UNUSED_RETURN inline String makeStringByReplacingAll(const String& string, char16_t target, char16_t replacement)
+[[nodiscard]] inline String makeStringByReplacingAll(const String& string, char16_t target, char16_t replacement)
 {
     if (auto impl = string.impl())
         return String { impl->replace(target, replacement) };
     return string;
 }
 
-WARN_UNUSED_RETURN ALWAYS_INLINE String makeStringByReplacingAll(const String& string, char16_t target, ASCIILiteral literal)
+[[nodiscard]] ALWAYS_INLINE String makeStringByReplacingAll(const String& string, char16_t target, ASCIILiteral literal)
 {
     if (auto impl = string.impl())
         return String { impl->replace(target, literal.span8()) };
     return string;
 }
 
-WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE String makeStringByRemoving(const String&, unsigned position, unsigned lengthToRemove);
+[[nodiscard]] WTF_EXPORT_PRIVATE String makeStringByRemoving(const String&, unsigned position, unsigned lengthToRemove);
 
 WTF_EXPORT_PRIVATE String makeStringByJoining(std::span<const String> strings, const String& separator);
 

--- a/Source/WTF/wtf/unix/UnixFileDescriptor.h
+++ b/Source/WTF/wtf/unix/UnixFileDescriptor.h
@@ -83,7 +83,7 @@ public:
         return UnixFileDescriptor { m_value, Duplicate };
     }
 
-    WARN_UNUSED_RETURN int release() { return std::exchange(m_value, -1); }
+    [[nodiscard]] int release() { return std::exchange(m_value, -1); }
 
 private:
     int m_value { -1 };

--- a/Source/WTF/wtf/win/GDIObject.h
+++ b/Source/WTF/wtf/win/GDIObject.h
@@ -49,7 +49,7 @@ public:
     T get() const { return m_object; }
 
     void clear();
-    WARN_UNUSED_RETURN T leak();
+    [[nodiscard]] T leak();
 
     bool operator!() const { return !m_object; }
 

--- a/Source/WTF/wtf/win/Win32Handle.h
+++ b/Source/WTF/wtf/win/Win32Handle.h
@@ -46,7 +46,7 @@ public:
 
     HANDLE get() const { return m_handle; }
 
-    WARN_UNUSED_RETURN WTF_EXPORT_PRIVATE HANDLE leak();
+    [[nodiscard]] WTF_EXPORT_PRIVATE HANDLE leak();
 
     struct IPCData {
         uintptr_t handle;

--- a/Source/WebCore/Modules/WebGPU/GPUPresentationContext.h
+++ b/Source/WebCore/Modules/WebGPU/GPUPresentationContext.h
@@ -49,7 +49,7 @@ public:
         return adoptRef(*new GPUPresentationContext(WTF::move(backing)));
     }
 
-    WARN_UNUSED_RETURN bool configure(const GPUCanvasConfiguration&, GPUIntegerCoordinate, GPUIntegerCoordinate, bool);
+    [[nodiscard]] bool configure(const GPUCanvasConfiguration&, GPUIntegerCoordinate, GPUIntegerCoordinate, bool);
     void unconfigure();
 
     RefPtr<GPUTexture> getCurrentTexture(uint32_t);

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPresentationContext.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPresentationContext.h
@@ -48,7 +48,7 @@ class PresentationContext : public RefCountedAndCanMakeWeakPtr<PresentationConte
 public:
     virtual ~PresentationContext() = default;
 
-    WARN_UNUSED_RETURN virtual bool configure(const CanvasConfiguration&) = 0;
+    [[nodiscard]] virtual bool configure(const CanvasConfiguration&) = 0;
     virtual void unconfigure() = 0;
     virtual void present(uint32_t frameIndex, bool = false) = 0;
 

--- a/Source/WebCore/Modules/indexeddb/IDBKeyData.h
+++ b/Source/WebCore/Modules/indexeddb/IDBKeyData.h
@@ -86,7 +86,7 @@ public:
     WEBCORE_EXPORT IDBKeyData isolatedCopy() const;
 
     WEBCORE_EXPORT void encode(KeyedEncoder&) const;
-    WARN_UNUSED_RETURN WEBCORE_EXPORT static bool decode(KeyedDecoder&, IDBKeyData&);
+    [[nodiscard]] WEBCORE_EXPORT static bool decode(KeyedDecoder&, IDBKeyData&);
 
     void setArrayValue(const Vector<IDBKeyData>&);
     void setBinaryValue(const ThreadSafeDataBuffer&);

--- a/Source/WebCore/Modules/indexeddb/server/IDBSerialization.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/IDBSerialization.cpp
@@ -289,7 +289,7 @@ RefPtr<SharedBuffer> serializeIDBKeyData(const IDBKeyData& key)
     return SharedBuffer::create(WTF::move(data));
 }
 
-WARN_UNUSED_RETURN static bool decodeKey(std::span<const uint8_t>& data, IDBKeyData& result)
+[[nodiscard]] static bool decodeKey(std::span<const uint8_t>& data, IDBKeyData& result)
 {
     if (data.empty())
         return false;

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h
@@ -154,7 +154,7 @@ private:
     void prepareDataChannel(GstWebRTCDataChannel*, gboolean isLocal);
     void onDataChannel(GstWebRTCDataChannel*);
 
-    WARN_UNUSED_RETURN GstElement* requestAuxiliarySender(GRefPtr<GstWebRTCDTLSTransport>&&);
+    [[nodiscard]] GstElement* requestAuxiliarySender(GRefPtr<GstWebRTCDTLSTransport>&&);
 
     MediaStream& mediaStreamFromRTCStream(String mediaStreamId);
 
@@ -167,7 +167,7 @@ private:
 
     void processSDPMessage(const GstSDPMessage*, Function<void(unsigned index, CStringView mid, const GstSDPMedia*)>);
 
-    WARN_UNUSED_RETURN GRefPtr<GstPad> requestPad(const GRefPtr<GstCaps>&, const String& mediaStreamID);
+    [[nodiscard]] GRefPtr<GstPad> requestPad(const GRefPtr<GstCaps>&, const String& mediaStreamID);
 
     std::optional<bool> isIceGatheringComplete(const String& currentLocalDescription);
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp
@@ -119,7 +119,7 @@ bool GStreamerRtpTransceiverBackend::stopped() const
     return m_isStopped;
 }
 
-WARN_UNUSED_RETURN static inline ExceptionOr<GRefPtr<GstCaps>> toRtpCodecCapability(const RTCRtpCodecCapability& codec, int& dynamicPayloadType, const String& msid)
+[[nodiscard]] static inline ExceptionOr<GRefPtr<GstCaps>> toRtpCodecCapability(const RTCRtpCodecCapability& codec, int& dynamicPayloadType, const String& msid)
 {
     if (!codec.mimeType.startsWith("video/"_s) && !codec.mimeType.startsWith("audio/"_s))
         return Exception { ExceptionCode::InvalidModificationError, "RTCRtpCodecCapability bad mimeType"_s };

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h
@@ -332,10 +332,10 @@ std::optional<int> payloadTypeForEncodingName(const String& encodingName);
 
 using RTPHeaderExtensionMapping = HashMap<String, uint8_t>;
 
-WARN_UNUSED_RETURN GRefPtr<GstCaps> capsFromRtpCapabilities(const RTPHeaderExtensionMapping&, const RTCRtpCapabilities&, Function<void(GstStructure*)> supplementCapsCallback);
+[[nodiscard]] GRefPtr<GstCaps> capsFromRtpCapabilities(const RTPHeaderExtensionMapping&, const RTCRtpCapabilities&, Function<void(GstStructure*)> supplementCapsCallback);
 
 GstWebRTCRTPTransceiverDirection getDirectionFromSDPMedia(const GstSDPMedia*);
-WARN_UNUSED_RETURN GRefPtr<GstCaps> capsFromSDPMedia(const GstSDPMedia*);
+[[nodiscard]] GRefPtr<GstCaps> capsFromSDPMedia(const GstSDPMedia*);
 
 void setSsrcAudioLevelVadOn(GstStructure*);
 
@@ -393,7 +393,7 @@ String sdpAsString(const GstSDPMessage*);
 
 bool sdpMediaHasRTPHeaderExtension(const GstSDPMedia*, const String&);
 
-WARN_UNUSED_RETURN GRefPtr<GstCaps> extractMidAndRidFromRTPBuffer(const GstMappedRtpBuffer&, const GstSDPMessage*);
+[[nodiscard]] GRefPtr<GstCaps> extractMidAndRidFromRTPBuffer(const GstMappedRtpBuffer&, const GstSDPMessage*);
 
 bool validateRTPHeaderExtensions(const GstSDPMessage* previousSDP, const GstSDPMessage* newSDP);
 

--- a/Source/WebCore/css/CSSStyleProperties.h
+++ b/Source/WebCore/css/CSSStyleProperties.h
@@ -121,7 +121,7 @@ private:
 
     RefPtr<DeprecatedCSSOMValue> wrapForDeprecatedCSSOM(CSSValue*);
 
-    WARN_UNUSED_RETURN virtual bool willMutate() { return true; }
+    [[nodiscard]] virtual bool willMutate() { return true; }
     virtual void didMutate(MutationType) { }
 };
 
@@ -148,7 +148,7 @@ private:
 
     CSSRule* parentRule() const final;
 
-    WARN_UNUSED_RETURN bool willMutate() final;
+    [[nodiscard]] bool willMutate() final;
     void didMutate(MutationType) final;
     OptionalOrReference<CSSParserContext> cssParserContext() const final;
 
@@ -169,7 +169,7 @@ private:
     CSSStyleSheet* parentStyleSheet() const final;
     StyledElement* parentElement() const final { return m_parentElement.get(); }
 
-    WARN_UNUSED_RETURN bool willMutate() final;
+    [[nodiscard]] bool willMutate() final;
     void didMutate(MutationType) final;
     OptionalOrReference<CSSParserContext> cssParserContext() const final;
 

--- a/Source/WebCore/css/PropertySetCSSDescriptors.h
+++ b/Source/WebCore/css/PropertySetCSSDescriptors.h
@@ -73,7 +73,7 @@ protected:
     RefPtr<DeprecatedCSSOMValue> wrapForDeprecatedCSSOM(CSSValue*);
 
     enum class MutationType : uint8_t { NoChanges, StyleAttributeChanged, PropertyChanged };
-    WARN_UNUSED_RETURN bool willMutate();
+    [[nodiscard]] bool willMutate();
     void didMutate(MutationType);
 
     // CSSPropertyID versions of the CSSOM functions to support bindings.

--- a/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.h
+++ b/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.h
@@ -71,7 +71,7 @@ struct UnevaluatedCalcBase {
     ~UnevaluatedCalcBase();
 
     Ref<CSSCalc::Value> protectedCalc() const;
-    WARN_UNUSED_RETURN CSSCalc::Value& leakRef();
+    [[nodiscard]] CSSCalc::Value& leakRef();
 
     bool requiresConversionData() const;
 

--- a/Source/WebCore/editing/ReplaceSelectionCommand.cpp
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.cpp
@@ -2000,7 +2000,7 @@ void ReplaceSelectionCommand::updateDirectionForStartOfInsertedContentIfNeeded(c
 }
 
 using ElementToStyleProperties = HashMap<Ref<StyledElement>, Vector<CSSPropertyID, 2>>;
-WARN_UNUSED_RETURN static IterationStatus collectStylesToRemove(Node& node, const Node& lastLeaf, double backgroundLuminance, ElementToStyleProperties& stylesToRemove)
+[[nodiscard]] static IterationStatus collectStylesToRemove(Node& node, const Node& lastLeaf, double backgroundLuminance, ElementToStyleProperties& stylesToRemove)
 {
     auto addStylesToRemove = [&](StyledElement& element) {
         RefPtr style = element.inlineStyle();

--- a/Source/WebCore/fileapi/URLKeepingBlobAlive.h
+++ b/Source/WebCore/fileapi/URLKeepingBlobAlive.h
@@ -52,7 +52,7 @@ public:
     void clear();
 
     // We do not introduce a && version since it might break the register/unregister balance.
-    WARN_UNUSED_RETURN WEBCORE_EXPORT URLKeepingBlobAlive isolatedCopy() const;
+    [[nodiscard]] WEBCORE_EXPORT URLKeepingBlobAlive isolatedCopy() const;
 
 private:
     void registerBlobURLHandleIfNecessary();

--- a/Source/WebCore/inspector/InspectorResourceUtilities.cpp
+++ b/Source/WebCore/inspector/InspectorResourceUtilities.cpp
@@ -80,7 +80,7 @@ Inspector::Protocol::Page::ResourceType resourceTypeToProtocol(Inspector::Resour
     return Inspector::Protocol::Page::ResourceType::Other;
 }
 
-WARN_UNUSED_RETURN static bool decodeBuffer(std::span<const uint8_t> buffer, const String& textEncodingName, String* result)
+[[nodiscard]] static bool decodeBuffer(std::span<const uint8_t> buffer, const String& textEncodingName, String* result)
 {
     if (buffer.data()) {
         PAL::TextEncoding encoding(textEncodingName);

--- a/Source/WebCore/loader/FetchOptions.h
+++ b/Source/WebCore/loader/FetchOptions.h
@@ -54,7 +54,7 @@ struct FetchOptions {
     FetchOptions isolatedCopy() && { return { destination, mode, credentials, cache, redirect, referrerPolicy, keepAlive, WTF::move(integrity).isolatedCopy(), clientIdentifier, resultingClientIdentifier }; }
 
     template<class Encoder> void encodePersistent(Encoder&) const;
-    template<class Decoder> WARN_UNUSED_RETURN static bool decodePersistent(Decoder&, FetchOptions&);
+    template<class Decoder> [[nodiscard]] static bool decodePersistent(Decoder&, FetchOptions&);
 
     Destination destination { Destination::EmptyString };
     Mode mode { Mode::NoCors };

--- a/Source/WebCore/page/OpportunisticTaskScheduler.h
+++ b/Source/WebCore/page/OpportunisticTaskScheduler.h
@@ -67,7 +67,7 @@ public:
     void rescheduleIfNeeded(MonotonicTime deadline);
     bool hasImminentlyScheduledWork() const { return m_imminentlyScheduledWorkCount; }
 
-    WARN_UNUSED_RETURN Ref<ImminentlyScheduledWorkScope> makeScheduledWorkScope();
+    [[nodiscard]] Ref<ImminentlyScheduledWorkScope> makeScheduledWorkScope();
 
     class FullGCActivityCallback final : public JSC::FullGCActivityCallback {
     public:

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.h
@@ -264,7 +264,7 @@ private:
     bool allPoliciesWithDispositionAllow(Disposition, ViolatedDirectiveCallback&&, Predicate&&, Args&&...) const;
 
     template<typename Predicate, typename... Args>
-    WARN_UNUSED_RETURN bool allPoliciesAllow(NOESCAPE const ViolatedDirectiveCallback&, Predicate&&, Args&&...) const;
+    [[nodiscard]] bool allPoliciesAllow(NOESCAPE const ViolatedDirectiveCallback&, Predicate&&, Args&&...) const;
     bool shouldPerformEarlyCSPCheck() const;
     
     using ResourcePredicate = const ContentSecurityPolicyDirective *(ContentSecurityPolicyDirectiveList::*)(const URL &, bool) const;

--- a/Source/WebCore/platform/KeyedCoding.h
+++ b/Source/WebCore/platform/KeyedCoding.h
@@ -41,17 +41,17 @@ public:
 
     virtual ~KeyedDecoder() = default;
 
-    WARN_UNUSED_RETURN virtual bool decodeBytes(const String& key, std::span<const uint8_t>&) = 0;
-    WARN_UNUSED_RETURN virtual bool decodeBool(const String& key, bool&) = 0;
-    WARN_UNUSED_RETURN virtual bool decodeUInt32(const String& key, uint32_t&) = 0;
-    WARN_UNUSED_RETURN virtual bool decodeUInt64(const String& key, uint64_t&) = 0;
-    WARN_UNUSED_RETURN virtual bool decodeInt32(const String& key, int32_t&) = 0;
-    WARN_UNUSED_RETURN virtual bool decodeInt64(const String& key, int64_t&) = 0;
-    WARN_UNUSED_RETURN virtual bool decodeFloat(const String& key, float&) = 0;
-    WARN_UNUSED_RETURN virtual bool decodeDouble(const String& key, double&) = 0;
-    WARN_UNUSED_RETURN virtual bool decodeString(const String& key, String&) = 0;
+    [[nodiscard]] virtual bool decodeBytes(const String& key, std::span<const uint8_t>&) = 0;
+    [[nodiscard]] virtual bool decodeBool(const String& key, bool&) = 0;
+    [[nodiscard]] virtual bool decodeUInt32(const String& key, uint32_t&) = 0;
+    [[nodiscard]] virtual bool decodeUInt64(const String& key, uint64_t&) = 0;
+    [[nodiscard]] virtual bool decodeInt32(const String& key, int32_t&) = 0;
+    [[nodiscard]] virtual bool decodeInt64(const String& key, int64_t&) = 0;
+    [[nodiscard]] virtual bool decodeFloat(const String& key, float&) = 0;
+    [[nodiscard]] virtual bool decodeDouble(const String& key, double&) = 0;
+    [[nodiscard]] virtual bool decodeString(const String& key, String&) = 0;
 
-    template<typename T> WARN_UNUSED_RETURN
+    template<typename T> [[nodiscard]]
     bool decodeBytes(const String& key, Vector<T>& vector)
     {
         static_assert(sizeof(T) == 1);
@@ -64,7 +64,7 @@ public:
         return true;
     }
 
-    template<typename T, typename F> WARN_UNUSED_RETURN
+    template<typename T, typename F> [[nodiscard]]
     bool decodeEnum(const String& key, T& value, F&& isValidEnumFunction)
     {
         static_assert(std::is_enum<T>::value, "T must be an enum type");
@@ -80,7 +80,7 @@ public:
         return true;
     }
 
-    template<typename T, typename F> WARN_UNUSED_RETURN
+    template<typename T, typename F> [[nodiscard]]
     bool decodeObject(const String& key, T& object, F&& function)
     {
         if (!beginObject(key))
@@ -90,7 +90,7 @@ public:
         return result;
     }
 
-    template<typename T, typename F> WARN_UNUSED_RETURN
+    template<typename T, typename F> [[nodiscard]]
     bool decodeConditionalObject(const String& key, T& object, F&& function)
     {
         // FIXME: beginObject can return false for two reasons: either the
@@ -105,7 +105,7 @@ public:
         return result;
     }
 
-    template<typename ContainerType, typename F> WARN_UNUSED_RETURN
+    template<typename ContainerType, typename F> [[nodiscard]]
     bool decodeObjects(const String& key, ContainerType& objects, F&& function)
     {
         if (!beginArray(key))

--- a/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp
+++ b/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp
@@ -64,7 +64,7 @@
 
 namespace WebCore {
 
-WARN_UNUSED_RETURN static AudioBufferList* tryCreateAudioBufferList(size_t numberOfBuffers)
+[[nodiscard]] static AudioBufferList* tryCreateAudioBufferList(size_t numberOfBuffers)
 {
     if (!numberOfBuffers)
         return nullptr;

--- a/Source/WebCore/platform/cf/KeyedDecoderCF.h
+++ b/Source/WebCore/platform/cf/KeyedDecoderCF.h
@@ -40,15 +40,15 @@ public:
     ~KeyedDecoderCF() override;
 
 private:
-    WARN_UNUSED_RETURN bool decodeBytes(const String& key, std::span<const uint8_t>&) override;
-    WARN_UNUSED_RETURN bool decodeBool(const String& key, bool&) override;
-    WARN_UNUSED_RETURN bool decodeUInt32(const String& key, uint32_t&) override;
-    WARN_UNUSED_RETURN bool decodeUInt64(const String& key, uint64_t&) override;
-    WARN_UNUSED_RETURN bool decodeInt32(const String& key, int32_t&) override;
-    WARN_UNUSED_RETURN bool decodeInt64(const String& key, int64_t&) override;
-    WARN_UNUSED_RETURN bool decodeFloat(const String& key, float&) override;
-    WARN_UNUSED_RETURN bool decodeDouble(const String& key, double&) override;
-    WARN_UNUSED_RETURN bool decodeString(const String& key, String&) override;
+    [[nodiscard]] bool decodeBytes(const String& key, std::span<const uint8_t>&) override;
+    [[nodiscard]] bool decodeBool(const String& key, bool&) override;
+    [[nodiscard]] bool decodeUInt32(const String& key, uint32_t&) override;
+    [[nodiscard]] bool decodeUInt64(const String& key, uint64_t&) override;
+    [[nodiscard]] bool decodeInt32(const String& key, int32_t&) override;
+    [[nodiscard]] bool decodeInt64(const String& key, int64_t&) override;
+    [[nodiscard]] bool decodeFloat(const String& key, float&) override;
+    [[nodiscard]] bool decodeDouble(const String& key, double&) override;
+    [[nodiscard]] bool decodeString(const String& key, String&) override;
 
     bool beginObject(const String& key) override;
     void endObject() override;

--- a/Source/WebCore/platform/encryptedmedia/CDMProxy.h
+++ b/Source/WebCore/platform/encryptedmedia/CDMProxy.h
@@ -150,7 +150,7 @@ public:
     void clear() { m_keys.clear(); }
     bool containsKeyID(const KeyIDType& keyID) const { return m_keys.contains(keyID); }
 
-    WARN_UNUSED_RETURN RefPtr<T> keyHandle(const KeyIDType& keyID) const
+    [[nodiscard]] RefPtr<T> keyHandle(const KeyIDType& keyID) const
     {
         auto findingResult = m_keys.find(keyID);
         if (findingResult == m_keys.end())
@@ -158,7 +158,7 @@ public:
         return findingResult->value;
     }
 
-    WARN_UNUSED_RETURN KeyStatusVector allKeysAs(CDMInstanceSession::KeyStatus status) const
+    [[nodiscard]] KeyStatusVector allKeysAs(CDMInstanceSession::KeyStatus status) const
     {
         CDMInstanceSession::KeyStatusVector keyStatusVector = convertToJSKeyStatusVector();
         for (auto& keyStatus : keyStatusVector)
@@ -166,7 +166,7 @@ public:
         return keyStatusVector;
     }
 
-    WARN_UNUSED_RETURN KeyStatusVector convertToJSKeyStatusVector() const
+    [[nodiscard]] KeyStatusVector convertToJSKeyStatusVector() const
     {
         KeyStoreBase::KeyStatusVector vector;
         for (const auto& key : m_keys.values())
@@ -283,7 +283,7 @@ public:
 
     WEBCORE_EXPORT static void registerFactory(CDMProxyFactory&);
     WEBCORE_EXPORT static void unregisterFactory(CDMProxyFactory&);
-    WARN_UNUSED_RETURN WEBCORE_EXPORT static RefPtr<CDMProxy> createCDMProxyForKeySystem(const String&);
+    [[nodiscard]] WEBCORE_EXPORT static RefPtr<CDMProxy> createCDMProxyForKeySystem(const String&);
 
 protected:
     virtual RefPtr<CDMProxy> createCDMProxy(const String&) = 0;

--- a/Source/WebCore/platform/generic/KeyedDecoderGeneric.h
+++ b/Source/WebCore/platform/generic/KeyedDecoderGeneric.h
@@ -37,15 +37,15 @@ public:
     using Array = Vector<std::unique_ptr<Dictionary>>;
 
 private:
-    WARN_UNUSED_RETURN bool decodeBytes(const String& key, std::span<const uint8_t>&) override;
-    WARN_UNUSED_RETURN bool decodeBool(const String& key, bool&) override;
-    WARN_UNUSED_RETURN bool decodeUInt32(const String& key, uint32_t&) override;
-    WARN_UNUSED_RETURN bool decodeUInt64(const String& key, uint64_t&) override;
-    WARN_UNUSED_RETURN bool decodeInt32(const String& key, int32_t&) override;
-    WARN_UNUSED_RETURN bool decodeInt64(const String& key, int64_t&) override;
-    WARN_UNUSED_RETURN bool decodeFloat(const String& key, float&) override;
-    WARN_UNUSED_RETURN bool decodeDouble(const String& key, double&) override;
-    WARN_UNUSED_RETURN bool decodeString(const String& key, String&) override;
+    [[nodiscard]] bool decodeBytes(const String& key, std::span<const uint8_t>&) override;
+    [[nodiscard]] bool decodeBool(const String& key, bool&) override;
+    [[nodiscard]] bool decodeUInt32(const String& key, uint32_t&) override;
+    [[nodiscard]] bool decodeUInt64(const String& key, uint64_t&) override;
+    [[nodiscard]] bool decodeInt32(const String& key, int32_t&) override;
+    [[nodiscard]] bool decodeInt64(const String& key, int64_t&) override;
+    [[nodiscard]] bool decodeFloat(const String& key, float&) override;
+    [[nodiscard]] bool decodeDouble(const String& key, double&) override;
+    [[nodiscard]] bool decodeString(const String& key, String&) override;
 
     bool beginObject(const String& key) override;
     void endObject() override;
@@ -58,7 +58,7 @@ private:
     template<typename T>
     const T* getPointerFromDictionaryStack(const String& key);
 
-    template<typename T> WARN_UNUSED_RETURN
+    template<typename T> [[nodiscard]]
     bool decodeSimpleValue(const String& key, T& result);
 
     std::unique_ptr<Dictionary> m_rootDictionary;

--- a/Source/WebCore/platform/glib/KeyedDecoderGlib.h
+++ b/Source/WebCore/platform/glib/KeyedDecoderGlib.h
@@ -41,15 +41,15 @@ public:
     ~KeyedDecoderGlib() override;
 
 private:
-    WARN_UNUSED_RETURN bool decodeBytes(const String& key, std::span<const uint8_t>&) override;
-    WARN_UNUSED_RETURN bool decodeBool(const String& key, bool&) override;
-    WARN_UNUSED_RETURN bool decodeUInt32(const String& key, uint32_t&) override;
-    WARN_UNUSED_RETURN bool decodeUInt64(const String& key, uint64_t&) override;
-    WARN_UNUSED_RETURN bool decodeInt32(const String& key, int32_t&) override;
-    WARN_UNUSED_RETURN bool decodeInt64(const String& key, int64_t&) override;
-    WARN_UNUSED_RETURN bool decodeFloat(const String& key, float&) override;
-    WARN_UNUSED_RETURN bool decodeDouble(const String& key, double&) override;
-    WARN_UNUSED_RETURN bool decodeString(const String& key, String&) override;
+    [[nodiscard]] bool decodeBytes(const String& key, std::span<const uint8_t>&) override;
+    [[nodiscard]] bool decodeBool(const String& key, bool&) override;
+    [[nodiscard]] bool decodeUInt32(const String& key, uint32_t&) override;
+    [[nodiscard]] bool decodeUInt64(const String& key, uint64_t&) override;
+    [[nodiscard]] bool decodeInt32(const String& key, int32_t&) override;
+    [[nodiscard]] bool decodeInt64(const String& key, int64_t&) override;
+    [[nodiscard]] bool decodeFloat(const String& key, float&) override;
+    [[nodiscard]] bool decodeDouble(const String& key, double&) override;
+    [[nodiscard]] bool decodeString(const String& key, String&) override;
 
     bool beginObject(const String& key) override;
     void endObject() override;
@@ -59,7 +59,7 @@ private:
     void endArrayElement() override;
     void endArray() override;
 
-    template<typename T, typename F> WARN_UNUSED_RETURN bool decodeSimpleValue(const String& key, T& result, F getFunction);
+    template<typename T, typename F> [[nodiscard]] bool decodeSimpleValue(const String& key, T& result, F getFunction);
     HashMap<String, GRefPtr<GVariant>> dictionaryFromGVariant(GVariant*);
 
     Vector<HashMap<String, GRefPtr<GVariant>>> m_dictionaryStack;

--- a/Source/WebCore/platform/graphics/IntRect.h
+++ b/Source/WebCore/platform/graphics/IntRect.h
@@ -201,7 +201,7 @@ public:
 
     // Return false if x + width or y + height overflows.
     WEBCORE_EXPORT bool isValid() const;
-    WARN_UNUSED_RETURN WEBCORE_EXPORT IntRect toRectWithExtentsClippedToNumericLimits() const;
+    [[nodiscard]] WEBCORE_EXPORT IntRect toRectWithExtentsClippedToNumericLimits() const;
 
     friend bool operator==(const IntRect&, const IntRect&) = default;
 

--- a/Source/WebCore/platform/graphics/TrackBuffer.cpp
+++ b/Source/WebCore/platform/graphics/TrackBuffer.cpp
@@ -377,7 +377,7 @@ PlatformTimeRanges TrackBuffer::removeSamples(const DecodeOrderSampleMap::MapTyp
     return erasedRanges;
 }
 
-WARN_UNUSED_RETURN static bool decodeTimeComparator(const PresentationOrderSampleMap::MapType::value_type& a, const PresentationOrderSampleMap::MapType::value_type& b)
+[[nodiscard]] static bool decodeTimeComparator(const PresentationOrderSampleMap::MapType::value_type& a, const PresentationOrderSampleMap::MapType::value_type& b)
 {
     return Ref { a.second }->decodeTime() < Ref { b.second }->decodeTime();
 };

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
@@ -362,7 +362,7 @@ protected:
     bool updateErrors();
 
     // Called once by all the public entry points that eventually call OpenGL.
-    WARN_UNUSED_RETURN bool makeContextCurrent();
+    [[nodiscard]] bool makeContextCurrent();
 
     // Initializes the instance. Returns false if the instance should not be used.
     bool initialize();
@@ -406,7 +406,7 @@ protected:
     virtual void invalidateKnownTextureContent(GCGLuint);
     bool supportsExtensionImpl(ASCIILiteral) const;
     // Enables extensions only if all are supported, returns true if all the extensions are supported. No changes if false is returned.
-    WARN_UNUSED_RETURN bool enableExtensionsImpl(std::initializer_list<ASCIILiteral>);
+    [[nodiscard]] bool enableExtensionsImpl(std::initializer_list<ASCIILiteral>);
     bool isExtensionEnabledImpl(ASCIILiteral) const;
 
     // Only for non-WebGL 2.0 contexts.

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -123,7 +123,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(WebCoreLogObserver);
 
 static GstClockTime s_webkitGstInitTime;
 
-WARN_UNUSED_RETURN GstPad* webkitGstGhostPadFromStaticTemplate(GstStaticPadTemplate* staticPadTemplate, CStringView name, GstPad* target)
+[[nodiscard]] GstPad* webkitGstGhostPadFromStaticTemplate(GstStaticPadTemplate* staticPadTemplate, CStringView name, GstPad* target)
 {
     GstPad* pad;
     GRefPtr padTemplate = gst_static_pad_template_get(staticPadTemplate);

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -85,7 +85,7 @@ inline bool gst_check_version(guint major, guint minor, guint micro)
 #define GST_AUDIO_CAPS_TYPE_PREFIX  "audio/"_s
 #define GST_TEXT_CAPS_TYPE_PREFIX   "text/"_s
 
-WARN_UNUSED_RETURN GstPad* webkitGstGhostPadFromStaticTemplate(GstStaticPadTemplate*, CStringView name, GstPad* target);
+[[nodiscard]] GstPad* webkitGstGhostPadFromStaticTemplate(GstStaticPadTemplate*, CStringView name, GstPad* target);
 #if ENABLE(VIDEO)
 bool getVideoSizeAndFormatFromCaps(const GstCaps*, WebCore::IntSize&, GstVideoFormat&, int& pixelAspectRatioNumerator, int& pixelAspectRatioDenominator, int& stride, double& frameRate, PlatformVideoColorSpace&);
 std::optional<FloatSize> getVideoResolutionFromCaps(const GstCaps*);
@@ -376,7 +376,7 @@ String gstIdToString(GstId);
 void gstStructureFilterAndMapInPlace(GstStructure*, Function<bool(GstId, GValue*)>&&);
 
 #if USE(GBM)
-WARN_UNUSED_RETURN GRefPtr<GstCaps> buildDMABufCaps();
+[[nodiscard]] GRefPtr<GstCaps> buildDMABufCaps();
 #endif
 
 #if USE(GSTREAMER_GL)

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoFrameConverter.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoFrameConverter.h
@@ -40,7 +40,7 @@ public:
     void ref() const { }
     void deref() const { }
 
-    WARN_UNUSED_RETURN GRefPtr<GstSample> convert(const GRefPtr<GstSample>&, const GRefPtr<GstCaps>&);
+    [[nodiscard]] GRefPtr<GstSample> convert(const GRefPtr<GstSample>&, const GRefPtr<GstCaps>&);
 
 private:
     GStreamerVideoFrameConverter();

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameMetadataGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameMetadataGStreamer.h
@@ -31,7 +31,7 @@
 void webkitGstBufferAddVideoFrameMetadata(GstBuffer*, std::optional<WebCore::VideoFrameTimeMetadata>, WebCore::VideoFrame::Rotation, bool isMirrored, WebCore::VideoFrameContentHint);
 
 // Makes the buffer writable before modifying it.
-WARN_UNUSED_RETURN GRefPtr<GstBuffer> webkitGstBufferSetVideoFrameMetadata(GRefPtr<GstBuffer>&&, std::optional<WebCore::VideoFrameTimeMetadata>, WebCore::VideoFrame::Rotation = WebCore::VideoFrame::Rotation::None, bool isMirrored = false, WebCore::VideoFrameContentHint = WebCore::VideoFrameContentHint::None);
+[[nodiscard]] GRefPtr<GstBuffer> webkitGstBufferSetVideoFrameMetadata(GRefPtr<GstBuffer>&&, std::optional<WebCore::VideoFrameTimeMetadata>, WebCore::VideoFrame::Rotation = WebCore::VideoFrame::Rotation::None, bool isMirrored = false, WebCore::VideoFrameContentHint = WebCore::VideoFrameContentHint::None);
 
 void webkitGstTraceProcessingTimeForElement(GstElement*);
 WebCore::VideoFrameMetadata webkitGstBufferGetVideoFrameMetadata(GstBuffer*);

--- a/Source/WebCore/platform/graphics/transforms/TransformationMatrix.h
+++ b/Source/WebCore/platform/graphics/transforms/TransformationMatrix.h
@@ -336,10 +336,10 @@ public:
         friend bool operator==(const Decomposed4Type&, const Decomposed4Type&) = default;
     };
     
-    WARN_UNUSED_RETURN bool decompose2(Decomposed2Type&) const;
+    [[nodiscard]] bool decompose2(Decomposed2Type&) const;
     void recompose2(const Decomposed2Type&);
 
-    WARN_UNUSED_RETURN WEBCORE_EXPORT bool decompose4(Decomposed4Type&) const;
+    [[nodiscard]] WEBCORE_EXPORT bool decompose4(Decomposed4Type&) const;
     void recompose4(const Decomposed4Type&);
 
     WEBCORE_EXPORT void blend(const TransformationMatrix& from, double progress, CompositeOperation = CompositeOperation::Replace);

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDevice.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDevice.h
@@ -36,7 +36,7 @@ public:
     {
     }
 
-    WARN_UNUSED_RETURN GRefPtr<GstCaps> caps() const { return adoptGRef(gst_device_get_caps(m_device.get())); }
+    [[nodiscard]] GRefPtr<GstCaps> caps() const { return adoptGRef(gst_device_get_caps(m_device.get())); }
     GstDevice* device() const { return m_device.get(); }
 
 private:

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h
@@ -65,7 +65,7 @@ public:
     void start();
     void stop();
     bool isStopped() const;
-    WARN_UNUSED_RETURN GRefPtr<GstCaps> caps();
+    [[nodiscard]] GRefPtr<GstCaps> caps();
 
     std::pair<GstClockTime, GstClockTime> queryLatency();
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
@@ -63,7 +63,7 @@ static GstStaticPadTemplate audioSrcTemplate = GST_STATIC_PAD_TEMPLATE("audio_sr
 GST_DEBUG_CATEGORY_STATIC(webkitMediaStreamSrcDebug);
 #define GST_CAT_DEFAULT webkitMediaStreamSrcDebug
 
-WARN_UNUSED_RETURN GRefPtr<GstTagList> mediaStreamTrackPrivateGetTags(const RefPtr<MediaStreamTrackPrivate>& track)
+[[nodiscard]] GRefPtr<GstTagList> mediaStreamTrackPrivateGetTags(const RefPtr<MediaStreamTrackPrivate>& track)
 {
     auto tagList = adoptGRef(gst_tag_list_new_empty());
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerRTPPacketizer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerRTPPacketizer.h
@@ -38,7 +38,7 @@ public:
     GstElement* bin() const { return m_bin.get(); }
     GstElement* payloader() const { return m_payloader.get(); }
 
-    WARN_UNUSED_RETURN GUniquePtr<GstStructure> rtpParameters() const;
+    [[nodiscard]] GUniquePtr<GstStructure> rtpParameters() const;
 
     void configureExtensions();
     void ensureMidExtension(const String&);

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.h
@@ -38,7 +38,7 @@ public:
     ~RealtimeOutgoingAudioSourceGStreamer();
 
     void setInitialParameters(GUniquePtr<GstStructure>&&) final;
-    WARN_UNUSED_RETURN GRefPtr<GstPad> outgoingSourcePad() const final;
+    [[nodiscard]] GRefPtr<GstPad> outgoingSourcePad() const final;
     RefPtr<GStreamerRTPPacketizer> createPacketizer(RefPtr<UniqueSSRCGenerator>, const GstStructure*, GUniquePtr<GstStructure>&&) final;
 
     void dispatchBitrateRequest(uint32_t bitrate) final;

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.h
@@ -49,7 +49,7 @@ public:
     void setMediaStreamID(const String& mediaStreamId) { m_mediaStreamId = mediaStreamId; }
     const String& mediaStreamID() const { return m_mediaStreamId; }
     const GRefPtr<GstCaps>& allowedCaps() const;
-    WARN_UNUSED_RETURN GRefPtr<GstCaps> rtpCaps() const;
+    [[nodiscard]] GRefPtr<GstCaps> rtpCaps() const;
 
     void link();
     const GRefPtr<GstPad>& pad() const { return m_webrtcSinkPad; }
@@ -66,11 +66,11 @@ public:
 
     void configure(GRefPtr<GstCaps>&&);
 
-    WARN_UNUSED_RETURN GUniquePtr<GstStructure> stats();
+    [[nodiscard]] GUniquePtr<GstStructure> stats();
 
-    WARN_UNUSED_RETURN GUniquePtr<GstStructure> mediaCaptureStats();
+    [[nodiscard]] GUniquePtr<GstStructure> mediaCaptureStats();
 
-    WARN_UNUSED_RETURN virtual GRefPtr<GstPad> outgoingSourcePad() const = 0;
+    [[nodiscard]] virtual GRefPtr<GstPad> outgoingSourcePad() const = 0;
     virtual RefPtr<GStreamerRTPPacketizer> createPacketizer(RefPtr<UniqueSSRCGenerator>, const GstStructure*, GUniquePtr<GstStructure>&&) = 0;
 
     void replaceTrack(const RefPtr<MediaStreamTrack>&);

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.h
@@ -34,7 +34,7 @@ public:
 
     void setApplyRotation(bool shouldApplyRotation) { m_shouldApplyRotation = shouldApplyRotation; }
 
-    WARN_UNUSED_RETURN GRefPtr<GstPad> outgoingSourcePad() const final;
+    [[nodiscard]] GRefPtr<GstPad> outgoingSourcePad() const final;
     RefPtr<GStreamerRTPPacketizer> createPacketizer(RefPtr<UniqueSSRCGenerator>, const GstStructure*, GUniquePtr<GstStructure>&&) final;
 
     void dispatchBitrateRequest(uint32_t bitrate) final;

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoFrameLibWebRTC.h
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoFrameLibWebRTC.h
@@ -31,7 +31,7 @@
 
 namespace WebCore {
 
-WARN_UNUSED_RETURN GRefPtr<GstSample> convertLibWebRTCVideoFrameToGStreamerSample(const webrtc::VideoFrame&);
+[[nodiscard]] GRefPtr<GstSample> convertLibWebRTCVideoFrameToGStreamerSample(const webrtc::VideoFrame&);
 
 webrtc::VideoFrame convertGStreamerSampleToLibWebRTCVideoFrame(GRefPtr<GstSample>&&, uint32_t rtpTimestamp);
 

--- a/Source/WebCore/rendering/RenderWidget.h
+++ b/Source/WebCore/rendering/RenderWidget.h
@@ -72,7 +72,7 @@ public:
     static RenderWidget* find(const Widget&);
 
     enum class ChildWidgetState { Valid, Destroyed };
-    WARN_UNUSED_RETURN ChildWidgetState updateWidgetPosition();
+    [[nodiscard]] ChildWidgetState updateWidgetPosition();
     WEBCORE_EXPORT IntRect windowClipRect() const;
 
     virtual bool requiresAcceleratedCompositing() const;

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -38,7 +38,7 @@ public:
     explicit RenderStyle(CreateDefaultStyleTag);
     RenderStyle(const RenderStyle&, CloneTag);
 
-    WARN_UNUSED_RETURN RenderStyle replace(RenderStyle&&);
+    [[nodiscard]] RenderStyle replace(RenderStyle&&);
 
     static RenderStyle& defaultStyleSingleton();
 

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.h
@@ -51,7 +51,7 @@ public:
     enum class IsInternalMove : bool { No, Yes };
     enum class WillBeDestroyed : bool { No, Yes };
     enum class CanCollapseAnonymousBlock : bool { No, Yes };
-    WARN_UNUSED_RETURN RenderPtr<RenderObject> detach(RenderElement&, RenderObject&, WillBeDestroyed, CanCollapseAnonymousBlock = CanCollapseAnonymousBlock::Yes);
+    [[nodiscard]] RenderPtr<RenderObject> detach(RenderElement&, RenderObject&, WillBeDestroyed, CanCollapseAnonymousBlock = CanCollapseAnonymousBlock::Yes);
 
     enum class TearDownType : uint8_t {
         Root,                          // destroy root renderer
@@ -82,8 +82,8 @@ private:
     void attachToRenderElement(RenderElement& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild = nullptr);
     void attachToRenderElementInternal(RenderElement& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild = nullptr);
 
-    WARN_UNUSED_RETURN RenderPtr<RenderObject> detachFromRenderElement(RenderElement& parent, RenderObject& child, WillBeDestroyed);
-    WARN_UNUSED_RETURN RenderPtr<RenderObject> detachFromRenderGrid(RenderGrid& parent, RenderObject& child, WillBeDestroyed);
+    [[nodiscard]] RenderPtr<RenderObject> detachFromRenderElement(RenderElement& parent, RenderObject& child, WillBeDestroyed);
+    [[nodiscard]] RenderPtr<RenderObject> detachFromRenderGrid(RenderGrid& parent, RenderObject& child, WillBeDestroyed);
 
     void move(RenderBoxModelObject& from, RenderBoxModelObject& to, RenderObject& child, RenderObject* beforeChild, NormalizeAfterInsertion);
     // Move all of the kids from |startChild| up to but excluding |endChild|. 0 can be passed as the |endChild| to denote

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderBlock.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderBlock.h
@@ -42,8 +42,8 @@ public:
     void attach(RenderBlock& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild);
     void attachIgnoringContinuation(RenderBlock& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild);
 
-    WARN_UNUSED_RETURN RenderPtr<RenderObject> detach(RenderBlock& parent, RenderObject& oldChild, RenderTreeBuilder::WillBeDestroyed, CanCollapseAnonymousBlock = CanCollapseAnonymousBlock::Yes);
-    WARN_UNUSED_RETURN RenderPtr<RenderObject> detach(RenderBlockFlow& parent, RenderObject& child, RenderTreeBuilder::WillBeDestroyed, CanCollapseAnonymousBlock = CanCollapseAnonymousBlock::Yes);
+    [[nodiscard]] RenderPtr<RenderObject> detach(RenderBlock& parent, RenderObject& oldChild, RenderTreeBuilder::WillBeDestroyed, CanCollapseAnonymousBlock = CanCollapseAnonymousBlock::Yes);
+    [[nodiscard]] RenderPtr<RenderObject> detach(RenderBlockFlow& parent, RenderObject& child, RenderTreeBuilder::WillBeDestroyed, CanCollapseAnonymousBlock = CanCollapseAnonymousBlock::Yes);
 
     void dropAnonymousBoxChild(RenderBlock& parent, RenderBlock& child);
     void childBecameNonInline(RenderBlock& parent, RenderElement& child);

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderFormControls.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderFormControls.h
@@ -42,8 +42,8 @@ public:
     void attach(RenderButton& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild);
     void attach(RenderMenuList& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild);
 
-    WARN_UNUSED_RETURN RenderPtr<RenderObject> detach(RenderButton& parent, RenderObject& child, RenderTreeBuilder::WillBeDestroyed);
-    WARN_UNUSED_RETURN RenderPtr<RenderObject> detach(RenderMenuList& parent, RenderObject& child, RenderTreeBuilder::WillBeDestroyed);
+    [[nodiscard]] RenderPtr<RenderObject> detach(RenderButton& parent, RenderObject& child, RenderTreeBuilder::WillBeDestroyed);
+    [[nodiscard]] RenderPtr<RenderObject> detach(RenderMenuList& parent, RenderObject& child, RenderTreeBuilder::WillBeDestroyed);
 
 private:
     RenderBlock& findOrCreateParentForChild(RenderButton&);

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderSVG.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderSVG.h
@@ -51,11 +51,11 @@ public:
     void attach(RenderSVGText& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild);
     void attach(RenderSVGRoot& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild);
 
-    WARN_UNUSED_RETURN RenderPtr<RenderObject> detach(LegacyRenderSVGRoot& parent, RenderObject& child, RenderTreeBuilder::WillBeDestroyed);
-    WARN_UNUSED_RETURN RenderPtr<RenderObject> detach(LegacyRenderSVGContainer& parent, RenderObject& child, RenderTreeBuilder::WillBeDestroyed);
-    WARN_UNUSED_RETURN RenderPtr<RenderObject> detach(RenderSVGInline& parent, RenderObject& child, RenderTreeBuilder::WillBeDestroyed);
+    [[nodiscard]] RenderPtr<RenderObject> detach(LegacyRenderSVGRoot& parent, RenderObject& child, RenderTreeBuilder::WillBeDestroyed);
+    [[nodiscard]] RenderPtr<RenderObject> detach(LegacyRenderSVGContainer& parent, RenderObject& child, RenderTreeBuilder::WillBeDestroyed);
+    [[nodiscard]] RenderPtr<RenderObject> detach(RenderSVGInline& parent, RenderObject& child, RenderTreeBuilder::WillBeDestroyed);
 
-    WARN_UNUSED_RETURN RenderPtr<RenderObject> detach(RenderSVGText& parent, RenderObject& child, RenderTreeBuilder::WillBeDestroyed);
+    [[nodiscard]] RenderPtr<RenderObject> detach(RenderSVGText& parent, RenderObject& child, RenderTreeBuilder::WillBeDestroyed);
 
 private:
     RenderSVGViewportContainer& findOrCreateParentForChild(RenderSVGRoot&);

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -160,49 +160,49 @@ public:
 
     std::optional<FailedCheck> check();
 
-    WARN_UNUSED_RETURN Result<void> visit(ShaderModule&);
+    [[nodiscard]] Result<void> visit(ShaderModule&);
 
     // Declarations
-    WARN_UNUSED_RETURN Result<void> visit(AST::Declaration&);
-    WARN_UNUSED_RETURN Result<void> visit(AST::Structure&);
-    WARN_UNUSED_RETURN Result<void> visit(AST::Variable&);
-    WARN_UNUSED_RETURN Result<void> visit(AST::Function&);
-    WARN_UNUSED_RETURN Result<void> visit(AST::TypeAlias&);
-    WARN_UNUSED_RETURN Result<void> visit(AST::ConstAssert&);
+    [[nodiscard]] Result<void> visit(AST::Declaration&);
+    [[nodiscard]] Result<void> visit(AST::Structure&);
+    [[nodiscard]] Result<void> visit(AST::Variable&);
+    [[nodiscard]] Result<void> visit(AST::Function&);
+    [[nodiscard]] Result<void> visit(AST::TypeAlias&);
+    [[nodiscard]] Result<void> visit(AST::ConstAssert&);
 
     // Attributes
-    WARN_UNUSED_RETURN Result<void> visit(AST::Attribute&);
-    WARN_UNUSED_RETURN Result<void> visit(AST::AlignAttribute&);
-    WARN_UNUSED_RETURN Result<void> visit(AST::BindingAttribute&);
-    WARN_UNUSED_RETURN Result<void> visit(AST::GroupAttribute&);
-    WARN_UNUSED_RETURN Result<void> visit(AST::IdAttribute&);
-    WARN_UNUSED_RETURN Result<void> visit(AST::LocationAttribute&);
-    WARN_UNUSED_RETURN Result<void> visit(AST::SizeAttribute&);
-    WARN_UNUSED_RETURN Result<void> visit(AST::WorkgroupSizeAttribute&);
+    [[nodiscard]] Result<void> visit(AST::Attribute&);
+    [[nodiscard]] Result<void> visit(AST::AlignAttribute&);
+    [[nodiscard]] Result<void> visit(AST::BindingAttribute&);
+    [[nodiscard]] Result<void> visit(AST::GroupAttribute&);
+    [[nodiscard]] Result<void> visit(AST::IdAttribute&);
+    [[nodiscard]] Result<void> visit(AST::LocationAttribute&);
+    [[nodiscard]] Result<void> visit(AST::SizeAttribute&);
+    [[nodiscard]] Result<void> visit(AST::WorkgroupSizeAttribute&);
 
     // Statements
-    WARN_UNUSED_RETURN Result<void> visit(AST::Statement&);
-    WARN_UNUSED_RETURN Result<void> visit(AST::AssignmentStatement&);
-    WARN_UNUSED_RETURN Result<void> visit(AST::CallStatement&);
-    WARN_UNUSED_RETURN Result<void> visit(AST::CompoundAssignmentStatement&);
-    WARN_UNUSED_RETURN Result<void> visit(AST::CompoundStatement&);
-    WARN_UNUSED_RETURN Result<void> visit(AST::DecrementIncrementStatement&);
-    WARN_UNUSED_RETURN Result<void> visit(AST::IfStatement&);
-    WARN_UNUSED_RETURN Result<void> visit(AST::PhonyAssignmentStatement&);
-    WARN_UNUSED_RETURN Result<void> visit(AST::ReturnStatement&);
-    WARN_UNUSED_RETURN Result<void> visit(AST::ForStatement&);
-    WARN_UNUSED_RETURN Result<void> visit(AST::LoopStatement&);
-    WARN_UNUSED_RETURN Result<void> visit(AST::WhileStatement&);
-    WARN_UNUSED_RETURN Result<void> visit(AST::SwitchStatement&);
+    [[nodiscard]] Result<void> visit(AST::Statement&);
+    [[nodiscard]] Result<void> visit(AST::AssignmentStatement&);
+    [[nodiscard]] Result<void> visit(AST::CallStatement&);
+    [[nodiscard]] Result<void> visit(AST::CompoundAssignmentStatement&);
+    [[nodiscard]] Result<void> visit(AST::CompoundStatement&);
+    [[nodiscard]] Result<void> visit(AST::DecrementIncrementStatement&);
+    [[nodiscard]] Result<void> visit(AST::IfStatement&);
+    [[nodiscard]] Result<void> visit(AST::PhonyAssignmentStatement&);
+    [[nodiscard]] Result<void> visit(AST::ReturnStatement&);
+    [[nodiscard]] Result<void> visit(AST::ForStatement&);
+    [[nodiscard]] Result<void> visit(AST::LoopStatement&);
+    [[nodiscard]] Result<void> visit(AST::WhileStatement&);
+    [[nodiscard]] Result<void> visit(AST::SwitchStatement&);
 
     // Expressions
-    WARN_UNUSED_RETURN Result<void> visit(AST::Expression&);
-    WARN_UNUSED_RETURN Result<void> visit(AST::FieldAccessExpression&);
-    WARN_UNUSED_RETURN Result<void> visit(AST::IndexAccessExpression&);
-    WARN_UNUSED_RETURN Result<void> visit(AST::BinaryExpression&);
-    WARN_UNUSED_RETURN Result<void> visit(AST::IdentifierExpression&);
-    WARN_UNUSED_RETURN Result<void> visit(AST::CallExpression&);
-    WARN_UNUSED_RETURN Result<void> visit(AST::UnaryExpression&);
+    [[nodiscard]] Result<void> visit(AST::Expression&);
+    [[nodiscard]] Result<void> visit(AST::FieldAccessExpression&);
+    [[nodiscard]] Result<void> visit(AST::IndexAccessExpression&);
+    [[nodiscard]] Result<void> visit(AST::BinaryExpression&);
+    [[nodiscard]] Result<void> visit(AST::IdentifierExpression&);
+    [[nodiscard]] Result<void> visit(AST::CallExpression&);
+    [[nodiscard]] Result<void> visit(AST::UnaryExpression&);
 
     // Literal Expressions
     void visit(AST::BoolLiteral&);
@@ -214,59 +214,59 @@ public:
     void visit(AST::AbstractFloatLiteral&);
 
     // Types
-    WARN_UNUSED_RETURN Result<void> visit(AST::ArrayTypeExpression&);
-    WARN_UNUSED_RETURN Result<void> visit(AST::ElaboratedTypeExpression&);
+    [[nodiscard]] Result<void> visit(AST::ArrayTypeExpression&);
+    [[nodiscard]] Result<void> visit(AST::ElaboratedTypeExpression&);
 
-    WARN_UNUSED_RETURN Result<void> visit(AST::Continuing&);
+    [[nodiscard]] Result<void> visit(AST::Continuing&);
 
 private:
-    WARN_UNUSED_RETURN Result<void> declareBuiltins();
+    [[nodiscard]] Result<void> declareBuiltins();
 
-    WARN_UNUSED_RETURN Result<const Type*> vectorFieldAccess(const Types::Vector&, AST::FieldAccessExpression&);
-    WARN_UNUSED_RETURN Result<void> visitAttributes(AST::Attribute::List&);
-    WARN_UNUSED_RETURN Result<void> visitStatements(AST::Statement::List&);
-    WARN_UNUSED_RETURN Result<void> bitcast(AST::CallExpression&, const Vector<const Type*>&);
+    [[nodiscard]] Result<const Type*> vectorFieldAccess(const Types::Vector&, AST::FieldAccessExpression&);
+    [[nodiscard]] Result<void> visitAttributes(AST::Attribute::List&);
+    [[nodiscard]] Result<void> visitStatements(AST::Statement::List&);
+    [[nodiscard]] Result<void> bitcast(AST::CallExpression&, const Vector<const Type*>&);
 
-    WARN_UNUSED_RETURN Result<const Type*> check(AST::Expression&, Constraint, Evaluation);
-    WARN_UNUSED_RETURN Result<const Type*> infer(AST::Expression&, Evaluation, DiscardResult = DiscardResult::No);
-    WARN_UNUSED_RETURN Result<const Type*> resolve(AST::Expression&);
-    WARN_UNUSED_RETURN Result<const Type*> lookupType(const AST::Identifier&);
-    WARN_UNUSED_RETURN Result<void> validateF16Usage(const SourceSpan&, const Type*);
-    WARN_UNUSED_RETURN Result<void> introduceType(const AST::Identifier&, const Type*);
-    WARN_UNUSED_RETURN Result<void> introduceValue(const AST::Identifier&, const Type*, Evaluation = Evaluation::Runtime, std::optional<ConstantValue> = std::nullopt);
-    WARN_UNUSED_RETURN Result<void> introduceFunction(const AST::Identifier&, const Type*);
-    WARN_UNUSED_RETURN Result<void> convertValue(const SourceSpan&, const Type*, std::optional<ConstantValue>&);
+    [[nodiscard]] Result<const Type*> check(AST::Expression&, Constraint, Evaluation);
+    [[nodiscard]] Result<const Type*> infer(AST::Expression&, Evaluation, DiscardResult = DiscardResult::No);
+    [[nodiscard]] Result<const Type*> resolve(AST::Expression&);
+    [[nodiscard]] Result<const Type*> lookupType(const AST::Identifier&);
+    [[nodiscard]] Result<void> validateF16Usage(const SourceSpan&, const Type*);
+    [[nodiscard]] Result<void> introduceType(const AST::Identifier&, const Type*);
+    [[nodiscard]] Result<void> introduceValue(const AST::Identifier&, const Type*, Evaluation = Evaluation::Runtime, std::optional<ConstantValue> = std::nullopt);
+    [[nodiscard]] Result<void> introduceFunction(const AST::Identifier&, const Type*);
+    [[nodiscard]] Result<void> convertValue(const SourceSpan&, const Type*, std::optional<ConstantValue>&);
 
     void inferred(const Type*);
-    WARN_UNUSED_RETURN bool unify(const Type*, const Type*);
-    WARN_UNUSED_RETURN bool convertValueImpl(const SourceSpan&, const Type*, ConstantValue&);
+    [[nodiscard]] bool unify(const Type*, const Type*);
+    [[nodiscard]] bool convertValueImpl(const SourceSpan&, const Type*, ConstantValue&);
 
-    WARN_UNUSED_RETURN Result<void> binaryExpression(const SourceSpan&, AST::Expression*, AST::BinaryOperation, AST::Expression&, AST::Expression&);
+    [[nodiscard]] Result<void> binaryExpression(const SourceSpan&, AST::Expression*, AST::BinaryOperation, AST::Expression&, AST::Expression&);
 
     template<typename TargetConstructor, typename Validator, typename... Arguments>
-    WARN_UNUSED_RETURN Result<void> allocateSimpleConstructor(ASCIILiteral, TargetConstructor, const Validator&, Arguments&&...);
-    WARN_UNUSED_RETURN Result<void> allocateTextureStorageConstructor(ASCIILiteral, Types::TextureStorage::Kind);
+    [[nodiscard]] Result<void> allocateSimpleConstructor(ASCIILiteral, TargetConstructor, const Validator&, Arguments&&...);
+    [[nodiscard]] Result<void> allocateTextureStorageConstructor(ASCIILiteral, Types::TextureStorage::Kind);
 
     bool isModuleScope() const;
 
-    WARN_UNUSED_RETURN Result<AccessMode> accessMode(AST::Expression&);
-    WARN_UNUSED_RETURN Result<TexelFormat> texelFormat(AST::Expression&);
-    WARN_UNUSED_RETURN Result<AddressSpace> addressSpace(AST::Expression&);
+    [[nodiscard]] Result<AccessMode> accessMode(AST::Expression&);
+    [[nodiscard]] Result<TexelFormat> texelFormat(AST::Expression&);
+    [[nodiscard]] Result<AddressSpace> addressSpace(AST::Expression&);
 
     template<typename CallArguments>
-    WARN_UNUSED_RETURN Result<const Type*> chooseOverload(ASCIILiteral, const SourceSpan&, AST::Expression*, const String&, CallArguments&& valueArguments, const Vector<const Type*>& typeArguments);
+    [[nodiscard]] Result<const Type*> chooseOverload(ASCIILiteral, const SourceSpan&, AST::Expression*, const String&, CallArguments&& valueArguments, const Vector<const Type*>& typeArguments);
 
     template<typename Node>
-    WARN_UNUSED_RETURN Result<void> setConstantValue(Node&, const Type*, const ConstantValue&);
+    [[nodiscard]] Result<void> setConstantValue(Node&, const Type*, const ConstantValue&);
 
-    WARN_UNUSED_RETURN Result<Behaviors> analyze(AST::Statement&);
-    WARN_UNUSED_RETURN Result<Behaviors> analyze(AST::CompoundStatement&);
-    WARN_UNUSED_RETURN Result<Behaviors> analyze(AST::ForStatement&);
-    WARN_UNUSED_RETURN Result<Behaviors> analyze(AST::IfStatement&);
-    WARN_UNUSED_RETURN Result<Behaviors> analyze(AST::LoopStatement&);
-    WARN_UNUSED_RETURN Result<Behaviors> analyze(AST::SwitchStatement&);
-    WARN_UNUSED_RETURN Result<Behaviors> analyze(AST::WhileStatement&);
-    WARN_UNUSED_RETURN Result<Behaviors> analyzeStatements(AST::Statement::List&);
+    [[nodiscard]] Result<Behaviors> analyze(AST::Statement&);
+    [[nodiscard]] Result<Behaviors> analyze(AST::CompoundStatement&);
+    [[nodiscard]] Result<Behaviors> analyze(AST::ForStatement&);
+    [[nodiscard]] Result<Behaviors> analyze(AST::IfStatement&);
+    [[nodiscard]] Result<Behaviors> analyze(AST::LoopStatement&);
+    [[nodiscard]] Result<Behaviors> analyze(AST::SwitchStatement&);
+    [[nodiscard]] Result<Behaviors> analyze(AST::WhileStatement&);
+    [[nodiscard]] Result<Behaviors> analyzeStatements(AST::Statement::List&);
 
     ShaderModule& m_shaderModule;
     const Type* m_inferredType { nullptr };
@@ -469,7 +469,7 @@ Result<void> TypeChecker::declareBuiltins()
 std::optional<FailedCheck> TypeChecker::check()
 {
 
-    auto result = [&] WARN_UNUSED_RETURN -> Result<void> {
+    auto result = [&] [[nodiscard]] -> Result<void> {
         CHECK(declareBuiltins());
 
         ContextScope moduleScope(this);

--- a/Source/WebGPU/WebGPU/BindGroup.mm
+++ b/Source/WebGPU/WebGPU/BindGroup.mm
@@ -1449,7 +1449,7 @@ uint64_t BindGroup::makeEntryMapKey(uint32_t baseMipLevel, uint32_t baseArrayLay
     return (static_cast<uint64_t>(aspect) - 1) | (static_cast<uint64_t>(baseMipLevel) << 1) | (static_cast<uint64_t>(baseArrayLayer) << 32);
 }
 
-WARN_UNUSED_RETURN static bool setArgumentBuffer(id<MTLArgumentEncoder> encoder, id<MTLBuffer> buffer)
+[[nodiscard]] static bool setArgumentBuffer(id<MTLArgumentEncoder> encoder, id<MTLBuffer> buffer)
 {
     if (!encoder || !buffer)
         return false;

--- a/Source/WebGPU/WebGPU/Queue.h
+++ b/Source/WebGPU/WebGPU/Queue.h
@@ -98,7 +98,7 @@ public:
 
     // This can be called on a background thread.
     void scheduleWork(Instance::WorkItem&&);
-    WARN_UNUSED_RETURN uint64_t retainCounterSampleBuffer(CommandEncoder&);
+    [[nodiscard]] uint64_t retainCounterSampleBuffer(CommandEncoder&);
     void releaseCounterSampleBuffer(uint64_t);
     void retainTimestampsForOneUpdate(NSMutableSet<id<MTLCounterSampleBuffer>> *);
     void waitForAllCommitedWorkToComplete();

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.h
@@ -115,7 +115,7 @@ public:
         uint64_t offset;
     };
     static DrawIndexResult clampIndexBufferToValidValues(uint32_t indexCount, uint32_t instanceCount, int32_t baseVertex, uint32_t firstInstance, MTLIndexType, NSUInteger indexBufferOffsetInBytes, Buffer*, uint32_t minVertexCount, uint32_t minInstanceCount, RenderPassEncoder&, Device&, uint32_t rasterSampleCount, MTLPrimitiveType);
-    WARN_UNUSED_RETURN bool splitRenderPass();
+    [[nodiscard]] bool splitRenderPass();
     static std::pair<uint32_t, uint32_t> computeMininumVertexInstanceCount(const RenderPipeline*, bool& needsValidationLayerWorkaround, uint64_t (^)(uint32_t));
 
 private:

--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsDatabaseStore.h
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsDatabaseStore.h
@@ -147,7 +147,7 @@ private:
     void mergeStatistic(const ResourceLoadStatistics&);
     void merge(WebCore::SQLiteStatement*, const ResourceLoadStatistics&);
     void clearDatabaseContents();
-    WARN_UNUSED_RETURN bool insertObservedDomain(const ResourceLoadStatistics&);
+    [[nodiscard]] bool insertObservedDomain(const ResourceLoadStatistics&);
     void insertDomainRelationships(const ResourceLoadStatistics&);
     void insertDomainRelationshipList(const String&, const HashSet<RegistrableDomain>&, unsigned);
     bool relationshipExists(WebCore::SQLiteStatementAutoResetScope&, std::optional<unsigned> firstDomainID, const RegistrableDomain& secondDomain) const;
@@ -203,7 +203,7 @@ private:
     void removeDataRecords(CompletionHandler<void()>&&);
     void pruneStatisticsIfNeeded() override;
     enum class AddedRecord : bool { No, Yes };
-    WARN_UNUSED_RETURN std::pair<AddedRecord, std::optional<unsigned>> ensureResourceStatisticsForRegistrableDomain(const RegistrableDomain&);
+    [[nodiscard]] std::pair<AddedRecord, std::optional<unsigned>> ensureResourceStatisticsForRegistrableDomain(const RegistrableDomain&);
     bool shouldRemoveAllWebsiteDataFor(const DomainData&, bool shouldCheckForGrandfathering);
     bool shouldRemoveAllButCookiesFor(const DomainData&, bool shouldCheckForGrandfathering);
     bool shouldEnforceSameSiteStrictFor(DomainData&, bool shouldCheckForGrandfathering);

--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h
@@ -255,7 +255,7 @@ private:
     void mergeStatistic(const ResourceLoadStatistics&);
     void merge(WebCore::SQLiteStatement*, const ResourceLoadStatistics&);
     void incrementRecordsDeletedCountForDomains(HashSet<RegistrableDomain>&&);
-    WARN_UNUSED_RETURN bool insertObservedDomain(const ResourceLoadStatistics&);
+    [[nodiscard]] bool insertObservedDomain(const ResourceLoadStatistics&);
     void insertDomainRelationships(const ResourceLoadStatistics&);
     void insertDomainRelationshipList(const String&, const HashSet<RegistrableDomain>&, unsigned);
     bool relationshipExists(WebCore::SQLiteStatementAutoResetScope&, std::optional<unsigned> firstDomainID, const RegistrableDomain& secondDomain) const;
@@ -310,7 +310,7 @@ private:
     void markAsPrevalentIfHasRedirectedToPrevalent();
     
     // reason is used for logging purpose.
-    WARN_UNUSED_RETURN std::pair<AddedRecord, std::optional<unsigned>> ensureResourceStatisticsForRegistrableDomain(const RegistrableDomain&, ASCIILiteral reason);
+    [[nodiscard]] std::pair<AddedRecord, std::optional<unsigned>> ensureResourceStatisticsForRegistrableDomain(const RegistrableDomain&, ASCIILiteral reason);
     bool shouldRemoveAllWebsiteDataFor(const DomainData&, bool shouldCheckForGrandfathering);
     bool shouldRemoveAllButCookiesFor(const DomainData&, bool shouldCheckForGrandfathering);
     bool shouldEnforceSameSiteStrictFor(DomainData&, bool shouldCheckForGrandfathering);

--- a/Source/WebKit/NetworkProcess/DatabaseUtilities.h
+++ b/Source/WebKit/NetworkProcess/DatabaseUtilities.h
@@ -48,7 +48,7 @@ protected:
     ~DatabaseUtilities();
 
     WebCore::SQLiteStatementAutoResetScope scopedStatement(std::unique_ptr<WebCore::SQLiteStatement>&, ASCIILiteral query, ASCIILiteral logString) const;
-    WARN_UNUSED_RETURN ScopeExit<Function<void()>> beginTransactionIfNecessary();
+    [[nodiscard]] ScopeExit<Function<void()>> beginTransactionIfNecessary();
     enum class CreatedNewFile : bool { No, Yes };
     CreatedNewFile openDatabaseAndCreateSchemaIfNecessary();
     void enableForeignKeys();

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheKey.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheKey.h
@@ -47,7 +47,7 @@ struct DataKey {
         encoder << partition << type << identifier;
     }
 
-    template <class Decoder> WARN_UNUSED_RETURN static bool decodeForPersistence(Decoder& decoder, DataKey& dataKey)
+    template <class Decoder> [[nodiscard]] static bool decodeForPersistence(Decoder& decoder, DataKey& dataKey)
     {
         return decoder.decode(dataKey.partition) && decoder.decode(dataKey.type) && decoder.decode(dataKey.identifier);
     }

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp
@@ -601,7 +601,7 @@ struct RecordMetaData {
     uint64_t headerOffset { 0 };
 };
 
-WARN_UNUSED_RETURN static bool decodeRecordMetaData(RecordMetaData& metaData, const Data& fileData)
+[[nodiscard]] static bool decodeRecordMetaData(RecordMetaData& metaData, const Data& fileData)
 {
     bool success = false;
     fileData.apply([&metaData, &success](std::span<const uint8_t> span) {
@@ -665,7 +665,7 @@ WARN_UNUSED_RETURN static bool decodeRecordMetaData(RecordMetaData& metaData, co
     return success;
 }
 
-WARN_UNUSED_RETURN static bool decodeRecordHeader(const Data& fileData, RecordMetaData& metaData, Data& headerData, const Salt& salt)
+[[nodiscard]] static bool decodeRecordHeader(const Data& fileData, RecordMetaData& metaData, Data& headerData, const Salt& salt)
 {
     if (!decodeRecordMetaData(metaData, fileData)) {
         LOG(NetworkCacheStorage, "(NetworkProcess) meta data decode failure");

--- a/Source/WebKit/Platform/IPC/ArgumentCoders.cpp
+++ b/Source/WebKit/Platform/IPC/ArgumentCoders.cpp
@@ -67,7 +67,7 @@ static inline std::optional<String> decodeStringText(Decoder& decoder, unsigned 
 }
 
 template<typename Decoder>
-WARN_UNUSED_RETURN std::optional<String> ArgumentCoder<String>::decode(Decoder& decoder)
+[[nodiscard]] std::optional<String> ArgumentCoder<String>::decode(Decoder& decoder)
 {
     auto length = decoder.template decode<unsigned>();
     if (!length)

--- a/Source/WebKit/Platform/IPC/ConnectionHandle.h
+++ b/Source/WebKit/Platform/IPC/ConnectionHandle.h
@@ -55,19 +55,19 @@ public:
         : m_handle(WTF::move(inHandle))
     { }
     explicit operator bool() const { return !!m_handle; }
-    WARN_UNUSED_RETURN int release() { return m_handle.release(); }
+    [[nodiscard]] int release() { return m_handle.release(); }
 #elif OS(WINDOWS)
     ConnectionHandle(Win32Handle&& inHandle)
         : m_handle(WTF::move(inHandle))
     { }
     explicit operator bool() const { return !!m_handle; }
-    WARN_UNUSED_RETURN HANDLE leak() { return m_handle.leak(); }
+    [[nodiscard]] HANDLE leak() { return m_handle.leak(); }
 #elif OS(DARWIN)
     ConnectionHandle(MachSendRight&& sendRight)
         : m_handle(WTF::move(sendRight))
     { }
     explicit operator bool() const { return MACH_PORT_VALID(m_handle.sendRight()); }
-    WARN_UNUSED_RETURN mach_port_t leakSendRight() { return m_handle.leakSendRight(); }
+    [[nodiscard]] mach_port_t leakSendRight() { return m_handle.leakSendRight(); }
 #endif
 
 private:

--- a/Source/WebKit/Platform/IPC/DaemonDecoder.h
+++ b/Source/WebKit/Platform/IPC/DaemonDecoder.h
@@ -49,7 +49,7 @@ public:
     }
 
     template<typename T>
-    WARN_UNUSED_RETURN bool bufferIsLargeEnoughToContain(size_t numElements) const
+    [[nodiscard]] bool bufferIsLargeEnoughToContain(size_t numElements) const
     {
         static_assert(std::is_arithmetic<T>::value, "Type T must have a fixed, known encoded size!");
 
@@ -59,11 +59,11 @@ public:
         return bufferIsLargeEnoughToContainBytes(numElements * sizeof(T));
     }
 
-    WARN_UNUSED_RETURN bool decodeFixedLengthData(std::span<uint8_t> data);
+    [[nodiscard]] bool decodeFixedLengthData(std::span<uint8_t> data);
     std::span<const uint8_t> decodeFixedLengthReference(size_t);
 
 private:
-    WARN_UNUSED_RETURN bool bufferIsLargeEnoughToContainBytes(size_t) const;
+    [[nodiscard]] bool bufferIsLargeEnoughToContainBytes(size_t) const;
 
     std::span<const uint8_t> m_buffer;
     size_t m_bufferPosition { 0 };

--- a/Source/WebKit/Platform/IPC/Decoder.h
+++ b/Source/WebKit/Platform/IPC/Decoder.h
@@ -127,7 +127,7 @@ public:
     std::span<const uint8_t> span() const { return m_buffer; }
     size_t currentBufferOffset() const { return std::distance(m_buffer.begin(), m_bufferPosition); }
 
-    WARN_UNUSED_RETURN bool isValid() const { return !!m_buffer.data(); }
+    [[nodiscard]] bool isValid() const { return !!m_buffer.data(); }
     void markInvalid()
     {
         auto buffer = std::exchange(m_buffer, { });
@@ -136,10 +136,10 @@ public:
     }
 
     template<typename T>
-    WARN_UNUSED_RETURN std::span<const T> decodeSpan(size_t);
+    [[nodiscard]] std::span<const T> decodeSpan(size_t);
 
     template<typename T>
-    WARN_UNUSED_RETURN std::optional<T> decodeObject();
+    [[nodiscard]] std::optional<T> decodeObject();
 
     template<typename T>
     Decoder& operator>>(std::optional<T>& t)

--- a/Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm
@@ -56,7 +56,7 @@ SandboxExtensionImpl::~SandboxExtensionImpl()
         secureMemsetSpan(m_token.mutableSpan(), 0);
 }
 
-WARN_UNUSED_RETURN bool SandboxExtensionImpl::consume()
+[[nodiscard]] bool SandboxExtensionImpl::consume()
 {
     m_handle = sandbox_extension_consume(m_token.data());
 #if PLATFORM(IOS_FAMILY_SIMULATOR)

--- a/Source/WebKit/Shared/SandboxExtension.h
+++ b/Source/WebKit/Shared/SandboxExtension.h
@@ -61,9 +61,9 @@ public:
     SandboxExtensionImpl(std::span<const uint8_t>);
     ~SandboxExtensionImpl();
 
-    WARN_UNUSED_RETURN bool consume();
+    [[nodiscard]] bool consume();
     bool invalidate();
-    WARN_UNUSED_RETURN std::span<const uint8_t> getSerializedFormat();
+    [[nodiscard]] std::span<const uint8_t> getSerializedFormat();
 
     SandboxExtensionImpl(SandboxExtensionImpl&& other)
         : m_token(std::exchange(other.m_token, CString()))

--- a/Source/WebKit/UIProcess/Cocoa/SessionStateCoding.h
+++ b/Source/WebKit/UIProcess/Cocoa/SessionStateCoding.h
@@ -33,7 +33,7 @@ namespace WebKit {
 struct SessionState;
 
 RetainPtr<NSData> encodeSessionState(const SessionState&);
-WARN_UNUSED_RETURN bool decodeSessionState(NSData *, SessionState&);
+[[nodiscard]] bool decodeSessionState(NSData *, SessionState&);
 
 }
 

--- a/Source/WebKit/UIProcess/LegacySessionStateCoding.h
+++ b/Source/WebKit/UIProcess/LegacySessionStateCoding.h
@@ -37,6 +37,6 @@ namespace WebKit {
 struct SessionState;
 
 RefPtr<API::Data> encodeLegacySessionState(const SessionState&);
-WARN_UNUSED_RETURN bool decodeLegacySessionState(std::span<const uint8_t> data, SessionState&);
+[[nodiscard]] bool decodeLegacySessionState(std::span<const uint8_t> data, SessionState&);
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp
+++ b/Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp
@@ -977,7 +977,7 @@ static void decodeBackForwardTreeNode(HistoryEntryDataDecoder& decoder, FrameSta
 #endif
 }
 
-WARN_UNUSED_RETURN static bool decodeSessionHistoryEntryData(std::span<const uint8_t> buffer, FrameState& mainFrameState)
+[[nodiscard]] static bool decodeSessionHistoryEntryData(std::span<const uint8_t> buffer, FrameState& mainFrameState)
 {
     HistoryEntryDataDecoder decoder { buffer };
 
@@ -992,12 +992,12 @@ WARN_UNUSED_RETURN static bool decodeSessionHistoryEntryData(std::span<const uin
     return decoder.finishDecoding();
 }
 
-WARN_UNUSED_RETURN static bool decodeSessionHistoryEntryData(CFDataRef historyEntryData, FrameState& mainFrameState)
+[[nodiscard]] static bool decodeSessionHistoryEntryData(CFDataRef historyEntryData, FrameState& mainFrameState)
 {
     return decodeSessionHistoryEntryData(span(historyEntryData), mainFrameState);
 }
 
-WARN_UNUSED_RETURN static bool decodeSessionHistoryEntry(CFDictionaryRef entryDictionary, FrameState& backForwardListItemState)
+[[nodiscard]] static bool decodeSessionHistoryEntry(CFDictionaryRef entryDictionary, FrameState& backForwardListItemState)
 {
     RetainPtr title = dynamic_cf_cast<CFStringRef>(CFDictionaryGetValue(entryDictionary, sessionHistoryEntryTitleKey));
     if (!title)
@@ -1032,7 +1032,7 @@ WARN_UNUSED_RETURN static bool decodeSessionHistoryEntry(CFDictionaryRef entryDi
     return true;
 }
 
-WARN_UNUSED_RETURN static bool decodeSessionHistoryEntries(CFArrayRef entriesArray, Vector<Ref<FrameState>>& entries)
+[[nodiscard]] static bool decodeSessionHistoryEntries(CFArrayRef entriesArray, Vector<Ref<FrameState>>& entries)
 {
     for (CFIndex i = 0, size = CFArrayGetCount(entriesArray); i < size; ++i) {
         RetainPtr entryDictionary = dynamic_cf_cast<CFDictionaryRef>(CFArrayGetValueAtIndex(entriesArray, i));
@@ -1049,7 +1049,7 @@ WARN_UNUSED_RETURN static bool decodeSessionHistoryEntries(CFArrayRef entriesArr
     return true;
 }
 
-WARN_UNUSED_RETURN static bool decodeV0SessionHistory(CFDictionaryRef sessionHistoryDictionary, BackForwardListState& backForwardListState)
+[[nodiscard]] static bool decodeV0SessionHistory(CFDictionaryRef sessionHistoryDictionary, BackForwardListState& backForwardListState)
 {
     RetainPtr currentIndexNumber = dynamic_cf_cast<CFNumberRef>(CFDictionaryGetValue(sessionHistoryDictionary, sessionHistoryCurrentIndexKey));
     if (!currentIndexNumber)
@@ -1085,7 +1085,7 @@ WARN_UNUSED_RETURN static bool decodeV0SessionHistory(CFDictionaryRef sessionHis
     return true;
 }
 
-WARN_UNUSED_RETURN static bool decodeV1SessionHistory(CFDictionaryRef sessionHistoryDictionary, BackForwardListState& backForwardListState)
+[[nodiscard]] static bool decodeV1SessionHistory(CFDictionaryRef sessionHistoryDictionary, BackForwardListState& backForwardListState)
 {
     RetainPtr currentIndexNumber = dynamic_cf_cast<CFNumberRef>(CFDictionaryGetValue(sessionHistoryDictionary, sessionHistoryCurrentIndexKey));
     if (!currentIndexNumber) {
@@ -1116,7 +1116,7 @@ WARN_UNUSED_RETURN static bool decodeV1SessionHistory(CFDictionaryRef sessionHis
     return true;
 }
 
-WARN_UNUSED_RETURN static bool decodeSessionHistory(CFDictionaryRef backForwardListDictionary, BackForwardListState& backForwardListState)
+[[nodiscard]] static bool decodeSessionHistory(CFDictionaryRef backForwardListDictionary, BackForwardListState& backForwardListState)
 {
     RetainPtr sessionHistoryVersionNumber = dynamic_cf_cast<CFNumberRef>(CFDictionaryGetValue(backForwardListDictionary, sessionHistoryVersionKey));
     if (!sessionHistoryVersionNumber) {

--- a/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteDDMeshProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteDDMeshProxy.h
@@ -69,7 +69,7 @@ private:
     DDModelIdentifier backing() const { return m_backing; }
 
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Error send(T&& message)
+    [[nodiscard]] IPC::Error send(T&& message)
     {
         return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
@@ -383,12 +383,12 @@ protected:
     void markContextLost();
 
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Error send(T&& message)
+    [[nodiscard]] IPC::Error send(T&& message)
     {
         return protectedStreamConnection()->send(std::forward<T>(message), m_identifier);
     }
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
+    [[nodiscard]] IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
         return protectedStreamConnection()->sendSync(std::forward<T>(message), m_identifier);
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.h
@@ -69,12 +69,12 @@ private:
     bool xrCompatible() final;
     
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Error send(T&& message)
+    [[nodiscard]] IPC::Error send(T&& message)
     {
         return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
     }
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
+    [[nodiscard]] IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
         return root().protectedStreamClientConnection()->sendSync(WTF::move(message), backing());
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupLayoutProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupLayoutProxy.h
@@ -64,7 +64,7 @@ private:
     WebGPUIdentifier backing() const { return m_backing; }
     
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Error send(T&& message)
+    [[nodiscard]] IPC::Error send(T&& message)
     {
         return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.h
@@ -68,12 +68,12 @@ private:
     WebGPUIdentifier backing() const { return m_backing; }
     
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Error send(T&& message)
+    [[nodiscard]] IPC::Error send(T&& message)
     {
         return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
     }
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
+    [[nodiscard]] IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
         return root().protectedStreamClientConnection()->sendSync(WTF::move(message), backing());
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.h
@@ -65,17 +65,17 @@ private:
     WebGPUIdentifier backing() const { return m_backing; }
     
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Error send(T&& message)
+    [[nodiscard]] IPC::Error send(T&& message)
     {
         return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
     }
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
+    [[nodiscard]] IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
         return root().protectedStreamClientConnection()->sendSync(WTF::move(message), backing());
     }
     template<typename T, typename C>
-    WARN_UNUSED_RETURN std::optional<IPC::StreamClientConnection::AsyncReplyID> sendWithAsyncReply(T&& message, C&& completionHandler)
+    [[nodiscard]] std::optional<IPC::StreamClientConnection::AsyncReplyID> sendWithAsyncReply(T&& message, C&& completionHandler)
     {
         return root().protectedStreamClientConnection()->sendWithAsyncReply(WTF::move(message), completionHandler, backing());
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.h
@@ -63,7 +63,7 @@ private:
     WebGPUIdentifier backing() const { return m_backing; }
     
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Error send(T&& message)
+    [[nodiscard]] IPC::Error send(T&& message)
     {
         return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.h
@@ -63,12 +63,12 @@ private:
     WebGPUIdentifier backing() const { return m_backing; }
     
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Error send(T&& message)
+    [[nodiscard]] IPC::Error send(T&& message)
     {
         return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
     }
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
+    [[nodiscard]] IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
         return root().protectedStreamClientConnection()->sendSync(WTF::move(message), backing());
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.h
@@ -82,12 +82,12 @@ private:
     WebGPUIdentifier backing() const { return m_backing; }
     
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Error send(T&& message)
+    [[nodiscard]] IPC::Error send(T&& message)
     {
         return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
     }
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
+    [[nodiscard]] IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
         return root().protectedStreamClientConnection()->sendSync(WTF::move(message), backing());
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.h
@@ -63,7 +63,7 @@ private:
     WebGPUIdentifier backing() const { return m_backing; }
     
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Error send(T&& message)
+    [[nodiscard]] IPC::Error send(T&& message)
     {
         return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.h
@@ -66,7 +66,7 @@ private:
     WebGPUIdentifier backing() const { return m_backing; }
     
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Error send(T&& message)
+    [[nodiscard]] IPC::Error send(T&& message)
     {
         return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h
@@ -69,12 +69,12 @@ private:
     RemoteDeviceProxy& operator=(RemoteDeviceProxy&&) = delete;
 
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Error send(T&& message)
+    [[nodiscard]] IPC::Error send(T&& message)
     {
         return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
     }
     template<typename T, typename C>
-    WARN_UNUSED_RETURN std::optional<IPC::StreamClientConnection::AsyncReplyID> sendWithAsyncReply(T&& message, C&& completionHandler)
+    [[nodiscard]] std::optional<IPC::StreamClientConnection::AsyncReplyID> sendWithAsyncReply(T&& message, C&& completionHandler)
     {
         return root().protectedStreamClientConnection()->sendWithAsyncReply(WTF::move(message), completionHandler, backing());
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteExternalTextureProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteExternalTextureProxy.h
@@ -64,7 +64,7 @@ private:
     WebGPUIdentifier backing() const { return m_backing; }
     
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Error send(T&& message)
+    [[nodiscard]] IPC::Error send(T&& message)
     {
         return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h
@@ -103,17 +103,17 @@ private:
     void waitUntilInitialized();
 
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Error send(T&& message)
+    [[nodiscard]] IPC::Error send(T&& message)
     {
         return root().protectedStreamClientConnection()->send(std::forward<T>(message), backing());
     }
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
+    [[nodiscard]] IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
         return root().protectedStreamClientConnection()->sendSync(std::forward<T>(message), backing());
     }
     template<typename T, typename C>
-    WARN_UNUSED_RETURN std::optional<IPC::StreamClientConnection::AsyncReplyID> sendWithAsyncReply(T&& message, C&& completionHandler)
+    [[nodiscard]] std::optional<IPC::StreamClientConnection::AsyncReplyID> sendWithAsyncReply(T&& message, C&& completionHandler)
     {
         return root().protectedStreamClientConnection()->sendWithAsyncReply(WTF::move(message), completionHandler, backing());
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePipelineLayoutProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePipelineLayoutProxy.h
@@ -64,7 +64,7 @@ private:
     WebGPUIdentifier backing() const { return m_backing; }
     
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Error send(T&& message)
+    [[nodiscard]] IPC::Error send(T&& message)
     {
         return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.h
@@ -76,7 +76,7 @@ private:
     RefPtr<WebCore::NativeImage> getMetalTextureAsNativeImage(uint32_t, bool& isIOSurfaceSupportedFormat) final;
 
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Error send(T&& message)
+    [[nodiscard]] IPC::Error send(T&& message)
     {
         return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQuerySetProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQuerySetProxy.h
@@ -64,7 +64,7 @@ private:
     WebGPUIdentifier backing() const { return m_backing; }
     
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Error send(T&& message)
+    [[nodiscard]] IPC::Error send(T&& message)
     {
         return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h
@@ -66,12 +66,12 @@ private:
     WebGPUIdentifier backing() const { return m_backing; }
 
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Error send(T&& message)
+    [[nodiscard]] IPC::Error send(T&& message)
     {
         return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
     }
     template<typename T, typename C>
-    WARN_UNUSED_RETURN std::optional<IPC::StreamClientConnection::AsyncReplyID> sendWithAsyncReply(T&& message, C&& completionHandler)
+    [[nodiscard]] std::optional<IPC::StreamClientConnection::AsyncReplyID> sendWithAsyncReply(T&& message, C&& completionHandler)
     {
         return root().protectedStreamClientConnection()->sendWithAsyncReply(WTF::move(message), completionHandler, backing());
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.h
@@ -64,7 +64,7 @@ private:
     WebGPUIdentifier backing() const { return m_backing; }
 
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Error send(T&& message)
+    [[nodiscard]] IPC::Error send(T&& message)
     {
         return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleProxy.h
@@ -64,7 +64,7 @@ private:
     WebGPUIdentifier backing() const { return m_backing; }
     
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Error send(T&& message)
+    [[nodiscard]] IPC::Error send(T&& message)
     {
         return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.h
@@ -63,7 +63,7 @@ private:
     WebGPUIdentifier backing() const { return m_backing; }
     
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Error send(T&& message)
+    [[nodiscard]] IPC::Error send(T&& message)
     {
         return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.h
@@ -66,7 +66,7 @@ private:
     WebGPUIdentifier backing() const { return m_backing; }
     
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Error send(T&& message)
+    [[nodiscard]] IPC::Error send(T&& message)
     {
         return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSamplerProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSamplerProxy.h
@@ -64,7 +64,7 @@ private:
     WebGPUIdentifier backing() const { return m_backing; }
     
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Error send(T&& message)
+    [[nodiscard]] IPC::Error send(T&& message)
     {
         return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.h
@@ -64,12 +64,12 @@ private:
     WebGPUIdentifier backing() const { return m_backing; }
     
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Error send(T&& message)
+    [[nodiscard]] IPC::Error send(T&& message)
     {
         return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
     }
     template<typename T, typename C>
-    WARN_UNUSED_RETURN std::optional<IPC::StreamClientConnection::AsyncReplyID> sendWithAsyncReply(T&& message, C&& completionHandler)
+    [[nodiscard]] std::optional<IPC::StreamClientConnection::AsyncReplyID> sendWithAsyncReply(T&& message, C&& completionHandler)
     {
         return root().protectedStreamClientConnection()->sendWithAsyncReply(WTF::move(message), completionHandler, backing());
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.h
@@ -68,7 +68,7 @@ private:
     WebGPUIdentifier backing() const { return m_backing; }
     
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Error send(T&& message)
+    [[nodiscard]] IPC::Error send(T&& message)
     {
         return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.h
@@ -63,7 +63,7 @@ private:
     WebGPUIdentifier backing() const { return m_backing; }
     
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Error send(T&& message)
+    [[nodiscard]] IPC::Error send(T&& message)
     {
         return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRBindingProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRBindingProxy.h
@@ -82,12 +82,12 @@ private:
     WebCore::WebGPU::TextureFormat getPreferredColorFormat() final;
 
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Error send(T&& message)
+    [[nodiscard]] IPC::Error send(T&& message)
     {
         return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
     }
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
+    [[nodiscard]] IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
         return root().protectedStreamClientConnection()->sendSync(WTF::move(message), backing());
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRProjectionLayerProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRProjectionLayerProxy.h
@@ -88,12 +88,12 @@ private:
     void endFrame() final;
 
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Error send(T&& message)
+    [[nodiscard]] IPC::Error send(T&& message)
     {
         return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
     }
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
+    [[nodiscard]] IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
         return root().protectedStreamClientConnection()->sendSync(WTF::move(message), backing());
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRSubImageProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRSubImageProxy.h
@@ -76,12 +76,12 @@ private:
     RefPtr<WebCore::WebGPU::Texture> motionVectorTexture() final;
 
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Error send(T&& message)
+    [[nodiscard]] IPC::Error send(T&& message)
     {
         return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
     }
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
+    [[nodiscard]] IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
         return root().protectedStreamClientConnection()->sendSync(WTF::move(message), backing());
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRViewProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRViewProxy.h
@@ -76,12 +76,12 @@ private:
     WebGPUIdentifier backing() const { return m_backing; }
 
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Error send(T&& message)
+    [[nodiscard]] IPC::Error send(T&& message)
     {
         return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
     }
     template<typename T>
-    WARN_UNUSED_RETURN IPC::Connection::SendSyncResult<T> sendSync(T&& message)
+    [[nodiscard]] IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
         return root().protectedStreamClientConnection()->sendSync(WTF::move(message), backing());
     }

--- a/Source/WebKit/WebProcess/WebPage/WebCookieCache.h
+++ b/Source/WebKit/WebProcess/WebPage/WebCookieCache.h
@@ -63,7 +63,7 @@ public:
     String cookiesForDOM(const URL& firstParty, const WebCore::SameSiteInfo&, const URL&, WebCore::FrameIdentifier, WebCore::PageIdentifier, WebPageProxyIdentifier, WebCore::IncludeSecureCookies);
     void setCookiesFromDOM(const URL& firstParty, const WebCore::SameSiteInfo&, const URL&, WebCore::FrameIdentifier, WebCore::PageIdentifier, const String& cookieString, WebCore::ShouldRelaxThirdPartyCookieBlocking);
 
-    WARN_UNUSED_RETURN PendingCookieUpdateCounter::Token willSetCookieFromDOM();
+    [[nodiscard]] PendingCookieUpdateCounter::Token willSetCookieFromDOM();
     void didSetCookieFromDOM(PendingCookieUpdateCounter::Token, const URL& firstParty, const WebCore::SameSiteInfo&, const URL&, WebCore::FrameIdentifier, WebCore::PageIdentifier, const WebCore::Cookie&, WebCore::ShouldRelaxThirdPartyCookieBlocking);
 
     void allCookiesDeleted();


### PR DESCRIPTION
#### 8196718d19599eb501dce8f9877d916ff60e4e28
<pre>
Drop WTF WARN_UNUSED_RETURN and directly use C++17 [[nodiscard]]
<a href="https://bugs.webkit.org/show_bug.cgi?id=305274">https://bugs.webkit.org/show_bug.cgi?id=305274</a>
<a href="https://rdar.apple.com/167913946">rdar://167913946</a>

Reviewed by Darin Adler.

This is a follow-up to 304354@main. This modernizes and standardizes the codebase.

* Source/JavaScriptCore/API/JSRetainPtr.h:
* Source/JavaScriptCore/assembler/AbstractMacroAssembler.h:
(JSC::AbstractMacroAssembler::CachedTempRegister::value):
* Source/JavaScriptCore/bytecode/ArrayAllocationProfile.h:
(JSC::ArrayAllocationProfile::IndexingTypeAndVectorLength::withIndexingType):
* Source/JavaScriptCore/heap/Weak.h:
* Source/JavaScriptCore/jit/RegisterSet.h:
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.cpp:
(JSC::decodeHexImpl):
(JSC::decodeHex):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.h:
* Source/JavaScriptCore/runtime/JSObject.h:
(JSC::JSObject::ensureLength):
* Source/JavaScriptCore/runtime/PropertyTable.h:
(JSC::PropertyTable::add):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addTableSet):
(JSC::Wasm::BBQJITImpl::BBQJIT::addTableInit):
(JSC::Wasm::BBQJITImpl::BBQJIT::addElemDrop):
(JSC::Wasm::BBQJITImpl::BBQJIT::addTableSize):
(JSC::Wasm::BBQJITImpl::BBQJIT::addTableGrow):
(JSC::Wasm::BBQJITImpl::BBQJIT::addTableFill):
(JSC::Wasm::BBQJITImpl::BBQJIT::addTableCopy):
(JSC::Wasm::BBQJITImpl::BBQJIT::getLocal):
(JSC::Wasm::BBQJITImpl::BBQJIT::setLocal):
(JSC::Wasm::BBQJITImpl::BBQJIT::teeLocal):
(JSC::Wasm::BBQJITImpl::BBQJIT::addGrowMemory):
(JSC::Wasm::BBQJITImpl::BBQJIT::addCurrentMemory):
(JSC::Wasm::BBQJITImpl::BBQJIT::addMemoryFill):
(JSC::Wasm::BBQJITImpl::BBQJIT::addMemoryCopy):
(JSC::Wasm::BBQJITImpl::BBQJIT::addMemoryInit):
(JSC::Wasm::BBQJITImpl::BBQJIT::addDataDrop):
(JSC::Wasm::BBQJITImpl::BBQJIT::atomicLoad):
(JSC::Wasm::BBQJITImpl::BBQJIT::atomicStore):
(JSC::Wasm::BBQJITImpl::BBQJIT::atomicBinaryRMW):
(JSC::Wasm::BBQJITImpl::BBQJIT::atomicCompareExchange):
(JSC::Wasm::BBQJITImpl::BBQJIT::atomicWait):
(JSC::Wasm::BBQJITImpl::BBQJIT::atomicNotify):
(JSC::Wasm::BBQJITImpl::BBQJIT::atomicFence):
(JSC::Wasm::BBQJITImpl::BBQJIT::truncTrapping):
(JSC::Wasm::BBQJITImpl::BBQJIT::truncSaturated):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayNewData):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayNewElem):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayCopy):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayInitElem):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayInitData):
(JSC::Wasm::BBQJITImpl::BBQJIT::addAnyConvertExtern):
(JSC::Wasm::BBQJITImpl::BBQJIT::addExternConvertAny):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSelect):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32Add):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Add):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Add):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32Sub):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Sub):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Sub):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32Mul):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Mul):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Mul):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32DivS):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64DivS):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32DivU):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64DivU):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32RemS):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64RemS):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32RemU):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64RemU):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Div):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Div):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Min):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Min):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Max):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Max):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32And):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32Xor):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32Or):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32Shl):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32ShrS):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32ShrU):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32Rotl):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32Rotr):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32Clz):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32Ctz):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32Eq):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Eq):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32Ne):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Ne):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32LtS):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64LtS):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32LeS):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64LeS):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32GtS):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64GtS):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32GeS):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64GeS):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32LtU):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64LtU):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32LeU):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64LeU):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32GtU):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64GtU):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32GeU):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64GeU):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Eq):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Eq):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Ne):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Ne):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Lt):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Lt):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Le):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Le):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Gt):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Gt):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Ge):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Ge):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32Extend16S):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32Eqz):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32Popcnt):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Popcnt):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32ReinterpretF32):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32ReinterpretI32):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32DemoteF64):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64PromoteF32):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Copysign):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32ConvertSI32):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64ConvertSI32):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Copysign):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Abs):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Abs):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Sqrt):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Sqrt):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Neg):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Neg):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32TruncSF32):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32TruncSF64):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32TruncUF32):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI32TruncUF64):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64TruncSF32):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64TruncSF64):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64TruncUF32):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64TruncUF64):
(JSC::Wasm::BBQJITImpl::BBQJIT::addRefEq):
(JSC::Wasm::BBQJITImpl::BBQJIT::addRefFunc):
(JSC::Wasm::BBQJITImpl::BBQJIT::addTopLevel):
(JSC::Wasm::BBQJITImpl::BBQJIT::addBlock):
(JSC::Wasm::BBQJITImpl::BBQJIT::addLoop):
(JSC::Wasm::BBQJITImpl::BBQJIT::addIf):
(JSC::Wasm::BBQJITImpl::BBQJIT::addElse):
(JSC::Wasm::BBQJITImpl::BBQJIT::addElseToUnreachable):
(JSC::Wasm::BBQJITImpl::BBQJIT::addTry):
(JSC::Wasm::BBQJITImpl::BBQJIT::addTryTable):
(JSC::Wasm::BBQJITImpl::BBQJIT::addCatch):
(JSC::Wasm::BBQJITImpl::BBQJIT::addCatchToUnreachable):
(JSC::Wasm::BBQJITImpl::BBQJIT::addCatchAll):
(JSC::Wasm::BBQJITImpl::BBQJIT::addCatchAllToUnreachable):
(JSC::Wasm::BBQJITImpl::BBQJIT::addDelegate):
(JSC::Wasm::BBQJITImpl::BBQJIT::addDelegateToUnreachable):
(JSC::Wasm::BBQJITImpl::BBQJIT::addThrow):
(JSC::Wasm::BBQJITImpl::BBQJIT::addReturn):
(JSC::Wasm::BBQJITImpl::BBQJIT::addBranch):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSwitch):
(JSC::Wasm::BBQJITImpl::BBQJIT::endBlock):
(JSC::Wasm::BBQJITImpl::BBQJIT::addEndToUnreachable):
(JSC::Wasm::BBQJITImpl::BBQJIT::endTopLevel):
(JSC::Wasm::BBQJITImpl::BBQJIT::addCall):
(JSC::Wasm::BBQJITImpl::BBQJIT::addCallIndirect):
(JSC::Wasm::BBQJITImpl::BBQJIT::addUnreachable):
(JSC::Wasm::BBQJITImpl::BBQJIT::addCrash):
(JSC::Wasm::BBQJITImpl::BBQJIT::addFusedIfCompare):
* Source/JavaScriptCore/wasm/WasmBBQJIT.h:
* Source/JavaScriptCore/wasm/WasmBBQJIT32_64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addTableGet):
(JSC::Wasm::BBQJITImpl::BBQJIT::getGlobal):
(JSC::Wasm::BBQJITImpl::BBQJIT::setGlobal):
(JSC::Wasm::BBQJITImpl::BBQJIT::load):
(JSC::Wasm::BBQJITImpl::BBQJIT::store):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitAtomicLoadOp):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitAtomicCompareExchange):
(JSC::Wasm::BBQJITImpl::BBQJIT::addRefI31):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI31GetS):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI31GetU):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayNew):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayNewFixed):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayNewDefault):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayGet):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArraySet):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayLen):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayFill):
(JSC::Wasm::BBQJITImpl::BBQJIT::addStructNewDefault):
(JSC::Wasm::BBQJITImpl::BBQJIT::addStructNew):
(JSC::Wasm::BBQJITImpl::BBQJIT::addStructGet):
(JSC::Wasm::BBQJITImpl::BBQJIT::addStructSet):
(JSC::Wasm::BBQJITImpl::BBQJIT::addRefCast):
(JSC::Wasm::BBQJITImpl::BBQJIT::addRefTest):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Add):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Sub):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Mul):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64And):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Xor):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Or):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Shl):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64ShrS):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64ShrU):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Rotl):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Rotr):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Clz):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Ctz):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Extend8S):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Extend16S):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Extend32S):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64ExtendSI32):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64ExtendUI32):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Eqz):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64ReinterpretF64):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64ReinterpretI64):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32ConvertUI32):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32ConvertSI64):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32ConvertUI64):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64ConvertUI32):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64ConvertSI64):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64ConvertUI64):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Floor):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Floor):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Ceil):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Ceil):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Nearest):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Nearest):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Trunc):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Trunc):
(JSC::Wasm::BBQJITImpl::BBQJIT::addRefIsNull):
(JSC::Wasm::BBQJITImpl::BBQJIT::addRefAsNonNull):
(JSC::Wasm::BBQJITImpl::BBQJIT::addThrowRef):
(JSC::Wasm::BBQJITImpl::BBQJIT::addRethrow):
(JSC::Wasm::BBQJITImpl::BBQJIT::addBranchNull):
(JSC::Wasm::BBQJITImpl::BBQJIT::addBranchCast):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDLoad):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDStore):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDSplat):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDShuffle):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDShift):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDExtmul):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDLoadSplat):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDLoadLane):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDStoreLane):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDLoadExtend):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDLoadPad):
(JSC::Wasm::BBQJITImpl::BBQJIT::addExtractLane):
(JSC::Wasm::BBQJITImpl::BBQJIT::addReplaceLane):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDI_V):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDV_V):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDBitwiseSelect):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDRelOp):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDV_VV):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDRelaxedFMA):
(JSC::Wasm::BBQJITImpl::BBQJIT::addCallRef):
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addTableGet):
(JSC::Wasm::BBQJITImpl::BBQJIT::getGlobal):
(JSC::Wasm::BBQJITImpl::BBQJIT::setGlobal):
(JSC::Wasm::BBQJITImpl::BBQJIT::load):
(JSC::Wasm::BBQJITImpl::BBQJIT::store):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitAtomicLoadOp):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitAtomicCompareExchange):
(JSC::Wasm::BBQJITImpl::BBQJIT::addRefI31):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI31GetS):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI31GetU):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayNew):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayNewFixed):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayNewDefault):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayGet):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArraySet):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayLen):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayFill):
(JSC::Wasm::BBQJITImpl::BBQJIT::addStructNewDefault):
(JSC::Wasm::BBQJITImpl::BBQJIT::addStructNew):
(JSC::Wasm::BBQJITImpl::BBQJIT::addStructGet):
(JSC::Wasm::BBQJITImpl::BBQJIT::addStructSet):
(JSC::Wasm::BBQJITImpl::BBQJIT::addRefCast):
(JSC::Wasm::BBQJITImpl::BBQJIT::addRefTest):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Add):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Sub):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Mul):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64And):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Xor):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Or):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Shl):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64ShrS):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64ShrU):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Rotl):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Rotr):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Clz):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Ctz):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Extend8S):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Extend16S):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Extend32S):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64ExtendSI32):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64ExtendUI32):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64Eqz):
(JSC::Wasm::BBQJITImpl::BBQJIT::addI64ReinterpretF64):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64ReinterpretI64):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32ConvertUI32):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32ConvertSI64):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32ConvertUI64):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64ConvertUI32):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64ConvertSI64):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64ConvertUI64):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Floor):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Floor):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Ceil):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Ceil):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Nearest):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Nearest):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF32Trunc):
(JSC::Wasm::BBQJITImpl::BBQJIT::addF64Trunc):
(JSC::Wasm::BBQJITImpl::BBQJIT::addRefIsNull):
(JSC::Wasm::BBQJITImpl::BBQJIT::addRefAsNonNull):
(JSC::Wasm::BBQJITImpl::BBQJIT::addThrowRef):
(JSC::Wasm::BBQJITImpl::BBQJIT::addRethrow):
(JSC::Wasm::BBQJITImpl::BBQJIT::addBranchNull):
(JSC::Wasm::BBQJITImpl::BBQJIT::addBranchCast):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDLoad):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDStore):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDSplat):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDShuffle):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDShift):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDExtmul):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDLoadSplat):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDLoadLane):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDStoreLane):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDLoadExtend):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDLoadPad):
(JSC::Wasm::BBQJITImpl::BBQJIT::addConstant):
(JSC::Wasm::BBQJITImpl::BBQJIT::addExtractLane):
(JSC::Wasm::BBQJITImpl::BBQJIT::addReplaceLane):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDI_V):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDV_V):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDBitwiseSelect):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDRelOp):
(JSC::Wasm::BBQJITImpl::BBQJIT::fixupOutOfBoundsIndicesForSwizzle):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDV_VV):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDRelaxedFMA):
(JSC::Wasm::BBQJITImpl::BBQJIT::addCallRef):
* Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp:
(JSC::Wasm::ConstExprGenerator::fail const):
(JSC::Wasm::ConstExprGenerator::getGlobal):
(JSC::Wasm::ConstExprGenerator::addRefI31):
(JSC::Wasm::ConstExprGenerator::addArrayNew):
(JSC::Wasm::ConstExprGenerator::addArrayNewDefault):
(JSC::Wasm::ConstExprGenerator::addArrayNewFixed):
(JSC::Wasm::ConstExprGenerator::addStructNewDefault):
(JSC::Wasm::ConstExprGenerator::addStructNew):
(JSC::Wasm::ConstExprGenerator::addAnyConvertExtern):
(JSC::Wasm::ConstExprGenerator::addExternConvertAny):
(JSC::Wasm::ConstExprGenerator::addI32Add):
(JSC::Wasm::ConstExprGenerator::addI64Add):
(JSC::Wasm::ConstExprGenerator::addI32Sub):
(JSC::Wasm::ConstExprGenerator::addI64Sub):
(JSC::Wasm::ConstExprGenerator::addI32Mul):
(JSC::Wasm::ConstExprGenerator::addI64Mul):
(JSC::Wasm::ConstExprGenerator::addRefFunc):
(JSC::Wasm::ConstExprGenerator::endBlock):
(JSC::Wasm::ConstExprGenerator::endTopLevel):
(JSC::Wasm::ConstExprGenerator::addConstant):
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser::simd):
(JSC::Wasm::FunctionParser::validationFail const):
(JSC::Wasm::FunctionParser::validationFailHelper const):
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
(JSC::Wasm::IPIntGenerator::fail const):
(JSC::Wasm::IPIntGenerator::addFusedBranchCompare):
(JSC::Wasm::IPIntGenerator::addFusedIfCompare):
(JSC::Wasm::IPIntGenerator::addDrop):
(JSC::Wasm::IPIntGenerator::addSIMDLoad):
(JSC::Wasm::IPIntGenerator::addSIMDStore):
(JSC::Wasm::IPIntGenerator::addSIMDSplat):
(JSC::Wasm::IPIntGenerator::addSIMDShuffle):
(JSC::Wasm::IPIntGenerator::addSIMDShift):
(JSC::Wasm::IPIntGenerator::addSIMDExtmul):
(JSC::Wasm::IPIntGenerator::addSIMDLoadSplat):
(JSC::Wasm::IPIntGenerator::addSIMDLoadLane):
(JSC::Wasm::IPIntGenerator::addSIMDStoreLane):
(JSC::Wasm::IPIntGenerator::addSIMDLoadExtend):
(JSC::Wasm::IPIntGenerator::addSIMDLoadPad):
(JSC::Wasm::IPIntGenerator::addExtractLane):
(JSC::Wasm::IPIntGenerator::addReplaceLane):
(JSC::Wasm::IPIntGenerator::addSIMDI_V):
(JSC::Wasm::IPIntGenerator::addSIMDV_V):
(JSC::Wasm::IPIntGenerator::addSIMDBitwiseSelect):
(JSC::Wasm::IPIntGenerator::addSIMDRelOp):
(JSC::Wasm::IPIntGenerator::addSIMDV_VV):
(JSC::Wasm::IPIntGenerator::addSIMDRelaxedFMA):
(JSC::Wasm::IPIntGenerator::addRefIsNull):
(JSC::Wasm::IPIntGenerator::addRefFunc):
(JSC::Wasm::IPIntGenerator::addRefAsNonNull):
(JSC::Wasm::IPIntGenerator::addRefEq):
(JSC::Wasm::IPIntGenerator::addTableGet):
(JSC::Wasm::IPIntGenerator::addTableSet):
(JSC::Wasm::IPIntGenerator::addTableInit):
(JSC::Wasm::IPIntGenerator::addElemDrop):
(JSC::Wasm::IPIntGenerator::addTableSize):
(JSC::Wasm::IPIntGenerator::addTableGrow):
(JSC::Wasm::IPIntGenerator::addTableFill):
(JSC::Wasm::IPIntGenerator::addTableCopy):
(JSC::Wasm::IPIntGenerator::addArguments):
(JSC::Wasm::IPIntGenerator::addLocal):
(JSC::Wasm::IPIntGenerator::getLocal):
(JSC::Wasm::IPIntGenerator::setLocal):
(JSC::Wasm::IPIntGenerator::teeLocal):
(JSC::Wasm::IPIntGenerator::getGlobal):
(JSC::Wasm::IPIntGenerator::setGlobal):
(JSC::Wasm::IPIntGenerator::load):
(JSC::Wasm::IPIntGenerator::store):
(JSC::Wasm::IPIntGenerator::addGrowMemory):
(JSC::Wasm::IPIntGenerator::addCurrentMemory):
(JSC::Wasm::IPIntGenerator::addMemoryFill):
(JSC::Wasm::IPIntGenerator::addMemoryCopy):
(JSC::Wasm::IPIntGenerator::addMemoryInit):
(JSC::Wasm::IPIntGenerator::addDataDrop):
(JSC::Wasm::IPIntGenerator::atomicLoad):
(JSC::Wasm::IPIntGenerator::atomicStore):
(JSC::Wasm::IPIntGenerator::atomicBinaryRMW):
(JSC::Wasm::IPIntGenerator::atomicCompareExchange):
(JSC::Wasm::IPIntGenerator::atomicWait):
(JSC::Wasm::IPIntGenerator::atomicNotify):
(JSC::Wasm::IPIntGenerator::atomicFence):
(JSC::Wasm::IPIntGenerator::addRefI31):
(JSC::Wasm::IPIntGenerator::addI31GetS):
(JSC::Wasm::IPIntGenerator::addI31GetU):
(JSC::Wasm::IPIntGenerator::addArrayNew):
(JSC::Wasm::IPIntGenerator::addArrayNewData):
(JSC::Wasm::IPIntGenerator::addArrayNewElem):
(JSC::Wasm::IPIntGenerator::addArrayNewFixed):
(JSC::Wasm::IPIntGenerator::addArrayNewDefault):
(JSC::Wasm::IPIntGenerator::addArrayGet):
(JSC::Wasm::IPIntGenerator::addArraySet):
(JSC::Wasm::IPIntGenerator::addArrayLen):
(JSC::Wasm::IPIntGenerator::addArrayFill):
(JSC::Wasm::IPIntGenerator::addArrayCopy):
(JSC::Wasm::IPIntGenerator::addArrayInitElem):
(JSC::Wasm::IPIntGenerator::addArrayInitData):
(JSC::Wasm::IPIntGenerator::addStructNew):
(JSC::Wasm::IPIntGenerator::addStructNewDefault):
(JSC::Wasm::IPIntGenerator::addStructGet):
(JSC::Wasm::IPIntGenerator::addStructSet):
(JSC::Wasm::IPIntGenerator::addRefTest):
(JSC::Wasm::IPIntGenerator::addRefCast):
(JSC::Wasm::IPIntGenerator::addAnyConvertExtern):
(JSC::Wasm::IPIntGenerator::addExternConvertAny):
(JSC::Wasm::IPIntGenerator::addI32Add):
(JSC::Wasm::IPIntGenerator::addI64Add):
(JSC::Wasm::IPIntGenerator::addI32Sub):
(JSC::Wasm::IPIntGenerator::addI64Sub):
(JSC::Wasm::IPIntGenerator::addI32Mul):
(JSC::Wasm::IPIntGenerator::addI64Mul):
(JSC::Wasm::IPIntGenerator::addI32DivS):
(JSC::Wasm::IPIntGenerator::addI32DivU):
(JSC::Wasm::IPIntGenerator::addI64DivS):
(JSC::Wasm::IPIntGenerator::addI64DivU):
(JSC::Wasm::IPIntGenerator::addI32RemS):
(JSC::Wasm::IPIntGenerator::addI32RemU):
(JSC::Wasm::IPIntGenerator::addI64RemS):
(JSC::Wasm::IPIntGenerator::addI64RemU):
(JSC::Wasm::IPIntGenerator::addI32And):
(JSC::Wasm::IPIntGenerator::addI64And):
(JSC::Wasm::IPIntGenerator::addI32Xor):
(JSC::Wasm::IPIntGenerator::addI64Xor):
(JSC::Wasm::IPIntGenerator::addI32Or):
(JSC::Wasm::IPIntGenerator::addI64Or):
(JSC::Wasm::IPIntGenerator::addI32Shl):
(JSC::Wasm::IPIntGenerator::addI32ShrU):
(JSC::Wasm::IPIntGenerator::addI32ShrS):
(JSC::Wasm::IPIntGenerator::addI64Shl):
(JSC::Wasm::IPIntGenerator::addI64ShrU):
(JSC::Wasm::IPIntGenerator::addI64ShrS):
(JSC::Wasm::IPIntGenerator::addI32Rotl):
(JSC::Wasm::IPIntGenerator::addI64Rotl):
(JSC::Wasm::IPIntGenerator::addI32Rotr):
(JSC::Wasm::IPIntGenerator::addI64Rotr):
(JSC::Wasm::IPIntGenerator::addI32Popcnt):
(JSC::Wasm::IPIntGenerator::addI64Popcnt):
(JSC::Wasm::IPIntGenerator::addI32Clz):
(JSC::Wasm::IPIntGenerator::addI64Clz):
(JSC::Wasm::IPIntGenerator::addI32Ctz):
(JSC::Wasm::IPIntGenerator::addI64Ctz):
(JSC::Wasm::IPIntGenerator::addF32Add):
(JSC::Wasm::IPIntGenerator::addF64Add):
(JSC::Wasm::IPIntGenerator::addF32Sub):
(JSC::Wasm::IPIntGenerator::addF64Sub):
(JSC::Wasm::IPIntGenerator::addF32Mul):
(JSC::Wasm::IPIntGenerator::addF64Mul):
(JSC::Wasm::IPIntGenerator::addF32Div):
(JSC::Wasm::IPIntGenerator::addF64Div):
(JSC::Wasm::IPIntGenerator::addF32Min):
(JSC::Wasm::IPIntGenerator::addF32Max):
(JSC::Wasm::IPIntGenerator::addF64Min):
(JSC::Wasm::IPIntGenerator::addF64Max):
(JSC::Wasm::IPIntGenerator::addF32Nearest):
(JSC::Wasm::IPIntGenerator::addF64Nearest):
(JSC::Wasm::IPIntGenerator::addF32Floor):
(JSC::Wasm::IPIntGenerator::addF64Floor):
(JSC::Wasm::IPIntGenerator::addF32Ceil):
(JSC::Wasm::IPIntGenerator::addF64Ceil):
(JSC::Wasm::IPIntGenerator::addF32Copysign):
(JSC::Wasm::IPIntGenerator::addF64Copysign):
(JSC::Wasm::IPIntGenerator::addF32Sqrt):
(JSC::Wasm::IPIntGenerator::addF64Sqrt):
(JSC::Wasm::IPIntGenerator::addF32Neg):
(JSC::Wasm::IPIntGenerator::addF64Neg):
(JSC::Wasm::IPIntGenerator::addF32Abs):
(JSC::Wasm::IPIntGenerator::addF64Abs):
(JSC::Wasm::IPIntGenerator::addI32Eq):
(JSC::Wasm::IPIntGenerator::addI32Ne):
(JSC::Wasm::IPIntGenerator::addI32LtS):
(JSC::Wasm::IPIntGenerator::addI32LtU):
(JSC::Wasm::IPIntGenerator::addI32LeS):
(JSC::Wasm::IPIntGenerator::addI32LeU):
(JSC::Wasm::IPIntGenerator::addI32GtS):
(JSC::Wasm::IPIntGenerator::addI32GtU):
(JSC::Wasm::IPIntGenerator::addI32GeU):
(JSC::Wasm::IPIntGenerator::addI32GeS):
(JSC::Wasm::IPIntGenerator::addI32Eqz):
(JSC::Wasm::IPIntGenerator::addI64Eq):
(JSC::Wasm::IPIntGenerator::addI64Ne):
(JSC::Wasm::IPIntGenerator::addI64GtS):
(JSC::Wasm::IPIntGenerator::addI64GtU):
(JSC::Wasm::IPIntGenerator::addI64GeS):
(JSC::Wasm::IPIntGenerator::addI64GeU):
(JSC::Wasm::IPIntGenerator::addI64LtS):
(JSC::Wasm::IPIntGenerator::addI64LtU):
(JSC::Wasm::IPIntGenerator::addI64LeS):
(JSC::Wasm::IPIntGenerator::addI64LeU):
(JSC::Wasm::IPIntGenerator::addI64Eqz):
(JSC::Wasm::IPIntGenerator::addF32Eq):
(JSC::Wasm::IPIntGenerator::addF32Ne):
(JSC::Wasm::IPIntGenerator::addF32Lt):
(JSC::Wasm::IPIntGenerator::addF32Le):
(JSC::Wasm::IPIntGenerator::addF32Gt):
(JSC::Wasm::IPIntGenerator::addF32Ge):
(JSC::Wasm::IPIntGenerator::addF64Eq):
(JSC::Wasm::IPIntGenerator::addF64Ne):
(JSC::Wasm::IPIntGenerator::addF64Lt):
(JSC::Wasm::IPIntGenerator::addF64Le):
(JSC::Wasm::IPIntGenerator::addF64Gt):
(JSC::Wasm::IPIntGenerator::addF64Ge):
(JSC::Wasm::IPIntGenerator::addI64ExtendSI32):
(JSC::Wasm::IPIntGenerator::addI64ExtendUI32):
(JSC::Wasm::IPIntGenerator::addI32Extend8S):
(JSC::Wasm::IPIntGenerator::addI32Extend16S):
(JSC::Wasm::IPIntGenerator::addI64Extend8S):
(JSC::Wasm::IPIntGenerator::addI64Extend16S):
(JSC::Wasm::IPIntGenerator::addI64Extend32S):
(JSC::Wasm::IPIntGenerator::addF64Trunc):
(JSC::Wasm::IPIntGenerator::addF32Trunc):
(JSC::Wasm::IPIntGenerator::addI32TruncSF64):
(JSC::Wasm::IPIntGenerator::addI32TruncSF32):
(JSC::Wasm::IPIntGenerator::addI32TruncUF64):
(JSC::Wasm::IPIntGenerator::addI32TruncUF32):
(JSC::Wasm::IPIntGenerator::addI64TruncSF64):
(JSC::Wasm::IPIntGenerator::addI64TruncSF32):
(JSC::Wasm::IPIntGenerator::addI64TruncUF64):
(JSC::Wasm::IPIntGenerator::addI64TruncUF32):
(JSC::Wasm::IPIntGenerator::truncSaturated):
(JSC::Wasm::IPIntGenerator::addI32WrapI64):
(JSC::Wasm::IPIntGenerator::addF32DemoteF64):
(JSC::Wasm::IPIntGenerator::addF64PromoteF32):
(JSC::Wasm::IPIntGenerator::addF32ReinterpretI32):
(JSC::Wasm::IPIntGenerator::addI32ReinterpretF32):
(JSC::Wasm::IPIntGenerator::addF64ReinterpretI64):
(JSC::Wasm::IPIntGenerator::addI64ReinterpretF64):
(JSC::Wasm::IPIntGenerator::addF32ConvertSI32):
(JSC::Wasm::IPIntGenerator::addF32ConvertUI32):
(JSC::Wasm::IPIntGenerator::addF32ConvertSI64):
(JSC::Wasm::IPIntGenerator::addF32ConvertUI64):
(JSC::Wasm::IPIntGenerator::addF64ConvertSI32):
(JSC::Wasm::IPIntGenerator::addF64ConvertUI32):
(JSC::Wasm::IPIntGenerator::addF64ConvertSI64):
(JSC::Wasm::IPIntGenerator::addF64ConvertUI64):
(JSC::Wasm::IPIntGenerator::addTopLevel):
(JSC::Wasm::IPIntGenerator::addSelect):
(JSC::Wasm::IPIntGenerator::addBlock):
(JSC::Wasm::IPIntGenerator::addLoop):
(JSC::Wasm::IPIntGenerator::addIf):
(JSC::Wasm::IPIntGenerator::addElse):
(JSC::Wasm::IPIntGenerator::addElseToUnreachable):
(JSC::Wasm::IPIntGenerator::addTry):
(JSC::Wasm::IPIntGenerator::addTryTable):
(JSC::Wasm::IPIntGenerator::addCatch):
(JSC::Wasm::IPIntGenerator::addCatchToUnreachable):
(JSC::Wasm::IPIntGenerator::addCatchAll):
(JSC::Wasm::IPIntGenerator::addCatchAllToUnreachable):
(JSC::Wasm::IPIntGenerator::addDelegate):
(JSC::Wasm::IPIntGenerator::addDelegateToUnreachable):
(JSC::Wasm::IPIntGenerator::addThrow):
(JSC::Wasm::IPIntGenerator::addRethrow):
(JSC::Wasm::IPIntGenerator::addThrowRef):
(JSC::Wasm::IPIntGenerator::addReturn):
(JSC::Wasm::IPIntGenerator::addBranch):
(JSC::Wasm::IPIntGenerator::addBranchNull):
(JSC::Wasm::IPIntGenerator::addBranchCast):
(JSC::Wasm::IPIntGenerator::addSwitch):
(JSC::Wasm::IPIntGenerator::endBlock):
(JSC::Wasm::IPIntGenerator::addEndToUnreachable):
(JSC::Wasm::IPIntGenerator::addCall):
(JSC::Wasm::IPIntGenerator::addCallIndirect):
(JSC::Wasm::IPIntGenerator::addCallRef):
(JSC::Wasm::IPIntGenerator::addUnreachable):
(JSC::Wasm::IPIntGenerator::addCrash):
* Source/JavaScriptCore/wasm/WasmNameSectionParser.h:
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::fail const):
(JSC::Wasm::OMGIRGenerator::addConstant):
(JSC::Wasm::OMGIRGenerator::addEndToUnreachable):
(JSC::Wasm::OMGIRGenerator::endTopLevel):
(JSC::Wasm::OMGIRGenerator::addFusedBranchCompare):
(JSC::Wasm::OMGIRGenerator::addFusedIfCompare):
(JSC::Wasm::OMGIRGenerator::emitStructSet):
(JSC::Wasm::OMGIRGenerator::addThrowRef):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp:
(JSC::Wasm::OMGIRGenerator::fail const):
(JSC::Wasm::OMGIRGenerator::addConstant):
(JSC::Wasm::OMGIRGenerator::addEndToUnreachable):
(JSC::Wasm::OMGIRGenerator::endTopLevel):
(JSC::Wasm::OMGIRGenerator::addFusedBranchCompare):
(JSC::Wasm::OMGIRGenerator::addFusedIfCompare):
(JSC::Wasm::OMGIRGenerator::emitStructSet):
(JSC::Wasm::OMGIRGenerator::addThrowRef):
* Source/JavaScriptCore/wasm/WasmParser.h:
(JSC::Wasm::ParserBase::fail const):
* Source/JavaScriptCore/wasm/WasmPlan.h:
(JSC::Wasm::Plan::failed const):
* Source/JavaScriptCore/wasm/WasmSectionParser.h:
* Source/JavaScriptCore/wasm/WasmStreamingParser.cpp:
(JSC::Wasm::StreamingParser::fail):
* Source/JavaScriptCore/wasm/WasmStreamingParser.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.h:
* Source/JavaScriptCore/yarr/YarrInterpreter.cpp:
(JSC::Yarr::ByteCompiler::emitDisjunction):
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::YarrPatternConstructor::setupAlternativeOffsets):
* Source/WTF/wtf/AllocSpanMixin.h:
(WTF::AllocSpanMixin::leakSpan):
* Source/WTF/wtf/CheckedArithmetic.h:
* Source/WTF/wtf/Compiler.h:
* Source/WTF/wtf/CompletionHandler.h:
(WTF::CompletionHandler&lt;Out):
* Source/WTF/wtf/FileSystem.h:
* Source/WTF/wtf/Function.h:
(WTF::Function&lt;Out):
* Source/WTF/wtf/InlineWeakPtr.h:
* Source/WTF/wtf/InlineWeakRef.h:
* Source/WTF/wtf/LEBDecoder.h:
(WTF::LEBDecoder::decodeUInt):
(WTF::LEBDecoder::decodeInt):
(WTF::LEBDecoder::decodeUInt32):
(WTF::LEBDecoder::decodeUInt64):
(WTF::LEBDecoder::decodeInt32):
(WTF::LEBDecoder::decodeInt64):
* Source/WTF/wtf/MachSendRight.h:
* Source/WTF/wtf/MallocCommon.h:
* Source/WTF/wtf/MallocPtr.h:
(WTF::MallocPtr::leakPtr):
* Source/WTF/wtf/MappedFileData.h:
(WTF::FileSystemImpl::MappedFileData::leakHandle):
* Source/WTF/wtf/OSObjectPtr.h:
(WTF::OSObjectPtr::leakRef):
* Source/WTF/wtf/OptionSet.h:
(WTF::isValidOptionSet):
* Source/WTF/wtf/Ref.h:
(WTF::Ref::copyRef const):
(WTF::Ref::leakRef):
* Source/WTF/wtf/RefPtr.h:
(WTF::RefPtr::copyRef const):
* Source/WTF/wtf/RetainPtr.h:
* Source/WTF/wtf/Scope.h:
* Source/WTF/wtf/glib/GMallocString.h:
* Source/WTF/wtf/glib/GRefPtr.h:
(WTF::GRefPtr::leakRef):
(WTF::GRefPtr::ref):
* Source/WTF/wtf/glib/GThreadSafeWeakPtr.h:
(WTF::GThreadSafeWeakPtr::get):
* Source/WTF/wtf/persistence/PersistentDecoder.h:
* Source/WTF/wtf/text/AtomString.h:
(WTF::makeStringByReplacingAll):
* Source/WTF/wtf/text/MakeString.h:
(WTF::makeStringByInserting):
* Source/WTF/wtf/text/StringView.h:
(WTF::makeStringByReplacingAll):
(WTF::makeStringByReplacing):
(WTF::makeStringBySimplifyingNewLines):
* Source/WTF/wtf/text/WTFString.h:
(WTF::makeStringByReplacingAll):
* Source/WTF/wtf/unix/UnixFileDescriptor.h:
(WTF::UnixFileDescriptor::release):
* Source/WTF/wtf/win/GDIObject.h:
* Source/WTF/wtf/win/Win32Handle.h:
* Source/WebCore/Modules/WebGPU/GPUPresentationContext.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPresentationContext.h:
* Source/WebCore/Modules/indexeddb/IDBKeyData.h:
* Source/WebCore/Modules/indexeddb/server/IDBSerialization.cpp:
(WebCore::decodeKey):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp:
(WebCore::toRtpCodecCapability):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h:
* Source/WebCore/css/CSSStyleProperties.h:
(WebCore::PropertySetCSSStyleProperties::willMutate):
* Source/WebCore/css/PropertySetCSSDescriptors.h:
* Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.h:
* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
(WebCore::collectStylesToRemove):
* Source/WebCore/fileapi/URLKeepingBlobAlive.h:
* Source/WebCore/inspector/InspectorResourceUtilities.cpp:
(Inspector::ResourceUtilities::decodeBuffer):
* Source/WebCore/loader/FetchOptions.h:
* Source/WebCore/page/OpportunisticTaskScheduler.h:
* Source/WebCore/page/csp/ContentSecurityPolicy.h:
* Source/WebCore/platform/KeyedCoding.h:
* Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp:
(WebCore::tryCreateAudioBufferList):
* Source/WebCore/platform/cf/KeyedDecoderCF.h:
* Source/WebCore/platform/encryptedmedia/CDMProxy.h:
(WebCore::KeyStoreBase::keyHandle const):
(WebCore::KeyStoreBase::allKeysAs const):
(WebCore::KeyStoreBase::convertToJSKeyStatusVector const):
* Source/WebCore/platform/generic/KeyedDecoderGeneric.h:
* Source/WebCore/platform/glib/KeyedDecoderGlib.h:
* Source/WebCore/platform/graphics/IntRect.h:
* Source/WebCore/platform/graphics/TrackBuffer.cpp:
(WebCore::decodeTimeComparator):
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h:
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::webkitGstGhostPadFromStaticTemplate):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h:
* Source/WebCore/platform/graphics/gstreamer/GStreamerVideoFrameConverter.h:
* Source/WebCore/platform/graphics/gstreamer/VideoFrameMetadataGStreamer.h:
* Source/WebCore/platform/graphics/transforms/TransformationMatrix.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDevice.h:
(WebCore::GStreamerCaptureDevice::caps const):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp:
(mediaStreamTrackPrivateGetTags):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerRTPPacketizer.h:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.h:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.h:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.h:
* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoFrameLibWebRTC.h:
* Source/WebCore/rendering/RenderWidget.h:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/updating/RenderTreeBuilder.h:
* Source/WebCore/rendering/updating/RenderTreeBuilderBlock.h:
* Source/WebCore/rendering/updating/RenderTreeBuilderFormControls.h:
* Source/WebCore/rendering/updating/RenderTreeBuilderSVG.h:
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::check):
* Source/WebGPU/WebGPU/BindGroup.mm:
(WebGPU::setArgumentBuffer):
* Source/WebGPU/WebGPU/Queue.h:
* Source/WebGPU/WebGPU/RenderPassEncoder.h:
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsDatabaseStore.h:
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h:
* Source/WebKit/NetworkProcess/DatabaseUtilities.h:
* Source/WebKit/NetworkProcess/cache/NetworkCacheKey.h:
(WebKit::NetworkCache::DataKey::decodeForPersistence):
* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp:
(WebKit::NetworkCache::decodeRecordMetaData):
(WebKit::NetworkCache::decodeRecordHeader):
* Source/WebKit/Platform/IPC/ArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;String&gt;::decode):
* Source/WebKit/Platform/IPC/ConnectionHandle.h:
(IPC::ConnectionHandle::release):
(IPC::ConnectionHandle::leak):
(IPC::ConnectionHandle::leakSendRight):
* Source/WebKit/Platform/IPC/DaemonDecoder.h:
(WebKit::Daemon::Decoder::bufferIsLargeEnoughToContain const):
* Source/WebKit/Platform/IPC/Decoder.h:
(IPC::Decoder::isValid const):
* Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm:
(WebKit::SandboxExtensionImpl::consume):
* Source/WebKit/Shared/SandboxExtension.h:
* Source/WebKit/UIProcess/Cocoa/SessionStateCoding.h:
* Source/WebKit/UIProcess/LegacySessionStateCoding.h:
* Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp:
(WebKit::decodeSessionHistoryEntryData):
(WebKit::decodeSessionHistoryEntry):
(WebKit::decodeSessionHistoryEntries):
(WebKit::decodeV0SessionHistory):
(WebKit::decodeV1SessionHistory):
(WebKit::decodeSessionHistory):
* Source/WebKit/WebProcess/GPU/graphics/Model/RemoteDDMeshProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h:
(WebKit::RemoteGraphicsContextGLProxy::send):
(WebKit::RemoteGraphicsContextGLProxy::sendSync):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupLayoutProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteExternalTextureProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePipelineLayoutProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQuerySetProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSamplerProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRBindingProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRProjectionLayerProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRSubImageProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRViewProxy.h:
* Source/WebKit/WebProcess/WebPage/WebCookieCache.h:

Canonical link: <a href="https://commits.webkit.org/305420@main">https://commits.webkit.org/305420@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f49b1cc8203ca0fdb5432bcb0e07fbcc3993d54

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138367 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10732 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49777 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146450 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91342 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140241 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11436 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10886 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105867 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77218 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141314 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8582 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124040 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86715 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8169 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5934 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6736 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/130331 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117587 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42241 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149163 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/136950 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10414 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42798 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114267 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10431 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8805 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114609 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29101 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8144 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120328 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65248 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10461 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38261 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/169640 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10195 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74040 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44217 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10401 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10252 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->