### PR TITLE
Enable Enhanced Security tests on regular macOS builds

### DIFF
--- a/Source/WTF/wtf/PlatformHave.h
+++ b/Source/WTF/wtf/PlatformHave.h
@@ -1898,3 +1898,8 @@
     || PLATFORM(IOS_FAMILY))
 #define HAVE_IMMERSIVE_VIDEO_METADATA_SUPPORT 1
 #endif
+
+#if !defined(HAVE_LIBPROC) \
+    && __has_include(<libproc.h>)
+#define HAVE_LIBPROC 1
+#endif

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurity.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurity.mm
@@ -76,11 +76,8 @@ TEST(EnhancedSecurity, EnhancedSecurityEnablesTrue)
     [webView loadRequest:[NSURLRequest requestWithURL:url]];
     [webView _test_waitForDidFinishNavigation];
     EXPECT_EQ(true, isEnhancedSecurityEnabled(webView.get()));
-// _webContentProcessVariantForFrame relies on private entitlements not available on public builds
-#if USE(APPLE_INTERNAL_SDK)
     NSString *processVariant = [webView _webContentProcessVariantForFrame:nil];
     EXPECT_STREQ("security", processVariant.UTF8String);
-#endif
 }
 
 TEST(EnhancedSecurity, EnhancedSecurityEnableFalse)
@@ -92,11 +89,8 @@ TEST(EnhancedSecurity, EnhancedSecurityEnableFalse)
     [webView loadRequest:[NSURLRequest requestWithURL:url]];
     [webView _test_waitForDidFinishNavigation];
     EXPECT_EQ(false, isEnhancedSecurityEnabled(webView.get()));
-// _webContentProcessVariantForFrame relies on private entitlements not available on public builds
-#if USE(APPLE_INTERNAL_SDK)
     NSString *processVariant = [webView _webContentProcessVariantForFrame:nil];
     EXPECT_STREQ("standard", processVariant.UTF8String);
-#endif
 }
 
 TEST(EnhancedSecurity, EnhancedSecurityDisablesJIT)
@@ -153,10 +147,7 @@ TEST(EnhancedSecurity, PSONToEnhancedSecurity)
     [webView loadRequest:[NSURLRequest requestWithURL:url]];
     TestWebKitAPI::Util::run(&finishedNavigation);
     EXPECT_EQ(false, isEnhancedSecurityEnabled(webView.get()));
-// _webContentProcessVariantForFrame relies on private entitlements not available on public builds
-#if USE(APPLE_INTERNAL_SDK)
     EXPECT_STREQ("standard", [webView _webContentProcessVariantForFrame:nil].UTF8String);
-#endif
     pid_t pid1 = [webView _webProcessIdentifier];
     EXPECT_NE(pid1, 0);
 
@@ -173,10 +164,7 @@ TEST(EnhancedSecurity, PSONToEnhancedSecurity)
     TestWebKitAPI::Util::run(&finishedNavigation);
 
     EXPECT_EQ(true, isEnhancedSecurityEnabled(webView.get()));
-// _webContentProcessVariantForFrame relies on private entitlements not available on public builds
-#if USE(APPLE_INTERNAL_SDK)
     EXPECT_STREQ("security", [webView _webContentProcessVariantForFrame:nil].UTF8String);
-#endif
     EXPECT_NE(pid1, [webView _webProcessIdentifier]);
 }
 
@@ -197,10 +185,7 @@ TEST(EnhancedSecurity, PSONToEnhancedSecuritySamePage)
     [webView loadRequest:[NSURLRequest requestWithURL:url]];
     TestWebKitAPI::Util::run(&finishedNavigation);
     EXPECT_EQ(false, isEnhancedSecurityEnabled(webView.get()));
-// _webContentProcessVariantForFrame relies on private entitlements not available on public builds
-#if USE(APPLE_INTERNAL_SDK)
     EXPECT_STREQ("standard", [webView _webContentProcessVariantForFrame:nil].UTF8String);
