### PR TITLE
Update compileSelector() to take in CSSSelector by reference

### DIFF
--- a/Source/WebCore/cssjit/SelectorCompiler.h
+++ b/Source/WebCore/cssjit/SelectorCompiler.h
@@ -47,7 +47,7 @@ enum class SelectorContext {
     QuerySelector
 };
 
-void compileSelector(CompiledSelector&, const CSSSelector*, SelectorContext);
+void compileSelector(CompiledSelector&, const CSSSelector&, SelectorContext);
 
 inline unsigned ruleCollectorSimpleSelectorChecker(CompiledSelector& compiledSelector, const Element* element, unsigned* value)
 {

--- a/Source/WebCore/dom/SelectorQuery.h
+++ b/Source/WebCore/dom/SelectorQuery.h
@@ -59,7 +59,7 @@ public:
 
 private:
     struct SelectorData {
-        const CSSSelector* selector;
+        const CSSSelector& selector;
 #if ENABLE(CSS_SELECTOR_JIT)
         mutable CompiledSelector compiledSelector { };
 #endif

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -525,7 +525,7 @@ inline bool ElementRuleCollector::ruleMatches(const RuleData& ruleData, unsigned
 
     if (compilerEnabled) {
         if (compiledSelector.status == SelectorCompilationStatus::NotCompiled)
-            SelectorCompiler::compileSelector(compiledSelector, &ruleData.selector(), SelectorCompiler::SelectorContext::RuleCollector);
+            SelectorCompiler::compileSelector(compiledSelector, ruleData.selector(), SelectorCompiler::SelectorContext::RuleCollector);
 
         if (compiledSelector.status == SelectorCompilationStatus::SimpleSelectorChecker) {
             compiledSelector.wasUsed();


### PR DESCRIPTION
#### daee78a99c7070edeefd4a82514384900570513d
<pre>
Update compileSelector() to take in CSSSelector by reference
<a href="https://bugs.webkit.org/show_bug.cgi?id=305301">https://bugs.webkit.org/show_bug.cgi?id=305301</a>

Reviewed by Darin Adler.

Update compileSelector() to take in CSSSelector by reference instead of
raw pointer, given that it cannot be null.

* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::compileSelector):
(WebCore::SelectorCompiler::addNthChildType):
(WebCore::SelectorCompiler::addPseudoClassType):
(WebCore::SelectorCompiler::SelectorCodeGenerator::SelectorCodeGenerator):
(WebCore::SelectorCompiler::constructFragmentsInternal):
(WebCore::SelectorCompiler::constructFragments):
(WebCore::SelectorCompiler::SelectorCodeGenerator::compile):
* Source/WebCore/cssjit/SelectorCompiler.h:
* Source/WebCore/dom/SelectorQuery.cpp:
(WebCore::SelectorDataList::SelectorDataList):
(WebCore::SelectorDataList::selectorMatches const):
(WebCore::SelectorDataList::selectorClosest const):
(WebCore::SelectorDataList::executeSingleTagNameSelectorData const):
(WebCore::SelectorDataList::executeSingleClassNameSelectorData const):
(WebCore::SelectorDataList::classNameToMatch const):
(WebCore::SelectorDataList::executeSingleAttributeExactSelectorData const):
(WebCore::SelectorDataList::execute const):
* Source/WebCore/dom/SelectorQuery.h:
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::ruleMatches):

Canonical link: <a href="https://commits.webkit.org/305436@main">https://commits.webkit.org/305436@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/056fb25860482a15cc60b56a51950098caca0896

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138435 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10800 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49845 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146519 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91410 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/79c6864c-18a2-42c8-8a47-2c80acba17b7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140309 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11504 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10954 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105921 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/77272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fa73b9f3-c71a-484a-aba4-329b1bf9f4aa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141382 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8636 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124102 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86769 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3e1b27a1-493b-4f2b-a2f3-4b489102a6e5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8223 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5994 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6811 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117643 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42301 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149239 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10482 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42858 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114321 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10499 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8862 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114663 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29109 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8294 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120388 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65361 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10530 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38321 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10264 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74128 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10469 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10320 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->