### PR TITLE
Third nested iframe with srcdoc does not render in Safari

### DIFF
--- a/LayoutTests/fast/frames/nested-about-srcdocs-expected.html
+++ b/LayoutTests/fast/frames/nested-about-srcdocs-expected.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div>frame 0</div>
+<div>frame 1</div>
+<div>frame 2</div>
+<div>frame 3</div>
+</body>
+</html>

--- a/LayoutTests/fast/frames/nested-about-srcdocs.html
+++ b/LayoutTests/fast/frames/nested-about-srcdocs.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+window.addEventListener("load", async () => {
+    let doc = document;
+    
+    for (let i = 0; i < 4; i++) {
+        const iframe = doc.createElement("iframe");
+        iframe.style.border = 'none';
+        iframe.srcdoc = '<style>html, body { margin: 0px; padding: 0px; overflow: hidden; }</style>';
+        doc.body.appendChild(iframe);
+        
+        // Wait for srcdoc to load
+        await new Promise(resolve => {
+            iframe.addEventListener('load', resolve, { once: true });
+        });
+        
+        doc = iframe.contentDocument;
+        const div = doc.createElement("div");
+        div.textContent = `frame ${i}`;
+        doc.body.appendChild(div);
+    }
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/HTMLFrameOwnerElement.cpp
+++ b/Source/WebCore/html/HTMLFrameOwnerElement.cpp
@@ -146,7 +146,7 @@ void HTMLFrameOwnerElement::scheduleInvalidateStyleAndLayerComposition()
 
 bool HTMLFrameOwnerElement::isProhibitedSelfReference(const URL& completeURL) const
 {
-    if (completeURL.isAboutBlank())
+    if (completeURL.isAboutBlank() || completeURL.isAboutSrcDoc())
         return false;
     // We allow one level of self-reference because some websites depend on that, but we don't allow more than one.
     bool foundOneSelfReference = false;


### PR DESCRIPTION
#### e62c8b61b1e2f193986af19fc95211ce32d1fab9
<pre>
Third nested iframe with srcdoc does not render in Safari
<a href="https://bugs.webkit.org/show_bug.cgi?id=305276">https://bugs.webkit.org/show_bug.cgi?id=305276</a>
<a href="https://rdar.apple.com/167917471">rdar://167917471</a>

Reviewed by Ryosuke Niwa.

The fix is similar to 305404@main, which was to fix about:blank case,
we had similar issue for about:srcdoc, where isProhibitedSelfReference
incorrectly determines about:srcdoc inside another about:srcdoc as self
referencing.

* Source/WebCore/html/HTMLFrameOwnerElement.cpp:
(WebCore::HTMLFrameOwnerElement::isProhibitedSelfReference const):
* LayoutTests/fast/frames/nested-about-srcdocs-expected.html: Added.
* LayoutTests/fast/frames/nested-about-srcdocs.html: Added.

Canonical link: <a href="https://commits.webkit.org/305421@main">https://commits.webkit.org/305421@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49be596e87f6e605902380844a9e6c7feeebec80

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138380 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10745 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49790 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146463 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91355 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b8e6c8ee-dc90-4bbf-a71c-f02529bdbe73) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140254 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11449 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10899 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105879 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77230 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3cbfc03b-1bad-4d7e-bdc7-3b02a767378f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141327 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8594 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124052 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86723 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8e44e1f3-5806-4f0a-8018-e2a6ac4520a4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8181 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5945 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6749 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117600 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42253 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149176 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10427 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42810 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114278 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10444 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8816 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114621 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29102 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8161 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120340 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65268 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10474 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38273 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10208 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74056 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10414 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10265 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->