-#endif
     pid_t pid1 = [webView _webProcessIdentifier];
     EXPECT_NE(pid1, 0);
 
@@ -217,10 +202,7 @@ TEST(EnhancedSecurity, PSONToEnhancedSecuritySamePage)
     TestWebKitAPI::Util::run(&finishedNavigation);
 
     EXPECT_EQ(true, isEnhancedSecurityEnabled(webView.get()));
-// _webContentProcessVariantForFrame relies on private entitlements not available on public builds
-#if USE(APPLE_INTERNAL_SDK)
     EXPECT_STREQ("security", [webView _webContentProcessVariantForFrame:nil].UTF8String);
-#endif
     EXPECT_NE(pid1, [webView _webProcessIdentifier]);
 }
 
@@ -257,10 +239,7 @@ TEST(EnhancedSecurity, PSONToEnhancedSecuritySharedProcessPool)
     [webView loadRequest:[NSURLRequest requestWithURL:url]];
     TestWebKitAPI::Util::run(&finishedNavigation);
     EXPECT_EQ(false, isEnhancedSecurityEnabled(webView.get()));
-// _webContentProcessVariantForFrame relies on private entitlements not available on public builds
-#if USE(APPLE_INTERNAL_SDK)
     EXPECT_STREQ("standard", [webView _webContentProcessVariantForFrame:nil].UTF8String);
-#endif
     pid_t pid1 = [webView _webProcessIdentifier];
     EXPECT_NE(pid1, 0);
 
@@ -279,10 +258,7 @@ TEST(EnhancedSecurity, PSONToEnhancedSecuritySharedProcessPool)
     TestWebKitAPI::Util::run(&finishedNavigation);
 
     EXPECT_EQ(true, isEnhancedSecurityEnabled(webView2.get()));
-// _webContentProcessVariantForFrame relies on private entitlements not available on public builds
-#if USE(APPLE_INTERNAL_SDK)
     EXPECT_STREQ("security", [webView2 _webContentProcessVariantForFrame:nil].UTF8String);
-#endif
     EXPECT_NE(pid1, [webView2 _webProcessIdentifier]);
 }
 
@@ -309,10 +285,7 @@ TEST(EnhancedSecurity, PSONToEnhancedSecuritySharedProcessPoolReverse)
     [webView loadRequest:[NSURLRequest requestWithURL:url]];
     TestWebKitAPI::Util::run(&finishedNavigation);
     EXPECT_EQ(true, isEnhancedSecurityEnabled(webView.get()));
-// _webContentProcessVariantForFrame relies on private entitlements not available on public builds
-#if USE(APPLE_INTERNAL_SDK)
     EXPECT_STREQ("security", [webView _webContentProcessVariantForFrame:nil].UTF8String);
-#endif
     pid_t pid1 = [webView _webProcessIdentifier];
     EXPECT_NE(pid1, 0);
 
@@ -331,14 +304,10 @@ TEST(EnhancedSecurity, PSONToEnhancedSecuritySharedProcessPoolReverse)
     TestWebKitAPI::Util::run(&finishedNavigation);
 
     EXPECT_EQ(false, isEnhancedSecurityEnabled(webView2.get()));
-// _webContentProcessVariantForFrame relies on private entitlements not available on public builds
-#if USE(APPLE_INTERNAL_SDK)
     EXPECT_STREQ("standard", [webView2 _webContentProcessVariantForFrame:nil].UTF8String);
-#endif
     EXPECT_NE(pid1, [webView2 _webProcessIdentifier]);
 }
 
-#if USE(APPLE_INTERNAL_SDK)
 TEST(EnhancedSecurity, ProcessVariantMatchesConfiguration)
 {
     auto webViewConfiguration1 = adoptNS([WKWebViewConfiguration new]);
@@ -361,7 +330,6 @@ TEST(EnhancedSecurity, ProcessVariantMatchesConfiguration)
     EXPECT_EQ(false, isEnhancedSecurityEnabled(webView2.get()));
     EXPECT_STREQ("standard", [webView2 _webContentProcessVariantForFrame:nil].UTF8String);
 }
