### PR TITLE
Apply LIFETIME_BOUND attribute consistently on both declaration and definition of methods

### DIFF
--- a/Source/JavaScriptCore/API/OpaqueJSString.cpp
+++ b/Source/JavaScriptCore/API/OpaqueJSString.cpp
@@ -79,7 +79,7 @@ Identifier OpaqueJSString::identifier(VM* vm) const
     return Identifier::fromString(*vm, m_string.span16());
 }
 
-const char16_t* OpaqueJSString::characters()
+const char16_t* OpaqueJSString::characters() LIFETIME_BOUND
 {
     // m_characters is put in a local here to avoid an extra atomic load.
     char16_t* characters = m_characters;

--- a/Source/JavaScriptCore/debugger/DebuggerScope.h
+++ b/Source/JavaScriptCore/debugger/DebuggerScope.h
@@ -108,14 +108,14 @@ private:
     friend class DebuggerCallFrame;
 };
 
-inline DebuggerScope::iterator DebuggerScope::begin()
+inline DebuggerScope::iterator DebuggerScope::begin() LIFETIME_BOUND
 {
-    return iterator(this); 
+    return iterator(this);
 }
 
-inline DebuggerScope::iterator DebuggerScope::end()
-{ 
-    return iterator(nullptr); 
+inline DebuggerScope::iterator DebuggerScope::end() LIFETIME_BOUND
+{
+    return iterator(nullptr);
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/ArrayBuffer.h
+++ b/Source/JavaScriptCore/runtime/ArrayBuffer.h
@@ -379,22 +379,22 @@ private:
     bool m_locked { false };
 };
 
-void* ArrayBuffer::data()
+void* ArrayBuffer::data() LIFETIME_BOUND
 {
     return m_contents.data();
 }
 
-const void* ArrayBuffer::data() const
+const void* ArrayBuffer::data() const LIFETIME_BOUND
 {
     return m_contents.data();
 }
 
-void* ArrayBuffer::dataWithoutPACValidation()
+void* ArrayBuffer::dataWithoutPACValidation() LIFETIME_BOUND
 {
     return m_contents.dataWithoutPACValidation();
 }
 
-const void* ArrayBuffer::dataWithoutPACValidation() const
+const void* ArrayBuffer::dataWithoutPACValidation() const LIFETIME_BOUND
 {
     return m_contents.dataWithoutPACValidation();
 }

--- a/Source/JavaScriptCore/runtime/CachePayload.cpp
+++ b/Source/JavaScriptCore/runtime/CachePayload.cpp
@@ -54,7 +54,7 @@ CachePayload::CachePayload(DataType&& data)
 
 CachePayload::~CachePayload() = default;
 
-std::span<const uint8_t> CachePayload::span() const
+std::span<const uint8_t> CachePayload::span() const LIFETIME_BOUND
 {
     return WTF::switchOn(m_data, [](const auto& data) {
         return data.span();

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyArrayInlines.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyArrayInlines.h
@@ -49,7 +49,7 @@ WebAssemblyGCStructure* JSWebAssemblyArray::createStructure(VM& vm, JSGlobalObje
 }
 
 template<typename T>
-std::span<T> JSWebAssemblyArray::span()
+std::span<T> JSWebAssemblyArray::span() LIFETIME_BOUND
 {
     ASSERT(sizeof(T) == elementType().type.elementSize());
     uint8_t* data = this->data();
@@ -61,7 +61,7 @@ std::span<T> JSWebAssemblyArray::span()
     return { std::bit_cast<T*>(data), size() };
 }
 
-std::span<uint64_t> JSWebAssemblyArray::refTypeSpan()
+std::span<uint64_t> JSWebAssemblyArray::refTypeSpan() LIFETIME_BOUND
 {
     ASSERT(elementsAreRefTypes());
     return span<uint64_t>();

--- a/Source/WTF/wtf/Deque.h
+++ b/Source/WTF/wtf/Deque.h
@@ -412,14 +412,14 @@ inline void Deque<T, inlineCapacity>::clear()
 
 template<typename T, size_t inlineCapacity>
 template<typename Predicate>
-inline auto Deque<T, inlineCapacity>::findIf(NOESCAPE const Predicate& predicate) -> iterator
+inline auto Deque<T, inlineCapacity>::findIf(NOESCAPE const Predicate& predicate) LIFETIME_BOUND -> iterator
 {
     return std::find_if(begin(), end(), predicate);
 }
 
 template<typename T, size_t inlineCapacity>
 template<typename Predicate>
-inline auto Deque<T, inlineCapacity>::findIf(NOESCAPE const Predicate& predicate) const -> const_iterator
+inline auto Deque<T, inlineCapacity>::findIf(NOESCAPE const Predicate& predicate) const LIFETIME_BOUND -> const_iterator
 {
     return std::find_if(begin(), end(), predicate);
 }

--- a/Source/WTF/wtf/HashCountedSet.h
+++ b/Source/WTF/wtf/HashCountedSet.h
@@ -161,49 +161,49 @@ inline bool HashCountedSet<Value, HashFunctions, Traits>::isEmpty() const
 }
 
 template<typename Value, typename HashFunctions, typename Traits>
-inline auto HashCountedSet<Value, HashFunctions, Traits>::begin() -> iterator
+inline auto HashCountedSet<Value, HashFunctions, Traits>::begin() LIFETIME_BOUND -> iterator
 {
     return m_impl.begin();
 }
 
 template<typename Value, typename HashFunctions, typename Traits>
-inline auto HashCountedSet<Value, HashFunctions, Traits>::end() -> iterator
+inline auto HashCountedSet<Value, HashFunctions, Traits>::end() LIFETIME_BOUND -> iterator
 {
     return m_impl.end();
 }
 
 template<typename Value, typename HashFunctions, typename Traits>
-inline auto HashCountedSet<Value, HashFunctions, Traits>::begin() const -> const_iterator
+inline auto HashCountedSet<Value, HashFunctions, Traits>::begin() const LIFETIME_BOUND -> const_iterator
 {
     return m_impl.begin();
 }
 
 template<typename Value, typename HashFunctions, typename Traits>
-inline auto HashCountedSet<Value, HashFunctions, Traits>::end() const -> const_iterator
+inline auto HashCountedSet<Value, HashFunctions, Traits>::end() const LIFETIME_BOUND -> const_iterator
 {
     return m_impl.end();
 }
 
 template<typename Value, typename HashFunctions, typename Traits>
-inline auto HashCountedSet<Value, HashFunctions, Traits>::values() -> ValuesIteratorRange
+inline auto HashCountedSet<Value, HashFunctions, Traits>::values() LIFETIME_BOUND -> ValuesIteratorRange
 {
     return m_impl.keys();
 }
 
 template<typename Value, typename HashFunctions, typename Traits>
-inline auto HashCountedSet<Value, HashFunctions, Traits>::values() const -> const ValuesConstIteratorRange
+inline auto HashCountedSet<Value, HashFunctions, Traits>::values() const LIFETIME_BOUND -> const ValuesConstIteratorRange
 {
     return m_impl.keys();
 }
 
 template<typename Value, typename HashFunctions, typename Traits>
-inline auto HashCountedSet<Value, HashFunctions, Traits>::find(const ValueType& value) -> iterator
+inline auto HashCountedSet<Value, HashFunctions, Traits>::find(const ValueType& value) LIFETIME_BOUND -> iterator
 {
     return m_impl.find(value);
 }
 
 template<typename Value, typename HashFunctions, typename Traits>
-inline auto HashCountedSet<Value, HashFunctions, Traits>::find(const ValueType& value) const -> const_iterator
+inline auto HashCountedSet<Value, HashFunctions, Traits>::find(const ValueType& value) const LIFETIME_BOUND -> const_iterator
 {
     return m_impl.find(value);
 }
@@ -221,7 +221,7 @@ inline unsigned HashCountedSet<Value, HashFunctions, Traits>::count(const ValueT
 }
 
 template<typename Value, typename HashFunctions, typename Traits>
-inline auto HashCountedSet<Value, HashFunctions, Traits>::add(const ValueType &value) -> AddResult
+inline auto HashCountedSet<Value, HashFunctions, Traits>::add(const ValueType &value) LIFETIME_BOUND -> AddResult
 {
     auto result = m_impl.add(value, 0);
     ++result.iterator->value;
@@ -229,7 +229,7 @@ inline auto HashCountedSet<Value, HashFunctions, Traits>::add(const ValueType &v
 }
 
 template<typename Value, typename HashFunctions, typename Traits>
-inline auto HashCountedSet<Value, HashFunctions, Traits>::add(ValueType&& value) -> AddResult
+inline auto HashCountedSet<Value, HashFunctions, Traits>::add(ValueType&& value) LIFETIME_BOUND -> AddResult
 {
     auto result = m_impl.add(std::forward<Value>(value), 0);
     ++result.iterator->value;
@@ -237,7 +237,7 @@ inline auto HashCountedSet<Value, HashFunctions, Traits>::add(ValueType&& value)
 }
 
 template<typename Value, typename HashFunctions, typename Traits>
-inline auto HashCountedSet<Value, HashFunctions, Traits>::add(const ValueType& value, unsigned count) -> AddResult
+inline auto HashCountedSet<Value, HashFunctions, Traits>::add(const ValueType& value, unsigned count) LIFETIME_BOUND -> AddResult
 {
     auto result = m_impl.add(value, 0);
     result.iterator->value += count;
@@ -245,7 +245,7 @@ inline auto HashCountedSet<Value, HashFunctions, Traits>::add(const ValueType& v
 }
 
 template<typename Value, typename HashFunctions, typename Traits>
-inline auto HashCountedSet<Value, HashFunctions, Traits>::add(ValueType&& value, unsigned count) -> AddResult
+inline auto HashCountedSet<Value, HashFunctions, Traits>::add(ValueType&& value, unsigned count) LIFETIME_BOUND -> AddResult
 {
     auto result = m_impl.add(std::forward<Value>(value), 0);
     result.iterator->value += count;
@@ -323,14 +323,14 @@ inline bool HashCountedSet<Value, HashFunctions, Traits>::isValidValue(const Val
 
 template<typename Value, typename HashFunctions, typename Traits>
 template<SmartPtr V>
-inline auto HashCountedSet<Value, HashFunctions, Traits>::find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) -> iterator
+inline auto HashCountedSet<Value, HashFunctions, Traits>::find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) LIFETIME_BOUND -> iterator
 {
     return m_impl.find(value);
 }
 
 template<typename Value, typename HashFunctions, typename Traits>
 template<SmartPtr V>
-inline auto HashCountedSet<Value, HashFunctions, Traits>::find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) const -> const_iterator
+inline auto HashCountedSet<Value, HashFunctions, Traits>::find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) const LIFETIME_BOUND -> const_iterator
 {
     return m_impl.find(value);
 }
@@ -358,14 +358,14 @@ inline auto HashCountedSet<Value, HashFunctions, Traits>::remove(std::add_const_
 
 template<typename Value, typename HashFunctions, typename Traits>
 template<NonNullableSmartPtr V>
-inline auto HashCountedSet<Value, HashFunctions, Traits>::find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& value) -> iterator
+inline auto HashCountedSet<Value, HashFunctions, Traits>::find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& value) LIFETIME_BOUND -> iterator
 {
     return find(&value);
 }
 
 template<typename Value, typename HashFunctions, typename Traits>
 template<NonNullableSmartPtr V>
-inline auto HashCountedSet<Value, HashFunctions, Traits>::find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& value) const -> const_iterator
+inline auto HashCountedSet<Value, HashFunctions, Traits>::find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& value) const LIFETIME_BOUND -> const_iterator
 {
     return find(&value);
 }

--- a/Source/WTF/wtf/HashMap.h
+++ b/Source/WTF/wtf/HashMap.h
@@ -337,37 +337,37 @@ inline bool HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::isEmpty() const
 }
 
 template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
-inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::begin() -> iterator
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::begin() LIFETIME_BOUND -> iterator
 {
     return m_impl.begin();
 }
 
 template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
-inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::end() -> iterator
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::end() LIFETIME_BOUND -> iterator
 {
     return m_impl.end();
 }
 
 template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
-inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::begin() const -> const_iterator
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::begin() const LIFETIME_BOUND -> const_iterator
 {
     return m_impl.begin();
 }
 
 template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
-inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::end() const -> const_iterator
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::end() const LIFETIME_BOUND -> const_iterator
 {
     return m_impl.end();
 }
 
 template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
-inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::find(const KeyType& key) -> iterator
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::find(const KeyType& key) LIFETIME_BOUND -> iterator
 {
     return m_impl.template find<shouldValidateKey>(key);
 }
 
 template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
-inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::find(const KeyType& key) const -> const_iterator
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::find(const KeyType& key) const LIFETIME_BOUND -> const_iterator
 {
     return m_impl.template find<shouldValidateKey>(key);
 }
