### PR TITLE
[SVG] Don't early-out in RenderSVGText::nodeAtFloatPoint

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/elementsFromPoint-svg-text-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/elementsFromPoint-svg-text-expected.txt
@@ -4,7 +4,7 @@ Some text
 Text underText over
 
 PASS elementsFromPoint for a point inside a <text>
-FAIL elementsFromPoint for a point inside a <tspan> nested in a <text> without content assert_equals: document.elementsFromPoint(125,185) expected "tspan#tspan1, svg#svg, DIV#sandbox, BODY, HTML" but got "tspan#tspan1, text#text2, svg#svg, DIV#sandbox, BODY, HTML"
-FAIL elementsFromPoint for a point inside a <textPath> nested in a <text> without content assert_equals: document.elementsFromPoint(125,245) expected "textPath#textpath1, svg#svg, DIV#sandbox, BODY, HTML" but got "textPath#textpath1, text#text3, svg#svg, DIV#sandbox, BODY, HTML"
+PASS elementsFromPoint for a point inside a <tspan> nested in a <text> without content
+PASS elementsFromPoint for a point inside a <textPath> nested in a <text> without content
 PASS elementsFromPoint for a point inside an overlapping <tspan> nested in a <text>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/interact/scripted/text-hittest-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/interact/scripted/text-hittest-002-expected.txt
@@ -1,5 +1,4 @@
 MMMMMM
 
-FAIL elementFromPoint(...) on <svg:text> with fill=none but fill=black descendants assert_equals: element @ (175, 25) expected Element node <tspan fill="black">MM</tspan> but got Element node <svg width="400" height="400">
-  <text x="50" y="50" font...
+PASS elementFromPoint(...) on <svg:text> with fill=none but fill=black descendants
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/interact/scripted/text-hittest-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/interact/scripted/text-hittest-003-expected.txt
@@ -1,5 +1,4 @@
 MM
 
-FAIL elementFromPoint(...) on visibility=hidden <svg:text> with visible descendants assert_equals: element @ (175, 25) expected Element node <tspan visibility="visible">MM</tspan> but got Element node <svg width="400" height="400">
-  <text x="50" y="50" font...
+PASS elementFromPoint(...) on visibility=hidden <svg:text> with visible descendants
 