-#endif
 
 TEST(EnhancedSecurity, ProcessCanLaunch)
 {
@@ -473,11 +441,8 @@ TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysEnabledAfterSubFrameNaviga
     EXPECT_WK_STREQ([webView _test_waitForAlert], "done");
 
     EXPECT_EQ(true, isEnhancedSecurityEnabled(webView.get()));
-// _webContentProcessVariantForFrame relies on private entitlements not available on public builds
-#if USE(APPLE_INTERNAL_SDK)
     EXPECT_STREQ("security", [webView _webContentProcessVariantForFrame:nil].UTF8String);
     EXPECT_STREQ("security", [webView _webContentProcessVariantForFrame:[webView firstChildFrame]._handle].UTF8String);
-#endif
 
 }
 
@@ -522,11 +487,8 @@ TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysEnabledAfterSubFrameNaviga
     EXPECT_WK_STREQ([webView _test_waitForAlert], "done");
 
     EXPECT_EQ(true, isEnhancedSecurityEnabled(webView.get()));
-// _webContentProcessVariantForFrame relies on private entitlements not available on public builds
-#if USE(APPLE_INTERNAL_SDK)
     EXPECT_STREQ("security", [webView _webContentProcessVariantForFrame:nil].UTF8String);
     EXPECT_STREQ("security", [webView _webContentProcessVariantForFrame:[webView firstChildFrame]._handle].UTF8String);
-#endif
 
 }
 
@@ -571,11 +533,8 @@ TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysDisabledAfterSubFrameNavig
     EXPECT_WK_STREQ([webView _test_waitForAlert], "done");
 
     EXPECT_EQ(false, isEnhancedSecurityEnabled(webView.get()));
-// _webContentProcessVariantForFrame relies on private entitlements not available on public builds
-#if USE(APPLE_INTERNAL_SDK)
     EXPECT_STREQ("standard", [webView _webContentProcessVariantForFrame:nil].UTF8String);
     EXPECT_STREQ("standard", [webView _webContentProcessVariantForFrame:[webView firstChildFrame]._handle].UTF8String);
-#endif
 
 }
 
@@ -620,11 +579,8 @@ TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysDisabledAfterSubFrameNavig
     EXPECT_WK_STREQ([webView _test_waitForAlert], "done");
 
     EXPECT_EQ(false, isEnhancedSecurityEnabled(webView.get()));
-// _webContentProcessVariantForFrame relies on private entitlements not available on public builds
-#if USE(APPLE_INTERNAL_SDK)
     EXPECT_STREQ("standard", [webView _webContentProcessVariantForFrame:nil].UTF8String);
     EXPECT_STREQ("standard", [webView _webContentProcessVariantForFrame:[webView firstChildFrame]._handle].UTF8String);
-#endif
 }
 
 TEST(EnhancedSecurity, WindowOpenWithNoopenerFromEnhancedSecurityPage)
@@ -661,10 +617,7 @@ TEST(EnhancedSecurity, WindowOpenWithNoopenerFromEnhancedSecurityPage)
         TestWebKitAPI::Util::spinRunLoop();
 
     EXPECT_EQ(true, isEnhancedSecurityEnabled(openedWebView.get()));
-// _webContentProcessVariantForFrame relies on private entitlements not available on public builds
-#if USE(APPLE_INTERNAL_SDK)
     EXPECT_STREQ("security", [openedWebView _webContentProcessVariantForFrame:nil].UTF8String);
-#endif
 
     bool hasOpener = [[openedWebView objectByEvaluatingJavaScript:@"!!window.opener"] boolValue];
     EXPECT_FALSE(hasOpener);
@@ -704,11 +657,8 @@ TEST(EnhancedSecurity, WindowOpenWithOpenerFromEnhancedSecurityPage)
         TestWebKitAPI::Util::spinRunLoop();
 
     EXPECT_EQ(true, isEnhancedSecurityEnabled(openedWebView.get()));