@@ -380,14 +380,14 @@ inline bool HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::contains(const KeyT
 
 template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
 template<typename HashTranslator, typename TYPE>
-inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::find(const TYPE& value) -> iterator
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::find(const TYPE& value) LIFETIME_BOUND -> iterator
 {
     return m_impl.template find<HashMapTranslatorAdapter<KeyValuePairTraits, HashTranslator>, shouldValidateKey>(value);
 }
 
 template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
 template<typename HashTranslator, typename TYPE>
-inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::find(const TYPE& value) const -> const_iterator
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::find(const TYPE& value) const LIFETIME_BOUND -> const_iterator
 {
     return m_impl.template find<HashMapTranslatorAdapter<KeyValuePairTraits, HashTranslator>, shouldValidateKey>(value);
 }
@@ -458,68 +458,68 @@ ALWAYS_INLINE auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTrait
 
 template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey, typename M>
 template<typename T>
-auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey, M>::set(const KeyType& key, T&& mapped) -> AddResult
+auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey, M>::set(const KeyType& key, T&& mapped) LIFETIME_BOUND -> AddResult
 {
     return inlineSet(key, std::forward<T>(mapped));
 }
 
 template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey, typename M>
 template<typename T>
-auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey, M>::set(KeyType&& key, T&& mapped) -> AddResult
+auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey, M>::set(KeyType&& key, T&& mapped) LIFETIME_BOUND -> AddResult
 {
     return inlineSet(WTF::move(key), std::forward<T>(mapped));
 }
 
 template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey, typename M>
 template<typename HashTranslator, typename K>
-auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey, M>::ensure(K&& key, NOESCAPE const Invocable<MappedType()> auto& functor) -> AddResult
+auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey, M>::ensure(K&& key, NOESCAPE const Invocable<MappedType()> auto& functor) LIFETIME_BOUND -> AddResult
 {
     return m_impl.template addPassingHashCode<HashMapEnsureTranslatorAdapter<KeyValuePairTraits, HashTranslator>, shouldValidateKey>(std::forward<K>(key), functor);
 }
 
 template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey, typename M>
 template<typename HashTranslator, typename K, typename V>
-auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey, M>::add(K&& key, V&& value) -> AddResult
+auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey, M>::add(K&& key, V&& value) LIFETIME_BOUND -> AddResult
 {
     return m_impl.template addPassingHashCode<HashMapTranslatorAdapter<KeyValuePairTraits, HashTranslator>, shouldValidateKey>(std::forward<K>(key), [&] () ALWAYS_INLINE_LAMBDA -> MappedType { return std::forward<V>(value); });
 }
 
 template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey, typename M>
 template<typename T>
-auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey, M>::add(const KeyType& key, T&& mapped) -> AddResult
+auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey, M>::add(const KeyType& key, T&& mapped) LIFETIME_BOUND -> AddResult
 {
     return inlineAdd(key, std::forward<T>(mapped));
 }
 
 template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey, typename M>
 template<typename T>
-auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey, M>::add(KeyType&& key, T&& mapped) -> AddResult
+auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey, M>::add(KeyType&& key, T&& mapped) LIFETIME_BOUND -> AddResult
 {
     return inlineAdd(WTF::move(key), std::forward<T>(mapped));
 }
 
 template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey, typename M>
 template<typename T>
-ALWAYS_INLINE auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey, M>::fastAdd(const KeyType& key, T&& mapped) -> AddResult
+ALWAYS_INLINE auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey, M>::fastAdd(const KeyType& key, T&& mapped) LIFETIME_BOUND -> AddResult
 {
     return inlineAdd(key, std::forward<T>(mapped));
 }
 
 template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey, typename M>
 template<typename T>
-ALWAYS_INLINE auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey, M>::fastAdd(KeyType&& key, T&& mapped) -> AddResult
+ALWAYS_INLINE auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey, M>::fastAdd(KeyType&& key, T&& mapped) LIFETIME_BOUND -> AddResult
 {
     return inlineAdd(WTF::move(key), std::forward<T>(mapped));
 }
 
 template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey, typename M>
-auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey, M>::ensure(const KeyType& key, NOESCAPE const Invocable<MappedType()> auto& functor) -> AddResult
+auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey, M>::ensure(const KeyType& key, NOESCAPE const Invocable<MappedType()> auto& functor) LIFETIME_BOUND -> AddResult
 {
     return inlineEnsure(key, functor);
 }
 
 template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey, typename M>
-auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey, M>::ensure(KeyType&& key, NOESCAPE const Invocable<MappedType()> auto& functor) -> AddResult
+auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg, shouldValidateKey, M>::ensure(KeyType&& key, NOESCAPE const Invocable<MappedType()> auto& functor) LIFETIME_BOUND -> AddResult
 {
     return inlineEnsure(std::forward<KeyType>(key), functor);
 }
@@ -627,14 +627,14 @@ inline void HashMap<T, U, V, KeyTraits, MappedTraits, Y, shouldValidateKey, M>::
 
 template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
 template<SmartPtr K>
-inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::find(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>* key) -> iterator
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::find(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>* key) LIFETIME_BOUND -> iterator
 {
     return m_impl.template find<HashMapTranslator<KeyValuePairTraits, HashFunctions>, shouldValidateKey>(key);
 }
 
 template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey, typename M>
 template<SmartPtr K>
-inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::find(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>* key) const -> const_iterator
+inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey, M>::find(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>* key) const LIFETIME_BOUND -> const_iterator
 {
     return m_impl.template find<HashMapTranslator<KeyValuePairTraits, HashFunctions>, shouldValidateKey>(key);
 }

--- a/Source/WTF/wtf/HashSet.h
+++ b/Source/WTF/wtf/HashSet.h
@@ -311,19 +311,19 @@ inline void HashSet<T, U, V, W, shouldValidateKey>::removeWeakNullEntries() requ
 }
 
 template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
-inline auto HashSet<T, U, V, W, shouldValidateKey>::begin() const -> iterator
+inline auto HashSet<T, U, V, W, shouldValidateKey>::begin() const LIFETIME_BOUND -> iterator
 {
-    return m_impl.begin(); 
+    return m_impl.begin();
 }
 
 template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
-inline auto HashSet<T, U, V, W, shouldValidateKey>::end() const -> iterator
+inline auto HashSet<T, U, V, W, shouldValidateKey>::end() const LIFETIME_BOUND -> iterator
 {
-    return m_impl.end(); 
+    return m_impl.end();
 }
 
 template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
-inline auto HashSet<T, U, V, W, shouldValidateKey>::find(const ValueType& value) const -> iterator
+inline auto HashSet<T, U, V, W, shouldValidateKey>::find(const ValueType& value) const LIFETIME_BOUND -> iterator
 {
     return m_impl.template find<shouldValidateKey>(value);
 }
@@ -336,7 +336,7 @@ inline bool HashSet<T, U, V, W, shouldValidateKey>::contains(const ValueType& va
 
 template<typename Value, typename HashFunctions, typename Traits, typename TableTraits, ShouldValidateKey shouldValidateKey>
 template<typename HashTranslator, typename T>
-inline auto HashSet<Value, HashFunctions, Traits, TableTraits, shouldValidateKey>::find(const T& value) const -> iterator
+inline auto HashSet<Value, HashFunctions, Traits, TableTraits, shouldValidateKey>::find(const T& value) const LIFETIME_BOUND -> iterator
 {
     return m_impl.template find<HashSetTranslatorAdapter<HashTranslator>, shouldValidateKey>(value);
 }
@@ -350,19 +350,19 @@ inline bool HashSet<Value, HashFunctions, Traits, TableTraits, shouldValidateKey
 
 template<typename Value, typename HashFunctions, typename Traits, typename TableTraits, ShouldValidateKey shouldValidateKey>
 template<typename HashTranslator, typename T>
-inline auto HashSet<Value, HashFunctions, Traits, TableTraits, shouldValidateKey>::ensure(T&& key, NOESCAPE const Invocable<ValueType()> auto& functor) -> AddResult
+inline auto HashSet<Value, HashFunctions, Traits, TableTraits, shouldValidateKey>::ensure(T&& key, NOESCAPE const Invocable<ValueType()> auto& functor) LIFETIME_BOUND -> AddResult
 {
     return m_impl.template add<HashSetEnsureTranslatorAdaptor<Traits, HashTranslator>, shouldValidateKey>(std::forward<T>(key), functor);
 }
 
 template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
-inline auto HashSet<T, U, V, W, shouldValidateKey>::add(const ValueType& value) -> AddResult
+inline auto HashSet<T, U, V, W, shouldValidateKey>::add(const ValueType& value) LIFETIME_BOUND -> AddResult
 {
     return m_impl.template add<shouldValidateKey>(value);
 }
 
 template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
-inline auto HashSet<T, U, V, W, shouldValidateKey>::add(ValueType&& value) -> AddResult
+inline auto HashSet<T, U, V, W, shouldValidateKey>::add(ValueType&& value) LIFETIME_BOUND -> AddResult
 {
     return m_impl.template add<shouldValidateKey>(WTF::move(value));
 }
@@ -381,7 +381,7 @@ inline void HashSet<T, U, V, W, shouldValidateKey>::addVoid(ValueType&& value)
 
 template<typename Value, typename HashFunctions, typename Traits, typename TableTraits, ShouldValidateKey shouldValidateKey>
 template<typename HashTranslator>
-inline auto HashSet<Value, HashFunctions, Traits, TableTraits, shouldValidateKey>::add(const auto& value) -> AddResult
+inline auto HashSet<Value, HashFunctions, Traits, TableTraits, shouldValidateKey>::add(const auto& value) LIFETIME_BOUND -> AddResult
 {
     return m_impl.template addPassingHashCode<HashSetTranslatorAdapter<HashTranslator>, shouldValidateKey>(value, [&]() ALWAYS_INLINE_LAMBDA { return value; });
 }
@@ -532,7 +532,7 @@ inline bool HashSet<T, U, V, W, shouldValidateKey>::isSubset(const OtherCollecti
 
 template<typename Value, typename HashFunctions, typename Traits, typename TableTraits, ShouldValidateKey shouldValidateKey>
 template<SmartPtr V>
-inline auto HashSet<Value, HashFunctions, Traits, TableTraits, shouldValidateKey>::find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) const -> iterator
+inline auto HashSet<Value, HashFunctions, Traits, TableTraits, shouldValidateKey>::find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) const LIFETIME_BOUND -> iterator
 {
     return m_impl.template find<HashSetTranslator<Traits, HashFunctions>, shouldValidateKey>(value);
 }

--- a/Source/WTF/wtf/HashTable.h
+++ b/Source/WTF/wtf/HashTable.h
@@ -859,7 +859,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
 
     template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename Malloc>
     template<typename HashTranslator, ShouldValidateKey shouldValidateKey, typename T>
-    ALWAYS_INLINE auto HashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, Malloc>::add(T&& key, NOESCAPE const std::invocable<> auto& functor) -> AddResult
+    ALWAYS_INLINE auto HashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, Malloc>::add(T&& key, NOESCAPE const std::invocable<> auto& functor) LIFETIME_BOUND -> AddResult
     {
         invalidateIterators(this);
 
@@ -946,7 +946,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
 
     template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename Malloc>
     template<typename HashTranslator, ShouldValidateKey shouldValidateKey, typename T>
-    inline auto HashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, Malloc>::addPassingHashCode(T&& key, NOESCAPE const std::invocable<> auto& functor) -> AddResult
+    inline auto HashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, Malloc>::addPassingHashCode(T&& key, NOESCAPE const std::invocable<> auto& functor) LIFETIME_BOUND -> AddResult
     {
         invalidateIterators(this);
 
@@ -1003,7 +1003,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
 
     template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename Malloc>
     template <typename HashTranslator, ShouldValidateKey shouldValidateKey, typename T>
-    auto HashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, Malloc>::find(const T& key) -> iterator
+    auto HashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, Malloc>::find(const T& key) LIFETIME_BOUND -> iterator
     {
         if (!m_table)
             return end();
@@ -1017,7 +1017,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
 
     template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename Malloc>
     template <typename HashTranslator, ShouldValidateKey shouldValidateKey, typename T>
-    auto HashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, Malloc>::find(const T& key) const -> const_iterator
+    auto HashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, Malloc>::find(const T& key) const LIFETIME_BOUND -> const_iterator
     {
         if (!m_table)
             return end();

--- a/Source/WTF/wtf/IndexSparseSet.h
+++ b/Source/WTF/wtf/IndexSparseSet.h
@@ -235,13 +235,13 @@ void IndexSparseSet<EntryType, EntryTypeTraits, OverflowHandler>::validate()
 }
 
 template<typename EntryType, typename EntryTypeTraits, typename OverflowHandler>
-auto IndexSparseSet<EntryType, EntryTypeTraits, OverflowHandler>::begin() const -> const_iterator
+auto IndexSparseSet<EntryType, EntryTypeTraits, OverflowHandler>::begin() const LIFETIME_BOUND -> const_iterator
 {
     return m_values.begin();
 }
 
 template<typename EntryType, typename EntryTypeTraits, typename OverflowHandler>
-auto IndexSparseSet<EntryType, EntryTypeTraits, OverflowHandler>::end() const -> const_iterator
+auto IndexSparseSet<EntryType, EntryTypeTraits, OverflowHandler>::end() const LIFETIME_BOUND -> const_iterator
 {
     return m_values.end();
 }

--- a/Source/WTF/wtf/JSONValues.h
+++ b/Source/WTF/wtf/JSONValues.h
@@ -315,12 +315,12 @@ public:
     using ArrayBase::end;
 };
 
-inline ObjectBase::iterator ObjectBase::find(const String& name)
+inline ObjectBase::iterator ObjectBase::find(const String& name) LIFETIME_BOUND
 {
     return m_map.find(name);
 }
 
-inline ObjectBase::const_iterator ObjectBase::find(const String& name) const
+inline ObjectBase::const_iterator ObjectBase::find(const String& name) const LIFETIME_BOUND
 {
     return m_map.find(name);
 }

--- a/Source/WTF/wtf/ListHashSet.h
+++ b/Source/WTF/wtf/ListHashSet.h
@@ -580,13 +580,13 @@ inline bool ListHashSet<T, U>::isEmpty() const
 }
 
 template<typename T, typename U>
-inline T& ListHashSet<T, U>::first()
+inline T& ListHashSet<T, U>::first() LIFETIME_BOUND
 {
     return *begin();
 }
 
 template<typename T, typename U>
-inline const T& ListHashSet<T, U>::first() const
+inline const T& ListHashSet<T, U>::first() const LIFETIME_BOUND
 {
     return *begin();
 }
@@ -609,14 +609,14 @@ inline T ListHashSet<T, U>::takeFirst()
 }
 
 template<typename T, typename U>
-inline T& ListHashSet<T, U>::last()
+inline T& ListHashSet<T, U>::last() LIFETIME_BOUND
 {
     auto last = --end();
     return *last;
 }
 
 template<typename T, typename U>
