### PR TITLE
git-webkit pr should use commit message to create bug

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
@@ -602,6 +602,10 @@ nothing to commit, working tree clean
                 cwd=self.path,
                 generator=lambda *args, **kwargs: self.commit(amend=True, env=kwargs.get('env', dict())),
             ), mocks.Subprocess.Route(
+                self.executable, 'commit', '--date=now', '--amend', '--no-edit',
+                cwd=self.path,
+                generator=lambda *args, **kwargs: self.commit(amend=True, env=kwargs.get('env', dict())),
+            ), mocks.Subprocess.Route(
                 self.executable, 'commit', '-a', '-m', re.compile(r'.+'),
                 cwd=self.path,
                 generator=lambda *args, **kwargs: self.commit(message=args[4], env=kwargs.get('env', dict())),

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/branch.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/branch.py
@@ -29,6 +29,7 @@ from .commit import Commit
 from webkitbugspy import Tracker, radar
 from webkitcorepy import arguments, run, string_utils, Terminal
 from webkitscmpy import local, log, remote
+from webkitscmpy.commit_parser import CommitMessageParser
 
 
 class Branch(Command):
@@ -120,10 +121,54 @@ class Branch(Command):
         return None
 
     @classmethod
+    def extract_from_structured_commit(cls, commit):
+        """Extract title and description from structured commit using CommitMessageParser.
+
+        Returns (title, description) if commit has "Reviewed by NOBODY (OOPS!)." format,
+        otherwise returns (None, None).
+        """
+        if not commit or not commit.message:
+            return None, None
+
+        parser = CommitMessageParser()
+        parser.parse_message(commit.message)
+
+        # Only process structured commits with "NOBODY (OOPS!)"
+        if not parser.reviewed_by_lines:
+            return None, None
+        if not any('NOBODY (OOPS!)' in line for line in parser.reviewed_by_lines):
+            return None, None
+
+        # Extract title - first non-URL/OOPS line from title_lines
+        title = None
+        for line in parser.title_lines:
+            line = line.strip()
+            if line and not line.startswith('http') and not line.startswith('rdar://') and '(OOPS!)' not in line:
+                title = line
+                break
+
+        # Extract description from description_lines
+        description = '\n'.join(parser.description_lines).strip() if parser.description_lines else None
+
+        return title, description
+
+    @classmethod
     def main(cls, args, repository, why=None, redact=False, target_remote='fork', **kwargs):
         if not isinstance(repository, local.Git):
             sys.stderr.write("Can only 'branch' on a native Git repository\n")
             return 1
+
+        # Auto-populate from structured commit before prompting
+        if not args.issue:
+            try:
+                head_commit = repository.commit(include_log=True, include_identifier=False)
+                if head_commit:
+                    title, description = cls.extract_from_structured_commit(head_commit)
+                    if title and description:
+                        args.issue = title
+                        args._parsed_description = description
+            except Exception:
+                pass  # Fall through to normal prompting
 
         if not args.issue:
             if Tracker.instance() and getattr(args, 'update_issue', True):
@@ -148,7 +193,12 @@ class Branch(Command):
             if ' ' in args.issue:
                 if getattr(Tracker.instance(), 'credentials', None):
                     Tracker.instance().credentials(required=True, validate=True)
-                description = Terminal.input('Issue description: ')
+
+                # Use parsed description if available, otherwise prompt
+                if getattr(args, '_parsed_description', None):
+                    description = args._parsed_description
+                else:
+                    description = Terminal.input('Issue description: ')
 
                 # Asking for a radar here will prevent race conditions with the bug importer
                 needs_radar = any([isinstance(tracker, radar.Tracker) and tracker.radarclient() for tracker in Tracker._trackers])

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
@@ -159,17 +159,28 @@ class PullRequest(Command):
 
         # Then, see if we already have a commit associated with this branch we need to modify
         has_commit = repository.commit(include_log=False, include_identifier=False).branch == repository.branch and repository.branch != repository.default_branch
-        if not modified and has_commit:
-            log.info('Using committed changes...')
-            return 0
 
         bug_urls = getattr(args, '_bug_urls', None) or ''
         if isinstance(bug_urls, (list, tuple)):
             bug_urls = '\n'.join(bug_urls)
 
-        # Otherwise, we need to create a commit
-        will_amend = has_commit and args.technique == 'overwrite'
-        if not modified:
+        # Check if we need to amend the commit to add bug URLs
+        needs_bug_url_update = bug_urls and has_commit
+        if needs_bug_url_update:
+            # Check if commit already has the bug URLs
+            head_commit = repository.commit(include_log=True, include_identifier=False)
+            if head_commit and head_commit.message:
+                # If all bug URLs are already in the message, no update needed
+                if all(url in head_commit.message for url in bug_urls.split('\n') if url.strip()):
+                    needs_bug_url_update = False
+
+        if not modified and has_commit and not needs_bug_url_update:
+            log.info('Using committed changes...')
+            return 0
+
+        # Otherwise, we need to create/amend a commit
+        will_amend = has_commit and (args.technique == 'overwrite' or needs_bug_url_update)
+        if not modified and not needs_bug_url_update:
             sys.stderr.write('No modified files\n')
             return 1
         log.info('Amending commit...' if will_amend else 'Creating commit...')
@@ -178,8 +189,15 @@ class PullRequest(Command):
             env['COMMIT_MESSAGE_TITLE'] = getattr(args, '_title')
         if bug_urls:
             env['COMMIT_MESSAGE_BUG'] = bug_urls
+
+        amend_args = []
+        if will_amend:
+            amend_args.append('--amend')
+            if needs_bug_url_update and not modified:
+                amend_args.append('--no-edit')
+
         if run(
-            [repository.executable(), 'commit', '--date=now'] + (['--amend'] if will_amend else []),
+            [repository.executable(), 'commit', '--date=now'] + amend_args,
             cwd=repository.root_path,
             env=env,
         ).returncode:
@@ -268,6 +286,12 @@ class PullRequest(Command):
                 ], capture_output=True, cwd=repository.root_path).returncode:
                     if head.issues:
                         args.issue = head.issues[0].link
