### PR TITLE
[YARR] Add JIT support for non-capturing parentheses with fixed count quantifiers

### DIFF
--- a/JSTests/microbenchmarks/regexp-fixed-count-non-capturing-parens.js
+++ b/JSTests/microbenchmarks/regexp-fixed-count-non-capturing-parens.js
@@ -1,0 +1,34 @@
+//@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
+// This benchmarks non-capturing parentheses with fixed count quantifiers like (?:x){5}.
+// These patterns use the ParenthesesSubpatternFixedCount JIT optimization.
+
+(function() {
+    var result = 0;
+    var n = 500000;
+
+    // Test strings that will match
+    var str1 = "aaaaabbbbb";          // for (?:a){5}
+    var str2 = "abcabcabc";           // for (?:abc){3}
+    var str3 = "xyxyxyxy";            // for (?:xy){4}
+    var str4 = "testabcdefabcdefend"; // for (?:abcdef){2}
+
+    // Patterns with non-capturing fixed count groups
+    var re1 = /(?:a){5}/;
+    var re2 = /(?:abc){3}/;
+    var re3 = /(?:xy){4}/;
+    var re4 = /(?:abcdef){2}/;
+
+    for (var i = 0; i < n; ++i) {
+        if (re1.exec(str1))
+            ++result;
+        if (re2.exec(str2))
+            ++result;
+        if (re3.exec(str3))
+            ++result;
+        if (re4.exec(str4))
+            ++result;
+    }
+
+    if (result != n * 4)
+        throw "Error: bad result: " + result;
+})();

