### PR TITLE
Refactor BlobData to use a variant

### DIFF
--- a/Source/WebCore/platform/network/BlobData.cpp
+++ b/Source/WebCore/platform/network/BlobData.cpp
@@ -48,7 +48,7 @@ long long BlobDataItem::length() const
     if (m_length != toEndOfFile)
         return m_length;
 
-    switch (m_type) {
+    switch (type()) {
     case Type::Data:
         ASSERT_NOT_REACHED();
         return m_length;
@@ -74,7 +74,7 @@ void BlobData::appendData(Ref<DataSegment>&& data, long long offset, long long l
 void BlobData::replaceData(const DataSegment& oldData, Ref<DataSegment>&& newData)
 {
     for (auto& blobItem : m_items) {
-        if (blobItem.data() == &oldData) {
+        if (blobItem.type() == BlobDataItem::Type::Data && &blobItem.data() == &oldData) {
             blobItem.m_data = WTF::move(newData);
             break;
         }
@@ -95,9 +95,9 @@ Ref<BlobData> BlobData::clone() const
     return blobData;
 }
 
-void BlobData::appendFile(BlobDataFileReference* file, long long offset, long long length)
+void BlobData::appendFile(Ref<BlobDataFileReference>&& file, long long offset, long long length)
 {
-    m_items.append(BlobDataItem(file, offset, length));
+    m_items.append(BlobDataItem(WTF::move(file), offset, length));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/network/BlobRegistryImpl.h
+++ b/Source/WebCore/platform/network/BlobRegistryImpl.h
@@ -83,7 +83,7 @@ public:
     };
 
     bool populateBlobsForFileWriting(const Vector<String>& blobURLs, Vector<BlobForFileWriting>&);
-    Vector<RefPtr<BlobDataFileReference>> filesInBlob(const URL&, const std::optional<WebCore::SecurityOriginData>& topOrigin = std::nullopt) const;
+    Vector<Ref<BlobDataFileReference>> filesInBlob(const URL&, const std::optional<WebCore::SecurityOriginData>& topOrigin = std::nullopt) const;
 
     void setFileDirectory(String&&);
 

--- a/Source/WebCore/platform/network/BlobResourceHandleBase.cpp
+++ b/Source/WebCore/platform/network/BlobResourceHandleBase.cpp
@@ -188,15 +188,13 @@ void BlobResourceHandleBase::getSizeForNext()
         break;
     case BlobDataItem::Type::File: {
         // Files know their sizes, but asking the stream to verify that the file wasn't modified.
-        RefPtr file = item.file();
+        Ref file = item.file();
         if (async())
             asyncStream()->getSize(file->path(), file->expectedModificationTime());
         else
             didGetSize(syncStream()->getSize(file->path(), file->expectedModificationTime()));
         break;
     }
-    default:
-        ASSERT_NOT_REACHED();
     }
 }
 
@@ -284,7 +282,6 @@ void BlobResourceHandleBase::readAsync()
 bool BlobResourceHandleBase::readDataAsync(const BlobDataItem& item)
 {
     ASSERT(isMainThread());
-    ASSERT(item.data());
 
     ASSERT(m_currentItemReadSize <= static_cast<uint64_t>(item.length()));
     uint64_t bytesToRead = static_cast<uint64_t>(item.length()) - m_currentItemReadSize;

--- a/Source/WebCore/platform/network/FormData.cpp
+++ b/Source/WebCore/platform/network/FormData.cpp
@@ -315,14 +315,16 @@ static void appendBlobResolved(BlobRegistryImpl* blobRegistry, FormData& formDat
     }
 
     for (const auto& blobItem : blobData->items()) {
-        if (blobItem.type() == BlobDataItem::Type::Data) {
-            ASSERT(blobItem.data());
+        switch (blobItem.type()) {
+        case BlobDataItem::Type::Data:
             formData.appendData(blobItem.protectedData()->span().subspan(blobItem.offset(), blobItem.length()));
-        } else if (blobItem.type() == BlobDataItem::Type::File) {
-            RefPtr file = blobItem.file();
+            break;
+        case BlobDataItem::Type::File: {
+            Ref file = blobItem.file();
             formData.appendFileRange(file->path(), blobItem.offset(), blobItem.length(), file->expectedModificationTime());
-        } else
-            ASSERT_NOT_REACHED();
+            break;
+        }
+        }
     }
 }
 

--- a/Source/WebKit/NetworkProcess/BackgroundFetchLoad.h
+++ b/Source/WebKit/NetworkProcess/BackgroundFetchLoad.h
@@ -94,7 +94,7 @@ private:
     WebCore::ResourceRequest m_request;
     RefPtr<NetworkDataTask> m_task;
     const Ref<NetworkLoadChecker> m_networkLoadChecker;
-    Vector<RefPtr<WebCore::BlobDataFileReference>> m_blobFiles;
+    Vector<Ref<WebCore::BlobDataFileReference>> m_blobFiles;
 };
 
 }

--- a/Source/WebKit/NetworkProcess/Downloads/Download.h
+++ b/Source/WebKit/NetworkProcess/Downloads/Download.h
@@ -130,7 +130,7 @@ private:
     DownloadID m_downloadID;
     const Ref<DownloadManager::Client> m_client;
 
-    Vector<RefPtr<WebCore::BlobDataFileReference>> m_blobFileReferences;
+    Vector<Ref<WebCore::BlobDataFileReference>> m_blobFileReferences;
     RefPtr<SandboxExtension> m_sandboxExtension;
 
     const RefPtr<NetworkDataTask> m_download;

--- a/Source/WebKit/NetworkProcess/Downloads/DownloadManager.cpp
+++ b/Source/WebKit/NetworkProcess/Downloads/DownloadManager.cpp
@@ -85,7 +85,7 @@ void DownloadManager::dataTaskBecameDownloadTask(DownloadID downloadID, Ref<Down
     m_downloads.add(downloadID, WTF::move(download));
 }
 
-void DownloadManager::convertNetworkLoadToDownload(DownloadID downloadID, Ref<NetworkLoad>&& networkLoad, ResponseCompletionHandler&& completionHandler, Vector<RefPtr<WebCore::BlobDataFileReference>>&& blobFileReferences, const ResourceRequest& request, const ResourceResponse& response)
+void DownloadManager::convertNetworkLoadToDownload(DownloadID downloadID, Ref<NetworkLoad>&& networkLoad, ResponseCompletionHandler&& completionHandler, Vector<Ref<WebCore::BlobDataFileReference>>&& blobFileReferences, const ResourceRequest& request, const ResourceResponse& response)
 {
     ASSERT(!m_pendingDownloads.contains(downloadID));
     m_pendingDownloads.add(downloadID, PendingDownload::create(protectedClient()->protectedParentProcessConnectionForDownloads().get(), WTF::move(networkLoad), WTF::move(completionHandler), downloadID, request, response));

--- a/Source/WebKit/NetworkProcess/Downloads/DownloadManager.h
+++ b/Source/WebKit/NetworkProcess/Downloads/DownloadManager.h
@@ -91,7 +91,7 @@ public:
 
     void startDownload(PAL::SessionID, DownloadID, const WebCore::ResourceRequest&, const std::optional<WebCore::SecurityOriginData>& topOrigin, std::optional<NavigatingToAppBoundDomain>, const String& suggestedName = { }, WebCore::FromDownloadAttribute = WebCore::FromDownloadAttribute::No, std::optional<WebCore::FrameIdentifier> frameID = std::nullopt, std::optional<WebCore::PageIdentifier> = std::nullopt, std::optional<WebCore::ProcessIdentifier> = std::nullopt);
     void dataTaskBecameDownloadTask(DownloadID, Ref<Download>&&);
-    void convertNetworkLoadToDownload(DownloadID, Ref<NetworkLoad>&&, ResponseCompletionHandler&&,  Vector<RefPtr<WebCore::BlobDataFileReference>>&&, const WebCore::ResourceRequest&, const WebCore::ResourceResponse&);
+    void convertNetworkLoadToDownload(DownloadID, Ref<NetworkLoad>&&, ResponseCompletionHandler&&,  Vector<Ref<WebCore::BlobDataFileReference>>&&, const WebCore::ResourceRequest&, const WebCore::ResourceResponse&);
     void downloadDestinationDecided(DownloadID, Ref<NetworkDataTask>&&);
 
     void resumeDownload(PAL::SessionID, DownloadID, std::span<const uint8_t> resumeData, const String& path, SandboxExtension::Handle&&, CallDownloadDidStart, std::span<const uint8_t> activityAccessToken);

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -236,7 +236,7 @@ public:
     std::optional<NetworkActivityTracker> startTrackingResourceLoad(WebCore::PageIdentifier, WebCore::ResourceLoaderIdentifier resourceID, bool isTopResource);
     void stopTrackingResourceLoad(WebCore::ResourceLoaderIdentifier resourceID, NetworkActivityTracker::CompletionCode);
 
-    Vector<RefPtr<WebCore::BlobDataFileReference>> resolveBlobReferences(const NetworkResourceLoadParameters&);
+    Vector<Ref<WebCore::BlobDataFileReference>> resolveBlobReferences(const NetworkResourceLoadParameters&);
 
     void removeSocketChannel(WebCore::WebSocketIdentifier);
 

--- a/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
@@ -74,7 +74,7 @@ static RefPtr<BlobData> blobDataFrom(NetworkSession& session, const WebCore::Res
     return session.blobRegistry().blobDataFromURL(request.url(), topOriginData);
 }
 
-NetworkDataTaskBlob::NetworkDataTaskBlob(NetworkSession& session, NetworkDataTaskClient& client, const ResourceRequest& request, const Vector<RefPtr<WebCore::BlobDataFileReference>>& fileReferences, const RefPtr<SecurityOrigin>& topOrigin)
+NetworkDataTaskBlob::NetworkDataTaskBlob(NetworkSession& session, NetworkDataTaskClient& client, const ResourceRequest& request, const Vector<Ref<WebCore::BlobDataFileReference>>& fileReferences, const RefPtr<SecurityOrigin>& topOrigin)
     : NetworkDataTask(session, client, request, StoredCredentialsPolicy::DoNotUse, false, false, false)
     , BlobResourceHandleBase(true /* async */, blobDataFrom(session, request, topOrigin.get()))
     , m_fileReferences(fileReferences)

--- a/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.h
+++ b/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.h
@@ -51,7 +51,7 @@ class NetworkProcess;
 
 class NetworkDataTaskBlob final : public NetworkDataTask, public WebCore::BlobResourceHandleBase {
 public:
-    static Ref<NetworkDataTask> create(NetworkSession& session, NetworkDataTaskClient& client, const WebCore::ResourceRequest& request, const Vector<RefPtr<WebCore::BlobDataFileReference>>& fileReferences, const RefPtr<WebCore::SecurityOrigin>& topOrigin)
+    static Ref<NetworkDataTask> create(NetworkSession& session, NetworkDataTaskClient& client, const WebCore::ResourceRequest& request, const Vector<Ref<WebCore::BlobDataFileReference>>& fileReferences, const RefPtr<WebCore::SecurityOrigin>& topOrigin)
     {
         return adoptRef(*new NetworkDataTaskBlob(session, client, request, fileReferences, topOrigin));
     }
@@ -63,7 +63,7 @@ public:
     void deref() const final { NetworkDataTask::deref(); }
 
 private:
-    NetworkDataTaskBlob(NetworkSession&, NetworkDataTaskClient&, const WebCore::ResourceRequest&, const Vector<RefPtr<WebCore::BlobDataFileReference>>&, const RefPtr<WebCore::SecurityOrigin>& topOrigin);
+    NetworkDataTaskBlob(NetworkSession&, NetworkDataTaskClient&, const WebCore::ResourceRequest&, const Vector<Ref<WebCore::BlobDataFileReference>>&, const RefPtr<WebCore::SecurityOrigin>& topOrigin);
 
     // NetworkDataTask.
     void cancel() final;
@@ -91,7 +91,7 @@ private:
     State m_state { State::Suspended };
     uint64_t m_downloadBytesWritten { 0 };
     FileSystem::FileHandle m_downloadFile;
-    Vector<RefPtr<WebCore::BlobDataFileReference>> m_fileReferences;
+    Vector<Ref<WebCore::BlobDataFileReference>> m_fileReferences;
     RefPtr<SandboxExtension> m_sandboxExtension;
     const Ref<NetworkProcess> m_networkProcess;
 };

--- a/Source/WebKit/NetworkProcess/NetworkLoadParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkLoadParameters.h
@@ -57,7 +57,7 @@ struct NetworkLoadParameters {
     bool needsCertificateInfo { false };
     bool isMainFrameNavigation { false };
     std::optional<NavigationActionData> mainResourceNavigationDataForAnyFrame;
-    Vector<RefPtr<WebCore::BlobDataFileReference>> blobFileReferences;
+    Vector<Ref<WebCore::BlobDataFileReference>> blobFileReferences;
     PreconnectOnly shouldPreconnectOnly { PreconnectOnly::No };
     std::optional<NetworkActivityTracker> networkActivityTracker;
     std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain { NavigatingToAppBoundDomain::No };

--- a/Source/WebKit/NetworkProcess/NetworkLoadScheduler.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoadScheduler.cpp
@@ -278,11 +278,11 @@ void NetworkLoadScheduler::setResourceLoadSchedulingMode(WebCore::PageIdentifier
     }
 }
 
-void NetworkLoadScheduler::prioritizeLoads(const Vector<RefPtr<NetworkLoad>>& loads)
+void NetworkLoadScheduler::prioritizeLoads(const Vector<Ref<NetworkLoad>>& loads)
 {
-    for (RefPtr load : loads) {
-        if (auto* context = contextForLoad(*load))
-            context->prioritize(*load);
+    for (Ref load : loads) {
+        if (auto* context = contextForLoad(load))
+            context->prioritize(load);
     }
 }
 

--- a/Source/WebKit/NetworkProcess/NetworkLoadScheduler.h
+++ b/Source/WebKit/NetworkProcess/NetworkLoadScheduler.h
@@ -61,7 +61,7 @@ public:
     void finishedPreconnectForMainResource(const URL&, const String& userAgent, const WebCore::ResourceError&);
 
     void setResourceLoadSchedulingMode(WebCore::PageIdentifier, WebCore::LoadSchedulingMode);
-    void prioritizeLoads(const Vector<RefPtr<NetworkLoad>>&);
+    void prioritizeLoads(const Vector<Ref<NetworkLoad>>&);
     void clearPageData(WebCore::PageIdentifier);
 
 private:

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
@@ -309,7 +309,7 @@ private:
     unsigned m_redirectCount { 0 };
 
     std::unique_ptr<SynchronousLoadData> m_synchronousLoadData;
-    Vector<RefPtr<WebCore::BlobDataFileReference>> m_fileReferences;
+    Vector<Ref<WebCore::BlobDataFileReference>> m_fileReferences;
 
     bool m_wasStarted { false };
     bool m_didConsumeSandboxExtensions { false };

--- a/Source/WebKit/NetworkProcess/PingLoad.cpp
+++ b/Source/WebKit/NetworkProcess/PingLoad.cpp
@@ -59,10 +59,8 @@ PingLoad::PingLoad(NetworkConnectionToWebProcess& connection, NetworkResourceLoa
     , m_networkLoadChecker(NetworkLoadChecker::create(connection.networkProcess(), nullptr,  &connection.schemeRegistry(), FetchOptions { m_parameters.options }, m_sessionID, m_parameters.webPageProxyID, WTF::move(m_parameters.originalRequestHeaders), URL { m_parameters.request.url() }, URL { m_parameters.documentURL }, m_parameters.sourceOrigin.copyRef(), m_parameters.topOrigin.copyRef(), m_parameters.parentOrigin(), m_parameters.preflightPolicy, m_parameters.request.httpReferrer(), m_parameters.allowPrivacyProxy, m_parameters.advancedPrivacyProtections))
     , m_blobFiles(connection.resolveBlobReferences(m_parameters))
 {
-    for (auto& file : m_blobFiles) {
-        if (file)
-            file->prepareForFileAccess();
-    }
+    for (auto& file : m_blobFiles)
+        file->prepareForFileAccess();
 
     initialize(Ref { connection.networkProcess() });
 }
@@ -108,10 +106,8 @@ PingLoad::~PingLoad()
         task->clearClient();
         task->cancel();
     }
-    for (auto& file : m_blobFiles) {
-        if (file)
-            file->revokeFileAccess();
-    }
+    for (auto& file : m_blobFiles)
+        file->revokeFileAccess();
 }
 
 void PingLoad::didFinish(const ResourceError& error, const ResourceResponse& response)

--- a/Source/WebKit/NetworkProcess/PingLoad.h
+++ b/Source/WebKit/NetworkProcess/PingLoad.h
@@ -94,7 +94,7 @@ private:
     RefPtr<NetworkDataTask> m_task;
     WebCore::Timer m_timeoutTimer;
     const Ref<NetworkLoadChecker> m_networkLoadChecker;
-    Vector<RefPtr<WebCore::BlobDataFileReference>> m_blobFiles;
+    Vector<Ref<WebCore::BlobDataFileReference>> m_blobFiles;
 };
 
 }