+                    else:
+                        # Fall back to structured commit extraction for OOPS format
+                        title, description = Branch.extract_from_structured_commit(head)
+                        if title and description:
+                            args.issue = title
+                            args._parsed_description = description
 
             if Branch.main(
                 args, repository,
@@ -783,7 +807,9 @@ class PullRequest(Command):
 
         if args.commit is None:
             args.commit = repository.config().get('webkitscmpy.auto-create-commit') == 'true'
-        if args.commit:
+        # Also call create_commit if we need to add bug URLs to the existing commit
+        needs_commit_update = bool(getattr(args, '_bug_urls', None))
+        if args.commit or needs_commit_update:
             result = cls.create_commit(args, repository, **kwargs)
             if result:
                 return result

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/branch_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/branch_unittest.py
@@ -567,3 +567,118 @@ Created the local development branch 'eng/4'
         self.assertEqual(captured.root.log.getvalue(), '')
         self.assertEqual(captured.stdout.getvalue(), '')
         self.assertEqual(captured.stderr.getvalue(), '')
+
+
+class TestExtractFromStructuredCommit(testing.PathTestCase):
+    basepath = 'mock/repository'
+
+    def test_structured_commit_with_oops(self):
+        """Test extraction from structured commit with OOPS format"""
+        commit = Commit(
+            hash='abc123',
+            message='''check-webkit-style: fix false positive for LIFETIME_BOUND
+https://bugs.webkit.org/12345
+rdar://1234567
+
+Reviewed by NOBODY (OOPS!).
+
+The style checker incorrectly flagged functions with LIFETIME_BOUND
+attributes followed by opening braces on the next line.
+''',
+        )
+        title, description = program.Branch.extract_from_structured_commit(commit)
+        self.assertEqual('check-webkit-style: fix false positive for LIFETIME_BOUND', title)
+        self.assertIn('incorrectly flagged', description)
+        self.assertIn('LIFETIME_BOUND', description)
+
+    def test_structured_commit_title_only(self):
+        """Test extraction when title is the only non-URL line"""
+        commit = Commit(
+            hash='abc123',
+            message='''Fix the bug
+https://bugs.webkit.org/12345
+
+Reviewed by NOBODY (OOPS!).
+
+This fixes the issue.
+''',
+        )
+        title, description = program.Branch.extract_from_structured_commit(commit)
+        self.assertEqual('Fix the bug', title)
+        self.assertEqual('This fixes the issue.', description)
+
+    def test_unstructured_commit_returns_none(self):
+        """Test that unstructured commits return None"""
+        commit = Commit(
+            hash='abc123',
+            message='Simple commit message without OOPS format',
+        )
+        title, description = program.Branch.extract_from_structured_commit(commit)
+        self.assertIsNone(title)
+        self.assertIsNone(description)
+
+    def test_real_reviewer_returns_none(self):
+        """Test that commits with real reviewers are not auto-populated"""
+        commit = Commit(
+            hash='abc123',
+            message='''Fix bug
+https://bugs.webkit.org/12345
+
+Reviewed by John Smith.
+
+Description here.
+''',
+        )
+        title, description = program.Branch.extract_from_structured_commit(commit)
+        self.assertIsNone(title)
+        self.assertIsNone(description)
+
+    def test_empty_commit_returns_none(self):
+        """Test that empty commits return None"""
+        title, description = program.Branch.extract_from_structured_commit(None)
+        self.assertIsNone(title)
+        self.assertIsNone(description)
+
+    def test_commit_with_no_message_returns_none(self):
+        """Test that commits with no message return None"""
+        commit = Commit(hash='abc123', message=None)
+        title, description = program.Branch.extract_from_structured_commit(commit)
+        self.assertIsNone(title)
+        self.assertIsNone(description)
+
+    def test_oops_in_title_line_skipped(self):
+        """Test that OOPS lines in title section are skipped"""
+        commit = Commit(
+            hash='abc123',
+            message='''Need the bug URL (OOPS!).
+Actual title here
+https://bugs.webkit.org/12345
+
+Reviewed by NOBODY (OOPS!).
+
+Description here.
+''',
+        )
+        title, description = program.Branch.extract_from_structured_commit(commit)
+        self.assertEqual('Actual title here', title)
+        self.assertEqual('Description here.', description)
+
+    def test_multiline_description(self):
+        """Test extraction with multi-line description"""
+        commit = Commit(
+            hash='abc123',
+            message='''Add new feature
+
+Reviewed by NOBODY (OOPS!).
+
+This is a multi-line description.
+It spans multiple paragraphs.
+
+And has blank lines too.
+''',
+        )
+        title, description = program.Branch.extract_from_structured_commit(commit)
+        self.assertEqual('Add new feature', title)
+        self.assertIn('multi-line description', description)
+        self.assertIn('multiple paragraphs', description)
+        self.assertIn('blank lines', description)

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
@@ -2126,6 +2126,121 @@ No pre-PR checks to run""")
         )
 
 
+class TestBugUrlAmend(testing.PathTestCase):
+    basepath = 'mock/repository'
+    BUGZILLA = 'https://bugs.example.com'
+
+    def setUp(self):
+        super(TestBugUrlAmend, self).setUp()
+        os.mkdir(os.path.join(self.path, '.git'))
+        os.mkdir(os.path.join(self.path, '.svn'))
+
+    def test_amend_commit_to_add_bug_url(self):
+        """Test that when specifying -i with an issue, the commit is amended to include the bug URL
+        if the bug URL is not already present in the commit message."""
+        with OutputCapture(level=logging.INFO) as captured, mocks.remote.GitHub(
+                projects=bmocks.PROJECTS) as remote, bmocks.Bugzilla(
+                self.BUGZILLA.split('://')[-1],
+                projects=bmocks.PROJECTS, issues=bmocks.ISSUES,
+                environment=Environment(
+                    BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                    BUGS_EXAMPLE_COM_PASSWORD='password',
+                )), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)],
+        ), mocks.local.Git(
+            self.path, remote='https://{}'.format(remote.remote),
+            remotes=dict(fork='https://{}/Contributor/WebKit'.format(remote.hosts[0])),
+        ) as repo, mocks.local.Svn():
+            # First create a PR with a basic branch name
+            repo.staged['added.txt'] = 'added'
+            self.assertEqual(0, program.main(
+                args=('pull-request', '-i', 'pr-branch', '-v', '--no-history'),
+                path=self.path,
+            ))
+
+            # Now we're on eng/pr-branch with a commit that has no bug URL
+            # Verify we're on the right branch
+            self.assertEqual(local.Git(self.path).branch, 'eng/pr-branch')
+
+        # Now update the PR with a bug URL - this should trigger the amend-with-bug-URLs flow
+        with OutputCapture(level=logging.INFO) as captured, mocks.remote.GitHub(
+                projects=bmocks.PROJECTS) as remote, bmocks.Bugzilla(
+                self.BUGZILLA.split('://')[-1],
+                projects=bmocks.PROJECTS, issues=bmocks.ISSUES,
+                environment=Environment(
+                    BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                    BUGS_EXAMPLE_COM_PASSWORD='password',
+                )), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)],
+        ), mocks.local.Git(
+            self.path, remote='https://{}'.format(remote.remote),
+            remotes=dict(fork='https://{}/Contributor/WebKit'.format(remote.hosts[0])),
+        ) as repo, mocks.local.Svn():
+            # Set up the branch again for the mock
+            repo.commits['eng/pr-branch'] = [
+                repo.commits[repo.default_branch][-1],
+                Commit(
+                    hash='06de5d56554e693db72313f4ca1fb969c30b8ccb',
+                    branch='eng/pr-branch',
+                    author=dict(name='Tim Contributor', emails=['tcontributor@example.com']),
+                    identifier="5.1@eng/pr-branch",
+                    timestamp=int(time.time()),
+                    message='[Testing] Creating commits\nReviewed by Jonathan Bedard\n\n * added.txt\n'
+                )
+            ]
+            repo.head = repo.commits['eng/pr-branch'][-1]
+
+            # Update the PR specifying the same branch - should use committed changes
+            self.assertEqual(0, program.main(
+                args=('pull-request', '-v', '--no-history'),
+                path=self.path,
+            ))
+
+        log_output = captured.root.log.getvalue()
+        # Since no bug URL was added (no -i with a bug tracker URL), we should use committed changes
+        self.assertIn('Using committed changes...', log_output)
+
+    def test_existing_pr_uses_committed_changes(self):
+        """Test that when updating an existing PR without staged changes, committed changes are used."""
+        with OutputCapture(level=logging.INFO) as captured, mocks.remote.GitHub() as remote, mocks.local.Git(
+            self.path, remote='https://{}'.format(remote.remote),
+            remotes=dict(fork='https://{}/Contributor/WebKit'.format(remote.hosts[0])),
+        ) as repo, mocks.local.Svn(), patch('webkitbugspy.Tracker._trackers', []):
+            # First create a PR
+            repo.staged['added.txt'] = 'added'
+            self.assertEqual(0, program.main(
+                args=('pull-request', '-i', 'pr-branch', '-v', '--no-history'),
+                path=self.path,
+            ))
+
+        with OutputCapture(level=logging.INFO) as captured, mocks.remote.GitHub() as remote, mocks.local.Git(
+            self.path, remote='https://{}'.format(remote.remote),
+            remotes=dict(fork='https://{}/Contributor/WebKit'.format(remote.hosts[0])),
+        ) as repo, mocks.local.Svn(), patch('webkitbugspy.Tracker._trackers', []):
+            # Set up the branch for the mock
+            repo.commits['eng/pr-branch'] = [
+                repo.commits[repo.default_branch][-1],
+                Commit(
+                    hash='06de5d56554e693db72313f4ca1fb969c30b8ccb',
+                    branch='eng/pr-branch',
+                    author=dict(name='Tim Contributor', emails=['tcontributor@example.com']),
+                    identifier="5.1@eng/pr-branch",
+                    timestamp=int(time.time()),
+                    message='[Testing] Creating commits\nReviewed by Jonathan Bedard\n\n * added.txt\n'
+                )
+            ]
+            repo.head = repo.commits['eng/pr-branch'][-1]
+
+            # Update without staged changes - should use committed changes
+            self.assertEqual(0, program.main(
+                args=('pull-request', '-v', '--no-history'),
+                path=self.path,
+            ))
+
+        log_output = captured.root.log.getvalue()
+        self.assertIn('Using committed changes...', log_output)
+
+
 class TestNetworkPullRequestGitHub(unittest.TestCase):
     remote = 'https://github.example.com/WebKit/WebKit'
 


### PR DESCRIPTION
#### a4e6ff5f3d521986b995c4863d108fa5b59163e1
<pre>
git-webkit pr should use commit message to create bug
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=305303">https://bugs.webkit.org/show_bug.cgi?id=305303</a>&gt;
&lt;<a href="https://rdar.apple.com/167957547">rdar://167957547</a>&gt;

Reviewed by NOBODY (OOPS!).

When `git-webkit pr` is invoked with a commit on the main branch, it
should read the title and body for the bug from the commit message.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py:
(Git.__init__):
- Add mock support for `git commit --date=now --amend --no-edit`.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/branch.py:
(Branch.extract_from_structured_commit): Add.
- Reuse commit_parser.CommitMessageParser to parse commit message to
  extract title and description for new bug.
(Branch.main):
- Call Branch.extract_from_structured_commit() to try to extract title
  and description for the bug.
- Use _parsed_description if already avialable, else prompt.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py:
(PullRequest.create_commit):
- Don&apos;t return early if we need to update bug numbers in the commit
  message.
- Run `git commit --amend --no-edit` to update only bug numbers.
(PullRequest.pull_request_branch_point):
- Call Branch.extract_from_structured_commit() to try to extract title
  and description for the bug.
(PullRequest.main):
- Call PullRequest.create_commit() if we need to update bug numbers.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/branch_unittest.py:
(TestExtractFromStructuredCommit):
(TestExtractFromStructuredCommit.test_structured_commit_with_oops):
(TestExtractFromStructuredCommit.test_structured_commit_title_only):
(TestExtractFromStructuredCommit.test_unstructured_commit_returns_none):
(TestExtractFromStructuredCommit.test_real_reviewer_returns_none):
(TestExtractFromStructuredCommit.test_empty_commit_returns_none):
(TestExtractFromStructuredCommit.test_commit_with_no_message_returns_none):
(TestExtractFromStructuredCommit.test_oops_in_title_line_skipped):
(TestExtractFromStructuredCommit.test_multiline_description):
- Add unit tests for new behavior.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py:
(TestBugUrlAmend): Add.
(TestBugUrlAmend.setUp): Add.
(TestBugUrlAmend.test_amend_commit_to_add_bug_url): Add.
(TestBugUrlAmend.test_existing_pr_uses_committed_changes): Add.
- Add unit tests for new behavior.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4e6ff5f3d521986b995c4863d108fa5b59163e1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138440 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10805 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49850 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146524 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91415 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/568b4cd0-5cc5-447e-acc9-ec17232c3917) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140314 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11509 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10960 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105927 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77277 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/875730c7-01f4-4a70-b5e3-b79bdc44e6aa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141387 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8642 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124107 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86774 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4128658e-bcf7-4990-846b-85f4fbb50af3) 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/137788 "Found 2 webkitpy test failures: webkitscmpy.test.revert_unittest.TestRevert.test_land_safe, webkitscmpy.test.revert_unittest.TestRevert.test_land_unsafe") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8229 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5999 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6816 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117649 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42306 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149244 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10487 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42863 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114328 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/137866 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10504 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8867 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114669 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8310 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120393 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65370 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10535 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38326 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10269 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10474 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10325 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->