--- a/JSTests/stress/regexp-fixed-count-parentheses-unroll.js
+++ b/JSTests/stress/regexp-fixed-count-parentheses-unroll.js
@@ -1,0 +1,147 @@
+//@ runDefault
+
+// Tests for JIT compilation of non-capturing parenthesized subpatterns with fixed minimum counts.
+// This tests the expansion of (?:x){n,m} where n > 1 into (?:x){1,1} × n + (?:x){0,m-n}.
+
+function shouldBe(actual, expected, message) {
+    if (actual !== expected)
+        throw new Error((message ? message + ": " : "") + "expected: " + expected + ", actual: " + actual);
+}
+
+function shouldBeTrue(value, message) {
+    shouldBe(value, true, message);
+}
+
+function shouldBeFalse(value, message) {
+    shouldBe(value, false, message);
+}
+
+// Basic tests for {3,} pattern (like marked's hr pattern)
+(function testBasicThreeOrMore() {
+    let re = /(?:a){3,}/;
+    shouldBeTrue(re.test("aaa"), "{3,} should match 3");
+    shouldBeTrue(re.test("aaaa"), "{3,} should match 4");
+    shouldBeTrue(re.test("aaaaa"), "{3,} should match 5");
+    shouldBeFalse(re.test("aa"), "{3,} should not match 2");
+    shouldBeFalse(re.test("a"), "{3,} should not match 1");
+    shouldBeFalse(re.test(""), "{3,} should not match empty");
+})();
+
+// Tests for {3,9} pattern (bounded range)
+(function testBoundedRange() {
+    let re = /^(?:a){3,9}$/;
+    shouldBeFalse(re.test("aa"), "{3,9} should not match 2");
+    shouldBeTrue(re.test("aaa"), "{3,9} should match 3");
+    shouldBeTrue(re.test("aaaa"), "{3,9} should match 4");
+    shouldBeTrue(re.test("aaaaaaaaa"), "{3,9} should match 9");
+    shouldBeFalse(re.test("aaaaaaaaaa"), "{3,9} should not match 10");
+})();
+
+// Tests for {4,} pattern (at threshold)
+(function testFourOrMore() {
+    let re = /(?:ab){4,}/;
+    shouldBeFalse(re.test("ababab"), "{4,} should not match 3 repetitions");
+    shouldBeTrue(re.test("abababab"), "{4,} should match 4 repetitions");
+    shouldBeTrue(re.test("ababababab"), "{4,} should match 5 repetitions");
+})();
+
+// Tests for {2,5} pattern
+(function testTwoToFive() {
+    let re = /^(?:xy){2,5}$/;
+    shouldBeFalse(re.test("xy"), "{2,5} should not match 1");
+    shouldBeTrue(re.test("xyxy"), "{2,5} should match 2");
+    shouldBeTrue(re.test("xyxyxy"), "{2,5} should match 3");
+    shouldBeTrue(re.test("xyxyxyxy"), "{2,5} should match 4");
+    shouldBeTrue(re.test("xyxyxyxyxy"), "{2,5} should match 5");
+    shouldBeFalse(re.test("xyxyxyxyxyxy"), "{2,5} should not match 6");
+})();
+
+// Tests for marked-style hr patterns
+(function testMarkedHrPatterns() {
+    // Simulating marked's hr patterns: (?:-[\t ]*){3,}
+    let hrDash = /(?:-[\t ]*){3,}/;
+    shouldBeTrue(hrDash.test("---"), "hr dash should match ---");
+    shouldBeTrue(hrDash.test("- - -"), "hr dash should match - - -");
+    shouldBeTrue(hrDash.test("-\t-\t-"), "hr dash should match with tabs");
+    shouldBeTrue(hrDash.test("----"), "hr dash should match ----");
+    shouldBeFalse(hrDash.test("--"), "hr dash should not match --");
+
+    let hrStar = /(?:\*[\t ]*){3,}/;
+    shouldBeTrue(hrStar.test("***"), "hr star should match ***");
+    shouldBeTrue(hrStar.test("* * *"), "hr star should match * * *");
+    shouldBeFalse(hrStar.test("**"), "hr star should not match **");
+
+    let hrUnderscore = /(?:_[\t ]*){3,}/;
+    shouldBeTrue(hrUnderscore.test("___"), "hr underscore should match ___");
+    shouldBeTrue(hrUnderscore.test("_ _ _"), "hr underscore should match _ _ _");
+    shouldBeFalse(hrUnderscore.test("__"), "hr underscore should not match __");
+})();
+
+// Tests for complex patterns inside parentheses
+(function testComplexPatterns() {
+    let re = /(?:[a-z]+\d+){3,}/;
+    shouldBeTrue(re.test("a1b2c3"), "complex pattern should match");
+    shouldBeTrue(re.test("abc123def456ghi789"), "complex pattern should match longer");
+    shouldBeFalse(re.test("a1b2"), "complex pattern should not match 2 repetitions");
+})();
+
+// Tests for nested parentheses
+(function testNestedParentheses() {
+    let re = /(?:(?:ab)+){2,}/;
+    shouldBeTrue(re.test("abab"), "nested should match abab");
+    shouldBeTrue(re.test("ababab"), "nested should match ababab");
+    shouldBeTrue(re.test("abababab"), "nested should match abababab");
+})();
+
+// Ensure capturing groups still work correctly (should NOT be unrolled)
+(function testCapturingGroups() {
+    let re = /(a){3}/;
+    let match = "aaa".match(re);
+    shouldBe(match[0], "aaa", "capturing group full match");
+    shouldBe(match[1], "a", "capturing group should capture last iteration");
+
+    let re2 = /(ab){2,4}/;
+    let match2 = "abababab".match(re2);
+    shouldBe(match2[0], "abababab", "capturing group {2,4} full match");
+    shouldBe(match2[1], "ab", "capturing group {2,4} should capture last iteration");
+})();
+
+// Tests for {n,n} fixed count (exact match)
+(function testExactCount() {
+    let re = /^(?:abc){3,3}$/;
+    shouldBeFalse(re.test("abcabc"), "{3,3} should not match 2");
+    shouldBeTrue(re.test("abcabcabc"), "{3,3} should match exactly 3");
+    shouldBeFalse(re.test("abcabcabcabc"), "{3,3} should not match 4");
+})();
+
+// Performance-sensitive test: run many times to ensure JIT compilation
+(function testJITCompilation() {
+    let re = /(?:-[\t ]*){3,}/;
+    let testString = "---";
+    for (let i = 0; i < 10000; i++) {
+        if (!re.test(testString))
+            throw new Error("JIT test failed at iteration " + i);
+    }
+})();
+
+// Tests for greedy vs non-greedy (should both work)
+(function testGreedyNonGreedy() {
+    // Greedy (default)
+    let greedy = /(?:a){2,4}/;
+    let greedyMatch = "aaaa".match(greedy);
+    shouldBe(greedyMatch[0], "aaaa", "greedy should match all 4");
+
+    // Non-greedy
+    let nonGreedy = /(?:a){2,4}?/;
+    let nonGreedyMatch = "aaaa".match(nonGreedy);
+    shouldBe(nonGreedyMatch[0], "aa", "non-greedy should match minimum 2");
+})();
+
+// Edge case: {1,n} should use original path (no unrolling needed)
+(function testOneToN() {
+    let re = /(?:x){1,5}/;
+    shouldBeTrue(re.test("x"), "{1,5} should match 1");
+    shouldBeTrue(re.test("xxxxx"), "{1,5} should match 5");
+})();
+
+print("All tests passed!");