--- a/Source/WebCore/rendering/svg/RenderSVGText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGText.cpp
@@ -655,24 +655,24 @@ bool RenderSVGText::nodeAtFloatPoint(const HitTestRequest& request, HitTestResul
 {
     ASSERT(!document().settings().layerBasedSVGEngineEnabled());
 
-    PointerEventsHitRules hitRules(PointerEventsHitRules::HitTestingTargetType::SVGText, request, usedPointerEvents());
-    if (request.isVisibleForStyle(style()) || !hitRules.requireVisible) {
-        if ((hitRules.canHitStroke && (!style().stroke().isNone() || !hitRules.requireStroke))
-            || (hitRules.canHitFill && (!style().fill().isNone() || !hitRules.requireFill))) {
-            static NeverDestroyed<SVGVisitedRendererTracking::VisitedSet> s_visitedSet;
+    // We only draw in the foreground phase, so we only hit-test then.
+    if (hitTestAction != HitTestForeground)
+        return false;
 
-            SVGVisitedRendererTracking recursionTracking(s_visitedSet);
-            if (recursionTracking.isVisiting(*this))
-                return false;
+    FloatPoint localPoint = valueOrDefault(localToParentTransform().inverse()).mapPoint(pointInParent);
+    if (!SVGRenderSupport::pointInClippingArea(*this, localPoint))
+        return false;
 
-            SVGVisitedRendererTracking::Scope recursionScope(recursionTracking, *this);
+    HitTestLocation hitTestLocation(roundedIntPoint(localPoint));
+    if (RenderBlock::nodeAtPoint(request, result, hitTestLocation, LayoutPoint(), hitTestAction))
+        return true;
 
-            FloatPoint localPoint = valueOrDefault(localToParentTransform().inverse()).mapPoint(pointInParent);
-            if (!SVGRenderSupport::pointInClippingArea(*this, localPoint))
-                return false;
-
-            HitTestLocation hitTestLocation(LayoutPoint(flooredIntPoint(localPoint)));
-            return RenderBlock::nodeAtPoint(request, result, hitTestLocation, LayoutPoint(), hitTestAction);
+    // Consider the bounding box if requested.
+    if (style().usedPointerEvents() == PointerEvents::BoundingBox) {
+        if (isObjectBoundingBoxValid() && objectBoundingBox().contains(localPoint)) {
+            updateHitTestResult(result, LayoutPoint(flooredIntPoint(localPoint)));
+            if (result.addNodeToListBasedTestResult(protect(nodeForHitTest()).get(), request, hitTestLocation) == HitTestProgress::Stop)
+                return true;
         }
     }
 


### PR DESCRIPTION
#### 038395c2a6de4732b1680acfa458a84304d43243
<pre>
[SVG] Don&apos;t early-out in RenderSVGText::nodeAtFloatPoint
<a href="https://bugs.webkit.org/show_bug.cgi?id=305298">https://bugs.webkit.org/show_bug.cgi?id=305298</a>
<a href="https://rdar.apple.com/167953495">rdar://167953495</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/90a5f0bd2096695800bcd2ec0bb6f1eed4d8a7eb">https://chromium.googlesource.com/chromium/src.git/+/90a5f0bd2096695800bcd2ec0bb6f1eed4d8a7eb</a>

Since &lt;text&gt; can have descendants that may both differ in visibility as
well as fill/stroke, we can&apos;t evaluate pointer-events in RenderSVGText,
but should rather let RenderBlock (and SVGInlineTextBox et al) handle
the hit query. This makes RenderSVGText somewhat similar to the same
method on RenderSVGContainer.

* Source/WebCore/rendering/svg/RenderSVGText.cpp:
(WebCore::RenderSVGText::nodeAtFloatPoint):

&gt; Progressions:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/elementsFromPoint-svg-text-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/interact/scripted/text-hittest-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/interact/scripted/text-hittest-003-expected.txt:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/038395c2a6de4732b1680acfa458a84304d43243

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162777 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36257 "Hash 038395c2 for PR 56427 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29406 "Hash 038395c2 for PR 56427 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171715 "Hash 038395c2 for PR 56427 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119223 "Hash 038395c2 for PR 56427 does not build (failure)") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/84dbf9b0-327d-495f-ba65-0ae06d516115) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164646 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36357 "Hash 038395c2 for PR 56427 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36257 "Hash 038395c2 for PR 56427 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/171715 "Hash 038395c2 for PR 56427 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/119223 "Hash 038395c2 for PR 56427 does not build (failure)") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/05ab4ecb-069d-46fd-a183-162136c51f81) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165736 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/36357 "Hash 038395c2 for PR 56427 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/29406 "Hash 038395c2 for PR 56427 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/171715 "Hash 038395c2 for PR 56427 does not build (failure)") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a152c66c-9223-42b1-940e-9f3d2346e129) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/36357 "Hash 038395c2 for PR 56427 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/36257 "Hash 038395c2 for PR 56427 does not build (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19415 "Hash 038395c2 for PR 56427 does not build (failure)") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/36357 "Hash 038395c2 for PR 56427 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/29406 "Hash 038395c2 for PR 56427 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174219 "Hash 038395c2 for PR 56427 does not build (failure)") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21711 "Failed to build and analyze WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/29406 "Hash 038395c2 for PR 56427 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/174219 "Hash 038395c2 for PR 56427 does not build (failure)") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35927 "Hash 038395c2 for PR 56427 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/36257 "Hash 038395c2 for PR 56427 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/174219 "Hash 038395c2 for PR 56427 does not build (failure)") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35911 "Hash 038395c2 for PR 56427 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/29406 "Hash 038395c2 for PR 56427 does not build (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98326 "Hash 038395c2 for PR 56427 does not build (failure)") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/35911 "Hash 038395c2 for PR 56427 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/29406 "Hash 038395c2 for PR 56427 does not build (failure)") | | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35421 "Hash 038395c2 for PR 56427 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/103388 "Failed to build and analyze WebKit") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34922 "Hash 038395c2 for PR 56427 does not build (failure)") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35167 "Hash 038395c2 for PR 56427 does not build (failure)") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35070 "Hash 038395c2 for PR 56427 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->