### PR TITLE
Avoid heap-allocating PseudoStyleCache since it is a HashMap

### DIFF
--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -131,10 +131,7 @@ RenderStyle RenderStyle::replace(RenderStyle&& newStyle)
 
 void RenderStyle::copyPseudoElementsFrom(const RenderStyle& other)
 {
-    if (!other.m_computedStyle.m_cachedPseudoStyles)
-        return;
-
-    for (auto& [key, pseudoElementStyle] : other.m_computedStyle.m_cachedPseudoStyles->styles) {
+    for (auto& [key, pseudoElementStyle] : other.m_computedStyle.cachedPseudoStyles()) {
         if (!pseudoElementStyle) {
             ASSERT_NOT_REACHED();
             continue;

--- a/Source/WebCore/rendering/style/RenderStyleBase.h
+++ b/Source/WebCore/rendering/style/RenderStyleBase.h
@@ -165,8 +165,8 @@ public:
     RenderStyle* getCachedPseudoStyle(const Style::PseudoElementIdentifier&) const;
     RenderStyle* addCachedPseudoStyle(std::unique_ptr<RenderStyle>);
 
-    bool hasCachedPseudoStyles() const { return m_computedStyle.m_cachedPseudoStyles && m_computedStyle.m_cachedPseudoStyles->styles.size(); }
-    const Style::PseudoStyleCache* cachedPseudoStyles() const { return m_computedStyle.m_cachedPseudoStyles.get(); }
+    bool hasCachedPseudoStyles() const { return m_computedStyle.hasCachedPseudoStyles(); }
+    const Style::PseudoStyleCache& cachedPseudoStyles() const { return m_computedStyle.cachedPseudoStyles(); }
 
     // MARK: - Custom properties
 

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -393,12 +393,7 @@ void RenderTreeUpdater::updateAfterDescendants(Element& element, const Style::El
 static bool pseudoStyleCacheIsInvalid(RenderElement* renderer, RenderStyle* newStyle)
 {
     const auto& currentStyle = renderer->style();
-
-    const auto* pseudoStyleCache = currentStyle.cachedPseudoStyles();
-    if (!pseudoStyleCache)
-        return false;
-
-    for (auto& [key, value] : pseudoStyleCache->styles) {
+    for (auto& [key, value] : currentStyle.cachedPseudoStyles()) {
         auto newPseudoStyle = renderer->getUncachedPseudoStyle(*value->pseudoElementIdentifier(), newStyle, newStyle);
         if (!newPseudoStyle)
             return true;

--- a/Source/WebCore/style/computed/StyleComputedStyle.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyle.cpp
@@ -58,7 +58,7 @@ struct SameSizeAsComputedStyle : CanMakeCheckedPtr<SameSizeAsComputedStyle> {
     struct InheritedFlags {
         unsigned m_bitfields[2];
     } m_inheritedFlags;
-    void* pseudos;
+    HashMap<PseudoElementIdentifier, std::unique_ptr<RenderStyle>> pseudos;
     void* dataRefSvgStyle;
 
 #if ASSERT_ENABLED || ENABLE(SECURITY_ASSERTIONS)

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.cpp
@@ -65,7 +65,6 @@ static_assert(!(static_cast<unsigned>(maxTextTransformValue) >> TextTransformBit
 // Value zero is used to indicate no pseudo-element.
 static_assert(!((enumToUnderlyingType(PseudoElementType::HighestEnumValue) + 1) >> PseudoElementTypeBits));
 
-DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(PseudoStyleCache);
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(ComputedStyleBase);
 
 ComputedStyleBase::~ComputedStyleBase()
@@ -103,10 +102,7 @@ std::optional<PseudoElementIdentifier> ComputedStyleBase::pseudoElementIdentifie
 
 RenderStyle* ComputedStyleBase::getCachedPseudoStyle(const PseudoElementIdentifier& pseudoElementIdentifier) const
 {
-    if (!m_cachedPseudoStyles)
-        return nullptr;
-
-    return m_cachedPseudoStyles->styles.get(pseudoElementIdentifier);
+    return m_cachedPseudoStyles.get(pseudoElementIdentifier);
 }
 
 RenderStyle* ComputedStyleBase::addCachedPseudoStyle(std::unique_ptr<RenderStyle> pseudo)
@@ -117,12 +113,7 @@ RenderStyle* ComputedStyleBase::addCachedPseudoStyle(std::unique_ptr<RenderStyle
     ASSERT(pseudo->pseudoElementType());
 
     auto* result = pseudo.get();
-
-    if (!m_cachedPseudoStyles)
-        m_cachedPseudoStyles = makeUnique<PseudoStyleCache>();
-
-    m_cachedPseudoStyles->styles.add(*result->pseudoElementIdentifier(), WTF::move(pseudo));
-
+    m_cachedPseudoStyles.add(*result->pseudoElementIdentifier(), WTF::move(pseudo));
     return result;
 }
 

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.h
@@ -444,11 +444,7 @@ constexpr auto TextDecorationLineBits = 5;
 constexpr auto TextTransformBits = 6;
 constexpr auto PseudoElementTypeBits = 5;
 
-DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(PseudoStyleCache);
-struct PseudoStyleCache {
-    WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(PseudoStyleCache, PseudoStyleCache);
-    HashMap<PseudoElementIdentifier, std::unique_ptr<RenderStyle>> styles;
-};
+using PseudoStyleCache = HashMap<PseudoElementIdentifier, std::unique_ptr<RenderStyle>>;
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(ComputedStyleBase);
 class ComputedStyleBase : public CanMakeCheckedPtr<ComputedStyleBase, WTF::DefaultedOperatorEqual::No, WTF::CheckedPtrDeleteCheckException::Yes> {
@@ -593,8 +589,8 @@ public:
     RenderStyle* getCachedPseudoStyle(const PseudoElementIdentifier&) const;
     RenderStyle* addCachedPseudoStyle(std::unique_ptr<RenderStyle>);
 
-    bool hasCachedPseudoStyles() const { return m_cachedPseudoStyles && m_cachedPseudoStyles->styles.size(); }
-    const PseudoStyleCache* cachedPseudoStyles() const { return m_cachedPseudoStyles.get(); }
+    bool hasCachedPseudoStyles() const { return !m_cachedPseudoStyles.isEmpty(); }
+    const PseudoStyleCache& cachedPseudoStyles() const { return m_cachedPseudoStyles; }
 
     // MARK: - Custom properties
 
@@ -862,7 +858,7 @@ protected:
     DataRef<SVGData> m_svgData;
 
     // Associated pseudo styles
-    std::unique_ptr<PseudoStyleCache> m_cachedPseudoStyles;
+    PseudoStyleCache m_cachedPseudoStyles;
 
 #if ASSERT_ENABLED || ENABLE(SECURITY_ASSERTIONS)
     bool m_deletionHasBegun { false };


### PR DESCRIPTION
#### 5809a27bdb93d2b3ee4e580653ec42c33e7722d1
<pre>
Avoid heap-allocating PseudoStyleCache since it is a HashMap
<a href="https://bugs.webkit.org/show_bug.cgi?id=305302">https://bugs.webkit.org/show_bug.cgi?id=305302</a>

Reviewed by Darin Adler.

Avoid heap-allocating PseudoStyleCache since it is a HashMap and a
HashMap is already essentially a pointer. This avoid unnecessary heap
allocation and extra pointer dereference.

* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::copyPseudoElementsFrom):
* Source/WebCore/rendering/style/RenderStyleBase.h:
(WebCore::RenderStyleBase::hasCachedPseudoStyles const):
(WebCore::RenderStyleBase::cachedPseudoStyles const):
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::pseudoStyleCacheIsInvalid):
* Source/WebCore/style/computed/StyleComputedStyle.cpp:
* Source/WebCore/style/computed/StyleComputedStyleBase.cpp:
(WebCore::Style::ComputedStyleBase::getCachedPseudoStyle const):
(WebCore::Style::ComputedStyleBase::addCachedPseudoStyle):
* Source/WebCore/style/computed/StyleComputedStyleBase.h:
(WebCore::Style::ComputedStyleBase::hasCachedPseudoStyles const):
(WebCore::Style::ComputedStyleBase::cachedPseudoStyles const):

Canonical link: <a href="https://commits.webkit.org/305491@main">https://commits.webkit.org/305491@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/696a383cfbe78e6b2c143b61e3f50143643898f0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138537 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10902 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/146641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91512 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d149f5ce-f71e-43cc-a200-53a4b6ef5f07) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140411 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11606 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11057 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/146641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77344 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/43fed4e3-e408-417f-b9b9-e96b0628c4b6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141484 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8728 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124185 "Found 1 new API test failure: TestWebKitAPI.ContextMenuTests.ContextMenuElementInfoContainsQRCodePayloadString (failure)") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/146641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/00e84947-7e12-49e6-93c0-e9b5e91d9dc2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8317 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6082 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionDataRecord.GetDataRecords (failure)") | [  ~~🛠 wpe-cairo-libwebrtc~~](https://ews-build.webkit.org/#/builders/166/builds/6937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117733 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/149421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10584 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/15 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/149421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10601 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8955 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/149421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/29152 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8479 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120473 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65474 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21337 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10633 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10367 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74264 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10571 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10422 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->