--- a/Source/JavaScriptCore/yarr/Yarr.h
+++ b/Source/JavaScriptCore/yarr/Yarr.h
@@ -40,6 +40,7 @@ namespace JSC { namespace Yarr {
 #define YarrStackSpaceForBackTrackInfoParentheticalAssertion 1
 #define YarrStackSpaceForBackTrackInfoParenthesesOnce 2
 #define YarrStackSpaceForBackTrackInfoParenthesesTerminal 1
+#define YarrStackSpaceForBackTrackInfoParenthesesFixedCount 2
 #define YarrStackSpaceForBackTrackInfoParentheses 4
 #define YarrStackSpaceForDotStarEnclosure 1
 

--- a/Source/JavaScriptCore/yarr/YarrPattern.h
+++ b/Source/JavaScriptCore/yarr/YarrPattern.h
@@ -829,6 +829,14 @@ private:
         static unsigned beginIndex() { return offsetof(BackTrackInfoParenthesesTerminal, begin) / sizeof(uintptr_t); }
     };
 
+    struct BackTrackInfoParenthesesFixedCount {
+        uintptr_t begin;
+        uintptr_t matchAmount;
+
+        static unsigned beginIndex() { return offsetof(BackTrackInfoParenthesesFixedCount, begin) / sizeof(uintptr_t); }
+        static unsigned matchAmountIndex() { return offsetof(BackTrackInfoParenthesesFixedCount, matchAmount) / sizeof(uintptr_t); }
+    };
+
     struct BackTrackInfoParentheses {
         uintptr_t begin;
         uintptr_t returnAddress;


### PR DESCRIPTION
#### ac63cc259d741c45ff70bc7109c3974b0561e103
<pre>
[YARR] Add JIT support for non-capturing parentheses with fixed count quantifiers
<a href="https://bugs.webkit.org/show_bug.cgi?id=305284">https://bugs.webkit.org/show_bug.cgi?id=305284</a>

Reviewed by Yusuke Suzuki.

Previously, non-capturing parenthesized subpatterns with fixed count quantifiers
like (?:abc){3} would fail JIT compilation with FixedCountParenthesizedSubpattern
and fall back to the slower interpreter.

This patch adds new YarrOpCodes (ParenthesesSubpatternFixedCountBegin/End) to
handle these patterns in JIT. The implementation uses a simple counter-based
loop that iterates until the required count is reached.

Also fixes a bug in checkAdjust calculation where the condition for reducing
checkAdjust was inconsistent between opCompileParenthesesSubpattern and
SimpleNestedAlternativeBegin/Next, causing incorrect character read positions
for FixedCount patterns with quantityMaxCount &gt; 1.

                                                 TipOfTree                  Patched

regexp-fixed-count-non-capturing-parens      159.5820+-1.7347     ^     40.9978+-0.4434        ^ definitely 3.8925x faster

* JSTests/microbenchmarks/regexp-fixed-count-non-capturing-parens.js: Added.
(re1):
(re2):
(re3):
(re4):
* JSTests/stress/regexp-fixed-count-parentheses-unroll.js: Added.
(shouldBe):
(shouldBeFalse):
(testBasicThreeOrMore):
(testBoundedRange):
(testFourOrMore):
(testTwoToFive):
(testMarkedHrPatterns):
(testComplexPatterns):
(testNestedParentheses):
(testCapturingGroups):
(testExactCount):
(testJITCompilation):
(testGreedyNonGreedy):
(testOneToN):
* Source/JavaScriptCore/yarr/Yarr.h:
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
* Source/JavaScriptCore/yarr/YarrPattern.h:
(JSC::Yarr::BackTrackInfoParenthesesFixedCount::beginIndex):
(JSC::Yarr::BackTrackInfoParenthesesFixedCount::matchAmountIndex):

Canonical link: <a href="https://commits.webkit.org/306402@main">https://commits.webkit.org/306402@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9cdefa3e9c1c84e4ffab131a3b66776bc7bca4db

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141247 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13631 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2945 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149821 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14342 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13784 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108516 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144198 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11061 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/126414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89421 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10637 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8248 "Passed tests") | [⏳ 🛠 wpe-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/133227 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119898 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2388 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152215 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/2049 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13317 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/2834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116615 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13333 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11629 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116955 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29765 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13003 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123064 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68491 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13360 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/172540 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13099 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77066 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44709 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13298 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13143 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->