-// _webContentProcessVariantForFrame relies on private entitlements not available on public builds
-#if USE(APPLE_INTERNAL_SDK)
     EXPECT_STREQ("security", [openedWebView _webContentProcessVariantForFrame:nil].UTF8String);
     EXPECT_EQ([openerWebView _webProcessIdentifier], [openedWebView _webProcessIdentifier]);
-#endif
 }
 
 TEST(EnhancedSecurity, WindowOpenNoopenerFromEnhancedSecurityInheritsEnhancedSecurity)
@@ -735,10 +685,7 @@ TEST(EnhancedSecurity, WindowOpenNoopenerFromEnhancedSecurityInheritsEnhancedSec
     [standardDelegate waitForDidFinishNavigation];
 
     EXPECT_EQ(false, isEnhancedSecurityEnabled(standardWebView.get()));
-// _webContentProcessVariantForFrame relies on private entitlements not available on public builds
-#if USE(APPLE_INTERNAL_SDK)
     EXPECT_STREQ("standard", [standardWebView _webContentProcessVariantForFrame:nil].UTF8String);
-#endif
     pid_t standardPid = [standardWebView _webProcessIdentifier];
     EXPECT_NE(standardPid, 0);
 
@@ -771,11 +718,8 @@ TEST(EnhancedSecurity, WindowOpenNoopenerFromEnhancedSecurityInheritsEnhancedSec
         TestWebKitAPI::Util::spinRunLoop();
 
     EXPECT_EQ(true, isEnhancedSecurityEnabled(openedWebView.get()));
-// _webContentProcessVariantForFrame relies on private entitlements not available on public builds
-#if USE(APPLE_INTERNAL_SDK)
     EXPECT_STREQ("security", [openedWebView _webContentProcessVariantForFrame:nil].UTF8String);
     EXPECT_NE(standardPid, [openedWebView _webProcessIdentifier]);
-#endif
 
     bool hasOpener = [[openedWebView objectByEvaluatingJavaScript:@"!!window.opener"] boolValue];
     EXPECT_FALSE(hasOpener);
@@ -833,8 +777,6 @@ TEST(EnhancedSecurity, WindowOpenNoopenerFromStandardWithEnhancedSecurityViaDele
     EXPECT_EQ(false, isEnhancedSecurityEnabled(openerWebView.get()));
     EXPECT_EQ(true, isEnhancedSecurityEnabled(openedWebView.get()));
 
-// _webContentProcessVariantForFrame relies on private entitlements not available on public builds
-#if USE(APPLE_INTERNAL_SDK)
     pid_t openerPID = [openerWebView _webProcessIdentifier];
     pid_t openedPID = [openedWebView _webProcessIdentifier];
     bool isEnhanced = isEnhancedSecurityEnabled(openedWebView.get());
@@ -844,7 +786,6 @@ TEST(EnhancedSecurity, WindowOpenNoopenerFromStandardWithEnhancedSecurityViaDele
         EXPECT_NE(openerPID, openedPID);
     } else
         EXPECT_STREQ("standard", [openedWebView _webContentProcessVariantForFrame:nil].UTF8String);
-#endif
 
     bool hasOpener = [[openedWebView objectByEvaluatingJavaScript:@"!!window.opener"] boolValue];
     EXPECT_FALSE(hasOpener);
@@ -902,12 +843,9 @@ TEST(EnhancedSecurity, WindowOpenNoopenerFromEnhancedSecurityWithStandardViaDele
     EXPECT_EQ(true, isEnhancedSecurityEnabled(openerWebView.get()));
     EXPECT_EQ(false, isEnhancedSecurityEnabled(openedWebView.get()));
 
-// _webContentProcessVariantForFrame relies on private entitlements not available on public builds
-#if USE(APPLE_INTERNAL_SDK)
     pid_t openerPID = [openerWebView _webProcessIdentifier];
     EXPECT_STREQ("standard", [openedWebView _webContentProcessVariantForFrame:nil].UTF8String);
     EXPECT_NE(openerPID, [openedWebView _webProcessIdentifier]);
-#endif
 
     bool hasOpener = [[openedWebView objectByEvaluatingJavaScript:@"!!window.opener"] boolValue];
     EXPECT_FALSE(hasOpener);
@@ -926,10 +864,7 @@ TEST(EnhancedSecurity, LockdownModeTakesPrecedenceOverEnhancedSecurity)
 
     EXPECT_EQ(false, isJITEnabled(webView.get()));
     EXPECT_EQ(false, isEnhancedSecurityEnabled(webView.get()));
-// _webContentProcessVariantForFrame relies on private entitlements not available on public builds
-#if USE(APPLE_INTERNAL_SDK)
     EXPECT_STREQ("lockdown", [webView _webContentProcessVariantForFrame:nil].UTF8String);
-#endif
 }
 
 TEST(EnhancedSecurity, EnhancedSecurityRequestedWhenLockdownModeActive)
@@ -966,10 +901,7 @@ TEST(EnhancedSecurity, EnhancedSecurityRequestedWhenLockdownModeActive)
     EXPECT_EQ(false, isJITEnabled(webView.get()));
     EXPECT_EQ(false, isEnhancedSecurityEnabled(webView.get()));
     EXPECT_EQ(true, webViewConfiguration.get().defaultWebpagePreferences.isLockdownModeEnabled);
-// _webContentProcessVariantForFrame relies on private entitlements not available on public builds
-#if USE(APPLE_INTERNAL_SDK)
     EXPECT_STREQ("lockdown", [webView _webContentProcessVariantForFrame:nil].UTF8String);
-#endif
 }
 
 #if HAVE(ENHANCED_SECURITY_WEB_CONTENT_PROCESS)
@@ -988,10 +920,8 @@ TEST(EnhancedSecurity, SystemLockdownModeEnablesEnhancedSecurityWhenAPIOptsOut)
 
     EXPECT_EQ(false, isJITEnabled(webView.get()));
 
-#if USE(APPLE_INTERNAL_SDK)
     NSString *processVariant = [webView _webContentProcessVariantForFrame:nil];
     EXPECT_STREQ("security", processVariant.UTF8String);
-#endif
 
     [WKProcessPool _clearCaptivePortalModeEnabledGloballyForTesting];
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm
@@ -73,14 +73,7 @@ using namespace TestWebKitAPI;
 
     self.runJavaScriptAlertPanelWithMessage = ^(WKWebView *webView, NSString *message, WKFrameInfo *frameInfo, void (^completionHandler)(void)) {
         alertMessage = message;
-
-        // FIXME: rdar://164477631 (Fix Enhanced Security tests to work on non Apple Internal builds)
-#if USE(APPLE_INTERNAL_SDK)
         childFrameVariant = [webView _webContentProcessVariantForFrame:frameInfo._handle];
-#else
-        childFrameVariant = @"unknown";
-#endif
-
         finished = true;
         completionHandler();
     };
@@ -120,11 +113,7 @@ static void testAlertWithEnhancedSecurity(RetainPtr<TestUIDelegate> uiDelegate, 
     NSArray *result = [uiDelegate waitForAlertWithEnhancedSecurity];
 
     EXPECT_WK_STREQ(result[0], message);
-
-    // FIXME: rdar://164477631 (Fix Enhanced Security tests to work on non Apple Internal builds)
-#if USE(APPLE_INTERNAL_SDK)
     EXPECT_EQ([result[1] boolValue], enhancedSecurityEnabled);
-#endif
 }
 
 static RetainPtr<TestWKWebView> enhancedSecurityTestConfiguration(


### PR DESCRIPTION
#### ccec7f05bf0711f26723cb3fdc7ac91b8fdef6a3
<pre>
Enable Enhanced Security tests on regular macOS builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=305295">https://bugs.webkit.org/show_bug.cgi?id=305295</a>
<a href="https://rdar.apple.com/164477631">rdar://164477631</a>

Reviewed by Chris Dumez.

Enhanced Security tests rely on _webContentProcessVariantForFrame to
identify the variant of the WebContent process that has been spawned.
This previously relied on entitlements that could only be used on
internal builds.

This change uses proc_pidpath, where feasible, to answer this question
instead, allowing us to run these tests without the entitlements.

Tests: Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurity.mm
       Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _webContentProcessVariantForFrame:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurity.mm:
(TestWebKitAPI::TEST(EnhancedSecurity, EnhancedSecurityEnablesTrue)):
(TestWebKitAPI::TEST(EnhancedSecurity, EnhancedSecurityEnableFalse)):
(TestWebKitAPI::TEST(EnhancedSecurity, PSONToEnhancedSecurity)):
(TestWebKitAPI::TEST(EnhancedSecurity, PSONToEnhancedSecuritySamePage)):
(TestWebKitAPI::TEST(EnhancedSecurity, PSONToEnhancedSecuritySharedProcessPool)):
(TestWebKitAPI::TEST(EnhancedSecurity, PSONToEnhancedSecuritySharedProcessPoolReverse)):
(TestWebKitAPI::TEST(EnhancedSecurity, ProcessVariantMatchesConfiguration)):
(TestWebKitAPI::TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysEnabledAfterSubFrameNavigationRequestDisables)):
(TestWebKitAPI::TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysEnabledAfterSubFrameNavigationRequestDisablesCrossOrigin)):
(TestWebKitAPI::TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysDisabledAfterSubFrameNavigationRequestEnabled)):
(TestWebKitAPI::TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysDisabledAfterSubFrameNavigationRequestEnabledCrossOrigin)):
(TestWebKitAPI::TEST(EnhancedSecurity, WindowOpenWithNoopenerFromEnhancedSecurityPage)):
(TestWebKitAPI::TEST(EnhancedSecurity, WindowOpenWithOpenerFromEnhancedSecurityPage)):
(TestWebKitAPI::TEST(EnhancedSecurity, WindowOpenNoopenerFromEnhancedSecurityInheritsEnhancedSecurity)):
(TestWebKitAPI::TEST(EnhancedSecurity, WindowOpenNoopenerFromStandardWithEnhancedSecurityViaDelegate)):
(TestWebKitAPI::TEST(EnhancedSecurity, WindowOpenNoopenerFromEnhancedSecurityWithStandardViaDelegate)):
(TestWebKitAPI::TEST(EnhancedSecurity, LockdownModeTakesPrecedenceOverEnhancedSecurity)):
(TestWebKitAPI::TEST(EnhancedSecurity, EnhancedSecurityRequestedWhenLockdownModeActive)):
(TestWebKitAPI::TEST(EnhancedSecurity, SystemLockdownModeEnablesEnhancedSecurityWhenAPIOptsOut)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm:
(-[TestUIDelegate waitForAlertWithEnhancedSecurity]):
(testAlertWithEnhancedSecurity):

Canonical link: <a href="https://commits.webkit.org/305466@main">https://commits.webkit.org/305466@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a78943089aee8fd7e17d495fc35746fcd0eeffb1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138468 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10833 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49878 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146552 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91443 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/50fc3189-8b7e-4827-a7ac-b7a6376e7ffa) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140342 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11537 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10988 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105952 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77312 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/05397d7f-ae79-4af6-b376-d8bacbb75b44) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141415 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8667 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124131 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86799 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/03af8287-80aa-427e-b5c4-a27d1faaf971) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8254 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6023 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6845 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/130432 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117674 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42330 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149272 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/137057 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10515 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42887 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114352 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10532 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8890 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114690 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29127 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8366 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120417 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/65401 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10563 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38350 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/169742 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10298 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74171 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44248 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10502 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10353 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->