### PR DESCRIPTION
#### d9bdf0f1d3a1ff70a608d9f35a37fe3283cfc756
<pre>
Refactor BlobData to use a variant
<a href="https://bugs.webkit.org/show_bug.cgi?id=305280">https://bugs.webkit.org/show_bug.cgi?id=305280</a>

Reviewed by Chris Dumez.

This reduces the size of BlobDataItem from 40 to 32 bytes and clarifies
its semantics. As the accessors were always used in a mutual exclusive
fashion we enforced this with asserts and made them return references
instead of pointers.

This also allowed us to replace many Vector of RefPtr with Ref in
NetworkProcess.

Claude AI provided assistance with analysis and trivial changes.

Canonical link: <a href="https://commits.webkit.org/305496@main">https://commits.webkit.org/305496@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89de5f89b2a2496051c9399d3b92764a8a9c3f90

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138479 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10844 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49889 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146563 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91454 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e036fcfa-52e8-4aec-af62-0b15771d518b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140353 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11548 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10999 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105986 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77307 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/47781d3d-388b-4e68-a0dc-4c558c18f2d2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141426 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8677 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124138 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86848 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/492138ee-4e5b-443d-9009-182e88addb68) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8264 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6031 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6856 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117684 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42337 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149352 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10526 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42894 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114373 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10543 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8898 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114710 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29160 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8381 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120424 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65413 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10574 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38357 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10309 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74184 "Built successfully") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10513 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10364 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->