### PR TITLE
Handle IDL required dictionary members more consistently on the C++ side

### DIFF
--- a/Source/WebCore/Modules/mediarecorder/MediaRecorderErrorEvent.cpp
+++ b/Source/WebCore/Modules/mediarecorder/MediaRecorderErrorEvent.cpp
@@ -42,7 +42,7 @@ Ref<MediaRecorderErrorEvent> MediaRecorderErrorEvent::create(const AtomString& t
 
 Ref<MediaRecorderErrorEvent> MediaRecorderErrorEvent::create(const AtomString& type, Init&& init, IsTrusted isTrusted)
 {
-    auto domError = init.error.releaseNonNull();
+    Ref domError = init.error.releaseNonNull();
     return adoptRef(*new MediaRecorderErrorEvent(type, WTF::move(init), WTF::move(domError), isTrusted));
 }
 

--- a/Source/WebCore/Modules/notifications/NotificationEvent.cpp
+++ b/Source/WebCore/Modules/notifications/NotificationEvent.cpp
@@ -37,20 +37,19 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(NotificationEvent);
 
 Ref<NotificationEvent> NotificationEvent::create(const AtomString& type, Init&& init, IsTrusted isTrusted)
 {
-    auto notification = init.notification;
-    ASSERT(notification);
+    Ref notification = init.notification.releaseNonNull();
     auto action = init.action;
-    return adoptRef(*new NotificationEvent(type, WTF::move(init), notification.get(), action, isTrusted));
+    return adoptRef(*new NotificationEvent(type, WTF::move(init), WTF::move(notification), action, isTrusted));
 }
 
-Ref<NotificationEvent> NotificationEvent::create(const AtomString& type, Notification* notification, const String& action, IsTrusted isTrusted)
+Ref<NotificationEvent> NotificationEvent::create(const AtomString& type, Ref<Notification>&& notification, const String& action, IsTrusted isTrusted)
 {
-    return adoptRef(*new NotificationEvent(type, { }, notification, action, isTrusted));
+    return adoptRef(*new NotificationEvent(type, { }, WTF::move(notification), action, isTrusted));
 }
 
-NotificationEvent::NotificationEvent(const AtomString& type, NotificationEventInit&& eventInit, Notification* notification, const String& action, IsTrusted isTrusted)
+NotificationEvent::NotificationEvent(const AtomString& type, NotificationEventInit&& eventInit, Ref<Notification>&& notification, const String& action, IsTrusted isTrusted)
     : ExtendableEvent(EventInterfaceType::NotificationEvent, type, WTF::move(eventInit), isTrusted)
-    , m_notification(notification)
+    , m_notification(WTF::move(notification))
     , m_action(action)
 {
 }

--- a/Source/WebCore/Modules/notifications/NotificationEvent.h
+++ b/Source/WebCore/Modules/notifications/NotificationEvent.h
@@ -47,17 +47,17 @@ public:
     using Init = NotificationEventInit;
 
     static Ref<NotificationEvent> create(const AtomString&, Init&&, IsTrusted = IsTrusted::No);
-    static Ref<NotificationEvent> create(const AtomString&, Notification*, const String& action, IsTrusted = IsTrusted::No);
+    static Ref<NotificationEvent> create(const AtomString&, Ref<Notification>&&, const String& action, IsTrusted = IsTrusted::No);
 
-    Notification* notification() { return m_notification.get(); }
+    Notification& notification() { return m_notification; }
     const String& action() { return m_action; }
 
 private:
-    NotificationEvent(const AtomString&, NotificationEventInit&&, Notification*, const String& action, IsTrusted = IsTrusted::No);
+    NotificationEvent(const AtomString&, NotificationEventInit&&, Ref<Notification>&&, const String& action, IsTrusted = IsTrusted::No);
 
     bool isNotificationEvent() const final { return true; }
 
-    RefPtr<Notification> m_notification;
+    const Ref<Notification> m_notification;
     String m_action;
 };
 

