### PR TITLE
[WebRTC] Apply ABSL_ATTRIBUTE_LIFETIME_BOUND attribute consistently on both declaration and definition of methods

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/third_party/abseil-cpp/absl/strings/cord.h
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/abseil-cpp/absl/strings/cord.h
@@ -1610,11 +1610,15 @@ inline void Cord::ChunkIterator::AdvanceBytes(size_t n) {
   }
 }
 
-inline Cord::ChunkIterator Cord::chunk_begin() const {
+inline Cord::ChunkIterator Cord::chunk_begin() const
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
   return ChunkIterator(this);
 }
 
-inline Cord::ChunkIterator Cord::chunk_end() const { return ChunkIterator(); }
+inline Cord::ChunkIterator Cord::chunk_end() const
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  return ChunkIterator();
+}
 
 inline Cord::ChunkIterator Cord::ChunkRange::begin() const {
   return cord_->chunk_begin();
@@ -1624,7 +1628,9 @@ inline Cord::ChunkIterator Cord::ChunkRange::end() const {
   return cord_->chunk_end();
 }
 
-inline Cord::ChunkRange Cord::Chunks() const { return ChunkRange(this); }
+inline Cord::ChunkRange Cord::Chunks() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  return ChunkRange(this);
+}
 
 inline Cord::CharIterator& Cord::CharIterator::operator++() {
   if (ABSL_PREDICT_TRUE(chunk_iterator_->size() > 1)) {
@@ -1674,11 +1680,14 @@ inline ptrdiff_t Cord::Distance(const CharIterator& first,
                                 last.chunk_iterator_.bytes_remaining_);
 }
 
-inline Cord::CharIterator Cord::char_begin() const {
+inline Cord::CharIterator Cord::char_begin() const
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
   return CharIterator(this);
 }
 
-inline Cord::CharIterator Cord::char_end() const { return CharIterator(); }
+inline Cord::CharIterator Cord::char_end() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  return CharIterator();
+}
 
 inline Cord::CharIterator Cord::CharRange::begin() const {
   return cord_->char_begin();
@@ -1688,7 +1697,9 @@ inline Cord::CharIterator Cord::CharRange::end() const {
   return cord_->char_end();
 }
 
-inline Cord::CharRange Cord::Chars() const { return CharRange(this); }
+inline Cord::CharRange Cord::Chars() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  return CharRange(this);
+}
 
 inline void Cord::ForEachChunk(
     absl::FunctionRef<void(absl::string_view)> callback) const {

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/rtc_base/bitstream_reader.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/rtc_base/bitstream_reader.h
@@ -126,11 +126,13 @@ class BitstreamReader {
   mutable bool last_read_is_verified_ = true;
 };
 
-inline BitstreamReader::BitstreamReader(ArrayView<const uint8_t> bytes)
+inline BitstreamReader::BitstreamReader(
+    ArrayView<const uint8_t> bytes ABSL_ATTRIBUTE_LIFETIME_BOUND)
     : bytes_(bytes.data()),
       remaining_bits_(checked_cast<int>(bytes.size() * 8)) {}
 
-inline BitstreamReader::BitstreamReader(absl::string_view bytes)
+inline BitstreamReader::BitstreamReader(
+    absl::string_view bytes ABSL_ATTRIBUTE_LIFETIME_BOUND)
     : bytes_(reinterpret_cast<const uint8_t*>(bytes.data())),
       remaining_bits_(checked_cast<int>(bytes.size() * 8)) {}
 

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/rtc_base/byte_buffer.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/rtc_base/byte_buffer.cc
@@ -25,7 +25,8 @@ ByteBufferWriter::ByteBufferWriter() : ByteBufferWriterT() {}
 ByteBufferWriter::ByteBufferWriter(const uint8_t* bytes, size_t len)
     : ByteBufferWriterT(bytes, len) {}
 
-ByteBufferReader::ByteBufferReader(ArrayView<const uint8_t> bytes) {
+ByteBufferReader::ByteBufferReader(
+    ArrayView<const uint8_t> bytes ABSL_ATTRIBUTE_LIFETIME_BOUND) {
   Construct(bytes.data(), bytes.size());
 }
 


### PR DESCRIPTION
#### 7308d50c563b126130f9c825fda7f7fb5321e254
<pre>
[WebRTC] Apply ABSL_ATTRIBUTE_LIFETIME_BOUND attribute consistently on both declaration and definition of methods
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=305293">https://bugs.webkit.org/show_bug.cgi?id=305293</a>&gt;
&lt;<a href="https://rdar.apple.com/167944066">rdar://167944066</a>&gt;

Reviewed by NOBODY (OOPS!).

Apply ABSL_ATTRIBUTE_LIFETIME_BOUND attribute consistently to both
declaration and definition of each function.

This works around a bug in clang where the attribute is ignored in
certain cases: &lt;<a href="https://github.com/llvm/llvm-project/issues/175391">https://github.com/llvm/llvm-project/issues/175391</a>&gt;

* Source/ThirdParty/libwebrtc/Source/third_party/abseil-cpp/absl/strings/cord.h:
(absl::Cord::chunk_begin const):
(absl::Cord::chunk_end const):
(absl::Cord::Chunks const):
(absl::Cord::char_begin const):
(absl::Cord::char_end const):
(absl::Cord::Chars const):
* Source/ThirdParty/libwebrtc/Source/webrtc/rtc_base/bitstream_reader.h:
(webrtc::BitstreamReader::BitstreamReader):
* Source/ThirdParty/libwebrtc/Source/webrtc/rtc_base/byte_buffer.cc:
(webrtc::ByteBufferReader::ByteBufferReader):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7308d50c563b126130f9c825fda7f7fb5321e254

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138408 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10773 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49818 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146492 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91383 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/45617d7f-01fc-46a8-a0be-a92fac12f6c2) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11477 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10927 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105899 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77251 "layout-tests (failure)") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9ca33edc-e7e1-4348-afe6-ec6a42534d92) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141355 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8616 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124076 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86744 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ecd5cbfe-9166-4dff-8189-2cabf960690c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8203 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5971 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6780 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117623 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42275 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149213 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10455 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42832 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114298 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10472 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8839 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114641 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8254 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120362 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65320 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10502 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38295 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10237 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10442 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10293 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->