### PR TITLE
[WTF] Fix `isPowerOfTwo` to Correctly Handle Signed Integers

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.h
@@ -290,7 +290,7 @@ void BBQJIT::emitModOrDiv(Value& lhs, Location lhsLocation, Value& rhs, Location
             }
 
             // Fall through to general case.
-        } else if (isPowerOfTwo<size_t>(divisor)) {
+        } else if (isPowerOfTwo(divisor)) {
             if constexpr (IsMod) {
                 if constexpr (isSigned) {
                     // This constructs an extra operand with log2(divisor) bits equal to the sign bit of the dividend. If the dividend

--- a/Source/WTF/wtf/MathExtras.h
+++ b/Source/WTF/wtf/MathExtras.h
@@ -447,9 +447,10 @@ constexpr uint32_t roundUpToPowerOfTwo(auto v)
     return std::bit_ceil(v);
 }
 
-constexpr bool isPowerOfTwo(auto value)
+template<std::integral T>
+constexpr bool isPowerOfTwo(T value)
 {
-    return std::has_single_bit(value);
+    return value > 0 && std::has_single_bit(static_cast<std::make_unsigned_t<T>>(value));
 }
 
 constexpr unsigned maskForSize(unsigned size)

--- a/Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp
@@ -676,6 +676,28 @@ TEST(WTF, isIntegral)
     EXPECT_FALSE(WTF::isIntegral(std::numeric_limits<float>::quiet_NaN()));
 }
 
+TEST(WTF, isPowerOfTwo)
+{
+    for (int i = 1; i < 10000; ++i) {
+        if (!((i & (i - 1))))
+            EXPECT_TRUE(WTF::isPowerOfTwo(i));
+        else
+            EXPECT_FALSE(WTF::isPowerOfTwo(i));
+    }
+
+    for (size_t i = 1; i < 10000; ++i) {
+        if (!((i & (i - 1))))
+            EXPECT_TRUE(WTF::isPowerOfTwo(i));
+        else
+            EXPECT_FALSE(WTF::isPowerOfTwo(i));
+    }
+
+    for (int i = 0; -10000 < i; --i)
+        EXPECT_FALSE(WTF::isPowerOfTwo(i));
+
+    EXPECT_FALSE(WTF::isPowerOfTwo(std::numeric_limits<int64_t>::min()));
+}
+
 TEST(WTF, negate)
 {
     auto expected_int8_t = WTF::negate<int8_t>(0);


### PR DESCRIPTION
#### 093ad7759fb9dce88a9586bffa01bd5d06b9f30a
<pre>
[WTF] Fix `isPowerOfTwo` to Correctly Handle Signed Integers
<a href="https://bugs.webkit.org/show_bug.cgi?id=305288">https://bugs.webkit.org/show_bug.cgi?id=305288</a>

Reviewed by NOBODY (OOPS!).

When value is INT64_MIN and is converted to size_t,
the previous implementation returns true instead of false.
This patch fixes `isPowerOfTwo` to correctly handle signed integers.

Test: Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp

* Source/JavaScriptCore/wasm/WasmBBQJIT64.h:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitModOrDiv):
* Source/WTF/wtf/MathExtras.h:
(WTF::isPowerOfTwo):
* Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp:
(TestWebKitAPI::TEST(WTF, isPowerOfTwo)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/093ad7759fb9dce88a9586bffa01bd5d06b9f30a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138455 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10820 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49865 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146539 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91430 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140329 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11524 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10975 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105943 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77293 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141402 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8655 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124121 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86790 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8242 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6014 "Found 1 new API test failure: TestWebKitAPI.PermissionsAPI.GeolocationPermissionDeniedFromPromptAndGeolocationRequestedSinceLoad (failure)") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6831 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/130419 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117662 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42320 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149259 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/137044 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10502 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42877 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114342 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10519 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8881 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114683 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8339 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120407 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/65388 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10550 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38340 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/169729 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10285 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74154 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44245 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10489 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10340 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->