--- a/Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.cpp
@@ -52,13 +52,11 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaElementAudioSourceNode);
 
 ExceptionOr<Ref<MediaElementAudioSourceNode>> MediaElementAudioSourceNode::create(BaseAudioContext& context, MediaElementAudioSourceOptions&& options)
 {
-    RefPtr mediaElement = WTF::move(options.mediaElement);
-    RELEASE_ASSERT(mediaElement);
-
-    if (!mediaElement || mediaElement->audioSourceNode())
+    Ref mediaElement = options.mediaElement.releaseNonNull();
+    if (mediaElement->audioSourceNode())
         return Exception { ExceptionCode::InvalidStateError, "Media element is already associated with an audio source node"_s };
 
-    auto node = adoptRef(*new MediaElementAudioSourceNode(context, *mediaElement));
+    Ref node = adoptRef(*new MediaElementAudioSourceNode(context, mediaElement.get()));
 
     mediaElement->setAudioSourceNode(node.ptr());
 

--- a/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceNode.cpp
@@ -44,9 +44,9 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaStreamAudioSourceNode);
 
 ExceptionOr<Ref<MediaStreamAudioSourceNode>> MediaStreamAudioSourceNode::create(BaseAudioContext& context, MediaStreamAudioSourceOptions&& options)
 {
-    RELEASE_ASSERT(options.mediaStream);
+    Ref mediaStream = options.mediaStream.releaseNonNull();
 
-    auto audioTracks = options.mediaStream->getAudioTracks();
+    auto audioTracks = mediaStream->getAudioTracks();
     if (audioTracks.isEmpty())
         return Exception { ExceptionCode::InvalidStateError, "Media stream has no audio tracks"_s };
 
@@ -59,7 +59,7 @@ ExceptionOr<Ref<MediaStreamAudioSourceNode>> MediaStreamAudioSourceNode::create(
     if (!provider)
         return Exception { ExceptionCode::InvalidStateError, "Could not find an audio track with an audio source provider"_s };
 
-    auto node = adoptRef(*new MediaStreamAudioSourceNode(context, *options.mediaStream, provider.releaseNonNull()));
+    auto node = adoptRef(*new MediaStreamAudioSourceNode(context, WTF::move(mediaStream), provider.releaseNonNull()));
     node->setFormat(2, context.sampleRate());
 
     // Context keeps reference until node is disconnected.
@@ -68,9 +68,9 @@ ExceptionOr<Ref<MediaStreamAudioSourceNode>> MediaStreamAudioSourceNode::create(
     return node;
 }
 
-MediaStreamAudioSourceNode::MediaStreamAudioSourceNode(BaseAudioContext& context, MediaStream& mediaStream, Ref<WebAudioSourceProvider>&& provider)
+MediaStreamAudioSourceNode::MediaStreamAudioSourceNode(BaseAudioContext& context, Ref<MediaStream>&& mediaStream, Ref<WebAudioSourceProvider>&& provider)
     : AudioNode(context, NodeTypeMediaStreamAudioSource)
-    , m_mediaStream(mediaStream)
+    , m_mediaStream(WTF::move(mediaStream))
     , m_provider(provider)
 {
     m_provider->setClient(this);

--- a/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceNode.h
+++ b/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceNode.h
@@ -53,7 +53,7 @@ public:
     void deref() const final { AudioNode::deref(); }
 
 private:
-    MediaStreamAudioSourceNode(BaseAudioContext&, MediaStream&, Ref<WebAudioSourceProvider>&&);
+    MediaStreamAudioSourceNode(BaseAudioContext&, Ref<MediaStream>&&, Ref<WebAudioSourceProvider>&&);
 
     // AudioNode
     void process(size_t framesToProcess) final;

--- a/Source/WebCore/Modules/webaudio/OfflineAudioDestinationNode.h
+++ b/Source/WebCore/Modules/webaudio/OfflineAudioDestinationNode.h
@@ -67,7 +67,7 @@ private:
     unsigned m_numberOfChannels;
 
     // This AudioNode renders into this AudioBuffer.
-    RefPtr<AudioBuffer> m_renderTarget;
+    const RefPtr<AudioBuffer> m_renderTarget;
     
     // Temporary AudioBus for each render quantum.
     const Ref<AudioBus> m_renderBus;

--- a/Source/WebCore/Modules/webxr/WebXRInputSource.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRInputSource.cpp
@@ -134,7 +134,7 @@ void WebXRInputSource::pollEvents(Vector<Ref<XRInputSourceEvent>>& events)
         init.frame = WebXRFrame::create(*session, WebXRFrame::IsAnimationFrame::No);
         init.inputSource = RefPtr { this };
 
-        return XRInputSourceEvent::create(name, init);
+        return XRInputSourceEvent::create(name, WTF::move(init));
     };
 
     if (!m_connected) {

--- a/Source/WebCore/Modules/webxr/XRInputSourceEvent.cpp
+++ b/Source/WebCore/Modules/webxr/XRInputSourceEvent.cpp
@@ -37,30 +37,28 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(XRInputSourceEvent);
 
-Ref<XRInputSourceEvent> XRInputSourceEvent::create(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
+Ref<XRInputSourceEvent> XRInputSourceEvent::create(const AtomString& type, Init&& initializer, IsTrusted isTrusted)
 {
-    return adoptRef(*new XRInputSourceEvent(type, initializer, isTrusted));
+    return adoptRef(*new XRInputSourceEvent(type, WTF::move(initializer), isTrusted));
 }
 
-XRInputSourceEvent::XRInputSourceEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
+XRInputSourceEvent::XRInputSourceEvent(const AtomString& type, Init&& initializer, IsTrusted isTrusted)
     : Event(EventInterfaceType::XRInputSourceEvent, type, initializer, isTrusted)
-    , m_frame(initializer.frame)
-    , m_inputSource(initializer.inputSource)
+    , m_frame(initializer.frame.releaseNonNull())
+    , m_inputSource(initializer.inputSource.releaseNonNull())
 {
-    ASSERT(m_frame);
-    ASSERT(m_inputSource);
 }
 
 XRInputSourceEvent::~XRInputSourceEvent() = default;
 
 const WebXRFrame& XRInputSourceEvent::frame() const
 {
-    return *m_frame;
+    return m_frame;
 }
 
 const WebXRInputSource& XRInputSourceEvent::inputSource() const
 {
-    return *m_inputSource;
+    return m_inputSource;
 }
 
 void XRInputSourceEvent::setFrameActive(bool active)

--- a/Source/WebCore/Modules/webxr/XRInputSourceEvent.h
+++ b/Source/WebCore/Modules/webxr/XRInputSourceEvent.h
@@ -43,7 +43,7 @@ public:
         RefPtr<WebXRInputSource> inputSource;
     };
 
-    static Ref<XRInputSourceEvent> create(const AtomString&, const Init&, IsTrusted = IsTrusted::No);
+    static Ref<XRInputSourceEvent> create(const AtomString&, Init&&, IsTrusted = IsTrusted::No);
     virtual ~XRInputSourceEvent();
 
     const WebXRFrame& frame() const;
@@ -51,10 +51,10 @@ public:
     void setFrameActive(bool);
 
 private:
-    XRInputSourceEvent(const AtomString&, const Init&, IsTrusted);
+    XRInputSourceEvent(const AtomString&, Init&&, IsTrusted);
 
-    RefPtr<WebXRFrame> m_frame;
-    RefPtr<WebXRInputSource> m_inputSource;
+    const Ref<WebXRFrame> m_frame;
+    const Ref<WebXRInputSource> m_inputSource;
     std::optional<int> m_buttonIndex;
 };
 

--- a/Source/WebCore/Modules/webxr/XRLayerEvent.cpp
+++ b/Source/WebCore/Modules/webxr/XRLayerEvent.cpp
@@ -34,16 +34,15 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(XRLayerEvent);
 
-Ref<XRLayerEvent> XRLayerEvent::create(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
+Ref<XRLayerEvent> XRLayerEvent::create(const AtomString& type, Init&& initializer, IsTrusted isTrusted)
 {
-    return adoptRef(*new XRLayerEvent(type, initializer, isTrusted));
+    return adoptRef(*new XRLayerEvent(type, WTF::move(initializer), isTrusted));
 }
 
-XRLayerEvent::XRLayerEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
+XRLayerEvent::XRLayerEvent(const AtomString& type, Init&& initializer, IsTrusted isTrusted)
     : Event(EventInterfaceType::XRLayerEvent, type, initializer, isTrusted)
-    , m_layer(initializer.layer)
+    , m_layer(initializer.layer.releaseNonNull())
 {
-    ASSERT(m_layer);
 }
 
 XRLayerEvent::~XRLayerEvent() = default;
@@ -55,8 +54,7 @@ EventInterfaceType XRLayerEvent::eventInterfaceType() const
 
 const WebXRLayer& XRLayerEvent::layer() const
 {
-    ASSERT(m_layer);
-    return *m_layer;
+    return m_layer;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webxr/XRLayerEvent.h
+++ b/Source/WebCore/Modules/webxr/XRLayerEvent.h
@@ -44,19 +44,19 @@ public:
         RefPtr<WebXRLayer> layer;
     };
 
-    static Ref<XRLayerEvent> create(const AtomString&, const Init&, IsTrusted = IsTrusted::No);
+    static Ref<XRLayerEvent> create(const AtomString&, Init&&, IsTrusted = IsTrusted::No);
     virtual ~XRLayerEvent();
 
     const WebXRLayer& layer() const;
 
 protected:
-    XRLayerEvent(const AtomString&, const Init&, IsTrusted);
+    XRLayerEvent(const AtomString&, Init&&, IsTrusted);
 
     // Event.
     EventInterfaceType eventInterfaceType() const;
 
 private:
-    RefPtr<WebXRLayer> m_layer;
+    const Ref<WebXRLayer> m_layer;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webxr/XRReferenceSpaceEvent.cpp
+++ b/Source/WebCore/Modules/webxr/XRReferenceSpaceEvent.cpp
@@ -36,24 +36,23 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(XRReferenceSpaceEvent);
 
-Ref<XRReferenceSpaceEvent> XRReferenceSpaceEvent::create(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
+Ref<XRReferenceSpaceEvent> XRReferenceSpaceEvent::create(const AtomString& type, Init&& initializer, IsTrusted isTrusted)
 {
-    return adoptRef(*new XRReferenceSpaceEvent(type, initializer, isTrusted));
+    return adoptRef(*new XRReferenceSpaceEvent(type, WTF::move(initializer), isTrusted));
 }
 
-XRReferenceSpaceEvent::XRReferenceSpaceEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
+XRReferenceSpaceEvent::XRReferenceSpaceEvent(const AtomString& type, Init&& initializer, IsTrusted isTrusted)
     : Event(EventInterfaceType::XRReferenceSpaceEvent, type, initializer, isTrusted)
-    , m_referenceSpace(initializer.referenceSpace)
+    , m_referenceSpace(initializer.referenceSpace.releaseNonNull())
     , m_transform(initializer.transform)
 {
-    ASSERT(m_referenceSpace);
 }
 
 XRReferenceSpaceEvent::~XRReferenceSpaceEvent() = default;
 
 const WebXRReferenceSpace& XRReferenceSpaceEvent::referenceSpace() const
 {
-    return *m_referenceSpace;
+    return m_referenceSpace;
 }
 
 WebXRRigidTransform* XRReferenceSpaceEvent::transform() const

--- a/Source/WebCore/Modules/webxr/XRReferenceSpaceEvent.h
+++ b/Source/WebCore/Modules/webxr/XRReferenceSpaceEvent.h
@@ -44,17 +44,17 @@ public:
         RefPtr<WebXRRigidTransform> transform;
     };
 
-    static Ref<XRReferenceSpaceEvent> create(const AtomString&, const Init&, IsTrusted = IsTrusted::No);
+    static Ref<XRReferenceSpaceEvent> create(const AtomString&, Init&&, IsTrusted = IsTrusted::No);
     virtual ~XRReferenceSpaceEvent();
 
     const WebXRReferenceSpace& referenceSpace() const;
     WebXRRigidTransform* transform() const;
 
 private:
-    XRReferenceSpaceEvent(const AtomString&, const Init&, IsTrusted);
+    XRReferenceSpaceEvent(const AtomString&, Init&&, IsTrusted);
 
-    RefPtr<WebXRReferenceSpace> m_referenceSpace;
-    RefPtr<WebXRRigidTransform> m_transform;
+    const Ref<WebXRReferenceSpace> m_referenceSpace;
+    const RefPtr<WebXRRigidTransform> m_transform;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webxr/XRSessionEvent.cpp
+++ b/Source/WebCore/Modules/webxr/XRSessionEvent.cpp
@@ -35,24 +35,22 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(XRSessionEvent);
 
-Ref<XRSessionEvent> XRSessionEvent::create(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
+Ref<XRSessionEvent> XRSessionEvent::create(const AtomString& type, Init&& initializer, IsTrusted isTrusted)
 {
-    return adoptRef(*new XRSessionEvent(type, initializer, isTrusted));
+    return adoptRef(*new XRSessionEvent(type, WTF::move(initializer), isTrusted));
 }
 
-XRSessionEvent::XRSessionEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
+XRSessionEvent::XRSessionEvent(const AtomString& type, Init&& initializer, IsTrusted isTrusted)
     : Event(EventInterfaceType::XRSessionEvent, type, initializer, isTrusted)
-    , m_session(initializer.session)
+    , m_session(initializer.session.releaseNonNull())
 {
-    ASSERT(m_session);
 }
 
 XRSessionEvent::~XRSessionEvent() = default;
 
 const WebXRSession& XRSessionEvent::session() const
 {
-    ASSERT(m_session);
-    return *m_session;
+    return m_session;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webxr/XRSessionEvent.h
+++ b/Source/WebCore/Modules/webxr/XRSessionEvent.h
@@ -44,15 +44,15 @@ public:
         RefPtr<WebXRSession> session;
     };
 
-    static Ref<XRSessionEvent> create(const AtomString&, const Init&, IsTrusted = IsTrusted::No);
+    static Ref<XRSessionEvent> create(const AtomString&, Init&&, IsTrusted = IsTrusted::No);
     virtual ~XRSessionEvent();
 
     const WebXRSession& session() const;
 
 private:
-    XRSessionEvent(const AtomString&, const Init&, IsTrusted);
+    XRSessionEvent(const AtomString&, Init&&, IsTrusted);
 
-    RefPtr<WebXRSession> m_session;
+    const Ref<WebXRSession> m_session;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -50,7 +50,6 @@ Modules/webaudio/DefaultAudioDestinationNode.cpp
 Modules/webaudio/DynamicsCompressorNode.cpp
 Modules/webaudio/MediaElementAudioSourceNode.cpp
 Modules/webaudio/MediaStreamAudioDestinationNode.cpp
-Modules/webaudio/MediaStreamAudioSourceNode.cpp
 Modules/webaudio/OfflineAudioDestinationNode.cpp
 Modules/webaudio/OscillatorNode.cpp
 Modules/webaudio/PannerNode.cpp

--- a/Source/WebCore/bindings/js/JSNavigateEventCustom.cpp
+++ b/Source/WebCore/bindings/js/JSNavigateEventCustom.cpp
@@ -33,8 +33,7 @@ void JSNavigateEvent::visitAdditionalChildren(Visitor& visitor)
 {
     auto& event = wrapped();
     event.infoWrapper().visit(visitor);
-    if (auto* signal = event.signal())
-        addWebCoreOpaqueRoot(visitor, signal);
+    addWebCoreOpaqueRoot(visitor, &event.signal());
 }
 
 DEFINE_VISIT_ADDITIONAL_CHILDREN(JSNavigateEvent);

--- a/Source/WebCore/dom/InputEvent.h
+++ b/Source/WebCore/dom/InputEvent.h
@@ -54,7 +54,6 @@ public:
         return adoptRef(*new InputEvent(type, initializer));
     }
 
-    bool isInputEvent() const override { return true; }
     const String& inputType() const { return m_inputType; }
     const String& data() const { return m_data; }
     RefPtr<DataTransfer> dataTransfer() const;
@@ -65,6 +64,8 @@ private:
     InputEvent(const AtomString& eventType, const String& inputType, IsCancelable, RefPtr<WindowProxy>&&,
         const String& data, RefPtr<DataTransfer>&&, const Vector<Ref<StaticRange>>& targetRanges, int detail, IsInputMethodComposing);
     InputEvent(const AtomString& eventType, const Init&);
+
+    bool isInputEvent() const final { return true; }
 
     String m_inputType;
     String m_data;

--- a/Source/WebCore/dom/PromiseRejectionEvent.cpp
+++ b/Source/WebCore/dom/PromiseRejectionEvent.cpp
@@ -37,9 +37,9 @@ using namespace JSC;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(PromiseRejectionEvent);
 
-PromiseRejectionEvent::PromiseRejectionEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
+PromiseRejectionEvent::PromiseRejectionEvent(const AtomString& type, Init&& initializer, IsTrusted isTrusted)
     : Event(EventInterfaceType::PromiseRejectionEvent, type, initializer, isTrusted)
-    , m_promise(*(initializer.promise))
+    , m_promise(initializer.promise.releaseNonNull())
     , m_reason(initializer.reason)
 {
 }

--- a/Source/WebCore/dom/PromiseRejectionEvent.h
+++ b/Source/WebCore/dom/PromiseRejectionEvent.h
@@ -40,9 +40,9 @@ public:
         JSC::JSValue reason;
     };
 
-    static Ref<PromiseRejectionEvent> create(const AtomString& type, const Init& initializer, IsTrusted isTrusted = IsTrusted::No)
+    static Ref<PromiseRejectionEvent> create(const AtomString& type, Init&& initializer, IsTrusted isTrusted = IsTrusted::No)
     {
-        return adoptRef(*new PromiseRejectionEvent(type, initializer, isTrusted));
+        return adoptRef(*new PromiseRejectionEvent(type, WTF::move(initializer), isTrusted));
     }
 
     virtual ~PromiseRejectionEvent();
@@ -51,7 +51,7 @@ public:
     const JSValueInWrappedObject& reason() const { return m_reason; }
 
 private:
-    PromiseRejectionEvent(const AtomString&, const Init&, IsTrusted);
+    PromiseRejectionEvent(const AtomString&, Init&&, IsTrusted);
 
     const Ref<DOMPromise> m_promise;
     JSValueInWrappedObject m_reason;

--- a/Source/WebCore/dom/RejectedPromiseTracker.cpp
+++ b/Source/WebCore/dom/RejectedPromiseTracker.cpp
@@ -169,7 +169,7 @@ void RejectedPromiseTracker::reportUnhandledRejections(Vector<UnhandledPromise>&
         initializer.promise = domPromise;
         initializer.reason = promise.result();
 
-        Ref event = PromiseRejectionEvent::create(eventNames().unhandledrejectionEvent, initializer);
+        Ref event = PromiseRejectionEvent::create(eventNames().unhandledrejectionEvent, WTF::move(initializer));
         RefPtr target = m_context->errorEventTarget();
         target->dispatchEvent(event);
 
@@ -197,7 +197,7 @@ void RejectedPromiseTracker::reportRejectionHandled(Ref<DOMPromise>&& rejectedPr
     initializer.promise = rejectedPromise.ptr();
     initializer.reason = promise.result();
 
-    Ref event = PromiseRejectionEvent::create(eventNames().rejectionhandledEvent, initializer);
+    Ref event = PromiseRejectionEvent::create(eventNames().rejectionhandledEvent, WTF::move(initializer));
     RefPtr target = m_context->errorEventTarget();
     target->dispatchEvent(event);
 }

--- a/Source/WebCore/page/NavigateEvent.cpp
+++ b/Source/WebCore/page/NavigateEvent.cpp
@@ -45,11 +45,11 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(NavigateEvent);
 
-NavigateEvent::NavigateEvent(const AtomString& type, const NavigateEvent::Init& init, EventIsTrusted isTrusted, AbortController* abortController)
+NavigateEvent::NavigateEvent(const AtomString& type, NavigateEvent::Init&& init, EventIsTrusted isTrusted, AbortController* abortController)
     : Event(EventInterfaceType::NavigateEvent, type, init, isTrusted)
     , m_navigationType(init.navigationType)
-    , m_destination(init.destination)
-    , m_signal(init.signal)
+    , m_destination(init.destination.releaseNonNull())
+    , m_signal(init.signal.releaseNonNull())
     , m_formData(init.formData)
     , m_downloadRequest(init.downloadRequest)
     , m_sourceElement(init.sourceElement)
@@ -63,15 +63,15 @@ NavigateEvent::NavigateEvent(const AtomString& type, const NavigateEvent::Init& 
     m_info.setWeakly(init.info);
 }
 
-Ref<NavigateEvent> NavigateEvent::create(const AtomString& type, const NavigateEvent::Init& init, AbortController* abortController)
+Ref<NavigateEvent> NavigateEvent::create(const AtomString& type, NavigateEvent::Init&& init, AbortController* abortController)
 {
-    return adoptRef(*new NavigateEvent(type, init, EventIsTrusted::Yes, abortController));
+    return adoptRef(*new NavigateEvent(type, WTF::move(init), EventIsTrusted::Yes, abortController));
 }
 
-Ref<NavigateEvent> NavigateEvent::create(const AtomString& type, const NavigateEvent::Init& init)
+Ref<NavigateEvent> NavigateEvent::create(const AtomString& type, NavigateEvent::Init&& init)
 {
     // FIXME: AbortController is required but JS bindings need to create it with one.
-    return adoptRef(*new NavigateEvent(type, init, EventIsTrusted::No, nullptr));
+    return adoptRef(*new NavigateEvent(type, WTF::move(init), EventIsTrusted::No, nullptr));
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigateevent-perform-shared-checks

--- a/Source/WebCore/page/NavigateEvent.h
+++ b/Source/WebCore/page/NavigateEvent.h
@@ -89,16 +89,16 @@ public:
         std::optional<NavigationScrollBehavior> scroll;
     };
 
-    static Ref<NavigateEvent> create(const AtomString& type, const Init&);
-    static Ref<NavigateEvent> create(const AtomString& type, const Init&, AbortController*);
+    static Ref<NavigateEvent> create(const AtomString& type, Init&&);
+    static Ref<NavigateEvent> create(const AtomString& type, Init&&, AbortController*);
 
     NavigationNavigationType navigationType() const { return m_navigationType; }
     bool canIntercept() const { return m_canIntercept; }
     bool userInitiated() const { return m_userInitiated; }
     bool hashChange() const { return m_hashChange; }
     bool hasUAVisualTransition() const { return m_hasUAVisualTransition; }
-    NavigationDestination* destination() { return m_destination.get(); }
-    AbortSignal* signal() { return m_signal.get(); }
+    NavigationDestination& destination() { return m_destination; }
+    AbortSignal& signal() { return m_signal; }
     DOMFormData* formData() { return m_formData.get(); }
     String downloadRequest() { return m_downloadRequest; }
     JSC::JSValue info() { return m_info.getValue(); }
@@ -117,20 +117,20 @@ public:
     Vector<Ref<NavigationInterceptHandler>>& handlers() { return m_handlers; }
 
 private:
-    NavigateEvent(const AtomString& type, const Init&, EventIsTrusted, AbortController*);
+    NavigateEvent(const AtomString& type, Init&&, EventIsTrusted, AbortController*);
 
     ExceptionOr<void> sharedChecks(Document&);
     void potentiallyProcessScrollBehavior(Document&);
     void processScrollBehavior(Document&);
 
     NavigationNavigationType m_navigationType;
-    RefPtr<NavigationDestination> m_destination;
-    RefPtr<AbortSignal> m_signal;
-    RefPtr<DOMFormData> m_formData;
+    const Ref<NavigationDestination> m_destination;
+    const Ref<AbortSignal> m_signal;
+    const RefPtr<DOMFormData> m_formData;
     String m_downloadRequest;
     Vector<Ref<NavigationInterceptHandler>> m_handlers;
     JSValueInWrappedObject m_info;
-    RefPtr<Element> m_sourceElement;
+    const RefPtr<Element> m_sourceElement;
     bool m_canIntercept { false };
     bool m_userInitiated { false };
     bool m_hashChange { false };
@@ -138,7 +138,7 @@ private:
     std::optional<InterceptionState> m_interceptionState;
     std::optional<NavigationFocusReset> m_focusReset;
     std::optional<NavigationScrollBehavior> m_scrollBehavior;
-    RefPtr<AbortController> m_abortController;
+    const RefPtr<AbortController> m_abortController;
 };
 
 WebCoreOpaqueRoot root(NavigateEvent*);

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -1094,7 +1094,7 @@ Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavi
     if (apiMethodTracker)
         apiMethodTracker->info.clear();
 
-    Ref event = NavigateEvent::create(eventNames().navigateEvent, init, abortController.get());
+    Ref event = NavigateEvent::create(eventNames().navigateEvent, WTF::move(init), abortController.get());
     m_ongoingNavigateEvent = event.ptr();
     m_focusChangedDuringOngoingNavigation = FocusDidChange::No;
     m_suppressNormalScrollRestorationDuringOngoingNavigation = false;
@@ -1109,7 +1109,7 @@ Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavi
 
     if (event->defaultPrevented()) {
         // FIXME: If navigationType is "traverse", then consume history-action user activation.
-        if (!event->signal()->aborted())
+        if (!event->signal().aborted())
             abortOngoingNavigation(event);
         return DispatchResult::Aborted;
     }

--- a/Source/WebCore/page/NavigationCurrentEntryChangeEvent.cpp
+++ b/Source/WebCore/page/NavigationCurrentEntryChangeEvent.cpp
@@ -32,16 +32,16 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(NavigationCurrentEntryChangeEvent);
 
-NavigationCurrentEntryChangeEvent::NavigationCurrentEntryChangeEvent(const AtomString& type, const NavigationCurrentEntryChangeEvent::Init& init)
+NavigationCurrentEntryChangeEvent::NavigationCurrentEntryChangeEvent(const AtomString& type, NavigationCurrentEntryChangeEvent::Init&& init)
     : Event(EventInterfaceType::NavigationCurrentEntryChangeEvent, type, CanBubble::No, IsCancelable::No)
     , m_navigationType(init.navigationType)
-    , m_from(init.from)
+    , m_from(init.from.releaseNonNull())
 {
 }
 
-Ref<NavigationCurrentEntryChangeEvent> NavigationCurrentEntryChangeEvent::create(const AtomString& type, const NavigationCurrentEntryChangeEvent::Init& init)
+Ref<NavigationCurrentEntryChangeEvent> NavigationCurrentEntryChangeEvent::create(const AtomString& type, NavigationCurrentEntryChangeEvent::Init&& init)
 {
-    return adoptRef(*new NavigationCurrentEntryChangeEvent(type, init));
+    return adoptRef(*new NavigationCurrentEntryChangeEvent(type, WTF::move(init)));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/NavigationCurrentEntryChangeEvent.h
+++ b/Source/WebCore/page/NavigationCurrentEntryChangeEvent.h
@@ -40,16 +40,16 @@ public:
         RefPtr<NavigationHistoryEntry> from;
     };
 
-    static Ref<NavigationCurrentEntryChangeEvent> create(const AtomString& type, const Init&);
+    static Ref<NavigationCurrentEntryChangeEvent> create(const AtomString& type, Init&&);
 
     std::optional<NavigationNavigationType> navigationType() const { return m_navigationType; };
-    RefPtr<NavigationHistoryEntry> from() const { return m_from; };
+    NavigationHistoryEntry& from() const { return m_from; };
 
 private:
-    NavigationCurrentEntryChangeEvent(const AtomString& type, const Init&);
+    NavigationCurrentEntryChangeEvent(const AtomString& type, Init&&);
 
     std::optional<NavigationNavigationType> m_navigationType;
-    RefPtr<NavigationHistoryEntry> m_from;
+    const Ref<NavigationHistoryEntry> m_from;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/UndoItem.h
+++ b/Source/WebCore/page/UndoItem.h
@@ -65,7 +65,7 @@ public:
     VoidCallback& redoHandler() const { return m_redoHandler.get(); }
 
 private:
-    UndoItem(Init&& init)
+    explicit UndoItem(Init&& init)
         : m_label(WTF::move(init.label))
         , m_undoHandler(init.undo.releaseNonNull())
         , m_redoHandler(init.redo.releaseNonNull())

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchEvent.cpp
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchEvent.cpp
@@ -34,11 +34,11 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(BackgroundFetchEvent);
 
 Ref<BackgroundFetchEvent> BackgroundFetchEvent::create(const AtomString& type, Init&& init, IsTrusted isTrusted)
 {
-    auto registration = init.registration;
+    Ref registration = init.registration.releaseNonNull();
     return adoptRef(*new BackgroundFetchEvent(EventInterfaceType::BackgroundFetchEvent, type, WTF::move(init), WTF::move(registration), isTrusted));
 }
 
-BackgroundFetchEvent::BackgroundFetchEvent(enum EventInterfaceType eventInterface, const AtomString& type, ExtendableEventInit&& eventInit, RefPtr<BackgroundFetchRegistration>&& registration, IsTrusted isTrusted)
+BackgroundFetchEvent::BackgroundFetchEvent(enum EventInterfaceType eventInterface, const AtomString& type, ExtendableEventInit&& eventInit, Ref<BackgroundFetchRegistration>&& registration, IsTrusted isTrusted)
     : ExtendableEvent(eventInterface, type, WTF::move(eventInit), isTrusted)
     , m_registration(WTF::move(registration))
 {
@@ -48,7 +48,7 @@ BackgroundFetchEvent::~BackgroundFetchEvent()
 {
 }
 
-RefPtr<BackgroundFetchRegistration> BackgroundFetchEvent::registration() const
+BackgroundFetchRegistration& BackgroundFetchEvent::registration() const
 {
     return m_registration;
 }

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchEvent.h
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchEvent.h
@@ -38,15 +38,15 @@ public:
     using Init = BackgroundFetchEventInit;
     static Ref<BackgroundFetchEvent> create(const AtomString&, Init&&, IsTrusted = IsTrusted::No);
 
-    RefPtr<BackgroundFetchRegistration> registration() const;
+    BackgroundFetchRegistration& registration() const;
 
 protected:
-    BackgroundFetchEvent(enum EventInterfaceType, const AtomString&, ExtendableEventInit&&, RefPtr<BackgroundFetchRegistration>&&, IsTrusted);
+    BackgroundFetchEvent(enum EventInterfaceType, const AtomString&, ExtendableEventInit&&, Ref<BackgroundFetchRegistration>&&, IsTrusted);
 
 private:
     bool isBackgroundFetchEvent() const final { return true; }
 
-    RefPtr<BackgroundFetchRegistration> m_registration;
+    const Ref<BackgroundFetchRegistration> m_registration;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchUpdateUIEvent.cpp
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchUpdateUIEvent.cpp
@@ -35,11 +35,11 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(BackgroundFetchUpdateUIEvent);
 
 Ref<BackgroundFetchUpdateUIEvent> BackgroundFetchUpdateUIEvent::create(const AtomString& type, Init&& init, IsTrusted isTrusted)
 {
-    auto registration = init.registration;
+    Ref registration = init.registration.releaseNonNull();
     return adoptRef(*new BackgroundFetchUpdateUIEvent(type, WTF::move(init), WTF::move(registration), isTrusted));
 }
 
-BackgroundFetchUpdateUIEvent::BackgroundFetchUpdateUIEvent(const AtomString& type, ExtendableEventInit&& eventInit, RefPtr<BackgroundFetchRegistration>&& registration, IsTrusted isTrusted)
+BackgroundFetchUpdateUIEvent::BackgroundFetchUpdateUIEvent(const AtomString& type, ExtendableEventInit&& eventInit, Ref<BackgroundFetchRegistration>&& registration, IsTrusted isTrusted)
     : BackgroundFetchEvent(EventInterfaceType::BackgroundFetchUpdateUIEvent, type, WTF::move(eventInit), WTF::move(registration), isTrusted)
 {
 }

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchUpdateUIEvent.h
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchUpdateUIEvent.h
@@ -43,7 +43,7 @@ public:
     void updateUI(BackgroundFetchUIOptions&&, DOMPromiseDeferred<void>&&);
 
 private:
-    BackgroundFetchUpdateUIEvent(const AtomString&, ExtendableEventInit&&, RefPtr<BackgroundFetchRegistration>&&, IsTrusted);
+    BackgroundFetchUpdateUIEvent(const AtomString&, ExtendableEventInit&&, Ref<BackgroundFetchRegistration>&&, IsTrusted);
 
     bool isBackgroundFetchUpdateUIEvent() const final { return true; }
 };

--- a/Source/WebCore/workers/service/context/ServiceWorkerThread.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThread.cpp
@@ -408,7 +408,7 @@ void ServiceWorkerThread::queueTaskToFireNotificationEvent(NotificationData&& da
     serviceWorkerGlobalScope->checkedEventLoop()->queueTask(TaskSource::DOMManipulation, [serviceWorkerGlobalScope, data = WTF::move(data), eventType, callback = WTF::move(callback)]() mutable {
         RELEASE_LOG(ServiceWorker, "ServiceWorkerThread::queueTaskToFireNotificationEvent firing event for worker %" PRIu64, serviceWorkerGlobalScope->thread()->identifier().toUInt64());
 
-        auto notification = Notification::create(serviceWorkerGlobalScope.get(), WTF::move(data));
+        Ref notification = Notification::create(serviceWorkerGlobalScope.get(), WTF::move(data));
         AtomString eventName;
         switch (eventType) {
         case NotificationEventType::Click:
@@ -421,7 +421,7 @@ void ServiceWorkerThread::queueTaskToFireNotificationEvent(NotificationData&& da
             break;
         }
 
-        auto notificationEvent = NotificationEvent::create(eventName, notification.ptr(), emptyString(), ExtendableEvent::IsTrusted::Yes);
+        Ref notificationEvent = NotificationEvent::create(eventName, WTF::move(notification), emptyString(), ExtendableEvent::IsTrusted::Yes);
         serviceWorkerGlobalScope->dispatchEvent(notificationEvent);
 
         notificationEvent->whenAllExtendLifetimePromisesAreSettled([serviceWorkerGlobalScope, callback = WTF::move(callback)](auto&& extendLifetimePromises) mutable {


### PR DESCRIPTION
#### bdd255338ebf9826e1f91b0522f0e4c3a109a4da
<pre>
Handle IDL required dictionary members more consistently on the C++ side
<a href="https://bugs.webkit.org/show_bug.cgi?id=305292">https://bugs.webkit.org/show_bug.cgi?id=305292</a>

Reviewed by Chris Dumez.

In quite a few places we already used releaseNonNull(), Init&amp;&amp;,
const Ref, and a reference getter, but evidently not consistently.

Canonical link: <a href="https://commits.webkit.org/305448@main">https://commits.webkit.org/305448@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d76003341f98ea68ccece146315017d3c37a742

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138449 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10814 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49859 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146533 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91424 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6081e0c2-a0e5-471b-b968-dd00e2c93bce) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140323 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11518 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10969 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105933 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77284 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/53d7084b-b6a3-4f8c-a6f0-ca2785894dd3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141396 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8648 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124116 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86780 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/46936c15-421d-44fb-99ea-250b52dd4f59) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8235 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6006 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6825 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117655 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42315 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149253 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10496 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42872 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114332 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10513 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8874 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114673 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8326 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120402 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65382 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21325 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10544 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38335 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10279 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74148 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10483 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10334 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->