-inline const T& ListHashSet<T, U>::last() const
+inline const T& ListHashSet<T, U>::last() const LIFETIME_BOUND
 {
     auto last = --end();
     return *last;
@@ -641,7 +641,7 @@ inline T ListHashSet<T, U>::takeLast()
 }
 
 template<typename T, typename U>
-inline auto ListHashSet<T, U>::find(const ValueType& value) -> iterator
+inline auto ListHashSet<T, U>::find(const ValueType& value) LIFETIME_BOUND -> iterator
 {
     auto it = m_impl.template find<BaseTranslator, ShouldValidateKey::Yes>(value);
     if (it == m_impl.end())
@@ -650,7 +650,7 @@ inline auto ListHashSet<T, U>::find(const ValueType& value) -> iterator
 }
 
 template<typename T, typename U>
-inline auto ListHashSet<T, U>::find(const ValueType& value) const -> const_iterator
+inline auto ListHashSet<T, U>::find(const ValueType& value) const LIFETIME_BOUND -> const_iterator
 {
     auto it = m_impl.template find<BaseTranslator, ShouldValidateKey::Yes>(value);
     if (it == m_impl.end())
@@ -666,7 +666,7 @@ struct ListHashSetTranslatorAdapter {
 
 template<typename ValueType, typename U>
 template<typename HashTranslator, typename T>
-inline auto ListHashSet<ValueType, U>::find(const T& value) -> iterator
+inline auto ListHashSet<ValueType, U>::find(const T& value) LIFETIME_BOUND -> iterator
 {
     auto it = m_impl.template find<ListHashSetTranslatorAdapter<HashTranslator>, ShouldValidateKey::Yes>(value);
     if (it == m_impl.end())
@@ -676,7 +676,7 @@ inline auto ListHashSet<ValueType, U>::find(const T& value) -> iterator
 
 template<typename ValueType, typename U>
 template<typename HashTranslator, typename T>
-inline auto ListHashSet<ValueType, U>::find(const T& value) const -> const_iterator
+inline auto ListHashSet<ValueType, U>::find(const T& value) const LIFETIME_BOUND -> const_iterator
 {
     auto it = m_impl.template find<ListHashSetTranslatorAdapter<HashTranslator>, ShouldValidateKey::Yes>(value);
     if (it == m_impl.end())
@@ -698,7 +698,7 @@ inline bool ListHashSet<T, U>::contains(const ValueType& value) const
 }
 
 template<typename T, typename U>
-auto ListHashSet<T, U>::add(const ValueType& value) -> AddResult
+auto ListHashSet<T, U>::add(const ValueType& value) LIFETIME_BOUND -> AddResult
 {
     auto result = m_impl.template add<BaseTranslator, ShouldValidateKey::Yes>(value, [] { return nullptr; });
     if (result.isNewEntry)
@@ -707,7 +707,7 @@ auto ListHashSet<T, U>::add(const ValueType& value) -> AddResult
 }
 
 template<typename T, typename U>
-auto ListHashSet<T, U>::add(ValueType&& value) -> AddResult
+auto ListHashSet<T, U>::add(ValueType&& value) LIFETIME_BOUND -> AddResult
 {
     auto result = m_impl.template add<BaseTranslator, ShouldValidateKey::Yes>(WTF::move(value), [] { return nullptr; });
     if (result.isNewEntry)
@@ -716,7 +716,7 @@ auto ListHashSet<T, U>::add(ValueType&& value) -> AddResult
 }
 
 template<typename T, typename U>
-auto ListHashSet<T, U>::appendOrMoveToLast(const ValueType& value) -> AddResult
+auto ListHashSet<T, U>::appendOrMoveToLast(const ValueType& value) LIFETIME_BOUND -> AddResult
 {
     auto result = m_impl.template add<BaseTranslator, ShouldValidateKey::Yes>(value, [] { return nullptr; });
     Node* node = result.iterator->get();
@@ -728,7 +728,7 @@ auto ListHashSet<T, U>::appendOrMoveToLast(const ValueType& value) -> AddResult
 }
 
 template<typename T, typename U>
-auto ListHashSet<T, U>::appendOrMoveToLast(ValueType&& value) -> AddResult
+auto ListHashSet<T, U>::appendOrMoveToLast(ValueType&& value) LIFETIME_BOUND -> AddResult
 {
     auto result = m_impl.template add<BaseTranslator, ShouldValidateKey::Yes>(WTF::move(value), [] { return nullptr; });
     Node* node = result.iterator->get();
@@ -752,7 +752,7 @@ bool ListHashSet<T, U>::moveToLastIfPresent(const ValueType& value)
 }
 
 template<typename T, typename U>
-auto ListHashSet<T, U>::prependOrMoveToFirst(const ValueType& value) -> AddResult
+auto ListHashSet<T, U>::prependOrMoveToFirst(const ValueType& value) LIFETIME_BOUND -> AddResult
 {
     auto result = m_impl.template add<BaseTranslator, ShouldValidateKey::Yes>(value, [] { return nullptr; });
     Node* node = result.iterator->get();
@@ -764,7 +764,7 @@ auto ListHashSet<T, U>::prependOrMoveToFirst(const ValueType& value) -> AddResul
 }
 
 template<typename T, typename U>
-auto ListHashSet<T, U>::prependOrMoveToFirst(ValueType&& value) -> AddResult
+auto ListHashSet<T, U>::prependOrMoveToFirst(ValueType&& value) LIFETIME_BOUND -> AddResult
 {
     auto result = m_impl.template add<BaseTranslator, ShouldValidateKey::Yes>(WTF::move(value), [] { return nullptr; });
     Node* node = result.iterator->get();
@@ -776,19 +776,19 @@ auto ListHashSet<T, U>::prependOrMoveToFirst(ValueType&& value) -> AddResult
 }
 
 template<typename T, typename U>
-auto ListHashSet<T, U>::insertBefore(const ValueType& beforeValue, const ValueType& newValue) -> AddResult
+auto ListHashSet<T, U>::insertBefore(const ValueType& beforeValue, const ValueType& newValue) LIFETIME_BOUND -> AddResult
 {
     return insertBefore(find(beforeValue), newValue);
 }
 
 template<typename T, typename U>
-auto ListHashSet<T, U>::insertBefore(const ValueType& beforeValue, ValueType&& newValue) -> AddResult
+auto ListHashSet<T, U>::insertBefore(const ValueType& beforeValue, ValueType&& newValue) LIFETIME_BOUND -> AddResult
 {
     return insertBefore(find(beforeValue), WTF::move(newValue));
 }
 
 template<typename T, typename U>
-auto ListHashSet<T, U>::insertBefore(iterator it, const ValueType& newValue) -> AddResult
+auto ListHashSet<T, U>::insertBefore(iterator it, const ValueType& newValue) LIFETIME_BOUND -> AddResult
 {
     auto result = m_impl.template add<BaseTranslator, ShouldValidateKey::Yes>(newValue, [] { return nullptr; });
     if (result.isNewEntry)
@@ -797,7 +797,7 @@ auto ListHashSet<T, U>::insertBefore(iterator it, const ValueType& newValue) -> 
 }
 
 template<typename T, typename U>
-auto ListHashSet<T, U>::insertBefore(iterator it, ValueType&& newValue) -> AddResult
+auto ListHashSet<T, U>::insertBefore(iterator it, ValueType&& newValue) LIFETIME_BOUND -> AddResult
 {
     auto result = m_impl.template add<BaseTranslator, ShouldValidateKey::Yes>(WTF::move(newValue), [] { return nullptr; });
     if (result.isNewEntry)
@@ -858,7 +858,7 @@ inline void ListHashSet<T, U>::clear()
 
 template<typename T, typename U>
 template<SmartPtr V>
-inline auto ListHashSet<T, U>::find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) -> iterator
+inline auto ListHashSet<T, U>::find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) LIFETIME_BOUND -> iterator
 {
     auto it = m_impl.template find<BaseTranslator, ShouldValidateKey::Yes>(value);
     if (it == m_impl.end())
@@ -868,7 +868,7 @@ inline auto ListHashSet<T, U>::find(std::add_const_t<typename GetPtrHelper<V>::U
 
 template<typename T, typename U>
 template<SmartPtr V>
-inline auto ListHashSet<T, U>::find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) const -> const_iterator
+inline auto ListHashSet<T, U>::find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) const LIFETIME_BOUND -> const_iterator
 {
     auto it = m_impl.template find<BaseTranslator, ShouldValidateKey::Yes>(value);
     if (it == m_impl.end())
@@ -885,14 +885,14 @@ inline auto ListHashSet<T, U>::contains(std::add_const_t<typename GetPtrHelper<V
 
 template<typename T, typename U>
 template<SmartPtr V>
-inline auto ListHashSet<T, U>::insertBefore(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* beforeValue, const ValueType& newValue) -> AddResult
+inline auto ListHashSet<T, U>::insertBefore(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* beforeValue, const ValueType& newValue) LIFETIME_BOUND -> AddResult
 {
     return insertBefore(find(beforeValue), newValue);
 }
 
 template<typename T, typename U>
 template<SmartPtr V>
-inline auto ListHashSet<T, U>::insertBefore(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* beforeValue, ValueType&& newValue) -> AddResult
+inline auto ListHashSet<T, U>::insertBefore(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* beforeValue, ValueType&& newValue) LIFETIME_BOUND -> AddResult
 {
     return insertBefore(find(beforeValue), WTF::move(newValue));
 }

--- a/Source/WTF/wtf/RobinHoodHashTable.h
+++ b/Source/WTF/wtf/RobinHoodHashTable.h
@@ -379,7 +379,7 @@ inline void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, Key
 
 template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, typename Malloc>
 template<typename HashTranslator, ShouldValidateKey shouldValidateKey, typename T>
-ALWAYS_INLINE auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, Malloc>::add(T&& key, NOESCAPE const std::invocable<> auto& functor) -> AddResult
+ALWAYS_INLINE auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, Malloc>::add(T&& key, NOESCAPE const std::invocable<> auto& functor) LIFETIME_BOUND -> AddResult
 {
     checkKey<HashTranslator, shouldValidateKey>(key);
 
@@ -469,7 +469,7 @@ ALWAYS_INLINE void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Trai
 
 template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, typename Malloc>
 template<typename HashTranslator, ShouldValidateKey shouldValidateKey, typename T>
-inline auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, Malloc>::addPassingHashCode(T&& key, NOESCAPE const std::invocable<> auto& functor) -> AddResult
+inline auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, Malloc>::addPassingHashCode(T&& key, NOESCAPE const std::invocable<> auto& functor) LIFETIME_BOUND -> AddResult
 {
     checkKey<HashTranslator, shouldValidateKey>(key);
 
@@ -563,7 +563,7 @@ inline void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, Key
 
 template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, typename Malloc>
 template <typename HashTranslator, ShouldValidateKey shouldValidateKey, typename T>
-auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, Malloc>::find(const T& key) -> iterator
+auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, Malloc>::find(const T& key) LIFETIME_BOUND -> iterator
 {
     if (!m_table)
         return end();
@@ -577,7 +577,7 @@ auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits,
 
 template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy, typename Malloc>
 template <typename HashTranslator, ShouldValidateKey shouldValidateKey, typename T>
-auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, Malloc>::find(const T& key) const -> const_iterator
+auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy, Malloc>::find(const T& key) const LIFETIME_BOUND -> const_iterator
 {
     if (!m_table)
         return end();

--- a/Source/WTF/wtf/SentinelLinkedList.h
+++ b/Source/WTF/wtf/SentinelLinkedList.h
@@ -176,22 +176,22 @@ template <typename T, typename PtrTraits> void BasicRawSentinelNode<T, PtrTraits
         static_cast<T*>(this), static_cast<T*>(node));
 }
 
-template <typename T, typename RawNode> inline typename SentinelLinkedList<T, RawNode>::iterator SentinelLinkedList<T, RawNode>::begin()
+template <typename T, typename RawNode> inline typename SentinelLinkedList<T, RawNode>::iterator SentinelLinkedList<T, RawNode>::begin() LIFETIME_BOUND
 {
     return iterator { m_sentinel.next() };
 }
 
-template <typename T, typename RawNode> inline typename SentinelLinkedList<T, RawNode>::iterator SentinelLinkedList<T, RawNode>::end()
+template <typename T, typename RawNode> inline typename SentinelLinkedList<T, RawNode>::iterator SentinelLinkedList<T, RawNode>::end() LIFETIME_BOUND
 {
     return iterator { &m_sentinel };
 }
 
-template <typename T, typename RawNode> inline typename SentinelLinkedList<T, RawNode>::const_iterator SentinelLinkedList<T, RawNode>::begin() const
+template <typename T, typename RawNode> inline typename SentinelLinkedList<T, RawNode>::const_iterator SentinelLinkedList<T, RawNode>::begin() const LIFETIME_BOUND
 {
     return const_iterator { m_sentinel.next() };
 }
 
-template <typename T, typename RawNode> inline typename SentinelLinkedList<T, RawNode>::const_iterator SentinelLinkedList<T, RawNode>::end() const
+template <typename T, typename RawNode> inline typename SentinelLinkedList<T, RawNode>::const_iterator SentinelLinkedList<T, RawNode>::end() const LIFETIME_BOUND
 {
     return const_iterator { &m_sentinel };
 }

--- a/Source/WTF/wtf/URL.cpp
+++ b/Source/WTF/wtf/URL.cpp
@@ -94,7 +94,7 @@ URL URL::isolatedCopy() &&
     return result;
 }
 
-StringView URL::lastPathComponent() const
+StringView URL::lastPathComponent() const LIFETIME_BOUND
 {
     if (!hasPath())
         return { };
@@ -157,7 +157,7 @@ unsigned URL::pathStart() const
     return start;
 }
 
-StringView URL::protocol() const
+StringView URL::protocol() const LIFETIME_BOUND
 {
     if (!m_isValid)
         return { };
@@ -165,7 +165,7 @@ StringView URL::protocol() const
     return StringView(m_string).left(m_schemeEnd);
 }
 
-StringView URL::host() const
+StringView URL::host() const LIFETIME_BOUND
 {
     if (!m_isValid)
         return { };
@@ -244,12 +244,12 @@ String URL::password() const
     return decodeEscapeSequencesFromParsedURL(encodedPassword());
 }
 
-StringView URL::encodedUser() const
+StringView URL::encodedUser() const LIFETIME_BOUND
 {
     return StringView(m_string).substring(m_userStart, m_userEnd - m_userStart);
 }
 
-StringView URL::encodedPassword() const
+StringView URL::encodedPassword() const LIFETIME_BOUND
 {
     if (m_passwordEnd == m_userEnd)
         return { };
@@ -257,7 +257,7 @@ StringView URL::encodedPassword() const
     return StringView(m_string).substring(m_userEnd + 1, m_passwordEnd - m_userEnd - 1);
 }
 
-StringView URL::fragmentIdentifier() const
+StringView URL::fragmentIdentifier() const LIFETIME_BOUND
 {
     if (!hasFragmentIdentifier())
         return { };
@@ -403,7 +403,7 @@ bool URL::protocolIs(StringView protocol) const
     return true;
 }
 
-StringView URL::query() const
+StringView URL::query() const LIFETIME_BOUND
 {
     if (m_queryEnd == m_pathEnd)
         return { };
@@ -411,7 +411,7 @@ StringView URL::query() const
     return StringView(m_string).substring(m_pathEnd + 1, m_queryEnd - (m_pathEnd + 1));
 }
 
-StringView URL::path() const
+StringView URL::path() const LIFETIME_BOUND
 {
     if (!m_isValid)
         return { };
@@ -775,7 +775,7 @@ void URL::setPath(StringView path)
     ));
 }
 
-StringView URL::viewWithoutQueryOrFragmentIdentifier() const
+StringView URL::viewWithoutQueryOrFragmentIdentifier() const LIFETIME_BOUND
 {
     if (!m_isValid)
         return m_string;
@@ -783,7 +783,7 @@ StringView URL::viewWithoutQueryOrFragmentIdentifier() const
     return StringView(m_string).left(pathEnd());
 }
 
-StringView URL::viewWithoutFragmentIdentifier() const
+StringView URL::viewWithoutFragmentIdentifier() const LIFETIME_BOUND
 {
     if (!m_isValid)
         return m_string;
@@ -1144,7 +1144,7 @@ URL URL::fileURLWithFileSystemPath(StringView path)
     ));
 }
 
-StringView URL::queryWithLeadingQuestionMark() const
+StringView URL::queryWithLeadingQuestionMark() const LIFETIME_BOUND
 {
     if (m_queryEnd <= m_pathEnd)
         return { };
@@ -1152,7 +1152,7 @@ StringView URL::queryWithLeadingQuestionMark() const
     return StringView(m_string).substring(m_pathEnd, m_queryEnd - m_pathEnd);
 }
 
-StringView URL::fragmentIdentifierWithLeadingNumberSign() const
+StringView URL::fragmentIdentifierWithLeadingNumberSign() const LIFETIME_BOUND
 {
     if (!m_isValid || m_string.length() <= m_queryEnd)
         return { };

--- a/Source/WTF/wtf/URLParser.cpp
+++ b/Source/WTF/wtf/URLParser.cpp
@@ -1059,7 +1059,7 @@ bool URLParser::isLocalhost(StringView view)
     return isAtLocalhost<char16_t>(view.span16());
 }
 
-ALWAYS_INLINE StringView URLParser::parsedDataView(size_t start, size_t length)
+ALWAYS_INLINE StringView URLParser::parsedDataView(size_t start, size_t length) LIFETIME_BOUND
 {
     if (m_didSeeSyntaxViolation) [[unlikely]] {
         ASSERT(start + length <= m_asciiBuffer.size());

--- a/Source/WTF/wtf/dtoa.cpp
+++ b/Source/WTF/wtf/dtoa.cpp
@@ -24,21 +24,21 @@
 
 namespace WTF {
 
-NumberToStringSpan numberToStringAndSize(float number, NumberToStringBuffer& buffer)
+NumberToStringSpan numberToStringAndSize(float number, NumberToStringBuffer& buffer LIFETIME_BOUND)
 {
     static_assert(sizeof(buffer) >= (dragonbox::max_string_length<dragonbox::ieee754_binary32>() + 1));
     auto result = dragonbox::detail::to_chars_n<WTF::dragonbox::Mode::ToShortest>(number, std::span { buffer });
     return std::span { buffer }.first(result.data() - buffer.data());
 }
 
-NumberToStringSpan numberToStringAndSize(double number, NumberToStringBuffer& buffer)
+NumberToStringSpan numberToStringAndSize(double number, NumberToStringBuffer& buffer LIFETIME_BOUND)
 {
     static_assert(sizeof(buffer) >= (dragonbox::max_string_length<dragonbox::ieee754_binary64>() + 1));
     auto result = dragonbox::detail::to_chars_n<WTF::dragonbox::Mode::ToShortest>(number, std::span { buffer });
     return std::span { buffer }.first(result.data() - buffer.data());
 }
 
-NumberToStringSpan numberToStringWithTrailingPoint(double d, NumberToStringBuffer& buffer)
+NumberToStringSpan numberToStringWithTrailingPoint(double d, NumberToStringBuffer& buffer LIFETIME_BOUND)
 {
     double_conversion::StringBuilder builder(std::span<char> { buffer });
     auto& converter = double_conversion::DoubleToStringConverter::EcmaScriptConverterWithTrailingPoint();
@@ -83,14 +83,14 @@ static inline void truncateTrailingZeros(std::span<const char> buffer, double_co
     builder.RemoveCharacters(truncatedLength, pastMantissa);
 }
 
-NumberToStringSpan numberToFixedPrecisionString(float number, unsigned significantFigures, NumberToStringBuffer& buffer, bool shouldTruncateTrailingZeros)
+NumberToStringSpan numberToFixedPrecisionString(float number, unsigned significantFigures, NumberToStringBuffer& buffer LIFETIME_BOUND, bool shouldTruncateTrailingZeros)
 {
     // For now, just call the double precision version.
     // Do that here instead of at callers to pave the way to add a more efficient code path later.
     return numberToFixedPrecisionString(static_cast<double>(number), significantFigures, buffer, shouldTruncateTrailingZeros);
 }
 
-NumberToStringSpan numberToFixedPrecisionString(double d, unsigned significantFigures, NumberToStringBuffer& buffer, bool shouldTruncateTrailingZeros)
+NumberToStringSpan numberToFixedPrecisionString(double d, unsigned significantFigures, NumberToStringBuffer& buffer LIFETIME_BOUND, bool shouldTruncateTrailingZeros)
 {
     // Mimic sprintf("%.[precision]g", ...).
     // "g": Signed value printed in f or e format, whichever is more compact for the given value and precision.
@@ -105,14 +105,14 @@ NumberToStringSpan numberToFixedPrecisionString(double d, unsigned significantFi
     return builder.Finalize();
 }
 
-NumberToStringSpan numberToFixedWidthString(float number, unsigned decimalPlaces, NumberToStringBuffer& buffer)
+NumberToStringSpan numberToFixedWidthString(float number, unsigned decimalPlaces, NumberToStringBuffer& buffer LIFETIME_BOUND)
 {
     // For now, just call the double precision version.
     // Do that here instead of at callers to pave the way to add a more efficient code path later.
     return numberToFixedWidthString(static_cast<double>(number), decimalPlaces, buffer);
 }
 
-NumberToStringSpan numberToFixedWidthString(double d, unsigned decimalPlaces, NumberToStringBuffer& buffer)
+NumberToStringSpan numberToFixedWidthString(double d, unsigned decimalPlaces, NumberToStringBuffer& buffer LIFETIME_BOUND)
 {
     // Mimic sprintf("%.[precision]f", ...).
     // "f": Signed value having the form [ – ]dddd.dddd, where dddd is one or more decimal digits.
@@ -120,14 +120,14 @@ NumberToStringSpan numberToFixedWidthString(double d, unsigned decimalPlaces, Nu
     // the number of digits after the decimal point depends on the requested precision.
     // "precision": The precision value specifies the number of digits after the decimal point.
     // If a decimal point appears, at least one digit appears before it.
-    // The value is rounded to the appropriate number of digits.    
+    // The value is rounded to the appropriate number of digits.
     double_conversion::StringBuilder builder(std::span<char> { buffer });
     auto& converter = double_conversion::DoubleToStringConverter::EcmaScriptConverter();
     converter.ToFixed(d, decimalPlaces, &builder);
     return builder.Finalize();
 }
 
-NumberToStringSpan numberToCSSString(double d, NumberToCSSStringBuffer& buffer)
+NumberToStringSpan numberToCSSString(double d, NumberToCSSStringBuffer& buffer LIFETIME_BOUND)
 {
     // Mimic sprintf("%.[precision]f", ...).
     // "f": Signed value having the form [ – ]dddd.dddd, where dddd is one or more decimal digits.

--- a/Source/WTF/wtf/text/CString.cpp
+++ b/Source/WTF/wtf/text/CString.cpp
@@ -83,7 +83,7 @@ void CString::init(std::span<const char> string)
     memcpySpan(m_buffer->mutableSpan(), string);
 }
 
-std::span<char> CString::mutableSpan()
+std::span<char> CString::mutableSpan() LIFETIME_BOUND
 {
     copyBufferIfNeeded();
     if (!m_buffer)
@@ -91,7 +91,7 @@ std::span<char> CString::mutableSpan()
     return m_buffer->mutableSpan();
 }
 
-std::span<char> CString::mutableSpanIncludingNullTerminator()
+std::span<char> CString::mutableSpanIncludingNullTerminator() LIFETIME_BOUND
 {
     copyBufferIfNeeded();
     if (!m_buffer)

--- a/Source/WTF/wtf/text/CString.h
+++ b/Source/WTF/wtf/text/CString.h
@@ -138,19 +138,19 @@ inline CString::CString(const std::string& value)
 {
 }
 
-inline const char* CString::data() const
+inline const char* CString::data() const LIFETIME_BOUND
 {
     return m_buffer ? m_buffer->spanIncludingNullTerminator().data() : nullptr;
 }
 
-inline std::span<const char> CString::span() const
+inline std::span<const char> CString::span() const LIFETIME_BOUND
 {
     if (m_buffer)
         return m_buffer->span();
     return { };
 }
 
-inline std::span<const char> CString::spanIncludingNullTerminator() const
+inline std::span<const char> CString::spanIncludingNullTerminator() const LIFETIME_BOUND
 {
     if (m_buffer)
         return m_buffer->spanIncludingNullTerminator();

--- a/Source/WTF/wtf/text/StringBuilder.h
+++ b/Source/WTF/wtf/text/StringBuilder.h
@@ -153,7 +153,7 @@ inline void StringBuilder::swap(StringBuilder& other)
     std::swap(m_shouldCrashOnOverflow, other.m_shouldCrashOnOverflow);
 }
 
-inline StringBuilder::operator StringView() const
+inline StringBuilder::operator StringView() const LIFETIME_BOUND
 {
     if (is8Bit())
         return span<Latin1Character>();
@@ -232,7 +232,7 @@ inline void StringBuilder::appendSubstring(const String& string, unsigned offset
     append(StringView { string }.substring(offset, length));
 }
 
-inline const String& StringBuilder::toString()
+inline const String& StringBuilder::toString() LIFETIME_BOUND
 {
     if (m_string.isNull()) {
         shrinkToFit();
@@ -241,7 +241,7 @@ inline const String& StringBuilder::toString()
     return m_string;
 }
 
-inline const String& StringBuilder::toStringPreserveCapacity() const
+inline const String& StringBuilder::toStringPreserveCapacity() const LIFETIME_BOUND
 {
     if (m_string.isNull())
         reifyString();
@@ -304,7 +304,7 @@ inline bool StringBuilder::is8Bit() const
     return m_buffer ? m_buffer->is8Bit() : m_string.is8Bit();
 }
 
-template<typename CharacterType> inline std::span<const CharacterType> StringBuilder::span() const
+template<typename CharacterType> inline std::span<const CharacterType> StringBuilder::span() const LIFETIME_BOUND
 {
     if (!m_length || hasOverflowed())
         return { };

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -687,12 +687,12 @@ template<> ALWAYS_INLINE Ref<StringImpl> StringImpl::constructInternal<char16_t>
     return adoptRef(*new (NotNull, &string) StringImpl { length });
 }
 
-template<> ALWAYS_INLINE std::span<const Latin1Character> StringImpl::span<Latin1Character>() const
+template<> ALWAYS_INLINE std::span<const Latin1Character> StringImpl::span<Latin1Character>() const LIFETIME_BOUND
 {
     return span8();
 }
 
-template<> ALWAYS_INLINE std::span<const char16_t> StringImpl::span<char16_t>() const
+template<> ALWAYS_INLINE std::span<const char16_t> StringImpl::span<char16_t>() const LIFETIME_BOUND
 {
     return span16();
 }

--- a/Source/WTF/wtf/text/StringView.cpp
+++ b/Source/WTF/wtf/text/StringView.cpp
@@ -254,7 +254,7 @@ private:
     unsigned m_indexEnd;
 };
 
-StringView::GraphemeClusters::Iterator::Iterator(StringView stringView, unsigned index)
+StringView::GraphemeClusters::Iterator::Iterator(StringView stringView LIFETIME_BOUND, unsigned index)
     : m_impl(makeUnique<Impl>(stringView, stringView.isNull() ? std::nullopt : std::optional<NonSharedCharacterBreakIterator>(NonSharedCharacterBreakIterator(stringView)), index))
 {
 }

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -401,12 +401,12 @@ inline void StringView::initialize(std::span<const char16_t> characters)
     m_is8Bit = false;
 }
 
-inline StringView::StringView(std::span<const Latin1Character> characters)
+inline StringView::StringView(std::span<const Latin1Character> characters LIFETIME_BOUND)
 {
     initialize(characters);
 }
 
-inline StringView::StringView(std::span<const char16_t> characters)
+inline StringView::StringView(std::span<const char16_t> characters LIFETIME_BOUND)
 {
     initialize(characters);
 }
@@ -416,12 +416,12 @@ inline StringView::StringView(const char* characters)
 {
 }
 
-inline StringView::StringView(std::span<const char> characters)
+inline StringView::StringView(std::span<const char> characters LIFETIME_BOUND)
 {
     initialize(byteCast<Latin1Character>(characters));
 }
 
-inline StringView::StringView(const void* characters, unsigned length, bool is8bit)
+inline StringView::StringView(const void* characters LIFETIME_BOUND, unsigned length, bool is8bit)
     : m_characters(characters)
     , m_length(length)
     , m_is8Bit(is8bit)
@@ -433,7 +433,7 @@ inline StringView::StringView(ASCIILiteral string)
     initialize(string.span8());
 }
 
-inline StringView::StringView(const StringImpl& string)
+inline StringView::StringView(const StringImpl& string LIFETIME_BOUND)
 {
     setUnderlyingString(&string);
     if (string.is8Bit())
@@ -442,7 +442,7 @@ inline StringView::StringView(const StringImpl& string)
         initialize(string.span16());
 }
 
-inline StringView::StringView(const StringImpl* string)
+inline StringView::StringView(const StringImpl* string LIFETIME_BOUND)
 {
     if (!string)
         return;
@@ -454,7 +454,7 @@ inline StringView::StringView(const StringImpl* string)
         initialize(string->span16());
 }
 
-inline StringView::StringView(const String& string)
+inline StringView::StringView(const String& string LIFETIME_BOUND)
 {
     setUnderlyingString(string.impl());
     if (!string.impl()) {
@@ -468,7 +468,7 @@ inline StringView::StringView(const String& string)
     initialize(string.span16());
 }
 
-inline StringView::StringView(const AtomString& atomString)
+inline StringView::StringView(const AtomString& atomString LIFETIME_BOUND)
     : StringView(atomString.string())
 {
 }
@@ -480,14 +480,14 @@ inline void StringView::clear()
     m_is8Bit = true;
 }
 
-inline std::span<const Latin1Character> StringView::span8() const
+inline std::span<const Latin1Character> StringView::span8() const LIFETIME_BOUND
 {
     ASSERT(is8Bit());
     ASSERT(underlyingStringIsValid());
     return unsafeMakeSpan(static_cast<const Latin1Character*>(m_characters), m_length);
 }
 
-inline std::span<const char16_t> StringView::span16() const
+inline std::span<const char16_t> StringView::span16() const LIFETIME_BOUND
 {
     ASSERT(!is8Bit() || isEmpty());
     ASSERT(underlyingStringIsValid());
@@ -501,12 +501,12 @@ inline unsigned StringView::hash() const
     return StringHasher::computeHashAndMaskTop8Bits(span16());
 }
 
-template<> ALWAYS_INLINE std::span<const Latin1Character> StringView::span<Latin1Character>() const
+template<> ALWAYS_INLINE std::span<const Latin1Character> StringView::span<Latin1Character>() const LIFETIME_BOUND
 {
     return span8();
 }
 
-template<> ALWAYS_INLINE std::span<const char16_t> StringView::span<char16_t>() const
+template<> ALWAYS_INLINE std::span<const char16_t> StringView::span<char16_t>() const LIFETIME_BOUND
 {
     return span16();
 }
@@ -962,27 +962,27 @@ inline auto StringView::codeUnits() const -> CodeUnits
     return CodeUnits(*this);
 }
 
-inline StringView::GraphemeClusters::GraphemeClusters(StringView stringView)
+inline StringView::GraphemeClusters::GraphemeClusters(StringView stringView LIFETIME_BOUND)
     : m_stringView(stringView)
 {
 }
 
-inline auto StringView::GraphemeClusters::begin() const -> Iterator
+inline auto StringView::GraphemeClusters::begin() const LIFETIME_BOUND -> Iterator
 {
     return Iterator(m_stringView, 0);
 }
 
-inline auto StringView::GraphemeClusters::end() const -> Iterator
+inline auto StringView::GraphemeClusters::end() const LIFETIME_BOUND -> Iterator
 {
     return Iterator(m_stringView, m_stringView.length());
 }
 
-inline StringView::CodePoints::CodePoints(StringView stringView)
+inline StringView::CodePoints::CodePoints(StringView stringView LIFETIME_BOUND)
     : m_stringView(stringView)
 {
 }
 
-inline StringView::CodePoints::Iterator::Iterator(StringView stringView, unsigned index)
+inline StringView::CodePoints::Iterator::Iterator(StringView stringView LIFETIME_BOUND, unsigned index)
     : m_is8Bit(stringView.is8Bit())
 #if CHECK_STRINGVIEW_LIFETIME
     , m_stringView(stringView)
@@ -1042,27 +1042,27 @@ inline bool StringView::CodePoints::Iterator::operator==(const Iterator& other) 
     return m_current == other.m_current;
 }
 
-inline auto StringView::CodePoints::begin() const -> Iterator
+inline auto StringView::CodePoints::begin() const LIFETIME_BOUND -> Iterator
 {
     return Iterator(m_stringView, 0);
 }
 
-inline auto StringView::CodePoints::end() const -> Iterator
+inline auto StringView::CodePoints::end() const LIFETIME_BOUND -> Iterator
 {
     return Iterator(m_stringView, m_stringView.length());
 }
 
-inline auto StringView::CodePoints::codePointAt(unsigned index) const -> Iterator
+inline auto StringView::CodePoints::codePointAt(unsigned index) const LIFETIME_BOUND -> Iterator
 {
     return Iterator(m_stringView, index);
 }
 
-inline StringView::CodeUnits::CodeUnits(StringView stringView)
+inline StringView::CodeUnits::CodeUnits(StringView stringView LIFETIME_BOUND)
     : m_stringView(stringView)
 {
 }
 
-inline StringView::CodeUnits::Iterator::Iterator(StringView stringView, unsigned index)
+inline StringView::CodeUnits::Iterator::Iterator(StringView stringView LIFETIME_BOUND, unsigned index)
     : m_stringView(stringView)
     , m_index(index)
 {
@@ -1086,12 +1086,12 @@ inline bool StringView::CodeUnits::Iterator::operator==(const Iterator& other) c
     return m_index == other.m_index;
 }
 
-inline auto StringView::CodeUnits::begin() const -> Iterator
+inline auto StringView::CodeUnits::begin() const LIFETIME_BOUND -> Iterator
 {
     return Iterator(m_stringView, 0);
 }
 
-inline auto StringView::CodeUnits::end() const -> Iterator
+inline auto StringView::CodeUnits::end() const LIFETIME_BOUND -> Iterator
 {
     return Iterator(m_stringView, m_stringView.length());
 }
@@ -1106,19 +1106,19 @@ inline auto StringView::splitAllowingEmptyEntries(char16_t separator) const -> S
     return SplitResult { *this, separator, true };
 }
 
-inline StringView::SplitResult::SplitResult(StringView stringView, char16_t separator, bool allowEmptyEntries)
+inline StringView::SplitResult::SplitResult(StringView stringView LIFETIME_BOUND, char16_t separator, bool allowEmptyEntries)
     : m_string { stringView }
     , m_separator { separator }
     , m_allowEmptyEntries { allowEmptyEntries }
 {
 }
 
-inline auto StringView::SplitResult::begin() const -> Iterator
+inline auto StringView::SplitResult::begin() const LIFETIME_BOUND -> Iterator
 {
     return Iterator { *this };
 }
 
-inline auto StringView::SplitResult::end() const -> Iterator
+inline auto StringView::SplitResult::end() const LIFETIME_BOUND -> Iterator
 {
     return Iterator { *this, Iterator::AtEnd };
 }

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -448,12 +448,12 @@ inline String::String(ASCIILiteral characters)
 {
 }
 
-template<> inline std::span<const Latin1Character> String::span<Latin1Character>() const
+template<> inline std::span<const Latin1Character> String::span<Latin1Character>() const LIFETIME_BOUND
 {
     return span8();
 }
 
-template<> inline std::span<const char16_t> String::span<char16_t>() const
+template<> inline std::span<const char16_t> String::span<char16_t>() const LIFETIME_BOUND
 {
     return span16();
 }

--- a/Source/WebCore/Modules/indexeddb/server/IndexValueEntry.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/IndexValueEntry.cpp
@@ -85,7 +85,7 @@ bool IndexValueEntry::contains(const IDBKeyData& key)
     return m_orderedKeys && m_orderedKeys->count(key);
 }
 
-const IDBKeyData* IndexValueEntry::getLowest() const
+const IDBKeyData* IndexValueEntry::getLowest() const LIFETIME_BOUND
 {
     if (m_unique)
         return m_key;
@@ -176,7 +176,7 @@ IndexValueEntry::Iterator& IndexValueEntry::Iterator::operator++()
     return *this;
 }
 
-IndexValueEntry::Iterator IndexValueEntry::begin()
+IndexValueEntry::Iterator IndexValueEntry::begin() LIFETIME_BOUND
 {
     if (m_unique) {
         ASSERT(m_key);
@@ -187,7 +187,7 @@ IndexValueEntry::Iterator IndexValueEntry::begin()
     return { *this, m_orderedKeys->begin() };
 }
 
-IndexValueEntry::Iterator IndexValueEntry::reverseBegin(CursorDuplicity duplicity)
+IndexValueEntry::Iterator IndexValueEntry::reverseBegin(CursorDuplicity duplicity) LIFETIME_BOUND
 {
     if (m_unique) {
         ASSERT(m_key);
@@ -204,7 +204,7 @@ IndexValueEntry::Iterator IndexValueEntry::reverseBegin(CursorDuplicity duplicit
     return { *this, iterator };
 }
 
-IndexValueEntry::Iterator IndexValueEntry::find(const IDBKeyData& key)
+IndexValueEntry::Iterator IndexValueEntry::find(const IDBKeyData& key) LIFETIME_BOUND
 {
     if (m_unique) {
         ASSERT(m_key);
@@ -219,7 +219,7 @@ IndexValueEntry::Iterator IndexValueEntry::find(const IDBKeyData& key)
     return { *this, iterator };
 }
 
-IndexValueEntry::Iterator IndexValueEntry::reverseFind(const IDBKeyData& key, CursorDuplicity)
+IndexValueEntry::Iterator IndexValueEntry::reverseFind(const IDBKeyData& key, CursorDuplicity) LIFETIME_BOUND
 {
     if (m_unique) {
         ASSERT(m_key);

--- a/Source/WebCore/Modules/mediasource/SampleMap.cpp
+++ b/Source/WebCore/Modules/mediasource/SampleMap.cpp
@@ -129,7 +129,7 @@ void SampleMap::removeSample(const MediaSample& sample)
     decodeOrder().m_samples.erase(decodeKey);
 }
 
-PresentationOrderSampleMap::iterator PresentationOrderSampleMap::findSampleWithPresentationTime(const MediaTime& time)
+PresentationOrderSampleMap::iterator PresentationOrderSampleMap::findSampleWithPresentationTime(const MediaTime& time) LIFETIME_BOUND
 {
     auto range = m_samples.equal_range(time);
     if (range.first == range.second)
@@ -137,7 +137,7 @@ PresentationOrderSampleMap::iterator PresentationOrderSampleMap::findSampleWithP
     return range.first;
 }
 
-PresentationOrderSampleMap::iterator PresentationOrderSampleMap::findSampleContainingPresentationTime(const MediaTime& time)
+PresentationOrderSampleMap::iterator PresentationOrderSampleMap::findSampleContainingPresentationTime(const MediaTime& time) LIFETIME_BOUND
 {
     if (m_samples.empty())
         return end();
@@ -154,7 +154,7 @@ PresentationOrderSampleMap::iterator PresentationOrderSampleMap::findSampleConta
     return end();
 }
 
-PresentationOrderSampleMap::iterator PresentationOrderSampleMap::findSampleContainingOrAfterPresentationTime(const MediaTime& time)
+PresentationOrderSampleMap::iterator PresentationOrderSampleMap::findSampleContainingOrAfterPresentationTime(const MediaTime& time) LIFETIME_BOUND
 {
     if (m_samples.empty())
         return end();
@@ -172,27 +172,27 @@ PresentationOrderSampleMap::iterator PresentationOrderSampleMap::findSampleConta
     return iter;
 }
 
-PresentationOrderSampleMap::iterator PresentationOrderSampleMap::findSampleStartingOnOrAfterPresentationTime(const MediaTime& time)
+PresentationOrderSampleMap::iterator PresentationOrderSampleMap::findSampleStartingOnOrAfterPresentationTime(const MediaTime& time) LIFETIME_BOUND
 {
     return m_samples.lower_bound(time);
 }
 
-PresentationOrderSampleMap::iterator PresentationOrderSampleMap::findSampleStartingAfterPresentationTime(const MediaTime& time)
+PresentationOrderSampleMap::iterator PresentationOrderSampleMap::findSampleStartingAfterPresentationTime(const MediaTime& time) LIFETIME_BOUND
 {
     return m_samples.upper_bound(time);
 }
 
-DecodeOrderSampleMap::iterator DecodeOrderSampleMap::findSampleWithDecodeKey(const KeyType& key)
+DecodeOrderSampleMap::iterator DecodeOrderSampleMap::findSampleWithDecodeKey(const KeyType& key) LIFETIME_BOUND
 {
     return m_samples.find(key);
 }
 
-DecodeOrderSampleMap::iterator DecodeOrderSampleMap::findSampleAfterDecodeKey(const KeyType& key)
+DecodeOrderSampleMap::iterator DecodeOrderSampleMap::findSampleAfterDecodeKey(const KeyType& key) LIFETIME_BOUND
 {
     return m_samples.upper_bound(key);
 }
 
-PresentationOrderSampleMap::reverse_iterator PresentationOrderSampleMap::reverseFindSampleContainingPresentationTime(const MediaTime& time)
+PresentationOrderSampleMap::reverse_iterator PresentationOrderSampleMap::reverseFindSampleContainingPresentationTime(const MediaTime& time) LIFETIME_BOUND
 {
     auto range = std::equal_range(rbegin(), rend(), time, SampleIsGreaterThanMediaTimeComparator<MapType>());
     if (range.first == range.second)
@@ -200,7 +200,7 @@ PresentationOrderSampleMap::reverse_iterator PresentationOrderSampleMap::reverse
     return range.first;
 }
 
-PresentationOrderSampleMap::reverse_iterator PresentationOrderSampleMap::reverseFindSampleBeforePresentationTime(const MediaTime& time)
+PresentationOrderSampleMap::reverse_iterator PresentationOrderSampleMap::reverseFindSampleBeforePresentationTime(const MediaTime& time) LIFETIME_BOUND
 {
     if (m_samples.empty())
         return rend();
@@ -220,7 +220,7 @@ PresentationOrderSampleMap::reverse_iterator PresentationOrderSampleMap::reverse
     return std::prev(reverse_iterator(std::prev(found)));
 }
 
-DecodeOrderSampleMap::reverse_iterator DecodeOrderSampleMap::reverseFindSampleWithDecodeKey(const KeyType& key)
+DecodeOrderSampleMap::reverse_iterator DecodeOrderSampleMap::reverseFindSampleWithDecodeKey(const KeyType& key) LIFETIME_BOUND
 {
     DecodeOrderSampleMap::iterator found = findSampleWithDecodeKey(key);
     if (found == end())
@@ -228,7 +228,7 @@ DecodeOrderSampleMap::reverse_iterator DecodeOrderSampleMap::reverseFindSampleWi
     return std::prev(reverse_iterator(found));
 }
 
-DecodeOrderSampleMap::reverse_iterator DecodeOrderSampleMap::findSyncSamplePriorToPresentationTime(const MediaTime& time, const MediaTime& threshold)
+DecodeOrderSampleMap::reverse_iterator DecodeOrderSampleMap::findSyncSamplePriorToPresentationTime(const MediaTime& time, const MediaTime& threshold) LIFETIME_BOUND
 {
     PresentationOrderSampleMap::reverse_iterator reverseCurrentSamplePTS = m_presentationOrder.reverseFindSampleBeforePresentationTime(time);
     if (reverseCurrentSamplePTS == m_presentationOrder.rend())
@@ -245,12 +245,12 @@ DecodeOrderSampleMap::reverse_iterator DecodeOrderSampleMap::findSyncSamplePrior
     return foundSample;
 }
 
-DecodeOrderSampleMap::reverse_iterator DecodeOrderSampleMap::findSyncSamplePriorToDecodeIterator(reverse_iterator iterator)
+DecodeOrderSampleMap::reverse_iterator DecodeOrderSampleMap::findSyncSamplePriorToDecodeIterator(reverse_iterator iterator) LIFETIME_BOUND
 {
     return std::find_if(iterator, rend(), SampleIsRandomAccess());
 }
 
-DecodeOrderSampleMap::iterator DecodeOrderSampleMap::findSyncSampleAfterPresentationTime(const MediaTime& time, const MediaTime& threshold)
+DecodeOrderSampleMap::iterator DecodeOrderSampleMap::findSyncSampleAfterPresentationTime(const MediaTime& time, const MediaTime& threshold) LIFETIME_BOUND
 {
     PresentationOrderSampleMap::iterator currentSamplePTS = m_presentationOrder.findSampleStartingOnOrAfterPresentationTime(time);
     if (currentSamplePTS == m_presentationOrder.end())
@@ -268,7 +268,7 @@ DecodeOrderSampleMap::iterator DecodeOrderSampleMap::findSyncSampleAfterPresenta
     return foundSample;
 }
 
-DecodeOrderSampleMap::iterator DecodeOrderSampleMap::findSyncSamplePriorToDecodeKey(const KeyType& key)
+DecodeOrderSampleMap::iterator DecodeOrderSampleMap::findSyncSamplePriorToDecodeKey(const KeyType& key) LIFETIME_BOUND
 {
     reverse_iterator reverseCursor = reverseFindSampleWithDecodeKey(key);
     if (reverseCursor == rend())
@@ -282,14 +282,14 @@ DecodeOrderSampleMap::iterator DecodeOrderSampleMap::findSyncSamplePriorToDecode
     return findSampleWithDecodeKey(KeyType(sample->decodeTime(), sample->presentationTime()));
 }
 
-DecodeOrderSampleMap::iterator DecodeOrderSampleMap::findSyncSampleAfterDecodeIterator(iterator currentSampleDTS)
+DecodeOrderSampleMap::iterator DecodeOrderSampleMap::findSyncSampleAfterDecodeIterator(iterator currentSampleDTS) LIFETIME_BOUND
 {
     if (currentSampleDTS == end())
         return end();
     return std::find_if(++currentSampleDTS, end(), SampleIsRandomAccess());
 }
 
-PresentationOrderSampleMap::iterator_range PresentationOrderSampleMap::findSamplesBetweenPresentationTimes(const MediaTime& beginTime, const MediaTime& endTime)
+PresentationOrderSampleMap::iterator_range PresentationOrderSampleMap::findSamplesBetweenPresentationTimes(const MediaTime& beginTime, const MediaTime& endTime) LIFETIME_BOUND
 {
     // startTime is inclusive, so use lower_bound to include samples wich start exactly at startTime.
     // endTime is not inclusive, so use lower_bound to exclude samples which start exactly at endTime.
@@ -300,7 +300,7 @@ PresentationOrderSampleMap::iterator_range PresentationOrderSampleMap::findSampl
     return { lower_bound, upper_bound };
 }
 
-PresentationOrderSampleMap::iterator_range PresentationOrderSampleMap::findSamplesBetweenPresentationTimesFromEnd(const MediaTime& beginTime, const MediaTime& endTime)
+PresentationOrderSampleMap::iterator_range PresentationOrderSampleMap::findSamplesBetweenPresentationTimesFromEnd(const MediaTime& beginTime, const MediaTime& endTime) LIFETIME_BOUND
 {
     reverse_iterator rangeEnd = std::find_if(rbegin(), rend(), [&endTime](const auto& value) {
         return value.first < endTime;
@@ -317,7 +317,7 @@ PresentationOrderSampleMap::iterator_range PresentationOrderSampleMap::findSampl
     return { rangeStart.base(), rangeEnd.base() };
 }
 
-DecodeOrderSampleMap::reverse_iterator_range DecodeOrderSampleMap::findDependentSamples(const MediaSample& sample)
+DecodeOrderSampleMap::reverse_iterator_range DecodeOrderSampleMap::findDependentSamples(const MediaSample& sample) LIFETIME_BOUND
 {
     reverse_iterator currentDecodeIter = reverseFindSampleWithDecodeKey(KeyType(sample.decodeTime(), sample.presentationTime()));
     reverse_iterator nextSyncSample = findSyncSamplePriorToDecodeIterator(currentDecodeIter);

--- a/Source/WebCore/Modules/webaudio/AudioBuffer.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioBuffer.cpp
@@ -218,7 +218,7 @@ RefPtr<Float32Array> AudioBuffer::channelData(unsigned channelIndex)
     return m_channels[channelIndex].copyRef();
 }
 
-std::span<float> AudioBuffer::rawChannelData(unsigned channelIndex)
+std::span<float> AudioBuffer::rawChannelData(unsigned channelIndex) LIFETIME_BOUND
 {
     if (channelIndex >= m_channels.size())
         return { };

--- a/Source/WebCore/Modules/webaudio/AudioNodeInput.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioNodeInput.cpp
@@ -178,7 +178,7 @@ unsigned AudioNodeInput::numberOfChannels() const
     return maxChannels;
 }
 
-AudioBus& AudioNodeInput::bus()
+AudioBus& AudioNodeInput::bus() LIFETIME_BOUND
 {
     ASSERT(context());
     ASSERT(context()->isAudioThread());

--- a/Source/WebCore/Modules/webaudio/AudioNodeOutput.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioNodeOutput.cpp
@@ -125,7 +125,7 @@ AudioBus& AudioNodeOutput::pull(AudioBus* inPlaceBus, size_t framesToProcess)
     return bus();
 }
 
-AudioBus& AudioNodeOutput::bus() const
+AudioBus& AudioNodeOutput::bus() const LIFETIME_BOUND
 {
     ASSERT(const_cast<AudioNodeOutput*>(this)->context().isAudioThread());
     return m_inPlaceBus ? *m_inPlaceBus : m_internalBus.get();

--- a/Source/WebCore/PAL/pal/text/TextCodec.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodec.cpp
@@ -38,7 +38,7 @@ namespace PAL {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(TextCodec);
 
-std::span<char> TextCodec::getUnencodableReplacement(char32_t codePoint, UnencodableHandling handling, UnencodableReplacementArray& replacement)
+std::span<char> TextCodec::getUnencodableReplacement(char32_t codePoint, UnencodableHandling handling, UnencodableReplacementArray& replacement LIFETIME_BOUND)
 {
     ASSERT(!(codePoint > UCHAR_MAX_VALUE));
 

--- a/Source/WebCore/css/CSSValueList.h
+++ b/Source/WebCore/css/CSSValueList.h
@@ -143,7 +143,7 @@ inline CSSValueContainingVector::~CSSValueContainingVector()
         value.deref();
 }
 
-inline const CSSValue& CSSValueContainingVector::operator[](unsigned index) const
+inline const CSSValue& CSSValueContainingVector::operator[](unsigned index) const LIFETIME_BOUND
 {
     unsigned maxInlineSize = m_inlineStorage.size();
     if (index < maxInlineSize) {

--- a/Source/WebCore/css/StylePropertiesInlines.h
+++ b/Source/WebCore/css/StylePropertiesInlines.h
@@ -45,7 +45,7 @@ inline StyleProperties::StyleProperties(CSSParserMode mode, unsigned immutableAr
 {
 }
 
-inline StyleProperties::PropertyReference StyleProperties::propertyAt(unsigned index) const
+inline StyleProperties::PropertyReference StyleProperties::propertyAt(unsigned index) const LIFETIME_BOUND
 {
     if (m_isMutable)
         return uncheckedDowncast<MutableStyleProperties>(*this).propertyAt(index);

--- a/Source/WebCore/css/calc/CSSCalcTree.h
+++ b/Source/WebCore/css/calc/CSSCalcTree.h
@@ -1264,42 +1264,42 @@ inline Children& Children::operator=(Vector<Child>&& other)
     return *this;
 }
 
-inline Children::iterator Children::begin()
+inline Children::iterator Children::begin() LIFETIME_BOUND
 {
     return value.begin();
 }
 
-inline Children::iterator Children::end()
+inline Children::iterator Children::end() LIFETIME_BOUND
 {
     return value.end();
 }
 
-inline Children::reverse_iterator Children::rbegin()
+inline Children::reverse_iterator Children::rbegin() LIFETIME_BOUND
 {
     return value.rbegin();
 }
 
-inline Children::reverse_iterator Children::rend()
+inline Children::reverse_iterator Children::rend() LIFETIME_BOUND
 {
     return value.rend();
 }
 
-inline Children::const_iterator Children::begin() const
+inline Children::const_iterator Children::begin() const LIFETIME_BOUND
 {
     return value.begin();
 }
 
-inline Children::const_iterator Children::end() const
+inline Children::const_iterator Children::end() const LIFETIME_BOUND
 {
     return value.end();
 }
 
-inline Children::const_reverse_iterator Children::rbegin() const
+inline Children::const_reverse_iterator Children::rbegin() const LIFETIME_BOUND
 {
     return value.rbegin();
 }
 
-inline Children::const_reverse_iterator Children::rend() const
+inline Children::const_reverse_iterator Children::rend() const LIFETIME_BOUND
 {
     return value.rend();
 }
@@ -1314,12 +1314,12 @@ inline size_t Children::size() const
     return value.size();
 }
 
-inline Child& Children::operator[](size_t i)
+inline Child& Children::operator[](size_t i) LIFETIME_BOUND
 {
     return value[i];
 }
 
-inline const Child& Children::operator[](size_t i) const
+inline const Child& Children::operator[](size_t i) const LIFETIME_BOUND
 {
     return value[i];
 }

--- a/Source/WebCore/css/parser/CSSParserTokenRange.cpp
+++ b/Source/WebCore/css/parser/CSSParserTokenRange.cpp
@@ -102,7 +102,7 @@ void CSSParserTokenRange::trimTrailingWhitespace()
     dropLast(m_tokens, m_tokens.size() - i);
 }
 
-const CSSParserToken& CSSParserTokenRange::consumeLast()
+const CSSParserToken& CSSParserTokenRange::consumeLast() LIFETIME_BOUND
 {
     if (atEnd())
         eofToken();

--- a/Source/WebCore/css/parser/CSSTokenizer.cpp
+++ b/Source/WebCore/css/parser/CSSTokenizer.cpp
@@ -130,7 +130,7 @@ CSSTokenizer::CSSTokenizer(const String& string, CSSParserObserverWrapper* wrapp
     }
 }
 
-CSSParserTokenRange CSSTokenizer::tokenRange() const
+CSSParserTokenRange CSSTokenizer::tokenRange() const LIFETIME_BOUND
 {
     return m_tokens;
 }

--- a/Source/WebCore/dom/ElementData.h
+++ b/Source/WebCore/dom/ElementData.h
@@ -217,7 +217,7 @@ inline const ImmutableStyleProperties* ElementData::presentationalHintStyle() co
     return nullptr;
 }
 
-inline std::span<const Attribute> ElementData::attributes() const
+inline std::span<const Attribute> ElementData::attributes() const LIFETIME_BOUND
 {
     if (isUnique())
         return uncheckedDowncast<UniqueElementData>(*this).attributes();

--- a/Source/WebCore/editing/TextCheckingHelper.cpp
+++ b/Source/WebCore/editing/TextCheckingHelper.cpp
@@ -183,7 +183,7 @@ const SimpleRange& TextCheckingParagraph::offsetAsRange() const
     return *m_offsetAsRange;
 }
 
-StringView TextCheckingParagraph::text() const
+StringView TextCheckingParagraph::text() const LIFETIME_BOUND
 {
     if (m_text.isNull())
         m_text = plainText(paragraphRange());

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -1702,7 +1702,7 @@ void WordAwareIterator::advance()
     }
 }
 
-StringView WordAwareIterator::text() const
+StringView WordAwareIterator::text() const LIFETIME_BOUND
 {
     if (!m_buffer.isEmpty())
         return m_buffer.span();

--- a/Source/WebCore/html/canvas/WebGLProgram.cpp
+++ b/Source/WebCore/html/canvas/WebGLProgram.cpp
@@ -122,7 +122,7 @@ bool WebGLProgram::linkStatus()
     return *m_state.linkStatus;
 }
 
-std::span<const GCGLAttribActiveInfo> WebGLProgram::activeAttribs()
+std::span<const GCGLAttribActiveInfo> WebGLProgram::activeAttribs() LIFETIME_BOUND
 {
     if (!m_state.activeAttribs) {
         RefPtr context = graphicsContextGL();
@@ -133,7 +133,7 @@ std::span<const GCGLAttribActiveInfo> WebGLProgram::activeAttribs()
     return *m_state.activeAttribs;
 }
 
-const HashMap<String, int>& WebGLProgram::attribLocations()
+const HashMap<String, int>& WebGLProgram::attribLocations() LIFETIME_BOUND
 {
     if (!m_state.attribLocations) {
         auto& locations = m_state.attribLocations.emplace();
@@ -156,7 +156,7 @@ std::span<const GCGLUniformActiveInfo> WebGLProgram::activeUniforms()
     return *m_state.activeUniforms;
 }
 
-const HashMap<String, int>& WebGLProgram::uniformLocations()
+const HashMap<String, int>& WebGLProgram::uniformLocations() LIFETIME_BOUND
 {
     if (!m_state.uniformLocations) {
         auto& locations = m_state.uniformLocations.emplace();
@@ -176,7 +176,7 @@ const HashMap<String, int>& WebGLProgram::uniformLocations()
     return *m_state.uniformLocations;
 }
 
-const HashMap<String, unsigned>& WebGLProgram::uniformIndices()
+const HashMap<String, unsigned>& WebGLProgram::uniformIndices() LIFETIME_BOUND
 {
     if (!m_state.uniformIndices) {
         auto& indices = m_state.uniformIndices.emplace();

--- a/Source/WebCore/html/track/TextTrack.cpp
+++ b/Source/WebCore/html/track/TextTrack.cpp
@@ -338,7 +338,7 @@ void TextTrack::removeAllCues()
     m_cues->clear();
 }
 
-TextTrackCueList* TextTrack::activeCues() const
+TextTrackCueList* TextTrack::activeCues() const LIFETIME_BOUND
 {
     // 4.8.10.12.5 If the text track mode ... is not the text track disabled mode,
     // then the activeCues attribute must return a live TextTrackCueList object ...

--- a/Source/WebCore/platform/ShareableResource.cpp
+++ b/Source/WebCore/platform/ShareableResource.cpp
@@ -99,7 +99,7 @@ auto ShareableResource::createHandle() -> std::optional<Handle>
     return { Handle { WTF::move(*memoryHandle), m_offset, m_size } };
 }
 
-std::span<const uint8_t> ShareableResource::span() const
+std::span<const uint8_t> ShareableResource::span() const LIFETIME_BOUND
 {
     return m_sharedMemory->span().subspan(m_offset, m_size);
 }

--- a/Source/WebCore/platform/SharedBuffer.cpp
+++ b/Source/WebCore/platform/SharedBuffer.cpp
@@ -566,7 +566,7 @@ Ref<DataSegment> DataSegment::create(Provider&& provider)
     return adoptRef(*new DataSegment(WTF::move(provider)));
 }
 
-std::span<const uint8_t> DataSegment::span() const
+std::span<const uint8_t> DataSegment::span() const LIFETIME_BOUND
 {
     auto visitor = WTF::makeVisitor(
         [](const Vector<uint8_t>& data) { return data.span(); },

--- a/Source/WebCore/platform/graphics/Region.cpp
+++ b/Source/WebCore/platform/graphics/Region.cpp
@@ -310,7 +310,7 @@ void Region::Shape::appendSpans(const Shape& shape, std::span<const Span> spans)
         appendSpan(spans[0].y, shape.segments(spans));
 }
 
-std::span<const int> Region::Shape::segments(std::span<const Span> span) const
+std::span<const int> Region::Shape::segments(std::span<const Span> span) const LIFETIME_BOUND
 {
     ASSERT(span.data() >= std::to_address(m_spans.begin()));
     ASSERT(span.data() < std::to_address(m_spans.end()));

--- a/Source/WebCore/platform/graphics/ShareableBitmap.cpp
+++ b/Source/WebCore/platform/graphics/ShareableBitmap.cpp
@@ -177,12 +177,12 @@ ShareableBitmap::ShareableBitmap(ShareableBitmapConfiguration configuration, Ref
     ASSERT(m_configuration.headroom() >= Headroom::None);
 }
 
-std::span<const uint8_t> ShareableBitmap::span() const
+std::span<const uint8_t> ShareableBitmap::span() const LIFETIME_BOUND
 {
     return m_sharedMemory->span();
 }
 
-std::span<uint8_t> ShareableBitmap::mutableSpan()
+std::span<uint8_t> ShareableBitmap::mutableSpan() LIFETIME_BOUND
 {
     return m_sharedMemory->mutableSpan();
 }

--- a/Source/WebCore/platform/graphics/transforms/AffineTransform.h
+++ b/Source/WebCore/platform/graphics/transforms/AffineTransform.h
@@ -249,7 +249,7 @@ constexpr AffineTransform::AffineTransform(std::span<const double, 6> transform)
 {
 }
 
-constexpr std::span<const double, 6> AffineTransform::span() const
+constexpr std::span<const double, 6> AffineTransform::span() const LIFETIME_BOUND
 {
     return m_transform;
 }

--- a/Source/WebCore/platform/network/HTTPParsers.cpp
+++ b/Source/WebCore/platform/network/HTTPParsers.cpp
@@ -337,7 +337,7 @@ std::optional<WallTime> parseHTTPDate(const String& value)
 // that arises from quoted-string, nor does this function properly unquote
 // attribute values. Further this function appears to process parameter names
 // in a case-sensitive manner. (There are likely other bugs as well.)
-StringView filenameFromHTTPContentDisposition(StringView value)
+StringView filenameFromHTTPContentDisposition(StringView value LIFETIME_BOUND)
 {
     for (auto keyValuePair : value.split(';')) {
         size_t valueStartPos = keyValuePair.find('=');
@@ -399,7 +399,7 @@ String extractMIMETypeFromMediaType(const String& mediaType)
     return mediaType.substring(typeStart, typeEnd - typeStart);
 }
 
-StringView extractCharsetFromMediaType(StringView mediaType)
+StringView extractCharsetFromMediaType(StringView mediaType LIFETIME_BOUND)
 {
     unsigned charsetPos = 0, charsetLen = 0;
     size_t pos = 0;

--- a/Source/WebCore/platform/sql/SQLiteStatement.cpp
+++ b/Source/WebCore/platform/sql/SQLiteStatement.cpp
@@ -289,7 +289,7 @@ Vector<uint8_t> SQLiteStatement::columnBlob(int col)
     return { columnBlobAsSpan(col) };
 }
 
-std::span<const uint8_t> SQLiteStatement::columnBlobAsSpan(int col)
+std::span<const uint8_t> SQLiteStatement::columnBlobAsSpan(int col) LIFETIME_BOUND
 {
     ASSERT(col >= 0);
 

--- a/Source/WebCore/style/calc/StyleCalculationTree.h
+++ b/Source/WebCore/style/calc/StyleCalculationTree.h
@@ -876,42 +876,42 @@ inline Children& Children::operator=(Vector<Child>&& other)
     return *this;
 }
 
-inline Children::iterator Children::begin()
+inline Children::iterator Children::begin() LIFETIME_BOUND
 {
     return value.begin();
 }
 
-inline Children::iterator Children::end()
+inline Children::iterator Children::end() LIFETIME_BOUND
 {
     return value.end();
 }
 
-inline Children::reverse_iterator Children::rbegin()
+inline Children::reverse_iterator Children::rbegin() LIFETIME_BOUND
 {
     return value.rbegin();
 }
 
-inline Children::reverse_iterator Children::rend()
+inline Children::reverse_iterator Children::rend() LIFETIME_BOUND
 {
     return value.rend();
 }
 
-inline Children::const_iterator Children::begin() const
+inline Children::const_iterator Children::begin() const LIFETIME_BOUND
 {
     return value.begin();
 }
 
-inline Children::const_iterator Children::end() const
+inline Children::const_iterator Children::end() const LIFETIME_BOUND
 {
     return value.end();
 }
 
-inline Children::const_reverse_iterator Children::rbegin() const
+inline Children::const_reverse_iterator Children::rbegin() const LIFETIME_BOUND
 {
     return value.rbegin();
 }
 
-inline Children::const_reverse_iterator Children::rend() const
+inline Children::const_reverse_iterator Children::rend() const LIFETIME_BOUND
 {
     return value.rend();
 }
@@ -926,12 +926,12 @@ inline size_t Children::size() const
     return value.size();
 }
 
-inline Child& Children::operator[](size_t i)
+inline Child& Children::operator[](size_t i) LIFETIME_BOUND
 {
     return value[i];
 }
 
-inline const Child& Children::operator[](size_t i) const
+inline const Child& Children::operator[](size_t i) const LIFETIME_BOUND
 {
     return value[i];
 }

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadMap.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadMap.cpp
@@ -41,7 +41,7 @@ NetworkResourceLoadMap::~NetworkResourceLoadMap()
     clear();
 }
 
-NetworkResourceLoadMap::MapType::AddResult NetworkResourceLoadMap::add(WebCore::ResourceLoaderIdentifier identifier, Ref<NetworkResourceLoader>&& loader)
+NetworkResourceLoadMap::MapType::AddResult NetworkResourceLoadMap::add(WebCore::ResourceLoaderIdentifier identifier, Ref<NetworkResourceLoader>&& loader) LIFETIME_BOUND
 {
     ASSERT(!m_loaders.contains(identifier));
     bool hasUpload = loader->originalRequest().hasUpload();
@@ -74,7 +74,7 @@ RefPtr<NetworkResourceLoader> NetworkResourceLoadMap::take(WebCore::ResourceLoad
     return loader;
 }
 
-NetworkResourceLoader* NetworkResourceLoadMap::get(WebCore::ResourceLoaderIdentifier identifier) const
+NetworkResourceLoader* NetworkResourceLoadMap::get(WebCore::ResourceLoaderIdentifier identifier) const LIFETIME_BOUND
 {
     return m_loaders.get(identifier);
 }

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheDataCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheDataCocoa.mm
@@ -68,7 +68,7 @@ Data Data::empty()
     return { OSObjectPtr<dispatch_data_t> { dispatch_data_empty } };
 }
 
-std::span<const uint8_t> Data::span() const
+std::span<const uint8_t> Data::span() const LIFETIME_BOUND
 {
     if (!m_data.data() && m_dispatchData) {
         const void* data = nullptr;

--- a/Source/WebKit/Platform/IPC/SharedBufferReference.cpp
+++ b/Source/WebKit/Platform/IPC/SharedBufferReference.cpp
@@ -80,7 +80,7 @@ RefPtr<WebCore::SharedBuffer> SharedBufferReference::unsafeBuffer() const
     return nullptr;
 }
 
-std::span<const uint8_t> SharedBufferReference::span() const
+std::span<const uint8_t> SharedBufferReference::span() const LIFETIME_BOUND
 {
 #if !USE(UNIX_DOMAIN_SOCKETS)
     RELEASE_ASSERT_WITH_MESSAGE(isEmpty() || (!m_buffer && m_memory), "Must only be called on IPC's receiver side");

--- a/Source/WebKit/Platform/IPC/TransferString.cpp
+++ b/Source/WebKit/Platform/IPC/TransferString.cpp
@@ -126,7 +126,7 @@ std::optional<String> TransferString::release(size_t maxCopySizeInBytes) && // N
     );
 }
 
-TransferString::IPCData TransferString::toIPCData() const
+TransferString::IPCData TransferString::toIPCData() const LIFETIME_BOUND
 {
     return WTF::switchOn(m_storage,
         [](const String& string) {


### PR DESCRIPTION
#### a92bc6cb0dcc1caa2894b2efeef80238032f28a8
<pre>
Apply LIFETIME_BOUND attribute consistently on both declaration and definition of methods
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=305278">https://bugs.webkit.org/show_bug.cgi?id=305278</a>&gt;
&lt;<a href="https://rdar.apple.com/167920705">rdar://167920705</a>&gt;

Reviewed by Geoffrey Garen.

Apply LIFETIMEBOUND attribute consistently to both declaration and
definition of each function.

This works around a bug in clang where the attribute is ignored in
certain cases: &lt;<a href="https://github.com/llvm/llvm-project/issues/175391">https://github.com/llvm/llvm-project/issues/175391</a>&gt;

* Source/JavaScriptCore/API/OpaqueJSString.cpp:
(OpaqueJSString::characters):
* Source/JavaScriptCore/debugger/DebuggerScope.h:
(JSC::DebuggerScope::begin):
(JSC::DebuggerScope::end):
* Source/JavaScriptCore/runtime/ArrayBuffer.h:
(JSC::ArrayBuffer::data):
(JSC::ArrayBuffer::data const):
(JSC::ArrayBuffer::dataWithoutPACValidation):
(JSC::ArrayBuffer::dataWithoutPACValidation const):
* Source/JavaScriptCore/runtime/CachePayload.cpp:
(JSC::CachePayload::span const):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyArrayInlines.h:
(JSC::JSWebAssemblyArray::span):
(JSC::JSWebAssemblyArray::refTypeSpan):
* Source/WTF/wtf/Deque.h:
(WTF::inlineCapacity&gt;::findIf):
(WTF::inlineCapacity&gt;::findIf const):
* Source/WTF/wtf/HashCountedSet.h:
(WTF:: const):
(WTF::Traits&gt;::begin):
(WTF::Traits&gt;::end):
(WTF::Traits&gt;::begin const):
(WTF::Traits&gt;::end const):
(WTF::Traits&gt;::values):
(WTF::Traits&gt;::values const const):
(WTF::Traits&gt;::find):
(WTF::Traits&gt;::find const):
(WTF::Traits&gt;::add):
* Source/WTF/wtf/HashMap.h:
(WTF::M&gt;::begin):
(WTF::M&gt;::end):
(WTF::M&gt;::begin const):
(WTF::M&gt;::end const):
(WTF::M&gt;::find):
(WTF::M&gt;::find const):
(WTF::M&gt;::set):
(WTF::M&gt;::ensure):
(WTF::M&gt;::add):
(WTF::M&gt;::fastAdd):
* Source/WTF/wtf/HashSet.h:
(WTF::shouldValidateKey&gt;::begin const):
(WTF::shouldValidateKey&gt;::end const):
(WTF::shouldValidateKey&gt;::find const):
(WTF::shouldValidateKey&gt;::ensure):
* Source/WTF/wtf/HashTable.h:
(WTF::Malloc&gt;::add):
(WTF::Malloc&gt;::addPassingHashCode):
(WTF::Malloc&gt;::find):
(WTF::Malloc&gt;::find const):
* Source/WTF/wtf/IndexSparseSet.h:
(WTF::OverflowHandler&gt;::begin const):
(WTF::OverflowHandler&gt;::end const):
* Source/WTF/wtf/JSONValues.h:
(WTF::JSONImpl::ObjectBase::find):
(WTF::JSONImpl::ObjectBase::find const):
* Source/WTF/wtf/ListHashSet.h:
(WTF::U&gt;::first):
(WTF::U&gt;::first const):
(WTF::U&gt;::last):
(WTF::U&gt;::last const):
(WTF::U&gt;::find):
(WTF::U&gt;::find const):
(WTF::U&gt;::add):
(WTF::U&gt;::appendOrMoveToLast):
(WTF::U&gt;::prependOrMoveToFirst):
(WTF::U&gt;::insertBefore):
* Source/WTF/wtf/RobinHoodHashTable.h:
(WTF::Malloc&gt;::add):
(WTF::Malloc&gt;::addPassingHashCode):
(WTF::Malloc&gt;::find):
(WTF::Malloc&gt;::find const):
* Source/WTF/wtf/SentinelLinkedList.h:
(WTF::RawNode&gt;::begin):
(WTF::RawNode&gt;::end):
(WTF::RawNode&gt;::begin const):
(WTF::RawNode&gt;::end const):
* Source/WTF/wtf/URL.cpp:
(WTF::URL::lastPathComponent const):
(WTF::URL::protocol const):
(WTF::URL::host const):
(WTF::URL::encodedUser const):
(WTF::URL::encodedPassword const):
(WTF::URL::fragmentIdentifier const):
(WTF::URL::query const):
(WTF::URL::path const):
(WTF::URL::viewWithoutQueryOrFragmentIdentifier const):
(WTF::URL::viewWithoutFragmentIdentifier const):
(WTF::URL::queryWithLeadingQuestionMark const):
(WTF::URL::fragmentIdentifierWithLeadingNumberSign const):
* Source/WTF/wtf/URLParser.cpp:
* Source/WTF/wtf/dtoa.cpp:
(WTF::numberToStringAndSize):
(WTF::numberToStringWithTrailingPoint):
(WTF::numberToFixedPrecisionString):
(WTF::numberToFixedWidthString):
(WTF::numberToCSSString):
* Source/WTF/wtf/text/CString.cpp:
(WTF::CString::mutableSpan):
(WTF::CString::mutableSpanIncludingNullTerminator):
* Source/WTF/wtf/text/CString.h:
(WTF::CString::data const):
(WTF::CString::span const):
(WTF::CString::spanIncludingNullTerminator const):
* Source/WTF/wtf/text/StringBuilder.h:
(WTF::StringBuilder::operator StringView const):
(WTF::StringBuilder::toString):
(WTF::StringBuilder::toStringPreserveCapacity const):
(WTF::StringBuilder::span const):
* Source/WTF/wtf/text/StringImpl.h:
(WTF::StringImpl::span&lt;Latin1Character&gt; const):
(WTF::StringImpl::span&lt;char16_t&gt; const):
* Source/WTF/wtf/text/StringView.cpp:
(WTF::StringView::GraphemeClusters::Iterator::Iterator):
* Source/WTF/wtf/text/StringView.h:
(WTF::StringView::StringView):
(WTF::StringView::GraphemeClusters::GraphemeClusters):
(WTF::StringView::CodePoints::CodePoints):
(WTF::StringView::CodePoints::Iterator::Iterator):
(WTF::StringView::CodeUnits::CodeUnits):
(WTF::StringView::CodeUnits::Iterator::Iterator):
(WTF::StringView::SplitResult::SplitResult):
(WTF::StringView::span8 const):
(WTF::StringView::span16 const):
(WTF::StringView::span&lt;Latin1Character&gt; const):
(WTF::StringView::span&lt;char16_t&gt; const):
(WTF::StringView::GraphemeClusters::begin const):
(WTF::StringView::GraphemeClusters::end const):
(WTF::StringView::CodePoints::begin const):
(WTF::StringView::CodePoints::end const):
(WTF::StringView::CodePoints::codePointAt const):
(WTF::StringView::CodeUnits::begin const):
(WTF::StringView::CodeUnits::end const):
(WTF::StringView::SplitResult::begin const):
(WTF::StringView::SplitResult::end const):
* Source/WTF/wtf/text/WTFString.h:
(WTF::String::span&lt;Latin1Character&gt; const):
(WTF::String::span&lt;char16_t&gt; const):
* Source/WebCore/Modules/indexeddb/server/IndexValueEntry.cpp:
(WebCore::IDBServer::IndexValueEntry::getLowest const):
(WebCore::IDBServer::IndexValueEntry::begin):
(WebCore::IDBServer::IndexValueEntry::reverseBegin):
(WebCore::IDBServer::IndexValueEntry::find):
(WebCore::IDBServer::IndexValueEntry::reverseFind):
* Source/WebCore/Modules/mediasource/SampleMap.cpp:
(WebCore::PresentationOrderSampleMap::findSampleWithPresentationTime):
(WebCore::PresentationOrderSampleMap::findSampleContainingPresentationTime):
(WebCore::PresentationOrderSampleMap::findSampleContainingOrAfterPresentationTime):
(WebCore::PresentationOrderSampleMap::findSampleStartingOnOrAfterPresentationTime):
(WebCore::PresentationOrderSampleMap::findSampleStartingAfterPresentationTime):
(WebCore::DecodeOrderSampleMap::findSampleWithDecodeKey):
(WebCore::DecodeOrderSampleMap::findSampleAfterDecodeKey):
(WebCore::PresentationOrderSampleMap::reverseFindSampleContainingPresentationTime):
(WebCore::PresentationOrderSampleMap::reverseFindSampleBeforePresentationTime):
(WebCore::DecodeOrderSampleMap::reverseFindSampleWithDecodeKey):
(WebCore::DecodeOrderSampleMap::findSyncSamplePriorToPresentationTime):
(WebCore::DecodeOrderSampleMap::findSyncSamplePriorToDecodeIterator):
(WebCore::DecodeOrderSampleMap::findSyncSampleAfterPresentationTime):
(WebCore::DecodeOrderSampleMap::findSyncSamplePriorToDecodeKey):
(WebCore::DecodeOrderSampleMap::findSyncSampleAfterDecodeIterator):
(WebCore::PresentationOrderSampleMap::findSamplesBetweenPresentationTimes):
(WebCore::PresentationOrderSampleMap::findSamplesBetweenPresentationTimesFromEnd):
(WebCore::DecodeOrderSampleMap::findDependentSamples):
* Source/WebCore/Modules/webaudio/AudioBuffer.cpp:
(WebCore::AudioBuffer::rawChannelData):
* Source/WebCore/Modules/webaudio/AudioNodeInput.cpp:
(WebCore::AudioNodeInput::bus):
* Source/WebCore/Modules/webaudio/AudioNodeOutput.cpp:
(WebCore::AudioNodeOutput::bus const):
* Source/WebCore/PAL/pal/text/TextCodec.cpp:
(PAL::TextCodec::getUnencodableReplacement):
* Source/WebCore/css/CSSValueList.h:
(WebCore::CSSValueContainingVector::operator[] const):
* Source/WebCore/css/StylePropertiesInlines.h:
(WebCore::StyleProperties::propertyAt const):
* Source/WebCore/css/calc/CSSCalcTree.h:
(WebCore::CSSCalc::Children::begin):
(WebCore::CSSCalc::Children::end):
(WebCore::CSSCalc::Children::rbegin):
(WebCore::CSSCalc::Children::rend):
(WebCore::CSSCalc::Children::begin const):
(WebCore::CSSCalc::Children::end const):
(WebCore::CSSCalc::Children::rbegin const):
(WebCore::CSSCalc::Children::rend const):
(WebCore::CSSCalc::Children::operator[]):
(WebCore::CSSCalc::Children::operator[] const):
* Source/WebCore/css/parser/CSSParserTokenRange.cpp:
(WebCore::CSSParserTokenRange::consumeLast):
* Source/WebCore/css/parser/CSSTokenizer.cpp:
(WebCore::CSSTokenizer::tokenRange const):
* Source/WebCore/dom/ElementData.h:
(WebCore::ElementData::attributes const):
* Source/WebCore/editing/TextCheckingHelper.cpp:
(WebCore::TextCheckingParagraph::text const):
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::WordAwareIterator::text const):
* Source/WebCore/html/canvas/WebGLProgram.cpp:
(WebCore::WebGLProgram::activeAttribs):
(WebCore::WebGLProgram::attribLocations):
(WebCore::WebGLProgram::uniformLocations):
(WebCore::WebGLProgram::uniformIndices):
* Source/WebCore/html/track/TextTrack.cpp:
(WebCore::TextTrack::activeCues const):
* Source/WebCore/platform/ShareableResource.cpp:
(WebCore::ShareableResource::span const):
* Source/WebCore/platform/SharedBuffer.cpp:
(WebCore::DataSegment::span const):
* Source/WebCore/platform/graphics/Region.cpp:
(WebCore::Region::Shape::segments const):
* Source/WebCore/platform/graphics/ShareableBitmap.cpp:
(WebCore::ShareableBitmap::span const):
(WebCore::ShareableBitmap::mutableSpan):
* Source/WebCore/platform/graphics/transforms/AffineTransform.h:
(WebCore::AffineTransform::span const):
* Source/WebCore/platform/network/HTTPParsers.cpp:
(WebCore::filenameFromHTTPContentDisposition):
(WebCore::extractCharsetFromMediaType):
* Source/WebCore/platform/sql/SQLiteStatement.cpp:
(WebCore::SQLiteStatement::columnBlobAsSpan):
* Source/WebCore/style/calc/StyleCalculationTree.h:
(WebCore::Style::Calculation::Children::begin):
(WebCore::Style::Calculation::Children::end):
(WebCore::Style::Calculation::Children::rbegin):
(WebCore::Style::Calculation::Children::rend):
(WebCore::Style::Calculation::Children::begin const):
(WebCore::Style::Calculation::Children::end const):
(WebCore::Style::Calculation::Children::rbegin const):
(WebCore::Style::Calculation::Children::rend const):
(WebCore::Style::Calculation::Children::operator[]):
(WebCore::Style::Calculation::Children::operator[] const):
* Source/WebKit/NetworkProcess/NetworkResourceLoadMap.cpp:
(WebKit::NetworkResourceLoadMap::add):
(WebKit::NetworkResourceLoadMap::get const):
* Source/WebKit/NetworkProcess/cache/NetworkCacheDataCocoa.mm:
(WebKit::NetworkCache::Data::span const):
* Source/WebKit/Platform/IPC/SharedBufferReference.cpp:
(IPC::SharedBufferReference::span const):
* Source/WebKit/Platform/IPC/TransferString.cpp:
(IPC::TransferString::toIPCData const):

Canonical link: <a href="https://commits.webkit.org/305483@main">https://commits.webkit.org/305483@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a8614f6cd9a8d09c5a75a3a83b2bb096f29449d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138507 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10872 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49917 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/146604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91482 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6ecf302c-1f10-45ed-9461-024dd0c6f4df) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140381 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11576 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11027 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/146604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77329 "1 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3a0ba489-c6a7-45f4-901c-ee78b8d304e3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141454 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8705 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124164 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/146604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/51e33a22-7ad9-411b-8d09-eb020c323ef6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8296 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6057 "Passed tests") | [  ~~🛠 wpe-cairo-libwebrtc~~](https://ews-build.webkit.org/#/builders/166/builds/6898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/130471 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117712 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42365 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/149358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/137100 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled JSC (warnings); jscore-tests (cancelled)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10554 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42922 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/149358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10571 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8924 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/149358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8432 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120452 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/65443 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21334 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10603 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38383 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/169781 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10337 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74234 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44255 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10541 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10392 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->