### PR TITLE
[JSC] Extend Float16, Float, Double, V128 constant materialization

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -6172,7 +6172,7 @@ public:
             m_assembler.movaps_rr(src, dest);
     }
 
-    void materializeVector(v128_t value, FPRegisterID dest)
+    void move128ToVector(v128_t value, FPRegisterID dest)
     {
         if (bitEquals(value, vectorAllZeros())) {
             moveZeroToVector(dest);

--- a/Source/JavaScriptCore/b3/air/AirArg.cpp
+++ b/Source/JavaScriptCore/b3/air/AirArg.cpp
@@ -119,6 +119,12 @@ unsigned Arg::jsHash() const
         result += static_cast<unsigned>(m_offset);
         result += static_cast<unsigned>(m_offset >> 32);
         break;
+    case FPImm128:
+        result += static_cast<unsigned>(m_offset);
+        result += static_cast<unsigned>(m_offset >> 32);
+        result += static_cast<unsigned>(m_additional);
+        result += static_cast<unsigned>(m_additional >> 32);
+        break;
     case SimpleAddr:
         result += m_base.internalValue();
         break;
@@ -173,6 +179,9 @@ void Arg::dump(PrintStream& out) const
         return;
     case FPImm64:
         out.printf("$0x%llx", static_cast<long long unsigned>(m_offset));
+        return;
+    case FPImm128:
+        out.print(asV128());
         return;
     case ZeroReg:
         out.print("%xzr");
@@ -270,6 +279,9 @@ void printInternal(PrintStream& out, Arg::Kind kind)
         return;
     case Arg::FPImm64:
         out.print("FPImm64");
+        return;
+    case Arg::FPImm128:
+        out.print("FPImm128");
         return;
     case Arg::ZeroReg:
         out.print("ZeroReg");

--- a/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
+++ b/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
@@ -872,6 +872,9 @@ MoveZeroToFloat D:F:32
 32: Move64ToDouble U:G:32, U:G:32, D:F:64
     Tmp, Tmp, Tmp
 
+arm64: Move128ToVector U:G:128, D:F:128
+    FPImm128, Tmp
+
 32: Move32ToDoubleHi U:G:32, UD:F:64
     Tmp, Tmp
 

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -3814,6 +3814,11 @@ void BBQJIT::notifyFunctionUsesSIMD()
 
 void BBQJIT::materializeVectorConstant(v128_t value, Location result)
 {
+    if (isARM64()) {
+        m_jit.move128ToVector(value, result.asFPR());
+        return;
+    }
+
     if (!value.u64x2[0] && !value.u64x2[1])
         m_jit.moveZeroToVector(result.asFPR());
     else if (value.u64x2[0] == 0xffffffffffffffffull && value.u64x2[1] == 0xffffffffffffffffull)
@@ -3823,7 +3828,7 @@ void BBQJIT::materializeVectorConstant(v128_t value, Location result)
         m_jit.compareIntegerVector(RelationalCondition::Equal, SIMDInfo { SIMDLane::i32x4, SIMDSignMode::Unsigned }, result.asFPR(), result.asFPR(), result.asFPR());
 #endif
     else
-        m_jit.materializeVector(value, result.asFPR());
+        m_jit.move128ToVector(value, result.asFPR());
 }
 
 [[nodiscard]] ExpressionType BBQJIT::addConstant(v128_t value)


### PR DESCRIPTION
#### 0521cc7f331af119ee2e4c952102974cf6e7fbb6
<pre>
[JSC] Extend Float16, Float, Double, V128 constant materialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=305286">https://bugs.webkit.org/show_bug.cgi?id=305286</a>
<a href="https://rdar.apple.com/167933094">rdar://167933094</a>

Reviewed by Justin Michaud.

This patch extends ARM64 Float16, Float, Double, V128 constant materialization.

1. materializeVector is renamed to move128ToVector, aligned to
   move16ToFloat16, move32ToFloat, move64ToDouble.
2. move128ToVector, move16ToFloat move32ToFloat, move64ToDouble are
   supporting comprehensive constant materialization patterns now, using
   movi, mvni, and fmov (with vector variant).
3. Avoid using load for Float constant. This is 32bit, so it is small
   enough to be materialized. Changing B3 MoveConstants phase to avoid
   it. And B3LowerToAir supports ConstFloat lowering.
4. Add FPImm128 and support Move128ToVector in Air. B3 can materialize
   vector constant via that instruction. Const128 lowering rule gets
   enhanced in B3LowerToAir.

Test: Source/JavaScriptCore/assembler/testmasm.cpp

* Source/JavaScriptCore/assembler/ARM64Assembler.h:
* Source/JavaScriptCore/assembler/AssemblerCommon.h:
(JSC::ARM64ShiftedImmediate32::create):
(JSC::ARM64ShiftedImmediate32::isValid const):
(JSC::ARM64ShiftedImmediate32::immediate const):
(JSC::ARM64ShiftedImmediate32::shift const):
(JSC::ARM64ShiftedImmediate32::ARM64ShiftedImmediate32):
(JSC::ARM64ShiftedImmediateMSL32::create):
(JSC::ARM64ShiftedImmediateMSL32::isValid const):
(JSC::ARM64ShiftedImmediateMSL32::immediate const):
(JSC::ARM64ShiftedImmediateMSL32::shift const):
(JSC::ARM64ShiftedImmediateMSL32::ARM64ShiftedImmediateMSL32):
(JSC::ARM64ShiftedImmediate16::create):
(JSC::ARM64ShiftedImmediate16::isValid const):
(JSC::ARM64ShiftedImmediate16::immediate const):
(JSC::ARM64ShiftedImmediate16::shift const):
(JSC::ARM64ShiftedImmediate16::ARM64ShiftedImmediate16):
* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::move128ToVector):
(JSC::MacroAssemblerARM64::moveZeroToDouble):
(JSC::MacroAssemblerARM64::moveZeroToFloat):
(JSC::MacroAssemblerARM64::moveZeroToFloat16):
(JSC::MacroAssemblerARM64::move64ToDouble):
(JSC::MacroAssemblerARM64::move32ToFloat):
(JSC::MacroAssemblerARM64::move16ToFloat16):
(JSC::MacroAssemblerARM64::moveZeroToVector):
(JSC::MacroAssemblerARM64::materializeVector): Deleted.
* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::move128ToVector):
(JSC::MacroAssemblerX86_64::materializeVector): Deleted.
* Source/JavaScriptCore/assembler/testmasm.cpp:
(JSC::testMove32ToFloatMovi):
(JSC::testMove64ToDoubleMovi):
(JSC::testMove64ToDoubleRepeated32BitPatternBug):
(JSC::testFMovHalfPrecisionEncoding):
(JSC::testMove128ToVectorMovi):
(JSC::testMove16ToFloat16Comprehensive):
(JSC::testMove32ToFloatComprehensive):
(JSC::testMove64ToDoubleComprehensive):
(JSC::testMove128ToVectorComprehensive):
* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/B3MoveConstants.cpp:
* Source/JavaScriptCore/b3/air/AirArg.cpp:
(JSC::B3::Air::Arg::jsHash const):
(JSC::B3::Air::Arg::dump const):
(WTF::printInternal):
* Source/JavaScriptCore/b3/air/AirArg.h:
(JSC::B3::Air::Arg::fpImm128):
(JSC::B3::Air::Arg::isFPImm128 const):
(JSC::B3::Air::Arg::isSomeImm const):
(JSC::B3::Air::Arg::isGP const):
(JSC::B3::Air::Arg::isFP const):
(JSC::B3::Air::Arg::isValidFPImm16Form):
(JSC::B3::Air::Arg::isValidFPImm32Form):
(JSC::B3::Air::Arg::isValidFPImm64Form):
(JSC::B3::Air::Arg::isValidFPImm128Form):
(JSC::B3::Air::Arg::isValidForm const):
(JSC::B3::Air::Arg::asV128 const):
* Source/JavaScriptCore/b3/air/AirOpcode.opcodes:
* Source/JavaScriptCore/b3/air/opcode_generator.rb:
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::materializeVectorConstant):

