### PR TITLE
[AutoFill Debugging] Support text extraction interactions for nodes in subframes

### DIFF
--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -2584,8 +2584,8 @@ window.UIHelper = class UIHelper {
             })()`, debugText => {
                 if (options.normalize) {
                     debugText = debugText
-                        .replace(/uid=\d+/g, "uid=…")
-                        .replace(/"uid":\d+/g, "\"uid\":\"…\"")
+                        .replace(/uid=((\d+_)+)?(\d+)/g, "uid=…")
+                        .replace(/"uid":\"((\d+_)+)?(\d+)\"/g, "\"uid\":\"…\"")
                         .replace(/\[\d+,\d+;\d+x\d+\]/g, "[…]")
                         .replace(/\t/g, "    ");
                 }

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -195,6 +195,7 @@ struct TraversalContext {
     const TextAndSelectedRangeMap visibleText;
     const WeakHashSet<Node, WeakPtrImplWithEventTargetData> nodesToSkip;
     const std::optional<FloatRect> rectInRootView;
+    const FrameIdentifier frameIdentifier;
     Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>> enclosingBlocks;
     WeakHashMap<Node, unsigned, WeakPtrImplWithEventTargetData> enclosingBlockNumberMap;
     unsigned onlyCollectTextAndLinksCount { 0 };
@@ -814,6 +815,7 @@ static inline void extractRecursive(Node& node, Item& parentItem, TraversalConte
                 { },
                 node.nodeName(),
                 WTF::move(nodeIdentifier),
+                { context.frameIdentifier },
                 eventListeners,
                 WTF::move(ariaAttributes),
                 WTF::move(role),
@@ -835,6 +837,7 @@ static inline void extractRecursive(Node& node, Item& parentItem, TraversalConte
                 { },
                 { },
                 { },
+                { context.frameIdentifier },
                 eventListeners,
                 WTF::move(ariaAttributes),
                 WTF::move(role),
@@ -951,7 +954,8 @@ static Node* nodeFromJSHandle(JSHandleIdentifier identifier)
 
 Item extractItem(Request&& request, LocalFrame& frame)
 {
-    Item root { ContainerType::Root, { }, { }, { }, { }, { }, { }, { }, { }, { }, 0 };
+    auto frameID = frame.frameID();
+    Item root { ContainerType::Root, { }, { }, { }, { }, frameID, { }, { }, { }, { }, { }, 0 };
     RefPtr document = frame.document();
     if (!document)
         return root;
@@ -1008,6 +1012,7 @@ Item extractItem(Request&& request, LocalFrame& frame)
             .visibleText = collectText(*extractionRootNode, includeTextInAutoFilledControls),
             .nodesToSkip = WTF::move(nodesToSkip),
             .rectInRootView = request.collectionRectInRootView,
+            .frameIdentifier = WTF::move(frameID),
             .enclosingBlocks = { },
             .enclosingBlockNumberMap = { },
             .onlyCollectTextAndLinksCount = 0,

--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -188,6 +188,7 @@ struct Item {
     Vector<Item> children;
     String nodeName;
     std::optional<NodeIdentifier> nodeIdentifier;
+    std::optional<FrameIdentifier> frameIdentifier;
     OptionSet<EventListenerCategory> eventListeners;
     HashMap<String, String> ariaAttributes;
     String accessibilityRole;

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.h
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.h
@@ -65,11 +65,12 @@ enum class TextExtractionOutputFormat : uint8_t {
 
 using TextExtractionOptionFlags = OptionSet<TextExtractionOptionFlag>;
 using TextExtractionFilterPromise = NativePromise<String, void>;
-using TextExtractionFilterCallback = Function<Ref<TextExtractionFilterPromise>(const String&, std::optional<WebCore::NodeIdentifier>&&)>;
+using TextExtractionFilterCallback = Function<Ref<TextExtractionFilterPromise>(const String&, std::optional<WebCore::FrameIdentifier>&&, std::optional<WebCore::NodeIdentifier>&&)>;
 
 struct TextExtractionOptions {
     TextExtractionOptions(TextExtractionOptions&& other)
-        : filterCallbacks(WTF::move(other.filterCallbacks))
+        : mainFrameIdentifier(WTF::move(other.mainFrameIdentifier))
+        , filterCallbacks(WTF::move(other.filterCallbacks))
         , nativeMenuItems(WTF::move(other.nativeMenuItems))
         , replacementStrings(WTF::move(other.replacementStrings))
         , version(other.version)
@@ -79,8 +80,9 @@ struct TextExtractionOptions {
     {
     }
 
-    TextExtractionOptions(Vector<TextExtractionFilterCallback>&& filters, Vector<String>&& items, HashMap<String, String>&& replacementStrings, std::optional<TextExtractionVersion> version, TextExtractionOptionFlags flags, TextExtractionOutputFormat outputFormat, TextExtractionURLCache* urlCache = nullptr)
-        : filterCallbacks(WTF::move(filters))
+    TextExtractionOptions(WebCore::FrameIdentifier&& mainFrameIdentifier, Vector<TextExtractionFilterCallback>&& filters, Vector<String>&& items, HashMap<String, String>&& replacementStrings, std::optional<TextExtractionVersion> version, TextExtractionOptionFlags flags, TextExtractionOutputFormat outputFormat, TextExtractionURLCache* urlCache = nullptr)
+        : mainFrameIdentifier(WTF::move(mainFrameIdentifier))
+        , filterCallbacks(WTF::move(filters))
         , nativeMenuItems(WTF::move(items))
         , replacementStrings(WTF::move(replacementStrings))
         , version(version)
@@ -90,6 +92,7 @@ struct TextExtractionOptions {
     {
     }
 
+    WebCore::FrameIdentifier mainFrameIdentifier;
     Vector<TextExtractionFilterCallback> filterCallbacks;
     Vector<String> nativeMenuItems;
     HashMap<String, String> replacementStrings;
@@ -106,5 +109,12 @@ struct TextExtractionResult {
 };
 
 void convertToText(WebCore::TextExtraction::Item&&, TextExtractionOptions&&, CompletionHandler<void(TextExtractionResult&&)>&&);
+
+struct FrameAndNodeIdentifiers {
+    std::optional<WebCore::FrameIdentifier> frameIdentifier;
+    WebCore::NodeIdentifier nodeIdentifier;
+};
+
+std::optional<FrameAndNodeIdentifiers> parseFrameAndNodeIdentifiers(StringView);
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6930,6 +6930,7 @@ header: <WebCore/TextExtractionTypes.h>
     Vector<WebCore::TextExtraction::Item> children;
     String nodeName;
     std::optional<WebCore::NodeIdentifier> nodeIdentifier;
+    std::optional<WebCore::FrameIdentifier> frameIdentifier;
     OptionSet<WebCore::TextExtraction::EventListenerCategory> eventListeners;
     HashMap<String, String> ariaAttributes;
     String accessibilityRole;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -651,7 +651,7 @@ struct PerWebProcessState {
 - (void)_requestTextExtractionInternal:(_WKTextExtractionConfiguration *)configuration completion:(CompletionHandler<void(std::optional<WebCore::TextExtraction::Item>&&)>&&)completion;
 - (void)_requestJSHandleForNodeIdentifier:(NSString *)nodeIdentifier searchText:(NSString *)searchText completionHandler:(void (^)(_WKJSHandle *))completionHandler;
 #if ENABLE(TEXT_EXTRACTION_FILTER)
-- (void)_validateText:(const String&)text inNode:(std::optional<WebCore::NodeIdentifier>&&)nodeIdentifier completionHandler:(CompletionHandler<void(const String&)>&&)completionHandler;
+- (void)_validateText:(const String&)text inFrame:(std::optional<WebCore::FrameIdentifier>&&)frameIdentifier inNode:(std::optional<WebCore::NodeIdentifier>&&)nodeIdentifier completionHandler:(CompletionHandler<void(const String&)>&&)completionHandler;
 #endif
 
 @end

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1211,7 +1211,6 @@
 		A17C48132C98E5C20023F3C7 /* two-paragraph-contenteditable.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4451C751EB8FD7C0020C5DA /* two-paragraph-contenteditable.html */; };
 		A17C48141C98E5C20023F3C9 /* hab.reality in Copy Resources */ = {isa = PBXBuildFile; fileRef = 31727A5329F733D300A7FB2F /* hab.reality */; };
 		A17C48142C98E5C20023F3C7 /* UnitBox.usdz in Copy Resources */ = {isa = PBXBuildFile; fileRef = 31727A5229F733D300A7FB0F /* UnitBox.usdz */; };
-		A17C48141C98E5C20023F3C9 /* hab.reality in Copy Resources */ = {isa = PBXBuildFile; fileRef = 31727A5329F733D300A7FB2F /* hab.reality */; };
 		A17C48152C98E5C20023F3C7 /* video-with-audio-and-web-audio.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD57779B211CE6CE001B371E /* video-with-audio-and-web-audio.html */; };
 		A17C48162C98E5C20023F3C7 /* web-audio-only.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD577798211CDE8F001B371E /* web-audio-only.html */; };
 		A17C48172C98E5C20023F3C7 /* web-authentication-get-assertion-hid-cancel.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 57663DF22357E45D00E85E09 /* web-authentication-get-assertion-hid-cancel.html */; };


### PR DESCRIPTION
#### 574355f8180ee2a8afa3b514627828eac30d251f
<pre>
[AutoFill Debugging] Support text extraction interactions for nodes in subframes
<a href="https://bugs.webkit.org/show_bug.cgi?id=305296">https://bugs.webkit.org/show_bug.cgi?id=305296</a>
<a href="https://rdar.apple.com/167950324">rdar://167950324</a>

Reviewed by Abrar Rahman Protyasha.

Add support for performing and describing `_WKTextExtractionInteraction`s that target nodes in
subframes; see below for more details.

Tests: TextExtractionTests.SubframeInteractions

* LayoutTests/resources/ui-helper.js:
(window.UIHelper.prototype.async requestDebugText):

Adjust this `UIHelper` method to handle both `uid=x_y_z` and `uid=z`.

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractRecursive):
(WebCore::TextExtraction::extractItem):

Plumb a `FrameIdentifier` through each extracted item.

* Source/WebCore/page/text-extraction/TextExtractionTypes.h:
* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::parseFrameAndNodeIdentifiers):

Add a helper method to parse a node ID string into a node ID and optional frame ID.

(WebKit::TextExtractionAggregator::filter):

Plumb an optional frame ID through text filtering codepaths.

(WebKit::TextExtractionAggregator::stringForIdentifiers const):

Add a helper method to return the string representation for a given node ID and (optional) frame ID.

(WebKit::TextExtractionAggregator::filterRecursive):
(WebKit::setCommonJSONProperties):
(WebKit::addJSONTextContent):
(WebKit::populateJSONForItem):
(WebKit::partsForItem):
(WebKit::addPartsForText):
(WebKit::addPartsForItem):
(WebKit::addTextRepresentationRecursive):

Plumb an optional frame ID from each extracted item through text filtering codepaths.

* Source/WebKit/Shared/TextExtractionToStringConversion.h:
(WebKit::TextExtractionOptions::TextExtractionOptions):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _extractDebugTextWithConfigurationWithoutUpdatingFilterRules:assertionScope:completionHandler:]):

Plumb the main frame ID when converting into text conversion codepaths; for identified items where
the frame ID is equal to the main frame, we represent it with `uid=x` rather than the full `x_y_z`.

(-[WKWebView _convertToWebCoreInteraction:]):
(-[WKWebView _performInteraction:completionHandler:]):
(-[WKWebView _describeInteraction:completionHandler:]):
(-[WKWebView _validateText:inFrame:inNode:completionHandler:]):

Instead of only supporting the main frame, parse the frame ID out of the node ID string and send the
IPC to the target frame corresponding to the frame ID.

(-[WKWebView _requestJSHandleForNodeIdentifier:searchText:completionHandler:]):
(toNodeIdentifier): Deleted.
(-[WKWebView _validateText:inNode:completionHandler:]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm:
(TestWebKitAPI::extractNodeIdentifier):
(TestWebKitAPI::addEventListener):
(TestWebKitAPI::(TextExtractionTests, SubframeInteractions)):

Add a test to exercise this change.

Canonical link: <a href="https://commits.webkit.org/305471@main">https://commits.webkit.org/305471@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab0a330c12d0f52472e862e021c06a5656d9e2ed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138424 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10789 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49834 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146508 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91399 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5e6d0866-7aaa-4a0c-81c2-69bebd794df9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140298 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11493 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10943 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105910 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77262 "5 flakes 2 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6c255725-c963-4aa3-a39a-648b40223a02) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141371 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8626 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124092 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86758 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8213 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5985 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6799 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117633 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42291 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149226 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10471 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42848 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114314 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10488 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8853 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114651 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29132 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8284 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120378 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65349 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10519 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38311 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10253 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74115 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10458 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10309 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->