Canonical link: <a href="https://commits.webkit.org/305613@main">https://commits.webkit.org/305613@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be31449fa6088f63863023c591a4376479e51b49

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138570 "17 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10935 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/51 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146680 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91545 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8014a000-91a5-4871-a093-626c4cf174c2) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11639 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11090 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106030 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77366 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141517 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8761 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124206 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86898 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d9ab582c-3161-4f7d-8513-363ebcd9d2de) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8349 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6108 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6980 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/130536 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117766 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/44 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149433 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/137162 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10617 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/40 "Found 1 new test failure: http/tests/performance/performance-resource-timing-redirection-cross-origin-media.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114408 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10634 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8986 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114747 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8523 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120501 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65507 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21405 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10666 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/43 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/169844 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10400 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74298 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44280 "Found 1 new JSC binary failure: testb3, Found 8 new JSC stress test failures: wasm.yaml/wasm/stress/wasm-js-string-builtins-signature-validation.js.default-wasm, wasm.yaml/wasm/stress/wasm-js-string-builtins-signature-validation.js.wasm-bbq, wasm.yaml/wasm/stress/wasm-js-string-builtins-signature-validation.js.wasm-bbq-no-consts, wasm.yaml/wasm/stress/wasm-js-string-builtins-signature-validation.js.wasm-collect-continuously, wasm.yaml/wasm/stress/wasm-js-string-builtins-signature-validation.js.wasm-eager, wasm.yaml/wasm/stress/wasm-js-string-builtins-signature-validation.js.wasm-eager-jettison, wasm.yaml/wasm/stress/wasm-js-string-builtins-signature-validation.js.wasm-no-cjit, wasm.yaml/wasm/stress/wasm-js-string-builtins-signature-validation.js.wasm-slow-memory (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10604 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10455 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->