### PR TITLE
SaferCPP: Fix a large batch of unretained local variables warnings

### DIFF
--- a/Source/JavaScriptCore/API/JSAPIGlobalObject.mm
+++ b/Source/JavaScriptCore/API/JSAPIGlobalObject.mm
@@ -199,23 +199,23 @@ JSInternalPromise* JSAPIGlobalObject::moduleLoaderFetch(JSGlobalObject* globalOb
         // This captures the globalObject but that's ok because our structure keeps it alive anyway.
         VM& vm = globalObject->vm();
         JSContext *context = [JSContext contextWithJSGlobalContextRef:toGlobalRef(globalObject)];
-        id script = valueToObject(context, toRef(globalObject, callFrame->argument(0)));
+        RetainPtr script = valueToObject(context, toRef(globalObject, callFrame->argument(0)));
 
         auto rejectPromise = [&] (String message) {
             strongPromise.get()->reject(vm, globalObject, createTypeError(globalObject, message));
             return encodedJSUndefined();
         };
 
-        if (![script isKindOfClass:[JSScript class]]) [[unlikely]]
+        if (![script.get() isKindOfClass:[JSScript class]]) [[unlikely]]
             return rejectPromise("First argument of resolution callback is not a JSScript"_s);
 
-        JSScript* jsScript = static_cast<JSScript *>(script);
+        RetainPtr jsScript = static_cast<JSScript *>(script.get());
 
-        JSSourceCode* source = [jsScript jsSourceCode];
-        if ([jsScript type] != kJSScriptTypeModule) [[unlikely]]
+        JSSourceCode* source = [jsScript.get() jsSourceCode];
+        if ([jsScript.get() type] != kJSScriptTypeModule) [[unlikely]]
             return rejectPromise("The JSScript that was provided did not have expected type of kJSScriptTypeModule."_s);
 
-        NSURL *sourceURL = [jsScript sourceURL];
+        NSURL *sourceURL = [jsScript.get() sourceURL];
         String oldModuleKey { [sourceURL absoluteString] };
         if (Identifier::fromString(vm, oldModuleKey) != moduleKey) [[unlikely]]
             return rejectPromise(makeString("The same JSScript was provided for two different identifiers, previously: "_s, oldModuleKey, " and now: "_s, moduleKey.string()));

--- a/Source/JavaScriptCore/API/JSWrapperMap.mm
+++ b/Source/JavaScriptCore/API/JSWrapperMap.mm
@@ -166,14 +166,14 @@ static RetainPtr<NSMutableDictionary> createRenameMap(Protocol *protocol, BOOL i
     auto renameMap = adoptNS([[NSMutableDictionary alloc] init]);
 
     forEachMethodInProtocol(protocol, NO, isInstanceMethod, ^(SEL sel, const char*){
-        NSString *rename = @(sel_getName(sel));
-        NSRange range = [rename rangeOfString:@"__JS_EXPORT_AS__"];
+        RetainPtr rename = @(sel_getName(sel));
+        NSRange range = [rename.get() rangeOfString:@"__JS_EXPORT_AS__"];
         if (range.location == NSNotFound)
             return;
-        NSString *selector = [rename substringToIndex:range.location];
+        NSString *selector = [rename.get() substringToIndex:range.location];
         NSUInteger begin = range.location + range.length;
-        NSUInteger length = [rename length] - begin - 1;
-        NSString *name = [rename substringWithRange:(NSRange){ begin, length }];
+        NSUInteger length = [rename.get() length] - begin - 1;
+        NSString *name = [rename.get() substringWithRange:(NSRange){ begin, length }];
         renameMap.get()[selector] = name;
     });
 
@@ -255,22 +255,22 @@ static void copyMethodsToObject(JSContext *context, Class objcClass, Protocol *p
 
     forEachMethodInProtocol(protocol, YES, isInstanceMethod, ^(SEL sel, const char* types){
         const char* nameCStr = sel_getName(sel);
-        NSString *name = @(nameCStr);
+        RetainPtr name = @(nameCStr);
 
-        if (shouldSkipMethodWithName(name))
+        if (shouldSkipMethodWithName(name.get()))
             return;
 
-        if (accessorMethods && accessorMethods[name]) {
+        if (accessorMethods && accessorMethods[name.get()]) {
             JSObjectRef method = objCCallbackFunctionForMethod(context, objcClass, protocol, isInstanceMethod, sel, types);
             if (!method)
                 return;
-            accessorMethods[name] = [JSValue valueWithJSValueRef:method inContext:context];
+            accessorMethods[name.get()] = [JSValue valueWithJSValueRef:method inContext:context];
         } else {
-            name = renameMap.get()[name];
+            name = renameMap.get()[name.get()];
             if (!name)
                 name = selectorToPropertyName(nameCStr);
             JSC::JSGlobalObject* globalObject = toJS([context JSGlobalContextRef]);
-            JSValue *existingMethod = object[name];
+            JSValue *existingMethod = object[name.get()];
             // ObjCCallbackFunction does a dynamic lookup for the
             // selector before calling the method. In order to save
             // memory we only put one callback object in any givin
@@ -282,7 +282,7 @@ static void copyMethodsToObject(JSContext *context, Class objcClass, Protocol *p
                 return;
             JSObjectRef method = objCCallbackFunctionForMethod(context, objcClass, protocol, isInstanceMethod, sel, types);
             if (method)
-                putNonEnumerable(context, object, name, [JSValue valueWithJSValueRef:method inContext:context]);
+                putNonEnumerable(context, object, name.get(), [JSValue valueWithJSValueRef:method inContext:context]);
         }
     });
 }
@@ -368,15 +368,15 @@ static void copyPrototypeProperties(JSContext *context, Class objcClass, Protoco
         JSValue* getter = accessorMethods[property.getterName.get()];
         ASSERT(![getter isUndefined]);
 
-        JSValue* setter = undefined;
+        RetainPtr setter = undefined;
         if (property.setterName) {
             setter = accessorMethods[property.setterName.get()];
-            ASSERT(![setter isUndefined]);
+            ASSERT(![setter.get() isUndefined]);
         }
-        
+
         [prototypeValue defineProperty:@(property.name) descriptor:@{
             JSPropertyDescriptorGetKey: getter,
-            JSPropertyDescriptorSetKey: setter,
+            JSPropertyDescriptorSetKey: setter.get(),
             JSPropertyDescriptorEnumerableKey: @NO,
             JSPropertyDescriptorConfigurableKey: @YES
         }];
@@ -431,9 +431,9 @@ static JSC::JSObject* allocateConstructorForCustomClass(JSContext *context, cons
 
     // For each protocol that the class implements, gather all of the init family methods into a hash table.
     __block UncheckedKeyHashMap<String, CFTypeRef> initTable;
-    Protocol *exportProtocol = getJSExportProtocol();
-    for (Class currentClass = cls; currentClass; currentClass = class_getSuperclass(currentClass)) {
-        forEachProtocolImplementingProtocol(currentClass, exportProtocol, ^(Protocol *protocol, bool&) {
+    RetainPtr exportProtocol = getJSExportProtocol();
+    for (RetainPtr currentClass = cls; currentClass.get(); currentClass = class_getSuperclass(currentClass.get())) {
+        forEachProtocolImplementingProtocol(currentClass.get(), exportProtocol.get(), ^(Protocol *protocol, bool&) {
             forEachMethodInProtocol(protocol, YES, YES, ^(SEL selector, const char*) {
                 const char* name = sel_getName(selector);
                 if (!isInitFamilyMethod(@(name)))
@@ -443,12 +443,12 @@ static JSC::JSObject* allocateConstructorForCustomClass(JSContext *context, cons
         });
     }
 
-    for (Class currentClass = cls; currentClass; currentClass = class_getSuperclass(currentClass)) {
+    for (RetainPtr currentClass = cls; currentClass.get(); currentClass = class_getSuperclass(currentClass.get())) {
         __block unsigned numberOfInitsFound = 0;
         __block SEL initMethod = 0;
-        __block Protocol *initProtocol = 0;
+        __block RetainPtr<Protocol> initProtocol;
         __block const char* types = 0;
-        forEachMethodInClass(currentClass, ^(Method method) {
+        forEachMethodInClass(currentClass.get(), ^(Method method) {
             SEL selector = method_getName(method);
             const char* name = sel_getName(selector);
             auto iter = initTable.find(String::fromLatin1(name));
@@ -470,7 +470,7 @@ static JSC::JSObject* allocateConstructorForCustomClass(JSContext *context, cons
             break;
         }
 
-        JSObjectRef method = objCCallbackFunctionForInit(context, cls, initProtocol, initMethod, types);
+        JSObjectRef method = objCCallbackFunctionForInit(context, cls, initProtocol.get(), initMethod, types);
         return toJS(method);
     }
     return constructorWithCustomBrand(context, [NSString stringWithFormat:@"%sConstructor", className], cls);
@@ -511,8 +511,8 @@ typedef std::pair<JSC::JSObject*, JSC::JSObject*> ConstructorPrototypePair;
         putNonEnumerable(context, prototype, @"constructor", constructor);
         putNonEnumerable(context, constructor, @"prototype", prototype);
 
-        Protocol *exportProtocol = getJSExportProtocol();
-        forEachProtocolImplementingProtocol(m_class, exportProtocol, ^(Protocol *protocol, bool&){
+        RetainPtr exportProtocol = getJSExportProtocol();
+        forEachProtocolImplementingProtocol(m_class, exportProtocol.get(), ^(Protocol *protocol, bool&){
             copyPrototypeProperties(context, m_class, protocol, prototype);
             copyMethodsToObject(context, m_class, protocol, NO, constructor);
         });
@@ -659,7 +659,7 @@ typedef std::pair<JSC::JSObject*, JSC::JSObject*> ConstructorPrototypePair;
 - (JSValue *)objcWrapperForJSValueRef:(JSValueRef)value inContext:context
 {
     ASSERT(toJSGlobalObject([context JSGlobalContextRef])->wrapperMap() == self);
-    auto wrapper = retainPtr((__bridge JSValue *)NSMapGet(m_cachedObjCWrappers.get(), value));
+    RetainPtr wrapper = (__bridge JSValue *)NSMapGet(m_cachedObjCWrappers.get(), value);
     if (!wrapper) {
         wrapper = adoptNS([[JSValue alloc] initWithValue:value inContext:context]);
         NSMapInsert(m_cachedObjCWrappers.get(), value, (__bridge void*)wrapper.get());
@@ -714,14 +714,14 @@ bool supportsInitMethodConstructors()
 
 Protocol *getJSExportProtocol()
 {
-    static Protocol *protocol = objc_getProtocol("JSExport");
-    return protocol;
+    static NeverDestroyed<RetainPtr<Protocol>> protocol = objc_getProtocol("JSExport");
+    return protocol->get();
 }
 
 Class getNSBlockClass()
 {
-    static Class cls = objc_getClass("NSBlock");
-    return cls;
+    static NeverDestroyed<RetainPtr<Class>> cls = objc_getClass("NSBlock");
+    return cls->get();
 }
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/API/ObjcRuntimeExtras.h
+++ b/Source/JavaScriptCore/API/ObjcRuntimeExtras.h
@@ -37,8 +37,8 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 inline bool protocolImplementsProtocol(Protocol *candidate, Protocol *target)
 {
     auto protocolProtocols = protocol_copyProtocolListSpan(candidate);
-    for (auto* protocolProtocol : protocolProtocols.span()) {
-        if (protocol_isEqual(protocolProtocol, target))
+    for (RetainPtr protocolProtocol : protocolProtocols.span()) {
+        if (protocol_isEqual(protocolProtocol.get(), target))
             return true;
     }
     return false;
@@ -60,22 +60,22 @@ inline void forEachProtocolImplementingProtocol(Class cls, Protocol *target, voi
 
     bool stop = false;
     while (!worklist.isEmpty()) {
-        Protocol *protocol = worklist.last();
+        RetainPtr protocol = worklist.last();
         worklist.removeLast();
 
         // Are we encountering this Protocol for the first time?
-        if (!visited.add((__bridge void*)protocol).isNewEntry)
+        if (!visited.add((__bridge void*)protocol.get()).isNewEntry)
             continue;
 
         // If it implements the protocol, make the callback.
-        if (protocolImplementsProtocol(protocol, target)) {
-            callback(protocol, stop);
+        if (protocolImplementsProtocol(protocol.get(), target)) {
+            callback(protocol.get(), stop);
             if (stop)
                 break;
         }
 
         // Add incorporated protocols to the worklist.
-        worklist.append(protocol_copyProtocolListSpan(protocol).span());
+        worklist.append(protocol_copyProtocolListSpan(protocol.get()).span());
     }
 }
 

--- a/Source/JavaScriptCore/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
@@ -1,4 +1,3 @@
 API/JSContextInternal.h
-API/JSValue.mm
-API/tests/Regress141275.mm
 [ iOS ] API/JSValue.h
+API/JSValue.mm

--- a/Source/JavaScriptCore/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations
@@ -2,5 +2,4 @@ API/JSAPIWrapperObject.mm
 API/JSContext.mm
 API/JSVirtualMachine.mm
 API/ObjCCallbackFunction.mm
-API/tests/Regress141275.mm
 API/tests/testapi.c

--- a/Source/JavaScriptCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -2,6 +2,5 @@ API/JSScript.mm
 API/JSValue.mm
 API/JSVirtualMachine.mm
 API/JSWrapperMap.mm
-API/tests/Regress141275.mm
 runtime/JSDateMath.cpp
 [ iOS ] runtime/ObjectPrototype.cpp

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_library_cache.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_library_cache.mm
@@ -60,11 +60,11 @@ angle::ObjCPtr<id<MTLLibrary>> LibraryCache::getOrCompileShaderLibrary(
     bool usesInvariance,
     angle::ObjCPtr<NSError> *errorOut)
 {
-    id<MTLDevice> metalDevice          = displayMtl->getMetalDevice();
+    angle::ObjCPtr metalDevice = displayMtl->getMetalDevice();
     const angle::FeaturesMtl &features = displayMtl->getFeatures();
     if (!features.enableInMemoryMtlLibraryCache.enabled)
     {
-        return CreateShaderLibrary(metalDevice, *source, macros, disableFastMath, usesInvariance,
+        return CreateShaderLibrary(metalDevice.get(), *source, macros, disableFastMath, usesInvariance,
                                    errorOut);
     }
 
@@ -80,7 +80,7 @@ angle::ObjCPtr<id<MTLLibrary>> LibraryCache::getOrCompileShaderLibrary(
         return entry.library;
     }
 
-    entry.library = CreateShaderLibrary(metalDevice, *source, macros, disableFastMath,
+    entry.library = CreateShaderLibrary(metalDevice.get(), *source, macros, disableFastMath,
                                         usesInvariance, errorOut);
     return entry.library;
 }

--- a/Source/WTF/wtf/darwin/TypeCastsOSObject.h
+++ b/Source/WTF/wtf/darwin/TypeCastsOSObject.h
@@ -61,8 +61,8 @@ template<typename T> bool isOSObject(CFTypeRef);
 #define WTF_IMPLEMENT_IS_OS_OBJECT_FUNCTIONS_INTERNAL(TypeName, ProtocolString) \
 template<> inline bool isOSObject<OSObjectTypeCastTraits<TypeName>::BaseType>(CFTypeRef object) \
 { \
-    Class cls = object_getClass(bridge_id_cast(object)); \
-    return class_conformsToProtocol(cls, objc_getProtocol(ProtocolString)); \
+    RetainPtr cls = object_getClass(bridge_id_cast(object)); \
+    return class_conformsToProtocol(cls.get(), objc_getProtocol(ProtocolString)); \
 } \
 
 #ifdef __OBJC__

--- a/Source/WebCore/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations
@@ -3,7 +3,6 @@ platform/audio/cocoa/AudioSampleBufferConverter.mm
 [ iOS ] platform/cocoa/WebAVPlayerLayerView.mm
 platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm
 platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
-platform/graphics/cg/GradientRendererCG.cpp
 platform/graphics/cg/GraphicsContextCG.cpp
 platform/graphics/cg/ImageDecoderCG.cpp
 platform/graphics/cg/PatternCG.cpp

--- a/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -1,76 +1,16 @@
 [ iOS ] Modules/async-clipboard/ios/ClipboardImageReaderIOS.mm
 [ iOS ] Modules/system-preview/ARKitBadgeSystemImage.mm
-[ Mac ] accessibility/cocoa/AXCoreObjectCocoa.mm
-accessibility/cocoa/AccessibilityObjectCocoa.mm
 [ iOS ] accessibility/ios/AccessibilityObjectIOS.mm
 [ iOS ] accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
-[ Mac ] accessibility/mac/AXObjectCacheMac.mm
-[ Mac ] accessibility/mac/AccessibilityObjectMac.mm
-accessibility/mac/WebAccessibilityObjectWrapperBase.mm
-bindings/js/ScriptControllerMac.mm
-bridge/objc/WebScriptObject.mm
-bridge/objc/objc_class.mm
-bridge/objc/objc_instance.mm
-bridge/objc/objc_runtime.mm
-bridge/objc/objc_utility.mm
-crypto/cocoa/SerializedCryptoKeyWrapMac.mm
-[ Mac ] editing/cocoa/AlternativeTextUIController.mm
-editing/cocoa/DataDetection.mm
-editing/cocoa/EditingHTMLConverter.mm
 editing/cocoa/NodeHTMLConverter.mm
-loader/archive/cf/LegacyWebArchive.cpp
 [ iOS ] page/ios/EventHandlerIOS.mm
-page/mac/ChromeMac.mm
-[ Mac ] page/mac/EventHandlerMac.mm
-[ Mac ] page/scrolling/mac/ScrollingStateScrollingNodeMac.mm
-[ Mac ] page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm
-[ Mac ] page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
-platform/audio/cocoa/AudioEncoderCocoa.cpp
-platform/audio/cocoa/AudioFileReaderCocoa.cpp
-platform/audio/cocoa/PlatformRawAudioDataCocoa.cpp
 [ iOS ] platform/audio/ios/AudioSessionIOS.mm
 platform/cf/KeyedDecoderCF.cpp
 [ iOS ] platform/cocoa/ContentFilterUnblockHandlerCocoa.mm
-[ Mac ] platform/cocoa/DragImageCocoa.mm
-platform/cocoa/PlatformPasteboardCocoa.mm
-platform/cocoa/RemoteCommandListenerCocoa.mm
-platform/cocoa/SearchPopupMenuCocoa.mm
-platform/cocoa/SerializedPlatformDataCueValue.mm
-platform/cocoa/SystemVersion.mm
 [ iOS ] platform/cocoa/WebAVPlayerLayerView.mm
-platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm
-platform/graphics/avfoundation/FormatDescriptionUtilities.cpp
-platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp
-[ Mac ] platform/graphics/avfoundation/objc/AVRoutePickerViewTargetPicker.mm
 platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
-platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
-platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
-platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
-platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
-platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
-platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
-platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
 platform/graphics/cg/GradientRendererCG.cpp
-platform/graphics/cg/GraphicsContextCG.cpp
-platform/graphics/cg/GraphicsContextGLCG.cpp
-platform/graphics/cg/ImageDecoderCG.cpp
 [ iOS ] platform/graphics/cg/PDFDocumentImage.cpp
-platform/graphics/cg/PathCG.cpp
-platform/graphics/cocoa/AV1UtilitiesCocoa.mm
-platform/graphics/cocoa/CMUtilities.mm
-platform/graphics/cocoa/FontCacheCoreText.cpp
-platform/graphics/cocoa/FontPlatformDataCocoa.mm
-platform/graphics/cocoa/GraphicsContextCocoa.mm
-[ Mac ] platform/graphics/cocoa/ImageAdapterCocoa.mm
-platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
-platform/graphics/cocoa/VideoMediaSampleRenderer.mm
-[ Mac ] platform/graphics/mac/controls/ControlMac.mm
-[ Mac ] platform/graphics/mac/controls/ImageControlsButtonMac.mm
-[ Mac ] platform/graphics/mac/controls/ProgressBarMac.mm
-[ Mac ] platform/graphics/mac/controls/SliderTrackMac.mm
-[ Mac ] platform/graphics/mac/controls/SwitchMacUtilities.mm
-[ Mac ] platform/graphics/mac/controls/SwitchThumbMac.mm
-[ Mac ] platform/graphics/mac/controls/SwitchTrackMac.mm
 [ iOS ] platform/ios/DragImageIOS.mm
 [ iOS ] platform/ios/LegacyTileCache.mm
 [ iOS ] platform/ios/LegacyTileGrid.mm
@@ -79,14 +19,12 @@ platform/graphics/cocoa/VideoMediaSampleRenderer.mm
 [ iOS ] platform/ios/PasteboardIOS.mm
 [ iOS ] platform/ios/PlatformPasteboardIOS.mm
 [ iOS ] platform/ios/PlatformScreenIOS.mm
-platform/ios/PlaybackSessionInterfaceAVKitLegacy.mm
 [ iOS ] platform/ios/QuickLook.mm
 [ iOS ] platform/ios/ScrollViewIOS.mm
 [ iOS ] platform/ios/UIViewControllerUtilities.mm
 [ iOS ] platform/ios/ValidationBubbleIOS.mm
 [ iOS ] platform/ios/VideoPresentationInterfaceAVKitLegacy.mm
 [ iOS ] platform/ios/VideoPresentationInterfaceIOS.mm
-platform/ios/WebAVPlayerController.mm
 [ iOS ] platform/ios/WebItemProviderPasteboard.mm
 [ iOS ] platform/ios/WidgetIOS.mm
 [ iOS ] platform/ios/wak/WAKScrollView.mm
@@ -97,14 +35,7 @@ platform/ios/WebAVPlayerController.mm
 [ iOS ] platform/ios/wak/WebCoreThread.mm
 platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp
 platform/mediastream/mac/AVVideoCaptureSource.mm
-platform/mediastream/mac/CoreAudioCaptureUnit.mm
-platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.mm
 [ iOS ] platform/network/ios/WebCoreURLResponseIOS.mm
 [ iOS ] platform/network/mac/ResourceErrorMac.mm
-platform/network/mac/ResourceHandleMac.mm
-platform/network/mac/WebCoreResourceHandleAsOperationQueueDelegate.mm
-platform/text/cocoa/LocaleCocoa.mm
 [ iOS ] platform/text/mac/TextBoundaries.mm
-rendering/AttachmentLayout.mm
 [ iOS ] rendering/ios/RenderThemeIOS.mm
-testing/cocoa/WebViewVisualIdentificationOverlay.mm

--- a/Source/WebCore/accessibility/cocoa/AccessibilityObjectCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AccessibilityObjectCocoa.mm
@@ -88,20 +88,20 @@ std::optional<NSRange> AccessibilityObject::visibleCharacterRange() const
 
 static void addObjectWrapperToArray(const AccessibilityObject& object, NSMutableArray *array)
 {
-    auto* wrapper = object.wrapper();
+    RetainPtr wrapper = object.wrapper();
     if (!wrapper)
         return;
 
     // Don't add the same object twice.
-    if ([array containsObject:wrapper])
+    if ([array containsObject:wrapper.get()])
         return;
 
 #if PLATFORM(IOS_FAMILY)
     // Explicitly set that this is a new element, in case other logic tries to override.
-    [wrapper setValue:@YES forKey:@"isAccessibilityElement"];
+    [wrapper.get() setValue:@YES forKey:@"isAccessibilityElement"];
 #endif
 
-    [array addObject:wrapper];
+    [array addObject:wrapper.get()];
 }
 
 void attributedStringSetNumber(NSMutableAttributedString *attrString, NSString *attribute, NSNumber *number, const NSRange& range)

--- a/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
+++ b/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
@@ -103,10 +103,10 @@ FloatRect AccessibilityObject::convertRectToPlatformSpace(const FloatRect& rect,
         CGRect cgRect = CGRectMake(point.x, point.y, size.width, size.height);
 
         NSRect nsRect = NSRectFromCGRect(cgRect);
-        NSView *view = frameView->documentView();
+        RetainPtr<id> view = frameView->documentView();
 
         ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        nsRect = [[view window] convertRectToScreen:[view convertRect:nsRect toView:nil]];
+        nsRect = [[view.get() window] convertRectToScreen:[view.get() convertRect:nsRect toView:nil]];
         ALLOW_DEPRECATED_DECLARATIONS_END
 
         return NSRectToCGRect(nsRect);
@@ -124,9 +124,9 @@ bool AccessibilityObject::accessibilityIgnoreAttachment() const
         return true;
 
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    id attachmentView = widget ? NSAccessibilityUnignoredDescendant(widget->platformWidget()) : nil;
+    RetainPtr<id> attachmentView = widget ? NSAccessibilityUnignoredDescendant(widget->platformWidget()) : nil;
     if (attachmentView)
-        return [attachmentView accessibilityIsIgnored];
+        return [attachmentView.get() accessibilityIsIgnored];
 ALLOW_DEPRECATED_DECLARATIONS_END
 
     // Attachments are ignored by default (unless we determine that we should expose them).

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
@@ -433,10 +433,10 @@ NSArray *makeNSArray(const WebCore::AXCoreObject::AccessibilityChildrenVector& c
     if (extendedDescription.length()) {
         accessibilityCustomContent = adoptNS([[NSMutableArray alloc] init]);
         Class customContentClass = PAL::getAXCustomContentClassSingleton();
-        AXCustomContent *contentItem = [customContentClass customContentWithLabel:WEB_UI_STRING("description", "description detail").createNSString().get() value:extendedDescription.createNSString().get()];
+        RetainPtr contentItem = [customContentClass customContentWithLabel:WEB_UI_STRING("description", "description detail").createNSString().get() value:extendedDescription.createNSString().get()];
         // Set this to high, so that it's always spoken.
-        [contentItem setImportance:AXCustomContentImportanceHigh];
-        [accessibilityCustomContent addObject:contentItem];
+        [contentItem.get() setImportance:AXCustomContentImportanceHigh];
+        [accessibilityCustomContent addObject:contentItem.get()];
     }
 
     return accessibilityCustomContent.autorelease();
@@ -833,12 +833,12 @@ static NSDictionary *dictionaryRemovingNonSupportedTypes(NSDictionary *dictionar
     return mutableDictionary.autorelease();
 }
 
-- (void)accessibilityPostedNotification:(NSString *)notificationName userInfo:(NSDictionary *)userInfo
+- (void)accessibilityPostedNotification:(NSString *)notificationName userInfo:(NSDictionary *)userInfoArg
 {
     if (accessibilityShouldRepostNotifications) {
         ASSERT(notificationName);
-        userInfo = dictionaryRemovingNonSupportedTypes(userInfo);
-        NSDictionary *info = [NSDictionary dictionaryWithObjectsAndKeys:notificationName, @"notificationName", userInfo, @"userInfo", nil];
+        RetainPtr userInfo = dictionaryRemovingNonSupportedTypes(userInfoArg);
+        NSDictionary *info = [NSDictionary dictionaryWithObjectsAndKeys:notificationName, @"notificationName", userInfo.get(), @"userInfo", nil];
         [[NSNotificationCenter defaultCenter] postNotificationName:NSAccessibilityDRTNotificationNotification object:self userInfo:info];
     }
 }

--- a/Source/WebCore/bridge/objc/WebScriptObject.mm
+++ b/Source/WebCore/bridge/objc/WebScriptObject.mm
@@ -85,8 +85,8 @@ NSObject *getJSWrapper(JSObject* impl)
     ASSERT(isMainThread());
     Locker locker { wrapperCacheLock };
 
-    NSObject* wrapper = wrapperCache().get(impl);
-    return wrapper ? retainPtr(wrapper).autorelease() : nil;
+    RetainPtr wrapper = wrapperCache().get(impl);
+    return wrapper ? wrapper.autorelease() : nil;
 }
 
 void addJSWrapper(NSObject *wrapper, JSObject* impl)
@@ -177,10 +177,10 @@ void disconnectWindowWrapper(WebScriptObject *windowWrapper)
     auto& wrapped = *toJS(jsObject);
 
     if (WebCore::createDOMWrapperFunction) {
-        if (auto wrapper = WebCore::createDOMWrapperFunction(wrapped)) {
-            if (![wrapper _hasImp]) // new wrapper, not from cache
-                [wrapper _setImp:&wrapped originRootObject:originRootObject rootObject:rootObject];
-            return wrapper;
+        if (RetainPtr wrapper = WebCore::createDOMWrapperFunction(wrapped)) {
+            if (![wrapper.get() _hasImp]) // new wrapper, not from cache
+                [wrapper.get() _setImp:&wrapped originRootObject:originRootObject rootObject:rootObject];
+            return wrapper.autorelease();
         }
     }
 

--- a/Source/WebCore/bridge/objc/objc_class.mm
+++ b/Source/WebCore/bridge/objc/objc_class.mm
@@ -113,34 +113,34 @@ Method* ObjcClass::methodNamed(PropertyName propertyName, Instance*) const
     RetainPtr<NSString> methodName = adoptNS([[NSString alloc] initWithCString:buffer.span().data() encoding:NSASCIIStringEncoding]);
 
     Method* methodPtr = 0;
-    ClassStructPtr thisClass = _isa;
-    
+    RetainPtr<ClassStructPtr> thisClass = _isa;
+
     while (thisClass && !methodPtr) {
-        auto objcMethodList = class_copyMethodListSpan(thisClass);
+        auto objcMethodList = class_copyMethodListSpan(thisClass.get());
         for (auto& objcMethod : objcMethodList.span()) {
             SEL objcMethodSelector = method_getName(objcMethod);
             auto objcMethodSelectorName = unsafeSpan(sel_getName(objcMethodSelector));
             NSString* mappedName = nil;
 
             // See if the class wants to exclude the selector from visibility in JavaScript.
-            if ([thisClass respondsToSelector:@selector(isSelectorExcludedFromWebScript:)])
-                if ([thisClass isSelectorExcludedFromWebScript:objcMethodSelector])
+            if ([thisClass.get() respondsToSelector:@selector(isSelectorExcludedFromWebScript:)])
+                if ([thisClass.get() isSelectorExcludedFromWebScript:objcMethodSelector])
                     continue;
 
             // See if the class want to provide a different name for the selector in JavaScript.
             // Note that we do not do any checks to guarantee uniqueness. That's the responsiblity
             // of the class.
-            if ([thisClass respondsToSelector:@selector(webScriptNameForSelector:)])
-                mappedName = [thisClass webScriptNameForSelector:objcMethodSelector];
+            if ([thisClass.get() respondsToSelector:@selector(webScriptNameForSelector:)])
+                mappedName = [thisClass.get() webScriptNameForSelector:objcMethodSelector];
 
             if ((mappedName && [mappedName isEqual:methodName.get()]) || equalSpans(objcMethodSelectorName, unsafeSpan(buffer.span().data()))) {
-                auto method = makeUnique<ObjcMethod>(thisClass, objcMethodSelector);
+                auto method = makeUnique<ObjcMethod>(thisClass.get(), objcMethodSelector);
                 methodPtr = method.get();
                 m_methodCache.add(name.impl(), WTF::move(method));
                 break;
             }
         }
-        thisClass = class_getSuperclass(thisClass);
+        thisClass = class_getSuperclass(thisClass.get());
     }
 
     return methodPtr;
@@ -156,17 +156,17 @@ Field* ObjcClass::fieldNamed(PropertyName propertyName, Instance* instance) cons
     if (field)
         return field;
 
-    ClassStructPtr thisClass = _isa;
+    RetainPtr<ClassStructPtr> thisClass = _isa;
 
     CString jsName = name.ascii();
     RetainPtr<NSString> fieldName = adoptNS([[NSString alloc] initWithCString:jsName.data() encoding:NSASCIIStringEncoding]);
-    id targetObject = (downcast<ObjcInstance>(instance))->getObject();
+    RetainPtr<ObjectStructPtr> targetObject = (downcast<ObjcInstance>(instance))->getObject();
 #if PLATFORM(IOS_FAMILY)
     IGNORE_WARNINGS_BEGIN("undeclared-selector")
-    id attributes = [targetObject respondsToSelector:@selector(attributeKeys)] ? [targetObject performSelector:@selector(attributeKeys)] : nil;
+    id attributes = [targetObject.get() respondsToSelector:@selector(attributeKeys)] ? [targetObject.get() performSelector:@selector(attributeKeys)] : nil;
     IGNORE_WARNINGS_END
 #else
-    id attributes = [targetObject attributeKeys];
+    id attributes = [targetObject.get() attributeKeys];
 #endif
     if (attributes) {
         // Class overrides attributeKeys, use that array of key names.
@@ -174,16 +174,16 @@ Field* ObjcClass::fieldNamed(PropertyName propertyName, Instance* instance) cons
             const char* UTF8KeyName = [keyName UTF8String]; // ObjC actually only supports ASCII names.
 
             // See if the class wants to exclude the selector from visibility in JavaScript.
-            if ([thisClass respondsToSelector:@selector(isKeyExcludedFromWebScript:)])
-                if ([thisClass isKeyExcludedFromWebScript:UTF8KeyName])
+            if ([thisClass.get() respondsToSelector:@selector(isKeyExcludedFromWebScript:)])
+                if ([thisClass.get() isKeyExcludedFromWebScript:UTF8KeyName])
                     continue;
 
             // See if the class want to provide a different name for the selector in JavaScript.
             // Note that we do not do any checks to guarantee uniqueness. That's the responsiblity
             // of the class.
             NSString* mappedName = nil;
-            if ([thisClass respondsToSelector:@selector(webScriptNameForKey:)])
-                mappedName = [thisClass webScriptNameForKey:UTF8KeyName];
+            if ([thisClass.get() respondsToSelector:@selector(webScriptNameForKey:)])
+                mappedName = [thisClass.get() webScriptNameForKey:UTF8KeyName];
 
             if ((mappedName && [mappedName isEqual:fieldName.get()]) || [keyName isEqual:fieldName.get()]) {
                 auto newField = makeUnique<ObjcField>((__bridge CFStringRef)keyName);
@@ -197,21 +197,21 @@ Field* ObjcClass::fieldNamed(PropertyName propertyName, Instance* instance) cons
         // introspection.
 
         while (thisClass) {
-            auto ivarsInClass = class_copyIvarListSpan(thisClass);
+            auto ivarsInClass = class_copyIvarListSpan(thisClass.get());
             for (auto& objcIVar : ivarsInClass.span()) {
                 const char* objcIvarName = ivar_getName(objcIVar);
                 NSString *mappedName = nullptr;
 
                 // See if the class wants to exclude the selector from visibility in JavaScript.
-                if ([thisClass respondsToSelector:@selector(isKeyExcludedFromWebScript:)])
-                    if ([thisClass isKeyExcludedFromWebScript:objcIvarName])
+                if ([thisClass.get() respondsToSelector:@selector(isKeyExcludedFromWebScript:)])
+                    if ([thisClass.get() isKeyExcludedFromWebScript:objcIvarName])
                         continue;
 
                 // See if the class want to provide a different name for the selector in JavaScript.
                 // Note that we do not do any checks to guarantee uniqueness. That's the responsiblity
                 // of the class.
-                if ([thisClass respondsToSelector:@selector(webScriptNameForKey:)])
-                    mappedName = [thisClass webScriptNameForKey:objcIvarName];
+                if ([thisClass.get() respondsToSelector:@selector(webScriptNameForKey:)])
+                    mappedName = [thisClass.get() webScriptNameForKey:objcIvarName];
 
                 if ((mappedName && [mappedName isEqual:fieldName.get()]) || equalSpans(unsafeSpan(objcIvarName), jsName.span())) {
                     auto newField = makeUnique<ObjcField>(objcIVar);
@@ -221,7 +221,7 @@ Field* ObjcClass::fieldNamed(PropertyName propertyName, Instance* instance) cons
                 }
             }
 
-            thisClass = class_getSuperclass(thisClass);
+            thisClass = class_getSuperclass(thisClass.get());
         }
     }
 
@@ -231,9 +231,9 @@ Field* ObjcClass::fieldNamed(PropertyName propertyName, Instance* instance) cons
 JSValue ObjcClass::fallbackObject(JSGlobalObject* lexicalGlobalObject, Instance* instance, PropertyName propertyName)
 {
     auto* objcInstance = downcast<ObjcInstance>(instance);
-    id targetObject = objcInstance->getObject();
-    
-    if (![targetObject respondsToSelector:@selector(invokeUndefinedMethodFromWebScript:withArguments:)])
+    RetainPtr<ObjectStructPtr> targetObject = objcInstance->getObject();
+
+    if (![targetObject.get() respondsToSelector:@selector(invokeUndefinedMethodFromWebScript:withArguments:)])
         return jsUndefined();
 
     if (!propertyName.publicName())

--- a/Source/WebCore/bridge/objc/objc_utility.mm
+++ b/Source/WebCore/bridge/objc/objc_utility.mm
@@ -193,28 +193,28 @@ JSValue convertObjcValueToValue(JSGlobalObject* lexicalGlobalObject, void* buffe
     
     switch (type) {
         case ObjcObjectType: {
-            id obj = *(const id*)buffer;
-            if (auto *str = dynamic_objc_cast<NSString>(obj))
-                return convertNSStringToString(lexicalGlobalObject, str);
-            if ([obj isKindOfClass:webUndefinedClass()])
+            RetainPtr obj = *(const id*)buffer;
+            if (RetainPtr str = RetainPtr { dynamic_objc_cast<NSString>(obj.get()) })
+                return convertNSStringToString(lexicalGlobalObject, str.get());
+            if ([obj.get() isKindOfClass:webUndefinedClass()])
                 return jsUndefined();
-            if ((__bridge CFBooleanRef)obj == kCFBooleanTrue)
+            if ((__bridge CFBooleanRef)obj.get() == kCFBooleanTrue)
                 return jsBoolean(true);
-            if ((__bridge CFBooleanRef)obj == kCFBooleanFalse)
+            if ((__bridge CFBooleanRef)obj.get() == kCFBooleanFalse)
                 return jsBoolean(false);
-            if ([obj isKindOfClass:[NSNumber class]])
-                return jsNumber([obj doubleValue]);
-            if ([obj isKindOfClass:[NSArray class]])
-                return RuntimeArray::create(lexicalGlobalObject, new ObjcArray(obj, rootObject));
-            if ([obj isKindOfClass:webScriptObjectClass()]) {
-                JSObject* imp = [obj _imp];
+            if ([obj.get() isKindOfClass:[NSNumber class]])
+                return jsNumber([obj.get() doubleValue]);
+            if ([obj.get() isKindOfClass:[NSArray class]])
+                return RuntimeArray::create(lexicalGlobalObject, new ObjcArray(obj.get(), rootObject));
+            if ([obj.get() isKindOfClass:webScriptObjectClass()]) {
+                JSObject* imp = [obj.get() _imp];
                 return imp ? imp : jsUndefined();
             }
-            if ([obj isKindOfClass:[NSNull class]])
+            if ([obj.get() isKindOfClass:[NSNull class]])
                 return jsNull();
-            if (obj == 0)
+            if (obj.get() == 0)
                 return jsUndefined();
-            return ObjcInstance::create(obj, rootObject)->createRuntimeObject(lexicalGlobalObject);
+            return ObjcInstance::create(obj.get(), rootObject)->createRuntimeObject(lexicalGlobalObject);
         }
         case ObjcCharType:
             return jsNumber(*(char*)buffer);

--- a/Source/WebCore/editing/cocoa/AlternativeTextUIController.mm
+++ b/Source/WebCore/editing/cocoa/AlternativeTextUIController.mm
@@ -73,13 +73,13 @@ void AlternativeTextUIController::showAlternatives(NSView *view, const FloatRect
 
     m_view = view;
 
-    PlatformTextAlternatives *alternatives = m_contextController.alternativesForContext(context);
+    RetainPtr alternatives = m_contextController.alternativesForContext(context);
     if (!alternatives)
         return;
 
-    [[NSSpellChecker sharedSpellChecker] showCorrectionIndicatorOfType:NSCorrectionIndicatorTypeGuesses primaryString:retainPtr(alternatives.primaryString).get() alternativeStrings:retainPtr(alternatives.alternativeStrings).get() forStringInRect:boundingBoxOfPrimaryString view:m_view.get() completionHandler:^(NSString *acceptedString) {
+    [[NSSpellChecker sharedSpellChecker] showCorrectionIndicatorOfType:NSCorrectionIndicatorTypeGuesses primaryString:retainPtr(alternatives.get().primaryString).get() alternativeStrings:retainPtr(alternatives.get().alternativeStrings).get() forStringInRect:boundingBoxOfPrimaryString view:m_view.get() completionHandler:^(NSString *acceptedString) {
         if (acceptedString) {
-            handleAcceptedAlternative(acceptedString, context, alternatives);
+            handleAcceptedAlternative(acceptedString, context, alternatives.get());
             acceptanceHandler(acceptedString);
         }
     }];

--- a/Source/WebCore/editing/cocoa/DataDetection.mm
+++ b/Source/WebCore/editing/cocoa/DataDetection.mm
@@ -100,12 +100,12 @@ static std::optional<DetectedItem> detectItem(const VisiblePosition& position, c
     RetainPtr results = adoptCF(DDScannerCopyResultsWithOptions(scanner.get(), DDScannerCopyResultsOptionsNoOverlap));
 
     // Find the DDResultRef that intersects the hitTestResult's VisiblePosition.
-    DDResultRef mainResult = nullptr;
+    RetainPtr<DDResultRef> mainResult;
     std::optional<SimpleRange> mainResultRange;
     CFIndex resultCount = CFArrayGetCount(results.get());
     for (CFIndex i = 0; i < resultCount; i++) {
-        auto result = checked_cf_cast<DDResultRef>(CFArrayGetValueAtIndex(results.get(), i));
-        CFRange resultRangeInContext = DDResultGetRange(result);
+        RetainPtr<DDResultRef> result = checked_cf_cast<DDResultRef>(CFArrayGetValueAtIndex(results.get(), i));
+        CFRange resultRangeInContext = DDResultGetRange(result.get());
         if (hitLocation >= resultRangeInContext.location && (hitLocation - resultRangeInContext.location) < resultRangeInContext.length) {
             mainResult = result;
             mainResultRange = resolveCharacterRange(contextRange, resultRangeInContext);
@@ -122,8 +122,8 @@ static std::optional<DetectedItem> detectItem(const VisiblePosition& position, c
 
     RetainPtr actionContext = adoptNS([PAL::allocWKDDActionContextInstance() init]);
 
-    [actionContext setAllResults:@[ (__bridge id)mainResult ]];
-    [actionContext setMainResult:mainResult];
+    [actionContext setAllResults:@[ (__bridge id)mainResult.get() ]];
+    [actionContext setMainResult:mainResult.get()];
 
     return { {
         WTF::move(actionContext),

--- a/Source/WebCore/editing/cocoa/EditingHTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/EditingHTMLConverter.mm
@@ -358,16 +358,17 @@ static void updateAttributes(const Node* node, const RenderStyle& style, OptionS
         [attributes removeObjectForKey:NSStrikethroughStyleAttributeName];
 
     CheckedRef fontCascade = style.fontCascade();
-    if (auto ctFont = fontCascade->primaryFont()->ctFont())
-        [attributes setObject:(__bridge PlatformFont *)ctFont forKey:NSFontAttributeName];
+    Ref primaryFont = fontCascade->primaryFont();
+    if (RetainPtr ctFont = primaryFont->ctFont())
+        [attributes setObject:(__bridge PlatformFont *)ctFont.get() forKey:NSFontAttributeName];
     else {
-        auto size = fontCascade->primaryFont()->platformData().size();
+        auto size = primaryFont->platformData().size();
 #if PLATFORM(IOS_FAMILY)
-        PlatformFont *platformFont = [PlatformFontClass systemFontOfSize:size];
+        RetainPtr platformFont = [PlatformFontClass systemFontOfSize:size];
 #else
-        PlatformFont *platformFont = [[NSFontManager sharedFontManager] convertFont:WebDefaultFont() toSize:size];
+        RetainPtr platformFont = [[NSFontManager sharedFontManager] convertFont:WebDefaultFont() toSize:size];
 #endif
-        [attributes setObject:platformFont forKey:NSFontAttributeName];
+        [attributes setObject:platformFont.get() forKey:NSFontAttributeName];
     }
 
     auto textAlignment = NSTextAlignmentNatural;

--- a/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
+++ b/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
@@ -250,61 +250,61 @@ RefPtr<ArchiveResource> LegacyWebArchive::createResource(CFDictionaryRef diction
     if (!dictionary)
         return nullptr;
 
-    auto resourceData = static_cast<CFDataRef>(CFDictionaryGetValue(dictionary, LegacyWebArchiveResourceDataKey));
-    if (resourceData && CFGetTypeID(resourceData) != CFDataGetTypeID()) {
+    RetainPtr resourceData = static_cast<CFDataRef>(CFDictionaryGetValue(dictionary, LegacyWebArchiveResourceDataKey));
+    if (resourceData && CFGetTypeID(resourceData.get()) != CFDataGetTypeID()) {
         LOG(Archives, "LegacyWebArchive - Resource data is not of type CFData, cannot create invalid resource");
         return nullptr;
     }
 
-    auto frameName = static_cast<CFStringRef>(CFDictionaryGetValue(dictionary, LegacyWebArchiveResourceFrameNameKey));
-    if (frameName && CFGetTypeID(frameName) != CFStringGetTypeID()) {
+    RetainPtr frameName = static_cast<CFStringRef>(CFDictionaryGetValue(dictionary, LegacyWebArchiveResourceFrameNameKey));
+    if (frameName && CFGetTypeID(frameName.get()) != CFStringGetTypeID()) {
         LOG(Archives, "LegacyWebArchive - Frame name is not of type CFString, cannot create invalid resource");
         return nullptr;
     }
 
-    auto mimeType = static_cast<CFStringRef>(CFDictionaryGetValue(dictionary, LegacyWebArchiveResourceMIMETypeKey));
-    if (mimeType && CFGetTypeID(mimeType) != CFStringGetTypeID()) {
+    RetainPtr mimeType = static_cast<CFStringRef>(CFDictionaryGetValue(dictionary, LegacyWebArchiveResourceMIMETypeKey));
+    if (mimeType && CFGetTypeID(mimeType.get()) != CFStringGetTypeID()) {
         LOG(Archives, "LegacyWebArchive - MIME type is not of type CFString, cannot create invalid resource");
         return nullptr;
     }
 
-    auto url = static_cast<CFStringRef>(CFDictionaryGetValue(dictionary, LegacyWebArchiveResourceURLKey));
-    if (url && CFGetTypeID(url) != CFStringGetTypeID()) {
+    RetainPtr url = static_cast<CFStringRef>(CFDictionaryGetValue(dictionary, LegacyWebArchiveResourceURLKey));
+    if (url && CFGetTypeID(url.get()) != CFStringGetTypeID()) {
         LOG(Archives, "LegacyWebArchive - URL is not of type CFString, cannot create invalid resource");
         return nullptr;
     }
 
-    auto textEncoding = static_cast<CFStringRef>(CFDictionaryGetValue(dictionary, LegacyWebArchiveResourceTextEncodingNameKey));
-    if (textEncoding && CFGetTypeID(textEncoding) != CFStringGetTypeID()) {
+    RetainPtr textEncoding = static_cast<CFStringRef>(CFDictionaryGetValue(dictionary, LegacyWebArchiveResourceTextEncodingNameKey));
+    if (textEncoding && CFGetTypeID(textEncoding.get()) != CFStringGetTypeID()) {
         LOG(Archives, "LegacyWebArchive - Text encoding is not of type CFString, cannot create invalid resource");
         return nullptr;
     }
 
     ResourceResponse response;
 
-    if (auto resourceResponseData = static_cast<CFDataRef>(CFDictionaryGetValue(dictionary, LegacyWebArchiveResourceResponseKey))) {
-        if (CFGetTypeID(resourceResponseData) != CFDataGetTypeID()) {
+    if (RetainPtr resourceResponseData = static_cast<CFDataRef>(CFDictionaryGetValue(dictionary, LegacyWebArchiveResourceResponseKey))) {
+        if (CFGetTypeID(resourceResponseData.get()) != CFDataGetTypeID()) {
             LOG(Archives, "LegacyWebArchive - Resource response data is not of type CFData, cannot create invalid resource");
             return nullptr;
         }
 
-        auto resourceResponseVersion = static_cast<CFStringRef>(CFDictionaryGetValue(dictionary, LegacyWebArchiveResourceResponseVersionKey));
-        if (resourceResponseVersion && CFGetTypeID(resourceResponseVersion) != CFStringGetTypeID()) {
+        RetainPtr resourceResponseVersion = static_cast<CFStringRef>(CFDictionaryGetValue(dictionary, LegacyWebArchiveResourceResponseVersionKey));
+        if (resourceResponseVersion && CFGetTypeID(resourceResponseVersion.get()) != CFStringGetTypeID()) {
             LOG(Archives, "LegacyWebArchive - Resource response version is not of type CFString, cannot create invalid resource");
             return nullptr;
         }
 
-        response = createResourceResponseFromPropertyListData(resourceResponseData, resourceResponseVersion);
+        response = createResourceResponseFromPropertyListData(resourceResponseData.get(), resourceResponseVersion.get());
     }
 
     auto filePathValue = CFDictionaryGetValue(dictionary, LegacyWebArchiveResourceFilePathKey);
-    auto filePath = dynamic_cf_cast<CFStringRef>(filePathValue);
+    RetainPtr filePath = dynamic_cf_cast<CFStringRef>(filePathValue);
     if (filePathValue && !filePath) {
         LOG(Archives, "LegacyWebArchive - File path is not of type CFString, cannot create invalid resource");
         return nullptr;
     }
 
-    return ArchiveResource::create(SharedBuffer::create(resourceData), URL { url }, mimeType, textEncoding, frameName, response, filePath);
+    return ArchiveResource::create(SharedBuffer::create(resourceData.get()), URL { url.get() }, mimeType.get(), textEncoding.get(), frameName.get(), response, filePath.get());
 }
 
 LegacyWebArchive::LegacyWebArchive(std::optional<FrameIdentifier> frameIdentifier, Vector<FrameIdentifier>&& subframeIdentifiers)
@@ -381,17 +381,17 @@ RefPtr<LegacyWebArchive> LegacyWebArchive::create(CFDictionaryRef dictionary)
         return nullptr;
     }
 
-    CFDictionaryRef mainResourceDict = static_cast<CFDictionaryRef>(CFDictionaryGetValue(dictionary, LegacyWebArchiveMainResourceKey));
+    RetainPtr mainResourceDict = static_cast<CFDictionaryRef>(CFDictionaryGetValue(dictionary, LegacyWebArchiveMainResourceKey));
     if (!mainResourceDict) {
         LOG(Archives, "LegacyWebArchive - No main resource in archive, aborting invalid WebArchive");
         return nullptr;
     }
-    if (CFGetTypeID(mainResourceDict) != CFDictionaryGetTypeID()) {
+    if (CFGetTypeID(mainResourceDict.get()) != CFDictionaryGetTypeID()) {
         LOG(Archives, "LegacyWebArchive - Main resource is not the expected CFDictionary, aborting invalid WebArchive");
         return nullptr;
     }
 
-    RefPtr mainResource = createResource(mainResourceDict);
+    RefPtr mainResource = createResource(mainResourceDict.get());
     if (!mainResource) {
         LOG(Archives, "LegacyWebArchive - Failed to parse main resource from CFDictionary or main resource does not exist, aborting invalid WebArchive");
         return nullptr;
@@ -402,44 +402,44 @@ RefPtr<LegacyWebArchive> LegacyWebArchive::create(CFDictionaryRef dictionary)
         return nullptr;
     }
 
-    auto subresourceArray = static_cast<CFArrayRef>(CFDictionaryGetValue(dictionary, LegacyWebArchiveSubresourcesKey));
-    if (subresourceArray && CFGetTypeID(subresourceArray) != CFArrayGetTypeID()) {
+    RetainPtr subresourceArray = static_cast<CFArrayRef>(CFDictionaryGetValue(dictionary, LegacyWebArchiveSubresourcesKey));
+    if (subresourceArray && CFGetTypeID(subresourceArray.get()) != CFArrayGetTypeID()) {
         LOG(Archives, "LegacyWebArchive - Subresources is not the expected Array, aborting invalid WebArchive");
         return nullptr;
     }
 
     Vector<Ref<ArchiveResource>> subresources;
     if (subresourceArray) {
-        auto count = CFArrayGetCount(subresourceArray);
+        auto count = CFArrayGetCount(subresourceArray.get());
         for (CFIndex i = 0; i < count; ++i) {
-            auto subresourceDict = static_cast<CFDictionaryRef>(CFArrayGetValueAtIndex(subresourceArray, i));
-            if (CFGetTypeID(subresourceDict) != CFDictionaryGetTypeID()) {
+            RetainPtr subresourceDict = static_cast<CFDictionaryRef>(CFArrayGetValueAtIndex(subresourceArray.get(), i));
+            if (CFGetTypeID(subresourceDict.get()) != CFDictionaryGetTypeID()) {
                 LOG(Archives, "LegacyWebArchive - Subresource is not expected CFDictionary, aborting invalid WebArchive");
                 return nullptr;
             }
 
-            if (auto subresource = createResource(subresourceDict))
+            if (auto subresource = createResource(subresourceDict.get()))
                 subresources.append(subresource.releaseNonNull());
         }
     }
 
-    auto subframeArray = static_cast<CFArrayRef>(CFDictionaryGetValue(dictionary, LegacyWebArchiveSubframeArchivesKey));
-    if (subframeArray && CFGetTypeID(subframeArray) != CFArrayGetTypeID()) {
+    RetainPtr subframeArray = static_cast<CFArrayRef>(CFDictionaryGetValue(dictionary, LegacyWebArchiveSubframeArchivesKey));
+    if (subframeArray && CFGetTypeID(subframeArray.get()) != CFArrayGetTypeID()) {
         LOG(Archives, "LegacyWebArchive - Subframe archives is not the expected Array, aborting invalid WebArchive");
         return nullptr;
     }
 
     Vector<Ref<LegacyWebArchive>> subframeArchives;
     if (subframeArray) {
-        auto count = CFArrayGetCount(subframeArray);
+        auto count = CFArrayGetCount(subframeArray.get());
         for (CFIndex i = 0; i < count; ++i) {
-            auto subframeDict = static_cast<CFDictionaryRef>(CFArrayGetValueAtIndex(subframeArray, i));
-            if (CFGetTypeID(subframeDict) != CFDictionaryGetTypeID()) {
+            RetainPtr subframeDict = static_cast<CFDictionaryRef>(CFArrayGetValueAtIndex(subframeArray.get(), i));
+            if (CFGetTypeID(subframeDict.get()) != CFDictionaryGetTypeID()) {
                 LOG(Archives, "LegacyWebArchive - Subframe array is not expected CFDictionary, aborting invalid WebArchive");
                 return nullptr;
             }
 
-            if (RefPtr subFrameArchive = create(subframeDict))
+            if (RefPtr subFrameArchive = create(subframeDict.get()))
                 subframeArchives.append(subFrameArchive.releaseNonNull());
         }
     }

--- a/Source/WebCore/page/mac/ChromeMac.mm
+++ b/Source/WebCore/page/mac/ChromeMac.mm
@@ -41,8 +41,8 @@ void Chrome::focusNSView(NSView* view)
         return;
     }
     
-    NSResponder *firstResponder = client().firstResponder();
-    if (firstResponder == view)
+    RetainPtr firstResponder = adoptNS(client().firstResponder());
+    if (firstResponder.get() == view)
         return;
 
     if (![view window] || ![view superview] || ![view acceptsFirstResponder])
@@ -55,7 +55,7 @@ void Chrome::focusNSView(NSView* view)
     // first responder. This confuses AppKit so we must restore
     // the old first responder.
     if (![view superview])
-        client().makeFirstResponder(firstResponder);
+        client().makeFirstResponder(firstResponder.get());
 
     END_BLOCK_OBJC_EXCEPTIONS
 }

--- a/Source/WebCore/page/scrolling/mac/ScrollingStateScrollingNodeMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingStateScrollingNodeMac.mm
@@ -32,6 +32,7 @@
 #import "Scrollbar.h"
 #import "ScrollbarThemeMac.h"
 #import "ScrollingStateTree.h"
+#include <wtf/RetainPtr.h>
 
 namespace WebCore {
 
@@ -42,16 +43,16 @@ void ScrollingStateScrollingNode::setScrollerImpsFromScrollbars(Scrollbar* verti
         return;
     ScrollbarThemeMac& macTheme = downcast<ScrollbarThemeMac>(scrollbarTheme);
 
-    NSScrollerImp *verticalPainter = verticalScrollbar && verticalScrollbar->supportsUpdateOnSecondaryThread()
+    RetainPtr verticalPainter = verticalScrollbar && verticalScrollbar->supportsUpdateOnSecondaryThread()
         ? macTheme.scrollerImpForScrollbar(*verticalScrollbar) : nullptr;
-    NSScrollerImp *horizontalPainter = horizontalScrollbar && horizontalScrollbar->supportsUpdateOnSecondaryThread()
+    RetainPtr horizontalPainter = horizontalScrollbar && horizontalScrollbar->supportsUpdateOnSecondaryThread()
         ? macTheme.scrollerImpForScrollbar(*horizontalScrollbar) : nullptr;
 
-    if (m_verticalScrollerImp == verticalPainter && m_horizontalScrollerImp == horizontalPainter)
+    if (m_verticalScrollerImp == verticalPainter.get() && m_horizontalScrollerImp == horizontalPainter.get())
         return;
 
-    m_verticalScrollerImp = verticalPainter;
-    m_horizontalScrollerImp = horizontalPainter;
+    m_verticalScrollerImp = verticalPainter.get();
+    m_horizontalScrollerImp = horizontalPainter.get();
 
     setPropertyChanged(Property::PainterForScrollbar);
 }

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
@@ -64,12 +64,12 @@ void ScrollingTreeScrollingNodeDelegateMac::updateFromStateNode(const ScrollingS
     CheckedRef verticalScroller = m_scrollerPair->verticalScroller();
 
     if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::PainterForScrollbar)) {
-        auto horizontalScrollbar = scrollingStateNode.horizontalScrollerImp();
-        auto verticalScrollbar = scrollingStateNode.verticalScrollerImp();
+        RetainPtr<NSScrollerImp> horizontalScrollbar = scrollingStateNode.horizontalScrollerImp();
+        RetainPtr<NSScrollerImp> verticalScrollbar = scrollingStateNode.verticalScrollerImp();
         if (horizontalScrollbar || verticalScrollbar) {
             m_scrollerPair->releaseReferencesToScrollerImpsOnTheMainThread();
-            horizontalScroller->setScrollerImp(horizontalScrollbar);
-            verticalScroller->setScrollerImp(verticalScrollbar);
+            horizontalScroller->setScrollerImp(horizontalScrollbar.get());
+            verticalScroller->setScrollerImp(verticalScrollbar.get());
         }
     }
 

--- a/Source/WebCore/platform/audio/cocoa/AudioEncoderCocoa.cpp
+++ b/Source/WebCore/platform/audio/cocoa/AudioEncoderCocoa.cpp
@@ -268,13 +268,13 @@ void InternalAudioEncoderCocoa::processEncodedOutputs()
 
     while (RetainPtr cmSample = converter()->takeOutputSampleBuffer()) {
         Ref sample = MediaSampleAVFObjC::create(cmSample.get(), 0);
-        CMBlockBufferRef rawBuffer = PAL::CMSampleBufferGetDataBuffer(cmSample.get());
+        RetainPtr rawBuffer = adoptCF(PAL::CMSampleBufferGetDataBuffer(cmSample.get()));
         ASSERT(rawBuffer);
-        RetainPtr buffer = rawBuffer;
+        RetainPtr buffer = rawBuffer.get();
         // Make sure block buffer is contiguous.
-        if (!PAL::CMBlockBufferIsRangeContiguous(rawBuffer, 0, 0)) {
+        if (!PAL::CMBlockBufferIsRangeContiguous(rawBuffer.get(), 0, 0)) {
             CMBlockBufferRef contiguousBuffer;
-            if (auto error = PAL::CMBlockBufferCreateContiguous(nullptr, rawBuffer, nullptr, nullptr, 0, 0, 0, &contiguousBuffer)) {
+            if (auto error = PAL::CMBlockBufferCreateContiguous(nullptr, rawBuffer.get(), nullptr, nullptr, 0, 0, 0, &contiguousBuffer)) {
                 RELEASE_LOG_ERROR(MediaStream, "Couldn't create buffer with error %d", error);
                 m_lastError = error;
                 continue;
@@ -317,10 +317,10 @@ Ref<AudioEncoder::EncodePromise> InternalAudioEncoderCocoa::encode(AudioEncoder:
     if (auto error = PAL::CMSampleBufferSetOutputPresentationTimeStamp(cmSample.get(), PAL::CMTimeMake(rawFrame.timestamp, 1000000)))
         RELEASE_LOG_ERROR(MediaStream, "AudioSampleBufferConverter CMSampleBufferSetOutputPresentationTimeStamp failed with %d", error);
 
-    CMFormatDescriptionRef formatDescription = PAL::CMSampleBufferGetFormatDescription(cmSample.get());
+    RetainPtr formatDescription = adoptCF(PAL::CMSampleBufferGetFormatDescription(cmSample.get()));
     if (!formatDescription)
         return EncodePromise::createAndReject("Couldn't retrieve AudioData's format description"_s);
-    const AudioStreamBasicDescription* const asbd = PAL::CMAudioFormatDescriptionGetStreamBasicDescription(formatDescription);
+    const AudioStreamBasicDescription* const asbd = PAL::CMAudioFormatDescriptionGetStreamBasicDescription(formatDescription.get());
     if (!asbd)
         return EncodePromise::createAndReject("Couldn't retrieve AudioData's basic description"_s);
 

--- a/Source/WebCore/platform/audio/cocoa/PlatformRawAudioDataCocoa.cpp
+++ b/Source/WebCore/platform/audio/cocoa/PlatformRawAudioDataCocoa.cpp
@@ -151,9 +151,9 @@ PlatformRawAudioDataCocoa::PlatformRawAudioDataCocoa(Ref<MediaSampleAVFObjC>&& s
 
 const AudioStreamBasicDescription& PlatformRawAudioDataCocoa::asbd() const
 {
-    auto description = PAL::CMSampleBufferGetFormatDescription(m_sample->sampleBuffer());
+    RetainPtr description = retainPtr(PAL::CMSampleBufferGetFormatDescription(m_sample->sampleBuffer()));
     ASSERT(description);
-    const AudioStreamBasicDescription* const asbd = PAL::CMAudioFormatDescriptionGetStreamBasicDescription(description);
+    const AudioStreamBasicDescription* const asbd = PAL::CMAudioFormatDescriptionGetStreamBasicDescription(description.get());
     ASSERT(asbd);
     return *asbd;
 }

--- a/Source/WebCore/platform/cocoa/DragImageCocoa.mm
+++ b/Source/WebCore/platform/cocoa/DragImageCocoa.mm
@@ -192,7 +192,7 @@ LinkImageLayout::LinkImageLayout(URL& url, const String& titleString)
     RetainPtr nsURL = url.createNSURL();
     NSString *absoluteURLString = [nsURL absoluteString];
 
-    NSString *domain = absoluteURLString;
+    RetainPtr domain = absoluteURLString;
 #if HAVE(URL_FORMATTING)
     domain = [nsURL _lp_simplifiedDisplayString];
 #else
@@ -239,8 +239,8 @@ LinkImageLayout::LinkImageLayout(URL& url, const String& titleString)
         RetainPtr<CGPathRef> textPath = adoptCF(CGPathCreateWithRect(CGRectMake(0, 0, textSize.width, textSize.height), nullptr));
         RetainPtr<CTFrameRef> textFrame = adoptCF(CTFramesetterCreateFrame(textFramesetter.get(), fitRange, textPath.get(), (CFDictionaryRef)frameAttributes));
 
-        CFArrayRef ctLines = CTFrameGetLines(textFrame.get());
-        CFIndex lineCount = CFArrayGetCount(ctLines);
+        RetainPtr ctLines = CTFrameGetLines(textFrame.get());
+        CFIndex lineCount = CFArrayGetCount(ctLines.get());
         if (!lineCount)
             return;
 
@@ -249,10 +249,10 @@ LinkImageLayout::LinkImageLayout(URL& url, const String& titleString)
         CGFloat height = 0;
         CTFrameGetLineOrigins(textFrame.get(), CFRangeMake(0, 0), origins.mutableSpan().data());
         for (CFIndex lineIndex = 0; lineIndex < lineCount; ++lineIndex) {
-            CTLineRef line = (CTLineRef)CFArrayGetValueAtIndex(ctLines, lineIndex);
+            RetainPtr line = (CTLineRef)CFArrayGetValueAtIndex(ctLines.get(), lineIndex);
 
-            lineBounds = CTLineGetBoundsWithOptions(line, 0);
-            CGFloat trailingWhitespaceWidth = CTLineGetTrailingWhitespaceWidth(line);
+            lineBounds = CTLineGetBoundsWithOptions(line.get(), 0);
+            CGFloat trailingWhitespaceWidth = CTLineGetTrailingWhitespaceWidth(line.get());
             CGFloat lineWidthIgnoringTrailingWhitespace = lineBounds.size.width - trailingWhitespaceWidth;
             maximumUsedTextWidth = std::max(maximumUsedTextWidth, lineWidthIgnoringTrailingWhitespace);
 
@@ -275,7 +275,7 @@ LinkImageLayout::LinkImageLayout(URL& url, const String& titleString)
         currentY += linkImageDomainBaselineToTitleBaseline - (domainFont.ascender - domainFont.descender);
 
     if (domain)
-        buildLines(domain, domainColor, domainFont, 1, kCTLineBreakByTruncatingMiddle);
+        buildLines(domain.get(), domainColor, domainFont, 1, kCTLineBreakByTruncatingMiddle);
 
     currentY += linkImagePadding;
 

--- a/Source/WebCore/platform/cocoa/PlatformPasteboardCocoa.mm
+++ b/Source/WebCore/platform/cocoa/PlatformPasteboardCocoa.mm
@@ -83,19 +83,21 @@ String PlatformPasteboard::urlStringSuitableForLoading(String& title)
 #endif
 
     if (types.contains(urlPasteboardType)) {
-        NSURL *URLFromPasteboard = [NSURL URLWithString:stringForType(urlPasteboardType).createNSString().get()];
+        RetainPtr urlString = stringForType(urlPasteboardType).createNSString();
+        RetainPtr URLFromPasteboard = [NSURL URLWithString:urlString.get()];
         // Cannot drop other schemes unless <rdar://problem/10562662> and <rdar://problem/11187315> are fixed.
-        if (URL { URLFromPasteboard }.protocolIsInHTTPFamily())
-            return [URLByCanonicalizingURL(URLFromPasteboard) absoluteString];
+        if (URL { URLFromPasteboard.get() }.protocolIsInHTTPFamily())
+            return [URLByCanonicalizingURL(URLFromPasteboard.get()) absoluteString];
     }
 
     if (types.contains(stringPasteboardType)) {
-        NSURL *URLFromPasteboard = [NSURL URLWithString:stringForType(stringPasteboardType).createNSString().get()];
+        RetainPtr stringValue = stringForType(stringPasteboardType).createNSString();
+        RetainPtr URLFromPasteboard = [NSURL URLWithString:stringValue.get()];
         // Pasteboard content is not trusted, because JavaScript code can modify it. We can sanitize it for URLs and other typed content, but not for strings.
         // The result of this function is used to initiate navigation, so we shouldn't allow arbitrary file URLs.
         // FIXME: Should we allow only http family schemes, or anything non-local?
-        if (URL { URLFromPasteboard }.protocolIsInHTTPFamily())
-            return [URLByCanonicalizingURL(URLFromPasteboard) absoluteString];
+        if (URL { URLFromPasteboard.get() }.protocolIsInHTTPFamily())
+            return [URLByCanonicalizingURL(URLFromPasteboard.get()) absoluteString];
     }
 
 #if PLATFORM(MAC)

--- a/Source/WebCore/platform/cocoa/RemoteCommandListenerCocoa.mm
+++ b/Source/WebCore/platform/cocoa/RemoteCommandListenerCocoa.mm
@@ -178,14 +178,14 @@ RemoteCommandListenerCocoa::RemoteCommandListenerCocoa(RemoteCommandListenerClie
                 break;
             }
 
-            CFNumberRef positionRef = static_cast<CFNumberRef>(CFDictionaryGetValue(options, kMRMediaRemoteOptionPlaybackPosition));
+            RetainPtr positionRef = static_cast<CFNumberRef>(CFDictionaryGetValue(options, kMRMediaRemoteOptionPlaybackPosition));
             if (!positionRef) {
                 status = MRMediaRemoteCommandHandlerStatusCommandFailed;
                 break;
             }
 
             double position = 0;
-            CFNumberGetValue(positionRef, kCFNumberDoubleType, &position);
+            CFNumberGetValue(positionRef.get(), kCFNumberDoubleType, &position);
             argument.time = position;
             platformCommand = PlatformMediaSession::RemoteControlCommandType::SeekToPlaybackPositionCommand;
             break;
@@ -197,9 +197,9 @@ RemoteCommandListenerCocoa::RemoteCommandListenerCocoa(RemoteCommandListenerClie
                 break;
             }
 
-            if (auto positionRef = static_cast<CFNumberRef>(CFDictionaryGetValue(options, kMRMediaRemoteOptionSkipInterval))) {
+            if (RetainPtr positionRef = static_cast<CFNumberRef>(CFDictionaryGetValue(options, kMRMediaRemoteOptionSkipInterval))) {
                 double position = 0;
-                CFNumberGetValue(positionRef, kCFNumberDoubleType, &position);
+                CFNumberGetValue(positionRef.get(), kCFNumberDoubleType, &position);
                 argument.time = position;
             }
 

--- a/Source/WebCore/platform/cocoa/SearchPopupMenuCocoa.mm
+++ b/Source/WebCore/platform/cocoa/SearchPopupMenuCocoa.mm
@@ -96,22 +96,22 @@ static RetainPtr<NSDictionary> typeCheckedRecentSearchesRemovingRecentSearchesAd
         if (![key isKindOfClass:[NSString class]])
             return nil;
 
-        NSMutableArray *recentSearches = typeCheckedRecentSearchesArray(itemsDictionary, key);
+        RetainPtr recentSearches = typeCheckedRecentSearchesArray(itemsDictionary, key);
         if (!recentSearches)
             return nil;
 
         RetainPtr<NSMutableArray> entriesToRemove = adoptNS([[NSMutableArray alloc] init]);
-        for (NSDictionary *recentSearch in recentSearches) {
-            NSDate *dateAdded = typeCheckedDateInRecentSearch(recentSearch);
+        for (NSDictionary *recentSearch in recentSearches.get()) {
+            RetainPtr dateAdded = typeCheckedDateInRecentSearch(recentSearch);
             if (!dateAdded)
                 return nil;
 
-            if ([dateAdded compare:date] == NSOrderedDescending)
+            if ([dateAdded.get() compare:date] == NSOrderedDescending)
                 [entriesToRemove addObject:recentSearch];
         }
 
-        [recentSearches removeObjectsInArray:entriesToRemove.get()];
-        if (!recentSearches.count)
+        [recentSearches.get() removeObjectsInArray:entriesToRemove.get()];
+        if (![recentSearches.get() count])
             [keysToRemove addObject:key];
     }
 
@@ -164,20 +164,20 @@ Vector<RecentSearch> loadRecentSearchesFromFile(const String& name, const String
     if (![items isKindOfClass:[NSDictionary class]])
         return searchItems;
 
-    NSArray *recentSearches = typeCheckedRecentSearchesArray(items, name.createNSString().get());
+    RetainPtr recentSearches = typeCheckedRecentSearchesArray(items, name.createNSString().get());
     if (!recentSearches)
         return searchItems;
-    
-    for (NSDictionary *item in recentSearches) {
-        NSDate *date = typeCheckedDateInRecentSearch(item);
+
+    for (NSDictionary *item in recentSearches.get()) {
+        RetainPtr date = typeCheckedDateInRecentSearch(item);
         if (!date)
             continue;
 
         NSString *searchString = [item objectForKey:searchStringKey];
         if (![searchString isKindOfClass:[NSString class]])
             continue;
-        
-        searchItems.append({ String{ searchString }, toSystemClockTime(date) });
+
+        searchItems.append({ String{ searchString }, toSystemClockTime(date.get()) });
     }
 
     return searchItems;
@@ -188,15 +188,15 @@ void removeRecentlyModifiedRecentSearchesFromFile(WallTime oldestTimeToRemove, c
     if (directory.isEmpty())
         return;
 
-    NSString *plistPath = searchFieldRecentSearchesPlistPath(directory.createNSString().get());
-    NSDate *date = toNSDateFromSystemClock(oldestTimeToRemove);
-    auto recentSearchesPlist = typeCheckedRecentSearchesRemovingRecentSearchesAddedAfterDate(date, directory);
+    RetainPtr plistPath = searchFieldRecentSearchesPlistPath(directory.createNSString().get());
+    RetainPtr date = toNSDateFromSystemClock(oldestTimeToRemove);
+    auto recentSearchesPlist = typeCheckedRecentSearchesRemovingRecentSearchesAddedAfterDate(date.get(), directory);
     if (recentSearchesPlist)
-        [recentSearchesPlist writeToFile:plistPath atomically:YES];
+        [recentSearchesPlist writeToFile:plistPath.get() atomically:YES];
     else {
         auto emptyItemsDictionary = adoptNS([[NSDictionary alloc] init]);
         auto emptyRecentSearchesDictionary = adoptNS([[NSDictionary alloc] initWithObjectsAndKeys:emptyItemsDictionary.get(), itemsKey, nil]);
-        [emptyRecentSearchesDictionary writeToFile:plistPath atomically:YES];
+        [emptyRecentSearchesDictionary writeToFile:plistPath.get() atomically:YES];
     }
 }
 

--- a/Source/WebCore/platform/cocoa/SerializedPlatformDataCueValue.mm
+++ b/Source/WebCore/platform/cocoa/SerializedPlatformDataCueValue.mm
@@ -48,13 +48,13 @@ SerializedPlatformDataCueValue::SerializedPlatformDataCueValue(AVMetadataItem *i
         NSString *value = [extras objectForKey:key];
         if (![value isKindOfClass:NSString.class])
             continue;
-        NSString *keyString = key;
+        RetainPtr keyString = key;
 
-        if ([key isEqualToString:@"MIMEtype"])
+        if ([keyString.get() isEqualToString:@"MIMEtype"])
             keyString = @"type";
-        else if ([key isEqualToString:@"dataTypeNamespace"] || [key isEqualToString:@"pictureType"])
+        else if ([keyString.get() isEqualToString:@"dataTypeNamespace"] || [keyString.get() isEqualToString:@"pictureType"])
             continue;
-        else if ([key isEqualToString:@"dataType"]) {
+        else if ([keyString.get() isEqualToString:@"dataType"]) {
             id dataTypeNamespace = [extras objectForKey:@"dataTypeNamespace"];
             if (!dataTypeNamespace || ![dataTypeNamespace isKindOfClass:[NSString class]] || ![dataTypeNamespace isEqualToString:@"org.iana.media-type"])
                 continue;
@@ -62,13 +62,13 @@ SerializedPlatformDataCueValue::SerializedPlatformDataCueValue(AVMetadataItem *i
         } else {
             if (![value length])
                 continue;
-            keyString = [key lowercaseString];
+            keyString = [keyString.get() lowercaseString];
         }
 
-        if ([keyString isEqualToString:@"type"])
+        if ([keyString.get() isEqualToString:@"type"])
             m_data->type = value;
         else
-            m_data->otherAttributes.add(keyString, value);
+            m_data->otherAttributes.add(keyString.get(), value);
     }
 
     if (auto *keyString = dynamic_objc_cast<NSString>(item.key))

--- a/Source/WebCore/platform/cocoa/SystemVersion.mm
+++ b/Source/WebCore/platform/cocoa/SystemVersion.mm
@@ -32,8 +32,8 @@ static RetainPtr<NSString> createSystemMarketingVersion()
 {
     // Can't use -[NSProcessInfo operatingSystemVersionString] because it has too much stuff we don't want.
     auto systemVersionDictionary = adoptCF(_CFCopySystemVersionDictionary());
-    CFStringRef productVersion = static_cast<CFStringRef>(CFDictionaryGetValue(systemVersionDictionary.get(), _kCFSystemVersionProductVersionKey));
-    return adoptNS([(__bridge NSString *)productVersion copy]);
+    RetainPtr productVersion = static_cast<CFStringRef>(CFDictionaryGetValue(systemVersionDictionary.get(), _kCFSystemVersionProductVersionKey));
+    return adoptNS([(__bridge NSString *)productVersion.get() copy]);
 }
 
 NSString *systemMarketingVersion()

--- a/Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm
@@ -394,11 +394,11 @@ void AVTrackPrivateAVFObjCImpl::setAudioTrackConfigurationObserver(AudioTrackCon
 
 static RetainPtr<CMFormatDescriptionRef> formatDescriptionFor(const AVTrackPrivateAVFObjCImpl& impl)
 {
-    auto assetTrack = assetTrackFor(impl);
-    if (!assetTrack || [assetTrack statusOfValueForKey:@"formatDescriptions" error:nil] != AVKeyValueStatusLoaded)
+    RetainPtr assetTrack = assetTrackFor(impl);
+    if (!assetTrack || [assetTrack.get() statusOfValueForKey:@"formatDescriptions" error:nil] != AVKeyValueStatusLoaded)
         return nullptr;
 
-    return static_cast<CMFormatDescriptionRef>(assetTrack.formatDescriptions.firstObject);
+    return static_cast<CMFormatDescriptionRef>(assetTrack.get().formatDescriptions.firstObject);
 }
 
 String AVTrackPrivateAVFObjCImpl::codec() const
@@ -408,16 +408,16 @@ String AVTrackPrivateAVFObjCImpl::codec() const
 
 uint32_t AVTrackPrivateAVFObjCImpl::width() const
 {
-    if (auto assetTrack = assetTrackFor(*this))
-        return assetTrack.naturalSize.width;
+    if (RetainPtr assetTrack = assetTrackFor(*this))
+        return assetTrack.get().naturalSize.width;
     ASSERT_NOT_REACHED();
     return 0;
 }
 
 uint32_t AVTrackPrivateAVFObjCImpl::height() const
 {
-    if (auto assetTrack = assetTrackFor(*this))
-        return assetTrack.naturalSize.height;
+    if (RetainPtr assetTrack = assetTrackFor(*this))
+        return assetTrack.get().naturalSize.height;
     ASSERT_NOT_REACHED();
     return 0;
 }
@@ -431,12 +431,12 @@ PlatformVideoColorSpace AVTrackPrivateAVFObjCImpl::colorSpace() const
 
 double AVTrackPrivateAVFObjCImpl::framerate() const
 {
-    auto assetTrack = assetTrackFor(*this);
+    RetainPtr assetTrack = assetTrackFor(*this);
     if (!assetTrack)
         return 0;
-    if ([assetTrack statusOfValueForKey:@"nominalFrameRate" error:nil] != AVKeyValueStatusLoaded)
+    if ([assetTrack.get() statusOfValueForKey:@"nominalFrameRate" error:nil] != AVKeyValueStatusLoaded)
         return 0;
-    return assetTrack.nominalFrameRate;
+    return assetTrack.get().nominalFrameRate;
 }
 
 uint32_t AVTrackPrivateAVFObjCImpl::sampleRate() const
@@ -467,14 +467,14 @@ uint32_t AVTrackPrivateAVFObjCImpl::numberOfChannels() const
 
 uint64_t AVTrackPrivateAVFObjCImpl::bitrate() const
 {
-    auto assetTrack = assetTrackFor(*this);
+    RetainPtr assetTrack = assetTrackFor(*this);
     if (!assetTrack)
         return 0;
-    if ([assetTrack statusOfValueForKey:@"estimatedDataRate" error:nil] != AVKeyValueStatusLoaded)
+    if ([assetTrack.get() statusOfValueForKey:@"estimatedDataRate" error:nil] != AVKeyValueStatusLoaded)
         return 0;
-    if (!std::isfinite(assetTrack.estimatedDataRate))
+    if (!std::isfinite(assetTrack.get().estimatedDataRate))
         return 0;
-    return assetTrack.estimatedDataRate;
+    return assetTrack.get().estimatedDataRate;
 }
 
 bool AVTrackPrivateAVFObjCImpl::isProtected() const

--- a/Source/WebCore/platform/graphics/avfoundation/FormatDescriptionUtilities.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/FormatDescriptionUtilities.cpp
@@ -83,9 +83,9 @@ std::optional<PlatformVideoColorSpace> colorSpaceFromFormatDescription(CMFormatD
         return std::nullopt;
 
     PlatformVideoColorSpace colorSpace;
-    auto primaries = dynamic_cf_cast<CFStringRef>(PAL::CMFormatDescriptionGetExtension(formatDescription, PAL::get_CoreMedia_kCMFormatDescriptionExtension_ColorPrimariesSingleton()));
-    auto transfer = dynamic_cf_cast<CFStringRef>(PAL::CMFormatDescriptionGetExtension(formatDescription, PAL::get_CoreMedia_kCMFormatDescriptionExtension_TransferFunctionSingleton()));
-    auto matrix = dynamic_cf_cast<CFStringRef>(PAL::CMFormatDescriptionGetExtension(formatDescription, PAL::get_CoreMedia_kCMFormatDescriptionExtension_YCbCrMatrixSingleton()));
+    RetainPtr primaries = dynamic_cf_cast<CFStringRef>(PAL::CMFormatDescriptionGetExtension(formatDescription, PAL::get_CoreMedia_kCMFormatDescriptionExtension_ColorPrimariesSingleton()));
+    RetainPtr transfer = dynamic_cf_cast<CFStringRef>(PAL::CMFormatDescriptionGetExtension(formatDescription, PAL::get_CoreMedia_kCMFormatDescriptionExtension_TransferFunctionSingleton()));
+    RetainPtr matrix = dynamic_cf_cast<CFStringRef>(PAL::CMFormatDescriptionGetExtension(formatDescription, PAL::get_CoreMedia_kCMFormatDescriptionExtension_YCbCrMatrixSingleton()));
 
     if (!primaries || !transfer || !matrix) {
         auto size = presentationSizeFromFormatDescription(formatDescription);
@@ -105,32 +105,32 @@ std::optional<PlatformVideoColorSpace> colorSpaceFromFormatDescription(CMFormatD
     }
 
     if (primaries) {
-        if (safeCFEqual(primaries, PAL::get_CoreMedia_kCMFormatDescriptionColorPrimaries_ITU_R_709_2Singleton()))
+        if (safeCFEqual(primaries.get(), PAL::get_CoreMedia_kCMFormatDescriptionColorPrimaries_ITU_R_709_2Singleton()))
             colorSpace.primaries = PlatformVideoColorPrimaries::Bt709;
-        else if (safeCFEqual(primaries, PAL::get_CoreMedia_kCMFormatDescriptionColorPrimaries_EBU_3213Singleton()))
+        else if (safeCFEqual(primaries.get(), PAL::get_CoreMedia_kCMFormatDescriptionColorPrimaries_EBU_3213Singleton()))
             colorSpace.primaries = PlatformVideoColorPrimaries::Bt470bg;
-        else if (safeCFEqual(primaries, PAL::get_CoreMedia_kCMFormatDescriptionColorPrimaries_SMPTE_CSingleton()))
+        else if (safeCFEqual(primaries.get(), PAL::get_CoreMedia_kCMFormatDescriptionColorPrimaries_SMPTE_CSingleton()))
             colorSpace.primaries = PlatformVideoColorPrimaries::Smpte170m;
     }
 
     if (transfer) {
-        if (safeCFEqual(transfer, PAL::get_CoreMedia_kCMFormatDescriptionTransferFunction_ITU_R_709_2Singleton()))
+        if (safeCFEqual(transfer.get(), PAL::get_CoreMedia_kCMFormatDescriptionTransferFunction_ITU_R_709_2Singleton()))
             colorSpace.transfer = PlatformVideoTransferCharacteristics::Bt709;
-        else if (safeCFEqual(transfer, PAL::kCMFormatDescriptionTransferFunction_sRGB))
+        else if (safeCFEqual(transfer.get(), PAL::kCMFormatDescriptionTransferFunction_sRGB))
             colorSpace.transfer = PlatformVideoTransferCharacteristics::Iec6196621;
     }
 
     if (matrix) {
-        if (safeCFEqual(matrix, PAL::get_CoreMedia_kCVImageBufferYCbCrMatrix_ITU_R_709_2Singleton()))
+        if (safeCFEqual(matrix.get(), PAL::get_CoreMedia_kCVImageBufferYCbCrMatrix_ITU_R_709_2Singleton()))
             colorSpace.matrix = PlatformVideoMatrixCoefficients::Bt709;
-        else if (safeCFEqual(matrix, PAL::get_CoreMedia_kCVImageBufferYCbCrMatrix_ITU_R_601_4Singleton()))
+        else if (safeCFEqual(matrix.get(), PAL::get_CoreMedia_kCVImageBufferYCbCrMatrix_ITU_R_601_4Singleton()))
             colorSpace.matrix = PlatformVideoMatrixCoefficients::Bt470bg;
-        else if (safeCFEqual(matrix, PAL::get_CoreMedia_kCMFormatDescriptionYCbCrMatrix_SMPTE_240M_1995Singleton()))
+        else if (safeCFEqual(matrix.get(), PAL::get_CoreMedia_kCMFormatDescriptionYCbCrMatrix_SMPTE_240M_1995Singleton()))
             colorSpace.matrix = PlatformVideoMatrixCoefficients::Smpte170m;
     }
 
-    if (auto fullRange = static_cast<CFBooleanRef>(PAL::CMFormatDescriptionGetExtension(formatDescription, PAL::kCMFormatDescriptionExtension_FullRangeVideo)))
-        colorSpace.fullRange = CFBooleanGetValue(fullRange);
+    if (RetainPtr fullRange = static_cast<CFBooleanRef>(PAL::CMFormatDescriptionGetExtension(formatDescription, PAL::kCMFormatDescriptionExtension_FullRangeVideo)))
+        colorSpace.fullRange = CFBooleanGetValue(fullRange.get());
 
     return colorSpace;
 }
@@ -142,19 +142,19 @@ String codecFromFormatDescription(CMFormatDescriptionRef formatDescription)
 
     auto subType = PAL::softLink_CoreMedia_CMFormatDescriptionGetMediaSubType(formatDescription);
     CFStringRef originalFormatKey = PAL::canLoad_CoreMedia_kCMFormatDescriptionExtension_ProtectedContentOriginalFormat() ? PAL::kCMFormatDescriptionExtension_ProtectedContentOriginalFormat : CFSTR("CommonEncryptionOriginalFormat");
-    if (auto originalFormat = dynamic_cf_cast<CFNumberRef>(PAL::CMFormatDescriptionGetExtension(formatDescription, originalFormatKey)))
-        CFNumberGetValue(originalFormat, kCFNumberSInt32Type, &subType);
+    if (RetainPtr originalFormat = dynamic_cf_cast<CFNumberRef>(PAL::CMFormatDescriptionGetExtension(formatDescription, originalFormatKey)))
+        CFNumberGetValue(originalFormat.get(), kCFNumberSInt32Type, &subType);
 
     switch (subType) {
     case kCMVideoCodecType_H264:
     case 'cavc': {
-        auto sampleExtensionsDict = dynamic_cf_cast<CFDictionaryRef>(PAL::CMFormatDescriptionGetExtension(formatDescription, PAL::kCMFormatDescriptionExtension_SampleDescriptionExtensionAtoms));
+        RetainPtr sampleExtensionsDict = dynamic_cf_cast<CFDictionaryRef>(PAL::CMFormatDescriptionGetExtension(formatDescription, PAL::kCMFormatDescriptionExtension_SampleDescriptionExtensionAtoms));
         if (!sampleExtensionsDict)
             return "avc1"_s;
-        auto sampleExtensions = dynamic_cf_cast<CFDataRef>(CFDictionaryGetValue(sampleExtensionsDict, CFSTR("avcC")));
+        RetainPtr sampleExtensions = dynamic_cf_cast<CFDataRef>(CFDictionaryGetValue(sampleExtensionsDict.get(), CFSTR("avcC")));
         if (!sampleExtensions)
             return "avc1"_s;
-        auto configurationRecordBuffer = SharedBuffer::create(sampleExtensions);
+        auto configurationRecordBuffer = SharedBuffer::create(sampleExtensions.get());
         auto parameters = parseAVCDecoderConfigurationRecord(configurationRecordBuffer);
         if (!parameters)
             return "avc1"_s;
@@ -163,13 +163,13 @@ String codecFromFormatDescription(CMFormatDescriptionRef formatDescription)
     case kCMVideoCodecType_HEVC:
     case kCMVideoCodecType_HEVCWithAlpha:
     case 'chvc': {
-        auto sampleExtensionsDict = dynamic_cf_cast<CFDictionaryRef>(PAL::CMFormatDescriptionGetExtension(formatDescription, PAL::kCMFormatDescriptionExtension_SampleDescriptionExtensionAtoms));
+        RetainPtr sampleExtensionsDict = dynamic_cf_cast<CFDictionaryRef>(PAL::CMFormatDescriptionGetExtension(formatDescription, PAL::kCMFormatDescriptionExtension_SampleDescriptionExtensionAtoms));
         if (!sampleExtensionsDict)
             return "hvc1"_s;
-        auto sampleExtensions = dynamic_cf_cast<CFDataRef>(CFDictionaryGetValue(sampleExtensionsDict, CFSTR("hvcC")));
+        RetainPtr sampleExtensions = dynamic_cf_cast<CFDataRef>(CFDictionaryGetValue(sampleExtensionsDict.get(), CFSTR("hvcC")));
         if (!sampleExtensions)
             return "hvc1"_s;
-        auto configurationRecordBuffer = SharedBuffer::create(sampleExtensions);
+        auto configurationRecordBuffer = SharedBuffer::create(sampleExtensions.get());
         auto parameters = parseHEVCDecoderConfigurationRecord(kCMVideoCodecType_HEVC, configurationRecordBuffer);
         if (!parameters)
             return "hvc1"_s;
@@ -177,13 +177,13 @@ String codecFromFormatDescription(CMFormatDescriptionRef formatDescription)
     }
     case kCMVideoCodecType_DolbyVisionHEVC:
     case 'cdh1': {
-        auto sampleExtensionsDict = dynamic_cf_cast<CFDictionaryRef>(PAL::CMFormatDescriptionGetExtension(formatDescription, PAL::kCMFormatDescriptionExtension_SampleDescriptionExtensionAtoms));
+        RetainPtr sampleExtensionsDict = dynamic_cf_cast<CFDictionaryRef>(PAL::CMFormatDescriptionGetExtension(formatDescription, PAL::kCMFormatDescriptionExtension_SampleDescriptionExtensionAtoms));
         if (!sampleExtensionsDict)
             return "dvh1"_s;
-        auto sampleExtensions = dynamic_cf_cast<CFDataRef>(CFDictionaryGetValue(sampleExtensionsDict, CFSTR("dvcC")));
+        RetainPtr sampleExtensions = dynamic_cf_cast<CFDataRef>(CFDictionaryGetValue(sampleExtensionsDict.get(), CFSTR("dvcC")));
         if (!sampleExtensions)
             return "dvh1"_s;
-        auto configurationRecordBuffer = SharedBuffer::create(sampleExtensions);
+        auto configurationRecordBuffer = SharedBuffer::create(sampleExtensions.get());
         auto parameters = parseDoViDecoderConfigurationRecord(configurationRecordBuffer);
         if (!parameters)
             return "dvh1"_s;

--- a/Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp
@@ -78,12 +78,12 @@ static std::optional<SRGBA<uint8_t>> makeSimpleColorFromARGBCFArray(CFArrayRef c
 
     std::array<float, 4> componentArray;
     for (int i = 0; i < 4; ++i) {
-        auto value = dynamic_cf_cast<CFNumberRef>(CFArrayGetValueAtIndex(colorArray, i));
+        RetainPtr value = dynamic_cf_cast<CFNumberRef>(CFArrayGetValueAtIndex(colorArray, i));
         if (!value)
             return std::nullopt;
 
         float component;
-        CFNumberGetValue(value, kCFNumberFloatType, &component);
+        CFNumberGetValue(value.get(), kCFNumberFloatType, &component);
         componentArray[i] = component;
     }
 
@@ -114,36 +114,36 @@ Ref<InbandGenericCue> InbandTextTrackPrivateAVF::processCueAttributes(CFAttribut
     CFRange effectiveRange = CFRangeMake(0, 0);
     while ((effectiveRange.location + effectiveRange.length) < length) {
 
-        CFDictionaryRef attributes = CFAttributedStringGetAttributes(attributedString, effectiveRange.location + effectiveRange.length, &effectiveRange);
+        RetainPtr attributes = CFAttributedStringGetAttributes(attributedString, effectiveRange.location + effectiveRange.length, &effectiveRange);
         if (!attributes)
             continue;
 
         StringBuilder tagStart;
         String tagEnd;
-        CFIndex attributeCount = CFDictionaryGetCount(attributes);
+        CFIndex attributeCount = CFDictionaryGetCount(attributes.get());
         Vector<const void*> keys(attributeCount);
         Vector<const void*> values(attributeCount);
-        CFDictionaryGetKeysAndValues(attributes, keys.mutableSpan().data(), values.mutableSpan().data());
+        CFDictionaryGetKeysAndValues(attributes.get(), keys.mutableSpan().data(), values.mutableSpan().data());
 
         for (CFIndex i = 0; i < attributeCount; ++i) {
-            auto key = dynamic_cf_cast<CFStringRef>(keys[i]);
-            CFTypeRef value = values[i];
-            if (!key || !CFStringGetLength(key))
+            RetainPtr key = dynamic_cf_cast<CFStringRef>(keys[i]);
+            RetainPtr value = static_cast<CFTypeRef>(values[i]);
+            if (!key || !CFStringGetLength(key.get()))
                 continue;
 
-            if (CFStringCompare(key, PAL::kCMTextMarkupAttribute_Alignment, 0) == kCFCompareEqualTo) {
-                auto valueString = dynamic_cf_cast<CFStringRef>(value);
-                if (!valueString || !CFStringGetLength(valueString))
+            if (CFStringCompare(key.get(), PAL::kCMTextMarkupAttribute_Alignment, 0) == kCFCompareEqualTo) {
+                RetainPtr valueString = dynamic_cf_cast<CFStringRef>(value.get());
+                if (!valueString || !CFStringGetLength(valueString.get()))
                     continue;
                 if (processed & Align)
                     continue;
                 processed |= Align;
 
-                if (CFStringCompare(valueString, PAL::kCMTextMarkupAlignmentType_Start, 0) == kCFCompareEqualTo)
+                if (CFStringCompare(valueString.get(), PAL::kCMTextMarkupAlignmentType_Start, 0) == kCFCompareEqualTo)
                     cueData->setAlign(GenericCueData::Alignment::Start);
-                else if (CFStringCompare(valueString, PAL::kCMTextMarkupAlignmentType_Middle, 0) == kCFCompareEqualTo)
+                else if (CFStringCompare(valueString.get(), PAL::kCMTextMarkupAlignmentType_Middle, 0) == kCFCompareEqualTo)
                     cueData->setAlign(GenericCueData::Alignment::Middle);
-                else if (CFStringCompare(valueString, PAL::kCMTextMarkupAlignmentType_End, 0) == kCFCompareEqualTo)
+                else if (CFStringCompare(valueString.get(), PAL::kCMTextMarkupAlignmentType_End, 0) == kCFCompareEqualTo)
                     cueData->setAlign(GenericCueData::Alignment::End);
                 else
                     ASSERT_NOT_REACHED();
@@ -151,8 +151,8 @@ Ref<InbandGenericCue> InbandTextTrackPrivateAVF::processCueAttributes(CFAttribut
                 continue;
             }
 
-            if (CFStringCompare(key, PAL::kCMTextMarkupAttribute_BoldStyle, 0) == kCFCompareEqualTo) {
-                if (value != kCFBooleanTrue)
+            if (CFStringCompare(key.get(), PAL::kCMTextMarkupAttribute_BoldStyle, 0) == kCFCompareEqualTo) {
+                if (value.get() != kCFBooleanTrue)
                     continue;
 
                 tagStart.append("<b>"_s);
@@ -160,8 +160,8 @@ Ref<InbandGenericCue> InbandTextTrackPrivateAVF::processCueAttributes(CFAttribut
                 continue;
             }
 
-            if (CFStringCompare(key, PAL::kCMTextMarkupAttribute_ItalicStyle, 0) == kCFCompareEqualTo) {
-                if (value != kCFBooleanTrue)
+            if (CFStringCompare(key.get(), PAL::kCMTextMarkupAttribute_ItalicStyle, 0) == kCFCompareEqualTo) {
+                if (value.get() != kCFBooleanTrue)
                     continue;
 
                 tagStart.append("<i>"_s);
@@ -169,8 +169,8 @@ Ref<InbandGenericCue> InbandTextTrackPrivateAVF::processCueAttributes(CFAttribut
                 continue;
             }
 
-            if (CFStringCompare(key, PAL::kCMTextMarkupAttribute_UnderlineStyle, 0) == kCFCompareEqualTo) {
-                if (value != kCFBooleanTrue)
+            if (CFStringCompare(key.get(), PAL::kCMTextMarkupAttribute_UnderlineStyle, 0) == kCFCompareEqualTo) {
+                if (value.get() != kCFBooleanTrue)
                     continue;
 
                 tagStart.append("<u>"_s);
@@ -178,8 +178,8 @@ Ref<InbandGenericCue> InbandTextTrackPrivateAVF::processCueAttributes(CFAttribut
                 continue;
             }
 
-            if (CFStringCompare(key, PAL::kCMTextMarkupAttribute_OrthogonalLinePositionPercentageRelativeToWritingDirection, 0) == kCFCompareEqualTo) {
-                auto valueNumber = dynamic_cf_cast<CFNumberRef>(value);
+            if (CFStringCompare(key.get(), PAL::kCMTextMarkupAttribute_OrthogonalLinePositionPercentageRelativeToWritingDirection, 0) == kCFCompareEqualTo) {
+                RetainPtr valueNumber = dynamic_cf_cast<CFNumberRef>(value.get());
                 if (!valueNumber)
                     continue;
                 if (processed & Line)
@@ -187,13 +187,13 @@ Ref<InbandGenericCue> InbandTextTrackPrivateAVF::processCueAttributes(CFAttribut
                 processed |= Line;
 
                 double line;
-                CFNumberGetValue(valueNumber, kCFNumberFloat64Type, &line);
+                CFNumberGetValue(valueNumber.get(), kCFNumberFloat64Type, &line);
                 cueData->setLine(line);
                 continue;
             }
 
-            if (CFStringCompare(key, PAL::kCMTextMarkupAttribute_TextPositionPercentageRelativeToWritingDirection, 0) == kCFCompareEqualTo) {
-                auto valueNumber = dynamic_cf_cast<CFNumberRef>(value);
+            if (CFStringCompare(key.get(), PAL::kCMTextMarkupAttribute_TextPositionPercentageRelativeToWritingDirection, 0) == kCFCompareEqualTo) {
+                RetainPtr valueNumber = dynamic_cf_cast<CFNumberRef>(value.get());
                 if (!valueNumber)
                     continue;
                 if (processed & Position)
@@ -201,13 +201,13 @@ Ref<InbandGenericCue> InbandTextTrackPrivateAVF::processCueAttributes(CFAttribut
                 processed |= Position;
 
                 double position;
-                CFNumberGetValue(valueNumber, kCFNumberFloat64Type, &position);
+                CFNumberGetValue(valueNumber.get(), kCFNumberFloat64Type, &position);
                 cueData->setPosition(position);
                 continue;
             }
 
-            if (CFStringCompare(key, PAL::kCMTextMarkupAttribute_WritingDirectionSizePercentage, 0) == kCFCompareEqualTo) {
-                auto valueNumber = dynamic_cf_cast<CFNumberRef>(value);
+            if (CFStringCompare(key.get(), PAL::kCMTextMarkupAttribute_WritingDirectionSizePercentage, 0) == kCFCompareEqualTo) {
+                RetainPtr valueNumber = dynamic_cf_cast<CFNumberRef>(value.get());
                 if (!valueNumber)
                     continue;
                 if (processed & Size)
@@ -215,87 +215,87 @@ Ref<InbandGenericCue> InbandTextTrackPrivateAVF::processCueAttributes(CFAttribut
                 processed |= Size;
 
                 double size;
-                CFNumberGetValue(valueNumber, kCFNumberFloat64Type, &size);
+                CFNumberGetValue(valueNumber.get(), kCFNumberFloat64Type, &size);
                 cueData->setSize(size);
                 continue;
             }
 
-            if (CFStringCompare(key, PAL::kCMTextMarkupAttribute_VerticalLayout, 0) == kCFCompareEqualTo) {
-                auto valueString = dynamic_cf_cast<CFStringRef>(value);
-                if (!valueString || !CFStringGetLength(valueString))
+            if (CFStringCompare(key.get(), PAL::kCMTextMarkupAttribute_VerticalLayout, 0) == kCFCompareEqualTo) {
+                RetainPtr valueString = dynamic_cf_cast<CFStringRef>(value.get());
+                if (!valueString || !CFStringGetLength(valueString.get()))
                     continue;
                 
-                if (CFStringCompare(valueString, PAL::kCMTextVerticalLayout_LeftToRight, 0) == kCFCompareEqualTo)
+                if (CFStringCompare(valueString.get(), PAL::kCMTextVerticalLayout_LeftToRight, 0) == kCFCompareEqualTo)
                     tagStart.append(leftToRightMark);
-                else if (CFStringCompare(valueString, PAL::kCMTextVerticalLayout_RightToLeft, 0) == kCFCompareEqualTo)
+                else if (CFStringCompare(valueString.get(), PAL::kCMTextVerticalLayout_RightToLeft, 0) == kCFCompareEqualTo)
                     tagStart.append(rightToLeftMark);
                 continue;
             }
 
-            if (CFStringCompare(key, PAL::kCMTextMarkupAttribute_BaseFontSizePercentageRelativeToVideoHeight, 0) == kCFCompareEqualTo) {
-                auto valueNumber = dynamic_cf_cast<CFNumberRef>(value);
+            if (CFStringCompare(key.get(), PAL::kCMTextMarkupAttribute_BaseFontSizePercentageRelativeToVideoHeight, 0) == kCFCompareEqualTo) {
+                RetainPtr valueNumber = dynamic_cf_cast<CFNumberRef>(value.get());
                 if (!valueNumber)
                     continue;
 
                 double baseFontSize;
-                CFNumberGetValue(valueNumber, kCFNumberFloat64Type, &baseFontSize);
+                CFNumberGetValue(valueNumber.get(), kCFNumberFloat64Type, &baseFontSize);
                 cueData->setBaseFontSize(baseFontSize);
                 continue;
             }
 
-            if (CFStringCompare(key, PAL::kCMTextMarkupAttribute_RelativeFontSize, 0) == kCFCompareEqualTo) {
-                auto valueNumber = dynamic_cf_cast<CFNumberRef>(value);
+            if (CFStringCompare(key.get(), PAL::kCMTextMarkupAttribute_RelativeFontSize, 0) == kCFCompareEqualTo) {
+                RetainPtr valueNumber = dynamic_cf_cast<CFNumberRef>(value.get());
                 if (!valueNumber)
                     continue;
 
                 double relativeFontSize;
-                CFNumberGetValue(valueNumber, kCFNumberFloat64Type, &relativeFontSize);
+                CFNumberGetValue(valueNumber.get(), kCFNumberFloat64Type, &relativeFontSize);
                 cueData->setRelativeFontSize(relativeFontSize);
                 continue;
             }
 
-            if (CFStringCompare(key, PAL::kCMTextMarkupAttribute_FontFamilyName, 0) == kCFCompareEqualTo) {
-                auto valueString = dynamic_cf_cast<CFStringRef>(value);
-                if (!valueString || !CFStringGetLength(valueString))
+            if (CFStringCompare(key.get(), PAL::kCMTextMarkupAttribute_FontFamilyName, 0) == kCFCompareEqualTo) {
+                RetainPtr valueString = dynamic_cf_cast<CFStringRef>(value.get());
+                if (!valueString || !CFStringGetLength(valueString.get()))
                     continue;
                 if (processed & FontName)
                     continue;
                 processed |= FontName;
-                
-                cueData->setFontName(valueString);
+
+                cueData->setFontName(valueString.get());
                 continue;
             }
 
-            if (CFStringCompare(key, PAL::kCMTextMarkupAttribute_ForegroundColorARGB, 0) == kCFCompareEqualTo) {
-                auto arrayValue = dynamic_cf_cast<CFArrayRef>(value);
+            if (CFStringCompare(key.get(), PAL::kCMTextMarkupAttribute_ForegroundColorARGB, 0) == kCFCompareEqualTo) {
+                RetainPtr arrayValue = dynamic_cf_cast<CFArrayRef>(value.get());
                 if (!arrayValue)
                     continue;
 
-                auto color = makeSimpleColorFromARGBCFArray(arrayValue);
+                auto color = makeSimpleColorFromARGBCFArray(arrayValue.get());
                 if (!color)
                     continue;
                 cueData->setForegroundColor(*color);
                 continue;
             }
 
-            if (CFStringCompare(key, PAL::kCMTextMarkupAttribute_BackgroundColorARGB, 0) == kCFCompareEqualTo) {
-                auto arrayValue = dynamic_cf_cast<CFArrayRef>(value);
+            if (CFStringCompare(key.get(), PAL::kCMTextMarkupAttribute_BackgroundColorARGB, 0) == kCFCompareEqualTo) {
+                RetainPtr arrayValue = dynamic_cf_cast<CFArrayRef>(value.get());
                 if (!arrayValue)
                     continue;
 
-                auto color = makeSimpleColorFromARGBCFArray(arrayValue);
+                auto color = makeSimpleColorFromARGBCFArray(arrayValue.get());
                 if (!color)
                     continue;
                 cueData->setBackgroundColor(*color);
                 continue;
             }
 
-            if (CFStringCompare(key, PAL::kCMTextMarkupAttribute_CharacterBackgroundColorARGB, 0) == kCFCompareEqualTo) {
-                auto arrayValue = dynamic_cf_cast<CFArrayRef>(value);
+            if (CFStringCompare(key.get(), PAL::kCMTextMarkupAttribute_CharacterBackgroundColorARGB, 0) == kCFCompareEqualTo) {
+                RetainPtr arrayValue = dynamic_cf_cast<CFArrayRef>(value.get());
                 if (!arrayValue)
                     continue;
 
-                auto color = makeSimpleColorFromARGBCFArray(arrayValue);
+                auto color = makeSimpleColorFromARGBCFArray(arrayValue.get());
                 if (!color)
                     continue;
                 cueData->setHighlightColor(*color);
@@ -358,12 +358,12 @@ void InbandTextTrackPrivateAVF::processAttributedStrings(CFArrayRef attributedSt
     Vector<Ref<InbandGenericCue>> arrivingCues;
     if (count) {
         for (CFIndex i = 0; i < count; i++) {
-            CFAttributedStringRef attributedString = static_cast<CFAttributedStringRef>(CFArrayGetValueAtIndex(attributedStrings, i));
+            RetainPtr attributedString = static_cast<CFAttributedStringRef>(CFArrayGetValueAtIndex(attributedStrings, i));
 
-            if (!attributedString || !CFAttributedStringGetLength(attributedString))
+            if (!attributedString || !CFAttributedStringGetLength(attributedString.get()))
                 continue;
 
-            auto cueData = processCueAttributes(attributedString);
+            auto cueData = processCueAttributes(attributedString.get());
             if (!cueData->content().length())
                 continue;
 
@@ -499,15 +499,15 @@ bool InbandTextTrackPrivateAVF::processVTTFileHeader(CMFormatDescriptionRef form
 
     RefPtr<ArrayBuffer> buffer;
 
-    auto extensions = PAL::CMFormatDescriptionGetExtensions(formatDescription);
+    RetainPtr extensions = PAL::CMFormatDescriptionGetExtensions(formatDescription);
     if (!extensions)
         return false;
 
-    auto sampleDescriptionExtensions = static_cast<CFDictionaryRef>(CFDictionaryGetValue(extensions, PAL::kCMFormatDescriptionExtension_SampleDescriptionExtensionAtoms));
+    RetainPtr sampleDescriptionExtensions = static_cast<CFDictionaryRef>(CFDictionaryGetValue(extensions.get(), PAL::kCMFormatDescriptionExtension_SampleDescriptionExtensionAtoms));
     if (!sampleDescriptionExtensions)
         return false;
 
-    RetainPtr webvttHeaderData = static_cast<CFDataRef>(CFDictionaryGetValue(sampleDescriptionExtensions, CFSTR("vttC")));
+    RetainPtr webvttHeaderData = static_cast<CFDataRef>(CFDictionaryGetValue(sampleDescriptionExtensions.get(), CFSTR("vttC")));
     if (!webvttHeaderData)
         return false;
 
@@ -588,9 +588,9 @@ void InbandTextTrackPrivateAVF::processVTTSamples(CFArrayRef nativeSamples, cons
     ALWAYS_LOG(LOGIDENTIFIER, count, " sample buffers at time ", presentationTime);
 
     for (CFIndex i = 0; i < count; i++) {
-        auto sampleBuffer = reinterpret_cast<CMSampleBufferRef>(const_cast<void*>(CFArrayGetValueAtIndex(nativeSamples, i)));
+        RetainPtr sampleBuffer = reinterpret_cast<CMSampleBufferRef>(const_cast<void*>(CFArrayGetValueAtIndex(nativeSamples, i)));
         if (sampleBuffer)
-            processVTTSample(sampleBuffer, presentationTime);
+            processVTTSample(sampleBuffer.get(), presentationTime);
     }
 }
 
@@ -599,15 +599,15 @@ bool InbandTextTrackPrivateAVF::readVTTSampleBuffer(CMSampleBufferRef sampleBuff
 #if OS(WINDOWS) && HAVE(AVCFPLAYERITEM_CALLBACK_VERSION_2)
     return false;
 #else
-    auto blockBuffer = PAL::CMSampleBufferGetDataBuffer(sampleBuffer);
-    auto bufferLength = PAL::CMBlockBufferGetDataLength(blockBuffer);
+    RetainPtr blockBuffer = PAL::CMSampleBufferGetDataBuffer(sampleBuffer);
+    auto bufferLength = PAL::CMBlockBufferGetDataLength(blockBuffer.get());
     if (bufferLength < ISOBox::minimumBoxSize()) {
         ERROR_LOG(LOGIDENTIFIER, "CMSampleBuffer size length unexpectedly small ", bufferLength);
         return false;
     }
 
     m_sampleInputBuffer.grow(m_sampleInputBuffer.size() + bufferLength);
-    PAL::CMBlockBufferCopyDataBytes(blockBuffer, 0, bufferLength, m_sampleInputBuffer.mutableSpan().last(bufferLength).data());
+    PAL::CMBlockBufferCopyDataBytes(blockBuffer.get(), 0, bufferLength, m_sampleInputBuffer.mutableSpan().last(bufferLength).data());
 
     formatDescription = PAL::CMSampleBufferGetFormatDescription(sampleBuffer);
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AVRoutePickerViewTargetPicker.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AVRoutePickerViewTargetPicker.mm
@@ -124,15 +124,15 @@ void AVRoutePickerViewTargetPicker::showPlaybackTargetPicker(NSView *view, const
     if (!client())
         return;
 
-    auto *picker = devicePicker();
+    RetainPtr picker = devicePicker();
     if (useDarkAppearance)
-        picker.routeListAlwaysHasDarkAppearance = YES;
+        picker.get().routeListAlwaysHasDarkAppearance = YES;
 
     m_hadActiveRoute = hasActiveRoute;
 
     auto rectInWindowCoordinates = [view.window convertRectFromScreen:NSMakeRect(rectInScreenCoordinates.x(), rectInScreenCoordinates.y(), 1.0, 1.0)];
     auto rectInViewCoordinates = [view convertRect:rectInWindowCoordinates fromView:view];
-    [picker showRoutePickingControlsForOutputContext:outputContextInternal() relativeToRect:rectInViewCoordinates ofView:view];
+    [picker.get() showRoutePickingControlsForOutputContext:outputContextInternal() relativeToRect:rectInViewCoordinates ofView:view];
 }
 
 void AVRoutePickerViewTargetPicker::startingMonitoringPlaybackTargets()

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
@@ -252,11 +252,11 @@ AVContentKeySession* CDMInstanceFairPlayStreamingAVFObjC::contentKeySession()
     if (!PAL::canLoad_AVFoundation_AVContentKeySystemFairPlayStreaming())
         return nullptr;
 
-    auto storageURL = this->storageURL();
+    RetainPtr storageURL = this->storageURL();
     if (!persistentStateAllowed() || !storageURL)
         m_session = [PAL::getAVContentKeySessionClassSingleton() contentKeySessionWithKeySystem:AVContentKeySystemFairPlayStreaming];
     else
-        m_session = [PAL::getAVContentKeySessionClassSingleton() contentKeySessionWithKeySystem:AVContentKeySystemFairPlayStreaming storageDirectoryAtURL:storageURL];
+        m_session = [PAL::getAVContentKeySessionClassSingleton() contentKeySessionWithKeySystem:AVContentKeySystemFairPlayStreaming storageDirectoryAtURL:storageURL.get()];
 
     if (!m_session)
         return nullptr;
@@ -805,13 +805,13 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     m_requestLicenseCallback = WTF::move(callback);
 
     if (m_group) {
-        auto* options = @{ ContentKeyReportGroupKey: m_group.get(), InitializationDataTypeKey: initDataType.createNSString().get() };
-        [m_group processContentKeyRequestWithIdentifier:identifier.get() initializationData:initializationData.get() options:options];
+        RetainPtr options = @{ ContentKeyReportGroupKey: m_group.get(), InitializationDataTypeKey: initDataType.createNSString().get() };
+        [m_group processContentKeyRequestWithIdentifier:identifier.get() initializationData:initializationData.get() options:options.get()];
         return;
     }
 
-    auto* options = @{ InitializationDataTypeKey: initDataType.createNSString().get() };
-    [m_session processContentKeyRequestWithIdentifier:identifier.get() initializationData:initializationData.get() options:options];
+    RetainPtr options = @{ InitializationDataTypeKey: initDataType.createNSString().get() };
+    [m_session processContentKeyRequestWithIdentifier:identifier.get() initializationData:initializationData.get() options:options.get()];
 }
 
 static bool isEqual(const SharedBuffer& data, const String& value)
@@ -836,7 +836,7 @@ void CDMInstanceSessionFairPlayStreamingAVFObjC::updateLicense(const String&, Li
 {
     if (!m_expiredSessions.isEmpty() && isEqual(responseData, "acknowledged"_s)) {
         auto* certificate = m_instance->serverCertificate();
-        auto* storageURL = m_instance->storageURL();
+        RetainPtr storageURL = m_instance->storageURL();
 
         if (!certificate || !storageURL) {
             ERROR_LOG(LOGIDENTIFIER, "\"acknowledged\", Failed, no certificate and storageURL");
@@ -849,13 +849,13 @@ void CDMInstanceSessionFairPlayStreamingAVFObjC::updateLicense(const String&, Li
             return data.get();
         });
         auto appIdentifier = certificate->makeContiguous()->createNSData();
-        [PAL::getAVContentKeySessionClassSingleton() removePendingExpiredSessionReports:expiredSessions.get() withAppIdentifier:appIdentifier.get() storageDirectoryAtURL:storageURL];
+        [PAL::getAVContentKeySessionClassSingleton() removePendingExpiredSessionReports:expiredSessions.get() withAppIdentifier:appIdentifier.get() storageDirectoryAtURL:storageURL.get()];
         callback(false, { }, std::nullopt, std::nullopt, Succeeded);
         return;
     }
 
     if (!m_requests.isEmpty() && isEqual(responseData, "renew"_s)) {
-        auto request = lastKeyRequest();
+        RetainPtr request = lastKeyRequest();
         if (!request) {
             ERROR_LOG(LOGIDENTIFIER, "\"renew\", Failed, no outstanding keys");
             callback(false, std::nullopt, std::nullopt, std::nullopt, Failed);
@@ -863,8 +863,8 @@ void CDMInstanceSessionFairPlayStreamingAVFObjC::updateLicense(const String&, Li
         }
         m_renewingRequest = m_requests.last();
         ALWAYS_LOG(LOGIDENTIFIER, "\"renew\", processing renewal");
-        auto session = m_session ? m_session.get() : m_instance->contentKeySession();
-        [session renewExpiringResponseDataForContentKeyRequest:request];
+        RetainPtr session = m_session ? m_session.get() : m_instance->contentKeySession();
+        [session.get() renewExpiringResponseDataForContentKeyRequest:request.get()];
         m_updateLicenseCallback = WTF::move(callback);
         return;
     }
@@ -997,7 +997,7 @@ void CDMInstanceSessionFairPlayStreamingAVFObjC::updateLicense(const String&, Li
 void CDMInstanceSessionFairPlayStreamingAVFObjC::loadSession(LicenseType licenseType, const String& sessionId, const String&, LoadSessionCallback&& callback)
 {
     if (licenseType == LicenseType::PersistentUsageRecord) {
-        auto* storageURL = m_instance->storageURL();
+        RetainPtr storageURL = m_instance->storageURL();
         if (!m_instance->persistentStateAllowed() || !storageURL) {
             ERROR_LOG(LOGIDENTIFIER, " Failed, mismatched session type");
             callback(std::nullopt, std::nullopt, std::nullopt, Failed, SessionLoadFailure::MismatchedSessionType);
@@ -1012,7 +1012,7 @@ void CDMInstanceSessionFairPlayStreamingAVFObjC::loadSession(LicenseType license
 
         RetainPtr<NSData> appIdentifier = certificate->makeContiguous()->createNSData();
         KeyStatusVector changedKeys;
-        for (NSData* expiredSessionData in [PAL::getAVContentKeySessionClassSingleton() pendingExpiredSessionReportsWithAppIdentifier:appIdentifier.get() storageDirectoryAtURL:storageURL]) {
+        for (NSData* expiredSessionData in [PAL::getAVContentKeySessionClassSingleton() pendingExpiredSessionReportsWithAppIdentifier:appIdentifier.get() storageDirectoryAtURL:storageURL.get()]) {
             static const NSString *PlaybackSessionIdKey = @"PlaybackSessionID";
             NSDictionary *expiredSession = [NSPropertyListSerialization propertyListWithData:expiredSessionData options:kCFPropertyListImmutable format:nullptr error:nullptr];
             RetainPtr playbackSessionIdValue = dynamic_objc_cast<NSString>([expiredSession objectForKey:PlaybackSessionIdKey]);
@@ -1066,7 +1066,7 @@ void CDMInstanceSessionFairPlayStreamingAVFObjC::removeSessionData(const String&
         [m_session expire];
 
     if (licenseType == LicenseType::PersistentUsageRecord) {
-        auto* storageURL = m_instance->storageURL();
+        RetainPtr storageURL = m_instance->storageURL();
         auto* certificate = m_instance->serverCertificate();
 
         if (!m_instance->persistentStateAllowed() || !storageURL || !certificate) {
@@ -1078,7 +1078,7 @@ void CDMInstanceSessionFairPlayStreamingAVFObjC::removeSessionData(const String&
         RetainPtr<NSData> appIdentifier = certificate->makeContiguous()->createNSData();
         RetainPtr<NSMutableArray> expiredSessionsArray = adoptNS([[NSMutableArray alloc] init]);
         KeyStatusVector changedKeys;
-        for (NSData* expiredSessionData in [PAL::getAVContentKeySessionClassSingleton() pendingExpiredSessionReportsWithAppIdentifier:appIdentifier.get() storageDirectoryAtURL:storageURL]) {
+        for (NSData* expiredSessionData in [PAL::getAVContentKeySessionClassSingleton() pendingExpiredSessionReportsWithAppIdentifier:appIdentifier.get() storageDirectoryAtURL:storageURL.get()]) {
             NSDictionary *expiredSession = [NSPropertyListSerialization propertyListWithData:expiredSessionData options:kCFPropertyListImmutable format:nullptr error:nullptr];
             static const NSString *PlaybackSessionIdKey = @"PlaybackSessionID";
             RetainPtr playbackSessionIdValue = dynamic_objc_cast<NSString>([expiredSession objectForKey:PlaybackSessionIdKey]);
@@ -1109,9 +1109,9 @@ void CDMInstanceSessionFairPlayStreamingAVFObjC::removeSessionData(const String&
             return;
         }
 
-        id propertyList = expiredSessionsCount == 1 ? [expiredSessionsArray firstObject] : expiredSessionsArray.get();
+        RetainPtr<id> propertyList = expiredSessionsCount == 1 ? [expiredSessionsArray firstObject] : expiredSessionsArray.get();
 
-        RetainPtr<NSData> expiredSessionsData = [NSPropertyListSerialization dataWithPropertyList:propertyList format:NSPropertyListBinaryFormat_v1_0 options:kCFPropertyListImmutable error:nullptr];
+        RetainPtr<NSData> expiredSessionsData = [NSPropertyListSerialization dataWithPropertyList:propertyList.get() format:NSPropertyListBinaryFormat_v1_0 options:kCFPropertyListImmutable error:nullptr];
 
         if (expiredSessionsCount > 1)
             ERROR_LOG(LOGIDENTIFIER, "Multiple(", expiredSessionsCount, ") expired session reports found with same sessionID(", sessionId, ")!");
@@ -1493,11 +1493,11 @@ void CDMInstanceSessionFairPlayStreamingAVFObjC::nextRequest()
     }
 
     ASSERT(nextRequest.requests.size() == 1);
-    auto* oneRequest = nextRequest.requests.first().get();
-    if (oneRequest.renewsExpiringResponseData)
-        didProvideRenewingRequest(oneRequest);
+    RetainPtr oneRequest = nextRequest.requests.first();
+    if (oneRequest.get().renewsExpiringResponseData)
+        didProvideRenewingRequest(oneRequest.get());
     else
-        didProvideRequest(oneRequest);
+        didProvideRequest(oneRequest.get());
 }
 
 AVContentKeyRequest* CDMInstanceSessionFairPlayStreamingAVFObjC::lastKeyRequest() const
@@ -1731,16 +1731,16 @@ bool CDMInstanceSessionFairPlayStreamingAVFObjC::ensureSessionOrGroup(KeyGroupin
     if (m_group)
         return true;
 
-    if (auto* session = m_instance->contentKeySession()) {
-        lazyInitialize(m_group, ContentKeyGroupFactoryAVFObjC::createContentKeyGroup(keyGroupingStrategy, session, *this));
+    if (RetainPtr session = m_instance->contentKeySession()) {
+        lazyInitialize(m_group, ContentKeyGroupFactoryAVFObjC::createContentKeyGroup(keyGroupingStrategy, session.get(), *this));
         return true;
     }
 
-    auto storageURL = m_instance->storageURL();
+    RetainPtr storageURL = m_instance->storageURL();
     if (!m_instance->persistentStateAllowed() || !storageURL)
         m_session = [PAL::getAVContentKeySessionClassSingleton() contentKeySessionWithKeySystem:AVContentKeySystemFairPlayStreaming];
     else
-        m_session = [PAL::getAVContentKeySessionClassSingleton() contentKeySessionWithKeySystem:AVContentKeySystemFairPlayStreaming storageDirectoryAtURL:storageURL];
+        m_session = [PAL::getAVContentKeySessionClassSingleton() contentKeySessionWithKeySystem:AVContentKeySystemFairPlayStreaming storageDirectoryAtURL:storageURL.get()];
 
     if (!m_session)
         return false;
@@ -1784,12 +1784,12 @@ AVContentKey *CDMInstanceSessionFairPlayStreamingAVFObjC::contentKeyForSample(co
 
 void CDMInstanceSessionFairPlayStreamingAVFObjC::attachContentKeyToSample(const MediaSampleAVFObjC& sample)
 {
-    AVContentKey *contentKey = contentKeyForSample(sample);
+    RetainPtr contentKey = contentKeyForSample(sample);
     if (!contentKey)
         return;
 
     NSError *error = nil;
-    if (!AVSampleBufferAttachContentKey(sample.platformSample().cmSampleBuffer(), contentKey, &error))
+    if (!AVSampleBufferAttachContentKey(sample.platformSample().cmSampleBuffer(), contentKey.get(), &error))
         ERROR_LOG(LOGIDENTIFIER, "Failed to attach content key with error: %{public}@", error);
 }
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -343,11 +343,11 @@ static AVAssetCache *ensureAssetCacheExistsForPath(const String& path)
 HashSet<SecurityOriginData> MediaPlayerPrivateAVFoundationObjC::originsInMediaCache(const String& path)
 {
     HashSet<SecurityOriginData> origins;
-    AVAssetCache* assetCache = assetCacheForPath(path);
+    RetainPtr assetCache = assetCacheForPath(path);
     if (!assetCache)
         return origins;
 
-    for (NSString *key in [assetCache allKeys]) {
+    for (NSString *key in [assetCache.get() allKeys]) {
         URL keyAsURL { key };
         if (keyAsURL.isValid())
             origins.add(SecurityOriginData::fromURL(keyAsURL));
@@ -363,17 +363,17 @@ static WallTime toSystemClockTime(NSDate *date)
 
 void MediaPlayerPrivateAVFoundationObjC::clearMediaCache(const String& path, WallTime modifiedSince)
 {
-    AVAssetCache* assetCache = assetCacheForPath(path);
+    RetainPtr assetCache = assetCacheForPath(path);
     if (!assetCache)
         return;
 
-    for (NSString *key in [assetCache allKeys]) {
-        if (toSystemClockTime([assetCache lastModifiedDateOfEntryForKey:key]) > modifiedSince)
-            [assetCache removeEntryForKey:key];
+    for (NSString *key in [assetCache.get() allKeys]) {
+        if (toSystemClockTime([assetCache.get() lastModifiedDateOfEntryForKey:key]) > modifiedSince)
+            [assetCache.get() removeEntryForKey:key];
     }
 
     NSFileManager *fileManager = [NSFileManager defaultManager];
-    NSURL *baseURL = [assetCache URL];
+    NSURL *baseURL = [assetCache.get() URL];
 
     if (modifiedSince <= WallTime::fromRawSeconds(0)) {
         [fileManager removeItemAtURL:baseURL error:nil];
@@ -407,15 +407,15 @@ void MediaPlayerPrivateAVFoundationObjC::clearMediaCache(const String& path, Wal
 
 void MediaPlayerPrivateAVFoundationObjC::clearMediaCacheForOrigins(const String& path, const HashSet<SecurityOriginData>& origins)
 {
-    AVAssetCache* assetCache = assetCacheForPath(path);
+    RetainPtr assetCache = assetCacheForPath(path);
     if (!assetCache)
         return;
 
-    for (NSString *key in [assetCache allKeys]) {
+    for (NSString *key in [assetCache.get() allKeys]) {
         URL keyAsURL { key };
         if (keyAsURL.isValid()) {
             if (origins.contains(SecurityOriginData::fromURL(keyAsURL)))
-                [assetCache removeEntryForKey:key];
+                [assetCache.get() removeEntryForKey:key];
         }
     }
 }
@@ -946,8 +946,8 @@ void MediaPlayerPrivateAVFoundationObjC::createAVAssetForURL(const URL& url, Ret
     [options setObject:@(!usePersistentCache) forKey:AVURLAssetUsesNoPersistentCacheKey];
 
     if (usePersistentCache) {
-        if (auto* assetCache = ensureAssetCacheExistsForPath(player->mediaCacheDirectory()))
-            [options setObject:assetCache forKey:AVURLAssetCacheKey];
+        if (RetainPtr assetCache = ensureAssetCacheExistsForPath(player->mediaCacheDirectory()))
+            [options setObject:assetCache.get() forKey:AVURLAssetCacheKey];
         else
             [options setObject:@NO forKey:AVURLAssetUsesNoPersistentCacheKey];
     }
@@ -2326,10 +2326,10 @@ void MediaPlayerPrivateAVFoundationObjC::tracksChanged()
     if (!m_avPlayerItem) {
         // We don't have a player item yet, so check with the asset because some assets support inspection
         // prior to becoming ready to play.
-        auto* firstEnabledVideoTrack = firstEnabledVisibleTrack();
-        setHasVideo(firstEnabledVideoTrack);
+        RetainPtr firstEnabledVideoTrack = firstEnabledVisibleTrack();
+        setHasVideo(firstEnabledVideoTrack.get());
         setHasAudio(firstEnabledAudibleTrack());
-        auto size = firstEnabledVideoTrack ? FloatSize(CGSizeApplyAffineTransform([firstEnabledVideoTrack naturalSize], [firstEnabledVideoTrack preferredTransform])) : FloatSize();
+        auto size = firstEnabledVideoTrack ? FloatSize(CGSizeApplyAffineTransform([firstEnabledVideoTrack.get() naturalSize], [firstEnabledVideoTrack.get() preferredTransform])) : FloatSize();
         // For videos with rotation tag set, the transformation above might return a CGSize instance with negative width or height.
         // See https://bugs.webkit.org/show_bug.cgi?id=172648.
         if (size.width() < 0)
@@ -2383,9 +2383,9 @@ void MediaPlayerPrivateAVFoundationObjC::tracksChanged()
 #endif
     }
 
-    AVMediaSelectionGroup *legibleGroup = safeMediaSelectionGroupForLegibleMedia();
+    RetainPtr legibleGroup = safeMediaSelectionGroupForLegibleMedia();
     if (legibleGroup && m_cachedTracks) {
-        hasCaptions = [[PAL::getAVMediaSelectionGroupClassSingleton() playableMediaSelectionOptionsFromArray:[legibleGroup options]] count];
+        hasCaptions = [[PAL::getAVMediaSelectionGroupClassSingleton() playableMediaSelectionOptionsFromArray:[legibleGroup.get() options]] count];
         if (hasCaptions)
             processMediaSelectionOptions();
     }
@@ -2414,9 +2414,9 @@ void MediaPlayerPrivateAVFoundationObjC::updateRotationSession()
 
     AffineTransform finalTransform = m_avAsset.get().preferredTransform;
     FloatSize naturalSize;
-    if (auto* firstEnabledVideoTrack = firstEnabledVisibleTrack()) {
-        naturalSize = FloatSize(firstEnabledVideoTrack.naturalSize);
-        finalTransform *= firstEnabledVideoTrack.preferredTransform;
+    if (RetainPtr firstEnabledVideoTrack = firstEnabledVisibleTrack()) {
+        naturalSize = FloatSize(firstEnabledVideoTrack.get().naturalSize);
+        finalTransform *= firstEnabledVideoTrack.get().preferredTransform;
     }
 
     if (finalTransform.isIdentity()) {
@@ -2551,8 +2551,8 @@ void MediaPlayerPrivateAVFoundationObjC::updateAudioTracks()
 
     Vector<String> characteristics = player->preferredAudioCharacteristics();
     if (!m_audibleGroup) {
-        if (AVMediaSelectionGroup *group = safeMediaSelectionGroupForAudibleMedia())
-            m_audibleGroup = MediaSelectionGroupAVFObjC::create(m_avPlayerItem.get(), group, characteristics);
+        if (RetainPtr group = safeMediaSelectionGroupForAudibleMedia())
+            m_audibleGroup = MediaSelectionGroupAVFObjC::create(m_avPlayerItem.get(), group.get(), characteristics);
     }
 
     if (m_audibleGroup)
@@ -2577,8 +2577,8 @@ void MediaPlayerPrivateAVFoundationObjC::updateVideoTracks()
     determineChangedTracksFromNewTracksAndOldItems(m_cachedTracks.get(), AVMediaTypeVideo, m_videoTracks, &VideoTrackPrivateAVFObjC::create, player, &MediaPlayer::removeVideoTrack, &MediaPlayer::addVideoTrack);
 
     if (!m_visualGroup) {
-        if (AVMediaSelectionGroup *group = safeMediaSelectionGroupForVisualMedia())
-            m_visualGroup = MediaSelectionGroupAVFObjC::create(m_avPlayerItem.get(), group, Vector<String>());
+        if (RetainPtr group = safeMediaSelectionGroupForVisualMedia())
+            m_visualGroup = MediaSelectionGroupAVFObjC::create(m_avPlayerItem.get(), group.get(), Vector<String>());
     }
 
     if (m_visualGroup)
@@ -2601,8 +2601,8 @@ void MediaPlayerPrivateAVFoundationObjC::syncTextTrackBounds()
 
 void MediaPlayerPrivateAVFoundationObjC::setTextTrackRepresentation(TextTrackRepresentation* representation)
 {
-    auto* representationLayer = representation ? representation->platformLayer() : nil;
-    m_videoLayerManager->setTextTrackRepresentationLayer(representationLayer);
+    RetainPtr representationLayer = representation ? representation->platformLayer() : nil;
+    m_videoLayerManager->setTextTrackRepresentationLayer(representationLayer.get());
 }
 
 #if ENABLE(WEB_AUDIO) && USE(MEDIATOOLBOX)
@@ -2735,8 +2735,8 @@ bool MediaPlayerPrivateAVFoundationObjC::updateLastPixelBuffer()
         m_lastPixelBuffer = m_imageRotationSession->rotate(m_lastPixelBuffer.get());
 
     if (m_resourceOwner && m_lastPixelBuffer) {
-        if (auto surface = CVPixelBufferGetIOSurface(m_lastPixelBuffer.get()))
-            IOSurface::setOwnershipIdentity(surface, m_resourceOwner);
+        if (RetainPtr surface = CVPixelBufferGetIOSurface(m_lastPixelBuffer.get()))
+            IOSurface::setOwnershipIdentity(surface.get(), m_resourceOwner);
     }
 
     m_lastImage = nullptr;
@@ -2763,7 +2763,7 @@ void MediaPlayerPrivateAVFoundationObjC::updateLastImage(NOESCAPE UpdateCompleti
         return;
     }
 
-    auto* firstEnabledVideoTrack = firstEnabledVisibleTrack();
+    RetainPtr firstEnabledVideoTrack = firstEnabledVisibleTrack();
     if (!firstEnabledVideoTrack) {
         completion();
         return;
@@ -3114,7 +3114,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 void MediaPlayerPrivateAVFoundationObjC::processMediaSelectionOptions()
 {
-    AVMediaSelectionGroup *legibleGroup = safeMediaSelectionGroupForLegibleMedia();
+    RetainPtr legibleGroup = safeMediaSelectionGroupForLegibleMedia();
     if (!legibleGroup) {
         ALWAYS_LOG(LOGIDENTIFIER, "no mediaSelectionGroup");
         return;
@@ -3131,7 +3131,7 @@ void MediaPlayerPrivateAVFoundationObjC::processMediaSelectionOptions()
     }
 
     Vector<RefPtr<InbandTextTrackPrivateAVF>> removedTextTracks = m_textTracks;
-    NSArray *legibleOptions = [PAL::getAVMediaSelectionGroupClassSingleton() playableMediaSelectionOptionsFromArray:[legibleGroup options]];
+    NSArray *legibleOptions = [PAL::getAVMediaSelectionGroupClassSingleton() playableMediaSelectionOptionsFromArray:[legibleGroup.get() options]];
     for (AVMediaSelectionOption *option in legibleOptions) {
         bool newTrack = true;
         for (unsigned i = removedTextTracks.size(); i > 0; --i) {
@@ -3168,7 +3168,7 @@ void MediaPlayerPrivateAVFoundationObjC::processMediaSelectionOptions()
             continue;
         }
 
-        m_textTracks.append(InbandTextTrackPrivateAVFObjC::create(legibleGroup, option, m_currentTextTrackID++, InbandTextTrackPrivate::CueFormat::Generic, WTF::move(modeChangedCallback)));
+        m_textTracks.append(InbandTextTrackPrivateAVFObjC::create(legibleGroup.get(), option, m_currentTextTrackID++, InbandTextTrackPrivate::CueFormat::Generic, WTF::move(modeChangedCallback)));
     }
 
     processNewAndRemovedTextTracks(removedTextTracks);
@@ -3488,16 +3488,16 @@ void MediaPlayerPrivateAVFoundationObjC::setShouldPlayToPlaybackTarget(bool shou
     INFO_LOG(LOGIDENTIFIER, shouldPlay);
 
     if (playbackTarget->type() == MediaPlaybackTarget::Type::AVOutputContext) {
-        AVOutputContext *newContext = shouldPlay ? m_outputContext.get() : nil;
+        RetainPtr newContext = shouldPlay ? m_outputContext.get() : nil;
 
         if (!m_avPlayer)
             return;
 
         RetainPtr<AVOutputContext> currentContext = m_avPlayer.get().outputContext;
-        if ((!newContext && !currentContext.get()) || [currentContext isEqual:newContext])
+        if ((!newContext && !currentContext.get()) || [currentContext isEqual:newContext.get()])
             return;
 
-        m_avPlayer.get().outputContext = newContext;
+        m_avPlayer.get().outputContext = newContext.get();
 
         return;
     }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
@@ -1085,8 +1085,9 @@ void MediaPlayerPrivateMediaStreamAVFObjC::updateCurrentFrameImage()
     if (!m_imagePainter.pixelBufferConformer)
         return;
 
-    if (auto pixelBuffer = m_imagePainter.videoFrame->pixelBuffer())
-        m_imagePainter.cgImage = NativeImage::create(m_imagePainter.pixelBufferConformer->createImageFromPixelBuffer(pixelBuffer));
+    RetainPtr pixelBuffer = m_imagePainter.videoFrame->pixelBuffer();
+    if (pixelBuffer)
+        m_imagePainter.cgImage = NativeImage::create(m_imagePainter.pixelBufferConformer->createImageFromPixelBuffer(pixelBuffer.get()));
 }
 
 static inline CGAffineTransform videoTransformationMatrix(VideoFrame& videoFrame)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
@@ -185,9 +185,9 @@ private:
         if (!description)
             return emptyString();
         FourCC originalCodec = PAL::softLink_CoreMedia_CMFormatDescriptionGetMediaSubType(description);
-        CFStringRef originalFormatKey = PAL::canLoad_CoreMedia_kCMFormatDescriptionExtension_ProtectedContentOriginalFormat() ? PAL::kCMFormatDescriptionExtension_ProtectedContentOriginalFormat : CFSTR("CommonEncryptionOriginalFormat");
-        if (auto originalFormat = dynamic_cf_cast<CFNumberRef>(PAL::CMFormatDescriptionGetExtension(description, originalFormatKey)))
-            CFNumberGetValue(originalFormat, kCFNumberSInt32Type, &originalCodec.value);
+        RetainPtr<CFStringRef> originalFormatKey = PAL::canLoad_CoreMedia_kCMFormatDescriptionExtension_ProtectedContentOriginalFormat() ? PAL::kCMFormatDescriptionExtension_ProtectedContentOriginalFormat : CFSTR("CommonEncryptionOriginalFormat");
+        if (RetainPtr originalFormat = dynamic_cf_cast<CFNumberRef>(PAL::CMFormatDescriptionGetExtension(description, originalFormatKey.get())))
+            CFNumberGetValue(originalFormat.get(), kCFNumberSInt32Type, &originalCodec.value);
         return String::fromLatin1(originalCodec.string().data());
     }
     bool m_isVideo { false };

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
@@ -659,13 +659,13 @@ void SourceBufferPrivateAVFObjC::enqueueSample(Ref<MediaSampleAVFObjC>&& sample,
 
     PlatformSample platformSample = sample->platformSample();
 
-    CMFormatDescriptionRef formatDescription = PAL::CMSampleBufferGetFormatDescription(platformSample.cmSampleBuffer());
+    RetainPtr formatDescription = PAL::CMSampleBufferGetFormatDescription(platformSample.cmSampleBuffer());
     ASSERT(formatDescription);
     if (!formatDescription) {
         ERROR_LOG(logSiteIdentifier, "Received sample with a null formatDescription. Bailing.");
         return;
     }
-    auto mediaType = PAL::CMFormatDescriptionGetMediaType(formatDescription);
+    auto mediaType = PAL::CMFormatDescriptionGetMediaType(formatDescription.get());
 
     if (auto trackIdentifier = trackIdentifierFor(trackId))
         protectedRenderer()->enqueueSample(*trackIdentifier, sample, mediaType == kCMMediaType_Video ? minimumUpcomingPresentationTimeForTrackID(trackId) : std::optional<MediaTime> { });

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
@@ -336,11 +336,11 @@ void PlatformCAAnimationCocoa::setTimingFunction(const TimingFunction* timingFun
     case AnimationType::Spring:
         if (auto* function = dynamicDowncast<SpringTimingFunction>(timingFunction)) {
             // FIXME: Handle reverse.
-            CASpringAnimation *springAnimation = (CASpringAnimation *)m_animation.get();
-            springAnimation.mass = function->mass();
-            springAnimation.stiffness = function->stiffness();
-            springAnimation.damping = function->damping();
-            springAnimation.initialVelocity = function->initialVelocity();
+            RetainPtr springAnimation = (CASpringAnimation *)m_animation.get();
+            springAnimation.get().mass = function->mass();
+            springAnimation.get().stiffness = function->stiffness();
+            springAnimation.get().damping = function->damping();
+            springAnimation.get().initialVelocity = function->initialVelocity();
         }
         break;
     case AnimationType::Group:
@@ -438,8 +438,8 @@ void PlatformCAAnimationCocoa::copyFromValueFrom(const PlatformCAAnimation& valu
 {
     if (!isBasicAnimation() || !value.isBasicAnimation())
         return;
-    auto otherAnimation = static_cast<CABasicAnimation *>(downcast<PlatformCAAnimationCocoa>(value).m_animation.get());
-    [static_cast<CABasicAnimation *>(m_animation.get()) setFromValue:[otherAnimation fromValue]];
+    RetainPtr otherAnimation = static_cast<CABasicAnimation *>(downcast<PlatformCAAnimationCocoa>(value).m_animation.get());
+    [static_cast<CABasicAnimation *>(m_animation.get()) setFromValue:[otherAnimation.get() fromValue]];
 }
 
 void PlatformCAAnimationCocoa::setToValue(float value)
@@ -482,8 +482,8 @@ void PlatformCAAnimationCocoa::copyToValueFrom(const PlatformCAAnimation& value)
     if (!isBasicAnimation() || !value.isBasicAnimation())
         return;
 
-    auto otherAnimation = static_cast<CABasicAnimation *>(downcast<PlatformCAAnimationCocoa>(value).m_animation.get());
-    [static_cast<CABasicAnimation *>(m_animation.get()) setToValue:[otherAnimation toValue]];
+    RetainPtr otherAnimation = static_cast<CABasicAnimation *>(downcast<PlatformCAAnimationCocoa>(value).m_animation.get());
+    [static_cast<CABasicAnimation *>(m_animation.get()) setToValue:[otherAnimation.get() toValue]];
 }
 
 
@@ -544,8 +544,8 @@ void PlatformCAAnimationCocoa::copyValuesFrom(const PlatformCAAnimation& value)
     if (animationType() != AnimationType::Keyframe || value.animationType() != AnimationType::Keyframe)
         return;
 
-    auto otherAnimation = static_cast<CAKeyframeAnimation *>(downcast<PlatformCAAnimationCocoa>(value).m_animation.get());
-    [static_cast<CAKeyframeAnimation *>(m_animation.get()) setValues:[otherAnimation values]];
+    RetainPtr otherAnimation = static_cast<CAKeyframeAnimation *>(downcast<PlatformCAAnimationCocoa>(value).m_animation.get());
+    [static_cast<CAKeyframeAnimation *>(m_animation.get()) setValues:[otherAnimation.get() values]];
 }
 
 void PlatformCAAnimationCocoa::setKeyTimes(const Vector<float>& value)
@@ -557,8 +557,8 @@ void PlatformCAAnimationCocoa::setKeyTimes(const Vector<float>& value)
 
 void PlatformCAAnimationCocoa::copyKeyTimesFrom(const PlatformCAAnimation& value)
 {
-    auto other = static_cast<CAKeyframeAnimation *>(downcast<PlatformCAAnimationCocoa>(value).m_animation.get());
-    [static_cast<CAKeyframeAnimation *>(m_animation.get()) setKeyTimes:[other keyTimes]];
+    RetainPtr other = static_cast<CAKeyframeAnimation *>(downcast<PlatformCAAnimationCocoa>(value).m_animation.get());
+    [static_cast<CAKeyframeAnimation *>(m_animation.get()) setKeyTimes:[other.get() keyTimes]];
 }
 
 void PlatformCAAnimationCocoa::setTimingFunctions(const Vector<Ref<const TimingFunction>>& timingFunctions, bool reverse)
@@ -570,8 +570,8 @@ void PlatformCAAnimationCocoa::setTimingFunctions(const Vector<Ref<const TimingF
 
 void PlatformCAAnimationCocoa::copyTimingFunctionsFrom(const PlatformCAAnimation& value)
 {
-    auto other = static_cast<CAKeyframeAnimation *>(downcast<PlatformCAAnimationCocoa>(value).m_animation.get());
-    [static_cast<CAKeyframeAnimation *>(m_animation.get()) setTimingFunctions:[other timingFunctions]];
+    RetainPtr other = static_cast<CAKeyframeAnimation *>(downcast<PlatformCAAnimationCocoa>(value).m_animation.get());
+    [static_cast<CAKeyframeAnimation *>(m_animation.get()) setTimingFunctions:[other.get() timingFunctions]];
 }
 
 void PlatformCAAnimationCocoa::setAnimations(const Vector<RefPtr<PlatformCAAnimation>>& value)
@@ -593,8 +593,8 @@ void PlatformCAAnimationCocoa::copyAnimationsFrom(const PlatformCAAnimation& val
     ASSERT([static_cast<CAAnimation *>(m_animation.get()) isKindOfClass:[CAAnimationGroup class]]);
     ASSERT([static_cast<CAAnimation *>(downcast<PlatformCAAnimationCocoa>(value).m_animation.get()) isKindOfClass:[CAAnimationGroup class]]);
 
-    auto other = static_cast<CAAnimationGroup *>(downcast<PlatformCAAnimationCocoa>(value).m_animation.get());
-    [static_cast<CAAnimationGroup *>(m_animation.get()) setAnimations:[other animations]];
+    RetainPtr other = static_cast<CAAnimationGroup *>(downcast<PlatformCAAnimationCocoa>(value).m_animation.get());
+    [static_cast<CAAnimationGroup *>(m_animation.get()) setAnimations:[other.get() animations]];
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
@@ -139,11 +139,11 @@ static MonotonicTime mediaTimeToCurrentTime(CFTimeInterval t)
     } else
         startTime = mediaTimeToCurrentTime([animation beginTime]);
 
-    CALayer *layer = owner->platformLayer();
+    RetainPtr layer = owner->platformLayer();
 
     String animationKey;
-    for (NSString *key in [layer animationKeys]) {
-        if ([layer animationForKey:key] == animation) {
+    for (NSString *key in [layer.get() animationKeys]) {
+        if ([layer.get() animationForKey:key] == animation) {
             animationKey = key;
             break;
         }
@@ -163,12 +163,12 @@ static MonotonicTime mediaTimeToCurrentTime(CFTimeInterval t)
     RefPtr owner = m_owner.get();
     if (!owner)
         return;
-    
-    CALayer *layer = owner->platformLayer();
+
+    RetainPtr layer = owner->platformLayer();
 
     String animationKey;
-    for (NSString *key in [layer animationKeys]) {
-        if ([layer animationForKey:key] == animation) {
+    for (NSString *key in [layer.get() animationKeys]) {
+        if ([layer.get() animationForKey:key] == animation) {
             animationKey = key;
             break;
         }
@@ -325,8 +325,8 @@ void PlatformCALayerCocoa::commonInit()
         [m_layer setValue:@YES forKey:@"isTile"];
 
     if (usesTiledBackingLayer()) {
-        WebTiledBackingLayer* tiledBackingLayer = static_cast<WebTiledBackingLayer*>(m_layer.get());
-        TileController* tileController = [tiledBackingLayer createTileController:this];
+        RetainPtr tiledBackingLayer = static_cast<WebTiledBackingLayer*>(m_layer.get());
+        TileController* tileController = [tiledBackingLayer.get() createTileController:this];
 
         m_customSublayers = makeUnique<PlatformCALayerList>(tileController->containerLayers());
     }
@@ -389,12 +389,12 @@ Ref<PlatformCALayer> PlatformCALayerCocoa::clone(PlatformCALayerClient* owner) c
     if (type == PlatformCALayer::LayerType::LayerTypeAVPlayerLayer) {
         ASSERT(PAL::isAVFoundationFrameworkAvailable() && [newLayer->platformLayer() isKindOfClass:PAL::getAVPlayerLayerClassSingleton()]);
 
-        AVPlayerLayer *destinationPlayerLayer = newLayer->avPlayerLayer();
-        AVPlayerLayer *sourcePlayerLayer = avPlayerLayer();
+        RetainPtr destinationPlayerLayer = newLayer->avPlayerLayer();
+        RetainPtr sourcePlayerLayer = avPlayerLayer();
         ASSERT(sourcePlayerLayer);
 
-        RunLoop::mainSingleton().dispatch([destinationPlayerLayer = retainPtr(destinationPlayerLayer), sourcePlayerLayer = retainPtr(sourcePlayerLayer)] {
-            [destinationPlayerLayer setPlayer:[sourcePlayerLayer player]];
+        RunLoop::mainSingleton().dispatch([destinationPlayerLayer, sourcePlayerLayer] {
+            [destinationPlayerLayer.get() setPlayer:[sourcePlayerLayer.get() player]];
         });
     }
     
@@ -461,9 +461,9 @@ bool PlatformCALayerCocoa::needsDisplay() const
 void PlatformCALayerCocoa::copyContentsFromLayer(PlatformCALayer* layer)
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS
-    CALayer* caLayer = layer->m_layer.get();
-    if ([m_layer contents] != [caLayer contents])
-        [m_layer setContents:[caLayer contents]];
+    RetainPtr caLayer = layer->m_layer.get();
+    if ([m_layer contents] != [caLayer.get() contents])
+        [m_layer setContents:[caLayer.get() contents]];
     else
         [m_layer reloadValueForKeyPath:@"contents"];
     END_BLOCK_OBJC_EXCEPTIONS
@@ -557,13 +557,13 @@ void PlatformCALayerCocoa::addAnimationForKey(const String& key, PlatformCAAnima
         [webAnimationDelegate setOwner:this];
         m_delegate = WTF::move(webAnimationDelegate);
     }
-    
-    CAAnimation *propertyAnimation = static_cast<CAAnimation *>(downcast<PlatformCAAnimationCocoa>(animation).platformAnimation());
-    if (![propertyAnimation delegate])
-        [propertyAnimation setDelegate:static_cast<id>(m_delegate.get())];
+
+    RetainPtr propertyAnimation = static_cast<CAAnimation *>(downcast<PlatformCAAnimationCocoa>(animation).platformAnimation());
+    if (![propertyAnimation.get() delegate])
+        [propertyAnimation.get() setDelegate:static_cast<id>(m_delegate.get())];
 
     BEGIN_BLOCK_OBJC_EXCEPTIONS
-    [m_layer addAnimation:propertyAnimation forKey:key.createNSString().get()];
+    [m_layer addAnimation:propertyAnimation.get() forKey:key.createNSString().get()];
     END_BLOCK_OBJC_EXCEPTIONS
 }
 
@@ -576,19 +576,19 @@ void PlatformCALayerCocoa::removeAnimationForKey(const String& key)
 
 RefPtr<PlatformCAAnimation> PlatformCALayerCocoa::animationForKey(const String& key)
 {
-    CAAnimation *propertyAnimation = static_cast<CAAnimation *>([m_layer animationForKey:key.createNSString().get()]);
+    RetainPtr propertyAnimation = static_cast<CAAnimation *>([m_layer animationForKey:key.createNSString().get()]);
     if (!propertyAnimation)
         return nullptr;
-    return PlatformCAAnimationCocoa::create(propertyAnimation);
+    return PlatformCAAnimationCocoa::create(propertyAnimation.get());
 }
 
 void PlatformCALayerCocoa::setMaskLayer(RefPtr<WebCore::PlatformCALayer>&& layer)
 {
-    auto* caLayer = layer ? layer->platformLayer() : nil;
+    RetainPtr caLayer = layer ? layer->platformLayer() : nil;
     PlatformCALayer::setMaskLayer(WTF::move(layer));
 
     BEGIN_BLOCK_OBJC_EXCEPTIONS
-    [m_layer setMask:caLayer];
+    [m_layer setMask:caLayer.get()];
     END_BLOCK_OBJC_EXCEPTIONS
 }
 
@@ -1181,8 +1181,8 @@ void PlatformCALayerCocoa::updateContentsFormat()
         BEGIN_BLOCK_OBJC_EXCEPTIONS
         auto contentsFormat = this->contentsFormat();
 
-        if (NSString *formatString = contentsFormatString(contentsFormat))
-            [m_layer setContentsFormat:formatString];
+        if (RetainPtr formatString = contentsFormatString(contentsFormat))
+            [m_layer setContentsFormat:formatString.get()];
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
         if (contentsFormat == ContentsFormat::RGBA16F) {
             ALLOW_DEPRECATED_DECLARATIONS_BEGIN
@@ -1200,8 +1200,8 @@ TiledBacking* PlatformCALayerCocoa::tiledBacking()
     if (!usesTiledBackingLayer())
         return nullptr;
 
-    WebTiledBackingLayer *tiledBackingLayer = static_cast<WebTiledBackingLayer *>(m_layer.get());
-    return [tiledBackingLayer tiledBacking];
+    RetainPtr tiledBackingLayer = static_cast<WebTiledBackingLayer *>(m_layer.get());
+    return [tiledBackingLayer.get() tiledBacking];
 }
 
 #if PLATFORM(IOS_FAMILY)
@@ -1338,20 +1338,20 @@ Ref<PlatformCALayer> PlatformCALayerCocoa::createCompatibleLayer(PlatformCALayer
 
 void PlatformCALayerCocoa::enumerateRectsBeingDrawn(GraphicsContext& context, void (^block)(FloatRect))
 {
-    CGSRegionObj region = (CGSRegionObj)[m_layer regionBeingDrawn];
+    RetainPtr region = (CGSRegionObj)[m_layer regionBeingDrawn];
     if (!region) {
         block(context.clipBounds());
         return;
     }
 
     CGAffineTransform inverseTransform = CGAffineTransformInvert(context.getCTM());
-    CGSRegionEnumeratorObj enumerator = CGSRegionEnumerator(region);
+    CGSRegionEnumeratorObj enumerator = CGSRegionEnumerator(region.get());
     const CGRect* nextRect;
     while ((nextRect = CGSNextRect(enumerator))) {
         CGRect rectToDraw = CGRectApplyAffineTransform(*nextRect, inverseTransform);
         block(rectToDraw);
     }
-    
+
     CGSReleaseRegionEnumerator(enumerator);
 }
 
@@ -1371,8 +1371,8 @@ AVPlayerLayer *PlatformCALayerCocoa::avPlayerLayer() const
     if ([platformLayer() isKindOfClass:PAL::getAVPlayerLayerClassSingleton()])
         return static_cast<AVPlayerLayer *>(platformLayer());
 
-    if (auto *layer = dynamic_objc_cast<WebVideoContainerLayer>(platformLayer()))
-        return layer.playerLayer;
+    if (RetainPtr layer = dynamic_objc_cast<WebVideoContainerLayer>(platformLayer()))
+        return [layer.get() playerLayer];
 
     ASSERT_NOT_REACHED();
     return nil;

--- a/Source/WebCore/platform/graphics/cg/GradientRendererCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GradientRendererCG.cpp
@@ -117,9 +117,9 @@ GradientRendererCG::Strategy GradientRendererCG::makeGradient(ColorInterpolation
     auto gradientInterpolatesPremultipliedOptionsDictionary = [] () -> CFDictionaryRef {
         static CFTypeRef keys[] = { kCGGradientInterpolatesPremultiplied };
         static CFTypeRef values[] = { kCFBooleanTrue };
-        static CFDictionaryRef options = CFDictionaryCreate(kCFAllocatorDefault, keys, values, std::size(keys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+        static NeverDestroyed<RetainPtr<CFDictionaryRef>> options = adoptCF(CFDictionaryCreate(kCFAllocatorDefault, keys, values, std::size(keys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
 
-        return options;
+        return options->get();
     };
 
    auto gradientOptionsDictionary = [&] (auto colorInterpolationMethod) -> CFDictionaryRef {
@@ -148,7 +148,7 @@ GradientRendererCG::Strategy GradientRendererCG::makeGradient(ColorInterpolation
     Vector<CGFloat, 4 * reservedStops> colorComponents;
     colorComponents.reserveInitialCapacity(numberOfStops * 4);
 
-    auto cgColorSpace = [&] {
+    RetainPtr cgColorSpace = [&] {
         // FIXME: Now that we only ever use CGGradientCreateWithColorComponents, we should investigate
         // if there is any real benefit to using sRGB when all the stops are bounded vs just using
         // extended sRGB for all gradients.
@@ -204,7 +204,7 @@ GradientRendererCG::Strategy GradientRendererCG::makeGradient(ColorInterpolation
 
     apply139572277Workaround();
 
-    return Gradient { adoptCF(CGGradientCreateWithColorComponentsAndOptions(cgColorSpace, colorComponents.span().data(), locations.span().data(), numberOfStops, gradientOptionsDictionary(colorInterpolationMethod))), destinationColorSpace };
+    return Gradient { adoptCF(CGGradientCreateWithColorComponentsAndOptions(cgColorSpace.get(), colorComponents.span().data(), locations.span().data(), numberOfStops, gradientOptionsDictionary(colorInterpolationMethod))), destinationColorSpace };
 }
 
 // MARK: - Shading strategy.

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextGLCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextGLCG.cpp
@@ -345,8 +345,8 @@ bool GraphicsContextGLImageExtractor::extractImage(bool premultiplyAlpha, bool i
     // so, re-render it into an RGB color space. The image re-packing
     // code requires color data, not color table indices, for the
     // image data.
-    CGColorSpaceRef colorSpace = CGImageGetColorSpace(decodedImage->platformImage().get());
-    CGColorSpaceModel model = CGColorSpaceGetModel(colorSpace);
+    RetainPtr<CGColorSpaceRef> colorSpace = CGImageGetColorSpace(decodedImage->platformImage().get());
+    CGColorSpaceModel model = CGColorSpaceGetModel(colorSpace.get());
     if (model == kCGColorSpaceModelIndexed) {
         RetainPtr<CGContextRef> bitmapContext;
         // FIXME: we should probably manually convert the image by indexing into

--- a/Source/WebCore/platform/graphics/cg/PathCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/PathCG.cpp
@@ -605,17 +605,17 @@ bool PathCG::strokeContains(const FloatPoint& point, NOESCAPE const Function<voi
 {
     ASSERT(strokeStyleApplier);
 
-    CGContextRef context = scratchContext();
+    RetainPtr context = scratchContext();
 
-    CGContextSaveGState(context);
-    CGContextBeginPath(context);
-    CGContextAddPath(context, platformPath());
+    CGContextSaveGState(context.get());
+    CGContextBeginPath(context.get());
+    CGContextAddPath(context.get(), platformPath());
 
-    GraphicsContextCG graphicsContext(context);
+    GraphicsContextCG graphicsContext(context.get());
     strokeStyleApplier(graphicsContext);
 
-    bool hitSuccess = CGContextPathContainsPoint(context, point, kCGPathStroke);
-    CGContextRestoreGState(context);
+    bool hitSuccess = CGContextPathContainsPoint(context.get(), point, kCGPathStroke);
+    CGContextRestoreGState(context.get());
 
     return hitSuccess;
 }
@@ -640,20 +640,20 @@ FloatRect PathCG::boundingRect() const
 
 FloatRect PathCG::strokeBoundingRect(NOESCAPE const Function<void(GraphicsContext&)>& strokeStyleApplier) const
 {
-    CGContextRef context = scratchContext();
+    RetainPtr context = scratchContext();
 
-    CGContextSaveGState(context);
-    CGContextBeginPath(context);
-    CGContextAddPath(context, platformPath());
+    CGContextSaveGState(context.get());
+    CGContextBeginPath(context.get());
+    CGContextAddPath(context.get(), platformPath());
 
     if (strokeStyleApplier) {
-        GraphicsContextCG graphicsContext(context);
+        GraphicsContextCG graphicsContext(context.get());
         strokeStyleApplier(graphicsContext);
     }
 
-    CGContextReplacePathWithStrokedPath(context);
-    CGRect box = CGContextIsPathEmpty(context) ? CGRectZero : CGContextGetPathBoundingBox(context);
-    CGContextRestoreGState(context);
+    CGContextReplacePathWithStrokedPath(context.get());
+    CGRect box = CGContextIsPathEmpty(context.get()) ? CGRectZero : CGContextGetPathBoundingBox(context.get());
+    CGContextRestoreGState(context.get());
 
     return zeroRectIfNull(box);
 }

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
@@ -83,21 +83,21 @@ VariationDefaultsMap defaultVariationValues(CTFontRef font, ShouldLocalizeAxisNa
         return result;
     auto size = CFArrayGetCount(axes.get());
     for (CFIndex i = 0; i < size; ++i) {
-        CFDictionaryRef axis = static_cast<CFDictionaryRef>(CFArrayGetValueAtIndex(axes.get(), i));
-        CFNumberRef axisIdentifier = static_cast<CFNumberRef>(CFDictionaryGetValue(axis, kCTFontVariationAxisIdentifierKey));
-        String axisName = static_cast<CFStringRef>(CFDictionaryGetValue(axis, kCTFontVariationAxisNameKey));
-        CFNumberRef defaultValue = static_cast<CFNumberRef>(CFDictionaryGetValue(axis, kCTFontVariationAxisDefaultValueKey));
-        CFNumberRef minimumValue = static_cast<CFNumberRef>(CFDictionaryGetValue(axis, kCTFontVariationAxisMinimumValueKey));
-        CFNumberRef maximumValue = static_cast<CFNumberRef>(CFDictionaryGetValue(axis, kCTFontVariationAxisMaximumValueKey));
+        RetainPtr axis = static_cast<CFDictionaryRef>(CFArrayGetValueAtIndex(axes.get(), i));
+        RetainPtr axisIdentifier = static_cast<CFNumberRef>(CFDictionaryGetValue(axis.get(), kCTFontVariationAxisIdentifierKey));
+        String axisName = static_cast<CFStringRef>(CFDictionaryGetValue(axis.get(), kCTFontVariationAxisNameKey));
+        RetainPtr defaultValue = static_cast<CFNumberRef>(CFDictionaryGetValue(axis.get(), kCTFontVariationAxisDefaultValueKey));
+        RetainPtr minimumValue = static_cast<CFNumberRef>(CFDictionaryGetValue(axis.get(), kCTFontVariationAxisMinimumValueKey));
+        RetainPtr maximumValue = static_cast<CFNumberRef>(CFDictionaryGetValue(axis.get(), kCTFontVariationAxisMaximumValueKey));
         uint32_t rawAxisIdentifier = 0;
-        Boolean success = CFNumberGetValue(axisIdentifier, kCFNumberSInt32Type, &rawAxisIdentifier);
+        Boolean success = CFNumberGetValue(axisIdentifier.get(), kCFNumberSInt32Type, &rawAxisIdentifier);
         ASSERT_UNUSED(success, success);
         float rawDefaultValue = 0;
         float rawMinimumValue = 0;
         float rawMaximumValue = 0;
-        CFNumberGetValue(defaultValue, kCFNumberFloatType, &rawDefaultValue);
-        CFNumberGetValue(minimumValue, kCFNumberFloatType, &rawMinimumValue);
-        CFNumberGetValue(maximumValue, kCFNumberFloatType, &rawMaximumValue);
+        CFNumberGetValue(defaultValue.get(), kCFNumberFloatType, &rawDefaultValue);
+        CFNumberGetValue(minimumValue.get(), kCFNumberFloatType, &rawMinimumValue);
+        CFNumberGetValue(maximumValue.get(), kCFNumberFloatType, &rawMaximumValue);
 
         if (rawMinimumValue > rawMaximumValue)
             std::swap(rawMinimumValue, rawMaximumValue);
@@ -203,16 +203,16 @@ Vector<String> FontCache::systemFontFamilies()
     auto availableFontFamilies = adoptCF(CTFontManagerCopyAvailableFontFamilyNames());
     CFIndex count = CFArrayGetCount(availableFontFamilies.get());
     for (CFIndex i = 0; i < count; ++i) {
-        auto fontName = dynamic_cf_cast<CFStringRef>(CFArrayGetValueAtIndex(availableFontFamilies.get(), i));
+        RetainPtr fontName = dynamic_cf_cast<CFStringRef>(CFArrayGetValueAtIndex(availableFontFamilies.get(), i));
         if (!fontName) {
             ASSERT_NOT_REACHED();
             continue;
         }
 
-        if (fontNameIsSystemFont(fontName))
+        if (fontNameIsSystemFont(fontName.get()))
             continue;
 
-        fontFamilies.append(fontName);
+        fontFamilies.append(fontName.get());
     }
 
     return fontFamilies;
@@ -319,12 +319,12 @@ struct VariationCapabilities {
 
 static std::optional<MinMax> extractVariationBounds(CFDictionaryRef axis)
 {
-    CFNumberRef minimumValue = static_cast<CFNumberRef>(CFDictionaryGetValue(axis, kCTFontVariationAxisMinimumValueKey));
-    CFNumberRef maximumValue = static_cast<CFNumberRef>(CFDictionaryGetValue(axis, kCTFontVariationAxisMaximumValueKey));
+    RetainPtr minimumValue = static_cast<CFNumberRef>(CFDictionaryGetValue(axis, kCTFontVariationAxisMinimumValueKey));
+    RetainPtr maximumValue = static_cast<CFNumberRef>(CFDictionaryGetValue(axis, kCTFontVariationAxisMaximumValueKey));
     float rawMinimumValue = 0;
     float rawMaximumValue = 0;
-    CFNumberGetValue(minimumValue, kCFNumberFloatType, &rawMinimumValue);
-    CFNumberGetValue(maximumValue, kCFNumberFloatType, &rawMaximumValue);
+    CFNumberGetValue(minimumValue.get(), kCFNumberFloatType, &rawMinimumValue);
+    CFNumberGetValue(maximumValue.get(), kCFNumberFloatType, &rawMaximumValue);
     if (rawMinimumValue < rawMaximumValue)
         return {{ rawMinimumValue, rawMaximumValue }};
     return std::nullopt;
@@ -346,17 +346,17 @@ static VariationCapabilities variationCapabilitiesForFontDescriptor(CTFontDescri
         return result;
 
     for (CFIndex i = 0; i < axisCount; ++i) {
-        CFDictionaryRef axis = static_cast<CFDictionaryRef>(CFArrayGetValueAtIndex(variations.get(), i));
-        CFNumberRef axisIdentifier = static_cast<CFNumberRef>(CFDictionaryGetValue(axis, kCTFontVariationAxisIdentifierKey));
+        RetainPtr axis = static_cast<CFDictionaryRef>(CFArrayGetValueAtIndex(variations.get(), i));
+        RetainPtr axisIdentifier = static_cast<CFNumberRef>(CFDictionaryGetValue(axis.get(), kCTFontVariationAxisIdentifierKey));
         uint32_t rawAxisIdentifier = 0;
-        Boolean success = CFNumberGetValue(axisIdentifier, kCFNumberSInt32Type, &rawAxisIdentifier);
+        Boolean success = CFNumberGetValue(axisIdentifier.get(), kCFNumberSInt32Type, &rawAxisIdentifier);
         ASSERT_UNUSED(success, success);
         if (rawAxisIdentifier == 0x77676874) // 'wght'
-            result.weight = extractVariationBounds(axis);
+            result.weight = extractVariationBounds(axis.get());
         else if (rawAxisIdentifier == 0x77647468) // 'wdth'
-            result.width = extractVariationBounds(axis);
+            result.width = extractVariationBounds(axis.get());
         else if (rawAxisIdentifier == 0x736C6E74) // 'slnt'
-            result.slope = extractVariationBounds(axis);
+            result.slope = extractVariationBounds(axis.get());
     }
 
     bool optOutFromGXNormalization = CTFontDescriptorIsSystemUIFont(fontDescriptor);
@@ -409,10 +409,10 @@ FontSelectionCapabilities capabilitiesForFontDescriptor(CTFontDescriptorRef font
         auto traits = adoptCF(static_cast<CFDictionaryRef>(CTFontDescriptorCopyAttribute(fontDescriptor, kCTFontTraitsAttribute)));
         if (traits) {
             if (!variationCapabilities.slope) {
-                auto symbolicTraitsNumber = static_cast<CFNumberRef>(CFDictionaryGetValue(traits.get(), kCTFontSymbolicTrait));
+                RetainPtr symbolicTraitsNumber = static_cast<CFNumberRef>(CFDictionaryGetValue(traits.get(), kCTFontSymbolicTrait));
                 if (symbolicTraitsNumber) {
                     int32_t symbolicTraits;
-                    auto success = CFNumberGetValue(symbolicTraitsNumber, kCFNumberSInt32Type, &symbolicTraits);
+                    auto success = CFNumberGetValue(symbolicTraitsNumber.get(), kCFNumberSInt32Type, &symbolicTraits);
                     ASSERT_UNUSED(success, success);
                     auto slopeValue = static_cast<float>(symbolicTraits & kCTFontTraitItalic ? italicValue() : normalItalicValue());
                     variationCapabilities.slope = {{ slopeValue, slopeValue }};
@@ -816,14 +816,14 @@ RefPtr<Font> FontCache::systemFallbackForCharacterCluster(const FontDescription&
     // FontCascade::drawGlyphBuffer() requires that there are no duplicate Font objects which refer to the same thing. This is enforced in
     // FontCache::fontForPlatformData(), where our equality check is based on hashing the FontPlatformData, whose hash includes the raw CoreText
     // font pointer.
-    CTFontRef substituteFont = m_fallbackFonts.add(result).iterator->get();
+    RetainPtr substituteFont = m_fallbackFonts.add(result).iterator->get();
 
-    auto [syntheticBold, syntheticOblique] = computeNecessarySynthesis(substituteFont, description, { }, ShouldComputePhysicalTraits::No, isForPlatformFont == IsForPlatformFont::Yes).boldObliquePair();
+    auto [syntheticBold, syntheticOblique] = computeNecessarySynthesis(substituteFont.get(), description, { }, ShouldComputePhysicalTraits::No, isForPlatformFont == IsForPlatformFont::Yes).boldObliquePair();
 
     RefPtr<const FontCustomPlatformData> customPlatformData = nullptr;
-    if (safeCFEqual(platformData.ctFont(), substituteFont))
+    if (safeCFEqual(platformData.ctFont(), substituteFont.get()))
         customPlatformData = platformData.customPlatformData();
-    FontPlatformData alternateFont(substituteFont, platformData.size(), syntheticBold, syntheticOblique, platformData.orientation(), platformData.widthVariant(), platformData.textRenderingMode(), customPlatformData.get());
+    FontPlatformData alternateFont(substituteFont.get(), platformData.size(), syntheticBold, syntheticOblique, platformData.orientation(), platformData.widthVariant(), platformData.textRenderingMode(), customPlatformData.get());
 
     return fontForPlatformData(alternateFont);
 }

--- a/Source/WebCore/platform/graphics/cocoa/FontPlatformDataCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/FontPlatformDataCocoa.mm
@@ -56,11 +56,11 @@ RefPtr<SharedBuffer> FontPlatformData::platformOpenTypeTable(uint32_t) const
 
 Vector<FontPlatformData::FontVariationAxis> FontPlatformData::variationAxes(ShouldLocalizeAxisNames shouldLocalizeAxisNames) const
 {
-    auto platformFont = ctFont();
+    RetainPtr<CTFontRef> platformFont = ctFont();
     if (!platformFont)
         return { };
-    
-    return WTF::map(defaultVariationValues(platformFont, shouldLocalizeAxisNames), [](auto&& entry) {
+
+    return WTF::map(defaultVariationValues(platformFont.get(), shouldLocalizeAxisNames), [](auto&& entry) {
         auto& [tag, values] = entry;
         return FontPlatformData::FontVariationAxis { values.axisName, String(tag), values.defaultValue, values.minimumValue, values.maximumValue };
     });

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextCocoa.mm
@@ -124,15 +124,15 @@ void GraphicsContextCG::drawFocusRing(const Path& path, float, const Color& colo
     focusRingStyle.accumulate = -1;
     auto style = adoptCF(CGStyleCreateFocusRingWithColor(&focusRingStyle, cachedCGColor(color).get()));
 
-    CGContextRef platformContext = this->platformContext();
+    RetainPtr platformContext = this->platformContext();
 
-    CGContextStateSaver stateSaver(platformContext);
+    CGContextStateSaver stateSaver(platformContext.get());
 
-    CGContextSetStyle(platformContext, style.get());
-    CGContextBeginPath(platformContext);
-    CGContextAddPath(platformContext, path.platformPath());
+    CGContextSetStyle(platformContext.get(), style.get());
+    CGContextBeginPath(platformContext.get());
+    CGContextAddPath(platformContext.get(), path.platformPath());
 
-    CGContextFillPath(platformContext);
+    CGContextFillPath(platformContext.get());
 }
 
 void GraphicsContextCG::drawFocusRing(const Vector<FloatRect>& rects, float outlineOffset, float outlineWidth, const Color& color)

--- a/Source/WebCore/platform/graphics/cocoa/ImageAdapterCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/ImageAdapterCocoa.mm
@@ -142,11 +142,11 @@ NSImage* ImageAdapter::nsImage()
     if (m_nsImage)
         return m_nsImage.get();
 
-    CFDataRef data = tiffRepresentation();
+    RetainPtr<CFDataRef> data = retainPtr(tiffRepresentation());
     if (!data)
         return nullptr;
 
-    m_nsImage = adoptNS([[NSImage alloc] initWithData:(__bridge NSData *)data]);
+    m_nsImage = adoptNS([[NSImage alloc] initWithData:(__bridge NSData *)data.get()]);
     return m_nsImage.get();
 }
 

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -958,13 +958,13 @@ void MediaPlayerPrivateWebM::enqueueSample(Ref<MediaSample>&& sample, TrackID tr
 
     PlatformSample platformSample = sample->platformSample();
 
-    CMFormatDescriptionRef formatDescription = PAL::CMSampleBufferGetFormatDescription(platformSample.cmSampleBuffer());
+    RetainPtr formatDescription = PAL::CMSampleBufferGetFormatDescription(platformSample.cmSampleBuffer());
     ASSERT(formatDescription);
     if (!formatDescription) {
         ERROR_LOG(logSiteIdentifier, "Received sample with a null formatDescription. Bailing.");
         return;
     }
-    auto mediaType = PAL::CMFormatDescriptionGetMediaType(formatDescription);
+    auto mediaType = PAL::CMFormatDescriptionGetMediaType(formatDescription.get());
 
     if (isEnabledVideoTrackID(trackId)) {
         // AVSampleBufferDisplayLayer will throw an un-documented exception if passed a sample

--- a/Source/WebCore/platform/graphics/mac/controls/ImageControlsButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ImageControlsButtonMac.mm
@@ -51,8 +51,8 @@ ImageControlsButtonMac::~ImageControlsButtonMac() = default;
 IntSize ImageControlsButtonMac::servicesRolloverButtonCellSize()
 {
     auto& controlFactory = ControlFactoryMac::singleton();
-    if (auto* servicesRolloverButtonCell = controlFactory.servicesRolloverButtonCell())
-        return IntSize { [servicesRolloverButtonCell cellSize] };
+    if (RetainPtr servicesRolloverButtonCell = controlFactory.servicesRolloverButtonCell())
+        return IntSize { [servicesRolloverButtonCell.get() cellSize] };
     return { };
 }
 

--- a/Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.mm
@@ -113,7 +113,7 @@ void ProgressBarMac::draw(GraphicsContext& context, const FloatRoundedRect& bord
     if (!imageBuffer)
         return;
 
-    CGContextRef cgContext = imageBuffer->context().platformContext();
+    RetainPtr<CGContextRef> cgContext = imageBuffer->context().platformContext();
 
     Ref progressBarPart = owningProgressBarPart();
     auto controlSize = controlSizeForFont(style);
@@ -135,7 +135,7 @@ void ProgressBarMac::draw(GraphicsContext& context, const FloatRoundedRect& bord
         return nullptr;
     };
 
-    [[NSAppearance currentDrawingAppearance] _drawInRect:NSMakeRect(0, 0, inflatedRect.width(), inflatedRect.height()) context:cgContext options:@{
+    [[NSAppearance currentDrawingAppearance] _drawInRect:NSMakeRect(0, 0, inflatedRect.width(), inflatedRect.height()) context:cgContext.get() options:@{
         (__bridge NSString *)kCUIWidgetKey: (__bridge NSString *)(isIndeterminate ? kCUIWidgetProgressIndeterminateBar : kCUIWidgetProgressBar),
         (__bridge NSString *)kCUIValueKey: @(isIndeterminate ? 1 : std::min(nextafter(1.0, -1), progressBarPart->position())),
         (__bridge NSString *)kCUISizeKey: (__bridge NSString *)coreUISizeForProgressBarSize(controlSize),

--- a/Source/WebCore/platform/graphics/mac/controls/SliderTrackMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SliderTrackMac.mm
@@ -78,7 +78,7 @@ void SliderTrackMac::draw(GraphicsContext& context, const FloatRoundedRect& bord
     static constexpr int sliderTrackRadius = 2;
     static constexpr IntSize sliderRadius(sliderTrackRadius, sliderTrackRadius);
 
-    CGContextRef cgContext = context.platformContext();
+    RetainPtr<CGContextRef> cgContext = context.platformContext();
     CGColorSpaceRef cspace = sRGBColorSpaceSingleton();
 
     Ref sliderTrackPart = owningSliderTrackPart();
@@ -88,7 +88,7 @@ void SliderTrackMac::draw(GraphicsContext& context, const FloatRoundedRect& bord
     GraphicsContextStateSaver stateSaver(context);
 
     auto logicalRect = rectForBounds(borderRect.rect(), style);
-    CGContextClipToRect(cgContext, logicalRect);
+    CGContextClipToRect(cgContext.get(), logicalRect);
 
     struct CGFunctionCallbacks mainCallbacks = { 0, trackGradientInterpolate, NULL };
     RetainPtr<CGFunctionRef> mainFunction = adoptCF(CGFunctionCreate(NULL, 1, NULL, 4, NULL, &mainCallbacks));
@@ -99,7 +99,7 @@ void SliderTrackMac::draw(GraphicsContext& context, const FloatRoundedRect& bord
         mainShading = adoptCF(CGShadingCreateAxial(cspace, CGPointMake(logicalRect.x(),  logicalRect.y()), CGPointMake(logicalRect.x(), logicalRect.maxY()), mainFunction.get(), false, false));
 
     context.clipRoundedRect(FloatRoundedRect(logicalRect, sliderRadius, sliderRadius, sliderRadius, sliderRadius));
-    CGContextDrawShading(cgContext, mainShading.get());
+    CGContextDrawShading(cgContext.get(), mainShading.get());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/mac/controls/SwitchMacUtilities.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SwitchMacUtilities.mm
@@ -124,13 +124,13 @@ RefPtr<ImageBuffer> trackMaskImage(GraphicsContext& context, FloatSize trackRect
     if (!maskImage)
         return nullptr;
 
-    auto cgContext = maskImage->context().platformContext();
+    RetainPtr cgContext = maskImage->context().platformContext();
 
     auto coreUIDirection = (__bridge NSString *)(isRTL ? kCUIUserInterfaceLayoutDirectionRightToLeft : kCUIUserInterfaceLayoutDirectionLeftToRight);
 
-    CGContextStateSaver stateSaver(cgContext);
+    CGContextStateSaver stateSaver(cgContext.get());
 
-    [[NSAppearance currentDrawingAppearance] _drawInRect:drawingTrackRect context:cgContext options:@{
+    [[NSAppearance currentDrawingAppearance] _drawInRect:drawingTrackRect context:cgContext.get() options:@{
         (__bridge NSString *)kCUIWidgetKey: (__bridge NSString *)kCUIWidgetSwitchFillMask,
         (__bridge NSString *)kCUISizeKey: coreUISize,
         (__bridge NSString *)kCUIUserInterfaceLayoutDirectionKey: coreUIDirection,

--- a/Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.mm
@@ -107,9 +107,9 @@ void SwitchThumbMac::draw(GraphicsContext& context, const FloatRoundedRect& bord
     auto drawingThumbLogicalX = drawingThumbIsLogicallyLeft ? drawingThumbLogicalXAxis - drawingThumbLogicalXAxisProgress : drawingThumbLogicalXAxisProgress;
     auto drawingThumbRect = NSMakeRect(drawingThumbLogicalX, 0, inflatedThumbRect.width(), inflatedThumbRect.height());
 
-    auto coreUISize = SwitchMacUtilities::coreUISizeForControlSize(controlSize);
+    RetainPtr coreUISize = SwitchMacUtilities::coreUISizeForControlSize(controlSize);
 
-    auto maskImage = SwitchMacUtilities::trackMaskImage(context, inflatedTrackRect.size(), deviceScaleFactor, isInlineFlipped, coreUISize);
+    auto maskImage = SwitchMacUtilities::trackMaskImage(context, inflatedTrackRect.size(), deviceScaleFactor, isInlineFlipped, coreUISize.get());
     if (!maskImage)
         return;
 
@@ -117,15 +117,15 @@ void SwitchThumbMac::draw(GraphicsContext& context, const FloatRoundedRect& bord
     if (!trackImage)
         return;
 
-    auto cgContext = trackImage->context().platformContext();
+    RetainPtr cgContext = trackImage->context().platformContext();
 
     {
-        CGContextStateSaver stateSaverTrack(cgContext);
+        CGContextStateSaver stateSaverTrack(cgContext.get());
 
         // FIXME: clipping in context() might not always be accurate for context().platformContext().
         trackImage->context().clipToImageBuffer(*maskImage, NSMakeRect(0, 0, inflatedTrackRect.width(), inflatedTrackRect.height()));
 
-        [[NSAppearance currentDrawingAppearance] _drawInRect:drawingThumbRect context:cgContext options:@{
+        [[NSAppearance currentDrawingAppearance] _drawInRect:drawingThumbRect context:cgContext.get() options:@{
             (__bridge NSString *)kCUIWidgetKey: (__bridge NSString *)kCUIWidgetSwitchKnob,
             (__bridge NSString *)kCUIStateKey: (__bridge NSString *)(!isEnabled ? kCUIStateDisabled : isPressed ? kCUIStatePressed : kCUIStateActive),
             (__bridge NSString *)kCUISizeKey: SwitchMacUtilities::coreUISizeForControlSize(controlSize),

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKitLegacy.mm
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKitLegacy.mm
@@ -94,18 +94,18 @@ void PlaybackSessionInterfaceAVKitLegacy::invalidate()
 
 void PlaybackSessionInterfaceAVKitLegacy::durationChanged(double duration)
 {
-    WebAVPlayerController* playerController = m_playerController.get();
+    RetainPtr playerController = m_playerController.get();
 
-    playerController.contentDuration = duration;
-    playerController.contentDurationWithinEndTimes = duration;
+    [playerController.get() setContentDuration:duration];
+    [playerController.get() setContentDurationWithinEndTimes:duration];
 
     // FIXME: we take this as an indication that playback is ready.
-    playerController.canPlay = YES;
-    playerController.canPause = YES;
-    playerController.canTogglePlayback = YES;
-    playerController.hasEnabledAudio = YES;
-    playerController.canSeek = YES;
-    playerController.status = AVPlayerControllerStatusReadyToPlay;
+    [playerController.get() setCanPlay:YES];
+    [playerController.get() setCanPause:YES];
+    [playerController.get() setCanTogglePlayback:YES];
+    [playerController.get() setHasEnabledAudio:YES];
+    [playerController.get() setCanSeek:YES];
+    [playerController.get() setStatus:AVPlayerControllerStatusReadyToPlay];
 }
 
 void PlaybackSessionInterfaceAVKitLegacy::currentTimeChanged(double currentTime, double anchorTime)
@@ -122,14 +122,14 @@ void PlaybackSessionInterfaceAVKitLegacy::currentTimeChanged(double currentTime,
 
 void PlaybackSessionInterfaceAVKitLegacy::bufferedTimeChanged(double bufferedTime)
 {
-    WebAVPlayerController* playerController = m_playerController.get();
-    double duration = playerController.contentDuration;
+    RetainPtr playerController = m_playerController.get();
+    double duration = [playerController.get() contentDuration];
     double normalizedBufferedTime;
     if (!duration)
         normalizedBufferedTime = 0;
     else
         normalizedBufferedTime = bufferedTime / duration;
-    playerController.loadedTimeRanges = @[@0, @(normalizedBufferedTime)];
+    [playerController.get() setLoadedTimeRanges:@[@0, @(normalizedBufferedTime)]];
 }
 
 void PlaybackSessionInterfaceAVKitLegacy::rateChanged(OptionSet<PlaybackSessionModel::PlaybackState> playbackState, double playbackRate, double defaultPlaybackRate)
@@ -205,10 +205,10 @@ void PlaybackSessionInterfaceAVKitLegacy::externalPlaybackChanged(bool enabled, 
     else if (enabled && targetType == PlaybackSessionModel::ExternalPlaybackTargetType::TargetTypeTVOut)
         externalPlaybackType = AVPlayerControllerExternalPlaybackTypeTVOut;
 
-    WebAVPlayerController* playerController = m_playerController.get();
-    playerController.externalPlaybackAirPlayDeviceLocalizedName = localizedDeviceName.createNSString().get();
-    playerController.externalPlaybackType = externalPlaybackType;
-    playerController.externalPlaybackActive = enabled;
+    RetainPtr playerController = m_playerController.get();
+    [playerController.get() setExternalPlaybackAirPlayDeviceLocalizedName:localizedDeviceName.createNSString().get()];
+    [playerController.get() setExternalPlaybackType:externalPlaybackType];
+    [playerController.get() setExternalPlaybackActive:enabled];
 }
 
 void PlaybackSessionInterfaceAVKitLegacy::wirelessVideoPlaybackDisabledChanged(bool disabled)

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureUnit.mm
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureUnit.mm
@@ -106,26 +106,26 @@ static void setNoopInputMuteStateChangeHandler(AVAudioApplication *audioApplicat
 
 void registerAudioInputMuteChangeListener(WebCoreAudioInputMuteChangeListener *listener)
 {
-    auto *audioApplication = getSharedAVAudioApplication();
+    RetainPtr audioApplication = getSharedAVAudioApplication();
     if (!audioApplication)
         return;
 
 #if PLATFORM(MAC)
-    setNoopInputMuteStateChangeHandler(audioApplication, true);
+    setNoopInputMuteStateChangeHandler(audioApplication.get(), true);
 #endif
 
-    [[NSNotificationCenter defaultCenter] addObserver:listener selector:@selector(handleMuteStatusChangedNotification:) name:AVAudioApplicationInputMuteStateChangeNotification object:audioApplication];
+    [[NSNotificationCenter defaultCenter] addObserver:listener selector:@selector(handleMuteStatusChangedNotification:) name:AVAudioApplicationInputMuteStateChangeNotification object:audioApplication.get()];
 
 }
 
 void unregisterAudioInputMuteChangeListener(WebCoreAudioInputMuteChangeListener *listener)
 {
-    auto *audioApplication = getSharedAVAudioApplication();
+    RetainPtr audioApplication = getSharedAVAudioApplication();
     if (!audioApplication)
         return;
 
 #if PLATFORM(MAC)
-    setNoopInputMuteStateChangeHandler(audioApplication, false);
+    setNoopInputMuteStateChangeHandler(audioApplication.get(), false);
 #endif
 
     [[NSNotificationCenter defaultCenter] removeObserver:listener];
@@ -244,12 +244,12 @@ void CoreAudioCaptureUnit::setMuteStatusChangedCallback(Function<void(bool)>&& c
 void CoreAudioCaptureUnit::setMutedState(bool isMuted)
 {
 #if HAVE(AVAUDIOAPPLICATION)
-    auto *audioApplication = getSharedAVAudioApplication();
+    RetainPtr audioApplication = getSharedAVAudioApplication();
     if (!audioApplication)
         return;
 
     NSError *error = nil;
-    [audioApplication setInputMuted:isMuted error:&error];
+    [audioApplication.get() setInputMuted:isMuted error:&error];
     RELEASE_LOG_ERROR_IF(error, WebRTC, "CoreAudioCaptureUnit::setMutedState failed due to error: %@.", error.localizedDescription);
 #else
     UNUSED_PARAM(isMuted);

--- a/Source/WebCore/platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.mm
+++ b/Source/WebCore/platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.mm
@@ -123,11 +123,11 @@ RefPtr<VideoFrame> RealtimeIncomingVideoSourceCocoa::toVideoFrame(const webrtc::
     return VideoFrameLibWebRTC::create(MediaTime(frame.timestamp_us(), 1000000), false, rotation, colorSpaceFromLibWebRTCVideoFrame(frame), toRef(frame.video_frame_buffer()), [protectedThis = Ref { *this }, this](auto& buffer) {
         return adoptCF(webrtc::createPixelBufferFromFrameBuffer(buffer, [this](size_t width, size_t height, webrtc::BufferType bufferType) -> CVPixelBufferRef {
             Locker lock(m_pixelBufferPoolLock);
-            auto pixelBufferPool = this->pixelBufferPool(width, height, bufferType);
-            if (!pixelBufferPool)
+            RetainPtr<CVPixelBufferPoolRef> pixelBufferPool = this->pixelBufferPool(width, height, bufferType);
+            if (!pixelBufferPool.get())
                 return nullptr;
             CVPixelBufferRef pixelBuffer = nullptr;
-            auto status = CVPixelBufferPoolCreatePixelBuffer(kCFAllocatorDefault, m_pixelBufferPool.get(), &pixelBuffer);
+            auto status = CVPixelBufferPoolCreatePixelBuffer(kCFAllocatorDefault, pixelBufferPool.get(), &pixelBuffer);
             if (status != kCVReturnSuccess) {
                 ERROR_LOG_IF(loggerPtr(), LOGIDENTIFIER, "Failed creating a pixel buffer with error ", status);
                 return nullptr;

--- a/Source/WebCore/platform/network/mac/ResourceHandleMac.mm
+++ b/Source/WebCore/platform/network/mac/ResourceHandleMac.mm
@@ -299,16 +299,16 @@ void ResourceHandle::platformSetDefersLoading(bool defers)
 
 void ResourceHandle::schedule(SchedulePair& pair)
 {
-    NSRunLoop *runLoop = pair.nsRunLoop();
+    RetainPtr runLoop = pair.nsRunLoop();
     if (!runLoop)
         return;
-    [d->m_connection.get() scheduleInRunLoop:runLoop forMode:(__bridge NSString *)pair.mode()];
+    [d->m_connection.get() scheduleInRunLoop:runLoop.get() forMode:(__bridge NSString *)pair.mode()];
 }
 
 void ResourceHandle::unschedule(SchedulePair& pair)
 {
-    if (NSRunLoop *runLoop = pair.nsRunLoop())
-        [d->m_connection.get() unscheduleFromRunLoop:runLoop forMode:(__bridge NSString *)pair.mode()];
+    if (RetainPtr runLoop = pair.nsRunLoop())
+        [d->m_connection.get() unscheduleFromRunLoop:runLoop.get() forMode:(__bridge NSString *)pair.mode()];
 }
 
 id ResourceHandle::makeDelegate(bool shouldUseCredentialStorage, RefPtr<SynchronousLoaderMessageQueue>&& queue)

--- a/Source/WebCore/platform/text/cocoa/LocaleCocoa.mm
+++ b/Source/WebCore/platform/text/cocoa/LocaleCocoa.mm
@@ -113,17 +113,17 @@ String LocaleCocoa::formatDateTime(const DateComponents& dateComponents, FormatT
     NSDate *date = [NSDate dateWithTimeIntervalSince1970:secondsSince1970];
 
     // Return a formatted string.
-    NSDateFormatter *dateFormatter = localizedDateCache().formatterForDateType(type);
-    return [dateFormatter stringFromDate:date];
+    RetainPtr dateFormatter = localizedDateCache().formatterForDateType(type);
+    return [dateFormatter.get() stringFromDate:date];
 }
 
 const Vector<String>& LocaleCocoa::monthLabels()
 {
     if (!m_monthLabels.isEmpty())
         return m_monthLabels;
-    NSArray *array = [shortDateFormatter().get() monthSymbols];
-    if ([array count] == 12) {
-        m_monthLabels = makeVector<String>(array);
+    RetainPtr array = [shortDateFormatter().get() monthSymbols];
+    if ([array.get() count] == 12) {
+        m_monthLabels = makeVector<String>(array.get());
         return m_monthLabels;
     }
     m_monthLabels = std::span { WTF::monthFullName };
@@ -224,9 +224,9 @@ const Vector<String>& LocaleCocoa::shortMonthLabels()
 {
     if (!m_shortMonthLabels.isEmpty())
         return m_shortMonthLabels;
-    NSArray *array = [shortDateFormatter().get() shortMonthSymbols];
-    if ([array count] == 12) {
-        m_shortMonthLabels = makeVector<String>(array);
+    RetainPtr array = [shortDateFormatter().get() shortMonthSymbols];
+    if ([array.get() count] == 12) {
+        m_shortMonthLabels = makeVector<String>(array.get());
         return m_shortMonthLabels;
     }
     m_shortMonthLabels = std::span { WTF::monthName };
@@ -237,9 +237,9 @@ const Vector<String>& LocaleCocoa::standAloneMonthLabels()
 {
     if (!m_standAloneMonthLabels.isEmpty())
         return m_standAloneMonthLabels;
-    NSArray *array = [shortDateFormatter().get() standaloneMonthSymbols];
-    if ([array count] == 12) {
-        m_standAloneMonthLabels = makeVector<String>(array);
+    RetainPtr array = [shortDateFormatter().get() standaloneMonthSymbols];
+    if ([array.get() count] == 12) {
+        m_standAloneMonthLabels = makeVector<String>(array.get());
         return m_standAloneMonthLabels;
     }
     m_standAloneMonthLabels = shortMonthLabels();
@@ -251,9 +251,9 @@ const Vector<String>& LocaleCocoa::shortStandAloneMonthLabels()
     if (!m_shortStandAloneMonthLabels.isEmpty())
         return m_shortStandAloneMonthLabels;
 
-    NSArray *array = [shortDateFormatter().get() shortStandaloneMonthSymbols];
-    if ([array count] == 12) {
-        m_shortStandAloneMonthLabels = makeVector<String>(array);
+    RetainPtr array = [shortDateFormatter().get() shortStandaloneMonthSymbols];
+    if ([array.get() count] == 12) {
+        m_shortStandAloneMonthLabels = makeVector<String>(array.get());
         return m_shortStandAloneMonthLabels;
     }
     m_shortStandAloneMonthLabels = shortMonthLabels();

--- a/Source/WebCore/testing/cocoa/WebViewVisualIdentificationOverlay.mm
+++ b/Source/WebCore/testing/cocoa/WebViewVisualIdentificationOverlay.mm
@@ -138,14 +138,14 @@ static void drawPattern(void *overlayPtr, CGContextRef ctx)
 {
     WebViewVisualIdentificationOverlay *overlay = (WebViewVisualIdentificationOverlay *)overlayPtr;
 
-    auto attributes = @{
+    RetainPtr<NSDictionary> attributes = @{
         (id)kCTFontAttributeName : (id)createIdentificationFont().get(),
         (id)kCTForegroundColorFromContextAttributeName : @YES
     };
-    auto attributedString = adoptCF(CFAttributedStringCreate(kCFAllocatorDefault, (__bridge CFStringRef)overlay->_kind.get(), (__bridge CFDictionaryRef)attributes));
+    auto attributedString = adoptCF(CFAttributedStringCreate(kCFAllocatorDefault, (__bridge CFStringRef)overlay->_kind.get(), (__bridge CFDictionaryRef)attributes.get()));
     auto line = adoptCF(CTLineCreateWithAttributedString(attributedString.get()));
 
-    CGSize textSize = [overlay->_kind sizeWithAttributes:attributes];
+    CGSize textSize = [overlay->_kind sizeWithAttributes:attributes.get()];
 
 #if PLATFORM(IOS_FAMILY)
     CGContextScaleCTM(ctx, 1, -1);

--- a/Source/WebGPU/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebGPU/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -1,1 +1,0 @@
-BindGroup.mm

--- a/Source/WebGPU/WebGPU/BindGroup.mm
+++ b/Source/WebGPU/WebGPU/BindGroup.mm
@@ -456,8 +456,8 @@ Device::ExternalTextureData Device::createExternalTextureFromPixelBuffer(CVPixel
 
     CVMetalTextureCacheFlush(m_coreVideoTextureCache.get(), 0);
     const bool supportsExtendedFormats = [m_device supportsFamily:MTLGPUFamilyApple4];
-    IOSurfaceRef ioSurface = CVPixelBufferGetIOSurface(pixelBuffer);
-    if (!ioSurface || isIntel()) {
+    RetainPtr ioSurface = adoptCF(CVPixelBufferGetIOSurface(pixelBuffer));
+    if (!ioSurface.get() || isIntel()) {
         auto planeCount = std::max<size_t>(CVPixelBufferGetPlaneCount(pixelBuffer), 1);
         if (planeCount > 2) {
             ASSERT_NOT_REACHED("non-IOSurface CVPixelBuffer instances with more than two planes are not supported");
@@ -516,7 +516,7 @@ Device::ExternalTextureData Device::createExternalTextureFromPixelBuffer(CVPixel
 
     if (auto optionalWebProcessID = webProcessID()) {
         if (auto webProcessID = optionalWebProcessID->sendRight())
-            IOSurfaceSetOwnershipIdentity(ioSurface, webProcessID, kIOSurfaceMemoryLedgerTagGraphics, 0);
+            IOSurfaceSetOwnershipIdentity(ioSurface.get(), webProcessID, kIOSurfaceMemoryLedgerTagGraphics, 0);
     }
 
     id<MTLTexture> baseTexture = nil;

--- a/Source/WebKitLegacy/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebKitLegacy/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -1,5 +1,3 @@
-WebCoreSupport/SocketStreamHandleImplCFNet.cpp
-cf/WebCoreSupport/WebInspectorClientCF.cpp
 [ iOS ] ios/WebCoreSupport/WebChromeClientIOS.mm
 [ iOS ] ios/WebCoreSupport/WebFixedPositionContent.mm
 [ iOS ] ios/WebCoreSupport/WebFrameIOS.mm
@@ -8,86 +6,21 @@ cf/WebCoreSupport/WebInspectorClientCF.cpp
 [ iOS ] ios/WebView/WebPDFViewIOS.mm
 [ iOS ] ios/WebView/WebPDFViewPlaceholder.mm
 [ iOS ] ios/WebView/WebPlainWhiteView.mm
-mac/DOM/DOM.mm
-mac/DOM/DOMAbstractView.mm
-mac/DOM/DOMBlob.mm
-mac/DOM/DOMCSSRule.mm
-mac/DOM/DOMCSSRuleList.mm
-mac/DOM/DOMCSSStyleDeclaration.mm
-mac/DOM/DOMCSSValue.mm
-mac/DOM/DOMCounter.mm
-mac/DOM/DOMEvent.mm
-mac/DOM/DOMFileList.mm
-mac/DOM/DOMHTMLCollection.mm
-mac/DOM/DOMHTMLOptionsCollection.mm
-mac/DOM/DOMImplementation.mm
-mac/DOM/DOMInternal.mm
-mac/DOM/DOMMediaError.mm
-mac/DOM/DOMMediaList.mm
-mac/DOM/DOMNamedNodeMap.mm
-mac/DOM/DOMNode.mm
-mac/DOM/DOMNodeIterator.mm
-mac/DOM/DOMNodeList.mm
-mac/DOM/DOMRGBColor.mm
-mac/DOM/DOMRange.mm
-mac/DOM/DOMRect.mm
-mac/DOM/DOMStyleSheet.mm
-mac/DOM/DOMStyleSheetList.mm
-mac/DOM/DOMTimeRanges.mm
-mac/DOM/DOMTokenList.mm
-mac/DOM/DOMTreeWalker.mm
-mac/DOM/DOMXPath.mm
-mac/DOM/DOMXPathExpression.mm
-mac/DOM/DOMXPathResult.mm
-mac/DOM/ObjCEventListener.mm
-[ Mac ] mac/DefaultDelegates/WebDefaultContextMenuDelegate.mm
-mac/History/WebHistory.mm
 mac/History/WebHistoryItem.mm
-[ Mac ] mac/Misc/WebDownload.mm
-[ Mac ] mac/Misc/WebKitNSStringExtras.mm
-mac/Misc/WebLocalizableStrings.mm
-mac/Misc/WebNSFileManagerExtras.mm
-[ Mac ] mac/Misc/WebNSPasteboardExtras.mm
-mac/Misc/WebNSURLExtras.mm
 [ Mac ] mac/Misc/WebNSViewExtras.m
-[ Mac ] mac/Misc/WebSharingServicePickerController.mm
 [ Mac ] mac/Panels/WebAuthenticationPanel.m
 [ Mac ] mac/Panels/WebPanelAuthenticationHandler.m
-mac/Plugins/WebBasePluginPackage.mm
-[ Mac ] mac/Plugins/WebPluginController.mm
-mac/Plugins/WebPluginDatabase.mm
 [ iOS ] mac/Storage/WebDatabaseManager.mm
 [ iOS ] mac/Storage/WebDatabaseManagerClient.mm
-mac/Storage/WebStorageManager.mm
 [ Mac ] mac/WebCoreSupport/PopupMenuMac.mm
 mac/WebCoreSupport/WebChromeClient.mm
-[ Mac ] mac/WebCoreSupport/WebContextMenuClient.mm
-[ Mac ] mac/WebCoreSupport/WebDragClient.mm
 mac/WebCoreSupport/WebEditorClient.mm
 mac/WebCoreSupport/WebFrameLoaderClient.mm
-mac/WebCoreSupport/WebFrameNetworkingContext.mm
-[ Mac ] mac/WebCoreSupport/WebInspectorClient.mm
 [ iOS ] mac/WebCoreSupport/WebProgressTrackerClient.mm
-mac/WebCoreSupport/WebVisitedLinkStore.mm
-[ Mac ] mac/WebInspector/WebNodeHighlight.mm
 [ iOS ] mac/WebInspector/WebNodeHighlighter.mm
-mac/WebView/WebArchive.mm
-mac/WebView/WebDataSource.mm
-mac/WebView/WebDelegateImplementationCaching.mm
-[ Mac ] mac/WebView/WebDynamicScrollBarsView.mm
 mac/WebView/WebFrame.mm
-mac/WebView/WebFrameView.mm
 mac/WebView/WebHTMLView.mm
 [ Mac ] mac/WebView/WebImmediateActionController.mm
-mac/WebView/WebJSPDFDoc.mm
-[ Mac ] mac/WebView/WebPDFRepresentation.mm
 [ Mac ] mac/WebView/WebPDFView.mm
-mac/WebView/WebPreferences.mm
-mac/WebView/WebResource.mm
-mac/WebView/WebScriptDebugDelegate.mm
-mac/WebView/WebScriptDebugger.mm
-mac/WebView/WebScriptWorld.mm
-[ Mac ] mac/WebView/WebTextCompletionController.mm
 [ Mac ] mac/WebView/WebVideoFullscreenController.mm
 mac/WebView/WebView.mm
-mac/WebView/WebViewRenderingUpdateScheduler.mm

--- a/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImplCFNet.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImplCFNet.cpp
@@ -228,10 +228,10 @@ void SocketStreamHandleImpl::chooseProxyFromArray(CFArrayRef proxyArray)
 
     // PAC is always the first entry, if present.
     if (proxyArrayCount) {
-        if (auto proxyInfo = dynamic_cf_cast<CFDictionaryRef>(CFArrayGetValueAtIndex(proxyArray, 0))) {
-            if (auto proxyType = dynamic_cf_cast<CFStringRef>(CFDictionaryGetValue(proxyInfo, kCFProxyTypeKey)); proxyType && CFEqual(proxyType, kCFProxyTypeAutoConfigurationURL)) {
-                if (auto pacFileURL = dynamic_cf_cast<CFURLRef>(CFDictionaryGetValue(proxyInfo, kCFProxyAutoConfigurationURLKey))) {
-                    executePACFileURL(static_cast<CFURLRef>(pacFileURL));
+        if (RetainPtr proxyInfo = dynamic_cf_cast<CFDictionaryRef>(CFArrayGetValueAtIndex(proxyArray, 0))) {
+            if (RetainPtr proxyType = dynamic_cf_cast<CFStringRef>(CFDictionaryGetValue(proxyInfo.get(), kCFProxyTypeKey)); proxyType && CFEqual(proxyType.get(), kCFProxyTypeAutoConfigurationURL)) {
+                if (RetainPtr pacFileURL = dynamic_cf_cast<CFURLRef>(CFDictionaryGetValue(proxyInfo.get(), kCFProxyAutoConfigurationURLKey))) {
+                    executePACFileURL(static_cast<CFURLRef>(pacFileURL.get()));
                     return;
                 }
             }
@@ -240,16 +240,16 @@ void SocketStreamHandleImpl::chooseProxyFromArray(CFArrayRef proxyArray)
 
     CFDictionaryRef chosenProxy = nullptr;
     for (CFIndex i = 0; i < proxyArrayCount; ++i) {
-        if (auto proxyInfo = dynamic_cf_cast<CFDictionaryRef>(CFArrayGetValueAtIndex(proxyArray, i))) {
-            if (auto proxyType = dynamic_cf_cast<CFStringRef>(CFDictionaryGetValue(proxyInfo, kCFProxyTypeKey))) {
-                if (CFEqual(proxyType, kCFProxyTypeSOCKS)) {
+        if (RetainPtr proxyInfo = dynamic_cf_cast<CFDictionaryRef>(CFArrayGetValueAtIndex(proxyArray, i))) {
+            if (RetainPtr proxyType = dynamic_cf_cast<CFStringRef>(CFDictionaryGetValue(proxyInfo.get(), kCFProxyTypeKey))) {
+                if (CFEqual(proxyType.get(), kCFProxyTypeSOCKS)) {
                     m_connectionType = SOCKSProxy;
-                    chosenProxy = proxyInfo;
+                    chosenProxy = proxyInfo.get();
                     break;
                 }
-                if (CFEqual(proxyType, kCFProxyTypeHTTPS)) {
+                if (CFEqual(proxyType.get(), kCFProxyTypeHTTPS)) {
                     m_connectionType = CONNECTProxy;
-                    chosenProxy = proxyInfo;
+                    chosenProxy = proxyInfo.get();
                     // Keep looking for proxies, as a SOCKS one is preferable.
                 }
             }
@@ -260,12 +260,12 @@ void SocketStreamHandleImpl::chooseProxyFromArray(CFArrayRef proxyArray)
         ASSERT(m_connectionType != Unknown);
         ASSERT(m_connectionType != Direct);
 
-        auto proxyHost = dynamic_cf_cast<CFStringRef>(CFDictionaryGetValue(chosenProxy, kCFProxyHostNameKey));
-        auto proxyPort = dynamic_cf_cast<CFNumberRef>(CFDictionaryGetValue(chosenProxy, kCFProxyPortNumberKey));
+        RetainPtr proxyHost = dynamic_cf_cast<CFStringRef>(CFDictionaryGetValue(chosenProxy, kCFProxyHostNameKey));
+        RetainPtr proxyPort = dynamic_cf_cast<CFNumberRef>(CFDictionaryGetValue(chosenProxy, kCFProxyPortNumberKey));
 
         if (proxyHost && proxyPort) {
-            m_proxyHost = proxyHost;
-            m_proxyPort = proxyPort;
+            m_proxyHost = proxyHost.get();
+            m_proxyPort = proxyPort.get();
             return;
         }
     }

--- a/Source/WebKitLegacy/cf/WebCoreSupport/WebInspectorClientCF.cpp
+++ b/Source/WebKitLegacy/cf/WebCoreSupport/WebInspectorClientCF.cpp
@@ -44,8 +44,8 @@ static RetainPtr<CFStringRef> createKeyForPreferences(const String& key)
 static String loadSetting(const String& key)
 {
     auto value = adoptCF(CFPreferencesCopyAppValue(createKeyForPreferences(key).get(), kCFPreferencesCurrentApplication));
-    if (auto string = dynamic_cf_cast<CFStringRef>(value.get()))
-        return string;
+    if (RetainPtr string = dynamic_cf_cast<CFStringRef>(value.get()))
+        return string.autorelease();
     if (value == kCFBooleanTrue)
         return "true"_s;
     if (value == kCFBooleanFalse)

--- a/Source/WebKitLegacy/mac/DOM/DOM.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOM.mm
@@ -179,10 +179,10 @@ static Class elementClass(const QualifiedName& tag, Class defaultClass)
 {
     if (!elementClassMap)
         createElementClassMap();
-    Class objcClass = lookupElementClass(tag);
+    RetainPtr objcClass = lookupElementClass(tag);
     if (!objcClass)
         objcClass = defaultClass;
-    return objcClass;
+    return objcClass.autorelease();
 }
 
 #if PLATFORM(IOS_FAMILY)
@@ -780,10 +780,10 @@ DOMNodeFilter *kit(WebCore::NodeFilter* impl)
 {
     if (!impl)
         return nil;
-    
-    if (DOMNodeFilter *wrapper = getDOMWrapper(impl))
-        return retainPtr(wrapper).autorelease();
-    
+
+    if (RetainPtr wrapper = getDOMWrapper(impl))
+        return retainPtr(wrapper.get()).autorelease();
+
     auto wrapper = adoptNS([[DOMNodeFilter alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(impl);
     impl->ref();

--- a/Source/WebKitLegacy/mac/DOM/DOMAbstractView.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMAbstractView.mm
@@ -86,8 +86,8 @@ DOMAbstractView *kit(WebCore::LocalDOMWindow* value)
     auto* frame = value->frame();
     if (!frame)
         return nil;
-    if (DOMAbstractView *wrapper = getDOMWrapper(frame))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(frame))
+        return wrapper.autorelease();
     auto wrapper = adoptNS([[DOMAbstractView alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(frame);
     addDOMWrapper(wrapper.get(), frame);

--- a/Source/WebKitLegacy/mac/DOM/DOMBlob.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMBlob.mm
@@ -34,6 +34,7 @@
 #import <WebCore/WebCoreObjCExtras.h>
 #import <WebCore/WebScriptObjectPrivate.h>
 #import <wtf/GetPtr.h>
+#import <wtf/RetainPtr.h>
 #import <wtf/URL.h>
 
 #define IMPL reinterpret_cast<WebCore::Blob*>(_internal)
@@ -69,8 +70,8 @@ DOMBlob *kit(WebCore::Blob* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMBlob *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr<DOMBlob> wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     auto wrapper = adoptNS([[DOMBlob alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(value);
     value->ref();

--- a/Source/WebKitLegacy/mac/DOM/DOMCSSRule.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMCSSRule.mm
@@ -90,8 +90,8 @@ DOMCSSRule *kit(WebCore::CSSRule* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMCSSRule *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     RetainPtr<DOMCSSRule> wrapper = adoptNS([[kitClass(value) alloc] _init]);
     if (!wrapper)
         return nil;

--- a/Source/WebKitLegacy/mac/DOM/DOMCSSRuleList.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMCSSRuleList.mm
@@ -71,8 +71,8 @@ DOMCSSRuleList *kit(WebCore::CSSRuleList* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMCSSRuleList *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     auto wrapper = adoptNS([[DOMCSSRuleList alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(value);
     value->ref();

--- a/Source/WebKitLegacy/mac/DOM/DOMCSSStyleDeclaration.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMCSSStyleDeclaration.mm
@@ -148,8 +148,8 @@ DOMCSSStyleDeclaration *kit(WebCore::CSSStyleDeclaration* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMCSSStyleDeclaration *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     auto wrapper = adoptNS([[DOMCSSStyleDeclaration alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(value);
     value->ref();

--- a/Source/WebKitLegacy/mac/DOM/DOMCSSValue.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMCSSValue.mm
@@ -75,8 +75,8 @@ DOMCSSValue *kit(WebCore::DeprecatedCSSOMValue* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMCSSValue *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     RetainPtr<DOMCSSValue> wrapper = adoptNS([[kitClass(value) alloc] _init]);
     if (!wrapper)
         return nil;

--- a/Source/WebKitLegacy/mac/DOM/DOMCounter.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMCounter.mm
@@ -75,8 +75,8 @@ DOMCounter *kit(WebCore::DeprecatedCSSOMCounter* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMCounter *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return retainPtr(wrapper.get()).autorelease();
     auto wrapper = adoptNS([[DOMCounter alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(value);
     value->ref();

--- a/Source/WebKitLegacy/mac/DOM/DOMEvent.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMEvent.mm
@@ -187,8 +187,8 @@ DOMEvent *kit(WebCore::Event* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMEvent *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     RetainPtr<DOMEvent> wrapper = adoptNS([[kitClass(value) alloc] _init]);
     if (!wrapper)
         return nil;

--- a/Source/WebKitLegacy/mac/DOM/DOMFileList.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMFileList.mm
@@ -75,8 +75,8 @@ DOMFileList *kit(WebCore::FileList* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMFileList *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     auto wrapper = adoptNS([[DOMFileList alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(value);
     value->ref();

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLCollection.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLCollection.mm
@@ -87,8 +87,8 @@ DOMHTMLCollection *kit(WebCore::HTMLCollection* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMHTMLCollection *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     RetainPtr<DOMHTMLCollection> wrapper = adoptNS([[kitClass(value) alloc] _init]);
     if (!wrapper)
         return nil;

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLOptionsCollection.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLOptionsCollection.mm
@@ -111,8 +111,8 @@ DOMHTMLOptionsCollection *kit(WebCore::HTMLOptionsCollection* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMHTMLOptionsCollection *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     auto wrapper = adoptNS([[DOMHTMLOptionsCollection alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(value);
     value->ref();

--- a/Source/WebKitLegacy/mac/DOM/DOMImplementation.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMImplementation.mm
@@ -117,8 +117,8 @@ DOMImplementation *kit(WebCore::DOMImplementation* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMImplementation *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     auto wrapper = adoptNS([[DOMImplementation alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(value);
     value->ref();

--- a/Source/WebKitLegacy/mac/DOM/DOMInternal.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMInternal.mm
@@ -110,8 +110,8 @@ void removeDOMWrapper(DOMObjectInternal* impl)
     }
     
     // Extract the WebCore::Node from the ObjectiveC wrapper.
-    DOMNode *n = (DOMNode *)self;
-    WebCore::Node *nodeImpl = core(n);
+    RetainPtr n = (DOMNode *)self;
+    WebCore::Node *nodeImpl = core(n.get());
 
     // Dig up Interpreter and ExecState.
     auto* frame = nodeImpl->document().frame();

--- a/Source/WebKitLegacy/mac/DOM/DOMMediaError.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMMediaError.mm
@@ -68,8 +68,8 @@ DOMMediaError *kit(WebCore::MediaError* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMMediaError *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     auto wrapper = adoptNS([[DOMMediaError alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(value);
     value->ref();

--- a/Source/WebKitLegacy/mac/DOM/DOMMediaList.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMMediaList.mm
@@ -95,8 +95,8 @@ DOMMediaList *kit(WebCore::MediaList* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMMediaList *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     auto wrapper = adoptNS([[DOMMediaList alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(value);
     value->ref();

--- a/Source/WebKitLegacy/mac/DOM/DOMNamedNodeMap.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMNamedNodeMap.mm
@@ -124,8 +124,8 @@ DOMNamedNodeMap *kit(WebCore::NamedNodeMap* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMNamedNodeMap *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return retainPtr(wrapper.get()).autorelease();
     auto wrapper = adoptNS([[DOMNamedNodeMap alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(value);
     value->ref();

--- a/Source/WebKitLegacy/mac/DOM/DOMNode.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMNode.mm
@@ -61,8 +61,8 @@ DOMNode *kit(Node* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMNode *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return retainPtr(wrapper.get()).autorelease();
     RetainPtr<DOMNode> wrapper = adoptNS([[kitClass(value) alloc] _init]);
     if (!wrapper)
         return nil;

--- a/Source/WebKitLegacy/mac/DOM/DOMNodeIterator.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMNodeIterator.mm
@@ -126,8 +126,8 @@ DOMNodeIterator *kit(WebCore::NodeIterator* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMNodeIterator *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return retainPtr(wrapper.get()).autorelease();
     auto wrapper = adoptNS([[DOMNodeIterator alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(value);
     value->ref();

--- a/Source/WebKitLegacy/mac/DOM/DOMNodeList.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMNodeList.mm
@@ -69,8 +69,8 @@ DOMNodeList *kit(WebCore::NodeList* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMNodeList *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     auto wrapper = adoptNS([[DOMNodeList alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(value);
     value->ref();

--- a/Source/WebKitLegacy/mac/DOM/DOMRGBColor.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMRGBColor.mm
@@ -103,8 +103,8 @@ DOMRGBColor *kit(WebCore::DeprecatedCSSOMRGBColor* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMRGBColor *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     auto wrapper = adoptNS([[DOMRGBColor alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(value);
     value->ref();

--- a/Source/WebKitLegacy/mac/DOM/DOMRange.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMRange.mm
@@ -304,8 +304,8 @@ DOMRange *kit(WebCore::Range* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMRange *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     auto wrapper = adoptNS([[DOMRange alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(value);
     value->ref();

--- a/Source/WebKitLegacy/mac/DOM/DOMRect.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMRect.mm
@@ -82,8 +82,8 @@ DOMRect *kit(WebCore::DeprecatedCSSOMRect* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMRect *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     auto wrapper = adoptNS([[DOMRect alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(value);
     value->ref();

--- a/Source/WebKitLegacy/mac/DOM/DOMStyleSheet.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMStyleSheet.mm
@@ -110,8 +110,8 @@ DOMStyleSheet *kit(WebCore::StyleSheet* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMStyleSheet *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     RetainPtr<DOMStyleSheet> wrapper = adoptNS([[kitClass(value) alloc] _init]);
     if (!wrapper)
         return nil;

--- a/Source/WebKitLegacy/mac/DOM/DOMStyleSheetList.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMStyleSheetList.mm
@@ -72,8 +72,8 @@ DOMStyleSheetList *kit(WebCore::StyleSheetList* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMStyleSheetList *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     auto wrapper = adoptNS([[DOMStyleSheetList alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(value);
     value->ref();

--- a/Source/WebKitLegacy/mac/DOM/DOMTimeRanges.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMTimeRanges.mm
@@ -79,8 +79,8 @@ DOMTimeRanges *kit(WebCore::TimeRanges* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMTimeRanges *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     auto wrapper = adoptNS([[DOMTimeRanges alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(value);
     value->ref();

--- a/Source/WebKitLegacy/mac/DOM/DOMTokenList.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMTokenList.mm
@@ -94,8 +94,8 @@ DOMTokenList *kit(WebCore::DOMTokenList* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMTokenList *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     auto wrapper = adoptNS([[DOMTokenList alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(value);
     value->ref();

--- a/Source/WebKitLegacy/mac/DOM/DOMTreeWalker.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMTreeWalker.mm
@@ -175,8 +175,8 @@ DOMTreeWalker *kit(WebCore::TreeWalker* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMTreeWalker *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     auto wrapper = adoptNS([[DOMTreeWalker alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(value);
     value->ref();

--- a/Source/WebKitLegacy/mac/DOM/DOMXPath.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMXPath.mm
@@ -62,8 +62,8 @@ DOMNativeXPathNSResolver *kit(WebCore::XPathNSResolver* impl)
     if (!impl)
         return nil;
     
-    if (DOMNativeXPathNSResolver *wrapper = getDOMWrapper(impl))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(impl))
+        return wrapper.autorelease();
     
     auto wrapper = adoptNS([[DOMNativeXPathNSResolver alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(impl);

--- a/Source/WebKitLegacy/mac/DOM/DOMXPathExpression.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMXPathExpression.mm
@@ -77,8 +77,8 @@ DOMXPathExpression *kit(WebCore::XPathExpression* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMXPathExpression *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     auto wrapper = adoptNS([[DOMXPathExpression alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(value);
     value->ref();

--- a/Source/WebKitLegacy/mac/DOM/DOMXPathResult.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMXPathResult.mm
@@ -117,8 +117,8 @@ DOMXPathResult *kit(WebCore::XPathResult* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMXPathResult *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     auto wrapper = adoptNS([[DOMXPathResult alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(value);
     value->ref();

--- a/Source/WebKitLegacy/mac/DOM/ObjCEventListener.mm
+++ b/Source/WebKitLegacy/mac/DOM/ObjCEventListener.mm
@@ -78,8 +78,8 @@ ObjCEventListener::~ObjCEventListener()
 
 void ObjCEventListener::handleEvent(ScriptExecutionContext&, Event& event)
 {
-    ObjCListener listener = m_listener.get();
-    [listener handleEvent:kit(&event)];
+    RetainPtr listener = m_listener.get();
+    [listener.get() handleEvent:kit(&event)];
 }
 
 bool ObjCEventListener::operator==(const EventListener& listener) const

--- a/Source/WebKitLegacy/mac/DefaultDelegates/WebDefaultContextMenuDelegate.mm
+++ b/Source/WebKitLegacy/mac/DefaultDelegates/WebDefaultContextMenuDelegate.mm
@@ -52,6 +52,7 @@
 #import <WebKitLegacy/DOMPrivate.h>
 #import <pal/system/mac/DefaultSearchProvider.h>
 #import <wtf/Assertions.h>
+#import <wtf/RetainPtr.h>
 
 @implementation WebDefaultUIDelegate (WebContextMenu)
 
@@ -61,8 +62,8 @@
     [menuItem setTag:tag];
     [menuItem setTarget:target]; // can be nil
     [menuItem setRepresentedObject:representedObject];
-    
-    NSString *title = nil;
+
+    RetainPtr<NSString> title;
     SEL action = NULL;
     
     switch(tag) {
@@ -106,7 +107,7 @@
     }
 
     if (title)
-        [menuItem setTitle:title];
+        [menuItem setTitle:title.get()];
 
     [menuItem setAction:action];
     

--- a/Source/WebKitLegacy/mac/History/WebHistory.mm
+++ b/Source/WebKitLegacy/mac/History/WebHistory.mm
@@ -228,11 +228,11 @@ static inline WebHistoryDateKey dateKey(NSTimeInterval date)
         return NO;
 
     DateToEntriesMap::iterator it = _entriesByDate->find(dateKey);
-    NSMutableArray *entriesForDate = it->value.get();
-    [entriesForDate removeObjectIdenticalTo:entry];
+    RetainPtr entriesForDate = it->value.get();
+    [entriesForDate.get() removeObjectIdenticalTo:entry];
     
     // remove this date entirely if there are no other entries on it
-    if ([entriesForDate count] == 0) {
+    if ([entriesForDate.get() count] == 0) {
         _entriesByDate->remove(it);
         // Clear _orderedLastVisitedDays so it will be regenerated when next requested.
         _orderedLastVisitedDays = nil;

--- a/Source/WebKitLegacy/mac/Misc/WebDownload.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebDownload.mm
@@ -132,9 +132,9 @@ using namespace WebCore;
 #if !PLATFORM(IOS_FAMILY)
     // Try previously stored credential first.
     if (![challenge previousFailureCount]) {
-        NSURLCredential *credential = NetworkStorageSessionMap::defaultStorageSession().credentialStorage().get(emptyString(), ProtectionSpace([challenge protectionSpace])).nsCredential();
+        RetainPtr credential = NetworkStorageSessionMap::defaultStorageSession().credentialStorage().get(emptyString(), ProtectionSpace([challenge protectionSpace])).nsCredential();
         if (credential) {
-            [[challenge sender] useCredential:credential forAuthenticationChallenge:challenge];
+            [[challenge sender] useCredential:credential.get() forAuthenticationChallenge:challenge];
             return;
         }
     }

--- a/Source/WebKitLegacy/mac/Misc/WebKitNSStringExtras.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebKitNSStringExtras.mm
@@ -77,19 +77,19 @@ static bool canUseFastRenderer(std::span<const UniChar> buffer)
         point.y = CGCeiling(point.y);
 
         NSGraphicsContext *nsContext = [NSGraphicsContext currentContext];
-        CGContextRef cgContext = [nsContext CGContext];
-        GraphicsContextCG graphicsContext { cgContext };
+        RetainPtr cgContext = [nsContext CGContext];
+        GraphicsContextCG graphicsContext { cgContext.get() };
 
         // WebCore requires a flipped graphics context.
         bool flipped = [nsContext isFlipped];
         if (!flipped)
-            CGContextScaleCTM(cgContext, 1, -1);
+            CGContextScaleCTM(cgContext.get(), 1, -1);
 
         graphicsContext.setFillColor(colorFromCocoaColor(textColor));
         webCoreFont.drawText(graphicsContext, run, FloatPoint(point.x, flipped ? point.y : -point.y));
 
         if (!flipped)
-            CGContextScaleCTM(cgContext, 1, -1);
+            CGContextScaleCTM(cgContext.get(), 1, -1);
     } else {
         // The given point is on the baseline.
         if ([[NSView focusView] isFlipped])

--- a/Source/WebKitLegacy/mac/Misc/WebLocalizableStrings.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebLocalizableStrings.mm
@@ -37,22 +37,22 @@ WebLocalizableStringsBundle WebKitLocalizableStringsBundle = { "com.apple.WebKit
 
 NSString *WebLocalizedString(WebLocalizableStringsBundle *stringsBundle, const char *key)
 {
-    NSBundle *bundle;
+    RetainPtr<NSBundle> bundle;
     if (stringsBundle == NULL) {
         static NeverDestroyed<RetainPtr<NSBundle>> mainBundle = [NSBundle mainBundle];
         ASSERT(mainBundle.get());
         bundle = mainBundle.get().get();
     } else {
         bundle = stringsBundle->bundle;
-        if (bundle == nil) {
+        if (!bundle) {
             bundle = [NSBundle bundleWithIdentifier:[NSString stringWithUTF8String:stringsBundle->identifier]];
-            ASSERT(bundle);
-            stringsBundle->bundle = bundle;
+            ASSERT(bundle.get());
+            stringsBundle->bundle = bundle.get();
         }
     }
     NSString *notFound = @"localized string not found";
     auto keyString = adoptCF(CFStringCreateWithCStringNoCopy(NULL, key, kCFStringEncodingUTF8, kCFAllocatorNull));
-    NSString *result = [bundle localizedStringForKey:(__bridge NSString *)keyString.get() value:notFound table:nil];
+    NSString *result = [bundle.get() localizedStringForKey:(__bridge NSString *)keyString.get() value:notFound table:nil];
     ASSERT_WITH_MESSAGE(result != notFound, "could not find localizable string %s in bundle", key);
     return result;
 }

--- a/Source/WebKitLegacy/mac/Misc/WebNSPasteboardExtras.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebNSPasteboardExtras.mm
@@ -199,18 +199,18 @@ static NSArray *writableTypesForImageWithArchive()
     // This image data is either the only subresource of an archive (HTML image case)
     // or the main resource (standalone image case).
     NSArray *subresources = [archive subresources];
-    WebResource *resource = [archive mainResource];
+    RetainPtr resource = [archive mainResource];
     if (containsImage && [subresources count] > 0) {
         WebResource *subresource = [subresources objectAtIndex:0];
         NSString *subresourceMIMEType = [subresource MIMEType];
         if (MIMETypeRegistry::isSupportedImageMIMEType(subresourceMIMEType) || MIMETypeRegistry::isPDFMIMEType(subresourceMIMEType))
             resource = subresource;
     }
-    ASSERT(resource != nil);
-    
-    ASSERT(!containsImage || MIMETypeRegistry::isSupportedImageMIMEType([resource MIMEType]) || MIMETypeRegistry::isPDFMIMEType([resource MIMEType]));
-    if (!containsImage || MIMETypeRegistry::isSupportedImageMIMEType([resource MIMEType]) || MIMETypeRegistry::isPDFMIMEType([resource MIMEType]))
-        [self _web_writeFileWrapperAsRTFDAttachment:[resource _fileWrapperRepresentation]];
+    ASSERT(resource.get() != nil);
+
+    ASSERT(!containsImage || MIMETypeRegistry::isSupportedImageMIMEType([resource.get() MIMEType]) || MIMETypeRegistry::isPDFMIMEType([resource.get() MIMEType]));
+    if (!containsImage || MIMETypeRegistry::isSupportedImageMIMEType([resource.get() MIMEType]) || MIMETypeRegistry::isPDFMIMEType([resource.get() MIMEType]))
+        [self _web_writeFileWrapperAsRTFDAttachment:[resource.get() _fileWrapperRepresentation]];
     
 }
 

--- a/Source/WebKitLegacy/mac/Misc/WebNSURLExtras.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebNSURLExtras.mm
@@ -138,13 +138,13 @@
 
 -(NSData *)_web_hostData
 {
-    NSData *result = WTF::dataForURLComponentType(self, kCFURLComponentHost);
+    RetainPtr result = WTF::dataForURLComponentType(self, kCFURLComponentHost);
 
     // Take off localhost for file.
-    if ([result _web_isCaseInsensitiveEqualToCString:"localhost"] && [[self _web_schemeData] _web_isCaseInsensitiveEqualToCString:"file"])
+    if ([result.get() _web_isCaseInsensitiveEqualToCString:"localhost"] && [[self _web_schemeData] _web_isCaseInsensitiveEqualToCString:"file"])
         return nil;
 
-    return result;
+    return result.autorelease();
 }
 
 - (NSString *)_web_hostString

--- a/Source/WebKitLegacy/mac/Misc/WebSharingServicePickerController.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebSharingServicePickerController.mm
@@ -193,12 +193,12 @@ RetainPtr<NSImage> WebSharingServicePickerClient::imageForCurrentSharingServiceP
     if ([item isKindOfClass:[NSImage class]])
         [self didShareImageData:[item TIFFRepresentation] confirmDataIsValidTIFFData:NO];
     else if ([item isKindOfClass:[NSItemProvider class]]) {
-        NSItemProvider *itemProvider = (NSItemProvider *)item;
-        NSString *itemUTI = itemProvider.registeredTypeIdentifiers.firstObject;
+        RetainPtr itemProvider = (NSItemProvider *)item;
+        NSString *itemUTI = itemProvider.get().registeredTypeIdentifiers.firstObject;
 
         // FIXME: <rdar://165255055> Migrate from deprecated NSItemProvider APIs
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        [itemProvider loadItemForTypeIdentifier:itemUTI options:nil completionHandler:^(id receivedData, NSError *dataError) {
+        [itemProvider.get() loadItemForTypeIdentifier:itemUTI options:nil completionHandler:^(id receivedData, NSError *dataError) {
             if (!receivedData) {
                 LOG_ERROR("Did not receive data from NSItemProvider");
                 return;

--- a/Source/WebKitLegacy/mac/Plugins/WebPluginController.mm
+++ b/Source/WebKitLegacy/mac/Plugins/WebPluginController.mm
@@ -616,12 +616,12 @@ static void installFlip4MacPlugInWorkaroundIfNecessary()
 {
     static bool hasInstalledFlip4MacPlugInWorkaround;
     if (!hasInstalledFlip4MacPlugInWorkaround) {
-        Class TSUpdateCheck = objc_lookUpClass("TSUpdateCheck");
+        RetainPtr TSUpdateCheck = objc_lookUpClass("TSUpdateCheck");
         if (!TSUpdateCheck)
             return;
 
 IGNORE_WARNINGS_BEGIN("undeclared-selector")
-        Method methodToPatch = class_getInstanceMethod(TSUpdateCheck, @selector(alertDidEnd:returnCode:contextInfo:));
+        Method methodToPatch = class_getInstanceMethod(TSUpdateCheck.get(), @selector(alertDidEnd:returnCode:contextInfo:));
 IGNORE_WARNINGS_END
         if (!methodToPatch)
             return;

--- a/Source/WebKitLegacy/mac/Plugins/WebPluginDatabase.mm
+++ b/Source/WebKitLegacy/mac/Plugins/WebPluginDatabase.mm
@@ -163,8 +163,8 @@ struct PluginPackageCandidates {
             candidates.update(plugin);
     }
     
-    WebBasePluginPackage *plugin = candidates.bestCandidate();
-    
+    RetainPtr plugin = candidates.bestCandidate();
+
     if (!plugin) {
         // If no plug-in was found from the extension, attempt to map from the extension to a MIME type
         // and find the a plug-in from the MIME type. This is done in case the plug-in has not fully specified
@@ -173,7 +173,7 @@ struct PluginPackageCandidates {
         if ([MIMEType length] > 0)
             plugin = [self pluginForMIMEType:MIMEType];
     }
-    return plugin;
+    return plugin.autorelease();
 }
 
 - (NSArray *)plugins

--- a/Source/WebKitLegacy/mac/Storage/WebStorageManager.mm
+++ b/Source/WebKitLegacy/mac/Storage/WebStorageManager.mm
@@ -100,8 +100,8 @@ NSString * const WebStorageDidModifyOriginNotification = @"WebStorageDidModifyOr
         NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
         RetainPtr<NSString> localStoragePath = [defaults objectForKey:WebStorageDirectoryDefaultsKey];
         if (!localStoragePath || ![localStoragePath isKindOfClass:[NSString class]]) {
-            NSArray *paths = NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES);
-            NSString *libraryDirectory = [paths objectAtIndex:0];
+            RetainPtr paths = NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES);
+            NSString *libraryDirectory = [paths.get() objectAtIndex:0];
             localStoragePath = [libraryDirectory stringByAppendingPathComponent:@"WebKit/LocalStorage"];
         }
         return [localStoragePath stringByStandardizingPath];

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.mm
@@ -275,17 +275,17 @@ void WebContextMenuClient::showContextMenu()
     if (!frameView)
         return;
 
-    NSView* view = frameView->documentView();
+    RetainPtr view = frameView->documentView();
     IntPoint point = frameView->contentsToWindow(page->contextMenuController().hitTestResult().roundedPointInInnerNodeFrame());
-    NSEvent* event = [NSEvent mouseEventWithType:NSEventTypeRightMouseDown location:point modifierFlags:0 timestamp:0 windowNumber:[[view window] windowNumber] context:0 eventNumber:0 clickCount:1 pressure:1];
+    NSEvent* event = [NSEvent mouseEventWithType:NSEventTypeRightMouseDown location:point modifierFlags:0 timestamp:0 windowNumber:[[view.get() window] windowNumber] context:0 eventNumber:0 clickCount:1 pressure:1];
 
     // Show the contextual menu for this event.
     bool isServicesMenu;
-    if (NSMenu *menu = contextMenuForEvent(event, view, isServicesMenu)) {
+    if (RetainPtr menu = contextMenuForEvent(event, view.get(), isServicesMenu)) {
         if (isServicesMenu)
-            [menu popUpMenuPositioningItem:nil atLocation:[view convertPoint:point toView:nil] inView:view];
+            [menu.get() popUpMenuPositioningItem:nil atLocation:[view.get() convertPoint:point toView:nil] inView:view.get()];
         else
-            [NSMenu popUpContextMenu:menu withEvent:event forView:view];
+            [NSMenu popUpContextMenu:menu.get() withEvent:event forView:view.get()];
     }
 }
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebDragClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebDragClient.mm
@@ -154,31 +154,30 @@ void WebDragClient::startDrag(DragItem dragItem, DataTransfer& dataTransfer, Fra
     if (![htmlView.get() isKindOfClass:[WebHTMLView class]])
         return;
     
-    NSEvent *event = (dragItem.sourceAction && *dragItem.sourceAction == DragSourceAction::Link) ? localFrame->eventHandler().currentNSEvent() : [htmlView.get() _mouseDownEvent];
-    WebHTMLView* topHTMLView = getTopHTMLView(localFrame);
-    RetainPtr<WebHTMLView> topViewProtector = topHTMLView;
-    
-    [topHTMLView _stopAutoscrollTimer];
-    NSPasteboard *pasteboard = [NSPasteboard pasteboardWithName:dataTransfer.pasteboard().name().createNSString().get()];
+    RetainPtr event = (dragItem.sourceAction && *dragItem.sourceAction == DragSourceAction::Link) ? localFrame->eventHandler().currentNSEvent() : [htmlView.get() _mouseDownEvent];
+    RetainPtr topHTMLView = getTopHTMLView(localFrame);
 
-    NSImage *dragNSImage = dragImage.get().unsafeGet();
-    WebHTMLView *sourceHTMLView = htmlView.get();
+    [topHTMLView.get() _stopAutoscrollTimer];
+    RetainPtr pasteboard = [NSPasteboard pasteboardWithName:dataTransfer.pasteboard().name().createNSString().get()];
 
-    IntSize size([dragNSImage size]);
+    RetainPtr dragNSImage = dragImage.get().unsafeGet();
+    RetainPtr sourceHTMLView = htmlView.get();
+
+    IntSize size([dragNSImage.get() size]);
     size.scale(1 / localFrame->page()->deviceScaleFactor());
-    [dragNSImage setSize:size];
+    [dragNSImage.get() setSize:size];
 
-    id delegate = [m_webView UIDelegate];
+    RetainPtr<id<WebUIDelegate>> delegate = [m_webView UIDelegate];
     SEL selector = @selector(webView:dragImage:at:offset:event:pasteboard:source:slideBack:forView:);
-    if ([delegate respondsToSelector:selector]) {
+    if ([delegate.get() respondsToSelector:selector]) {
         @try {
-            [delegate webView:m_webView dragImage:dragNSImage at:dragLocationInContentCoordinates offset:NSZeroSize event:event pasteboard:pasteboard source:sourceHTMLView slideBack:YES forView:topHTMLView];
+            [(id)delegate.get() webView:m_webView dragImage:dragNSImage.get() at:dragLocationInContentCoordinates offset:NSZeroSize event:event.get() pasteboard:pasteboard.get() source:sourceHTMLView.get() slideBack:YES forView:topHTMLView.get()];
         } @catch (id exception) {
             ReportDiscardedDelegateException(selector, exception);
         }
     } else
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        [topHTMLView dragImage:dragNSImage at:dragLocationInContentCoordinates offset:NSZeroSize event:event pasteboard:pasteboard source:sourceHTMLView slideBack:YES];
+        [topHTMLView.get() dragImage:dragNSImage.get() at:dragLocationInContentCoordinates offset:NSZeroSize event:event.get() pasteboard:pasteboard.get() source:sourceHTMLView.get() slideBack:YES];
 ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
@@ -202,8 +201,8 @@ void WebDragClient::beginDrag(DragItem dragItem, LocalFrame& frame, const IntPoi
     [draggingItem setDraggingFrame:draggingFrame contents:dragItem.image.get().get()];
 
     // FIXME: We should be able to make a fake event with the mosue dragged coordinates.
-    NSEvent *event = frame.eventHandler().currentNSEvent();
-    [topWebHTMLView.get() beginDraggingSessionWithItems:@[ draggingItem.get() ] event:event source:topWebHTMLView.get()];
+    RetainPtr event = frame.eventHandler().currentNSEvent();
+    [topWebHTMLView.get() beginDraggingSessionWithItems:@[ draggingItem.get() ] event:event.get() source:topWebHTMLView.get()];
 }
 
 void WebDragClient::declareAndWriteDragImage(const String& pasteboardName, Element& element, const URL& url, const String& title, WebCore::LocalFrame* frame)

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
@@ -268,15 +268,15 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 void WebFrameLoaderClient::detachedFromParent2()
 {
     //remove any NetScape plugins that are children of this frame because they are about to be detached
-    WebView *webView = getWebView(m_webFrame.get());
+    RetainPtr webView = getWebView(m_webFrame.get());
 #if !PLATFORM(IOS_FAMILY)
-    [webView removePluginInstanceViewsFor:(m_webFrame.get())];
+    [webView.get() removePluginInstanceViewsFor:(m_webFrame.get())];
 #endif
     [m_webFrame->_private->webFrameView _setWebFrame:nil]; // needed for now to be compatible w/ old behavior
 
-    WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(webView);
+    WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(webView.get());
     if (implementations->didRemoveFrameFromHierarchyFunc)
-        CallFrameLoadDelegate(implementations->didRemoveFrameFromHierarchyFunc, webView, @selector(webView:didRemoveFrameFromHierarchy:), m_webFrame.get());
+        CallFrameLoadDelegate(implementations->didRemoveFrameFromHierarchyFunc, webView.get(), @selector(webView:didRemoveFrameFromHierarchy:), m_webFrame.get());
 }
 
 void WebFrameLoaderClient::detachedFromParent3()
@@ -286,13 +286,13 @@ void WebFrameLoaderClient::detachedFromParent3()
 
 void WebFrameLoaderClient::convertMainResourceLoadToDownload(WebCore::DocumentLoader* documentLoader, const WebCore::ResourceRequest& request, const WebCore::ResourceResponse& response)
 {
-    WebView *webView = getWebView(m_webFrame.get());
+    RetainPtr webView = getWebView(m_webFrame.get());
     auto* mainResourceLoader = documentLoader->mainResourceLoader();
 
     if (!mainResourceLoader) {
         // The resource has already been cached, or the conversion is being attmpted when not calling SubresourceLoader::didReceiveResponse().
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        RetainPtr webDownload = adoptNS([[WebDownload alloc] initWithRequest:request.protectedNSURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody).get() delegate:[webView downloadDelegate]]);
+        RetainPtr webDownload = adoptNS([[WebDownload alloc] initWithRequest:request.protectedNSURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody).get() delegate:[webView.get() downloadDelegate]]);
 ALLOW_DEPRECATED_DECLARATIONS_END
         webDownload.autorelease();
         return;
@@ -301,51 +301,51 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     auto* handle = mainResourceLoader->handle();
 
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    [WebDownload _downloadWithLoadingConnection:handle->connection() request:request.protectedNSURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody).get() response:response.protectedNSURLResponse().get() delegate:[webView downloadDelegate] proxy:nil];
+    [WebDownload _downloadWithLoadingConnection:handle->connection() request:request.protectedNSURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody).get() response:response.protectedNSURLResponse().get() delegate:[webView.get() downloadDelegate] proxy:nil];
 ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
 bool WebFrameLoaderClient::dispatchDidLoadResourceFromMemoryCache(WebCore::DocumentLoader* loader, const WebCore::ResourceRequest& request, const WebCore::ResourceResponse& response, int length)
 {
-    WebView *webView = getWebView(m_webFrame.get());
-    WebResourceDelegateImplementationCache* implementations = WebViewGetResourceLoadDelegateImplementations(webView);
+    RetainPtr webView = getWebView(m_webFrame.get());
+    WebResourceDelegateImplementationCache* implementations = WebViewGetResourceLoadDelegateImplementations(webView.get());
 #if PLATFORM(IOS_FAMILY)
     if (implementations->webThreadDidLoadResourceFromMemoryCacheFunc) {
-        CallResourceLoadDelegateInWebThread(implementations->webThreadDidLoadResourceFromMemoryCacheFunc, webView, @selector(webThreadWebView:didLoadResourceFromMemoryCache:response:length:fromDataSource:), request.protectedNSURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody).get(), response.protectedNSURLResponse().get(), length, dataSource(loader));
+        CallResourceLoadDelegateInWebThread(implementations->webThreadDidLoadResourceFromMemoryCacheFunc, webView.get(), @selector(webThreadWebView:didLoadResourceFromMemoryCache:response:length:fromDataSource:), request.protectedNSURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody).get(), response.protectedNSURLResponse().get(), length, dataSource(loader));
         return true;
-    } 
+    }
 #endif
     if (!implementations->didLoadResourceFromMemoryCacheFunc)
         return false;
 
-    CallResourceLoadDelegate(implementations->didLoadResourceFromMemoryCacheFunc, webView, @selector(webView:didLoadResourceFromMemoryCache:response:length:fromDataSource:), request.protectedNSURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody).get(), response.protectedNSURLResponse().get(), length, dataSource(loader));
+    CallResourceLoadDelegate(implementations->didLoadResourceFromMemoryCacheFunc, webView.get(), @selector(webView:didLoadResourceFromMemoryCache:response:length:fromDataSource:), request.protectedNSURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody).get(), response.protectedNSURLResponse().get(), length, dataSource(loader));
     return true;
 }
 
 void WebFrameLoaderClient::assignIdentifierToInitialRequest(WebCore::ResourceLoaderIdentifier identifier, WebCore::DocumentLoader* loader, const WebCore::ResourceRequest& request)
 {
-    WebView *webView = getWebView(m_webFrame.get());
-    WebResourceDelegateImplementationCache* implementations = WebViewGetResourceLoadDelegateImplementations(webView);
+    RetainPtr webView = getWebView(m_webFrame.get());
+    WebResourceDelegateImplementationCache* implementations = WebViewGetResourceLoadDelegateImplementations(webView.get());
 
     RetainPtr<id> object;
 
 #if PLATFORM(IOS_FAMILY)
     if (implementations->webThreadIdentifierForRequestFunc) {
-        object = CallResourceLoadDelegateInWebThread(implementations->webThreadIdentifierForRequestFunc, webView, @selector(webThreadWebView:identifierForInitialRequest:fromDataSource:), request.protectedNSURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody).get(), dataSource(loader));
+        object = CallResourceLoadDelegateInWebThread(implementations->webThreadIdentifierForRequestFunc, webView.get(), @selector(webThreadWebView:identifierForInitialRequest:fromDataSource:), request.protectedNSURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody).get(), dataSource(loader));
     } else
 #endif
     if (implementations->identifierForRequestFunc)
-        object = CallResourceLoadDelegate(implementations->identifierForRequestFunc, webView, @selector(webView:identifierForInitialRequest:fromDataSource:), request.protectedNSURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody).get(), dataSource(loader));
+        object = CallResourceLoadDelegate(implementations->identifierForRequestFunc, webView.get(), @selector(webView:identifierForInitialRequest:fromDataSource:), request.protectedNSURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody).get(), dataSource(loader));
     else
         object = adoptNS([[NSObject alloc] init]);
 
-    [webView _addObject:object.get() forIdentifier:identifier];
+    [webView.get() _addObject:object.get() forIdentifier:identifier];
 }
 
 void WebFrameLoaderClient::dispatchWillSendRequest(WebCore::DocumentLoader* loader, WebCore::ResourceLoaderIdentifier identifier, WebCore::ResourceRequest& request, const WebCore::ResourceResponse& redirectResponse)
 {
-    WebView *webView = getWebView(m_webFrame.get());
-    WebResourceDelegateImplementationCache* implementations = WebViewGetResourceLoadDelegateImplementations(webView);
+    RetainPtr webView = getWebView(m_webFrame.get());
+    WebResourceDelegateImplementationCache* implementations = WebViewGetResourceLoadDelegateImplementations(webView.get());
 
     if (redirectResponse.isNull())
         static_cast<WebDocumentLoaderMac*>(loader)->increaseLoadCount(identifier);
@@ -362,11 +362,11 @@ void WebFrameLoaderClient::dispatchWillSendRequest(WebCore::DocumentLoader* load
     RetainPtr newURLRequest = currentURLRequest;
 #if PLATFORM(IOS_FAMILY)
     if (implementations->webThreadWillSendRequestFunc) {
-        newURLRequest = (NSURLRequest *)CallResourceLoadDelegateInWebThread(implementations->webThreadWillSendRequestFunc, webView, @selector(webThreadWebView:resource:willSendRequest:redirectResponse:fromDataSource:), [webView _objectForIdentifier:identifier], currentURLRequest.get(), redirectResponse.protectedNSURLResponse().get(), dataSource(loader));
+        newURLRequest = (NSURLRequest *)CallResourceLoadDelegateInWebThread(implementations->webThreadWillSendRequestFunc, webView.get(), @selector(webThreadWebView:resource:willSendRequest:redirectResponse:fromDataSource:), [webView.get() _objectForIdentifier:identifier], currentURLRequest.get(), redirectResponse.protectedNSURLResponse().get(), dataSource(loader));
     } else
 #endif
     if (implementations->willSendRequestFunc)
-        newURLRequest = (NSURLRequest *)CallResourceLoadDelegate(implementations->willSendRequestFunc, webView, @selector(webView:resource:willSendRequest:redirectResponse:fromDataSource:), [webView _objectForIdentifier:identifier], currentURLRequest.get(), redirectResponse.protectedNSURLResponse().get(), dataSource(loader));
+        newURLRequest = (NSURLRequest *)CallResourceLoadDelegate(implementations->willSendRequestFunc, webView.get(), @selector(webView:resource:willSendRequest:redirectResponse:fromDataSource:), [webView.get() _objectForIdentifier:identifier], currentURLRequest.get(), redirectResponse.protectedNSURLResponse().get(), dataSource(loader));
 
     if (newURLRequest != currentURLRequest)
         request.updateFromDelegatePreservingOldProperties(WebCore::ResourceRequest(newURLRequest.get()));
@@ -374,12 +374,12 @@ void WebFrameLoaderClient::dispatchWillSendRequest(WebCore::DocumentLoader* load
 
 bool WebFrameLoaderClient::shouldUseCredentialStorage(WebCore::DocumentLoader* loader, WebCore::ResourceLoaderIdentifier identifier)
 {
-    WebView *webView = getWebView(m_webFrame.get());
-    WebResourceDelegateImplementationCache* implementations = WebViewGetResourceLoadDelegateImplementations(webView);
+    RetainPtr webView = getWebView(m_webFrame.get());
+    WebResourceDelegateImplementationCache* implementations = WebViewGetResourceLoadDelegateImplementations(webView.get());
 
     if (implementations->shouldUseCredentialStorageFunc) {
-        if (id resource = [webView _objectForIdentifier:identifier])
-            return CallResourceLoadDelegateReturningBoolean(NO, implementations->shouldUseCredentialStorageFunc, webView, @selector(webView:resource:shouldUseCredentialStorageForDataSource:), resource, dataSource(loader));
+        if (id resource = [webView.get() _objectForIdentifier:identifier])
+            return CallResourceLoadDelegateReturningBoolean(NO, implementations->shouldUseCredentialStorageFunc, webView.get(), @selector(webView:resource:shouldUseCredentialStorageForDataSource:), resource, dataSource(loader));
     }
 
     return true;
@@ -387,35 +387,35 @@ bool WebFrameLoaderClient::shouldUseCredentialStorage(WebCore::DocumentLoader* l
 
 void WebFrameLoaderClient::dispatchDidReceiveAuthenticationChallenge(WebCore::DocumentLoader* loader, WebCore::ResourceLoaderIdentifier identifier, const WebCore::AuthenticationChallenge& challenge)
 {
-    WebView *webView = getWebView(m_webFrame.get());
-    WebResourceDelegateImplementationCache* implementations = WebViewGetResourceLoadDelegateImplementations(webView);
+    RetainPtr webView = getWebView(m_webFrame.get());
+    WebResourceDelegateImplementationCache* implementations = WebViewGetResourceLoadDelegateImplementations(webView.get());
 
-    NSURLAuthenticationChallenge *webChallenge = mac(challenge);
+    RetainPtr webChallenge = mac(challenge);
 
     if (implementations->didReceiveAuthenticationChallengeFunc) {
-        if (id resource = [webView _objectForIdentifier:identifier]) {
-            CallResourceLoadDelegate(implementations->didReceiveAuthenticationChallengeFunc, webView, @selector(webView:resource:didReceiveAuthenticationChallenge:fromDataSource:), resource, webChallenge, dataSource(loader));
+        if (id resource = [webView.get() _objectForIdentifier:identifier]) {
+            CallResourceLoadDelegate(implementations->didReceiveAuthenticationChallengeFunc, webView.get(), @selector(webView:resource:didReceiveAuthenticationChallenge:fromDataSource:), resource, webChallenge.get(), dataSource(loader));
             return;
         }
     }
 
 #if !PLATFORM(IOS_FAMILY)
-    NSWindow *window = [webView hostWindow] ? [webView hostWindow] : [webView window];
-    [[WebPanelAuthenticationHandler sharedHandler] startAuthentication:webChallenge window:window];
+    RetainPtr window = [webView.get() hostWindow] ? [webView.get() hostWindow] : [webView.get() window];
+    [[WebPanelAuthenticationHandler sharedHandler] startAuthentication:webChallenge.get() window:window.get()];
 #endif
 }
 
 #if USE(PROTECTION_SPACE_AUTH_CALLBACK)
 bool WebFrameLoaderClient::canAuthenticateAgainstProtectionSpace(WebCore::DocumentLoader* loader, WebCore::ResourceLoaderIdentifier identifier, const WebCore::ProtectionSpace& protectionSpace)
 {
-    WebView *webView = getWebView(m_webFrame.get());
-    WebResourceDelegateImplementationCache* implementations = WebViewGetResourceLoadDelegateImplementations(webView);
-    
-    NSURLProtectionSpace *webProtectionSpace = protectionSpace.nsSpace();
-    
+    RetainPtr webView = getWebView(m_webFrame.get());
+    WebResourceDelegateImplementationCache* implementations = WebViewGetResourceLoadDelegateImplementations(webView.get());
+
+    RetainPtr webProtectionSpace = protectionSpace.nsSpace();
+
     if (implementations->canAuthenticateAgainstProtectionSpaceFunc) {
-        if (id resource = [webView _objectForIdentifier:identifier]) {
-            return CallResourceLoadDelegateReturningBoolean(NO, implementations->canAuthenticateAgainstProtectionSpaceFunc, webView, @selector(webView:resource:canAuthenticateAgainstProtectionSpace:forDataSource:), resource, webProtectionSpace, dataSource(loader));
+        if (id resource = [webView.get() _objectForIdentifier:identifier]) {
+            return CallResourceLoadDelegateReturningBoolean(NO, implementations->canAuthenticateAgainstProtectionSpaceFunc, webView.get(), @selector(webView:resource:canAuthenticateAgainstProtectionSpace:forDataSource:), resource, webProtectionSpace.get(), dataSource(loader));
         }
     }
 
@@ -430,13 +430,13 @@ bool WebFrameLoaderClient::canAuthenticateAgainstProtectionSpace(WebCore::Docume
 RetainPtr<CFDictionaryRef> WebFrameLoaderClient::connectionProperties(WebCore::DocumentLoader* loader, WebCore::ResourceLoaderIdentifier identifier)
 {
     WebView *webView = getWebView(m_webFrame.get());
-    id resource = [webView _objectForIdentifier:identifier];
+    RetainPtr resource = [webView _objectForIdentifier:identifier];
     if (!resource)
         return nullptr;
 
     WebResourceDelegateImplementationCache* implementations = WebViewGetResourceLoadDelegateImplementations(webView);
     if (implementations->connectionPropertiesFunc)
-        return (CFDictionaryRef)CallResourceLoadDelegate(implementations->connectionPropertiesFunc, webView, @selector(webView:connectionPropertiesForResource:dataSource:), resource, dataSource(loader));
+        return (CFDictionaryRef)CallResourceLoadDelegate(implementations->connectionPropertiesFunc, webView, @selector(webView:connectionPropertiesForResource:dataSource:), resource.get(), dataSource(loader));
 
     return nullptr;
 }
@@ -444,49 +444,49 @@ RetainPtr<CFDictionaryRef> WebFrameLoaderClient::connectionProperties(WebCore::D
 
 bool WebFrameLoaderClient::shouldPaintBrokenImage(const URL& imageURL) const
 {
-    WebView *webView = getWebView(m_webFrame.get());
-    WebResourceDelegateImplementationCache* implementations = WebViewGetResourceLoadDelegateImplementations(webView);
+    RetainPtr webView = getWebView(m_webFrame.get());
+    WebResourceDelegateImplementationCache* implementations = WebViewGetResourceLoadDelegateImplementations(webView.get());
 
     if (implementations->shouldPaintBrokenImageForURLFunc) {
         RetainPtr url = imageURL.createNSURL();
-        return CallResourceLoadDelegateReturningBoolean(YES, implementations->shouldPaintBrokenImageForURLFunc, webView, @selector(webView:shouldPaintBrokenImageForURL:), url.get());
+        return CallResourceLoadDelegateReturningBoolean(YES, implementations->shouldPaintBrokenImageForURLFunc, webView.get(), @selector(webView:shouldPaintBrokenImageForURL:), url.get());
     }
     return true;
 }
 
 void WebFrameLoaderClient::dispatchDidReceiveResponse(WebCore::DocumentLoader* loader, WebCore::ResourceLoaderIdentifier identifier, const WebCore::ResourceResponse& response)
 {
-    WebView *webView = getWebView(m_webFrame.get());
-    WebResourceDelegateImplementationCache* implementations = WebViewGetResourceLoadDelegateImplementations(webView);
+    RetainPtr webView = getWebView(m_webFrame.get());
+    WebResourceDelegateImplementationCache* implementations = WebViewGetResourceLoadDelegateImplementations(webView.get());
 
 #if PLATFORM(IOS_FAMILY)
     if (implementations->webThreadDidReceiveResponseFunc) {
-        if (id resource = [webView _objectForIdentifier:identifier])
-            CallResourceLoadDelegateInWebThread(implementations->webThreadDidReceiveResponseFunc, webView, @selector(webThreadWebView:resource:didReceiveResponse:fromDataSource:), resource, response.protectedNSURLResponse().get(), dataSource(loader));
-        
+        if (id resource = [webView.get() _objectForIdentifier:identifier])
+            CallResourceLoadDelegateInWebThread(implementations->webThreadDidReceiveResponseFunc, webView.get(), @selector(webThreadWebView:resource:didReceiveResponse:fromDataSource:), resource, response.protectedNSURLResponse().get(), dataSource(loader));
+
     } else
 #endif
     if (implementations->didReceiveResponseFunc) {
-        if (id resource = [webView _objectForIdentifier:identifier])
-            CallResourceLoadDelegate(implementations->didReceiveResponseFunc, webView, @selector(webView:resource:didReceiveResponse:fromDataSource:), resource, response.protectedNSURLResponse().get(), dataSource(loader));
+        if (id resource = [webView.get() _objectForIdentifier:identifier])
+            CallResourceLoadDelegate(implementations->didReceiveResponseFunc, webView.get(), @selector(webView:resource:didReceiveResponse:fromDataSource:), resource, response.protectedNSURLResponse().get(), dataSource(loader));
     }
 }
 
 void WebFrameLoaderClient::willCacheResponse(WebCore::DocumentLoader* loader, WebCore::ResourceLoaderIdentifier identifier, NSCachedURLResponse* response, CompletionHandler<void(NSCachedURLResponse *)>&& completionHandler) const
 {
-    WebView *webView = getWebView(m_webFrame.get());
-    WebResourceDelegateImplementationCache* implementations = WebViewGetResourceLoadDelegateImplementations(webView);
+    RetainPtr webView = getWebView(m_webFrame.get());
+    WebResourceDelegateImplementationCache* implementations = WebViewGetResourceLoadDelegateImplementations(webView.get());
 
 #if PLATFORM(IOS_FAMILY)
     if (implementations->webThreadWillCacheResponseFunc) {
-        if (id resource = [webView _objectForIdentifier:identifier])
-            return completionHandler(CallResourceLoadDelegateInWebThread(implementations->webThreadWillCacheResponseFunc, webView, @selector(webThreadWebView:resource:willCacheResponse:fromDataSource:), resource, response, dataSource(loader)));
-        
+        if (id resource = [webView.get() _objectForIdentifier:identifier])
+            return completionHandler(CallResourceLoadDelegateInWebThread(implementations->webThreadWillCacheResponseFunc, webView.get(), @selector(webThreadWebView:resource:willCacheResponse:fromDataSource:), resource, response, dataSource(loader)));
+
     } else
 #endif
     if (implementations->willCacheResponseFunc) {
-        if (id resource = [webView _objectForIdentifier:identifier])
-            return completionHandler(CallResourceLoadDelegate(implementations->willCacheResponseFunc, webView, @selector(webView:resource:willCacheResponse:fromDataSource:), resource, response, dataSource(loader)));
+        if (id resource = [webView.get() _objectForIdentifier:identifier])
+            return completionHandler(CallResourceLoadDelegate(implementations->willCacheResponseFunc, webView.get(), @selector(webView:resource:willCacheResponse:fromDataSource:), resource, response, dataSource(loader)));
     }
 
     completionHandler(response);
@@ -494,17 +494,17 @@ void WebFrameLoaderClient::willCacheResponse(WebCore::DocumentLoader* loader, We
 
 void WebFrameLoaderClient::dispatchDidReceiveContentLength(WebCore::DocumentLoader* loader, WebCore::ResourceLoaderIdentifier identifier, int dataLength)
 {
-    WebView *webView = getWebView(m_webFrame.get());
-    WebResourceDelegateImplementationCache* implementations = WebViewGetResourceLoadDelegateImplementations(webView);
+    RetainPtr webView = getWebView(m_webFrame.get());
+    WebResourceDelegateImplementationCache* implementations = WebViewGetResourceLoadDelegateImplementations(webView.get());
 #if PLATFORM(IOS_FAMILY)
     if (implementations->webThreadDidReceiveContentLengthFunc) {
-        if (id resource = [webView _objectForIdentifier:identifier])
-            CallResourceLoadDelegateInWebThread(implementations->webThreadDidReceiveContentLengthFunc, webView, @selector(webThreadWebView:resource:didReceiveContentLength:fromDataSource:), resource, (NSInteger)dataLength, dataSource(loader));
+        if (id resource = [webView.get() _objectForIdentifier:identifier])
+            CallResourceLoadDelegateInWebThread(implementations->webThreadDidReceiveContentLengthFunc, webView.get(), @selector(webThreadWebView:resource:didReceiveContentLength:fromDataSource:), resource, (NSInteger)dataLength, dataSource(loader));
     } else
 #endif
     if (implementations->didReceiveContentLengthFunc) {
-        if (id resource = [webView _objectForIdentifier:identifier])
-            CallResourceLoadDelegate(implementations->didReceiveContentLengthFunc, webView, @selector(webView:resource:didReceiveContentLength:fromDataSource:), resource, (NSInteger)dataLength, dataSource(loader));
+        if (id resource = [webView.get() _objectForIdentifier:identifier])
+            CallResourceLoadDelegate(implementations->didReceiveContentLengthFunc, webView.get(), @selector(webView:resource:didReceiveContentLength:fromDataSource:), resource, (NSInteger)dataLength, dataSource(loader));
     }
 }
 
@@ -516,53 +516,53 @@ void WebFrameLoaderClient::dispatchDidFinishDataDetection(NSArray *)
 
 void WebFrameLoaderClient::dispatchDidFinishLoading(WebCore::DocumentLoader* loader, WebCore::ResourceLoaderIdentifier identifier)
 {
-    WebView *webView = getWebView(m_webFrame.get());
-    WebResourceDelegateImplementationCache* implementations = WebViewGetResourceLoadDelegateImplementations(webView);
+    RetainPtr webView = getWebView(m_webFrame.get());
+    WebResourceDelegateImplementationCache* implementations = WebViewGetResourceLoadDelegateImplementations(webView.get());
 
 #if PLATFORM(IOS_FAMILY)
     if (implementations->webThreadDidFinishLoadingFromDataSourceFunc) {
-        if (id resource = [webView _objectForIdentifier:identifier])
-            CallResourceLoadDelegateInWebThread(implementations->webThreadDidFinishLoadingFromDataSourceFunc, webView, @selector(webThreadWebView:resource:didFinishLoadingFromDataSource:), resource, dataSource(loader));
+        if (id resource = [webView.get() _objectForIdentifier:identifier])
+            CallResourceLoadDelegateInWebThread(implementations->webThreadDidFinishLoadingFromDataSourceFunc, webView.get(), @selector(webThreadWebView:resource:didFinishLoadingFromDataSource:), resource, dataSource(loader));
     } else
 #endif
 
     if (implementations->didFinishLoadingFromDataSourceFunc) {
-        if (id resource = [webView _objectForIdentifier:identifier])
-            CallResourceLoadDelegate(implementations->didFinishLoadingFromDataSourceFunc, webView, @selector(webView:resource:didFinishLoadingFromDataSource:), resource, dataSource(loader));
+        if (id resource = [webView.get() _objectForIdentifier:identifier])
+            CallResourceLoadDelegate(implementations->didFinishLoadingFromDataSourceFunc, webView.get(), @selector(webView:resource:didFinishLoadingFromDataSource:), resource, dataSource(loader));
     }
 
-    [webView _removeObjectForIdentifier:identifier];
+    [webView.get() _removeObjectForIdentifier:identifier];
 
     static_cast<WebDocumentLoaderMac*>(loader)->decreaseLoadCount(identifier);
 }
 
 void WebFrameLoaderClient::dispatchDidFailLoading(WebCore::DocumentLoader* loader, WebCore::ResourceLoaderIdentifier identifier, const WebCore::ResourceError& error)
 {
-    WebView *webView = getWebView(m_webFrame.get());
-    WebResourceDelegateImplementationCache* implementations = WebViewGetResourceLoadDelegateImplementations(webView);
+    RetainPtr webView = getWebView(m_webFrame.get());
+    WebResourceDelegateImplementationCache* implementations = WebViewGetResourceLoadDelegateImplementations(webView.get());
 
 #if PLATFORM(IOS_FAMILY)
     if (implementations->webThreadDidFailLoadingWithErrorFromDataSourceFunc) {
-        if (id resource = [webView _objectForIdentifier:identifier])
-            CallResourceLoadDelegateInWebThread(implementations->webThreadDidFailLoadingWithErrorFromDataSourceFunc, webView, @selector(webThreadWebView:resource:didFailLoadingWithError:fromDataSource:), resource, (NSError *)error, dataSource(loader));
+        if (id resource = [webView.get() _objectForIdentifier:identifier])
+            CallResourceLoadDelegateInWebThread(implementations->webThreadDidFailLoadingWithErrorFromDataSourceFunc, webView.get(), @selector(webThreadWebView:resource:didFailLoadingWithError:fromDataSource:), resource, (NSError *)error, dataSource(loader));
     } else
 #endif
     if (implementations->didFailLoadingWithErrorFromDataSourceFunc) {
-        if (id resource = [webView _objectForIdentifier:identifier])
-            CallResourceLoadDelegate(implementations->didFailLoadingWithErrorFromDataSourceFunc, webView, @selector(webView:resource:didFailLoadingWithError:fromDataSource:), resource, (NSError *)error, dataSource(loader));
+        if (id resource = [webView.get() _objectForIdentifier:identifier])
+            CallResourceLoadDelegate(implementations->didFailLoadingWithErrorFromDataSourceFunc, webView.get(), @selector(webView:resource:didFailLoadingWithError:fromDataSource:), resource, (NSError *)error, dataSource(loader));
     }
 
-    [webView _removeObjectForIdentifier:identifier];
+    [webView.get() _removeObjectForIdentifier:identifier];
 
     static_cast<WebDocumentLoaderMac*>(loader)->decreaseLoadCount(identifier);
 }
 
 void WebFrameLoaderClient::dispatchDidDispatchOnloadEvents()
 {
-    WebView *webView = getWebView(m_webFrame.get());
-    WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(webView);
+    RetainPtr webView = getWebView(m_webFrame.get());
+    WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(webView.get());
     if (implementations->didHandleOnloadEventsForFrameFunc)
-        CallFrameLoadDelegate(implementations->didHandleOnloadEventsForFrameFunc, webView, @selector(webView:didHandleOnloadEventsForFrame:), m_webFrame.get());
+        CallFrameLoadDelegate(implementations->didHandleOnloadEventsForFrameFunc, webView.get(), @selector(webView:didHandleOnloadEventsForFrame:), m_webFrame.get());
 }
 
 void WebFrameLoaderClient::dispatchDidReceiveServerRedirectForProvisionalLoad()
@@ -577,27 +577,27 @@ void WebFrameLoaderClient::dispatchDidReceiveServerRedirectForProvisionalLoad()
 
     m_webFrame->_private->provisionalURL = provisionalDocumentLoader->url().string().createNSString().autorelease();
 
-    WebView *webView = getWebView(m_webFrame.get());
-    WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(webView);
+    RetainPtr webView = getWebView(m_webFrame.get());
+    WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(webView.get());
     if (implementations->didReceiveServerRedirectForProvisionalLoadForFrameFunc)
-        CallFrameLoadDelegate(implementations->didReceiveServerRedirectForProvisionalLoadForFrameFunc, webView, @selector(webView:didReceiveServerRedirectForProvisionalLoadForFrame:), m_webFrame.get());
+        CallFrameLoadDelegate(implementations->didReceiveServerRedirectForProvisionalLoadForFrameFunc, webView.get(), @selector(webView:didReceiveServerRedirectForProvisionalLoadForFrame:), m_webFrame.get());
 }
 
 void WebFrameLoaderClient::dispatchDidCancelClientRedirect()
 {
-    WebView *webView = getWebView(m_webFrame.get());
-    WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(webView);
+    RetainPtr webView = getWebView(m_webFrame.get());
+    WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(webView.get());
     if (implementations->didCancelClientRedirectForFrameFunc)
-        CallFrameLoadDelegate(implementations->didCancelClientRedirectForFrameFunc, webView, @selector(webView:didCancelClientRedirectForFrame:), m_webFrame.get());
+        CallFrameLoadDelegate(implementations->didCancelClientRedirectForFrameFunc, webView.get(), @selector(webView:didCancelClientRedirectForFrame:), m_webFrame.get());
 }
 
 void WebFrameLoaderClient::dispatchWillPerformClientRedirect(const URL& url, double delay, WallTime fireDate, WebCore::LockBackForwardList)
 {
-    WebView *webView = getWebView(m_webFrame.get());
-    WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(webView);
+    RetainPtr webView = getWebView(m_webFrame.get());
+    WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(webView.get());
     if (implementations->willPerformClientRedirectToURLDelayFireDateForFrameFunc) {
         RetainPtr nsURL = url.createNSURL();
-        CallFrameLoadDelegate(implementations->willPerformClientRedirectToURLDelayFireDateForFrameFunc, webView, @selector(webView:willPerformClientRedirectToURL:delay:fireDate:forFrame:), nsURL.get(), delay, [NSDate dateWithTimeIntervalSince1970:fireDate.secondsSinceEpoch().seconds()], m_webFrame.get());
+        CallFrameLoadDelegate(implementations->willPerformClientRedirectToURLDelayFireDateForFrameFunc, webView.get(), @selector(webView:willPerformClientRedirectToURL:delay:fireDate:forFrame:), nsURL.get(), delay, [NSDate dateWithTimeIntervalSince1970:fireDate.secondsSinceEpoch().seconds()], m_webFrame.get());
     }
 }
 
@@ -605,12 +605,12 @@ void WebFrameLoaderClient::dispatchDidChangeLocationWithinPage()
 {
     m_webFrame->_private->url = core(m_webFrame.get())->document()->url().string().createNSString();
 
-    WebView *webView = getWebView(m_webFrame.get());
-    WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(webView);
+    RetainPtr webView = getWebView(m_webFrame.get());
+    WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(webView.get());
     if (implementations->didChangeLocationWithinPageForFrameFunc)
-        CallFrameLoadDelegate(implementations->didChangeLocationWithinPageForFrameFunc, webView, @selector(webView:didChangeLocationWithinPageForFrame:), m_webFrame.get());
+        CallFrameLoadDelegate(implementations->didChangeLocationWithinPageForFrameFunc, webView.get(), @selector(webView:didChangeLocationWithinPageForFrame:), m_webFrame.get());
 #if PLATFORM(IOS_FAMILY)
-    [[webView _UIKitDelegateForwarder] webView:webView didChangeLocationWithinPageForFrame:m_webFrame.get()];
+    [[webView.get() _UIKitDelegateForwarder] webView:webView.get() didChangeLocationWithinPageForFrame:m_webFrame.get()];
 #endif
 }
 
@@ -618,40 +618,40 @@ void WebFrameLoaderClient::dispatchDidPushStateWithinPage()
 {
     m_webFrame->_private->url = core(m_webFrame.get())->document()->url().string().createNSString();
 
-    WebView *webView = getWebView(m_webFrame.get());
-    WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(webView);
+    RetainPtr webView = getWebView(m_webFrame.get());
+    WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(webView.get());
     if (implementations->didPushStateWithinPageForFrameFunc)
-        CallFrameLoadDelegate(implementations->didPushStateWithinPageForFrameFunc, webView, @selector(webView:didPushStateWithinPageForFrame:), m_webFrame.get());
+        CallFrameLoadDelegate(implementations->didPushStateWithinPageForFrameFunc, webView.get(), @selector(webView:didPushStateWithinPageForFrame:), m_webFrame.get());
 }
 
 void WebFrameLoaderClient::dispatchDidReplaceStateWithinPage()
 {
     m_webFrame->_private->url = core(m_webFrame.get())->document()->url().string().createNSString();
 
-    WebView *webView = getWebView(m_webFrame.get());
-    WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(webView);
+    RetainPtr webView = getWebView(m_webFrame.get());
+    WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(webView.get());
     if (implementations->didReplaceStateWithinPageForFrameFunc)
-        CallFrameLoadDelegate(implementations->didReplaceStateWithinPageForFrameFunc, webView, @selector(webView:didReplaceStateWithinPageForFrame:), m_webFrame.get());
+        CallFrameLoadDelegate(implementations->didReplaceStateWithinPageForFrameFunc, webView.get(), @selector(webView:didReplaceStateWithinPageForFrame:), m_webFrame.get());
 }
 
 void WebFrameLoaderClient::dispatchDidPopStateWithinPage()
 {
     m_webFrame->_private->url = core(m_webFrame.get())->document()->url().string().createNSString();
 
-    WebView *webView = getWebView(m_webFrame.get());
-    WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(webView);
+    RetainPtr webView = getWebView(m_webFrame.get());
+    WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(webView.get());
     if (implementations->didPopStateWithinPageForFrameFunc)
-        CallFrameLoadDelegate(implementations->didPopStateWithinPageForFrameFunc, webView, @selector(webView:didPopStateWithinPageForFrame:), m_webFrame.get());
+        CallFrameLoadDelegate(implementations->didPopStateWithinPageForFrameFunc, webView.get(), @selector(webView:didPopStateWithinPageForFrame:), m_webFrame.get());
 }
 
 void WebFrameLoaderClient::dispatchWillClose()
 {
-    WebView *webView = getWebView(m_webFrame.get());   
-    WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(webView);
+    RetainPtr webView = getWebView(m_webFrame.get());
+    WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(webView.get());
     if (implementations->willCloseFrameFunc)
-        CallFrameLoadDelegate(implementations->willCloseFrameFunc, webView, @selector(webView:willCloseFrame:), m_webFrame.get());
+        CallFrameLoadDelegate(implementations->willCloseFrameFunc, webView.get(), @selector(webView:willCloseFrame:), m_webFrame.get());
 #if PLATFORM(IOS_FAMILY)
-    [[webView _UIKitDelegateForwarder] webView:webView willCloseFrame:m_webFrame.get()];
+    [[webView.get() _UIKitDelegateForwarder] webView:webView.get() willCloseFrame:m_webFrame.get()];
 #endif
 }
 
@@ -660,18 +660,18 @@ void WebFrameLoaderClient::dispatchDidStartProvisionalLoad()
     ASSERT(!m_webFrame->_private->provisionalURL);
     m_webFrame->_private->provisionalURL = core(m_webFrame.get())->loader().provisionalDocumentLoader()->url().string().createNSString();
 
-    WebView *webView = getWebView(m_webFrame.get());
+    RetainPtr webView = getWebView(m_webFrame.get());
 #if !PLATFORM(IOS_FAMILY)
-    [webView _didStartProvisionalLoadForFrame:m_webFrame.get()];
+    [webView.get() _didStartProvisionalLoadForFrame:m_webFrame.get()];
 #endif
 
 #if PLATFORM(IOS_FAMILY)
-    [[webView _UIKitDelegateForwarder] webView:webView didStartProvisionalLoadForFrame:m_webFrame.get()];
+    [[webView.get() _UIKitDelegateForwarder] webView:webView.get() didStartProvisionalLoadForFrame:m_webFrame.get()];
 #endif
 
-    WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(webView);
+    WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(webView.get());
     if (implementations->didStartProvisionalLoadForFrameFunc)
-        CallFrameLoadDelegate(implementations->didStartProvisionalLoadForFrameFunc, webView, @selector(webView:didStartProvisionalLoadForFrame:), m_webFrame.get());
+        CallFrameLoadDelegate(implementations->didStartProvisionalLoadForFrameFunc, webView.get(), @selector(webView:didStartProvisionalLoadForFrame:), m_webFrame.get());
 }
 
 static constexpr unsigned maxTitleLength = 1000; // Closest power of 10 above the W3C recommendation for Title length.
@@ -680,11 +680,11 @@ void WebFrameLoaderClient::dispatchDidReceiveTitle(const WebCore::StringWithDire
 {
     auto truncatedTitle = truncateFromEnd(title, maxTitleLength);
 
-    WebView *webView = getWebView(m_webFrame.get());   
-    WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(webView);
+    RetainPtr webView = getWebView(m_webFrame.get());
+    WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(webView.get());
     if (implementations->didReceiveTitleForFrameFunc) {
         // FIXME: Use direction of title.
-        CallFrameLoadDelegate(implementations->didReceiveTitleForFrameFunc, webView, @selector(webView:didReceiveTitle:forFrame:), truncatedTitle.string.createNSString().get(), m_webFrame.get());
+        CallFrameLoadDelegate(implementations->didReceiveTitleForFrameFunc, webView.get(), @selector(webView:didReceiveTitle:forFrame:), truncatedTitle.string.createNSString().get(), m_webFrame.get());
     }
 }
 
@@ -692,34 +692,34 @@ void WebFrameLoaderClient::dispatchDidCommitLoad(std::optional<WebCore::HasInsec
 {
     // Tell the client we've committed this URL.
     ASSERT([m_webFrame->_private->webFrameView documentView] != nil);
-    
-    WebView *webView = getWebView(m_webFrame.get());   
-    [webView _didCommitLoadForFrame:m_webFrame.get()];
+
+    RetainPtr webView = getWebView(m_webFrame.get());
+    [webView.get() _didCommitLoadForFrame:m_webFrame.get()];
 
     m_webFrame->_private->url = m_webFrame->_private->provisionalURL;
     m_webFrame->_private->provisionalURL = nullptr;
 
 #if PLATFORM(IOS_FAMILY)
-    [[webView _UIKitDelegateForwarder] webView:webView didCommitLoadForFrame:m_webFrame.get()];
+    [[webView.get() _UIKitDelegateForwarder] webView:webView.get() didCommitLoadForFrame:m_webFrame.get()];
 #endif
-    
-    WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(webView);
+
+    WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(webView.get());
     if (implementations->didCommitLoadForFrameFunc)
-        CallFrameLoadDelegate(implementations->didCommitLoadForFrameFunc, webView, @selector(webView:didCommitLoadForFrame:), m_webFrame.get());
+        CallFrameLoadDelegate(implementations->didCommitLoadForFrameFunc, webView.get(), @selector(webView:didCommitLoadForFrame:), m_webFrame.get());
 }
 
 void WebFrameLoaderClient::dispatchDidFailProvisionalLoad(const WebCore::ResourceError& error, WebCore::WillContinueLoading, WebCore::WillInternallyHandleFailure)
 {
     m_webFrame->_private->provisionalURL = nullptr;
 
-    WebView *webView = getWebView(m_webFrame.get());
+    RetainPtr webView = getWebView(m_webFrame.get());
 #if !PLATFORM(IOS_FAMILY)
-    [webView _didFailProvisionalLoadWithError:error forFrame:m_webFrame.get()];
+    [webView.get() _didFailProvisionalLoadWithError:error forFrame:m_webFrame.get()];
 #endif
 
-    WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(webView);
+    WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(webView.get());
     if (implementations->didFailProvisionalLoadWithErrorForFrameFunc)
-        CallFrameLoadDelegate(implementations->didFailProvisionalLoadWithErrorForFrameFunc, webView, @selector(webView:didFailProvisionalLoadWithError:forFrame:), (NSError *)error, m_webFrame.get());
+        CallFrameLoadDelegate(implementations->didFailProvisionalLoadWithErrorForFrameFunc, webView.get(), @selector(webView:didFailProvisionalLoadWithError:forFrame:), (NSError *)error, m_webFrame.get());
 
     [m_webFrame->_private->internalLoadDelegate webFrame:m_webFrame.get() didFinishLoadWithError:error];
 }
@@ -728,16 +728,16 @@ void WebFrameLoaderClient::dispatchDidFailLoad(const WebCore::ResourceError& err
 {
     ASSERT(!m_webFrame->_private->provisionalURL);
 
-    WebView *webView = getWebView(m_webFrame.get());
+    RetainPtr webView = getWebView(m_webFrame.get());
 #if !PLATFORM(IOS_FAMILY)
-    [webView _didFailLoadWithError:error forFrame:m_webFrame.get()];
+    [webView.get() _didFailLoadWithError:error forFrame:m_webFrame.get()];
 #endif
 
-    WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(webView);
+    WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(webView.get());
     if (implementations->didFailLoadWithErrorForFrameFunc)
-        CallFrameLoadDelegate(implementations->didFailLoadWithErrorForFrameFunc, webView, @selector(webView:didFailLoadWithError:forFrame:), (NSError *)error, m_webFrame.get());
+        CallFrameLoadDelegate(implementations->didFailLoadWithErrorForFrameFunc, webView.get(), @selector(webView:didFailLoadWithError:forFrame:), (NSError *)error, m_webFrame.get());
 #if PLATFORM(IOS_FAMILY)
-    [[webView _UIKitDelegateForwarder] webView:webView didFailLoadWithError:((NSError *)error) forFrame:m_webFrame.get()];
+    [[webView.get() _UIKitDelegateForwarder] webView:webView.get() didFailLoadWithError:((NSError *)error) forFrame:m_webFrame.get()];
 #endif
 
     [m_webFrame->_private->internalLoadDelegate webFrame:m_webFrame.get() didFinishLoadWithError:error];
@@ -745,66 +745,66 @@ void WebFrameLoaderClient::dispatchDidFailLoad(const WebCore::ResourceError& err
 
 void WebFrameLoaderClient::dispatchDidFinishDocumentLoad()
 {
-    WebView *webView = getWebView(m_webFrame.get());
+    RetainPtr webView = getWebView(m_webFrame.get());
 
 #if PLATFORM(IOS_FAMILY)
-    id webThreadDel = [webView _webMailDelegate];
+    RetainPtr webThreadDel = [webView.get() _webMailDelegate];
     if ([webThreadDel respondsToSelector:@selector(_webthread_webView:didFinishDocumentLoadForFrame:)]) {
-        [webThreadDel _webthread_webView:webView didFinishDocumentLoadForFrame:m_webFrame.get()];
+        [webThreadDel.get() _webthread_webView:webView.get() didFinishDocumentLoadForFrame:m_webFrame.get()];
     }
 #endif
 
-    WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(webView);
+    WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(webView.get());
     if (implementations->didFinishDocumentLoadForFrameFunc)
-        CallFrameLoadDelegate(implementations->didFinishDocumentLoadForFrameFunc, webView, @selector(webView:didFinishDocumentLoadForFrame:), m_webFrame.get());
+        CallFrameLoadDelegate(implementations->didFinishDocumentLoadForFrameFunc, webView.get(), @selector(webView:didFinishDocumentLoadForFrame:), m_webFrame.get());
 }
 
 void WebFrameLoaderClient::dispatchDidFinishLoad()
 {
     ASSERT(!m_webFrame->_private->provisionalURL);
 
-    WebView *webView = getWebView(m_webFrame.get());
+    RetainPtr webView = getWebView(m_webFrame.get());
 #if !PLATFORM(IOS_FAMILY)
-    [webView _didFinishLoadForFrame:m_webFrame.get()];
+    [webView.get() _didFinishLoadForFrame:m_webFrame.get()];
 #else
-    [[webView _UIKitDelegateForwarder] webView:webView didFinishLoadForFrame:m_webFrame.get()];
+    [[webView.get() _UIKitDelegateForwarder] webView:webView.get() didFinishLoadForFrame:m_webFrame.get()];
 
-    id webThreadDel = [webView _webMailDelegate];
+    RetainPtr webThreadDel = [webView.get() _webMailDelegate];
     if ([webThreadDel respondsToSelector:@selector(_webthread_webView:didFinishLoadForFrame:)]) {
-        [webThreadDel _webthread_webView:webView didFinishLoadForFrame:m_webFrame.get()];
+        [webThreadDel.get() _webthread_webView:webView.get() didFinishLoadForFrame:m_webFrame.get()];
     }
 #endif
 
-    WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(webView);
+    WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(webView.get());
     if (implementations->didFinishLoadForFrameFunc)
-        CallFrameLoadDelegate(implementations->didFinishLoadForFrameFunc, webView, @selector(webView:didFinishLoadForFrame:), m_webFrame.get());
+        CallFrameLoadDelegate(implementations->didFinishLoadForFrameFunc, webView.get(), @selector(webView:didFinishLoadForFrame:), m_webFrame.get());
 
     [m_webFrame->_private->internalLoadDelegate webFrame:m_webFrame.get() didFinishLoadWithError:nil];
 }
 
 void WebFrameLoaderClient::dispatchDidReachLayoutMilestone(OptionSet<WebCore::LayoutMilestone> milestones)
 {
-    WebView *webView = getWebView(m_webFrame.get());
-    WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(webView);
+    RetainPtr webView = getWebView(m_webFrame.get());
+    WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(webView.get());
 
 #if PLATFORM(IOS_FAMILY)
     if (implementations->webThreadDidLayoutFunc)
-        CallFrameLoadDelegateInWebThread(implementations->webThreadDidLayoutFunc, webView, @selector(webThreadWebView:didLayout:), kitLayoutMilestones(milestones));
+        CallFrameLoadDelegateInWebThread(implementations->webThreadDidLayoutFunc, webView.get(), @selector(webThreadWebView:didLayout:), kitLayoutMilestones(milestones));
 #else
     if (implementations->didLayoutFunc)
-        CallFrameLoadDelegate(implementations->didLayoutFunc, webView, @selector(webView:didLayout:), kitLayoutMilestones(milestones));
+        CallFrameLoadDelegate(implementations->didLayoutFunc, webView.get(), @selector(webView:didLayout:), kitLayoutMilestones(milestones));
 #endif
 
     if (milestones & WebCore::LayoutMilestone::DidFirstLayout) {
         // FIXME: We should consider removing the old didFirstLayout API since this is doing double duty with the
         // new didLayout API.
         if (implementations->didFirstLayoutInFrameFunc)
-            CallFrameLoadDelegate(implementations->didFirstLayoutInFrameFunc, webView, @selector(webView:didFirstLayoutInFrame:), m_webFrame.get());
+            CallFrameLoadDelegate(implementations->didFirstLayoutInFrameFunc, webView.get(), @selector(webView:didFirstLayoutInFrame:), m_webFrame.get());
 
 #if PLATFORM(IOS_FAMILY)
-        [[webView _UIKitDelegateForwarder] webView:webView didFirstLayoutInFrame:m_webFrame.get()];
+        [[webView.get() _UIKitDelegateForwarder] webView:webView.get() didFirstLayoutInFrame:m_webFrame.get()];
 #endif
- 
+
         // See WebFrameLoaderClient::provisionalLoadStarted.
         WebDynamicScrollBarsView *scrollView = [m_webFrame->_private->webFrameView _scrollView];
         if ([getWebView(m_webFrame.get()) drawsBackground])
@@ -819,19 +819,19 @@ void WebFrameLoaderClient::dispatchDidReachLayoutMilestone(OptionSet<WebCore::La
         // FIXME: We should consider removing the old didFirstVisuallyNonEmptyLayoutForFrame API since this is doing
         // double duty with the new didLayout API.
         if (implementations->didFirstVisuallyNonEmptyLayoutInFrameFunc)
-            CallFrameLoadDelegate(implementations->didFirstVisuallyNonEmptyLayoutInFrameFunc, webView, @selector(webView:didFirstVisuallyNonEmptyLayoutInFrame:), m_webFrame.get());
+            CallFrameLoadDelegate(implementations->didFirstVisuallyNonEmptyLayoutInFrameFunc, webView.get(), @selector(webView:didFirstVisuallyNonEmptyLayoutInFrame:), m_webFrame.get());
 #if PLATFORM(IOS_FAMILY)
-        if ([webView mainFrame] == m_webFrame.get())
-            [[webView _UIKitDelegateForwarder] webView:webView didFirstVisuallyNonEmptyLayoutInFrame:m_webFrame.get()];
+        if ([webView.get() mainFrame] == m_webFrame.get())
+            [[webView.get() _UIKitDelegateForwarder] webView:webView.get() didFirstVisuallyNonEmptyLayoutInFrame:m_webFrame.get()];
 #endif
     }
 }
 
 WebCore::LocalFrame* WebFrameLoaderClient::dispatchCreatePage(const WebCore::NavigationAction&, WebCore::NewFrameOpenerPolicy policy)
 {
-    WebView *currentWebView = getWebView(m_webFrame.get());
+    RetainPtr currentWebView = getWebView(m_webFrame.get());
     auto features = adoptNS([[NSDictionary alloc] init]);
-    WebView *newWebView = [[currentWebView _UIDelegateForwarder] webView:currentWebView 
+    RetainPtr newWebView = [[currentWebView.get() _UIDelegateForwarder] webView:currentWebView.get()
                                                 createWebViewWithRequest:nil
                                                           windowFeatures:features.get()];
 
@@ -844,7 +844,7 @@ WebCore::LocalFrame* WebFrameLoaderClient::dispatchCreatePage(const WebCore::Nav
             auto effectiveSandboxFlags = opener->effectiveSandboxFlags();
             if (!effectiveSandboxFlags.contains(WebCore::SandboxFlag::PropagatesToAuxiliaryBrowsingContexts))
                 effectiveSandboxFlags = { };
-            core(newWebView)->mainFrame().updateSandboxFlags(effectiveSandboxFlags, WebCore::Frame::NotifyUIProcess::No);
+            core(newWebView.get())->mainFrame().updateSandboxFlags(effectiveSandboxFlags, WebCore::Frame::NotifyUIProcess::No);
         }
     }
 
@@ -853,15 +853,15 @@ WebCore::LocalFrame* WebFrameLoaderClient::dispatchCreatePage(const WebCore::Nav
 
 void WebFrameLoaderClient::dispatchShow()
 {
-    WebView *webView = getWebView(m_webFrame.get());
-    [[webView _UIDelegateForwarder] webViewShow:webView];
+    RetainPtr webView = getWebView(m_webFrame.get());
+    [[webView.get() _UIDelegateForwarder] webViewShow:webView.get()];
 }
 
 void WebFrameLoaderClient::dispatchDecidePolicyForResponse(const WebCore::ResourceResponse& response, const WebCore::ResourceRequest& request, const String&, WebCore::FramePolicyFunction&& function)
 {
-    WebView *webView = getWebView(m_webFrame.get());
+    RetainPtr webView = getWebView(m_webFrame.get());
 
-    [[webView _policyDelegateForwarder] webView:webView
+    [[webView.get() _policyDelegateForwarder] webView:webView.get()
         decidePolicyForMIMEType:response.mimeType().createNSString().get()
         request:request.protectedNSURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody).get()
         frame:m_webFrame.get()
@@ -890,8 +890,8 @@ static BOOL shouldTryAppLink(WebView *webView, const WebCore::NavigationAction& 
 
 void WebFrameLoaderClient::dispatchDecidePolicyForNewWindowAction(const WebCore::NavigationAction& action, const WebCore::ResourceRequest& request, WebCore::FormState* formState, const String& frameName, std::optional<WebCore::HitTestResult>&&, WebCore::FramePolicyFunction&& function)
 {
-    WebView *webView = getWebView(m_webFrame.get());
-    BOOL tryAppLink = shouldTryAppLink(webView, action, nullptr);
+    RetainPtr webView = getWebView(m_webFrame.get());
+    BOOL tryAppLink = shouldTryAppLink(webView.get(), action, nullptr);
 
     RetainPtr<NSURL> appLinkURL;
     RetainPtr<NSURL> referrerURL;
@@ -901,7 +901,7 @@ void WebFrameLoaderClient::dispatchDecidePolicyForNewWindowAction(const WebCore:
             referrerURL = URL(request.httpReferrer()).createNSURL();
     }
 
-    [[webView _policyDelegateForwarder] webView:webView
+    [[webView.get() _policyDelegateForwarder] webView:webView.get()
         decidePolicyForNewWindowAction:actionDictionary(action, formState)
         request:request.protectedNSURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody).get()
         newFrameName:frameName.createNSString().get()
@@ -910,8 +910,8 @@ void WebFrameLoaderClient::dispatchDecidePolicyForNewWindowAction(const WebCore:
 
 void WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction(const WebCore::NavigationAction& action, const WebCore::ResourceRequest& request, const WebCore::ResourceResponse&, WebCore::FormState* formState, const String&, std::optional<WebCore::NavigationIdentifier>, std::optional<WebCore::HitTestResult>&&, bool, WebCore::NavigationUpgradeToHTTPSBehavior, WebCore::SandboxFlags, WebCore::PolicyDecisionMode, WebCore::FramePolicyFunction&& function)
 {
-    WebView *webView = getWebView(m_webFrame.get());
-    BOOL tryAppLink = shouldTryAppLink(webView, action, core(m_webFrame.get()));
+    RetainPtr webView = getWebView(m_webFrame.get());
+    BOOL tryAppLink = shouldTryAppLink(webView.get(), action, core(m_webFrame.get()));
 
     RetainPtr<NSURL> appLinkURL;
     RetainPtr<NSURL> referrerURL;
@@ -921,7 +921,7 @@ void WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction(const WebCore
             referrerURL = URL(request.httpReferrer()).createNSURL();
     }
 
-    [[webView _policyDelegateForwarder] webView:webView
+    [[webView.get() _policyDelegateForwarder] webView:webView.get()
         decidePolicyForNavigationAction:actionDictionary(action, formState)
         request:request.protectedNSURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody).get()
         frame:m_webFrame.get()
@@ -939,8 +939,8 @@ void WebFrameLoaderClient::cancelPolicyCheck()
 
 void WebFrameLoaderClient::dispatchUnableToImplementPolicy(const WebCore::ResourceError& error)
 {
-    WebView *webView = getWebView(m_webFrame.get());
-    [[webView _policyDelegateForwarder] webView:webView unableToImplementPolicyWithError:error frame:m_webFrame.get()];    
+    RetainPtr webView = getWebView(m_webFrame.get());
+    [[webView.get() _policyDelegateForwarder] webView:webView.get() unableToImplementPolicyWithError:error frame:m_webFrame.get()];
 }
 
 static NSDictionary *makeFormFieldValuesDictionary(WebCore::FormState& formState)
@@ -955,25 +955,25 @@ static NSDictionary *makeFormFieldValuesDictionary(WebCore::FormState& formState
 
 void WebFrameLoaderClient::dispatchWillSendSubmitEvent(Ref<WebCore::FormState>&& formState)
 {
-    id <WebFormDelegate> formDelegate = [getWebView(m_webFrame.get()) _formDelegate];
+    RetainPtr<id <WebFormDelegate>> formDelegate = [getWebView(m_webFrame.get()) _formDelegate];
     if (!formDelegate)
         return;
 
-    DOMHTMLFormElement *formElement = kit(&formState->form());
-    NSDictionary *values = makeFormFieldValuesDictionary(formState.get());
-    CallFormDelegate(getWebView(m_webFrame.get()), @selector(willSendSubmitEventToForm:inFrame:withValues:), formElement, m_webFrame.get(), values);
+    RetainPtr formElement = kit(&formState->form());
+    RetainPtr values = makeFormFieldValuesDictionary(formState.get());
+    CallFormDelegate(getWebView(m_webFrame.get()), @selector(willSendSubmitEventToForm:inFrame:withValues:), formElement.get(), m_webFrame.get(), values.get());
 }
 
 void WebFrameLoaderClient::dispatchWillSubmitForm(WebCore::FormState& formState, URL&&, String&&, CompletionHandler<void()>&& completionHandler)
 {
-    id <WebFormDelegate> formDelegate = [getWebView(m_webFrame.get()) _formDelegate];
+    RetainPtr<id <WebFormDelegate>> formDelegate = [getWebView(m_webFrame.get()) _formDelegate];
     if (!formDelegate) {
         completionHandler();
         return;
     }
 
-    NSDictionary *values = makeFormFieldValuesDictionary(formState);
-    CallFormDelegate(getWebView(m_webFrame.get()), @selector(frame:sourceFrame:willSubmitForm:withValues:submissionListener:), m_webFrame.get(), kit(formState.sourceDocument().frame()), kit(&formState.form()), values, setUpPolicyListener([completionHandler = WTF::move(completionHandler)] (WebCore::PolicyAction) mutable { completionHandler(); },
+    RetainPtr values = makeFormFieldValuesDictionary(formState);
+    CallFormDelegate(getWebView(m_webFrame.get()), @selector(frame:sourceFrame:willSubmitForm:withValues:submissionListener:), m_webFrame.get(), kit(formState.sourceDocument().frame()), kit(&formState.form()), values.get(), setUpPolicyListener([completionHandler = WTF::move(completionHandler)] (WebCore::PolicyAction) mutable { completionHandler(); },
         WebCore::PolicyAction::Ignore, nil, nil).get());
 }
 
@@ -1041,15 +1041,15 @@ static inline NSString *nilOrNSString(const String& string)
 
 void WebFrameLoaderClient::updateGlobalHistory()
 {
-    WebView* view = getWebView(m_webFrame.get());
+    RetainPtr view = getWebView(m_webFrame.get());
     auto* loader = core(m_webFrame.get())->loader().documentLoader();
 #if PLATFORM(IOS_FAMILY)
     if (loader->urlForHistory() == aboutBlankURL())
         return;
 #endif
 
-    if ([view historyDelegate]) {
-        WebHistoryDelegateImplementationCache* implementations = WebViewGetHistoryDelegateImplementations(view);
+    if ([view.get() historyDelegate]) {
+        WebHistoryDelegateImplementationCache* implementations = WebViewGetHistoryDelegateImplementations(view.get());
         if (implementations->navigatedFunc) {
             auto data = adoptNS([[WebNavigationData alloc] initWithURLString:loader->url().string().createNSString().get()
                 title:nilOrNSString(loader->title().string)
@@ -1058,9 +1058,9 @@ void WebFrameLoaderClient::updateGlobalHistory()
                 hasSubstituteData:loader->substituteData().isValid()
                 clientRedirectSource:loader->clientRedirectSourceForHistory().createNSString().get()]);
 
-            CallHistoryDelegate(implementations->navigatedFunc, view, @selector(webView:didNavigateWithNavigationData:inFrame:), data.get(), m_webFrame.get());
+            CallHistoryDelegate(implementations->navigatedFunc, view.get(), @selector(webView:didNavigateWithNavigationData:inFrame:), data.get(), m_webFrame.get());
         }
-    
+
         return;
     }
 
@@ -1080,37 +1080,37 @@ static void addRedirectURL(WebHistoryItem *item, const String& url)
 
 void WebFrameLoaderClient::updateGlobalHistoryRedirectLinks()
 {
-    WebView* view = getWebView(m_webFrame.get());
-    WebHistoryDelegateImplementationCache* implementations = [view historyDelegate] ? WebViewGetHistoryDelegateImplementations(view) : 0;
-    
+    RetainPtr view = getWebView(m_webFrame.get());
+    WebHistoryDelegateImplementationCache* implementations = [view.get() historyDelegate] ? WebViewGetHistoryDelegateImplementations(view.get()) : 0;
+
     auto* loader = core(m_webFrame.get())->loader().documentLoader();
     ASSERT(loader->unreachableURL().isEmpty());
 
     if (!loader->clientRedirectSourceForHistory().isNull()) {
         if (implementations) {
             if (implementations->clientRedirectFunc) {
-                CallHistoryDelegate(implementations->clientRedirectFunc, view, @selector(webView:didPerformClientRedirectFromURL:toURL:inFrame:), 
+                CallHistoryDelegate(implementations->clientRedirectFunc, view.get(), @selector(webView:didPerformClientRedirectFromURL:toURL:inFrame:),
                     m_webFrame->_private->url.get(), loader->clientRedirectDestinationForHistory().createNSString().get(), m_webFrame.get());
             }
-        } else if (WebHistoryItem *item = [[WebHistory optionalSharedHistory] _itemForURLString:loader->clientRedirectSourceForHistory().createNSString().get()])
-            addRedirectURL(item, loader->clientRedirectDestinationForHistory());
+        } else if (RetainPtr item = [[WebHistory optionalSharedHistory] _itemForURLString:loader->clientRedirectSourceForHistory().createNSString().get()])
+            addRedirectURL(item.get(), loader->clientRedirectDestinationForHistory());
     }
 
     if (!loader->serverRedirectSourceForHistory().isNull()) {
         if (implementations) {
             if (implementations->serverRedirectFunc) {
-                CallHistoryDelegate(implementations->serverRedirectFunc, view, @selector(webView:didPerformServerRedirectFromURL:toURL:inFrame:), 
+                CallHistoryDelegate(implementations->serverRedirectFunc, view.get(), @selector(webView:didPerformServerRedirectFromURL:toURL:inFrame:),
                     loader->serverRedirectSourceForHistory().createNSString().get(), loader->serverRedirectDestinationForHistory().createNSString().get(), m_webFrame.get());
             }
-        } else if (WebHistoryItem *item = [[WebHistory optionalSharedHistory] _itemForURLString:loader->serverRedirectSourceForHistory().createNSString().get()])
-            addRedirectURL(item, loader->serverRedirectDestinationForHistory());
+        } else if (RetainPtr item = [[WebHistory optionalSharedHistory] _itemForURLString:loader->serverRedirectSourceForHistory().createNSString().get()])
+            addRedirectURL(item.get(), loader->serverRedirectDestinationForHistory());
     }
 }
 
 WebCore::ShouldGoToHistoryItem WebFrameLoaderClient::shouldGoToHistoryItem(WebCore::HistoryItem& item, WebCore::IsSameDocumentNavigation, WebCore::ProcessSwapDisposition) const
 {
-    WebView* view = getWebView(m_webFrame.get());
-    return [[view _policyDelegateForwarder] webView:view shouldGoToHistoryItem:kit(&item)] ? WebCore::ShouldGoToHistoryItem::Yes : WebCore::ShouldGoToHistoryItem::No;
+    RetainPtr view = getWebView(m_webFrame.get());
+    return [[view.get() _policyDelegateForwarder] webView:view.get() shouldGoToHistoryItem:kit(&item)] ? WebCore::ShouldGoToHistoryItem::Yes : WebCore::ShouldGoToHistoryItem::No;
 }
 
 bool WebFrameLoaderClient::supportsAsyncShouldGoToHistoryItem() const
@@ -1207,12 +1207,12 @@ void WebFrameLoaderClient::restoreViewState()
         return;
     }
 #endif                    
-    
+
     NSView <WebDocumentView> *docView = [m_webFrame->_private->webFrameView documentView];
-    if ([docView conformsToProtocol:@protocol(_WebDocumentViewState)]) {        
-        id state = currentItem->viewState();
+    if ([docView conformsToProtocol:@protocol(_WebDocumentViewState)]) {
+        RetainPtr state = currentItem->viewState();
         if (state) {
-            [(id <_WebDocumentViewState>)docView setViewState:state];
+            [(id <_WebDocumentViewState>)docView setViewState:state.get()];
         }
     }
 }
@@ -1262,10 +1262,10 @@ void WebFrameLoaderClient::prepareForDataSourceReplacement()
     // Potentially one day someone could write a DocView whose editors were not all
     // replaced by loading new content, but that does not apply currently.
     auto frameView = m_webFrame->_private->webFrameView;
-    NSWindow *window = [frameView window];
-    NSResponder *firstResp = [window firstResponder];
-    if ([firstResp isKindOfClass:[NSView class]] && [(NSView *)firstResp isDescendantOf:frameView.get()])
-        [window endEditingFor:firstResp];
+    RetainPtr window = [frameView window];
+    RetainPtr firstResp = [window firstResponder];
+    if ([firstResp isKindOfClass:[NSView class]] && [(NSView *)firstResp.get() isDescendantOf:frameView.get()])
+        [window endEditingFor:firstResp.get()];
 #endif
 }
 
@@ -1281,16 +1281,16 @@ Ref<WebCore::DocumentLoader> WebFrameLoaderClient::createDocumentLoader(WebCore:
 
 void WebFrameLoaderClient::setTitle(const WebCore::StringWithDirection& title, const URL& url)
 {
-    WebView* view = getWebView(m_webFrame.get());
-    
-    if ([view historyDelegate]) {
-        WebHistoryDelegateImplementationCache* implementations = WebViewGetHistoryDelegateImplementations(view);
+    RetainPtr view = getWebView(m_webFrame.get());
+
+    if ([view.get() historyDelegate]) {
+        WebHistoryDelegateImplementationCache* implementations = WebViewGetHistoryDelegateImplementations(view.get());
         // FIXME: Use direction of title.
         if (implementations->setTitleFunc)
-            CallHistoryDelegate(implementations->setTitleFunc, view, @selector(webView:updateHistoryTitle:forURL:inFrame:), title.string.createNSString().get(), url.string().createNSString().get(), m_webFrame.get());
+            CallHistoryDelegate(implementations->setTitleFunc, view.get(), @selector(webView:updateHistoryTitle:forURL:inFrame:), title.string.createNSString().get(), url.string().createNSString().get(), m_webFrame.get());
         else if (implementations->deprecatedSetTitleFunc) {
             IGNORE_WARNINGS_BEGIN("undeclared-selector")
-            CallHistoryDelegate(implementations->deprecatedSetTitleFunc, view, @selector(webView:updateHistoryTitle:forURL:), title.string.createNSString().get(), url.string().createNSString().get());
+            CallHistoryDelegate(implementations->deprecatedSetTitleFunc, view.get(), @selector(webView:updateHistoryTitle:forURL:), title.string.createNSString().get(), url.string().createNSString().get());
             IGNORE_WARNINGS_END
         }
         return;
@@ -1321,18 +1321,18 @@ void WebFrameLoaderClient::savePlatformDataToCachedFrame(WebCore::CachedFrame* c
 void WebFrameLoaderClient::transitionToCommittedFromCachedFrame(WebCore::CachedFrame* cachedFrame)
 {
     WebCachedFramePlatformData* platformData = static_cast<WebCachedFramePlatformData*>(cachedFrame->cachedFramePlatformData());
-    NSView <WebDocumentView> *cachedView = platformData->webDocumentView();
-    ASSERT(cachedView != nil);
+    RetainPtr<NSView <WebDocumentView>> cachedView = platformData->webDocumentView();
+    ASSERT(cachedView);
     ASSERT(cachedFrame->documentLoader());
-    [cachedView setDataSource:dataSource(cachedFrame->documentLoader())];
-    
+    [cachedView.get() setDataSource:dataSource(cachedFrame->documentLoader())];
+
 #if !PLATFORM(IOS_FAMILY)
     // clean up webkit plugin instances before WebHTMLView gets freed.
-    WebView *webView = getWebView(m_webFrame.get());
-    [webView removePluginInstanceViewsFor:(m_webFrame.get())];
+    RetainPtr webView = getWebView(m_webFrame.get());
+    [webView.get() removePluginInstanceViewsFor:(m_webFrame.get())];
 #endif
-    
-    [m_webFrame->_private->webFrameView _setDocumentView:cachedView];
+
+    [m_webFrame->_private->webFrameView _setDocumentView:cachedView.get()];
 }
 
 #if PLATFORM(IOS_FAMILY)
@@ -1371,11 +1371,11 @@ void WebFrameLoaderClient::transitionToCommittedForNewPage(InitializingIframe)
     // Don't suppress scrollbars before the view creation if we're making the view for a non-HTML view.
     if (!willProduceHTMLView)
         [[m_webFrame->_private->webFrameView _scrollView] setScrollBarsSuppressed:NO repaintOnUnsuppress:NO];
-    
+
     // clean up webkit plugin instances before WebHTMLView gets freed.
-    WebView *webView = getWebView(m_webFrame.get());
-    [webView removePluginInstanceViewsFor:(m_webFrame.get())];
-    
+    RetainPtr webView = getWebView(m_webFrame.get());
+    [webView.get() removePluginInstanceViewsFor:(m_webFrame.get())];
+
     RetainPtr<NSView <WebDocumentView>> documentView = [m_webFrame->_private->webFrameView _makeDocumentViewForDataSource:dataSource];
 #else
     RetainPtr<NSView <WebDocumentView>> documentView;
@@ -1465,7 +1465,7 @@ RetainPtr<WebFramePolicyListener> WebFrameLoaderClient::setUpPolicyListener(WebC
 
 String WebFrameLoaderClient::userAgent(const URL& url) const
 {
-    WebView *webView = getWebView(m_webFrame.get());
+    RetainPtr webView = getWebView(m_webFrame.get());
     ASSERT(webView);
 
     // We should never get here with nil for the WebView unless there is a bug somewhere else.
@@ -1475,7 +1475,7 @@ String WebFrameLoaderClient::userAgent(const URL& url) const
     if (!webView)
         return emptyString();
 
-    return [webView _userAgentString];
+    return [webView.get() _userAgentString];
 }
 
 NSDictionary *WebFrameLoaderClient::actionDictionary(const WebCore::NavigationAction& action, WebCore::FormState* formState) const
@@ -1563,10 +1563,10 @@ RefPtr<WebCore::LocalFrame> WebFrameLoaderClient::createFrame(const AtomString& 
 
     auto childView = adoptNS([[WebFrameView alloc] init]);
     auto result = [WebFrame _createSubframeWithOwnerElement:ownerElement page:*page frameName:name frameView:childView.get()];
-    auto newFrame = kit(result.ptr());
+    RetainPtr newFrame = kit(result.ptr());
 
     if ([newFrame _dataSource])
-        [[newFrame _dataSource] _documentLoader]->setOverrideEncoding([[m_webFrame.get() _dataSource] _documentLoader]->overrideEncoding());  
+        [[newFrame.get() _dataSource] _documentLoader]->setOverrideEncoding([[m_webFrame.get() _dataSource] _documentLoader]->overrideEncoding());  
 
     // The creation of the frame may have run arbitrary JavaScript that removed it from the page already.
     if (!result->page())
@@ -1588,12 +1588,12 @@ WebCore::ObjectContentType WebFrameLoaderClient::objectContentType(const URL& ur
     if (type.isEmpty()) {
         // Try to guess the MIME type based off the extension.
         RetainPtr nsURL = url.createNSURL();
-        NSString *extension = [[nsURL path] pathExtension];
+        RetainPtr extension = [[nsURL path] pathExtension];
         if ([extension length] > 0) {
-            type = [[NSURLFileTypeMappings sharedMappings] MIMETypeForExtension:extension];
+            type = [[NSURLFileTypeMappings sharedMappings] MIMETypeForExtension:extension.get()];
             if (type.isEmpty()) {
                 // If no MIME type is specified, use a plug-in if we have one that can handle the extension.
-                if ([getWebView(m_webFrame.get()) _pluginForExtension:extension])
+                if ([getWebView(m_webFrame.get()) _pluginForExtension:extension.get()])
                     return WebCore::ObjectContentType::PlugIn;
             }
         }
@@ -1706,7 +1706,7 @@ RefPtr<WebCore::Widget> WebFrameLoaderClient::createPlugin(WebCore::HTMLPlugInEl
 
     int errorCode = 0;
 
-    WebView *webView = getWebView(m_webFrame.get());
+    RetainPtr webView = getWebView(m_webFrame.get());
     auto* document = core(m_webFrame.get())->document();
     RetainPtr baseURL = document->baseURL().createNSURL();
     RetainPtr pluginURL = url.createNSURL();
@@ -1714,10 +1714,10 @@ RefPtr<WebCore::Widget> WebFrameLoaderClient::createPlugin(WebCore::HTMLPlugInEl
 
 #if PLATFORM(MAC)
     SEL selector = @selector(webView:plugInViewWithArguments:);
-    if ([[webView UIDelegate] respondsToSelector:selector]) {
-        NSDictionary *attributes = [NSDictionary dictionaryWithObjects:createNSArray(paramValues).get() forKeys:attributeKeys.get()];
+    if ([[webView.get() UIDelegate] respondsToSelector:selector]) {
+        RetainPtr attributes = [NSDictionary dictionaryWithObjects:createNSArray(paramValues).get() forKeys:attributeKeys.get()];
         auto arguments = adoptNS([[NSDictionary alloc] initWithObjectsAndKeys:
-            attributes, WebPlugInAttributesKey,
+            attributes.get(), WebPlugInAttributesKey,
             @(loadManually ? WebPlugInModeFull : WebPlugInModeEmbed), WebPlugInModeKey,
             [NSNumber numberWithBool:!loadManually], WebPlugInShouldLoadMainResourceKey,
             kit(&element), WebPlugInContainingElementKey,
@@ -1725,10 +1725,10 @@ RefPtr<WebCore::Widget> WebFrameLoaderClient::createPlugin(WebCore::HTMLPlugInEl
             pluginURL.get(), WebPlugInBaseURLKey, // pluginURL might be nil, so add it last
             nil]);
 
-        NSView *view = CallUIDelegate(webView, selector, arguments.get());
+        RetainPtr<NSView> view = CallUIDelegate(webView.get(), selector, arguments.get());
 
         if (view)
-            return adoptRef(*new PluginWidget(view));
+            return adoptRef(*new PluginWidget(view.get()));
     }
 #endif
 
@@ -1738,10 +1738,10 @@ RefPtr<WebCore::Widget> WebFrameLoaderClient::createPlugin(WebCore::HTMLPlugInEl
         pluginPackage = nil;
     else {
         MIMEType = mimeType.createNSString();
-        pluginPackage = [webView _pluginForMIMEType:MIMEType.get()];
+        pluginPackage = [webView.get() _pluginForMIMEType:MIMEType.get()];
     }
 
-    NSString *extension = [[pluginURL path] pathExtension];
+    RetainPtr extension = [[pluginURL path] pathExtension];
 
 #if PLATFORM(IOS_FAMILY)
     if (!pluginPackage && [extension length])
@@ -1749,15 +1749,15 @@ RefPtr<WebCore::Widget> WebFrameLoaderClient::createPlugin(WebCore::HTMLPlugInEl
     if (!pluginPackage && [extension length] && ![MIMEType length])
 #endif
     {
-        pluginPackage = [webView _pluginForExtension:extension];
+        pluginPackage = [webView.get() _pluginForExtension:extension.get()];
         if (pluginPackage) {
-            RetainPtr newMIMEType = [pluginPackage MIMETypeForExtension:extension];
+            RetainPtr newMIMEType = [pluginPackage MIMETypeForExtension:extension.get()];
             if ([newMIMEType length] != 0)
                 MIMEType = WTF::move(newMIMEType);
         }
     }
 
-    NSView *view = nil;
+    RetainPtr<NSView> view = nil;
 
     if (pluginPackage) {
         if (shouldBlockPlugin(pluginPackage)) {
@@ -1773,9 +1773,9 @@ RefPtr<WebCore::Widget> WebFrameLoaderClient::createPlugin(WebCore::HTMLPlugInEl
 
     if (!errorCode && !view)
         errorCode = WebKitErrorCannotLoadPlugIn;
-    
+
     if (errorCode && m_webFrame) {
-        WebResourceDelegateImplementationCache* implementations = WebViewGetResourceLoadDelegateImplementations(webView);
+        WebResourceDelegateImplementationCache* implementations = WebViewGetResourceLoadDelegateImplementations(webView.get());
         if (implementations->plugInFailedWithErrorFunc) {
             URL pluginPageURL = document->completeURL(parameterValue(paramNames, paramValues, "pluginspage"_s));
             if (!pluginPageURL.protocolIsInHTTPFamily())
@@ -1789,9 +1789,9 @@ RefPtr<WebCore::Widget> WebFrameLoaderClient::createPlugin(WebCore::HTMLPlugInEl
 
         return nullptr;
     }
-    
+
     ASSERT(view);
-    return adoptRef(new PluginWidget(view));
+    return adoptRef(new PluginWidget(view.get()));
 
     END_BLOCK_OBJC_EXCEPTIONS
 
@@ -1804,12 +1804,12 @@ void WebFrameLoaderClient::redirectDataToPlugin(WebCore::Widget& pluginWidget)
 
     WebHTMLRepresentation *representation = (WebHTMLRepresentation *)[[m_webFrame.get() _dataSource] representation];
 
-    NSView *pluginView = pluginWidget.platformWidget();
+    RetainPtr<NSView> pluginView = pluginWidget.platformWidget();
 
     {
         WebHTMLView *documentView = (WebHTMLView *)[[m_webFrame.get() frameView] documentView];
         ASSERT([documentView isKindOfClass:[WebHTMLView class]]);
-        [representation _redirectDataToManualLoader:[documentView _pluginController] forPluginView:pluginView];
+        [representation _redirectDataToManualLoader:[documentView _pluginController] forPluginView:pluginView.get()];
     }
 
     END_BLOCK_OBJC_EXCEPTIONS
@@ -1823,20 +1823,20 @@ void WebFrameLoaderClient::sendH2Ping(const URL& url, CompletionHandler<void(Exp
 
 AtomString WebFrameLoaderClient::overrideMediaType() const
 {
-    NSString* overrideType = [getWebView(m_webFrame.get()) mediaStyle];
+    RetainPtr overrideType = [getWebView(m_webFrame.get()) mediaStyle];
     if (overrideType)
-        return AtomString(overrideType);
+        return AtomString(overrideType.get());
     return nullAtom();
 }
 
 void WebFrameLoaderClient::dispatchDidClearWindowObjectInWorld(WebCore::DOMWrapperWorld& world)
 {
-    WebView *webView = getWebView(m_webFrame.get());
-    WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(webView);
+    RetainPtr webView = getWebView(m_webFrame.get());
+    WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(webView.get());
 
     if (implementations->didClearWindowObjectForFrameInScriptWorldFunc) {
         CallFrameLoadDelegate(implementations->didClearWindowObjectForFrameInScriptWorldFunc,
-            webView, @selector(webView:didClearWindowObjectForFrame:inScriptWorld:), m_webFrame.get(), [WebScriptWorld findOrCreateWorld:world]);
+            webView.get(), @selector(webView:didClearWindowObjectForFrame:inScriptWorld:), m_webFrame.get(), [WebScriptWorld findOrCreateWorld:world]);
         return;
     }
 
@@ -1848,19 +1848,19 @@ void WebFrameLoaderClient::dispatchDidClearWindowObjectInWorld(WebCore::DOMWrapp
 
 #if JSC_OBJC_API_ENABLED
     if (implementations->didCreateJavaScriptContextForFrameFunc) {
-        CallFrameLoadDelegate(implementations->didCreateJavaScriptContextForFrameFunc, webView, @selector(webView:didCreateJavaScriptContext:forFrame:),
+        CallFrameLoadDelegate(implementations->didCreateJavaScriptContextForFrameFunc, webView.get(), @selector(webView:didCreateJavaScriptContext:forFrame:),
             script.javaScriptContext(), m_webFrame.get());
     } else
 #endif
     if (implementations->didClearWindowObjectForFrameFunc) {
-        CallFrameLoadDelegate(implementations->didClearWindowObjectForFrameFunc, webView, @selector(webView:didClearWindowObject:forFrame:),
+        CallFrameLoadDelegate(implementations->didClearWindowObjectForFrameFunc, webView.get(), @selector(webView:didClearWindowObject:forFrame:),
             script.windowScriptObject(), m_webFrame.get());
     } else if (implementations->windowScriptObjectAvailableFunc) {
-        CallFrameLoadDelegate(implementations->windowScriptObjectAvailableFunc, webView, @selector(webView:windowScriptObjectAvailable:),
+        CallFrameLoadDelegate(implementations->windowScriptObjectAvailableFunc, webView.get(), @selector(webView:windowScriptObjectAvailable:),
             script.windowScriptObject());
     }
 
-    if ([webView scriptDebugDelegate]) {
+    if ([webView.get() scriptDebugDelegate]) {
         [m_webFrame.get() _detachScriptDebugger];
         [m_webFrame.get() _attachScriptDebugger];
     }
@@ -2016,12 +2016,12 @@ static NSImage *webGetNSImage(WebCore::Image* image, NSSize size)
     // to WebCore::Image at some point.
     if (!image)
         return nil;
-    NSImage* nsImage = image->adapter().nsImage();
+    RetainPtr nsImage = image->adapter().nsImage();
     if (!nsImage)
         return nil;
     if (!NSEqualSizes([nsImage size], size))
         [nsImage setSize:size];
-    return nsImage;
+    return nsImage.autorelease();
 }
 #endif // !PLATFORM(IOS_FAMILY)
 
@@ -2031,7 +2031,7 @@ void WebFrameLoaderClient::finishedLoadingIcon(WebCore::FragmentedSharedBuffer* 
     ASSERT(m_loadingIcon);
     m_loadingIcon = false;
 
-    WebView *webView = getWebView(m_webFrame.get());
+    RetainPtr webView = getWebView(m_webFrame.get());
     if (!webView)
         return;
 
@@ -2039,9 +2039,9 @@ void WebFrameLoaderClient::finishedLoadingIcon(WebCore::FragmentedSharedBuffer* 
     if (image->setData(iconData, true) < WebCore::EncodedDataStatus::SizeAvailable)
         return;
 
-    NSImage *icon = webGetNSImage(image.ptr(), NSMakeSize(16, 16));
+    RetainPtr icon = webGetNSImage(image.ptr(), NSMakeSize(16, 16));
     if (icon)
-        [webView _setMainFrameIcon:icon];
+        [webView.get() _setMainFrameIcon:icon.get()];
 #else
     UNUSED_PARAM(iconData);
 #endif

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameNetworkingContext.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameNetworkingContext.mm
@@ -77,11 +77,11 @@ RetainPtr<CFDataRef> WebFrameNetworkingContext::sourceApplicationAuditData() con
     if (!frame() || !frame()->page())
         return nullptr;
     
-    WebView *webview = kit(frame()->page());
+    RetainPtr webview = kit(frame()->page());
     if (!webview)
         return nullptr;
 
-    return (__bridge CFDataRef)webview._sourceApplicationAuditData;
+    return (__bridge CFDataRef)webview.get()._sourceApplicationAuditData;
 }
 
 String WebFrameNetworkingContext::sourceApplicationIdentifier() const

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebVisitedLinkStore.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebVisitedLinkStore.mm
@@ -128,14 +128,14 @@ void WebVisitedLinkStore::populateVisitedLinksIfNeeded(Page& page)
 
     m_visitedLinksPopulated = true;
 
-    WebView *webView = kit(&page);
+    RetainPtr webView = kit(&page);
     ASSERT(webView);
 
-    if (webView.historyDelegate) {
-        WebHistoryDelegateImplementationCache* implementations = WebViewGetHistoryDelegateImplementations(webView);
+    if ([webView.get() historyDelegate]) {
+        WebHistoryDelegateImplementationCache* implementations = WebViewGetHistoryDelegateImplementations(webView.get());
 
         if (implementations->populateVisitedLinksFunc)
-            CallHistoryDelegate(implementations->populateVisitedLinksFunc, webView, @selector(populateVisitedLinksForWebView:));
+            CallHistoryDelegate(implementations->populateVisitedLinksFunc, webView.get(), @selector(populateVisitedLinksForWebView:));
 
         return;
     }

--- a/Source/WebKitLegacy/mac/WebInspector/WebNodeHighlight.mm
+++ b/Source/WebKitLegacy/mac/WebInspector/WebNodeHighlight.mm
@@ -143,12 +143,12 @@ using namespace WebCore;
 
     // Observe both frame-changed and bounds-changed notifications because either one could leave
     // the highlight incorrectly positioned with respect to the target view. We need to do this for
-    // the entire superview hierarchy to handle scrolling, bars coming and going, etc. 
+    // the entire superview hierarchy to handle scrolling, bars coming and going, etc.
     // (without making concrete assumptions about the view hierarchy).
     NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
-    for (NSView *v = _targetView; v; v = [v superview]) {
-        [notificationCenter addObserver:self selector:@selector(_repositionHighlightWindow) name:NSViewFrameDidChangeNotification object:v];
-        [notificationCenter addObserver:self selector:@selector(_repositionHighlightWindow) name:NSViewBoundsDidChangeNotification object:v];
+    for (RetainPtr v = _targetView; v; v = [v.get() superview]) {
+        [notificationCenter addObserver:self selector:@selector(_repositionHighlightWindow) name:NSViewFrameDidChangeNotification object:v.get()];
+        [notificationCenter addObserver:self selector:@selector(_repositionHighlightWindow) name:NSViewBoundsDidChangeNotification object:v.get()];
     }
 #else
     ASSERT(_highlightLayer);

--- a/Source/WebKitLegacy/mac/WebView/WebArchive.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebArchive.mm
@@ -209,27 +209,27 @@ static BOOL isArrayOfClass(id object, Class elementClass)
 }
 
 - (instancetype)initWithCoder:(NSCoder *)decoder
-{    
-    WebResource *mainResource = nil;
-    NSArray *subresources = nil;
-    NSArray *subframeArchives = nil;
-    
+{
+    RetainPtr<WebResource *> mainResource = nil;
+    RetainPtr<NSArray *> subresources = nil;
+    RetainPtr<NSArray *> subframeArchives = nil;
+
     @try {
-        id object = [decoder decodeObjectForKey:WebMainResourceKey];
-        if ([object isKindOfClass:[WebResource class]])
-            mainResource = object;
+        RetainPtr object = [decoder decodeObjectForKey:WebMainResourceKey];
+        if ([object.get() isKindOfClass:[WebResource class]])
+            mainResource = object.get();
         object = [decoder decodeObjectForKey:WebSubresourcesKey];
-        if (isArrayOfClass(object, [WebResource class]))
-            subresources = object;
+        if (isArrayOfClass(object.get(), [WebResource class]))
+            subresources = object.get();
         object = [decoder decodeObjectForKey:WebSubframeArchivesKey];
-        if (isArrayOfClass(object, [WebArchive class]))
-            subframeArchives = object;
+        if (isArrayOfClass(object.get(), [WebArchive class]))
+            subframeArchives = object.get();
     } @catch(id) {
         [self release];
         return nil;
     }
 
-    return [self initWithMainResource:mainResource subresources:subresources subframeArchives:subframeArchives];
+    return [self initWithMainResource:mainResource.get() subresources:subresources.get() subframeArchives:subframeArchives.get()];
 }
 
 - (void)encodeWithCoder:(NSCoder *)encoder

--- a/Source/WebKitLegacy/mac/WebView/WebDataSource.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebDataSource.mm
@@ -380,8 +380,8 @@ void addTypesFromClass(NSMutableDictionary *allTypes, Class objCClass, NSArray *
         [self _setRepresentation:(id <WebDocumentRepresentation>)newRep.get()];
     }
 
-    id<WebDocumentRepresentation> representation = toPrivate(_private)->representation.get();
-    [representation setDataSource:self];
+    RetainPtr representation = toPrivate(_private)->representation.get();
+    [representation.get() setDataSource:self];
 #if PLATFORM(IOS_FAMILY)
     toPrivate(_private)->loader->setResponseMIMEType([self _responseMIMEType]);
 #endif

--- a/Source/WebKitLegacy/mac/WebView/WebDelegateImplementationCaching.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebDelegateImplementationCaching.mm
@@ -98,16 +98,16 @@ static inline id CallDelegate(WebView *self, id delegate, SEL selector)
     if (!delegate || ![delegate respondsToSelector:selector])
         return nil;
 
-    NSInvocation *invocation = WebThreadMakeNSInvocation(delegate, selector);
-    [invocation setArgument:&self atIndex:2];
+    RetainPtr invocation = WebThreadMakeNSInvocation(delegate, selector);
+    [invocation.get() setArgument:&self atIndex:2];
 
     id returnValue;
     @try {
-        WebThreadCallDelegate(invocation);
-        if ([[invocation methodSignature] methodReturnLength] == 0) {
+        WebThreadCallDelegate(invocation.get());
+        if ([[invocation.get() methodSignature] methodReturnLength] == 0) {
             return nil;
         }
-        [invocation getReturnValue:&returnValue];
+        [invocation.get() getReturnValue:&returnValue];
         return returnValue;
     } @catch(id exception) {
         ReportDiscardedDelegateException(selector, exception);
@@ -131,17 +131,17 @@ static inline id CallDelegate(WebView *self, id delegate, SEL selector, id objec
     if (!delegate || ![delegate respondsToSelector:selector])
         return nil;
 
-    NSInvocation *invocation = WebThreadMakeNSInvocation(delegate, selector);
-    [invocation setArgument:&self atIndex:2];
-    [invocation setArgument:&object atIndex:3];
+    RetainPtr invocation = WebThreadMakeNSInvocation(delegate, selector);
+    [invocation.get() setArgument:&self atIndex:2];
+    [invocation.get() setArgument:&object atIndex:3];
 
     id returnValue;
     @try {
-        WebThreadCallDelegate(invocation);
-        if ([[invocation methodSignature] methodReturnLength] == 0) {
+        WebThreadCallDelegate(invocation.get());
+        if ([[invocation.get() methodSignature] methodReturnLength] == 0) {
             return nil;
         }
-        [invocation getReturnValue:&returnValue];
+        [invocation.get() getReturnValue:&returnValue];
         return returnValue;
     } @catch(id exception) {
         ReportDiscardedDelegateException(selector, exception);
@@ -165,17 +165,17 @@ static inline id CallDelegate(WebView *self, id delegate, SEL selector, NSRect r
     if (!delegate || ![delegate respondsToSelector:selector])
         return nil;
 
-    NSInvocation *invocation = WebThreadMakeNSInvocation(delegate, selector);
-    [invocation setArgument:&self atIndex:2];
-    [invocation setArgument:&rect atIndex:3];
+    RetainPtr invocation = WebThreadMakeNSInvocation(delegate, selector);
+    [invocation.get() setArgument:&self atIndex:2];
+    [invocation.get() setArgument:&rect atIndex:3];
 
     id returnValue;
     @try {
-        WebThreadCallDelegate(invocation);
-        if ([[invocation methodSignature] methodReturnLength] == 0) {
+        WebThreadCallDelegate(invocation.get());
+        if ([[invocation.get() methodSignature] methodReturnLength] == 0) {
             return nil;
         }
-        [invocation getReturnValue:&returnValue];
+        [invocation.get() getReturnValue:&returnValue];
         return returnValue;
     } @catch(id exception) {
         ReportDiscardedDelegateException(selector, exception);
@@ -199,18 +199,18 @@ static inline id CallDelegate(WebView *self, id delegate, SEL selector, id objec
     if (!delegate || ![delegate respondsToSelector:selector])
         return nil;
 
-    NSInvocation *invocation = WebThreadMakeNSInvocation(delegate, selector);
-    [invocation setArgument:&self atIndex:2];
-    [invocation setArgument:&object1 atIndex:3];
-    [invocation setArgument:&object2 atIndex:4];
+    RetainPtr invocation = WebThreadMakeNSInvocation(delegate, selector);
+    [invocation.get() setArgument:&self atIndex:2];
+    [invocation.get() setArgument:&object1 atIndex:3];
+    [invocation.get() setArgument:&object2 atIndex:4];
 
     id returnValue;
     @try {
-        WebThreadCallDelegate(invocation);
-        if ([[invocation methodSignature] methodReturnLength] == 0) {
+        WebThreadCallDelegate(invocation.get());
+        if ([[invocation.get() methodSignature] methodReturnLength] == 0) {
             return nil;
         }
-        [invocation getReturnValue:&returnValue];
+        [invocation.get() getReturnValue:&returnValue];
         return returnValue;
     } @catch(id exception) {
         ReportDiscardedDelegateException(selector, exception);
@@ -234,18 +234,18 @@ static inline id CallDelegate(WebView *self, id delegate, SEL selector, id objec
     if (!delegate || ![delegate respondsToSelector:selector])
         return nil;
 
-    NSInvocation *invocation = WebThreadMakeNSInvocation(delegate, selector);
-    [invocation setArgument:&self atIndex:2];
-    [invocation setArgument:&object atIndex:3];
-    [invocation setArgument:&boolean atIndex:4];
+    RetainPtr invocation = WebThreadMakeNSInvocation(delegate, selector);
+    [invocation.get() setArgument:&self atIndex:2];
+    [invocation.get() setArgument:&object atIndex:3];
+    [invocation.get() setArgument:&boolean atIndex:4];
 
     id returnValue;
     @try {
-        WebThreadCallDelegate(invocation);
-        if ([[invocation methodSignature] methodReturnLength] == 0) {
+        WebThreadCallDelegate(invocation.get());
+        if ([[invocation.get() methodSignature] methodReturnLength] == 0) {
             return nil;
         }
-        [invocation getReturnValue:&returnValue];
+        [invocation.get() getReturnValue:&returnValue];
         return returnValue;
     } @catch(id exception) {
         ReportDiscardedDelegateException(selector, exception);
@@ -269,19 +269,19 @@ static inline id CallDelegate(WebView *self, id delegate, SEL selector, id objec
     if (!delegate || ![delegate respondsToSelector:selector])
         return nil;
 
-    NSInvocation *invocation = WebThreadMakeNSInvocation(delegate, selector);
-    [invocation setArgument:&self atIndex:2];
-    [invocation setArgument:&object1 atIndex:3];
-    [invocation setArgument:&object2 atIndex:4];
-    [invocation setArgument:&object3 atIndex:5];
+    RetainPtr invocation = WebThreadMakeNSInvocation(delegate, selector);
+    [invocation.get() setArgument:&self atIndex:2];
+    [invocation.get() setArgument:&object1 atIndex:3];
+    [invocation.get() setArgument:&object2 atIndex:4];
+    [invocation.get() setArgument:&object3 atIndex:5];
 
     id returnValue;
     @try {
-        WebThreadCallDelegate(invocation);
-        if ([[invocation methodSignature] methodReturnLength] == 0) {
+        WebThreadCallDelegate(invocation.get());
+        if ([[invocation.get() methodSignature] methodReturnLength] == 0) {
             return nil;
         }
-        [invocation getReturnValue:&returnValue];
+        [invocation.get() getReturnValue:&returnValue];
         return returnValue;
     } @catch(id exception) {
         ReportDiscardedDelegateException(selector, exception);
@@ -305,18 +305,18 @@ static inline id CallDelegate(WebView *self, id delegate, SEL selector, id objec
     if (!delegate || ![delegate respondsToSelector:selector])
         return nil;
 
-    NSInvocation *invocation = WebThreadMakeNSInvocation(delegate, selector);
-    [invocation setArgument:&self atIndex:2];
-    [invocation setArgument:&object atIndex:3];
-    [invocation setArgument:&integer atIndex:4];
+    RetainPtr invocation = WebThreadMakeNSInvocation(delegate, selector);
+    [invocation.get() setArgument:&self atIndex:2];
+    [invocation.get() setArgument:&object atIndex:3];
+    [invocation.get() setArgument:&integer atIndex:4];
 
     id returnValue;
     @try {
-        WebThreadCallDelegate(invocation);
-        if ([[invocation methodSignature] methodReturnLength] == 0) {
+        WebThreadCallDelegate(invocation.get());
+        if ([[invocation.get() methodSignature] methodReturnLength] == 0) {
             return nil;
         }
-        [invocation getReturnValue:&returnValue];
+        [invocation.get() getReturnValue:&returnValue];
         return returnValue;
     } @catch(id exception) {
         ReportDiscardedDelegateException(selector, exception);
@@ -340,13 +340,13 @@ static inline float CallDelegateReturningFloat(WebView *self, id delegate, SEL s
     if (!delegate || ![delegate respondsToSelector:selector])
         return 0.0f;
 
-    NSInvocation *invocation = WebThreadMakeNSInvocation(delegate, selector);
-    [invocation setArgument:&self atIndex:2];
+    RetainPtr invocation = WebThreadMakeNSInvocation(delegate, selector);
+    [invocation.get() setArgument:&self atIndex:2];
 
     float returnValue = 0.0f;
     @try {
-        WebThreadCallDelegate(invocation);
-        [invocation getReturnValue:&returnValue];
+        WebThreadCallDelegate(invocation.get());
+        [invocation.get() getReturnValue:&returnValue];
         return returnValue;
     } @catch(id exception) {
         ReportDiscardedDelegateException(selector, exception);
@@ -370,13 +370,13 @@ static inline BOOL CallDelegateReturningBoolean(BOOL result, WebView *self, id d
     if (!delegate || ![delegate respondsToSelector:selector])
         return result;
 
-    NSInvocation *invocation = WebThreadMakeNSInvocation(delegate, selector);
-    [invocation setArgument:&self atIndex:2];
+    RetainPtr invocation = WebThreadMakeNSInvocation(delegate, selector);
+    [invocation.get() setArgument:&self atIndex:2];
 
     BOOL returnValue;
     @try {
-        WebThreadCallDelegate(invocation);
-        [invocation getReturnValue:&returnValue];
+        WebThreadCallDelegate(invocation.get());
+        [invocation.get() getReturnValue:&returnValue];
         return returnValue;
     } @catch(id exception) {
         ReportDiscardedDelegateException(selector, exception);
@@ -400,14 +400,14 @@ static inline BOOL CallDelegateReturningBoolean(BOOL result, WebView *self, id d
     if (!delegate || ![delegate respondsToSelector:selector])
         return result;
 
-    NSInvocation *invocation = WebThreadMakeNSInvocation(delegate, selector);
-    [invocation setArgument:&self atIndex:2];
-    [invocation setArgument:&object atIndex:3];
+    RetainPtr invocation = WebThreadMakeNSInvocation(delegate, selector);
+    [invocation.get() setArgument:&self atIndex:2];
+    [invocation.get() setArgument:&object atIndex:3];
 
     BOOL returnValue;
     @try {
-        WebThreadCallDelegate(invocation);
-        [invocation getReturnValue:&returnValue];
+        WebThreadCallDelegate(invocation.get());
+        [invocation.get() getReturnValue:&returnValue];
         return returnValue;
     } @catch(id exception) {
         ReportDiscardedDelegateException(selector, exception);
@@ -431,15 +431,15 @@ static inline BOOL CallDelegateReturningBoolean(BOOL result, WebView *self, id d
     if (!delegate || ![delegate respondsToSelector:selector])
         return result;
 
-    NSInvocation *invocation = WebThreadMakeNSInvocation(delegate, selector);
-    [invocation setArgument:&self atIndex:2];
-    [invocation setArgument:&object atIndex:3];
-    [invocation setArgument:&boolean atIndex:4];
+    RetainPtr invocation = WebThreadMakeNSInvocation(delegate, selector);
+    [invocation.get() setArgument:&self atIndex:2];
+    [invocation.get() setArgument:&object atIndex:3];
+    [invocation.get() setArgument:&boolean atIndex:4];
 
     BOOL returnValue;
     @try {
-        WebThreadCallDelegate(invocation);
-        [invocation getReturnValue:&returnValue];
+        WebThreadCallDelegate(invocation.get());
+        [invocation.get() getReturnValue:&returnValue];
         return returnValue;
     } @catch(id exception) {
         ReportDiscardedDelegateException(selector, exception);
@@ -475,15 +475,15 @@ static inline BOOL CallDelegateReturningBoolean(BOOL result, WebView *self, id d
     if (!delegate || ![delegate respondsToSelector:selector])
         return result;
 
-    NSInvocation *invocation = WebThreadMakeNSInvocation(delegate, selector);
-    [invocation setArgument:&self atIndex:2];
-    [invocation setArgument:&object1 atIndex:3];
-    [invocation setArgument:&object2 atIndex:4];
+    RetainPtr invocation = WebThreadMakeNSInvocation(delegate, selector);
+    [invocation.get() setArgument:&self atIndex:2];
+    [invocation.get() setArgument:&object1 atIndex:3];
+    [invocation.get() setArgument:&object2 atIndex:4];
 
     BOOL returnValue;
     @try {
-        WebThreadCallDelegate(invocation);
-        [invocation getReturnValue:&returnValue];
+        WebThreadCallDelegate(invocation.get());
+        [invocation.get() getReturnValue:&returnValue];
         return returnValue;
     } @catch(id exception) {
         ReportDiscardedDelegateException(selector, exception);
@@ -497,17 +497,17 @@ static inline BOOL CallDelegateReturningBoolean(BOOL result, WebView *self, id d
 {
     if (!delegate || ![delegate respondsToSelector:selector])
         return result;
-    
-    NSInvocation *invocation = WebThreadMakeNSInvocation(delegate, selector);
-    [invocation setArgument:&self atIndex:2];
-    [invocation setArgument:&object1 atIndex:3];
-    [invocation setArgument:&object2 atIndex:4];
-    [invocation setArgument:&boolean atIndex:5];
-    
+
+    RetainPtr invocation = WebThreadMakeNSInvocation(delegate, selector);
+    [invocation.get() setArgument:&self atIndex:2];
+    [invocation.get() setArgument:&object1 atIndex:3];
+    [invocation.get() setArgument:&object2 atIndex:4];
+    [invocation.get() setArgument:&boolean atIndex:5];
+
     BOOL returnValue;
     @try {
-        WebThreadCallDelegate(invocation);
-        [invocation getReturnValue:&returnValue];
+        WebThreadCallDelegate(invocation.get());
+        [invocation.get() getReturnValue:&returnValue];
         return returnValue;
     } @catch(id exception) {
         ReportDiscardedDelegateException(selector, exception);
@@ -531,16 +531,16 @@ static inline id CallDelegate(IMP implementation, WebView *self, id delegate, SE
     if (!delegate)
         return nil;
 
-    NSInvocation *invocation = WebThreadMakeNSInvocation(delegate, selector);
-    [invocation setArgument:&self atIndex:2];
+    RetainPtr invocation = WebThreadMakeNSInvocation(delegate, selector);
+    [invocation.get() setArgument:&self atIndex:2];
 
     id returnValue;
     @try {
-        WebThreadCallDelegate(invocation);
-        if ([[invocation methodSignature] methodReturnLength] == 0) {
+        WebThreadCallDelegate(invocation.get());
+        if ([[invocation.get() methodSignature] methodReturnLength] == 0) {
             return nil;
         }
-        [invocation getReturnValue:&returnValue];
+        [invocation.get() getReturnValue:&returnValue];
         return returnValue;
     } @catch(id exception) {
         ReportDiscardedDelegateException(selector, exception);
@@ -564,17 +564,17 @@ static inline id CallDelegate(IMP implementation, WebView *self, id delegate, SE
     if (!delegate || ![delegate respondsToSelector:selector])
         return nil;
 
-    NSInvocation *invocation = WebThreadMakeNSInvocation(delegate, selector);
-    [invocation setArgument:&self atIndex:2];
-    [invocation setArgument:&integer atIndex:3];
+    RetainPtr invocation = WebThreadMakeNSInvocation(delegate, selector);
+    [invocation.get() setArgument:&self atIndex:2];
+    [invocation.get() setArgument:&integer atIndex:3];
 
     id returnValue;
     @try {
-        WebThreadCallDelegate(invocation);
-        if ([[invocation methodSignature] methodReturnLength] == 0) {
+        WebThreadCallDelegate(invocation.get());
+        if ([[invocation.get() methodSignature] methodReturnLength] == 0) {
             return nil;
         }
-        [invocation getReturnValue:&returnValue];
+        [invocation.get() getReturnValue:&returnValue];
         return returnValue;
     } @catch(id exception) {
         ReportDiscardedDelegateException(selector, exception);
@@ -598,17 +598,17 @@ static inline id CallDelegate(IMP implementation, WebView *self, id delegate, SE
     if (!delegate)
         return nil;
 
-    NSInvocation *invocation = WebThreadMakeNSInvocation(delegate, selector);
-    [invocation setArgument:&self atIndex:2];
-    [invocation setArgument:&object atIndex:3];
+    RetainPtr invocation = WebThreadMakeNSInvocation(delegate, selector);
+    [invocation.get() setArgument:&self atIndex:2];
+    [invocation.get() setArgument:&object atIndex:3];
 
     id returnValue;
     @try {
-        WebThreadCallDelegate(invocation);
-        if ([[invocation methodSignature] methodReturnLength] == 0) {
+        WebThreadCallDelegate(invocation.get());
+        if ([[invocation.get() methodSignature] methodReturnLength] == 0) {
             return nil;
         }
-        [invocation getReturnValue:&returnValue];
+        [invocation.get() getReturnValue:&returnValue];
         return returnValue;
     } @catch(id exception) {
         ReportDiscardedDelegateException(selector, exception);
@@ -683,18 +683,18 @@ static inline id CallDelegate(IMP implementation, WebView *self, id delegate, SE
     if (!delegate)
         return nil;
 
-    NSInvocation *invocation = WebThreadMakeNSInvocation(delegate, selector);
-    [invocation setArgument:&self atIndex:2];
-    [invocation setArgument:&object1 atIndex:3];
-    [invocation setArgument:&object2 atIndex:4];
+    RetainPtr invocation = WebThreadMakeNSInvocation(delegate, selector);
+    [invocation.get() setArgument:&self atIndex:2];
+    [invocation.get() setArgument:&object1 atIndex:3];
+    [invocation.get() setArgument:&object2 atIndex:4];
 
     id returnValue;
     @try {
-        WebThreadCallDelegate(invocation);
-        if ([[invocation methodSignature] methodReturnLength] == 0) {
+        WebThreadCallDelegate(invocation.get());
+        if ([[invocation.get() methodSignature] methodReturnLength] == 0) {
             return nil;
         }
-        [invocation getReturnValue:&returnValue];
+        [invocation.get() getReturnValue:&returnValue];
         return returnValue;
     } @catch(id exception) {
         ReportDiscardedDelegateException(selector, exception);
@@ -709,18 +709,18 @@ static inline id CallDelegate(IMP implementation, WebView *self, id delegate, SE
     if (!delegate)
         return nil;
 
-    NSInvocation *invocation = WebThreadMakeNSInvocation(delegate, selector);
-    [invocation setArgument:&self atIndex:2];
-    [invocation setArgument:&object atIndex:3];
-    [invocation setArgument:&double1 atIndex:4];
+    RetainPtr invocation = WebThreadMakeNSInvocation(delegate, selector);
+    [invocation.get() setArgument:&self atIndex:2];
+    [invocation.get() setArgument:&object atIndex:3];
+    [invocation.get() setArgument:&double1 atIndex:4];
 
     id returnValue;
     @try {
-        WebThreadCallDelegate(invocation);
-        if ([[invocation methodSignature] methodReturnLength] == 0) {
+        WebThreadCallDelegate(invocation.get());
+        if ([[invocation.get() methodSignature] methodReturnLength] == 0) {
             return nil;
         }
-        [invocation getReturnValue:&returnValue];
+        [invocation.get() getReturnValue:&returnValue];
         return returnValue;
     } @catch(id exception) {
         ReportDiscardedDelegateException(selector, exception);
@@ -744,19 +744,19 @@ static inline id CallDelegate(IMP implementation, WebView *self, id delegate, SE
     if (!delegate)
         return nil;
 
-    NSInvocation *invocation = WebThreadMakeNSInvocation(delegate, selector);
-    [invocation setArgument:&self atIndex:2];
-    [invocation setArgument:&object1 atIndex:3];
-    [invocation setArgument:&object2 atIndex:4];
-    [invocation setArgument:&object3 atIndex:5];
+    RetainPtr invocation = WebThreadMakeNSInvocation(delegate, selector);
+    [invocation.get() setArgument:&self atIndex:2];
+    [invocation.get() setArgument:&object1 atIndex:3];
+    [invocation.get() setArgument:&object2 atIndex:4];
+    [invocation.get() setArgument:&object3 atIndex:5];
 
     id returnValue;
     @try {
-        WebThreadCallDelegate(invocation);
-        if ([[invocation methodSignature] methodReturnLength] == 0) {
+        WebThreadCallDelegate(invocation.get());
+        if ([[invocation.get() methodSignature] methodReturnLength] == 0) {
             return nil;
         }
-        [invocation getReturnValue:&returnValue];
+        [invocation.get() getReturnValue:&returnValue];
         return returnValue;
     } @catch(id exception) {
         ReportDiscardedDelegateException(selector, exception);
@@ -780,20 +780,20 @@ static inline id CallDelegate(IMP implementation, WebView *self, id delegate, SE
     if (!delegate)
         return nil;
 
-    NSInvocation *invocation = WebThreadMakeNSInvocation(delegate, selector);
-    [invocation setArgument:&self atIndex:2];
-    [invocation setArgument:&object1 atIndex:3];
-    [invocation setArgument:&object2 atIndex:4];
-    [invocation setArgument:&object3 atIndex:5];
-    [invocation setArgument:&object4 atIndex:6];
+    RetainPtr invocation = WebThreadMakeNSInvocation(delegate, selector);
+    [invocation.get() setArgument:&self atIndex:2];
+    [invocation.get() setArgument:&object1 atIndex:3];
+    [invocation.get() setArgument:&object2 atIndex:4];
+    [invocation.get() setArgument:&object3 atIndex:5];
+    [invocation.get() setArgument:&object4 atIndex:6];
 
     id returnValue;
     @try {
-        WebThreadCallDelegate(invocation);
-        if ([[invocation methodSignature] methodReturnLength] == 0) {
+        WebThreadCallDelegate(invocation.get());
+        if ([[invocation.get() methodSignature] methodReturnLength] == 0) {
             return nil;
         }
-        [invocation getReturnValue:&returnValue];
+        [invocation.get() getReturnValue:&returnValue];
         return returnValue;
     } @catch(id exception) {
         ReportDiscardedDelegateException(selector, exception);
@@ -817,19 +817,19 @@ static inline id CallDelegate(IMP implementation, WebView *self, id delegate, SE
     if (!delegate)
         return nil;
 
-    NSInvocation *invocation = WebThreadMakeNSInvocation(delegate, selector);
-    [invocation setArgument:&self atIndex:2];
-    [invocation setArgument:&object1 atIndex:3];
-    [invocation setArgument:&integer atIndex:4];
-    [invocation setArgument:&object2 atIndex:5];
+    RetainPtr invocation = WebThreadMakeNSInvocation(delegate, selector);
+    [invocation.get() setArgument:&self atIndex:2];
+    [invocation.get() setArgument:&object1 atIndex:3];
+    [invocation.get() setArgument:&integer atIndex:4];
+    [invocation.get() setArgument:&object2 atIndex:5];
 
     id returnValue;
     @try {
-        WebThreadCallDelegate(invocation);
-        if ([[invocation methodSignature] methodReturnLength] == 0) {
+        WebThreadCallDelegate(invocation.get());
+        if ([[invocation.get() methodSignature] methodReturnLength] == 0) {
             return nil;
         }
-        [invocation getReturnValue:&returnValue];
+        [invocation.get() getReturnValue:&returnValue];
         return returnValue;
     } @catch(id exception) {
         ReportDiscardedDelegateException(selector, exception);
@@ -881,20 +881,20 @@ static inline id CallDelegate(IMP implementation, WebView *self, id delegate, SE
     if (!delegate)
         return nil;
 
-    NSInvocation *invocation = WebThreadMakeNSInvocation(delegate, selector);
-    [invocation setArgument:&self atIndex:2];
-    [invocation setArgument:&object1 atIndex:3];
-    [invocation setArgument:&object2 atIndex:4];
-    [invocation setArgument:&integer atIndex:5];
-    [invocation setArgument:&object3 atIndex:6];
+    RetainPtr invocation = WebThreadMakeNSInvocation(delegate, selector);
+    [invocation.get() setArgument:&self atIndex:2];
+    [invocation.get() setArgument:&object1 atIndex:3];
+    [invocation.get() setArgument:&object2 atIndex:4];
+    [invocation.get() setArgument:&integer atIndex:5];
+    [invocation.get() setArgument:&object3 atIndex:6];
 
     id returnValue;
     @try {
-        WebThreadCallDelegate(invocation);
-        if ([[invocation methodSignature] methodReturnLength] == 0) {
+        WebThreadCallDelegate(invocation.get());
+        if ([[invocation.get() methodSignature] methodReturnLength] == 0) {
             return nil;
         }
-        [invocation getReturnValue:&returnValue];
+        [invocation.get() getReturnValue:&returnValue];
         return returnValue;
     } @catch(id exception) {
         ReportDiscardedDelegateException(selector, exception);
@@ -975,20 +975,20 @@ static inline id CallDelegate(IMP implementation, WebView *self, id delegate, SE
     if (!delegate)
         return nil;
 
-    NSInvocation *invocation = WebThreadMakeNSInvocation(delegate, selector);
-    [invocation setArgument:&self atIndex:2];
-    [invocation setArgument:&object1 atIndex:3];
-    [invocation setArgument:&interval atIndex:4];
-    [invocation setArgument:&object2 atIndex:5];
-    [invocation setArgument:&object3 atIndex:6];
+    RetainPtr invocation = WebThreadMakeNSInvocation(delegate, selector);
+    [invocation.get() setArgument:&self atIndex:2];
+    [invocation.get() setArgument:&object1 atIndex:3];
+    [invocation.get() setArgument:&interval atIndex:4];
+    [invocation.get() setArgument:&object2 atIndex:5];
+    [invocation.get() setArgument:&object3 atIndex:6];
 
     id returnValue;
     @try {
-        WebThreadCallDelegate(invocation);
-        if ([[invocation methodSignature] methodReturnLength] == 0) {
+        WebThreadCallDelegate(invocation.get());
+        if ([[invocation.get() methodSignature] methodReturnLength] == 0) {
             return nil;
         }
-        [invocation getReturnValue:&returnValue];
+        [invocation.get() getReturnValue:&returnValue];
         return returnValue;
     } @catch(id exception) {
         ReportDiscardedDelegateException(selector, exception);
@@ -1373,31 +1373,31 @@ id CallHistoryDelegate(IMP implementation, WebView *self, SEL selector, id objec
 id CallFormDelegate(WebView *self, SEL selector, id object1, id object2)
 {
 #if !PLATFORM(IOS_FAMILY)
-    id delegate = self->_private->formDelegate;
-    if (!delegate || ![delegate respondsToSelector:selector])
+    RetainPtr delegate = self->_private->formDelegate;
+    if (!delegate || ![(id)delegate.get() respondsToSelector:selector])
         return nil;
     @try {
-        return wtfObjCMsgSend<id>(delegate, selector, object1, object2);
+        return wtfObjCMsgSend<id>(delegate.get(), selector, object1, object2);
     } @catch(id exception) {
         ReportDiscardedDelegateException(selector, exception);
     }
     return nil;
 #else
-    id delegate = [self _formDelegateForSelector:selector];
+    RetainPtr delegate = [self _formDelegateForSelector:selector];
     if (!delegate)
         return nil;
 
-    NSInvocation *invocation = WebThreadMakeNSInvocation(delegate, selector);
-    [invocation setArgument:&object1 atIndex:2];
-    [invocation setArgument:&object2 atIndex:3];
+    RetainPtr invocation = WebThreadMakeNSInvocation(delegate.get(), selector);
+    [invocation.get() setArgument:&object1 atIndex:2];
+    [invocation.get() setArgument:&object2 atIndex:3];
 
     id returnValue;
     @try {
-        WebThreadCallDelegate(invocation);
-        if ([[invocation methodSignature] methodReturnLength] == 0) {
+        WebThreadCallDelegate(invocation.get());
+        if ([[invocation.get() methodSignature] methodReturnLength] == 0) {
             return nil;
         }
-        [invocation getReturnValue:&returnValue];
+        [invocation.get() getReturnValue:&returnValue];
         return returnValue;
     } @catch(id exception) {
         ReportDiscardedDelegateException(selector, exception);
@@ -1409,32 +1409,32 @@ id CallFormDelegate(WebView *self, SEL selector, id object1, id object2)
 id CallFormDelegate(WebView *self, SEL selector, id object1, id object2, id object3)
 {
 #if !PLATFORM(IOS_FAMILY)
-    id delegate = self->_private->formDelegate;
-    if (!delegate || ![delegate respondsToSelector:selector])
+    RetainPtr delegate = self->_private->formDelegate;
+    if (!delegate || ![(id)delegate.get() respondsToSelector:selector])
         return nil;
     @try {
-        return wtfObjCMsgSend<id>(delegate, selector, object1, object2, object3);
+        return wtfObjCMsgSend<id>(delegate.get(), selector, object1, object2, object3);
     } @catch(id exception) {
         ReportDiscardedDelegateException(selector, exception);
     }
     return nil;
 #else
-    id delegate = [self _formDelegateForSelector:selector];
+    RetainPtr delegate = [self _formDelegateForSelector:selector];
     if (!delegate)
         return nil;
 
-    NSInvocation *invocation = WebThreadMakeNSInvocation(delegate, selector);
-    [invocation setArgument:&object1 atIndex:2];
-    [invocation setArgument:&object2 atIndex:3];
-    [invocation setArgument:&object3 atIndex:4];
+    RetainPtr invocation = WebThreadMakeNSInvocation(delegate.get(), selector);
+    [invocation.get() setArgument:&object1 atIndex:2];
+    [invocation.get() setArgument:&object2 atIndex:3];
+    [invocation.get() setArgument:&object3 atIndex:4];
 
     id returnValue;
     @try {
-        WebThreadCallDelegate(invocation);
-        if ([[invocation methodSignature] methodReturnLength] == 0) {
+        WebThreadCallDelegate(invocation.get());
+        if ([[invocation.get() methodSignature] methodReturnLength] == 0) {
             return nil;
         }
-        [invocation getReturnValue:&returnValue];
+        [invocation.get() getReturnValue:&returnValue];
         return returnValue;
     } @catch(id exception) {
         ReportDiscardedDelegateException(selector, exception);
@@ -1446,34 +1446,34 @@ id CallFormDelegate(WebView *self, SEL selector, id object1, id object2, id obje
 id CallFormDelegate(WebView *self, SEL selector, id object1, id object2, id object3, id object4, id object5)
 {
 #if !PLATFORM(IOS_FAMILY)
-    id delegate = self->_private->formDelegate;
-    if (!delegate || ![delegate respondsToSelector:selector])
+    RetainPtr delegate = self->_private->formDelegate;
+    if (!delegate || ![(id)delegate.get() respondsToSelector:selector])
         return nil;
     @try {
-        return wtfObjCMsgSend<id>(delegate, selector, object1, object2, object3, object4, object5);
+        return wtfObjCMsgSend<id>(delegate.get(), selector, object1, object2, object3, object4, object5);
     } @catch(id exception) {
         ReportDiscardedDelegateException(selector, exception);
     }
     return nil;
 #else
-    id delegate = [self _formDelegateForSelector:selector];
+    RetainPtr delegate = [self _formDelegateForSelector:selector];
     if (!delegate)
         return nil;
 
-    NSInvocation *invocation = WebThreadMakeNSInvocation(delegate, selector);
-    [invocation setArgument:&object1 atIndex:2];
-    [invocation setArgument:&object2 atIndex:3];
-    [invocation setArgument:&object3 atIndex:4];
-    [invocation setArgument:&object4 atIndex:5];
-    [invocation setArgument:&object5 atIndex:6];
+    RetainPtr invocation = WebThreadMakeNSInvocation(delegate.get(), selector);
+    [invocation.get() setArgument:&object1 atIndex:2];
+    [invocation.get() setArgument:&object2 atIndex:3];
+    [invocation.get() setArgument:&object3 atIndex:4];
+    [invocation.get() setArgument:&object4 atIndex:5];
+    [invocation.get() setArgument:&object5 atIndex:6];
 
     id returnValue;
     @try {
-        WebThreadCallDelegate(invocation);
-        if ([[invocation methodSignature] methodReturnLength] == 0) {
+        WebThreadCallDelegate(invocation.get());
+        if ([[invocation.get() methodSignature] methodReturnLength] == 0) {
             return nil;
         }
-        [invocation getReturnValue:&returnValue];
+        [invocation.get() getReturnValue:&returnValue];
         return returnValue;
     } @catch(id exception) {
         ReportDiscardedDelegateException(selector, exception);
@@ -1485,29 +1485,29 @@ id CallFormDelegate(WebView *self, SEL selector, id object1, id object2, id obje
 BOOL CallFormDelegateReturningBoolean(BOOL result, WebView *self, SEL selector, id object1, SEL selectorArg, id object2)
 {
 #if !PLATFORM(IOS_FAMILY)
-    id delegate = self->_private->formDelegate;
-    if (!delegate || ![delegate respondsToSelector:selector])
+    RetainPtr delegate = self->_private->formDelegate;
+    if (!delegate || ![(id)delegate.get() respondsToSelector:selector])
         return result;
     @try {
-        return wtfObjCMsgSend<BOOL>(delegate, selector, object1, selectorArg, object2);
+        return wtfObjCMsgSend<BOOL>(delegate.get(), selector, object1, selectorArg, object2);
     } @catch(id exception) {
         ReportDiscardedDelegateException(selector, exception);
     }
     return result;
 #else
-    id delegate = [self _formDelegateForSelector:selector];
+    RetainPtr delegate = [self _formDelegateForSelector:selector];
     if (!delegate)
         return result;
 
-    NSInvocation *invocation = WebThreadMakeNSInvocation(delegate, selector);
-    [invocation setArgument:&object1 atIndex:2];
-    [invocation setArgument:&selectorArg atIndex:3];
-    [invocation setArgument:&object2 atIndex:4];
+    RetainPtr invocation = WebThreadMakeNSInvocation(delegate.get(), selector);
+    [invocation.get() setArgument:&object1 atIndex:2];
+    [invocation.get() setArgument:&selectorArg atIndex:3];
+    [invocation.get() setArgument:&object2 atIndex:4];
 
     BOOL returnValue;
     @try {
-        WebThreadCallDelegate(invocation);
-        [invocation getReturnValue:&returnValue];
+        WebThreadCallDelegate(invocation.get());
+        [invocation.get() getReturnValue:&returnValue];
         return returnValue;
     } @catch(id exception) {
         ReportDiscardedDelegateException(selector, exception);

--- a/Source/WebKitLegacy/mac/WebView/WebDynamicScrollBarsView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebDynamicScrollBarsView.mm
@@ -283,8 +283,8 @@ static const unsigned cMaxUpdateScrollbarsPass = 2;
     // (This will be the common case, e.g., when the page changes due to window resizing for example).
     // This layout will not re-enter updateScrollers and does not count towards our max layout pass total.
     if (!_private->suppressLayout && !_private->suppressScrollers && [documentView isKindOfClass:[WebHTMLView class]]) {
-        WebHTMLView* htmlView = (WebHTMLView*)documentView;
-        if ([htmlView _needsLayout]) {
+        RetainPtr htmlView = (WebHTMLView*)documentView;
+        if ([htmlView.get() _needsLayout]) {
             _private->inUpdateScrollers = YES;
             [(id <WebDocumentView>)documentView layout];
             _private->inUpdateScrollers = NO;
@@ -367,8 +367,8 @@ static const unsigned cMaxUpdateScrollbarsPass = 2;
     _private->verticalScrollingAllowedButScrollerHidden = newHasVerticalScroller && _private->alwaysHideVerticalScroller;
 
     if ([documentView isKindOfClass:[WebHTMLView class]]) {
-        WebHTMLView* htmlView = (WebHTMLView*)documentView;
-        WebCore::ScrollbarWidth scrollbarWidthStyle = [htmlView _scrollbarWidthStyle];
+        RetainPtr htmlView = (WebHTMLView*)documentView;
+        WebCore::ScrollbarWidth scrollbarWidthStyle = [htmlView.get() _scrollbarWidthStyle];
         if (scrollbarWidthStyle == WebCore::ScrollbarWidth::None) {
             _private->horizontalScrollingAllowedButScrollerHidden = true;
             _private->verticalScrollingAllowedButScrollerHidden = true;

--- a/Source/WebKitLegacy/mac/WebView/WebFrameView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrameView.mm
@@ -1143,18 +1143,18 @@ enum {
     unsigned i;
     for (i=0; i < [frameChildren count]; i++) {
         WebFrameView *childFrameView = [[frameChildren objectAtIndex:i] frameView];
-        WebFrameView *scrollableFrameView = [childFrameView _isScrollable] ? childFrameView : [childFrameView _largestScrollableChild];
+        RetainPtr scrollableFrameView = [childFrameView _isScrollable] ? childFrameView : [childFrameView _largestScrollableChild];
         if (!scrollableFrameView)
             continue;
-        
+
         // Some ads lurk in child frames of zero width and height, see radar 4406994. These don't count as scrollable.
         // Maybe someday we'll discover that this minimum area check should be larger, but this covers the known cases.
-        float area = [scrollableFrameView _area];
+        float area = [scrollableFrameView.get() _area];
         if (area < 1.0)
             continue;
-        
+
         if (!largest || (area > [largest _area])) {
-            largest = scrollableFrameView;
+            largest = scrollableFrameView.get();
         }
     }
     
@@ -1173,29 +1173,29 @@ enum {
 - (WebFrameView *)_largestChildWithScrollBars
 {
     // FIXME: This method was used by Safari 4.0.x and older versions, but has not been used by any other WebKit
-    // clients to my knowledge, and will not be used by future versions of Safari. It can probably be removed 
+    // clients to my knowledge, and will not be used by future versions of Safari. It can probably be removed
     // once we no longer need to keep nightly WebKit builds working with Safari 4.0.x and earlier.
     WebFrameView *largest = nil;
     NSArray *frameChildren = [[self webFrame] childFrames];
-    
+
     unsigned i;
     for (i=0; i < [frameChildren count]; i++) {
-        WebFrameView *childFrameView = [[frameChildren objectAtIndex:i] frameView];
-        WebFrameView *scrollableFrameView = [childFrameView _hasScrollBars] ? childFrameView : [childFrameView _largestChildWithScrollBars];
+        RetainPtr childFrameView = [[frameChildren objectAtIndex:i] frameView];
+        RetainPtr scrollableFrameView = [childFrameView _hasScrollBars] ? childFrameView : [childFrameView _largestChildWithScrollBars];
         if (!scrollableFrameView)
             continue;
-        
+
         // Some ads lurk in child frames of zero width and height, see radar 4406994. These don't count as scrollable.
         // Maybe someday we'll discover that this minimum area check should be larger, but this covers the known cases.
-        float area = [scrollableFrameView _area];
+        float area = [scrollableFrameView.get() _area];
         if (area < 1.0)
             continue;
-        
+
         if (!largest || (area > [largest _area])) {
-            largest = scrollableFrameView;
+            largest = scrollableFrameView.get();
         }
     }
-    
+
     return largest;
 }
 

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -721,7 +721,11 @@ static BOOL forceNSViewHitTest;
 // if YES, do the "top WebHTMLView" hit test (which we'd like to do all the time but can't because of Java requirements [see bug 4349721])
 static BOOL forceWebHTMLViewHitTest;
 
-static WebHTMLView *lastHitView;
+static RetainPtr<WebHTMLView>& lastHitView()
+{
+    static NeverDestroyed<RetainPtr<WebHTMLView>> lastHitView;
+    return lastHitView.get();
+}
 
 static bool needsCursorRectsSupportAtPoint(NSWindow* window, NSPoint point)
 {
@@ -779,25 +783,25 @@ static void setCursor(NSWindow *self, SEL cmd, NSPoint point)
     }
 
     static Class webFrameViewClass = [WebFrameView class];
-    WebFrameView *enclosingWebFrameView = (WebFrameView *)self;
-    while (enclosingWebFrameView && ![enclosingWebFrameView isKindOfClass:webFrameViewClass])
-        enclosingWebFrameView = (WebFrameView *)[enclosingWebFrameView superview];
+    RetainPtr enclosingWebFrameView = (WebFrameView *)self;
+    while (enclosingWebFrameView && ![enclosingWebFrameView.get() isKindOfClass:webFrameViewClass])
+        enclosingWebFrameView = (WebFrameView *)[enclosingWebFrameView.get() superview];
 
     if (!enclosingWebFrameView) {
         [self _web_setNeedsDisplayInRect:invalidRect];
         return;
     }
 
-    auto* coreFrame = core([enclosingWebFrameView webFrame]);
+    auto* coreFrame = core([enclosingWebFrameView.get() webFrame]);
     auto* frameView = coreFrame ? coreFrame->view() : 0;
     if (!frameView || !frameView->isEnclosedInCompositingLayer()) {
         [self _web_setNeedsDisplayInRect:invalidRect];
         return;
     }
 
-    NSRect invalidRectInWebFrameViewCoordinates = [enclosingWebFrameView convertRect:invalidRect fromView:self];
+    NSRect invalidRectInWebFrameViewCoordinates = [enclosingWebFrameView.get() convertRect:invalidRect fromView:self];
     WebCore::IntRect invalidRectInFrameViewCoordinates(invalidRectInWebFrameViewCoordinates);
-    if (![enclosingWebFrameView isFlipped])
+    if (![enclosingWebFrameView.get() isFlipped])
         invalidRectInFrameViewCoordinates.setY(frameView->frameRect().size().height() - invalidRectInFrameViewCoordinates.maxY());
 
     frameView->invalidateRect(invalidRectInFrameViewCoordinates);
@@ -1389,7 +1393,7 @@ static NSControlStateValue kit(TriState state)
         if (!attributedString)
             attributedString = [self selectedAttributedString];
         if ([attributedString containsAttachments])
-            attributedString = WebCore::attributedStringByStrippingAttachmentCharacters(attributedString);
+            attributedString = RetainPtr { WebCore::attributedStringByStrippingAttachmentCharacters(attributedString) }.get();
         NSData *RTFData = [attributedString RTFFromRange:NSMakeRange(0, [attributedString length]) documentAttributes:@{ }];
         [pasteboard setData:RTFData forType:WebCore::legacyRTFPasteboardTypeSingleton()];
     }
@@ -1561,8 +1565,8 @@ static NSControlStateValue kit(TriState state)
     _private->savedSubviews = self._subviewsIvar;
     // We need to keep the layer-hosting view in the subviews, otherwise the layers flash.
     if (_private->layerHostingView) {
-        NSMutableArray* newSubviews = [[NSMutableArray alloc] initWithObjects:_private->layerHostingView, nil];
-        self._subviewsIvar = newSubviews;
+        RetainPtr newSubviews = [[NSMutableArray alloc] initWithObjects:_private->layerHostingView, nil];
+        self._subviewsIvar = newSubviews.get();
     } else
         self._subviewsIvar = nil;
     _private->subviewsSetAside = YES;
@@ -1740,10 +1744,10 @@ static BOOL isQuickLookEvent(NSEvent *event)
     }
 
     if (!captureHitsOnSubviews) {
-        NSView* hitView = [super hitTest:point];
-        if (_private && hitView == _private->layerHostingView)
+        RetainPtr hitView = [super hitTest:point];
+        if (_private && hitView.get() == _private->layerHostingView)
             hitView = self;
-        return hitView;
+        return hitView.autorelease();
     }
 #endif // !PLATFORM(IOS_FAMILY)
 
@@ -1867,8 +1871,8 @@ static BOOL isQuickLookEvent(NSEvent *event)
 {
 #if PLATFORM(MAC)
     NSString *toolTip = [string length] == 0 ? nil : string;
-    NSString *oldToolTip = _private->toolTip.get();
-    if (toolTip == oldToolTip || [toolTip isEqualToString:oldToolTip])
+    RetainPtr oldToolTip = _private->toolTip.get();
+    if (toolTip == oldToolTip.get() || [toolTip isEqualToString:oldToolTip.get()])
         return;
     if (oldToolTip)
         [self _sendToolTipMouseExited];
@@ -1923,11 +1927,11 @@ static bool mouseEventIsPartOfClickOrDrag(NSEvent *event)
     forceWebHTMLViewHitTest = NO;
     
     auto view = retainPtr(dynamic_objc_cast<WebHTMLView>(hitView));
-    if (lastHitView != view && lastHitView && [lastHitView _frame]) {
+    if (lastHitView().get() != view && lastHitView().get() && [lastHitView().get() _frame]) {
         // If we are moving out of a view (or frame), let's pretend the mouse moved
         // all the way out of that view. But we have to account for scrolling, because
         // WebCore doesn't understand our clipping.
-        NSRect visibleRect = [[[[lastHitView _frame] frameView] _scrollView] documentVisibleRect];
+        NSRect visibleRect = [[[[lastHitView().get() _frame] frameView] _scrollView] documentVisibleRect];
         float yScroll = visibleRect.origin.y;
         float xScroll = visibleRect.origin.x;
 
@@ -1939,11 +1943,11 @@ static bool mouseEventIsPartOfClickOrDrag(NSEvent *event)
             context:nullptr
             eventNumber:0 clickCount:0 pressure:0];
 
-        if (auto* lastHitCoreFrame = core([lastHitView _frame]))
+        if (auto* lastHitCoreFrame = core([lastHitView().get() _frame]))
             lastHitCoreFrame->eventHandler().mouseMoved(event, [[self _webView] _pressureEvent]);
     }
 
-    lastHitView = view.get();
+    lastHitView() = view;
 
     if (view) {
         if (auto* coreFrame = core([view _frame])) {
@@ -2234,19 +2238,19 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 - (void)_writeSelectionToPasteboard:(NSPasteboard *)pasteboard
 {
     ASSERT([self _hasSelection]);
-    NSArray *types = [self pasteboardTypesForSelection];
+    RetainPtr types = [self pasteboardTypesForSelection];
 
     // Don't write RTFD to the pasteboard when the copied attributed string has no attachments.
     NSAttributedString *attributedString = [self selectedAttributedString];
     RetainPtr<NSMutableArray> mutableTypes;
     if (![attributedString containsAttachments]) {
-        mutableTypes = adoptNS([types mutableCopy]);
+        mutableTypes = adoptNS([types.get() mutableCopy]);
         [mutableTypes removeObject:WebCore::legacyRTFDPasteboardTypeSingleton()];
         types = mutableTypes.get();
     }
 
-    [pasteboard declareTypes:types owner:[self _topHTMLView]];
-    [self _writeSelectionWithPasteboardTypes:types toPasteboard:pasteboard cachedAttributedString:attributedString];
+    [pasteboard declareTypes:types.get() owner:[self _topHTMLView]];
+    [self _writeSelectionWithPasteboardTypes:types.get() toPasteboard:pasteboard cachedAttributedString:attributedString];
 }
 
 #endif
@@ -2261,8 +2265,8 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     _private->closed = YES;
 
 #if PLATFORM(MAC)
-    if (lastHitView == self)
-        lastHitView = nil;
+    if (lastHitView().get() == self)
+        lastHitView() = nil;
 
     [self _removeWindowObservers];
     [self _removeSuperviewObservers];
@@ -3116,24 +3120,24 @@ IGNORE_WARNINGS_END
 
     // Predict the case where we are losing first responder status only to
     // gain it back again. Want to keep the selection in that case.
-    id nextResponder = [[self window] _newFirstResponderAfterResigning];
+    RetainPtr nextResponder = [[self window] _newFirstResponderAfterResigning];
     if ([nextResponder isKindOfClass:[NSScrollView class]]) {
-        id contentView = [nextResponder contentView];
+        RetainPtr contentView = [nextResponder.get() contentView];
         if (contentView)
             nextResponder = contentView;
     }
     if ([nextResponder isKindOfClass:[NSClipView class]]) {
-        id documentView = [nextResponder documentView];
+        RetainPtr documentView = [nextResponder.get() documentView];
         if (documentView)
             nextResponder = documentView;
     }
-    if (nextResponder == self)
+    if (nextResponder.get() == self)
         return YES;
 
     auto* coreFrame = core([self _frame]);
     bool selectionIsEditable = coreFrame && coreFrame->selection().selection().isContentEditable();
-    bool nextResponderIsInWebView = [nextResponder isKindOfClass:[NSView class]]
-        && [nextResponder isDescendantOf:[[[self _webView] mainFrame] frameView]];
+    bool nextResponderIsInWebView = [nextResponder.get() isKindOfClass:[NSView class]]
+        && [nextResponder.get() isDescendantOf:[[[self _webView] mainFrame] frameView]];
 
     return selectionIsEditable && nextResponderIsInWebView;
 #endif
@@ -3245,9 +3249,9 @@ IGNORE_WARNINGS_END
 
 #if PLATFORM(MAC)
         if (!_private->flagsChangedEventMonitor) {
-            __block WebHTMLView *weakSelf = self;
+            __block RetainPtr weakSelf = self;
             _private->flagsChangedEventMonitor = [NSEvent addLocalMonitorForEventsMatchingMask:NSEventMaskFlagsChanged handler:^(NSEvent *flagsChangedEvent) {
-                [weakSelf _postFakeMouseMovedEventForFlagsChangedEvent:flagsChangedEvent];
+                [weakSelf.get() _postFakeMouseMovedEventForFlagsChangedEvent:flagsChangedEvent];
                 return flagsChangedEvent;
             }];
         }
@@ -3656,8 +3660,8 @@ static RetainPtr<NSArray> customMenuFromDefaultItems(WebView *webView, const Web
         });
     }
     auto defaultMenuItems = createMenuItems(hitTestResult, filteredItems);
-    
-    id delegate = [webView UIDelegate];
+
+    RetainPtr delegate = [webView UIDelegate];
     SEL selector = @selector(webView:contextMenuItemsForElement:defaultMenuItems:);
     if (![delegate respondsToSelector:selector])
         return defaultMenuItems;
@@ -3680,9 +3684,9 @@ static RetainPtr<NSArray> customMenuFromDefaultItems(WebView *webView, const Web
 
     auto savedItems = fixMenusToSendToOldClients(defaultMenuItems.get());
 
-    NSArray *delegateSuppliedItems = CallUIDelegate(webView, selector, element.get(), defaultMenuItems.get());
+    RetainPtr delegateSuppliedItems = CallUIDelegate(webView, selector, element.get(), defaultMenuItems.get());
 
-    return fixMenusReceivedFromOldClients(delegateSuppliedItems, savedItems.get());
+    return fixMenusReceivedFromOldClients(delegateSuppliedItems.get(), savedItems.get());
 }
 
 - (NSMenu *)menuForEvent:(NSEvent *)event
@@ -4094,21 +4098,21 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     retainPtr(event).autorelease();
 
     NSView *hitView = [self _hitViewForEvent:event];
-    WebHTMLView *hitHTMLView = [hitView isKindOfClass:[self class]] ? (WebHTMLView *)hitView : nil;
+    RetainPtr<WebHTMLView> hitHTMLView = [hitView isKindOfClass:[self class]] ? (WebHTMLView *)hitView : nil;
 
     if (hitHTMLView) {
         bool result = false;
-        if (auto* coreFrame = core([hitHTMLView _frame])) {
+        if (auto* coreFrame = core([hitHTMLView.get() _frame])) {
             coreFrame->eventHandler().setActivationEventNumber([event eventNumber]);
-            [hitHTMLView _setMouseDownEvent:event];
-            if ([hitHTMLView _isSelectionEvent:event]) {
+            [hitHTMLView.get() _setMouseDownEvent:event];
+            if ([hitHTMLView.get() _isSelectionEvent:event]) {
 #if ENABLE(DRAG_SUPPORT)
                 if (auto* page = coreFrame->page())
                     result = coreFrame->eventHandler().eventMayStartDrag(WebCore::PlatformEventFactory::createPlatformMouseEvent(event, [[self _webView] _pressureEvent], page->chrome().platformPageClient()));
 #endif
-            } else if ([hitHTMLView _isScrollBarEvent:event])
+            } else if ([hitHTMLView.get() _isScrollBarEvent:event])
                 result = true;
-            [hitHTMLView _setMouseDownEvent:nil];
+            [hitHTMLView.get() _setMouseDownEvent:nil];
         }
         return result;
     }
@@ -4123,18 +4127,18 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     retainPtr(event).autorelease();
 
     NSView *hitView = [self _hitViewForEvent:event];
-    WebHTMLView *hitHTMLView = [hitView isKindOfClass:[self class]] ? (WebHTMLView *)hitView : nil;
+    RetainPtr<WebHTMLView> hitHTMLView = [hitView isKindOfClass:[self class]] ? (WebHTMLView *)hitView : nil;
     if (hitHTMLView) {
         bool result = false;
-        if ([hitHTMLView _isSelectionEvent:event]) {
-            [hitHTMLView _setMouseDownEvent:event];
+        if ([hitHTMLView.get() _isSelectionEvent:event]) {
+            [hitHTMLView.get() _setMouseDownEvent:event];
 #if ENABLE(DRAG_SUPPORT)
-            if (auto* coreFrame = core([hitHTMLView _frame])) {
+            if (auto* coreFrame = core([hitHTMLView.get() _frame])) {
                 if (auto* page = coreFrame->page())
                     result = coreFrame->eventHandler().eventMayStartDrag(WebCore::PlatformEventFactory::createPlatformMouseEvent(event, [[self _webView] _pressureEvent], page->chrome().platformPageClient()));
             }
 #endif
-            [hitHTMLView _setMouseDownEvent:nil];
+            [hitHTMLView.get() _setMouseDownEvent:nil];
         }
         return result;
     }
@@ -4343,11 +4347,11 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
             RetainPtr response = tiffResource->response().nsURLResponse();
             draggingElementURL = [response URL];
             wrapper = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:buffer->makeContiguous()->createNSData().get()]);
-            NSString* filename = [response suggestedFilename];
+            RetainPtr filename = [response suggestedFilename];
             RetainPtr trueExtension = tiffResource->image()->filenameExtension().createNSString();
-            if (!matchesExtensionOrEquivalent(filename, trueExtension.get()))
+            if (!matchesExtensionOrEquivalent(filename.get(), trueExtension.get()))
                 filename = [[filename stringByAppendingString:@"."] stringByAppendingString:trueExtension.get()];
-            [wrapper setPreferredFilename:filename];
+            [wrapper setPreferredFilename:filename.get()];
         }
     }
 
@@ -4630,10 +4634,10 @@ static RefPtr<WebCore::KeyboardEvent> currentKeyboardEvent(WebCore::LocalFrame* 
             if (![[self _webView] _isPerformingProgrammaticFocus])
                 [self clearFocus];
         }
-        
-        id nextResponder = [[self window] _newFirstResponderAfterResigning];
-        bool nextResponderIsInWebView = [nextResponder isKindOfClass:[NSView class]]
-            && [nextResponder isDescendantOf:[[[self _webView] mainFrame] frameView]];
+
+        RetainPtr nextResponder = [[self window] _newFirstResponderAfterResigning];
+        bool nextResponderIsInWebView = [nextResponder.get() isKindOfClass:[NSView class]]
+            && [nextResponder.get() isDescendantOf:[[[self _webView] mainFrame] frameView]];
         if (!nextResponderIsInWebView && ![[self _webView] _isPerformingProgrammaticFocus])
             page->focusController().setFocused(false);
     }
@@ -4988,9 +4992,9 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
     if ([attributeName isEqualToString: NSAccessibilityChildrenAttribute]) {
-        id accTree = [[self _frame] accessibilityRoot];
+        RetainPtr accTree = [[self _frame] accessibilityRoot];
         if (accTree)
-            return @[accTree];
+            return @[accTree.get()];
         return nil;
     }
     return [super accessibilityAttributeValue:attributeName];
@@ -5000,21 +5004,21 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (id)accessibilityFocusedUIElement
 {
-    id accTree = [[self _frame] accessibilityRoot];
+    RetainPtr accTree = [[self _frame] accessibilityRoot];
     if (accTree)
-        return [accTree accessibilityFocusedUIElement];
+        return [accTree.get() accessibilityFocusedUIElement];
     return self;
 }
 
 - (id)accessibilityHitTest:(NSPoint)point
 {
-    id accTree = [[self _frame] accessibilityRoot];
+    RetainPtr accTree = [[self _frame] accessibilityRoot];
     if (accTree) {
 #if PLATFORM(IOS_FAMILY)
-        return [accTree accessibilityHitTest:point];
+        return [accTree.get() accessibilityHitTest:point];
 #else
         NSPoint windowCoord = [[self window] convertPointFromScreen:point];
-        return [accTree accessibilityHitTest:[self convertPoint:windowCoord fromView:nil]];
+        return [accTree.get() accessibilityHitTest:[self convertPoint:windowCoord fromView:nil]];
 #endif
     }
     return self;
@@ -5022,13 +5026,13 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (id)_accessibilityParentForSubview:(NSView *)subview
 {
-    id accTree = [[self _frame] accessibilityRoot];
+    RetainPtr accTree = [[self _frame] accessibilityRoot];
     if (!accTree)
         return self;
-    id parent = [accTree _accessibilityParentForSubview:subview];
+    RetainPtr parent = [accTree.get() _accessibilityParentForSubview:subview];
     if (!parent)
         return self;
-    return parent;
+    return parent.autorelease();
 }
 
 - (void)centerSelectionInVisibleArea:(id)sender
@@ -5972,13 +5976,13 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (!platformEvent)
         return NO;
 
-    NSEvent *macEvent = platformEvent->macEvent();
-    if ([macEvent type] == NSEventTypeKeyDown && [_private->completionController filterKeyDown:macEvent])
+    RetainPtr macEvent = platformEvent->macEvent();
+    if ([macEvent.get() type] == NSEventTypeKeyDown && [_private->completionController filterKeyDown:macEvent.get()])
         return YES;
-    
-    if ([macEvent type] == NSEventTypeFlagsChanged)
+
+    if ([macEvent.get() type] == NSEventTypeFlagsChanged)
         return NO;
-    
+
     parameters.event = event;
     _private->interpretKeyEventsParameters = &parameters;
     const Vector<WebCore::KeypressCommand>& commands = event->keypressCommands();
@@ -5992,7 +5996,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         // execute the calls immediately. DOM events like keydown are tweaked to have keyCode of 229, and canceling them has no effect.
         // Unfortunately, there is no real difference between plain text input and IM processing - for example, AppKit queries hasMarkedText
         // when typing with U.S. keyboard, and inserts marked text for dead keys.
-        [self interpretKeyEvents:@[macEvent]];
+        [self interpretKeyEvents:@[macEvent.get()]];
     } else {
         // Are there commands that could just cause text insertion if executed via Editor?
         // WebKit doesn't have enough information about mode to decide how they should be treated, so we leave it upon WebCore
@@ -6136,29 +6140,29 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     }
 
     // Make a container layer, which will get sized/positioned by AppKit and CA.
-    CALayer* viewLayer = [WebRootLayer layer];
+    RetainPtr viewLayer = [WebRootLayer layer];
 
     if ([self layer]) {
         // If we are in a layer-backed view, we need to manually initialize the geometry for our layer.
-        [viewLayer setBounds:NSRectToCGRect([_private->layerHostingView bounds])];
-        [viewLayer setAnchorPoint:CGPointMake(0, [self isFlipped] ? 1 : 0)];
+        [viewLayer.get() setBounds:NSRectToCGRect([_private->layerHostingView bounds])];
+        [viewLayer.get() setAnchorPoint:CGPointMake(0, [self isFlipped] ? 1 : 0)];
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         CGPoint layerPosition = NSPointToCGPoint([self convertPointToBase:[_private->layerHostingView frame].origin]);
 ALLOW_DEPRECATED_DECLARATIONS_END
-        [viewLayer setPosition:layerPosition];
+        [viewLayer.get() setPosition:layerPosition];
     }
-    
-    [_private->layerHostingView setLayer:viewLayer];
+
+    [_private->layerHostingView setLayer:viewLayer.get()];
     [_private->layerHostingView setWantsLayer:YES];
-    
+
     // Parent our root layer in the container layer
-    [viewLayer addSublayer:layer];
-    
+    [viewLayer.get() addSublayer:layer];
+
     if ([[self _webView] _postsAcceleratedCompositingNotifications])
         [[NSNotificationCenter defaultCenter] postNotificationName:_WebViewDidStartAcceleratedCompositingNotification object:[self _webView] userInfo:nil];
 
     if (!_CFExecutableLinkedOnOrAfter(CFSystemVersionMountainLion))
-        [viewLayer setGeometryFlipped:YES];
+        [viewLayer.get() setGeometryFlipped:YES];
 }
 
 - (void)detachRootLayer
@@ -6674,14 +6678,14 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
             if (!platformKeyEvent)
                 return NO;
 
-            NSEvent *nsEvent = platformKeyEvent->macEvent();
-            if (!(nsEvent.modifierFlags & NSEventModifierFlagFunction))
+            RetainPtr nsEvent = platformKeyEvent->macEvent();
+            if (!(nsEvent.get().modifierFlags & NSEventModifierFlagFunction))
                 return NO;
 
             if (![menu respondsToSelector:@selector(_containsItemMatchingEvent:includingDisabledItems:)])
                 return NO;
 
-            return [menu _containsItemMatchingEvent:nsEvent includingDisabledItems:YES];
+            return [menu _containsItemMatchingEvent:nsEvent.get() includingDisabledItems:YES];
 #else
             return NO;
 #endif
@@ -6761,7 +6765,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         // WebKit substitutes nil for input context when in password field, which corresponds to null TSMDocument. So, there is
         // no need to call TSMGetActiveDocument(), which may return an incorrect result when selection hasn't been yet updated
         // after focusing a node.
-        static CFArrayRef inputSources = TISCreateASCIICapableInputSourceList();
+        SUPPRESS_UNCOUNTED_LOCAL static CFArrayRef inputSources = TISCreateASCIICapableInputSourceList();
         TSMSetDocumentProperty(0, kTSMDocumentEnabledInputSourcesPropertyTag, sizeof(CFArrayRef), &inputSources);
     } else {
         if (_private->isInSecureInputState)

--- a/Source/WebKitLegacy/mac/WebView/WebJSPDFDoc.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebJSPDFDoc.mm
@@ -31,6 +31,7 @@
 #import "WebUIDelegate.h"
 #import "WebView.h"
 #import <JavaScriptCore/JSObjectRef.h>
+#import <wtf/RetainPtr.h>
 
 static void jsPDFDocInitialize(JSContextRef ctx, JSObjectRef object)
 {
@@ -49,10 +50,10 @@ static JSValueRef jsPDFDocPrint(JSContextRef ctx, JSObjectRef function, JSObject
     if (!JSValueIsObjectOfClass(ctx, thisObject, jsPDFDocClass()))
         return JSValueMakeUndefined(ctx);
 
-    WebDataSource *dataSource = (__bridge WebDataSource *)JSObjectGetPrivate(thisObject);
+    RetainPtr dataSource = (__bridge WebDataSource *)JSObjectGetPrivate(thisObject);
 
-    WebView *webView = [[dataSource webFrame] webView];
-    CallUIDelegate(webView, @selector(webView:printFrameView:), [[dataSource webFrame] frameView]);
+    WebView *webView = [[dataSource.get() webFrame] webView];
+    CallUIDelegate(webView, @selector(webView:printFrameView:), [[dataSource.get() webFrame] frameView]);
 
     return JSValueMakeUndefined(ctx);
 }

--- a/Source/WebKitLegacy/mac/WebView/WebPDFRepresentation.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPDFRepresentation.mm
@@ -77,13 +77,13 @@
     auto document = adoptNS([[[[self class] PDFDocumentClass] alloc] initWithData:[dataSource data]]);
     [view setPDFDocument:document.get()];
 
-    NSArray *scripts = allScriptsInPDFDocument(document.get());
-    if (![scripts count])
+    RetainPtr scripts = allScriptsInPDFDocument(document.get());
+    if (![scripts.get() count])
         return;
 
     JSGlobalContextRef ctx = JSGlobalContextCreate(0);
     JSObjectRef jsPDFDoc = makeJSPDFDoc(ctx, dataSource);
-    for (NSString *script in scripts)
+    for (NSString *script in scripts.get())
         JSEvaluateScript(ctx, OpaqueJSString::tryCreate(script).get(), jsPDFDoc, nullptr, 0, nullptr);
     JSGlobalContextRelease(ctx);
 }

--- a/Source/WebKitLegacy/mac/WebView/WebPreferences.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferences.mm
@@ -387,7 +387,7 @@ public:
 {
     WebCore::initializeMainThreadIfNeeded();
 
-    NSDictionary *dict = [NSDictionary dictionaryWithObjectsAndKeys:
+    RetainPtr dict = [NSDictionary dictionaryWithObjectsAndKeys:
         INITIALIZE_DEFAULT_PREFERENCES_DICTIONARY_FROM_GENERATED_PREFERENCES
 
         @NO, WebKitUserStyleSheetEnabledPreferenceKey,
@@ -428,7 +428,7 @@ public:
     // This value shouldn't ever change, which is assumed in the initialization of WebKitPDFDisplayModePreferenceKey above
     ASSERT(kPDFDisplaySinglePageContinuous == 1);
 #endif
-    [[NSUserDefaults standardUserDefaults] registerDefaults:dict];
+    [[NSUserDefaults standardUserDefaults] registerDefaults:dict.get()];
 }
 
 - (void)dealloc
@@ -492,13 +492,13 @@ public:
     if (![value isKindOfClass:[NSArray class]])
         return nil;
 
-    NSArray *array = (NSArray *)value;
-    for (id object in array) {
+    RetainPtr array = (NSArray *)value;
+    for (id object in array.get()) {
         if (![object isKindOfClass:[NSString class]])
             return nil;
     }
 
-    return (NSArray<NSString *> *)array;
+    return (NSArray<NSString *> *)array.autorelease();
 }
 
 - (void)_setStringArrayValueForKey:(NSArray<NSString *> *)value forKey:(NSString *)key

--- a/Source/WebKitLegacy/mac/WebView/WebResource.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebResource.mm
@@ -119,36 +119,36 @@ static NSString * const WebResourceResponseKey =          @"WebResourceResponse"
     if (!self)
         return nil;
 
-    NSData *data = nil;
-    NSURL *url = nil;
-    NSString *mimeType = nil, *textEncoding = nil, *frameName = nil;
-    NSURLResponse *response = nil;
-    
+    RetainPtr<NSData> data;
+    RetainPtr<NSURL> url;
+    RetainPtr<NSString> mimeType, textEncoding, frameName;
+    RetainPtr<NSURLResponse> response;
+
     @try {
-        id object = [decoder decodeObjectForKey:WebResourceDataKey];
+        RetainPtr object = [decoder decodeObjectForKey:WebResourceDataKey];
         if ([object isKindOfClass:[NSData class]])
-            data = object;
+            data = object.get();
         object = [decoder decodeObjectForKey:WebResourceURLKey];
         if ([object isKindOfClass:[NSURL class]])
-            url = object;
+            url = object.get();
         object = [decoder decodeObjectForKey:WebResourceMIMETypeKey];
         if ([object isKindOfClass:[NSString class]])
-            mimeType = object;
+            mimeType = object.get();
         object = [decoder decodeObjectForKey:WebResourceTextEncodingNameKey];
         if ([object isKindOfClass:[NSString class]])
-            textEncoding = object;
+            textEncoding = object.get();
         object = [decoder decodeObjectForKey:WebResourceFrameNameKey];
         if ([object isKindOfClass:[NSString class]])
-            frameName = object;
+            frameName = object.get();
         object = [decoder decodeObjectForKey:WebResourceResponseKey];
         if ([object isKindOfClass:[NSURLResponse class]])
-            response = object;
+            response = object.get();
     } @catch(id) {
         [self release];
         return nil;
     }
 
-    auto coreResource = ArchiveResource::create(SharedBuffer::create(data), url, mimeType, textEncoding, frameName, response);
+    auto coreResource = ArchiveResource::create(SharedBuffer::create(data.get()), url.get(), mimeType.get(), textEncoding.get(), frameName.get(), response.get());
     if (!coreResource) {
         [self release];
         return nil;
@@ -334,11 +334,11 @@ static NSString * const WebResourceResponseKey =          @"WebResourceResponse"
 #if !PLATFORM(IOS_FAMILY)
 - (NSFileWrapper *)_fileWrapperRepresentation
 {
-    auto wrapper = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:[self data]]);
-    NSString *filename = [self _suggestedFilename];
-    if (!filename || ![filename length])
+    RetainPtr wrapper = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:[self data]]);
+    RetainPtr filename = [self _suggestedFilename];
+    if (!filename || ![filename.get() length])
         filename = [[self URL] _webkit_suggestedFilenameWithMIMEType:[self MIMEType]];
-    [wrapper setPreferredFilename:filename];
+    [wrapper.get() setPreferredFilename:filename.get()];
     return wrapper.autorelease();
 }
 #endif

--- a/Source/WebKitLegacy/mac/WebView/WebScriptDebugDelegate.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebScriptDebugDelegate.mm
@@ -96,15 +96,15 @@ NSString * const WebScriptErrorLineNumberKey = @"WebScriptErrorLineNumber";
     if (!value)
         return nil;
 
-    WebScriptObject *globalObject = _private->globalObject;
-    if (value == [globalObject _imp])
-        return globalObject;
+    RetainPtr globalObject = _private->globalObject;
+    if (value == [globalObject.get() _imp])
+        return globalObject.autorelease();
 
-    JSC::Bindings::RootObject* root1 = [globalObject _originRootObject];
+    JSC::Bindings::RootObject* root1 = [globalObject.get() _originRootObject];
     if (!root1)
         return nil;
 
-    JSC::Bindings::RootObject* root2 = [globalObject _rootObject];
+    JSC::Bindings::RootObject* root2 = [globalObject.get() _rootObject];
     if (!root2)
         return nil;
 

--- a/Source/WebKitLegacy/mac/WebView/WebScriptWorld.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebScriptWorld.mm
@@ -86,8 +86,8 @@ static WorldMap& allWorlds()
 
 + (WebScriptWorld *)standardWorld
 {
-    static WebScriptWorld *world = [[WebScriptWorld alloc] initWithWorld:WebCore::mainThreadNormalWorldSingleton()];
-    return world;
+    static NeverDestroyed<RetainPtr<WebScriptWorld>> world = [[WebScriptWorld alloc] initWithWorld:WebCore::mainThreadNormalWorldSingleton()];
+    return world->get();
 }
 
 + (WebScriptWorld *)world

--- a/Source/WebKitLegacy/mac/WebView/WebTextCompletionController.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebTextCompletionController.mm
@@ -170,11 +170,11 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
         // Get preceeding word stem
         WebFrame *frame = [_htmlView _frame];
-        DOMRange *selection = kit(core(frame)->selection().selection().toNormalizedRange());
+        RetainPtr selection = kit(core(frame)->selection().selection().toNormalizedRange());
         DOMRange *wholeWord = [frame _rangeByAlteringCurrentSelection:FrameSelection::Alteration::Extend
             direction:SelectionDirection::Backward granularity:TextGranularity::WordGranularity];
         DOMRange *prefix = [wholeWord cloneRange];
-        [prefix setEnd:[selection startContainer] offset:[selection startOffset]];
+        [prefix setEnd:[selection.get() startContainer] offset:[selection.get() startOffset]];
 
         // Reject some NOP cases
         if ([prefix collapsed]) {
@@ -200,7 +200,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
             [self _insertMatch:[_completions objectAtIndex:0]];
         } else {
             ASSERT(!_originalString);       // this should only be set IFF we have a popup window
-            _originalString = [[frame _stringForRange:selection] retain];
+            _originalString = [[frame _stringForRange:selection.get()] retain];
             [self _buildUI];
             NSRect wordRect = [frame _caretRectAtPosition:Position(core([wholeWord startContainer]), [wholeWord startOffset], Position::PositionIsOffsetInAnchor) affinity:NSSelectionAffinityDownstream];
             // +1 to be under the word, not the caret

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -1018,22 +1018,22 @@ static const NSUInteger orderedListSegment = 2;
 
     _webView = webView;
 
-    NSSegmentedControl *insertListControl = [NSSegmentedControl segmentedControlWithLabels:@[ WebCore::insertListTypeNone().createNSString().get(), WebCore::insertListTypeBulleted().createNSString().get(), WebCore::insertListTypeNumbered().createNSString().get() ] trackingMode:NSSegmentSwitchTrackingSelectOne target:self action:@selector(_selectList:)];
-    [insertListControl setWidth:listControlSegmentWidth forSegment:noListSegment];
-    [insertListControl setWidth:listControlSegmentWidth forSegment:unorderedListSegment];
-    [insertListControl setWidth:listControlSegmentWidth forSegment:orderedListSegment];
-    insertListControl.font = [NSFont systemFontOfSize:15];
+    RetainPtr insertListControl = [NSSegmentedControl segmentedControlWithLabels:@[ WebCore::insertListTypeNone().createNSString().get(), WebCore::insertListTypeBulleted().createNSString().get(), WebCore::insertListTypeNumbered().createNSString().get() ] trackingMode:NSSegmentSwitchTrackingSelectOne target:self action:@selector(_selectList:)];
+    [insertListControl.get() setWidth:listControlSegmentWidth forSegment:noListSegment];
+    [insertListControl.get() setWidth:listControlSegmentWidth forSegment:unorderedListSegment];
+    [insertListControl.get() setWidth:listControlSegmentWidth forSegment:orderedListSegment];
+    insertListControl.get().font = [NSFont systemFontOfSize:15];
 
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    id segmentElement = NSAccessibilityUnignoredDescendant(insertListControl);
-    NSArray *segments = [segmentElement accessibilityAttributeValue:NSAccessibilityChildrenAttribute];
+    RetainPtr<id> segmentElement = NSAccessibilityUnignoredDescendant(insertListControl.get());
+    NSArray *segments = [segmentElement.get() accessibilityAttributeValue:NSAccessibilityChildrenAttribute];
     ASSERT(segments.count == 3);
     [segments[noListSegment] accessibilitySetOverrideValue:WebCore::insertListTypeNone().createNSString().get() forAttribute:NSAccessibilityDescriptionAttribute];
     [segments[unorderedListSegment] accessibilitySetOverrideValue:WebCore::insertListTypeBulletedAccessibilityTitle().createNSString().get() forAttribute:NSAccessibilityDescriptionAttribute];
     [segments[orderedListSegment] accessibilitySetOverrideValue:WebCore::insertListTypeNumberedAccessibilityTitle().createNSString().get() forAttribute:NSAccessibilityDescriptionAttribute];
 ALLOW_DEPRECATED_DECLARATIONS_END
 
-    self.view = insertListControl;
+    self.view = insertListControl.autorelease();
 
     return self;
 }
@@ -1044,7 +1044,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (![documentView isKindOfClass:[WebHTMLView class]])
         return;
 
-    WebHTMLView *webHTMLView = (WebHTMLView *)documentView;
+    RetainPtr webHTMLView = (WebHTMLView *)documentView;
     NSSegmentedControl *insertListControl = (NSSegmentedControl *)self.view;
     switch (insertListControl.selectedSegment) {
     case noListSegment:
@@ -1052,15 +1052,15 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         // behave as toggles, so we can invoke the appropriate method depending on our _currentListType
         // to remove an existing list. We don't have to do anything if _currentListType is WebListType::None.
         if (_currentListType == WebListType::Ordered)
-            [webHTMLView _insertOrderedList];
+            [webHTMLView.get() _insertOrderedList];
         else if (_currentListType == WebListType::Unordered)
-            [webHTMLView _insertUnorderedList];
+            [webHTMLView.get() _insertUnorderedList];
         break;
     case unorderedListSegment:
-        [webHTMLView _insertUnorderedList];
+        [webHTMLView.get() _insertUnorderedList];
         break;
     case orderedListSegment:
-        [webHTMLView _insertOrderedList];
+        [webHTMLView.get() _insertOrderedList];
         break;
     }
 
@@ -1135,15 +1135,15 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (isTextFormatItem || [identifier isEqualToString:NSTouchBarItemIdentifierTextAlignment])
         self.textAlignments.action = @selector(_webChangeTextAlignment:);
 
-    NSColorPickerTouchBarItem *colorPickerItem = nil;
+    RetainPtr<NSColorPickerTouchBarItem> colorPickerItem = nil;
     if ([identifier isEqualToString:NSTouchBarItemIdentifierTextColorPicker] && [item isKindOfClass:[NSColorPickerTouchBarItem class]])
         colorPickerItem = (NSColorPickerTouchBarItem *)item;
     if (isTextFormatItem)
         colorPickerItem = self.colorPickerItem;
     if (colorPickerItem) {
-        colorPickerItem.target = self;
-        colorPickerItem.action = @selector(_webChangeColor:);
-        colorPickerItem.showsAlpha = NO;
+        colorPickerItem.get().target = self;
+        colorPickerItem.get().action = @selector(_webChangeColor:);
+        colorPickerItem.get().showsAlpha = NO;
     }
 
     return item;
@@ -2290,9 +2290,9 @@ static NSMutableSet *knownPluginMIMETypes()
 
 - (void)_dispatchTileDidDraw:(CALayer*)tile
 {
-    id mailDelegate = [self _webMailDelegate];
-    if ([mailDelegate respondsToSelector:@selector(_webthread_webView:tileDidDraw:)]) {
-        [mailDelegate _webthread_webView:self tileDidDraw:tile];
+    RetainPtr mailDelegate = [self _webMailDelegate];
+    if ([mailDelegate.get() respondsToSelector:@selector(_webthread_webView:tileDidDraw:)]) {
+        [mailDelegate.get() _webthread_webView:self tileDidDraw:tile];
         return;
     }
 
@@ -2702,7 +2702,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (NSMenu *)_menuForElement:(NSDictionary *)element defaultItems:(NSArray *)items
 {
     NSArray *defaultMenuItems = [[WebDefaultUIDelegate sharedUIDelegate] webView:self contextMenuItemsForElement:element defaultMenuItems:items];
-    NSArray *menuItems = defaultMenuItems;
+    RetainPtr menuItems = defaultMenuItems;
 
     // CallUIDelegate returns nil if UIDelegate is nil or doesn't respond to the selector. So we need to check that here
     // to distinguish between using defaultMenuItems or the delegate really returning nil to say "no context menu".
@@ -2713,13 +2713,13 @@ ALLOW_DEPRECATED_DECLARATIONS_END
             return nil;
     }
 
-    unsigned count = [menuItems count];
+    unsigned count = [menuItems.get() count];
     if (!count)
         return nil;
 
     auto menu = adoptNS([[NSMenu alloc] init]);
     for (unsigned i = 0; i < count; i++)
-        [menu addItem:[menuItems objectAtIndex:i]];
+        [menu addItem:[menuItems.get() objectAtIndex:i]];
 
     return menu.autorelease();
 }
@@ -2917,8 +2917,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #if PLATFORM(MAC)
     // This parses the user stylesheet synchronously so anything that may affect it should be done first.
     if ([preferences userStyleSheetEnabled]) {
-        NSString* location = [[preferences userStyleSheetLocation] _web_originalDataAsString];
-        settings.setUserStyleSheetLocation([NSURL URLWithString:(location ? location : @"")]);
+        RetainPtr location = [[preferences userStyleSheetLocation] _web_originalDataAsString];
+        settings.setUserStyleSheetLocation([NSURL URLWithString:(location.get() ? location.get() : @"")]);
     } else
         settings.setUserStyleSheetLocation([NSURL URLWithString:@""]);
 #endif
@@ -2970,88 +2970,88 @@ static inline IMP getMethod(id o, SEL s)
 - (void)_cacheResourceLoadDelegateImplementations
 {
     WebResourceDelegateImplementationCache *cache = &_private->resourceLoadDelegateImplementations;
-    id delegate = _private->resourceProgressDelegate;
+    RetainPtr<id> delegate = _private->resourceProgressDelegate;
 
     if (!delegate) {
         bzero(cache, sizeof(WebResourceDelegateImplementationCache));
         return;
     }
 
-    cache->didFailLoadingWithErrorFromDataSourceFunc = getMethod(delegate, @selector(webView:resource:didFailLoadingWithError:fromDataSource:));
-    cache->didFinishLoadingFromDataSourceFunc = getMethod(delegate, @selector(webView:resource:didFinishLoadingFromDataSource:));
-    cache->didLoadResourceFromMemoryCacheFunc = getMethod(delegate, @selector(webView:didLoadResourceFromMemoryCache:response:length:fromDataSource:));
-    cache->didReceiveAuthenticationChallengeFunc = getMethod(delegate, @selector(webView:resource:didReceiveAuthenticationChallenge:fromDataSource:));
+    cache->didFailLoadingWithErrorFromDataSourceFunc = getMethod(delegate.get(), @selector(webView:resource:didFailLoadingWithError:fromDataSource:));
+    cache->didFinishLoadingFromDataSourceFunc = getMethod(delegate.get(), @selector(webView:resource:didFinishLoadingFromDataSource:));
+    cache->didLoadResourceFromMemoryCacheFunc = getMethod(delegate.get(), @selector(webView:didLoadResourceFromMemoryCache:response:length:fromDataSource:));
+    cache->didReceiveAuthenticationChallengeFunc = getMethod(delegate.get(), @selector(webView:resource:didReceiveAuthenticationChallenge:fromDataSource:));
 #if USE(PROTECTION_SPACE_AUTH_CALLBACK)
-    cache->canAuthenticateAgainstProtectionSpaceFunc = getMethod(delegate, @selector(webView:resource:canAuthenticateAgainstProtectionSpace:forDataSource:));
+    cache->canAuthenticateAgainstProtectionSpaceFunc = getMethod(delegate.get(), @selector(webView:resource:canAuthenticateAgainstProtectionSpace:forDataSource:));
 #endif
 
 #if PLATFORM(IOS_FAMILY)
-    cache->connectionPropertiesFunc = getMethod(delegate, @selector(webView:connectionPropertiesForResource:dataSource:));
-    cache->webThreadDidFinishLoadingFromDataSourceFunc = getMethod(delegate, @selector(webThreadWebView:resource:didFinishLoadingFromDataSource:));
-    cache->webThreadDidFailLoadingWithErrorFromDataSourceFunc = getMethod(delegate, @selector(webThreadWebView:resource:didFailLoadingWithError:fromDataSource:));
-    cache->webThreadIdentifierForRequestFunc = getMethod(delegate, @selector(webThreadWebView:identifierForInitialRequest:fromDataSource:));
-    cache->webThreadDidLoadResourceFromMemoryCacheFunc = getMethod(delegate, @selector(webThreadWebView:didLoadResourceFromMemoryCache:response:length:fromDataSource:));
-    cache->webThreadWillSendRequestFunc = getMethod(delegate, @selector(webThreadWebView:resource:willSendRequest:redirectResponse:fromDataSource:));
-    cache->webThreadDidReceiveResponseFunc = getMethod(delegate, @selector(webThreadWebView:resource:didReceiveResponse:fromDataSource:));
-    cache->webThreadDidReceiveContentLengthFunc = getMethod(delegate, @selector(webThreadWebView:resource:didReceiveContentLength:fromDataSource:));
-    cache->webThreadWillCacheResponseFunc = getMethod(delegate, @selector(webThreadWebView:resource:willCacheResponse:fromDataSource:));
+    cache->connectionPropertiesFunc = getMethod(delegate.get(), @selector(webView:connectionPropertiesForResource:dataSource:));
+    cache->webThreadDidFinishLoadingFromDataSourceFunc = getMethod(delegate.get(), @selector(webThreadWebView:resource:didFinishLoadingFromDataSource:));
+    cache->webThreadDidFailLoadingWithErrorFromDataSourceFunc = getMethod(delegate.get(), @selector(webThreadWebView:resource:didFailLoadingWithError:fromDataSource:));
+    cache->webThreadIdentifierForRequestFunc = getMethod(delegate.get(), @selector(webThreadWebView:identifierForInitialRequest:fromDataSource:));
+    cache->webThreadDidLoadResourceFromMemoryCacheFunc = getMethod(delegate.get(), @selector(webThreadWebView:didLoadResourceFromMemoryCache:response:length:fromDataSource:));
+    cache->webThreadWillSendRequestFunc = getMethod(delegate.get(), @selector(webThreadWebView:resource:willSendRequest:redirectResponse:fromDataSource:));
+    cache->webThreadDidReceiveResponseFunc = getMethod(delegate.get(), @selector(webThreadWebView:resource:didReceiveResponse:fromDataSource:));
+    cache->webThreadDidReceiveContentLengthFunc = getMethod(delegate.get(), @selector(webThreadWebView:resource:didReceiveContentLength:fromDataSource:));
+    cache->webThreadWillCacheResponseFunc = getMethod(delegate.get(), @selector(webThreadWebView:resource:willCacheResponse:fromDataSource:));
 #endif
 
-    cache->didReceiveContentLengthFunc = getMethod(delegate, @selector(webView:resource:didReceiveContentLength:fromDataSource:));
-    cache->didReceiveResponseFunc = getMethod(delegate, @selector(webView:resource:didReceiveResponse:fromDataSource:));
-    cache->identifierForRequestFunc = getMethod(delegate, @selector(webView:identifierForInitialRequest:fromDataSource:));
-    cache->plugInFailedWithErrorFunc = getMethod(delegate, @selector(webView:plugInFailedWithError:dataSource:));
-    cache->willCacheResponseFunc = getMethod(delegate, @selector(webView:resource:willCacheResponse:fromDataSource:));
-    cache->willSendRequestFunc = getMethod(delegate, @selector(webView:resource:willSendRequest:redirectResponse:fromDataSource:));
-    cache->shouldUseCredentialStorageFunc = getMethod(delegate, @selector(webView:resource:shouldUseCredentialStorageForDataSource:));
-    cache->shouldPaintBrokenImageForURLFunc = getMethod(delegate, @selector(webView:shouldPaintBrokenImageForURL:));
+    cache->didReceiveContentLengthFunc = getMethod(delegate.get(), @selector(webView:resource:didReceiveContentLength:fromDataSource:));
+    cache->didReceiveResponseFunc = getMethod(delegate.get(), @selector(webView:resource:didReceiveResponse:fromDataSource:));
+    cache->identifierForRequestFunc = getMethod(delegate.get(), @selector(webView:identifierForInitialRequest:fromDataSource:));
+    cache->plugInFailedWithErrorFunc = getMethod(delegate.get(), @selector(webView:plugInFailedWithError:dataSource:));
+    cache->willCacheResponseFunc = getMethod(delegate.get(), @selector(webView:resource:willCacheResponse:fromDataSource:));
+    cache->willSendRequestFunc = getMethod(delegate.get(), @selector(webView:resource:willSendRequest:redirectResponse:fromDataSource:));
+    cache->shouldUseCredentialStorageFunc = getMethod(delegate.get(), @selector(webView:resource:shouldUseCredentialStorageForDataSource:));
+    cache->shouldPaintBrokenImageForURLFunc = getMethod(delegate.get(), @selector(webView:shouldPaintBrokenImageForURL:));
 }
 
 - (void)_cacheFrameLoadDelegateImplementations
 {
     WebFrameLoadDelegateImplementationCache *cache = &_private->frameLoadDelegateImplementations;
-    id delegate = _private->frameLoadDelegate;
+    RetainPtr<id> delegate = _private->frameLoadDelegate;
 
     if (!delegate) {
         bzero(cache, sizeof(WebFrameLoadDelegateImplementationCache));
         return;
     }
 
-    cache->didCancelClientRedirectForFrameFunc = getMethod(delegate, @selector(webView:didCancelClientRedirectForFrame:));
-    cache->didChangeLocationWithinPageForFrameFunc = getMethod(delegate, @selector(webView:didChangeLocationWithinPageForFrame:));
-    cache->didPushStateWithinPageForFrameFunc = getMethod(delegate, @selector(webView:didPushStateWithinPageForFrame:));
-    cache->didReplaceStateWithinPageForFrameFunc = getMethod(delegate, @selector(webView:didReplaceStateWithinPageForFrame:));
-    cache->didPopStateWithinPageForFrameFunc = getMethod(delegate, @selector(webView:didPopStateWithinPageForFrame:));
+    cache->didCancelClientRedirectForFrameFunc = getMethod(delegate.get(), @selector(webView:didCancelClientRedirectForFrame:));
+    cache->didChangeLocationWithinPageForFrameFunc = getMethod(delegate.get(), @selector(webView:didChangeLocationWithinPageForFrame:));
+    cache->didPushStateWithinPageForFrameFunc = getMethod(delegate.get(), @selector(webView:didPushStateWithinPageForFrame:));
+    cache->didReplaceStateWithinPageForFrameFunc = getMethod(delegate.get(), @selector(webView:didReplaceStateWithinPageForFrame:));
+    cache->didPopStateWithinPageForFrameFunc = getMethod(delegate.get(), @selector(webView:didPopStateWithinPageForFrame:));
 #if JSC_OBJC_API_ENABLED
-    cache->didCreateJavaScriptContextForFrameFunc = getMethod(delegate, @selector(webView:didCreateJavaScriptContext:forFrame:));
+    cache->didCreateJavaScriptContextForFrameFunc = getMethod(delegate.get(), @selector(webView:didCreateJavaScriptContext:forFrame:));
 #endif
-    cache->didClearWindowObjectForFrameFunc = getMethod(delegate, @selector(webView:didClearWindowObject:forFrame:));
-    cache->didClearWindowObjectForFrameInScriptWorldFunc = getMethod(delegate, @selector(webView:didClearWindowObjectForFrame:inScriptWorld:));
-    cache->didClearInspectorWindowObjectForFrameFunc = getMethod(delegate, @selector(webView:didClearInspectorWindowObject:forFrame:));
-    cache->didCommitLoadForFrameFunc = getMethod(delegate, @selector(webView:didCommitLoadForFrame:));
-    cache->didFailLoadWithErrorForFrameFunc = getMethod(delegate, @selector(webView:didFailLoadWithError:forFrame:));
-    cache->didFailProvisionalLoadWithErrorForFrameFunc = getMethod(delegate, @selector(webView:didFailProvisionalLoadWithError:forFrame:));
-    cache->didFinishDocumentLoadForFrameFunc = getMethod(delegate, @selector(webView:didFinishDocumentLoadForFrame:));
-    cache->didFinishLoadForFrameFunc = getMethod(delegate, @selector(webView:didFinishLoadForFrame:));
-    cache->didFirstLayoutInFrameFunc = getMethod(delegate, @selector(webView:didFirstLayoutInFrame:));
-    cache->didFirstVisuallyNonEmptyLayoutInFrameFunc = getMethod(delegate, @selector(webView:didFirstVisuallyNonEmptyLayoutInFrame:));
-    cache->didLayoutFunc = getMethod(delegate, @selector(webView:didLayout:));
-    cache->didHandleOnloadEventsForFrameFunc = getMethod(delegate, @selector(webView:didHandleOnloadEventsForFrame:));
+    cache->didClearWindowObjectForFrameFunc = getMethod(delegate.get(), @selector(webView:didClearWindowObject:forFrame:));
+    cache->didClearWindowObjectForFrameInScriptWorldFunc = getMethod(delegate.get(), @selector(webView:didClearWindowObjectForFrame:inScriptWorld:));
+    cache->didClearInspectorWindowObjectForFrameFunc = getMethod(delegate.get(), @selector(webView:didClearInspectorWindowObject:forFrame:));
+    cache->didCommitLoadForFrameFunc = getMethod(delegate.get(), @selector(webView:didCommitLoadForFrame:));
+    cache->didFailLoadWithErrorForFrameFunc = getMethod(delegate.get(), @selector(webView:didFailLoadWithError:forFrame:));
+    cache->didFailProvisionalLoadWithErrorForFrameFunc = getMethod(delegate.get(), @selector(webView:didFailProvisionalLoadWithError:forFrame:));
+    cache->didFinishDocumentLoadForFrameFunc = getMethod(delegate.get(), @selector(webView:didFinishDocumentLoadForFrame:));
+    cache->didFinishLoadForFrameFunc = getMethod(delegate.get(), @selector(webView:didFinishLoadForFrame:));
+    cache->didFirstLayoutInFrameFunc = getMethod(delegate.get(), @selector(webView:didFirstLayoutInFrame:));
+    cache->didFirstVisuallyNonEmptyLayoutInFrameFunc = getMethod(delegate.get(), @selector(webView:didFirstVisuallyNonEmptyLayoutInFrame:));
+    cache->didLayoutFunc = getMethod(delegate.get(), @selector(webView:didLayout:));
+    cache->didHandleOnloadEventsForFrameFunc = getMethod(delegate.get(), @selector(webView:didHandleOnloadEventsForFrame:));
 #if PLATFORM(MAC)
-    cache->didReceiveIconForFrameFunc = getMethod(delegate, @selector(webView:didReceiveIcon:forFrame:));
+    cache->didReceiveIconForFrameFunc = getMethod(delegate.get(), @selector(webView:didReceiveIcon:forFrame:));
 #endif
-    cache->didReceiveServerRedirectForProvisionalLoadForFrameFunc = getMethod(delegate, @selector(webView:didReceiveServerRedirectForProvisionalLoadForFrame:));
-    cache->didReceiveTitleForFrameFunc = getMethod(delegate, @selector(webView:didReceiveTitle:forFrame:));
-    cache->didStartProvisionalLoadForFrameFunc = getMethod(delegate, @selector(webView:didStartProvisionalLoadForFrame:));
-    cache->willCloseFrameFunc = getMethod(delegate, @selector(webView:willCloseFrame:));
-    cache->willPerformClientRedirectToURLDelayFireDateForFrameFunc = getMethod(delegate, @selector(webView:willPerformClientRedirectToURL:delay:fireDate:forFrame:));
-    cache->windowScriptObjectAvailableFunc = getMethod(delegate, @selector(webView:windowScriptObjectAvailable:));
-    cache->didDisplayInsecureContentFunc = getMethod(delegate, @selector(webViewDidDisplayInsecureContent:));
-    cache->didRunInsecureContentFunc = getMethod(delegate, @selector(webView:didRunInsecureContent:));
-    cache->didDetectXSSFunc = getMethod(delegate, @selector(webView:didDetectXSS:));
-    cache->didRemoveFrameFromHierarchyFunc = getMethod(delegate, @selector(webView:didRemoveFrameFromHierarchy:));
+    cache->didReceiveServerRedirectForProvisionalLoadForFrameFunc = getMethod(delegate.get(), @selector(webView:didReceiveServerRedirectForProvisionalLoadForFrame:));
+    cache->didReceiveTitleForFrameFunc = getMethod(delegate.get(), @selector(webView:didReceiveTitle:forFrame:));
+    cache->didStartProvisionalLoadForFrameFunc = getMethod(delegate.get(), @selector(webView:didStartProvisionalLoadForFrame:));
+    cache->willCloseFrameFunc = getMethod(delegate.get(), @selector(webView:willCloseFrame:));
+    cache->willPerformClientRedirectToURLDelayFireDateForFrameFunc = getMethod(delegate.get(), @selector(webView:willPerformClientRedirectToURL:delay:fireDate:forFrame:));
+    cache->windowScriptObjectAvailableFunc = getMethod(delegate.get(), @selector(webView:windowScriptObjectAvailable:));
+    cache->didDisplayInsecureContentFunc = getMethod(delegate.get(), @selector(webViewDidDisplayInsecureContent:));
+    cache->didRunInsecureContentFunc = getMethod(delegate.get(), @selector(webView:didRunInsecureContent:));
+    cache->didDetectXSSFunc = getMethod(delegate.get(), @selector(webView:didDetectXSS:));
+    cache->didRemoveFrameFromHierarchyFunc = getMethod(delegate.get(), @selector(webView:didRemoveFrameFromHierarchy:));
 #if PLATFORM(IOS_FAMILY)
-    cache->webThreadDidLayoutFunc = getMethod(delegate, @selector(webThreadWebView:didLayout:));
+    cache->webThreadDidLayoutFunc = getMethod(delegate.get(), @selector(webThreadWebView:didLayout:));
 #endif
 
     // It would be nice to get rid of this code and transition all clients to using didLayout instead of
@@ -3073,50 +3073,50 @@ static inline IMP getMethod(id o, SEL s)
 - (void)_cacheScriptDebugDelegateImplementations
 {
     WebScriptDebugDelegateImplementationCache *cache = &_private->scriptDebugDelegateImplementations;
-    id delegate = _private->scriptDebugDelegate;
+    RetainPtr<id> delegate = _private->scriptDebugDelegate;
 
     if (!delegate) {
         bzero(cache, sizeof(WebScriptDebugDelegateImplementationCache));
         return;
     }
 
-    cache->didParseSourceFunc = getMethod(delegate, @selector(webView:didParseSource:baseLineNumber:fromURL:sourceId:forWebFrame:));
+    cache->didParseSourceFunc = getMethod(delegate.get(), @selector(webView:didParseSource:baseLineNumber:fromURL:sourceId:forWebFrame:));
     if (cache->didParseSourceFunc)
         cache->didParseSourceExpectsBaseLineNumber = YES;
     else {
         cache->didParseSourceExpectsBaseLineNumber = NO;
-        cache->didParseSourceFunc = getMethod(delegate, @selector(webView:didParseSource:fromURL:sourceId:forWebFrame:));
+        cache->didParseSourceFunc = getMethod(delegate.get(), @selector(webView:didParseSource:fromURL:sourceId:forWebFrame:));
     }
 
-    cache->failedToParseSourceFunc = getMethod(delegate, @selector(webView:failedToParseSource:baseLineNumber:fromURL:withError:forWebFrame:));
+    cache->failedToParseSourceFunc = getMethod(delegate.get(), @selector(webView:failedToParseSource:baseLineNumber:fromURL:withError:forWebFrame:));
 
-    cache->exceptionWasRaisedFunc = getMethod(delegate, @selector(webView:exceptionWasRaised:hasHandler:sourceId:line:forWebFrame:));
+    cache->exceptionWasRaisedFunc = getMethod(delegate.get(), @selector(webView:exceptionWasRaised:hasHandler:sourceId:line:forWebFrame:));
     if (cache->exceptionWasRaisedFunc)
         cache->exceptionWasRaisedExpectsHasHandlerFlag = YES;
     else {
         cache->exceptionWasRaisedExpectsHasHandlerFlag = NO;
-        cache->exceptionWasRaisedFunc = getMethod(delegate, @selector(webView:exceptionWasRaised:sourceId:line:forWebFrame:));
+        cache->exceptionWasRaisedFunc = getMethod(delegate.get(), @selector(webView:exceptionWasRaised:sourceId:line:forWebFrame:));
     }
 }
 
 - (void)_cacheHistoryDelegateImplementations
 {
     WebHistoryDelegateImplementationCache *cache = &_private->historyDelegateImplementations;
-    id delegate = _private->historyDelegate;
+    RetainPtr<id> delegate = _private->historyDelegate;
 
     if (!delegate) {
         bzero(cache, sizeof(WebHistoryDelegateImplementationCache));
         return;
     }
 
-    cache->navigatedFunc = getMethod(delegate, @selector(webView:didNavigateWithNavigationData:inFrame:));
-    cache->clientRedirectFunc = getMethod(delegate, @selector(webView:didPerformClientRedirectFromURL:toURL:inFrame:));
-    cache->serverRedirectFunc = getMethod(delegate, @selector(webView:didPerformServerRedirectFromURL:toURL:inFrame:));
+    cache->navigatedFunc = getMethod(delegate.get(), @selector(webView:didNavigateWithNavigationData:inFrame:));
+    cache->clientRedirectFunc = getMethod(delegate.get(), @selector(webView:didPerformClientRedirectFromURL:toURL:inFrame:));
+    cache->serverRedirectFunc = getMethod(delegate.get(), @selector(webView:didPerformServerRedirectFromURL:toURL:inFrame:));
 IGNORE_WARNINGS_BEGIN("undeclared-selector")
-    cache->deprecatedSetTitleFunc = getMethod(delegate, @selector(webView:updateHistoryTitle:forURL:));
+    cache->deprecatedSetTitleFunc = getMethod(delegate.get(), @selector(webView:updateHistoryTitle:forURL:));
 IGNORE_WARNINGS_END
-    cache->setTitleFunc = getMethod(delegate, @selector(webView:updateHistoryTitle:forURL:inFrame:));
-    cache->populateVisitedLinksFunc = getMethod(delegate, @selector(populateVisitedLinksForWebView:));
+    cache->setTitleFunc = getMethod(delegate.get(), @selector(webView:updateHistoryTitle:forURL:inFrame:));
+    cache->populateVisitedLinksFunc = getMethod(delegate.get(), @selector(populateVisitedLinksForWebView:));
 }
 
 - (id)_policyDelegateForwarder
@@ -3404,11 +3404,11 @@ IGNORE_WARNINGS_END
 {
     RetainPtr<NSMutableURLRequest> request = adoptNS([[NSMutableURLRequest alloc] initWithURL:URL]);
     [request _web_setHTTPUserAgent:[self userAgentForURL:URL]];
-    NSCachedURLResponse *cachedResponse;
+    RetainPtr<NSCachedURLResponse> cachedResponse;
 
     if (!_private->page)
         return nil;
-    
+
     auto* localMainFrame = dynamicDowncast<WebCore::LocalFrame>(_private->page->mainFrame());
     if (!localMainFrame)
         return nil;
@@ -3418,7 +3418,7 @@ IGNORE_WARNINGS_END
     else
         cachedResponse = [[NSURLCache sharedURLCache] cachedResponseForRequest:request.get()];
 
-    return cachedResponse;
+    return cachedResponse.autorelease();
 }
 
 - (void)_writeImageForElement:(NSDictionary *)element withPasteboardTypes:(NSArray *)types toPasteboard:(NSPasteboard *)pasteboard
@@ -3656,9 +3656,9 @@ IGNORE_WARNINGS_END
 - (BOOL)_locked_plugInsAreRunningInFrame:(WebFrame *)frame
 {
     // Ask plug-ins in this frame
-    id <WebDocumentView> documentView = [[frame frameView] documentView];
-    if (documentView && [documentView isKindOfClass:[WebHTMLView class]]) {
-        if ([[(WebHTMLView *)documentView _pluginController] plugInsAreRunning])
+    RetainPtr<id <WebDocumentView>> documentView = [[frame frameView] documentView];
+    if (documentView && [documentView.get() isKindOfClass:[WebHTMLView class]]) {
+        if ([[(WebHTMLView *)documentView.get() _pluginController] plugInsAreRunning])
             return YES;
     }
 
@@ -3683,9 +3683,9 @@ IGNORE_WARNINGS_END
 - (void)_locked_recursivelyPerformPlugInSelector:(SEL)selector inFrame:(WebFrame *)frame
 {
     // Send the message to plug-ins in this frame
-    id <WebDocumentView> documentView = [[frame frameView] documentView];
-    if (documentView && [documentView isKindOfClass:[WebHTMLView class]])
-        [[(WebHTMLView *)documentView _pluginController] performSelector:selector];
+    RetainPtr<id <WebDocumentView>> documentView = [[frame frameView] documentView];
+    if (documentView && [documentView.get() isKindOfClass:[WebHTMLView class]])
+        [[(WebHTMLView *)documentView.get() _pluginController] performSelector:selector];
 
     // Send the message to plug-ins in child frames
     NSArray *childFrames = [frame childFrames];
@@ -6007,9 +6007,9 @@ static bool needsWebViewInitThreadWorkaround()
 
 - (BOOL)_canZoomOut:(BOOL)isTextOnly
 {
-    id docView = [[[self mainFrame] frameView] documentView];
-    if ([docView conformsToProtocol:@protocol(_WebDocumentZooming)]) {
-        id <_WebDocumentZooming> zoomingDocView = (id <_WebDocumentZooming>)docView;
+    RetainPtr docView = [[[self mainFrame] frameView] documentView];
+    if ([docView.get() conformsToProtocol:@protocol(_WebDocumentZooming)]) {
+        id <_WebDocumentZooming> zoomingDocView = (id <_WebDocumentZooming>)docView.get();
         return [zoomingDocView _canZoomOut];
     }
     return [self _zoomMultiplier:isTextOnly] / ZoomMultiplierRatio > MinimumZoomMultiplier;
@@ -6018,9 +6018,9 @@ static bool needsWebViewInitThreadWorkaround()
 
 - (BOOL)_canZoomIn:(BOOL)isTextOnly
 {
-    id docView = [[[self mainFrame] frameView] documentView];
-    if ([docView conformsToProtocol:@protocol(_WebDocumentZooming)]) {
-        id <_WebDocumentZooming> zoomingDocView = (id <_WebDocumentZooming>)docView;
+    RetainPtr docView = [[[self mainFrame] frameView] documentView];
+    if ([docView.get() conformsToProtocol:@protocol(_WebDocumentZooming)]) {
+        id <_WebDocumentZooming> zoomingDocView = (id <_WebDocumentZooming>)docView.get();
         return [zoomingDocView _canZoomIn];
     }
     return [self _zoomMultiplier:isTextOnly] * ZoomMultiplierRatio < MaximumZoomMultiplier;
@@ -6028,9 +6028,9 @@ static bool needsWebViewInitThreadWorkaround()
 
 - (IBAction)_zoomOut:(id)sender isTextOnly:(BOOL)isTextOnly
 {
-    id docView = [[[self mainFrame] frameView] documentView];
-    if ([docView conformsToProtocol:@protocol(_WebDocumentZooming)]) {
-        id <_WebDocumentZooming> zoomingDocView = (id <_WebDocumentZooming>)docView;
+    RetainPtr docView = [[[self mainFrame] frameView] documentView];
+    if ([docView.get() conformsToProtocol:@protocol(_WebDocumentZooming)]) {
+        id <_WebDocumentZooming> zoomingDocView = (id <_WebDocumentZooming>)docView.get();
         return [zoomingDocView _zoomOut:sender];
     }
     float newScale = [self _zoomMultiplier:isTextOnly] / ZoomMultiplierRatio;
@@ -6040,9 +6040,9 @@ static bool needsWebViewInitThreadWorkaround()
 
 - (IBAction)_zoomIn:(id)sender isTextOnly:(BOOL)isTextOnly
 {
-    id docView = [[[self mainFrame] frameView] documentView];
-    if ([docView conformsToProtocol:@protocol(_WebDocumentZooming)]) {
-        id <_WebDocumentZooming> zoomingDocView = (id <_WebDocumentZooming>)docView;
+    RetainPtr docView = [[[self mainFrame] frameView] documentView];
+    if ([docView.get() conformsToProtocol:@protocol(_WebDocumentZooming)]) {
+        id <_WebDocumentZooming> zoomingDocView = (id <_WebDocumentZooming>)docView.get();
         return [zoomingDocView _zoomIn:sender];
     }
     float newScale = [self _zoomMultiplier:isTextOnly] * ZoomMultiplierRatio;
@@ -6052,9 +6052,9 @@ static bool needsWebViewInitThreadWorkaround()
 
 - (BOOL)_canResetZoom:(BOOL)isTextOnly
 {
-    id docView = [[[self mainFrame] frameView] documentView];
-    if ([docView conformsToProtocol:@protocol(_WebDocumentZooming)]) {
-        id <_WebDocumentZooming> zoomingDocView = (id <_WebDocumentZooming>)docView;
+    RetainPtr docView = [[[self mainFrame] frameView] documentView];
+    if ([docView.get() conformsToProtocol:@protocol(_WebDocumentZooming)]) {
+        id <_WebDocumentZooming> zoomingDocView = (id <_WebDocumentZooming>)docView.get();
         return [zoomingDocView _canResetZoom];
     }
     return [self _zoomMultiplier:isTextOnly] != 1.0f;
@@ -6062,9 +6062,9 @@ static bool needsWebViewInitThreadWorkaround()
 
 - (IBAction)_resetZoom:(id)sender isTextOnly:(BOOL)isTextOnly
 {
-    id docView = [[[self mainFrame] frameView] documentView];
-    if ([docView conformsToProtocol:@protocol(_WebDocumentZooming)]) {
-        id <_WebDocumentZooming> zoomingDocView = (id <_WebDocumentZooming>)docView;
+    RetainPtr docView = [[[self mainFrame] frameView] documentView];
+    if ([docView.get() conformsToProtocol:@protocol(_WebDocumentZooming)]) {
+        id <_WebDocumentZooming> zoomingDocView = (id <_WebDocumentZooming>)docView.get();
         return [zoomingDocView _resetZoom:sender];
     }
     if ([self _zoomMultiplier:isTextOnly] != 1.0f)
@@ -6122,9 +6122,9 @@ static bool needsWebViewInitThreadWorkaround()
 
 - (BOOL)supportsTextEncoding
 {
-    id documentView = [[[self mainFrame] frameView] documentView];
-    return [documentView conformsToProtocol:@protocol(WebDocumentText)]
-        && [documentView supportsTextEncoding];
+    RetainPtr<id<WebDocumentView>> documentView = [[[self mainFrame] frameView] documentView];
+    return [(id)documentView.get() conformsToProtocol:@protocol(WebDocumentText)]
+        && [(id)documentView.get() supportsTextEncoding];
 }
 
 - (void)setCustomTextEncodingName:(NSString *)encoding
@@ -6371,7 +6371,7 @@ static bool needsWebViewInitThreadWorkaround()
             return false;
         }
 
-        NSString *dropDestinationPath = FileSystem::createTemporaryDirectory(@"WebKitDropDestination");
+        RetainPtr dropDestinationPath = FileSystem::createTemporaryDirectory(@"WebKitDropDestination");
         if (!dropDestinationPath) {
             delete dragData;
             return false;
@@ -6379,7 +6379,7 @@ static bool needsWebViewInitThreadWorkaround()
 
         size_t fileCount = files.count;
         Vector<String> *fileNames = new Vector<String>;
-        NSURL *dropDestination = [NSURL fileURLWithPath:dropDestinationPath isDirectory:YES];
+        NSURL *dropDestination = [NSURL fileURLWithPath:dropDestinationPath.get() isDirectory:YES];
         [draggingInfo enumerateDraggingItemsWithOptions:0 forView:self classes:@[[NSFilePromiseReceiver class]] searchOptions:@{ } usingBlock:^(NSDraggingItem * __nonnull draggingItem, NSInteger idx, BOOL * __nonnull stop) {
             NSFilePromiseReceiver *item = draggingItem.item;
             NSDictionary *options = @{ };
@@ -6767,14 +6767,14 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     RetainPtr<CFMutableSetRef> visitedViews = adoptCF(CFSetCreateMutable(0, 0, 0));
     CFSetAddValue(visitedViews.get(), result);
 
-    NSView *previousView = self;
+    RetainPtr<NSView> previousView = self;
     do {
-        CFSetAddValue(visitedViews.get(), previousView);
-        previousView = [previousView previousKeyView];
-        if (!previousView || CFSetGetValue(visitedViews.get(), previousView))
+        CFSetAddValue(visitedViews.get(), previousView.get());
+        previousView = [previousView.get() previousKeyView];
+        if (!previousView || CFSetGetValue(visitedViews.get(), previousView.get()))
             return result;
-    } while ([result isDescendantOf:previousView]);
-    return [previousView previousValidKeyView];
+    } while ([result isDescendantOf:previousView.get()]);
+    return [previousView.get() previousValidKeyView];
 }
 
 #if HAVE(TOUCH_BAR)
@@ -6833,11 +6833,11 @@ static WebCore::TextCheckingResult textCheckingResultFromNSTextCheckingResult(NS
     if ((NSUInteger)index >= candidates.count)
         return;
 
-    id candidate = candidates[index];
-    ASSERT([candidate isKindOfClass:[NSTextCheckingResult class]]);
+    RetainPtr<id> candidate = candidates[index];
+    ASSERT([candidate.get() isKindOfClass:[NSTextCheckingResult class]]);
 
     if (auto* coreFrame = core(self._selectedOrMainFrame))
-        coreFrame->editor().client()->handleAcceptedCandidateWithSoftSpaces(textCheckingResultFromNSTextCheckingResult((NSTextCheckingResult *)candidate));
+        coreFrame->editor().client()->handleAcceptedCandidateWithSoftSpaces(textCheckingResultFromNSTextCheckingResult((NSTextCheckingResult *)candidate.get()));
 }
 
 - (void)candidateListTouchBarItem:(NSCandidateListTouchBarItem *)anItem changedCandidateListVisibility:(BOOL)isVisible
@@ -6924,9 +6924,9 @@ static WebFrameView *containingFrameView(NSView *view)
 {
     NSResponder *resp = [[self window] firstResponder];
     if (resp && [resp isKindOfClass:[NSView class]] && [(NSView *)resp isDescendantOf:[[self mainFrame] frameView]]) {
-        WebFrameView *frameView = containingFrameView((NSView *)resp);
-        ASSERT(frameView != nil);
-        return [frameView webFrame];
+        RetainPtr frameView = containingFrameView((NSView *)resp);
+        ASSERT(frameView);
+        return [frameView.get() webFrame];
     }
 
     return nil;
@@ -6951,9 +6951,9 @@ static WebFrameView *containingFrameView(NSView *view)
 #endif
     if (![view isDescendantOf:[[self mainFrame] frameView]])
         return nil;
-    WebFrameView *frameView = containingFrameView(view);
+    RetainPtr frameView = containingFrameView(view);
     ASSERT(frameView);
-    return frameView;
+    return frameView.autorelease();
 }
 
 + (void)_preflightSpellCheckerNow:(id)sender
@@ -7155,12 +7155,12 @@ static WebFrameView *containingFrameView(NSView *view)
 
 - (BOOL)_responderValidateUserInterfaceItem:(id <NSValidatedUserInterfaceItem>)item
 {
-    id responder = [self _responderForResponderOperations];
-    if (responder != self && [responder respondsToSelector:[item action]]) {
-        if ([responder respondsToSelector:@selector(validateUserInterfaceItemWithoutDelegate:)])
-            return [responder validateUserInterfaceItemWithoutDelegate:item];
-        if ([responder respondsToSelector:@selector(validateUserInterfaceItem:)])
-            return [responder validateUserInterfaceItem:item];
+    RetainPtr<id> responder = [self _responderForResponderOperations];
+    if (responder.get() != self && [responder.get() respondsToSelector:[item action]]) {
+        if ([responder.get() respondsToSelector:@selector(validateUserInterfaceItemWithoutDelegate:)])
+            return [responder.get() validateUserInterfaceItemWithoutDelegate:item];
+        if ([responder.get() respondsToSelector:@selector(validateUserInterfaceItem:)])
+            return [responder.get() validateUserInterfaceItem:item];
         return YES;
     }
     return NO;
@@ -7296,18 +7296,18 @@ static BOOL findString(NSView <WebDocumentSearching> *searchView, NSString *stri
 
     // Search the first frame, then all the other frames, in order
     NSView <WebDocumentSearching> *startSearchView = nil;
-    WebFrame *frame = startFrame;
+    RetainPtr frame = startFrame;
     do {
-        WebFrame *nextFrame = incrementFrame(frame, options);
+        RetainPtr nextFrame = incrementFrame(frame.get(), options);
 
         BOOL onlyOneFrame = (frame == nextFrame);
         ASSERT(!onlyOneFrame || frame == startFrame);
 
-        id <WebDocumentView> view = [[frame frameView] documentView];
-        if ([view conformsToProtocol:@protocol(WebDocumentSearching)]) {
-            NSView <WebDocumentSearching> *searchView = (NSView <WebDocumentSearching> *)view;
+        RetainPtr<id <WebDocumentView>> view = [[frame.get() frameView] documentView];
+        if ([view.get() conformsToProtocol:@protocol(WebDocumentSearching)]) {
+            NSView <WebDocumentSearching> *searchView = (NSView <WebDocumentSearching> *)view.get();
 
-            if (frame == startFrame)
+            if (frame.get() == startFrame)
                 startSearchView = searchView;
 
             // In some cases we have to search some content twice; see comment later in this method.
@@ -7317,7 +7317,7 @@ static BOOL findString(NSView <WebDocumentSearching> *searchView, NSString *stri
             WebFindOptions optionsForThisPass = onlyOneFrame ? options : (options & ~WebFindOptionsWrapAround);
 
             if (findString(searchView, string, optionsForThisPass)) {
-                if (frame != startFrame)
+                if (frame.get() != startFrame)
                     [startFrame _clearSelection];
                 [[self window] makeFirstResponder:searchView];
                 return YES;
@@ -7327,7 +7327,7 @@ static BOOL findString(NSView <WebDocumentSearching> *searchView, NSString *stri
                 return NO;
         }
         frame = nextFrame;
-    } while (frame && frame != startFrame);
+    } while (frame && frame.get() != startFrame);
 
     // If there are multiple frames and WebFindOptionsWrapAround is set and we've visited each one without finding a result, we still need to search in the
     // first-searched frame up to the selection. However, the API doesn't provide a way to search only up to a particular point. The only
@@ -7487,13 +7487,13 @@ static NSAppleEventDescriptor* aeDescFromJSValue(JSC::JSGlobalObject* lexicalGlo
     if (_private->closed)
         return NO;
 
-    WebFrame *frame = [self mainFrame];
+    RetainPtr frame = [self mainFrame];
     do {
-        id <WebDocumentView> view = [[frame frameView] documentView];
-        if (view && ![view conformsToProtocol:@protocol(WebMultipleTextMatches)])
+        RetainPtr<id <WebDocumentView>> view = [[frame.get() frameView] documentView];
+        if (view && ![view.get() conformsToProtocol:@protocol(WebMultipleTextMatches)])
             return NO;
 
-        frame = incrementFrame(frame);
+        frame = incrementFrame(frame.get());
     } while (frame);
 
     return YES;
@@ -7509,23 +7509,23 @@ static NSAppleEventDescriptor* aeDescFromJSValue(JSC::JSGlobalObject* lexicalGlo
     if (_private->closed)
         return 0;
 
-    WebFrame *frame = [self mainFrame];
+    RetainPtr frame = [self mainFrame];
     unsigned matchCount = 0;
     do {
-        id <WebDocumentView> view = [[frame frameView] documentView];
-        if ([view conformsToProtocol:@protocol(WebMultipleTextMatches)]) {
+        RetainPtr<id <WebDocumentView>> view = [[frame.get() frameView] documentView];
+        if ([view.get() conformsToProtocol:@protocol(WebMultipleTextMatches)]) {
             if (markMatches)
-                [(NSView <WebMultipleTextMatches>*)view setMarkedTextMatchesAreHighlighted:highlight];
+                [(NSView <WebMultipleTextMatches>*)view.get() setMarkedTextMatchesAreHighlighted:highlight];
 
             ASSERT(limit == 0 || matchCount < limit);
-            matchCount += [(NSView <WebMultipleTextMatches>*)view countMatchesForText:string inDOMRange:range options:options limit:(limit == 0 ? 0 : limit - matchCount) markMatches:markMatches];
+            matchCount += [(NSView <WebMultipleTextMatches>*)view.get() countMatchesForText:string inDOMRange:range options:options limit:(limit == 0 ? 0 : limit - matchCount) markMatches:markMatches];
 
             // Stop looking if we've reached the limit. A limit of 0 means no limit.
             if (limit > 0 && matchCount >= limit)
                 break;
         }
 
-        frame = incrementFrame(frame);
+        frame = incrementFrame(frame.get());
     } while (frame);
 
     return matchCount;
@@ -7536,13 +7536,13 @@ static NSAppleEventDescriptor* aeDescFromJSValue(JSC::JSGlobalObject* lexicalGlo
     if (_private->closed)
         return;
 
-    WebFrame *frame = [self mainFrame];
+    RetainPtr frame = [self mainFrame];
     do {
-        id <WebDocumentView> view = [[frame frameView] documentView];
-        if ([view conformsToProtocol:@protocol(WebMultipleTextMatches)])
-            [(NSView <WebMultipleTextMatches>*)view unmarkAllTextMatches];
+        RetainPtr<id <WebDocumentView>> view = [[frame.get() frameView] documentView];
+        if ([view.get() conformsToProtocol:@protocol(WebMultipleTextMatches)])
+            [(NSView <WebMultipleTextMatches>*)view.get() unmarkAllTextMatches];
 
-        frame = incrementFrame(frame);
+        frame = incrementFrame(frame.get());
     } while (frame);
 }
 
@@ -7552,11 +7552,11 @@ static NSAppleEventDescriptor* aeDescFromJSValue(JSC::JSGlobalObject* lexicalGlo
         return @[];
 
     NSMutableArray *result = [NSMutableArray array];
-    WebFrame *frame = [self mainFrame];
+    RetainPtr frame = [self mainFrame];
     do {
-        id <WebDocumentView> view = [[frame frameView] documentView];
-        if ([view conformsToProtocol:@protocol(WebMultipleTextMatches)]) {
-            NSView <WebMultipleTextMatches> *documentView = (NSView <WebMultipleTextMatches> *)view;
+        RetainPtr<id <WebDocumentView>> view = [[frame.get() frameView] documentView];
+        if ([view.get() conformsToProtocol:@protocol(WebMultipleTextMatches)]) {
+            NSView <WebMultipleTextMatches> *documentView = (NSView <WebMultipleTextMatches> *)view.get();
             NSRect documentViewVisibleRect = [documentView visibleRect];
             for (NSValue *rect in [documentView rectsForTextMatches]) {
                 NSRect r = [rect rectValue];
@@ -7573,7 +7573,7 @@ static NSAppleEventDescriptor* aeDescFromJSValue(JSC::JSGlobalObject* lexicalGlo
             }
         }
 
-        frame = incrementFrame(frame);
+        frame = incrementFrame(frame.get());
     } while (frame);
 
     return result;
@@ -7670,15 +7670,15 @@ static NSAppleEventDescriptor* aeDescFromJSValue(JSC::JSGlobalObject* lexicalGlo
 #if PLATFORM(MAC)
 - (BOOL)_allowsLinkPreview
 {
-    if (WebImmediateActionController *immediateActionController = _private->immediateActionController.get())
-        return immediateActionController.enabled;
+    if (RetainPtr immediateActionController = _private->immediateActionController.get())
+        return immediateActionController.get().enabled;
     return NO;
 }
 
 - (void)_setAllowsLinkPreview:(BOOL)allowsLinkPreview
 {
-    if (WebImmediateActionController *immediateActionController = _private->immediateActionController.get())
-        immediateActionController.enabled = allowsLinkPreview;
+    if (RetainPtr immediateActionController = _private->immediateActionController.get())
+        immediateActionController.get().enabled = allowsLinkPreview;
 }
 #endif
 
@@ -8616,12 +8616,12 @@ FORWARD(toggleUnderline)
 
 - (void)_searchWithGoogleFromMenu:(id)sender
 {
-    id documentView = [[[self selectedFrame] frameView] documentView];
-    if (![documentView conformsToProtocol:@protocol(WebDocumentText)]) {
+    RetainPtr documentView = [[[self selectedFrame] frameView] documentView];
+    if (![documentView.get() conformsToProtocol:@protocol(WebDocumentText)]) {
         return;
     }
 
-    NSString *selectedString = [(id <WebDocumentText>)documentView selectedString];
+    NSString *selectedString = [(id <WebDocumentText>)documentView.get() selectedString];
     if ([selectedString length] == 0) {
         return;
     }
@@ -9225,8 +9225,8 @@ FORWARD(toggleUnderline)
         }
     }
 
-    if (auto* touchBarItem = dynamic_objc_cast<NSPopoverTouchBarItem>(foundItem))
-        [touchBarItem dismissPopover:nil];
+    if (RetainPtr touchBarItem = dynamic_objc_cast<NSPopoverTouchBarItem>(foundItem))
+        [touchBarItem.get() dismissPopover:nil];
 }
 
 - (NSArray<NSString *> *)_textTouchBarCustomizationAllowedIdentifiers
@@ -9308,8 +9308,8 @@ FORWARD(toggleUnderline)
     if (![documentView isKindOfClass:[WebHTMLView class]])
         return NO;
 
-    WebHTMLView *webHTMLView = (WebHTMLView *)documentView;
-    return webHTMLView._isEditable && webHTMLView._canEditRichly;
+    RetainPtr webHTMLView = (WebHTMLView *)documentView;
+    return webHTMLView.get()._isEditable && webHTMLView.get()._canEditRichly;
 }
 
 - (NSTouchBar *)textTouchBar
@@ -9369,8 +9369,8 @@ static NSTextAlignment nsTextAlignmentFromRenderStyle(const WebCore::RenderStyle
     if (![documentView isKindOfClass:[WebHTMLView class]])
         return;
 
-    WebHTMLView *webHTMLView = (WebHTMLView *)documentView;
-    if (![webHTMLView _isEditable])
+    RetainPtr webHTMLView = (WebHTMLView *)documentView;
+    if (![webHTMLView.get() _isEditable])
         return;
 
     auto* coreFrame = core([self _selectedOrMainFrame]);
@@ -9435,7 +9435,7 @@ static NSTextAlignment nsTextAlignmentFromRenderStyle(const WebCore::RenderStyle
 
     // Set current typing attributes for rich text. This will ensure that the buttons reflect the state of
     // the text when changing selection throughout the document.
-    if (webHTMLView._canEditRichly) {
+    if (webHTMLView.get()._canEditRichly) {
         const VisibleSelection& selection = coreFrame->selection().selection();
         if (!selection.isNone()) {
             RefPtr<Node> nodeToRemove;
@@ -9484,9 +9484,9 @@ static NSTextAlignment nsTextAlignmentFromRenderStyle(const WebCore::RenderStyle
 
     if (![_private->mediaTouchBarProvider playbackControlsController]) {
         ASSERT(_private->playbackSessionInterface);
-        WebPlaybackControlsManager *manager = _private->playbackSessionInterface->playBackControlsManager();
-        [_private->mediaTouchBarProvider setPlaybackControlsController:(id <AVTouchBarPlaybackControlsControlling>)manager];
-        [_private->mediaPlaybackControlsView setPlaybackControlsController:(id <AVTouchBarPlaybackControlsControlling>)manager];
+        RetainPtr manager = _private->playbackSessionInterface->playBackControlsManager();
+        [_private->mediaTouchBarProvider setPlaybackControlsController:(id <AVTouchBarPlaybackControlsControlling>)manager.get()];
+        [_private->mediaPlaybackControlsView setPlaybackControlsController:(id <AVTouchBarPlaybackControlsControlling>)manager.get()];
     }
 #endif
 }
@@ -9503,8 +9503,8 @@ static NSTextAlignment nsTextAlignmentFromRenderStyle(const WebCore::RenderStyle
     NSTouchBar *touchBar = nil;
     NSView *documentView = [[[self _selectedOrMainFrame] frameView] documentView];
     if ([documentView isKindOfClass:[WebHTMLView class]]) {
-        WebHTMLView *webHTMLView = (WebHTMLView *)documentView;
-        if ([webHTMLView _isEditable]) {
+        RetainPtr webHTMLView = (WebHTMLView *)documentView;
+        if ([webHTMLView.get() _isEditable]) {
             [self updateTextTouchBar];
             touchBar = [self textTouchBar];
         }

--- a/Source/WebKitLegacy/mac/WebView/WebViewRenderingUpdateScheduler.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebViewRenderingUpdateScheduler.mm
@@ -101,15 +101,15 @@ void WebViewRenderingUpdateScheduler::registerCACommitHandlers()
     if (m_haveRegisteredCommitHandlers)
         return;
 
-    WebView* webView = m_webView;
+    RetainPtr webView = m_webView;
     [CATransaction addCommitHandler:^{
-        [webView _willStartRenderingUpdateDisplay];
+        [webView.get() _willStartRenderingUpdateDisplay];
     } forPhase:kCATransactionPhasePreLayout];
 
     [CATransaction addCommitHandler:^{
-        [webView _didCompleteRenderingUpdateDisplay];
+        [webView.get() _didCompleteRenderingUpdateDisplay];
     } forPhase:kCATransactionPhasePostCommit];
-    
+
     m_haveRegisteredCommitHandlers = true;
 }
 

--- a/Tools/DumpRenderTree/cg/PixelDumpSupportCG.cpp
+++ b/Tools/DumpRenderTree/cg/PixelDumpSupportCG.cpp
@@ -77,17 +77,17 @@ static void printPNG(CGImageRef image, const char* checksum, double scaleFactor)
 
 void computeSHA1HashStringForBitmapContext(BitmapContext* context, char hashString[33])
 {
-    CGContextRef bitmapContext = context->cgContext();
+    RetainPtr bitmapContext = context->cgContext();
 
-    ASSERT(CGBitmapContextGetBitsPerPixel(bitmapContext) == 32); // ImageDiff assumes 32 bit RGBA, we must as well.
-    size_t pixelsHigh = CGBitmapContextGetHeight(bitmapContext);
-    size_t pixelsWide = CGBitmapContextGetWidth(bitmapContext);
-    size_t bytesPerRow = CGBitmapContextGetBytesPerRow(bitmapContext);
+    ASSERT(CGBitmapContextGetBitsPerPixel(bitmapContext.get()) == 32); // ImageDiff assumes 32 bit RGBA, we must as well.
+    size_t pixelsHigh = CGBitmapContextGetHeight(bitmapContext.get());
+    size_t pixelsWide = CGBitmapContextGetWidth(bitmapContext.get());
+    size_t bytesPerRow = CGBitmapContextGetBytesPerRow(bitmapContext.get());
 
     // We need to swap the bytes to ensure consistent hashes independently of endianness
     SHA1 sha1;
-    unsigned char* bitmapData = static_cast<unsigned char*>(CGBitmapContextGetData(bitmapContext));
-    if ((CGBitmapContextGetBitmapInfo(bitmapContext) & kCGBitmapByteOrderMask) == kCGBitmapByteOrder32Big) {
+    unsigned char* bitmapData = static_cast<unsigned char*>(CGBitmapContextGetData(bitmapContext.get()));
+    if ((CGBitmapContextGetBitmapInfo(bitmapContext.get()) & kCGBitmapByteOrderMask) == kCGBitmapByteOrder32Big) {
         for (unsigned row = 0; row < pixelsHigh; row++) {
             Vector<uint32_t> buffer(pixelsWide);
             for (unsigned column = 0; column < pixelsWide; column++)

--- a/Tools/DumpRenderTree/mac/AccessibilityControllerMac.mm
+++ b/Tools/DumpRenderTree/mac/AccessibilityControllerMac.mm
@@ -88,9 +88,9 @@ static id findAccessibleObjectById(id obj, NSString *idAttribute)
     NSArray *children = [obj accessibilityAttributeValue:NSAccessibilityChildrenAttribute];
     NSUInteger childrenCount = [children count];
     for (NSUInteger i = 0; i < childrenCount; ++i) {
-        id result = findAccessibleObjectById([children objectAtIndex:i], idAttribute);
+        RetainPtr result = findAccessibleObjectById([children objectAtIndex:i], idAttribute);
         if (result)
-            return result;
+            return result.autorelease();
     }
     END_AX_OBJC_EXCEPTIONS
 
@@ -101,9 +101,9 @@ AccessibilityUIElement AccessibilityController::accessibleElementById(JSStringRe
 {
     NSString *idAttribute = [NSString stringWithJSStringRef:idAttributeRef];
     id root = [[mainFrame accessibilityRoot] accessibilityAttributeValue:NSAccessibilityParentAttribute];
-    id result = findAccessibleObjectById(root, idAttribute);
+    RetainPtr result = findAccessibleObjectById(root, idAttribute);
     if (result)
-        return AccessibilityUIElement(result);
+        return AccessibilityUIElement(result.get());
 
     return nullptr;
 }

--- a/Tools/DumpRenderTree/mac/AccessibilityNotificationHandler.mm
+++ b/Tools/DumpRenderTree/mac/AccessibilityNotificationHandler.mm
@@ -83,9 +83,9 @@
 
 static Class webAccessibilityObjectWrapperClassSingleton()
 {
-    static Class cls = objc_getClass("WebAccessibilityObjectWrapper");
-    ASSERT(cls);
-    return cls;
+    static NeverDestroyed<RetainPtr<Class>> cls = objc_getClass("WebAccessibilityObjectWrapper");
+    ASSERT(cls->get());
+    return cls->get();
 }
 
 - (void)startObserving

--- a/Tools/DumpRenderTree/mac/AccessibilityUIElementMac.mm
+++ b/Tools/DumpRenderTree/mac/AccessibilityUIElementMac.mm
@@ -325,32 +325,32 @@ bool AccessibilityUIElement::isEqual(AccessibilityUIElement* otherElement)
 void AccessibilityUIElement::getLinkedUIElements(Vector<AccessibilityUIElement>& elementVector)
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    NSArray* linkedElements = [m_element accessibilityAttributeValue:NSAccessibilityLinkedUIElementsAttribute];
-    elementVector = makeVector<AccessibilityUIElement>(linkedElements);
+    RetainPtr linkedElements = [m_element accessibilityAttributeValue:NSAccessibilityLinkedUIElementsAttribute];
+    elementVector = makeVector<AccessibilityUIElement>(linkedElements.get());
     END_AX_OBJC_EXCEPTIONS
 }
 
 void AccessibilityUIElement::getDocumentLinks(Vector<AccessibilityUIElement>& elementVector)
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    NSArray* linkElements = [m_element accessibilityAttributeValue:@"AXLinkUIElements"];
-    elementVector = makeVector<AccessibilityUIElement>(linkElements);
+    RetainPtr linkElements = [m_element accessibilityAttributeValue:@"AXLinkUIElements"];
+    elementVector = makeVector<AccessibilityUIElement>(linkElements.get());
     END_AX_OBJC_EXCEPTIONS
 }
 
 void AccessibilityUIElement::getChildren(Vector<AccessibilityUIElement>& elementVector)
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    NSArray* children = [m_element accessibilityAttributeValue:NSAccessibilityChildrenAttribute];
-    elementVector = makeVector<AccessibilityUIElement>(children);
+    RetainPtr children = [m_element accessibilityAttributeValue:NSAccessibilityChildrenAttribute];
+    elementVector = makeVector<AccessibilityUIElement>(children.get());
     END_AX_OBJC_EXCEPTIONS
 }
 
 void AccessibilityUIElement::getChildrenWithRange(Vector<AccessibilityUIElement>& elementVector, unsigned location, unsigned length)
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    NSArray* children = [m_element accessibilityArrayAttributeValues:NSAccessibilityChildrenAttribute index:location maxCount:length];
-    elementVector = makeVector<AccessibilityUIElement>(children);
+    RetainPtr children = [m_element accessibilityArrayAttributeValues:NSAccessibilityChildrenAttribute index:location maxCount:length];
+    elementVector = makeVector<AccessibilityUIElement>(children.get());
     END_AX_OBJC_EXCEPTIONS
 }
 
@@ -389,9 +389,9 @@ AccessibilityUIElement AccessibilityUIElement::getChildAtIndex(unsigned index)
 AccessibilityUIElement AccessibilityUIElement::linkedUIElementAtIndex(unsigned index)
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    NSArray* objects = [m_element accessibilityAttributeValue:NSAccessibilityLinkedUIElementsAttribute];
-    if (index < [objects count])
-        return [objects objectAtIndex:index];
+    RetainPtr objects = [m_element accessibilityAttributeValue:NSAccessibilityLinkedUIElementsAttribute];
+    if (index < [objects.get() count])
+        return [objects.get() objectAtIndex:index];
     END_AX_OBJC_EXCEPTIONS
 
     return nullptr;
@@ -400,9 +400,9 @@ AccessibilityUIElement AccessibilityUIElement::linkedUIElementAtIndex(unsigned i
 AccessibilityUIElement AccessibilityUIElement::ariaOwnsElementAtIndex(unsigned index)
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    NSArray* objects = [m_element accessibilityAttributeValue:NSAccessibilityOwnsAttribute];
-    if (index < [objects count])
-        return [objects objectAtIndex:index];
+    RetainPtr objects = [m_element accessibilityAttributeValue:NSAccessibilityOwnsAttribute];
+    if (index < [objects.get() count])
+        return [objects.get() objectAtIndex:index];
     END_AX_OBJC_EXCEPTIONS
 
     return nullptr;
@@ -411,9 +411,9 @@ AccessibilityUIElement AccessibilityUIElement::ariaOwnsElementAtIndex(unsigned i
 AccessibilityUIElement AccessibilityUIElement::ariaFlowToElementAtIndex(unsigned index)
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    NSArray* objects = [m_element accessibilityAttributeValue:NSAccessibilityLinkedUIElementsAttribute];
-    if (index < [objects count])
-        return [objects objectAtIndex:index];
+    RetainPtr objects = [m_element accessibilityAttributeValue:NSAccessibilityLinkedUIElementsAttribute];
+    if (index < [objects.get() count])
+        return [objects.get() objectAtIndex:index];
     END_AX_OBJC_EXCEPTIONS
 
     return nullptr;
@@ -430,9 +430,9 @@ AccessibilityUIElement AccessibilityUIElement::ariaControlsElementAtIndex(unsign
 AccessibilityUIElement AccessibilityUIElement::disclosedRowAtIndex(unsigned index)
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    NSArray* rows = [m_element accessibilityAttributeValue:NSAccessibilityDisclosedRowsAttribute];
-    if (index < [rows count])
-        return [rows objectAtIndex:index];
+    RetainPtr rows = [m_element accessibilityAttributeValue:NSAccessibilityDisclosedRowsAttribute];
+    if (index < [rows.get() count])
+        return [rows.get() objectAtIndex:index];
     END_AX_OBJC_EXCEPTIONS
 
     return nullptr;
@@ -441,9 +441,9 @@ AccessibilityUIElement AccessibilityUIElement::disclosedRowAtIndex(unsigned inde
 AccessibilityUIElement AccessibilityUIElement::selectedChildAtIndex(unsigned index) const
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    NSArray* array = [m_element accessibilityAttributeValue:NSAccessibilitySelectedChildrenAttribute];
-    if (index < [array count])
-        return [array objectAtIndex:index];
+    RetainPtr array = [m_element accessibilityAttributeValue:NSAccessibilitySelectedChildrenAttribute];
+    if (index < [array.get() count])
+        return [array.get() objectAtIndex:index];
     END_AX_OBJC_EXCEPTIONS
 
     return nullptr;
@@ -461,9 +461,9 @@ unsigned AccessibilityUIElement::selectedChildrenCount() const
 AccessibilityUIElement AccessibilityUIElement::selectedRowAtIndex(unsigned index)
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    NSArray* rows = [m_element accessibilityAttributeValue:NSAccessibilitySelectedRowsAttribute];
-    if (index < [rows count])
-        return [rows objectAtIndex:index];
+    RetainPtr rows = [m_element accessibilityAttributeValue:NSAccessibilitySelectedRowsAttribute];
+    if (index < [rows.get() count])
+        return [rows.get() objectAtIndex:index];
     END_AX_OBJC_EXCEPTIONS
 
     return nullptr;
@@ -472,9 +472,9 @@ AccessibilityUIElement AccessibilityUIElement::selectedRowAtIndex(unsigned index
 AccessibilityUIElement AccessibilityUIElement::rowAtIndex(unsigned index)
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    NSArray* rows = [m_element accessibilityAttributeValue:NSAccessibilityRowsAttribute];
-    if (index < [rows count])
-        return [rows objectAtIndex:index];
+    RetainPtr rows = [m_element accessibilityAttributeValue:NSAccessibilityRowsAttribute];
+    if (index < [rows.get() count])
+        return [rows.get() objectAtIndex:index];
     END_AX_OBJC_EXCEPTIONS
 
     return nullptr;
@@ -1182,16 +1182,16 @@ AccessibilityUIElement AccessibilityUIElement::uiElementForSearchPredicate(JSCon
 {
     BEGIN_AX_OBJC_EXCEPTIONS
     NSDictionary *parameter = searchPredicateParameterizedAttributeForSearchCriteria(context, startElement, isDirectionNext, 1, searchKey, searchText, visibleOnly, immediateDescendantsOnly);
-    id value = [m_element accessibilityAttributeValue:@"AXUIElementsForSearchPredicate" forParameter:parameter];
-    if (![value isKindOfClass:[NSArray class]] || ![value count])
+    RetainPtr value = [m_element accessibilityAttributeValue:@"AXUIElementsForSearchPredicate" forParameter:parameter];
+    if (![value.get() isKindOfClass:[NSArray class]] || ![value.get() count])
         return nullptr;
 
-    id result = [value firstObject];
-    if ([result isKindOfClass:NSDictionary.class]) {
-        RELEASE_ASSERT([result objectForKey:@"AXSearchResultElement"]);
-        return AccessibilityUIElement([result objectForKey:@"AXSearchResultElement"]);
+    RetainPtr result = [value.get() firstObject];
+    if ([result.get() isKindOfClass:NSDictionary.class]) {
+        RELEASE_ASSERT([result.get() objectForKey:@"AXSearchResultElement"]);
+        return AccessibilityUIElement([result.get() objectForKey:@"AXSearchResultElement"]);
     }
-    return AccessibilityUIElement(result);
+    return AccessibilityUIElement(result.get());
     END_AX_OBJC_EXCEPTIONS
 
     return nullptr;
@@ -1226,8 +1226,8 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfColumnHeaders()
 {
     // not yet defined in AppKit... odd
     BEGIN_AX_OBJC_EXCEPTIONS
-    NSArray* columnHeadersArray = [m_element accessibilityAttributeValue:@"AXColumnHeaderUIElements"];
-    auto columnHeadersVector = makeVector<AccessibilityUIElement>(columnHeadersArray);
+    RetainPtr columnHeadersArray = [m_element accessibilityAttributeValue:@"AXColumnHeaderUIElements"];
+    auto columnHeadersVector = makeVector<AccessibilityUIElement>(columnHeadersArray.get());
     return descriptionOfElements(columnHeadersVector);
     END_AX_OBJC_EXCEPTIONS
 
@@ -1237,8 +1237,8 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfColumnHeaders()
 JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfRowHeaders()
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    NSArray* rowHeadersArray = [m_element accessibilityAttributeValue:@"AXRowHeaderUIElements"];
-    auto rowHeadersVector = makeVector<AccessibilityUIElement>(rowHeadersArray);
+    RetainPtr rowHeadersArray = [m_element accessibilityAttributeValue:@"AXRowHeaderUIElements"];
+    auto rowHeadersVector = makeVector<AccessibilityUIElement>(rowHeadersArray.get());
     return descriptionOfElements(rowHeadersVector);
     END_AX_OBJC_EXCEPTIONS
 
@@ -1248,8 +1248,8 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfRowHeaders()
 JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfColumns()
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    NSArray* columnsArray = [m_element accessibilityAttributeValue:NSAccessibilityColumnsAttribute];
-    auto columnsVector = makeVector<AccessibilityUIElement>(columnsArray);
+    RetainPtr columnsArray = [m_element accessibilityAttributeValue:NSAccessibilityColumnsAttribute];
+    auto columnsVector = makeVector<AccessibilityUIElement>(columnsArray.get());
     return descriptionOfElements(columnsVector);
     END_AX_OBJC_EXCEPTIONS
 
@@ -1259,8 +1259,8 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfColumns()
 JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfRows()
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    NSArray* rowsArray = [m_element accessibilityAttributeValue:NSAccessibilityRowsAttribute];
-    auto rowsVector = makeVector<AccessibilityUIElement>(rowsArray);
+    RetainPtr rowsArray = [m_element accessibilityAttributeValue:NSAccessibilityRowsAttribute];
+    auto rowsVector = makeVector<AccessibilityUIElement>(rowsArray.get());
     return descriptionOfElements(rowsVector);
     END_AX_OBJC_EXCEPTIONS
 
@@ -1270,8 +1270,8 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfRows()
 JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfVisibleCells()
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    NSArray* cellsArray = [m_element accessibilityAttributeValue:@"AXVisibleCells"];
-    auto cellsVector = makeVector<AccessibilityUIElement>(cellsArray);
+    RetainPtr cellsArray = [m_element accessibilityAttributeValue:@"AXVisibleCells"];
+    auto cellsVector = makeVector<AccessibilityUIElement>(cellsArray.get());
     return descriptionOfElements(cellsVector);
     END_AX_OBJC_EXCEPTIONS
 
@@ -1505,10 +1505,10 @@ void AccessibilityUIElement::setSelectedChildAtIndex(unsigned index) const
     AccessibilityUIElement element = const_cast<AccessibilityUIElement*>(this)->getChildAtIndex(index);
     if (!element.platformUIElement())
         return;
-    NSArray *selectedChildren = [m_element accessibilityAttributeValue:NSAccessibilitySelectedChildrenAttribute];
+    RetainPtr selectedChildren = [m_element accessibilityAttributeValue:NSAccessibilitySelectedChildrenAttribute];
     NSArray *array = @[element.platformUIElement()];
     if (selectedChildren)
-        array = [selectedChildren arrayByAddingObjectsFromArray:array];
+        array = [selectedChildren.get() arrayByAddingObjectsFromArray:array];
     [m_element _accessibilitySetValue:array forAttribute:NSAccessibilitySelectedChildrenAttribute];
     END_AX_OBJC_EXCEPTIONS
 }
@@ -1517,10 +1517,10 @@ void AccessibilityUIElement::removeSelectionAtIndex(unsigned index) const
 {
     BEGIN_AX_OBJC_EXCEPTIONS
     AccessibilityUIElement element = const_cast<AccessibilityUIElement*>(this)->getChildAtIndex(index);
-    NSArray *selectedChildren = [m_element accessibilityAttributeValue:NSAccessibilitySelectedChildrenAttribute];
+    RetainPtr selectedChildren = [m_element accessibilityAttributeValue:NSAccessibilitySelectedChildrenAttribute];
     if (!element.platformUIElement() || !selectedChildren)
         return;
-    NSMutableArray *array = [NSMutableArray arrayWithArray:selectedChildren];
+    NSMutableArray *array = [NSMutableArray arrayWithArray:selectedChildren.get()];
     [array removeObject:element.platformUIElement()];
     [m_element _accessibilitySetValue:array forAttribute:NSAccessibilitySelectedChildrenAttribute];
     END_AX_OBJC_EXCEPTIONS
@@ -1766,17 +1766,17 @@ AccessibilityTextMarkerRange AccessibilityUIElement::selectedTextMarkerRange()
 
 void AccessibilityUIElement::resetSelectedTextMarkerRange()
 {
-    id start = [m_element accessibilityAttributeValue:@"AXStartTextMarker"];
+    RetainPtr start = [m_element accessibilityAttributeValue:@"AXStartTextMarker"];
     if (!start)
         return;
 
-    NSArray* textMarkers = @[start, start];
-    id textMarkerRange = [m_element accessibilityAttributeValue:@"AXTextMarkerRangeForUnorderedTextMarkers" forParameter:textMarkers];
+    NSArray* textMarkers = @[start.get(), start.get()];
+    RetainPtr textMarkerRange = [m_element accessibilityAttributeValue:@"AXTextMarkerRangeForUnorderedTextMarkers" forParameter:textMarkers];
     if (!textMarkerRange)
         return;
 
     BEGIN_AX_OBJC_EXCEPTIONS
-    [m_element _accessibilitySetValue:textMarkerRange forAttribute:NSAccessibilitySelectedTextMarkerRangeAttribute];
+    [m_element _accessibilitySetValue:textMarkerRange.get() forAttribute:NSAccessibilitySelectedTextMarkerRangeAttribute];
     END_AX_OBJC_EXCEPTIONS
 }
 
@@ -2237,13 +2237,13 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::supportedActions()
 
 static NSString *convertMathMultiscriptPairsToString(NSArray *pairs)
 {
-    __block NSMutableString *result = [NSMutableString string];
+    __block RetainPtr<NSMutableString> result = [NSMutableString string];
     [pairs enumerateObjectsUsingBlock:^(id pair, NSUInteger index, BOOL *stop) {
         for (NSString *key in pair)
-            [result appendFormat:@"\t%lu. %@ = %@\n", (unsigned long)index, key, [[pair objectForKey:key] accessibilityAttributeValue:NSAccessibilitySubroleAttribute]];
+            [result.get() appendFormat:@"\t%lu. %@ = %@\n", (unsigned long)index, key, [[pair objectForKey:key] accessibilityAttributeValue:NSAccessibilitySubroleAttribute]];
     }];
 
-    return result;
+    return result.autorelease();
 }
 
 JSRetainPtr<JSStringRef> AccessibilityUIElement::mathPostscriptsDescription() const

--- a/Tools/DumpRenderTree/mac/DumpRenderTreePasteboard.mm
+++ b/Tools/DumpRenderTree/mac/DumpRenderTreePasteboard.mm
@@ -274,9 +274,9 @@ static RetainPtr<CFStringRef> toUTI(NSString *type)
     }
 
     for (const auto& typeAndData : _data) {
-        NSData *data = (__bridge NSData *)typeAndData.value.get();
-        NSString *type = (__bridge NSString *)typeAndData.key.get();
-        [item setData:data forType:[NSPasteboard _modernPasteboardType:type]];
+        RetainPtr data = (__bridge NSData *)typeAndData.value.get();
+        RetainPtr type = (__bridge NSString *)typeAndData.key.get();
+        [item setData:data.get() forType:[NSPasteboard _modernPasteboardType:type.get()]];
     }
 
     _cachedPasteboardItems = @[ item.get() ];

--- a/Tools/DumpRenderTree/mac/DumpRenderTreeWindow.mm
+++ b/Tools/DumpRenderTree/mac/DumpRenderTreeWindow.mm
@@ -41,7 +41,7 @@
 #import <QuartzCore/CALayer.h>
 #endif
 
-CFMutableArrayRef openWindowsRef = 0;
+SUPPRESS_UNRETAINED_LOCAL CFMutableArrayRef openWindowsRef = 0;
 
 static CFArrayCallBacks NonRetainingArrayCallbacks = {
     0,

--- a/Tools/DumpRenderTree/mac/EventSendingController.mm
+++ b/Tools/DumpRenderTree/mac/EventSendingController.mm
@@ -800,10 +800,10 @@ static NSInteger swizzledEventButtonNumber()
                                      eventNumber:++eventNumber 
                                       clickCount:(leftMouseButtonDown ? clickCount : 0) 
                                         pressure:0.0]);
-    CGEventRef cgEvent = [event CGEvent];
-    CGEventSetIntegerValueField(cgEvent, kCGMouseEventDeltaX, newMousePosition.x - lastMousePosition.x);
-    CGEventSetIntegerValueField(cgEvent, kCGMouseEventDeltaY, -1 * (newMousePosition.y - lastMousePosition.y));
-    event = retainPtr([NSEvent eventWithCGEvent:cgEvent]);
+    RetainPtr<CGEventRef> cgEvent = [event CGEvent];
+    CGEventSetIntegerValueField(cgEvent.get(), kCGMouseEventDeltaX, newMousePosition.x - lastMousePosition.x);
+    CGEventSetIntegerValueField(cgEvent.get(), kCGMouseEventDeltaY, -1 * (newMousePosition.y - lastMousePosition.y));
+    event = retainPtr([NSEvent eventWithCGEvent:cgEvent.get()]);
     lastMousePosition = newMousePosition;
 #else
     lastMousePosition = [view convertPoint:NSMakePoint(x, y) toView:nil];

--- a/Tools/DumpRenderTree/mac/MockGeolocationProvider.mm
+++ b/Tools/DumpRenderTree/mac/MockGeolocationProvider.mm
@@ -127,22 +127,22 @@
     // Expect that views won't be (un)registered while iterating.
     auto copyOfRegisteredViews { _registeredViews };
     for (auto typelessView : copyOfRegisteredViews) {
-        auto webView = (__bridge WebView *)typelessView;
+        RetainPtr webView = (__bridge WebView *)typelessView;
 #if !PLATFORM(IOS_FAMILY)
         if (_hasError)
-            [webView _geolocationDidFailWithMessage:_errorMessage.get()];
+            [webView.get() _geolocationDidFailWithMessage:_errorMessage.get()];
         else
-            [webView _geolocationDidChangePosition:_lastPosition.get()];
+            [webView.get() _geolocationDidChangePosition:_lastPosition.get()];
 #else
         WebGeolocationPosition *lastPosition = _lastPosition.get();
         NSString *errorMessage = _errorMessage.get();
         if (_hasError) {
             WebThreadRun(^{
-                [webView _geolocationDidFailWithMessage:errorMessage];
+                [webView.get() _geolocationDidFailWithMessage:errorMessage];
             });
         } else {
             WebThreadRun(^{
-                [webView _geolocationDidChangePosition:lastPosition];
+                [webView.get() _geolocationDidChangePosition:lastPosition];
             });
         }
 #endif

--- a/Tools/DumpRenderTree/mac/PolicyDelegate.mm
+++ b/Tools/DumpRenderTree/mac/PolicyDelegate.mm
@@ -121,8 +121,8 @@ static NSString *dispositionTypeFromContentDispositionHeader(NSString *header)
     if (![HTTPResponse isKindOfClass:[NSHTTPURLResponse class]])
         HTTPResponse = nil;
 
-    NSString *dispositionType = dispositionTypeFromContentDispositionHeader([[HTTPResponse allHeaderFields] objectForKey:@"Content-Disposition"]);
-    if (dispositionType && [dispositionType compare:@"attachment" options:NSCaseInsensitiveSearch] == NSOrderedSame) {
+    RetainPtr dispositionType = dispositionTypeFromContentDispositionHeader([[HTTPResponse allHeaderFields] objectForKey:@"Content-Disposition"]);
+    if (dispositionType && [dispositionType.get() compare:@"attachment" options:NSCaseInsensitiveSearch] == NSOrderedSame) {
         printf("Policy delegate: resource is an attachment, suggested file name '%s'\n", [[HTTPResponse suggestedFilename] UTF8String]);
         [listener ignore];
         return;

--- a/Tools/DumpRenderTree/mac/UIDelegate.mm
+++ b/Tools/DumpRenderTree/mac/UIDelegate.mm
@@ -84,8 +84,8 @@ static NSString *stripTrailingSpaces(NSString *string)
 
 static NSString *addLeadingSpaceStripTrailingSpaces(NSString *string)
 {
-    auto result = stripTrailingSpaces(string);
-    return (result.length && ![result hasPrefix:@"\n"]) ? [@" " stringByAppendingString:result] : result;
+    RetainPtr result = stripTrailingSpaces(string);
+    return (result.get().length && ![result.get() hasPrefix:@"\n"]) ? [@" " stringByAppendingString:result.get()] : result.autorelease();
 }
 
 - (void)webView:(WebView *)sender addMessageToConsole:(NSDictionary *)dictionary withSource:(NSString *)source

--- a/Tools/DumpRenderTree/mac/WorkQueueItemMac.mm
+++ b/Tools/DumpRenderTree/mac/WorkQueueItemMac.mm
@@ -41,16 +41,16 @@
 bool LoadItem::invoke() const
 {
     RetainPtr<CFStringRef> urlCF = adoptCF(JSStringCopyCFString(kCFAllocatorDefault, m_url.get()));
-    NSString *urlNS = (__bridge NSString *)urlCF.get();
+    RetainPtr urlNS = (__bridge NSString *)urlCF.get();
     RetainPtr<CFStringRef> targetCF = adoptCF(JSStringCopyCFString(kCFAllocatorDefault, m_target.get()));
-    NSString *targetNS = (__bridge NSString *)targetCF.get();
+    RetainPtr targetNS = (__bridge NSString *)targetCF.get();
 
-    WebFrame *targetFrame;
-    if (targetNS && [targetNS length])
-        targetFrame = [mainFrame findFrameNamed:targetNS];
+    RetainPtr<WebFrame> targetFrame;
+    if (targetNS && [targetNS.get() length])
+        targetFrame = [mainFrame findFrameNamed:targetNS.get()];
     else
         targetFrame = mainFrame;
-    [targetFrame loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:urlNS]]];
+    [targetFrame.get() loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:urlNS.get()]]];
     return true;
 }
 
@@ -78,8 +78,8 @@ bool ReloadItem::invoke() const
 bool ScriptItem::invoke() const
 {
     RetainPtr<CFStringRef> scriptCF = adoptCF(JSStringCopyCFString(kCFAllocatorDefault, m_script.get()));
-    NSString *scriptNS = (__bridge NSString *)scriptCF.get();
-    [[mainFrame webView] stringByEvaluatingJavaScriptFromString:scriptNS];
+    RetainPtr scriptNS = (__bridge NSString *)scriptCF.get();
+    [[mainFrame webView] stringByEvaluatingJavaScriptFromString:scriptNS.get()];
     return true;
 }
 
@@ -90,8 +90,8 @@ bool BackForwardItem::invoke() const
     else if (m_howFar == -1)
         [[mainFrame webView] goBack];
     else {
-        WebBackForwardList *bfList = [[mainFrame webView] backForwardList];
-        [[mainFrame webView] goToBackForwardItem:[bfList itemAtIndex:m_howFar]];
+        RetainPtr bfList = [[mainFrame webView] backForwardList];
+        [[mainFrame webView] goToBackForwardItem:[bfList.get() itemAtIndex:m_howFar]];
     }
     return true;
 }

--- a/Tools/TestRunnerShared/EventSerialization/mac/EventSerializerMac.mm
+++ b/Tools/TestRunnerShared/EventSerialization/mac/EventSerializerMac.mm
@@ -196,7 +196,7 @@ bool eventIsOfGestureTypes(CGEventRef event, IOHIDEventType first, Types ... res
 
 + (NSDictionary *)dictionaryForEvent:(CGEventRef)rawEvent relativeToTime:(CGEventTimestamp)referenceTimestamp
 {
-    auto plainEvent = adoptCF(CGEventCreate(NULL));
+    RetainPtr plainEvent = adoptCF(CGEventCreate(NULL));
     CGEventRef rawPlainEvent = plainEvent.get();
 
     auto dict = adoptNS([[NSMutableDictionary alloc] init]);
@@ -227,7 +227,7 @@ bool eventIsOfGestureTypes(CGEventRef event, IOHIDEventType first, Types ... res
 
 + (RetainPtr<CGEventRef>)createEventForDictionary:(NSDictionary *)dict inWindow:(NSWindow *)window relativeToTime:(MonotonicTime)referenceTimestamp
 {
-    auto event = adoptCF(CGEventCreate(NULL));
+    RetainPtr event = adoptCF(CGEventCreate(NULL));
     CGEventRef rawEvent = event.get();
 
     FOR_EACH_CGEVENT_INTEGER_FIELD(STORE_INTEGER_FIELD_TO_EVENT);

--- a/Tools/TestRunnerShared/cocoa/LayoutTestSpellChecker.mm
+++ b/Tools/TestRunnerShared/cocoa/LayoutTestSpellChecker.mm
@@ -183,9 +183,9 @@ static LayoutTestSpellChecker *swizzledInitializeTextChecker()
 
 + (instancetype)checker
 {
-    auto *spellChecker = ensureGlobalLayoutTestSpellChecker();
+    RetainPtr spellChecker = ensureGlobalLayoutTestSpellChecker();
     if (hasSwizzledLayoutTestSpellChecker)
-        return spellChecker;
+        return spellChecker.autorelease();
 
 #if PLATFORM(MAC)
     originalSharedSpellCheckerMethod = class_getClassMethod(objc_getMetaClass("NSSpellChecker"), @selector(sharedSpellChecker));
@@ -196,7 +196,7 @@ static LayoutTestSpellChecker *swizzledInitializeTextChecker()
 #endif
 
     hasSwizzledLayoutTestSpellChecker = YES;
-    return spellChecker;
+    return spellChecker.autorelease();
 }
 
 + (void)uninstallAndReset

--- a/Tools/TestRunnerShared/cocoa/PoseAsClass.mm
+++ b/Tools/TestRunnerShared/cocoa/PoseAsClass.mm
@@ -28,6 +28,7 @@
 
 #import <objc/runtime.h>
 #import <wtf/Assertions.h>
+#import <wtf/RetainPtr.h>
 
 static void swizzleAllMethods(Class imposter, Class original)
 {
@@ -63,11 +64,11 @@ static void swizzleAllMethods(Class imposter, Class original)
 
 void poseAsClass(const char* imposter, const char* original)
 {
-    Class imposterClass = objc_getClass(imposter);
-    Class originalClass = objc_getClass(original);
+    RetainPtr imposterClass = objc_getClass(imposter);
+    RetainPtr originalClass = objc_getClass(original);
 
     // Swizzle instance methods
-    swizzleAllMethods(imposterClass, originalClass);
+    swizzleAllMethods(imposterClass.get(), originalClass.get());
     // and then class methods
-    swizzleAllMethods(object_getClass(imposterClass), object_getClass(originalClass));
+    swizzleAllMethods(object_getClass(imposterClass.get()), object_getClass(originalClass.get()));
 }

--- a/Tools/TestRunnerShared/mac/NSPasteboardAdditions.mm
+++ b/Tools/TestRunnerShared/mac/NSPasteboardAdditions.mm
@@ -34,41 +34,42 @@
 
 @implementation NSPasteboard (TestRunnerAdditions)
 
-+ (NSPasteboardType)_modernPasteboardType:(NSString *)type
++ (NSPasteboardType)_modernPasteboardType:(NSString *)typeArg
 {
-    if (UTTypeIsDynamic((__bridge CFStringRef)type)) {
-        if (auto legacyType = adoptCF(UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)type, kUTTagClassNSPboardType)))
+    RetainPtr<NSString> type = typeArg;
+    if (UTTypeIsDynamic((__bridge CFStringRef)type.get())) {
+        if (auto legacyType = adoptCF(UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)type.get(), kUTTagClassNSPboardType)))
             type = legacyType.bridgingAutorelease();
     }
 
-    if ([type isEqualToString:WebCore::legacyStringPasteboardTypeSingleton()])
+    if ([type.get() isEqualToString:WebCore::legacyStringPasteboardTypeSingleton()])
         return NSPasteboardTypeString;
 
-    if ([type isEqualToString:WebCore::legacyHTMLPasteboardTypeSingleton()])
+    if ([type.get() isEqualToString:WebCore::legacyHTMLPasteboardTypeSingleton()])
         return NSPasteboardTypeHTML;
 
-    if ([type isEqualToString:WebCore::legacyTIFFPasteboardTypeSingleton()])
+    if ([type.get() isEqualToString:WebCore::legacyTIFFPasteboardTypeSingleton()])
         return NSPasteboardTypeTIFF;
 
-    if ([type isEqualToString:WebCore::legacyURLPasteboardTypeSingleton()])
+    if ([type.get() isEqualToString:WebCore::legacyURLPasteboardTypeSingleton()])
         return NSPasteboardTypeURL;
 
-    if ([type isEqualToString:WebCore::legacyPDFPasteboardTypeSingleton()])
+    if ([type.get() isEqualToString:WebCore::legacyPDFPasteboardTypeSingleton()])
         return NSPasteboardTypePDF;
 
-    if ([type isEqualToString:WebCore::legacyRTFDPasteboardTypeSingleton()])
+    if ([type.get() isEqualToString:WebCore::legacyRTFDPasteboardTypeSingleton()])
         return NSPasteboardTypeRTFD;
 
-    if ([type isEqualToString:WebCore::legacyRTFPasteboardTypeSingleton()])
+    if ([type.get() isEqualToString:WebCore::legacyRTFPasteboardTypeSingleton()])
         return NSPasteboardTypeRTF;
 
-    if ([type isEqualToString:WebCore::legacyColorPasteboardTypeSingleton()])
+    if ([type.get() isEqualToString:WebCore::legacyColorPasteboardTypeSingleton()])
         return NSPasteboardTypeColor;
 
-    if ([type isEqualToString:WebCore::legacyFontPasteboardTypeSingleton()])
+    if ([type.get() isEqualToString:WebCore::legacyFontPasteboardTypeSingleton()])
         return NSPasteboardTypeFont;
 
-    return type;
+    return type.autorelease();
 }
 
 @end

--- a/Tools/TestWebKitAPI/Tests/WGSL/MetalCompilationTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WGSL/MetalCompilationTests.mm
@@ -52,8 +52,8 @@ static void testCompilation(const String& wgsl, Checks&&... checks)
     auto metalCompilationResult = metalCompile(msl);
     EXPECT_TRUE(std::holds_alternative<id<MTLLibrary>>(metalCompilationResult));
 
-    auto library = std::get<id<MTLLibrary>>(metalCompilationResult);
-    EXPECT_TRUE(library != nil);
+    RetainPtr library = std::get<id<MTLLibrary>>(metalCompilationResult);
+    EXPECT_TRUE(library.get() != nil);
 
     performChecks(std::get<String>(generationResult), std::forward<Checks>(checks)...);
 }

--- a/Tools/TestWebKitAPI/Tests/WTF/cf/RetainPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/cf/RetainPtr.cpp
@@ -46,12 +46,12 @@ TEST(RetainPtr, AdoptCF)
 
 TEST(RetainPtr, ConstructionFromMutableCFType)
 {
-    CFMutableStringRef string = CFStringCreateMutableCopy(kCFAllocatorDefault, 4, CFSTR("foo"));
+    RetainPtr string = adoptCF(CFStringCreateMutableCopy(kCFAllocatorDefault, 4, CFSTR("foo")));
 
     // This should invoke RetainPtr's move constructor.
     // FIXME: This doesn't actually test that we moved the value. We should use a mock
     // CFTypeRef that logs -retain and -release calls.
-    RetainPtr<CFStringRef> ptr = RetainPtr<CFMutableStringRef>(string);
+    RetainPtr<CFStringRef> ptr = RetainPtr<CFMutableStringRef>(string.get());
 
     EXPECT_EQ(string, ptr);
 
@@ -86,13 +86,13 @@ TEST(RetainPtr, ConstructionFromSameCFType)
 
 TEST(RetainPtr, MoveAssignmentFromMutableCFType)
 {
-    CFMutableStringRef string = CFStringCreateMutableCopy(kCFAllocatorDefault, 4, CFSTR("foo"));
+    RetainPtr string = adoptCF(CFStringCreateMutableCopy(kCFAllocatorDefault, 4, CFSTR("foo")));
     RetainPtr<CFStringRef> ptr;
 
     // This should invoke RetainPtr's move assignment operator.
     // FIXME: This doesn't actually test that we moved the value. We should use a mock
     // CFTypeRef that logs -retain and -release calls.
-    ptr = RetainPtr<CFMutableStringRef>(string);
+    ptr = RetainPtr<CFMutableStringRef>(string.get());
 
     EXPECT_EQ(string, ptr);
 

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/ContextualizedNSString.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/ContextualizedNSString.mm
@@ -230,22 +230,22 @@ TEST(WTF_ContextualizedNSString, cfString)
     auto context = "abc"_str;
     auto contents = "def"_str;
     auto contextualizedString = adoptNS([[WTFContextualizedNSString alloc] initWithContext:context contents:contents]);
-    auto contextualizedCFString = bridge_cast(static_cast<NSString *>(contextualizedString.get()));
+    RetainPtr contextualizedCFString = bridge_cast(static_cast<NSString *>(contextualizedString.get()));
 
-    EXPECT_EQ(CFStringGetCharacterAtIndex(contextualizedCFString, 0), 'a');
-    EXPECT_EQ(CFStringGetCharacterAtIndex(contextualizedCFString, 1), 'b');
-    EXPECT_EQ(CFStringGetCharacterAtIndex(contextualizedCFString, 2), 'c');
-    EXPECT_EQ(CFStringGetCharacterAtIndex(contextualizedCFString, 3), 'd');
-    EXPECT_EQ(CFStringGetCharacterAtIndex(contextualizedCFString, 4), 'e');
-    EXPECT_EQ(CFStringGetCharacterAtIndex(contextualizedCFString, 5), 'f');
+    EXPECT_EQ(CFStringGetCharacterAtIndex(contextualizedCFString.get(), 0), 'a');
+    EXPECT_EQ(CFStringGetCharacterAtIndex(contextualizedCFString.get(), 1), 'b');
+    EXPECT_EQ(CFStringGetCharacterAtIndex(contextualizedCFString.get(), 2), 'c');
+    EXPECT_EQ(CFStringGetCharacterAtIndex(contextualizedCFString.get(), 3), 'd');
+    EXPECT_EQ(CFStringGetCharacterAtIndex(contextualizedCFString.get(), 4), 'e');
+    EXPECT_EQ(CFStringGetCharacterAtIndex(contextualizedCFString.get(), 5), 'f');
 
-    EXPECT_NE(CFStringFind(contextualizedCFString, CFSTR("ab"), 0).location, kCFNotFound);
-    EXPECT_NE(CFStringFind(contextualizedCFString, CFSTR("bcd"), 0).location, kCFNotFound);
-    EXPECT_NE(CFStringFind(contextualizedCFString, CFSTR("de"), 0).location, kCFNotFound);
-    EXPECT_EQ(CFStringFind(contextualizedCFString, CFSTR("AB"), 0).location, kCFNotFound);
-    EXPECT_NE(CFStringFind(contextualizedCFString, CFSTR("AB"), kCFCompareCaseInsensitive).location, kCFNotFound);
+    EXPECT_NE(CFStringFind(contextualizedCFString.get(), CFSTR("ab"), 0).location, kCFNotFound);
+    EXPECT_NE(CFStringFind(contextualizedCFString.get(), CFSTR("bcd"), 0).location, kCFNotFound);
+    EXPECT_NE(CFStringFind(contextualizedCFString.get(), CFSTR("de"), 0).location, kCFNotFound);
+    EXPECT_EQ(CFStringFind(contextualizedCFString.get(), CFSTR("AB"), 0).location, kCFNotFound);
+    EXPECT_NE(CFStringFind(contextualizedCFString.get(), CFSTR("AB"), kCFCompareCaseInsensitive).location, kCFNotFound);
 
-    EXPECT_EQ(CFStringGetLength(contextualizedCFString), 6);
+    EXPECT_EQ(CFStringGetLength(contextualizedCFString.get()), 6);
 }
 
 TEST(WTF_ContextualizedNSString, tokenizer)
@@ -253,14 +253,14 @@ TEST(WTF_ContextualizedNSString, tokenizer)
     auto context = "th"_str;
     auto contents = "is is some text"_str;
     auto contextualizedString = adoptNS([[WTFContextualizedNSString alloc] initWithContext:context contents:contents]);
-    auto contextualizedCFString = bridge_cast(static_cast<NSString *>(contextualizedString.get()));
+    RetainPtr contextualizedCFString = bridge_cast(static_cast<NSString *>(contextualizedString.get()));
 
     auto locale = adoptCF(CFLocaleCreate(kCFAllocatorDefault, CFSTR("en_US")));
-    auto tokenizer = adoptCF(CFStringTokenizerCreate(kCFAllocatorDefault, contextualizedCFString, CFRangeMake(0, CFStringGetLength(contextualizedCFString)), kCFStringTokenizerUnitWord, locale.get()));
+    auto tokenizer = adoptCF(CFStringTokenizerCreate(kCFAllocatorDefault, contextualizedCFString.get(), CFRangeMake(0, CFStringGetLength(contextualizedCFString.get())), kCFStringTokenizerUnitWord, locale.get()));
 
     CFIndex indices[] = { 4, 7, 12, 17 };
     unsigned index = 0;
-    for (CFIndex i = 0; i < CFStringGetLength(contextualizedCFString); ++index) {
+    for (CFIndex i = 0; i < CFStringGetLength(contextualizedCFString.get()); ++index) {
         CFStringTokenizerGoToTokenAtIndex(tokenizer.get(), i);
         auto range = CFStringTokenizerGetCurrentTokenRange(tokenizer.get());
         ASSERT_NE(range.location, kCFNotFound);

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/TypeCastsCocoa.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/TypeCastsCocoa.mm
@@ -168,8 +168,8 @@ TEST(TypeCastsCocoa, checked_objc_cast)
         AUTORELEASEPOOL_FOR_ARC_DEBUG {
             objectNS = adoptNS([[NSString alloc] initWithFormat:@"%s", helloWorldCString]);
             objectNSPtr = reinterpret_cast<uintptr_t>(objectNS.get());
-            NSObject* objPtr = objectNS.get();
-            EXPECT_EQ(objectNS.get(), objPtr);
+            RetainPtr objPtr = objectNS.get();
+            EXPECT_EQ(objectNS.get(), objPtr.get());
         }
         EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectNSPtr));
     }

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
@@ -301,8 +301,8 @@ TEST(URLExtras, URLExtras_File)
 TEST(URLExtras, URLExtras_ParsingError)
 {
     // Expect IDN failure.
-    NSURL *url = WTF::URLWithUserTypedString(@"http://.com", nil);
-    EXPECT_TRUE(url == nil);
+    RetainPtr url = WTF::URLWithUserTypedString(@"http://.com", nil);
+    EXPECT_TRUE(url.get() == nil);
 
     RetainPtr encodedHostName = WTF::encodeHostName(@"http://.com");
     EXPECT_TRUE(encodedHostName.get() == nil);
@@ -330,11 +330,11 @@ TEST(URLExtras, URLExtras_ParsingError)
 
 TEST(URLExtras, URLExtras_Nil)
 {
-    NSURL *url1 = WTF::URLWithUserTypedString(nil);
-    EXPECT_TRUE(url1 == nil);
+    RetainPtr url1 = WTF::URLWithUserTypedString(nil);
+    EXPECT_TRUE(url1.get() == nil);
 
-    NSURL *url2 = WTF::URLWithUserTypedStringDeprecated(nil);
-    EXPECT_TRUE(url2 == nil);
+    RetainPtr url2 = WTF::URLWithUserTypedStringDeprecated(nil);
+    EXPECT_TRUE(url2.get() == nil);
 }
 
 TEST(URLExtras, CreateNSArray)

--- a/Tools/TestWebKitAPI/Tests/WTF/darwin/TypeCastsOSObjectCF.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/darwin/TypeCastsOSObjectCF.cpp
@@ -45,13 +45,13 @@ TEST(TypeCastsOSObjectCF, osObjectCast)
 
     // Same cast.
     OSObjectPtr<dispatch_group_t> group = adoptOSObject(dispatch_group_create());
-    CFTypeRef groupPtr = group.get();
-    EXPECT_EQ(group.get(), osObjectCast<dispatch_group_t>(groupPtr));
-    EXPECT_EQ(1L, CFGetRetainCount(groupPtr));
+    RetainPtr groupPtr = group.get();
+    EXPECT_EQ(group.get(), osObjectCast<dispatch_group_t>(groupPtr.get()));
+    EXPECT_EQ(1L, CFGetRetainCount(groupPtr.get()));
 
     // Up cast.
     EXPECT_EQ(group.get(), osObjectCast<dispatch_object_t>(group.get()));
-    EXPECT_EQ(1L, CFGetRetainCount(groupPtr));
+    EXPECT_EQ(1L, CFGetRetainCount(groupPtr.get()));
 
     // Down cast.
     auto object = adoptOSObject<dispatch_object_t>(dispatch_group_create());

--- a/Tools/TestWebKitAPI/Tests/WTF/ns/RetainPtr.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/ns/RetainPtr.mm
@@ -370,13 +370,13 @@ TEST(RETAIN_PTR_TEST_NAME, LeakRef)
 
 TEST(RETAIN_PTR_TEST_NAME, BridgingAutorelease)
 {
-    NSString *nsString;
+    RetainPtr<NSString> nsString;
     uintptr_t nsStringPtr;
 
     AUTORELEASEPOOL_FOR_ARC_DEBUG {
         RetainPtr<CFStringRef> string = adoptCF(CFStringCreateWithCString(nullptr, "hello world", kCFStringEncodingASCII));
         nsString = string.bridgingAutorelease();
-        nsStringPtr = reinterpret_cast<uintptr_t>(nsString);
+        nsStringPtr = reinterpret_cast<uintptr_t>(nsString.get());
     }
 
     EXPECT_EQ(1, CFGetRetainCount((CFTypeRef)nsStringPtr));

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/CaptionPreferencesTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/CaptionPreferencesTests.mm
@@ -449,26 +449,26 @@ TEST_F(CaptionPreferenceTests, CaptionStyleMenu)
     if (!CaptionUserPreferencesMediaAF::canSetActiveProfileID())
         return;
 
-    PlatformMenu *menu = ensureMenu();
+    RetainPtr menu = ensureMenu();
 
 #if PLATFORM(MAC)
-    EXPECT_EQ(menu.numberOfItems, 5);
-    EXPECT_WK_STREQ("Profile 1", [[menu itemAtIndex:0] title]);
-    EXPECT_WK_STREQ("Profile 2", [[menu itemAtIndex:1] title]);
-    EXPECT_WK_STREQ("Profile 3", [[menu itemAtIndex:2] title]);
+    EXPECT_EQ([menu.get() numberOfItems], 5);
+    EXPECT_WK_STREQ("Profile 1", [[menu.get() itemAtIndex:0] title]);
+    EXPECT_WK_STREQ("Profile 2", [[menu.get() itemAtIndex:1] title]);
+    EXPECT_WK_STREQ("Profile 3", [[menu.get() itemAtIndex:2] title]);
 
-    EXPECT_EQ(NSControlStateValueOn, [[menu itemAtIndex:0] state]);
-    EXPECT_EQ(NSControlStateValueOff, [[menu itemAtIndex:1] state]);
-    EXPECT_EQ(NSControlStateValueOff, [[menu itemAtIndex:2] state]);
+    EXPECT_EQ(NSControlStateValueOn, [[menu.get() itemAtIndex:0] state]);
+    EXPECT_EQ(NSControlStateValueOff, [[menu.get() itemAtIndex:1] state]);
+    EXPECT_EQ(NSControlStateValueOff, [[menu.get() itemAtIndex:2] state]);
 
-    [menu performActionForItemAtIndex:1];
+    [menu.get() performActionForItemAtIndex:1];
     EXPECT_WK_STREQ("Profile 2", CaptionUserPreferencesMediaAF::platformActiveProfileID());
 
-    [menu performActionForItemAtIndex:2];
+    [menu.get() performActionForItemAtIndex:2];
     EXPECT_WK_STREQ("Profile 3", CaptionUserPreferencesMediaAF::platformActiveProfileID());
 #elif PLATFORM(IOS_FAMILY)
-    EXPECT_EQ(menu.children.count, 2UL);
-    PlatformMenu *profileMenu = dynamic_objc_cast<PlatformMenu>(menu.children.firstObject);
+    EXPECT_EQ([menu.get() children].count, 2UL);
+    PlatformMenu *profileMenu = dynamic_objc_cast<PlatformMenu>([menu.get() children].firstObject);
 
     EXPECT_EQ(profileMenu.children.count, 3UL);
     EXPECT_WK_STREQ("Profile 1", profileMenu.children[0].title);
@@ -627,8 +627,8 @@ TEST_F(CaptionPreferenceTests, MenuAncestryCheck)
     if (!CaptionUserPreferencesMediaAF::canSetActiveProfileID())
         return;
 
-    WKCaptionStyleMenuController *controller = ensureController();
-    PlatformMenu *captionStyleMenu = controller.captionStyleMenu;
+    RetainPtr controller = ensureController();
+    PlatformMenu *captionStyleMenu = [controller.get() captionStyleMenu];
 
 #if PLATFORM(IOS_FAMILY)
     RetainPtr otherMenu = [UIMenu menuWithTitle:@"Other" children:@[]];
@@ -641,12 +641,12 @@ TEST_F(CaptionPreferenceTests, MenuAncestryCheck)
     [parentMenu addItem:parentItem.get()];
 #endif
 
-    EXPECT_FALSE([controller hasAncestor:captionStyleMenu]);
-    EXPECT_TRUE([controller isAncestorOf:captionStyleMenu]);
-    EXPECT_FALSE([controller isAncestorOf:otherMenu.get()]);
+    EXPECT_FALSE([controller.get() hasAncestor:captionStyleMenu]);
+    EXPECT_TRUE([controller.get() isAncestorOf:captionStyleMenu]);
+    EXPECT_FALSE([controller.get() isAncestorOf:otherMenu.get()]);
 
-    EXPECT_FALSE([controller hasAncestor:otherMenu.get()]);
-    EXPECT_TRUE([controller hasAncestor:parentMenu.get()]);
+    EXPECT_FALSE([controller.get() hasAncestor:otherMenu.get()]);
+    EXPECT_TRUE([controller.get() hasAncestor:parentMenu.get()]);
 }
 
 // FIXME: Re-enable this test for iOS when rdar://166158601 is resolved.

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/DatabaseTrackerTest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/DatabaseTrackerTest.mm
@@ -95,8 +95,8 @@ TEST(DatabaseTracker, DeleteOrigin)
     // tables, and an actual database on disk.
     // In this case, we should remove the origin's information from both the Origins
     // and Databases tables, and remove the database from disk.
-    NSString *webSQLDirectory = FileSystem::createTemporaryDirectory(@"WebSQL");
-    String databaseDirectoryPath(webSQLDirectory);
+    RetainPtr webSQLDirectory = FileSystem::createTemporaryDirectory(@"WebSQL");
+    String databaseDirectoryPath(webSQLDirectory.get());
 
     std::unique_ptr<DatabaseTracker> databaseTracker = DatabaseTracker::trackerWithDatabasePath(databaseDirectoryPath);
     SecurityOriginData origin("https"_s, "webkit.org"_s, 443);
@@ -140,8 +140,8 @@ TEST(DatabaseTracker, DeleteOriginWhenDatabaseDoesNotExist)
     // Test the case where there is an entry in both the Origins and Databases tables,
     // but not an actual database on disk.
     // The information should still be removed from the tables.
-    NSString *webSQLDirectory = FileSystem::createTemporaryDirectory(@"WebSQL");
-    String databaseDirectoryPath(webSQLDirectory);
+    RetainPtr webSQLDirectory = FileSystem::createTemporaryDirectory(@"WebSQL");
+    String databaseDirectoryPath(webSQLDirectory.get());
 
     std::unique_ptr<DatabaseTracker> databaseTracker = DatabaseTracker::trackerWithDatabasePath(databaseDirectoryPath);
     SecurityOriginData origin("https"_s, "webkit.org"_s, 443);
@@ -176,8 +176,8 @@ TEST(DatabaseTracker, DeleteOriginWhenDeletingADatabaseFails)
     // When we call deleteOrigin(), deleting one of these databases fails.
     // In this case, we shouldn't remove the information from either the Databases or
     // Origins tables.
-    NSString *webSQLDirectory = FileSystem::createTemporaryDirectory(@"WebSQL");
-    String databaseDirectoryPath(webSQLDirectory);
+    RetainPtr webSQLDirectory = FileSystem::createTemporaryDirectory(@"WebSQL");
+    String databaseDirectoryPath(webSQLDirectory.get());
 
     std::unique_ptr<DatabaseTracker> databaseTracker = DatabaseTracker::trackerWithDatabasePath(databaseDirectoryPath);
     SecurityOriginData origin("https"_s, "webkit.org"_s, 443);
@@ -233,8 +233,8 @@ TEST(DatabaseTracker, DeleteOriginWithMissingEntryInDatabasesTable)
     // the Databases table. There is an actual database on disk.
     // The information should still be removed from the Origins table, and the
     // database should be deleted from disk.
-    NSString *webSQLDirectory = FileSystem::createTemporaryDirectory(@"WebSQL");
-    String databaseDirectoryPath(webSQLDirectory);
+    RetainPtr webSQLDirectory = FileSystem::createTemporaryDirectory(@"WebSQL");
+    String databaseDirectoryPath(webSQLDirectory.get());
 
     std::unique_ptr<DatabaseTracker> databaseTracker = DatabaseTracker::trackerWithDatabasePath(databaseDirectoryPath);
     SecurityOriginData origin("https"_s, "webkit.org"_s, 443);
@@ -272,8 +272,8 @@ TEST(DatabaseTracker, DeleteDatabase)
     // Test the expected case. There is an entry in the Databases table
     // and a database on disk. After the deletion, the database should be deleted
     // from disk, and the information should be gone from the Databases table.
-    NSString *webSQLDirectory = FileSystem::createTemporaryDirectory(@"WebSQL");
-    String databaseDirectoryPath(webSQLDirectory);
+    RetainPtr webSQLDirectory = FileSystem::createTemporaryDirectory(@"WebSQL");
+    String databaseDirectoryPath(webSQLDirectory.get());
 
     std::unique_ptr<DatabaseTracker> databaseTracker = DatabaseTracker::trackerWithDatabasePath(databaseDirectoryPath);
     SecurityOriginData origin("https"_s, "webkit.org"_s, 443);
@@ -316,8 +316,8 @@ TEST(DatabaseTracker, DeleteDatabaseWhenDatabaseDoesNotExist)
 {
     // Test the case where we try to delete a database that doesn't exist on disk.
     // We should still remove the database information from the Databases table.
-    NSString *webSQLDirectory = FileSystem::createTemporaryDirectory(@"WebSQL");
-    String databaseDirectoryPath(webSQLDirectory);
+    RetainPtr webSQLDirectory = FileSystem::createTemporaryDirectory(@"WebSQL");
+    String databaseDirectoryPath(webSQLDirectory.get());
 
     std::unique_ptr<DatabaseTracker> databaseTracker = DatabaseTracker::trackerWithDatabasePath(databaseDirectoryPath);
     SecurityOriginData origin("https"_s, "webkit.org"_s, 443);

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestGraphicsContextGLCocoa.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestGraphicsContextGLCocoa.mm
@@ -529,12 +529,12 @@ TEST_P(AnyContextAttributeTest, DisplayBuffersAreNotRecycledWhedInUse)
         context->prepareForDisplay();
         WebCore::IOSurface* surface = context->displayBufferSurface();
         ASSERT_NE(surface, nullptr);
-        IOSurfaceRef surfaceRef = surface->surface();
-        EXPECT_NE(surfaceRef, nullptr);
-        EXPECT_FALSE(seenSurfaceRefs.contains(surfaceRef));
-        seenSurfaceRefs.add(surfaceRef);
+        RetainPtr surfaceRef = surface->surface();
+        EXPECT_NE(surfaceRef.get(), nullptr);
+        EXPECT_FALSE(seenSurfaceRefs.contains(surfaceRef.get()));
+        seenSurfaceRefs.add(surfaceRef.get());
 
-        IOSurfaceIncrementUseCount(surfaceRef);
+        IOSurfaceIncrementUseCount(surfaceRef.get());
     }
     ASSERT_EQ(seenSurfaceRefs.size(), 50u);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm
@@ -178,8 +178,8 @@ private:
 
 static RetainPtr<TestWKWebView> createWebViewWithAdvancedPrivacyProtections(BOOL enabled = YES, RetainPtr<WKWebpagePreferences>&& preferences = { }, WKWebsiteDataStore *dataStore = nil, bool enableResourceLoadStatistics = YES)
 {
-    auto store = dataStore ?: WKWebsiteDataStore.nonPersistentDataStore;
-    store._resourceLoadStatisticsEnabled = enableResourceLoadStatistics;
+    RetainPtr store = dataStore ?: WKWebsiteDataStore.nonPersistentDataStore;
+    store.get()._resourceLoadStatisticsEnabled = enableResourceLoadStatistics;
 
     auto policies = enabled
         ? _WKWebsiteNetworkConnectionIntegrityPolicyEnhancedTelemetry | _WKWebsiteNetworkConnectionIntegrityPolicyEnabled | _WKWebsiteNetworkConnectionIntegrityPolicyRequestValidation | _WKWebsiteNetworkConnectionIntegrityPolicySanitizeLookalikeCharacters
@@ -189,7 +189,7 @@ static RetainPtr<TestWKWebView> createWebViewWithAdvancedPrivacyProtections(BOOL
     [preferences _setNetworkConnectionIntegrityPolicy:policies];
 
     auto configuration = adoptNS([WKWebViewConfiguration new]);
-    [configuration setWebsiteDataStore:store];
+    [configuration setWebsiteDataStore:store.get()];
     [configuration setMediaTypesRequiringUserActionForPlayback:WKAudiovisualMediaTypeNone];
     [configuration setDefaultWebpagePreferences:preferences.get()];
     if (!enabled) {

--- a/Tools/TestWebKitAPI/Tests/WebKit/DeferredViewInWindowStateChange.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/DeferredViewInWindowStateChange.mm
@@ -58,7 +58,7 @@ TEST(WebKit, DeferredViewInWindowStateChange)
     WKRetainPtr<WKContextRef> context = adoptWK(Util::createContextForInjectedBundleTest("MouseMoveAfterCrashTest"));
 
     PlatformWebView webView(context.get());
-    WKWebView *wkView = webView.platformView();
+    RetainPtr wkView = webView.platformView();
     setPageLoaderClient(webView.page());
 
     WKRetainPtr<WKURLRef> url = adoptWK(Util::createURLForResource("lots-of-text", "html"));
@@ -68,13 +68,13 @@ TEST(WebKit, DeferredViewInWindowStateChange)
 
     EXPECT_JS_FALSE(webView.page(), "document.hidden");
 
-    [wkView _beginDeferringViewInWindowChanges];
-    [wkView removeFromSuperview];
+    [wkView.get() _beginDeferringViewInWindowChanges];
+    [wkView.get() removeFromSuperview];
 
     // The document should still not be hidden, even though we're not in-window, because we are deferring in-window changes.
     EXPECT_JS_FALSE(webView.page(), "document.hidden");
 
-    [wkView _endDeferringViewInWindowChanges];
+    [wkView.get() _endDeferringViewInWindowChanges];
 
     __block bool done = false;
     WKPageRef page = webView.page();

--- a/Tools/TestWebKitAPI/Tests/WebKit/GetUserMediaNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/GetUserMediaNavigation.mm
@@ -117,12 +117,12 @@ TEST(WebKit, NavigateDuringDeviceEnumeration)
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     initializeMediaCaptureConfiguration(configuration.get());
-    WKWebView *webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]).leakRef();
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
     auto delegate = adoptNS([[NavigationWhileGetUserMediaPromptDisplayedUIDelegate alloc] init]);
-    [webView setUIDelegate:delegate.get()];
+    [webView.get() setUIDelegate:delegate.get()];
 
     okToProceed = false;
-    [webView loadTestPageNamed:@"enumerateMediaDevices"];
+    [webView.get() loadTestPageNamed:@"enumerateMediaDevices"];
     TestWebKitAPI::Util::run(&okToProceed);
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/NetworkProcessCrashWithPendingConnection.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/NetworkProcessCrashWithPendingConnection.mm
@@ -40,7 +40,7 @@ static bool loadedOrCrashed = false;
 static bool loaded = false;
 static bool webProcessCrashed = false;
 static bool networkProcessCrashed = false;
-static WKWebView* testView;
+static NeverDestroyed<RetainPtr<WKWebView>> testView;
 
 @interface MonitorWebContentCrashNavigationDelegate : NSObject <WKNavigationDelegate>
 @end
@@ -143,7 +143,7 @@ TEST(WebKit, NetworkProcessRelaunchOnLaunchFailure)
     WKContextSetClient(static_cast<WKContextRef>(processPool.get()), &client.base);
 
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    testView = webView.get();
+    testView.get() = webView.get();
 
     // Constucting a WebView starts a network process so terminate this one. The page load below will then request a network process and we
     // make this new network process launch crash on startup.

--- a/Tools/TestWebKitAPI/Tests/WebKit/OverrideAppleLanguagesPreference.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/OverrideAppleLanguagesPreference.mm
@@ -108,9 +108,9 @@ static bool preferenceObserverPreferenceDidChangeCalled = false;
 
 static WKPreferenceObserver *sharedInstanceMethodOverride(id self, SEL selector)
 {
-    WKPreferenceObserver *observer = wtfCallIMP<WKPreferenceObserver *>(sharedInstanceMethodOriginal, self, selector);
+    RetainPtr observer = wtfCallIMP<WKPreferenceObserver *>(sharedInstanceMethodOriginal, self, selector);
     preferenceObserverSharedInstanceCalled = true;
-    return observer;
+    return observer.autorelease();
 }
 
 static WKPreferenceObserver *preferenceDidChangeMethodOverride(id self, SEL selector, NSString *domain, NSString *key, NSString *encodedValue)
@@ -118,8 +118,8 @@ static WKPreferenceObserver *preferenceDidChangeMethodOverride(id self, SEL sele
     NSLog(@"preferenceDidChangeMethodOverride: domain=%@, key=%@, encodedValue=%@", domain, key, encodedValue);
     if ([key isEqualToString:@"AppleLanguages"])
         preferenceObserverPreferenceDidChangeCalled = true;
-    WKPreferenceObserver *observer = wtfCallIMP<WKPreferenceObserver *>(preferenceDidChangeMethodOriginal, self, selector, domain, key, encodedValue);
-    return observer;
+    RetainPtr observer = wtfCallIMP<WKPreferenceObserver *>(preferenceDidChangeMethodOriginal, self, selector, domain, key, encodedValue);
+    return observer.autorelease();
 }
 
 // FIXME: This test times out on Apple Silicon (webkit.org/b/222619) and is a flaky failure on Intel (webkit.org/b/228309)

--- a/Tools/TestWebKitAPI/Tests/WebKit/PreferenceChanges.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/PreferenceChanges.mm
@@ -517,9 +517,9 @@ static bool sharedInstanceCalled = false;
 
 static WKPreferenceObserver *sharedInstanceMethodOverride(id self, SEL selector)
 {
-    WKPreferenceObserver *observer = wtfCallIMP<WKPreferenceObserver *>(sharedInstanceMethodOriginal, self, selector);
+    RetainPtr observer = wtfCallIMP<WKPreferenceObserver *>(sharedInstanceMethodOriginal, self, selector);
     sharedInstanceCalled = true;
-    return observer;
+    return observer.autorelease();
 }
 
 TEST(WebKit, PreferenceObserverStartedOnActivation)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKThumbnailView.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKThumbnailView.mm
@@ -109,7 +109,7 @@ TEST(WebKit, WKThumbnailViewKeepSnapshotWhenRemovedFromSuperview)
 {
     WKRetainPtr<WKContextRef> context = adoptWK(WKContextCreateWithConfiguration(nullptr));
     PlatformWebView webView(context.get());
-    WKWebView *wkView = webView.platformView();
+    RetainPtr wkView = webView.platformView();
     setPageLoaderClient(webView.page());
     WKPageSetCustomBackingScaleFactor(webView.page(), 1);
 
@@ -118,13 +118,13 @@ TEST(WebKit, WKThumbnailViewKeepSnapshotWhenRemovedFromSuperview)
     Util::run(&didFinishLoad);
     didFinishLoad = false;
 
-    RetainPtr<_WKThumbnailView> thumbnailView = adoptNS([[_WKThumbnailView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) fromWKWebView:wkView]);
+    RetainPtr<_WKThumbnailView> thumbnailView = adoptNS([[_WKThumbnailView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) fromWKWebView:wkView.get()]);
 
     RetainPtr<SnapshotSizeObserver> observer = adoptNS([[SnapshotSizeObserver alloc] init]);
 
     [thumbnailView addObserver:observer.get() forKeyPath:@"snapshotSize" options:NSKeyValueObservingOptionNew context:snapshotSizeChangeKVOContext];
 
-    [wkView.window.contentView addSubview:thumbnailView.get()];
+    [wkView.get().window.contentView addSubview:thumbnailView.get()];
     Util::run(&didTakeSnapshot);
     didTakeSnapshot = false;
 
@@ -135,7 +135,7 @@ TEST(WebKit, WKThumbnailViewKeepSnapshotWhenRemovedFromSuperview)
     // The snapshot should be removed when unparented.
     EXPECT_TRUE([thumbnailView layer].contents == nil);
 
-    [wkView.window.contentView addSubview:thumbnailView.get()];
+    [wkView.get().window.contentView addSubview:thumbnailView.get()];
     Util::run(&didTakeSnapshot);
     didTakeSnapshot = false;
 
@@ -155,7 +155,7 @@ TEST(WebKit, WKThumbnailViewMaximumSnapshotSize)
 {
     WKRetainPtr<WKContextRef> context = adoptWK(WKContextCreateWithConfiguration(nullptr));
     PlatformWebView webView(context.get());
-    WKWebView *wkView = webView.platformView();
+    RetainPtr wkView = webView.platformView();
     setPageLoaderClient(webView.page());
     WKPageSetCustomBackingScaleFactor(webView.page(), 1);
 
@@ -164,13 +164,13 @@ TEST(WebKit, WKThumbnailViewMaximumSnapshotSize)
     Util::run(&didFinishLoad);
     didFinishLoad = false;
 
-    RetainPtr<_WKThumbnailView> thumbnailView = adoptNS([[_WKThumbnailView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) fromWKWebView:wkView]);
+    RetainPtr<_WKThumbnailView> thumbnailView = adoptNS([[_WKThumbnailView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) fromWKWebView:wkView.get()]);
 
     RetainPtr<SnapshotSizeObserver> observer = adoptNS([[SnapshotSizeObserver alloc] init]);
 
     [thumbnailView addObserver:observer.get() forKeyPath:@"snapshotSize" options:NSKeyValueObservingOptionNew context:snapshotSizeChangeKVOContext];
 
-    [wkView.window.contentView addSubview:thumbnailView.get()];
+    [wkView.get().window.contentView addSubview:thumbnailView.get()];
     Util::run(&didTakeSnapshot);
     didTakeSnapshot = false;
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebArchive.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebArchive.cpp
@@ -56,31 +56,31 @@ static void didReceiveMessageFromInjectedBundle(WKContextRef, WKStringRef messag
     
     // It should be a dictionary.
     EXPECT_EQ(CFDictionaryGetTypeID(), CFGetTypeID(propertyList.get()));
-    CFDictionaryRef dictionary = (CFDictionaryRef)propertyList.get();
-    
+    RetainPtr dictionary = (CFDictionaryRef)propertyList.get();
+
     // It should have a main resource.
-    CFTypeRef mainResource = CFDictionaryGetValue(dictionary, CFSTR("WebMainResource"));
+    RetainPtr mainResource = CFDictionaryGetValue(dictionary.get(), CFSTR("WebMainResource"));
     EXPECT_TRUE(mainResource);
-    EXPECT_EQ(CFDictionaryGetTypeID(), CFGetTypeID(mainResource));
-    CFDictionaryRef mainResourceDictionary = (CFDictionaryRef)mainResource;
-    
+    EXPECT_EQ(CFDictionaryGetTypeID(), CFGetTypeID(mainResource.get()));
+    RetainPtr mainResourceDictionary = (CFDictionaryRef)mainResource.get();
+
     // Main resource should have a non-empty url and mime type.
-    CFTypeRef url = CFDictionaryGetValue(mainResourceDictionary, CFSTR("WebResourceURL"));
+    RetainPtr url = CFDictionaryGetValue(mainResourceDictionary.get(), CFSTR("WebResourceURL"));
     EXPECT_TRUE(url);
-    EXPECT_EQ(CFStringGetTypeID(), CFGetTypeID(url));
-    EXPECT_NE(CFStringGetLength((CFStringRef)url), 0);
-    
-    CFTypeRef mimeType = CFDictionaryGetValue(mainResourceDictionary, CFSTR("WebResourceMIMEType"));
+    EXPECT_EQ(CFStringGetTypeID(), CFGetTypeID(url.get()));
+    EXPECT_NE(CFStringGetLength((CFStringRef)url.get()), 0);
+
+    RetainPtr mimeType = CFDictionaryGetValue(mainResourceDictionary.get(), CFSTR("WebResourceMIMEType"));
     EXPECT_TRUE(mimeType);
-    EXPECT_EQ(CFStringGetTypeID(), CFGetTypeID(mimeType));
-    EXPECT_NE(CFStringGetLength((CFStringRef)mimeType), 0);
-    
+    EXPECT_EQ(CFStringGetTypeID(), CFGetTypeID(mimeType.get()));
+    EXPECT_NE(CFStringGetLength((CFStringRef)mimeType.get()), 0);
+
     // Main resource dictionary should have a "WebResourceData" key.
-    CFTypeRef resourceData = CFDictionaryGetValue(mainResourceDictionary, CFSTR("WebResourceData"));
+    RetainPtr resourceData = CFDictionaryGetValue(mainResourceDictionary.get(), CFSTR("WebResourceData"));
     EXPECT_TRUE(resourceData);
-    EXPECT_EQ(CFDataGetTypeID(), CFGetTypeID(resourceData));
-    
-    RetainPtr<CFStringRef> stringData = adoptCF(CFStringCreateFromExternalRepresentation(0, (CFDataRef)resourceData, kCFStringEncodingUTF8));
+    EXPECT_EQ(CFDataGetTypeID(), CFGetTypeID(resourceData.get()));
+
+    RetainPtr<CFStringRef> stringData = adoptCF(CFStringCreateFromExternalRepresentation(0, (CFDataRef)resourceData.get(), kCFStringEncodingUTF8));
     EXPECT_TRUE(stringData);
     
     // It should contain the string "Simple HTML file." in it.

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebRTC.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebRTC.mm
@@ -139,7 +139,7 @@ TEST(WebKit2, RTCDataChannelPostMessage)
         { "/sw.js"_s, { {{ "Content-Type"_s, "application/javascript"_s }}, js } },
         { "/"_s, { main } },
     }, HTTPServer::Protocol::Https);
-    auto* request = server.request();
+    RetainPtr request = server.request();
 
     auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [navigationDelegate setDidReceiveAuthenticationChallenge:^(WKWebView *, NSURLAuthenticationChallenge *challenge, void (^callback)(NSURLSessionAuthChallengeDisposition, NSURLCredential *)) {
@@ -158,7 +158,7 @@ TEST(WebKit2, RTCDataChannelPostMessage)
         isReady = true;
     }];
     isReady = false;
-    [webView1 loadRequest:request];
+    [webView1 loadRequest:request.get()];
     TestWebKitAPI::Util::run(&isReady);
 
     auto webView2 = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
@@ -170,7 +170,7 @@ TEST(WebKit2, RTCDataChannelPostMessage)
     }];
 
     isReady = false;
-    [webView2 loadRequest:request];
+    [webView2 loadRequest:request.get()];
     TestWebKitAPI::Util::run(&isReady);
 
     [messageHandler setMessageHandler:[](WKScriptMessage *message) {

--- a/Tools/TestWebKitAPI/Tests/WebKit/mac/ContextMenuImgWithVideo.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/mac/ContextMenuImgWithVideo.mm
@@ -60,7 +60,7 @@ TEST(WebKit, ContextMenuImgWithVideo)
     [webView synchronouslyLoadTestPageNamed:@"ContextMenuImgWithVideo"];
 
     NSWindow* window = [webView window];
-    NSEvent* event = [NSEvent mouseEventWithType:NSEventTypeRightMouseDown
+    RetainPtr event = [NSEvent mouseEventWithType:NSEventTypeRightMouseDown
         location:NSMakePoint(100, window.frame.size.height - 100)
         modifierFlags:0
         timestamp:GetCurrentEventTime()
@@ -70,12 +70,12 @@ TEST(WebKit, ContextMenuImgWithVideo)
         clickCount:0
         pressure:0.0];
 
-    NSView* subView = [webView hitTest:[event locationInWindow]];
+    NSView* subView = [webView hitTest:[event.get() locationInWindow]];
     if (!subView)
         return;
 
     contextMenuShown = false;
-    [subView mouseDown:event];
+    [subView mouseDown:event.get()];
     Util::run(&contextMenuShown);
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/BundleCSSStyleDeclarationHandle.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/BundleCSSStyleDeclarationHandle.mm
@@ -62,14 +62,14 @@ TEST(WebKit, WKWebProcessPlugInCSSStyleDeclarationHandle)
     auto interface = retainPtr([_WKRemoteObjectInterface remoteObjectInterfaceWithProtocol:@protocol(BundleCSSStyleDeclarationHandleProtocol)]);
     [[webView _remoteObjectRegistry] registerExportedObject:object.get() interface:interface.get()];
 
-    NSString *html = @(
+    RetainPtr html = @(
         "<script>"
         "function verifyStyle(style) {"
         "    return style === document.body.style;"
         "}"
         "</script>"
     );
-    [webView loadHTMLString:html baseURL:nil];
+    [webView loadHTMLString:html.get() baseURL:nil];
 
     TestWebKitAPI::Util::run(&didVerifyStyle);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/BundleParametersPlugIn.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/BundleParametersPlugIn.mm
@@ -64,8 +64,8 @@ static NSString * const testParameter2 = @"TestParameter2";
     WKBundlePageLoaderClientV6 loaderClient = { };
     loaderClient.base.version = 6;
     loaderClient.willLoadDataRequest = [] (WKBundlePageRef page, WKURLRequestRef, WKDataRef, WKStringRef, WKStringRef, WKURLRef, WKTypeRef userData, const void*) {
-        id data = WKObjCTypeWrapperGetObject((WKObjCTypeWrapperRef)userData);
-        RELEASE_ASSERT([data isKindOfClass:NSData.class]);
+        RetainPtr data = WKObjCTypeWrapperGetObject((WKObjCTypeWrapperRef)userData);
+        RELEASE_ASSERT([data.get() isKindOfClass:NSData.class]);
     };
     WKBundlePageSetPageLoaderClient(static_cast<WKBundlePageRef>(browserContextController), &loaderClient.base);
 #endif

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Challenge.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Challenge.mm
@@ -591,9 +591,9 @@ void verifyCertificateAndPublicKey(SecTrustRef trust)
 {
     EXPECT_WK_STREQ(challenge.protectionSpace.authenticationMethod, NSURLAuthenticationMethodServerTrust);
     _authenticationChallengeCount++;
-    SecTrustRef trust = challenge.protectionSpace.serverTrust;
-    verifyCertificateAndPublicKey(trust);
-    completionHandler(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:trust]);
+    RetainPtr<SecTrustRef> trust = challenge.protectionSpace.serverTrust;
+    verifyCertificateAndPublicKey(trust.get());
+    completionHandler(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:trust.get()]);
 }
 
 @end

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/CopyHTML.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/CopyHTML.mm
@@ -114,10 +114,10 @@ TEST(CopyHTML, SanitizationPreservesCharacterSetInSelectedText)
     [webView copy:nil];
     [webView waitForNextPresentationUpdate];
 
-    NSString *copiedMarkup = readHTMLStringFromPasteboard();
-    EXPECT_TRUE([copiedMarkup containsString:@"<span "]);
-    EXPECT_TRUE([copiedMarkup containsString:@"我叫謝文昇"]);
-    EXPECT_TRUE([copiedMarkup containsString:@"</span>"]);
+    RetainPtr copiedMarkup = readHTMLStringFromPasteboard();
+    EXPECT_TRUE([copiedMarkup.get() containsString:@"<span "]);
+    EXPECT_TRUE([copiedMarkup.get() containsString:@"我叫謝文昇"]);
+    EXPECT_TRUE([copiedMarkup.get() containsString:@"</span>"]);
 
     auto attributedString = adoptNS([[NSAttributedString alloc] initWithData:readHTMLDataFromPasteboard() options:@{ NSDocumentTypeDocumentOption: NSHTMLTextDocumentType } documentAttributes:nil error:nil]);
     EXPECT_WK_STREQ("我叫謝文昇", [attributedString string]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/CopyRTF.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/CopyRTF.mm
@@ -75,10 +75,10 @@ static RetainPtr<NSAttributedString> copyAttributedStringFromHTML(NSString *html
     [webView selectAll:nil];
     [webView _synchronouslyExecuteEditCommand:@"Copy" argument:nil];
 
-    NSData *rtfData = readRTFDataFromPasteboard();
+    RetainPtr rtfData = readRTFDataFromPasteboard();
     EXPECT_NOT_NULL(rtfData);
 
-    auto attributedString = adoptNS([[NSAttributedString alloc] initWithData:rtfData options:@{ } documentAttributes:nil error:nullptr]);
+    auto attributedString = adoptNS([[NSAttributedString alloc] initWithData:rtfData.get() options:@{ } documentAttributes:nil error:nullptr]);
     EXPECT_NOT_NULL(attributedString.get());
 
     return attributedString;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/CreateWebArchive.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/CreateWebArchive.mm
@@ -313,7 +313,7 @@ TEST(WebArchive, SaveResourcesIframe)
         NSString *mainResourcePath = [directoryURL URLByAppendingPathComponent:@"host.html"].path;
         EXPECT_TRUE([fileManager fileExistsAtPath:mainResourcePath]);
 
-        NSString *savedMainResourceString = [[NSString alloc] initWithData:[NSData dataWithContentsOfFile:mainResourcePath] encoding:NSUTF8StringEncoding];
+        RetainPtr savedMainResourceString = [[NSString alloc] initWithData:[NSData dataWithContentsOfFile:mainResourcePath] encoding:NSUTF8StringEncoding];
         NSString *resourceDirectoryName = @"host_files";
         NSString *resourceDirectoryPath = [directoryURL URLByAppendingPathComponent:resourceDirectoryName].path;
         NSArray *savedResourceFileNames = [fileManager contentsOfDirectoryAtPath:resourceDirectoryPath error:0];
@@ -328,13 +328,13 @@ TEST(WebArchive, SaveResourcesIframe)
             if ([fileName containsString:@"frame_"]) {
                 // Ensure urls are replaced with file path.
                 NSString *replacementPath = [resourceDirectoryName stringByAppendingPathComponent:fileName];
-                EXPECT_TRUE([savedMainResourceString containsString:replacementPath]);
+                EXPECT_TRUE([savedMainResourceString.get() containsString:replacementPath]);
                 // Ensure all iframes are saved by looking at content.
                 NSString *resourceFilePath = [resourceDirectoryPath stringByAppendingPathComponent:fileName];
-                NSString* savedSubframeResourceString = [[NSString alloc] initWithData:[NSData dataWithContentsOfFile:resourceFilePath] encoding:NSUTF8StringEncoding];
-                NSRange range = [savedSubframeResourceString rangeOfString:@"iframe"];
+                RetainPtr savedSubframeResourceString = [[NSString alloc] initWithData:[NSData dataWithContentsOfFile:resourceFilePath] encoding:NSUTF8StringEncoding];
+                NSRange range = [savedSubframeResourceString.get() rangeOfString:@"iframe"];
                 EXPECT_NE(NSNotFound, (long)range.location);
-                NSString *iframeContent = [savedSubframeResourceString substringWithRange:NSMakeRange(range.location, range.length + 1)];
+                NSString *iframeContent = [savedSubframeResourceString.get() substringWithRange:NSMakeRange(range.location, range.length + 1)];
                 [frameResourceContentsToFind removeObject:iframeContent];
                 ++frameFileCount;
             }
@@ -419,7 +419,7 @@ TEST(WebArchive, SaveResourcesFrame)
         NSString *mainResourcePath = [directoryURL URLByAppendingPathComponent:@"host.html"].path;
         EXPECT_TRUE([fileManager fileExistsAtPath:mainResourcePath]);
 
-        NSString *savedMainResource = [[NSString alloc] initWithData:[NSData dataWithContentsOfFile:mainResourcePath] encoding:NSUTF8StringEncoding];
+        RetainPtr savedMainResource = [[NSString alloc] initWithData:[NSData dataWithContentsOfFile:mainResourcePath] encoding:NSUTF8StringEncoding];
         NSString *resourceDirectoryName = @"host_files";
         NSString *resourceDirectoryPath = [directoryURL URLByAppendingPathComponent:resourceDirectoryName].path;
         NSArray *resourceFileNames = [fileManager contentsOfDirectoryAtPath:resourceDirectoryPath error:0];
@@ -432,12 +432,12 @@ TEST(WebArchive, SaveResourcesFrame)
         for (NSString *fileName in resourceFileNames) {
             if ([fileName containsString:@"frame_"]) {
                 NSString *replacementPath = [resourceDirectoryName stringByAppendingPathComponent:fileName];
-                EXPECT_TRUE([savedMainResource containsString:replacementPath]);
+                EXPECT_TRUE([savedMainResource.get() containsString:replacementPath]);
                 NSString *resourceFilePath = [resourceDirectoryPath stringByAppendingPathComponent:fileName];
-                NSString* savedSubframeResource = [[NSString alloc] initWithData:[NSData dataWithContentsOfFile:resourceFilePath] encoding:NSUTF8StringEncoding];
-                NSRange range = [savedSubframeResource rangeOfString:@"thisisframe"];
+                RetainPtr savedSubframeResource = [[NSString alloc] initWithData:[NSData dataWithContentsOfFile:resourceFilePath] encoding:NSUTF8StringEncoding];
+                NSRange range = [savedSubframeResource.get() rangeOfString:@"thisisframe"];
                 EXPECT_NE(NSNotFound, (long)range.location);
-                NSString *frameContent = [savedSubframeResource substringWithRange:NSMakeRange(range.location, range.length + 1)];
+                NSString *frameContent = [savedSubframeResource.get() substringWithRange:NSMakeRange(range.location, range.length + 1)];
                 [frameResourceContentsToFind removeObject:frameContent];
                 ++frameFileCount;
             }
@@ -598,7 +598,7 @@ TEST(WebArchive, SaveResourcesBlobURL)
         NSString *mainResourcePath = [directoryURL URLByAppendingPathComponent:@"host.html"].path;
         EXPECT_TRUE([fileManager fileExistsAtPath:mainResourcePath]);
 
-        NSString *savedMainResource = [[NSString alloc] initWithData:[NSData dataWithContentsOfFile:mainResourcePath] encoding:NSUTF8StringEncoding];
+        RetainPtr savedMainResource = [[NSString alloc] initWithData:[NSData dataWithContentsOfFile:mainResourcePath] encoding:NSUTF8StringEncoding];
         NSString *resourceDirectoryName = @"host_files";
         NSString *resourceDirectoryPath = [directoryURL URLByAppendingPathComponent:resourceDirectoryName].path;
         NSArray *resourceFileNames = [fileManager contentsOfDirectoryAtPath:resourceDirectoryPath error:0];
@@ -608,14 +608,14 @@ TEST(WebArchive, SaveResourcesBlobURL)
             NSString *replacementPath = [resourceDirectoryName stringByAppendingPathComponent:fileName];
             if ([fileName containsString:@"frame_"]) {
                 // HTML file from the first iframe element.
-                EXPECT_TRUE([savedMainResource containsString:replacementPath]);
+                EXPECT_TRUE([savedMainResource.get() containsString:replacementPath]);
                 NSString *resourceFilePath = [resourceDirectoryPath stringByAppendingPathComponent:fileName];
-                NSString* savedSubframeResource = [[NSString alloc] initWithData:[NSData dataWithContentsOfFile:resourceFilePath] encoding:NSUTF8StringEncoding];
-                EXPECT_TRUE([savedSubframeResource containsString:@"thisisframe"]);
+                RetainPtr savedSubframeResource = [[NSString alloc] initWithData:[NSData dataWithContentsOfFile:resourceFilePath] encoding:NSUTF8StringEncoding];
+                EXPECT_TRUE([savedSubframeResource.get() containsString:@"thisisframe"]);
             } else {
                 // Image file from img and the second iframe element.
                 unsigned replacementPathCount = 0;
-                NSString *savedMainResourceCopy = [NSString stringWithString:savedMainResource];
+                NSString *savedMainResourceCopy = [NSString stringWithString:savedMainResource.get()];
                 NSRange range = [savedMainResourceCopy rangeOfString:replacementPath];
                 while (range.location != NSNotFound) {
                     ++replacementPathCount;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurity.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurity.mm
@@ -72,8 +72,8 @@ TEST(EnhancedSecurity, EnhancedSecurityEnablesTrue)
     auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeMaximizeCompatibility;
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
-    [webView loadRequest:[NSURLRequest requestWithURL:url]];
+    RetainPtr url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+    [webView loadRequest:[NSURLRequest requestWithURL:url.get()]];
     [webView _test_waitForDidFinishNavigation];
     EXPECT_EQ(true, isEnhancedSecurityEnabled(webView.get()));
     NSString *processVariant = [webView _webContentProcessVariantForFrame:nil];
@@ -85,8 +85,8 @@ TEST(EnhancedSecurity, EnhancedSecurityEnableFalse)
     auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeNone;
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
-    [webView loadRequest:[NSURLRequest requestWithURL:url]];
+    RetainPtr url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+    [webView loadRequest:[NSURLRequest requestWithURL:url.get()]];
     [webView _test_waitForDidFinishNavigation];
     EXPECT_EQ(false, isEnhancedSecurityEnabled(webView.get()));
     NSString *processVariant = [webView _webContentProcessVariantForFrame:nil];
@@ -98,8 +98,8 @@ TEST(EnhancedSecurity, EnhancedSecurityDisablesJIT)
     auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeMaximizeCompatibility;
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
-    [webView loadRequest:[NSURLRequest requestWithURL:url]];
+    RetainPtr url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+    [webView loadRequest:[NSURLRequest requestWithURL:url.get()]];
     [webView _test_waitForDidFinishNavigation];
     EXPECT_EQ(false, isJITEnabled(webView.get()));
 }
@@ -117,14 +117,14 @@ TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysEnabledAfterNavigation)
         finishedNavigation = true;
     };
 
-    NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
-    [webView loadRequest:[NSURLRequest requestWithURL:url]];
+    RetainPtr url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+    [webView loadRequest:[NSURLRequest requestWithURL:url.get()]];
     TestWebKitAPI::Util::run(&finishedNavigation);
     EXPECT_EQ(true, isEnhancedSecurityEnabled(webView.get()));
 
     finishedNavigation = false;
-    NSURL *url2 = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
-    [webView loadRequest:[NSURLRequest requestWithURL:url2]];
+    RetainPtr url2 = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
+    [webView loadRequest:[NSURLRequest requestWithURL:url2.get()]];
     TestWebKitAPI::Util::run(&finishedNavigation);
 
     EXPECT_EQ(true, isEnhancedSecurityEnabled(webView.get()));
@@ -143,8 +143,8 @@ TEST(EnhancedSecurity, PSONToEnhancedSecurity)
         finishedNavigation = true;
     };
 
-    NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
-    [webView loadRequest:[NSURLRequest requestWithURL:url]];
+    RetainPtr url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+    [webView loadRequest:[NSURLRequest requestWithURL:url.get()]];
     TestWebKitAPI::Util::run(&finishedNavigation);
     EXPECT_EQ(false, isEnhancedSecurityEnabled(webView.get()));
     EXPECT_STREQ("standard", [webView _webContentProcessVariantForFrame:nil].UTF8String);
@@ -159,8 +159,8 @@ TEST(EnhancedSecurity, PSONToEnhancedSecurity)
         completionHandler(WKNavigationActionPolicyAllow, preferences);
     };
 
-    NSURL *url2 = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
-    [webView loadRequest:[NSURLRequest requestWithURL:url2]];
+    RetainPtr url2 = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
+    [webView loadRequest:[NSURLRequest requestWithURL:url2.get()]];
     TestWebKitAPI::Util::run(&finishedNavigation);
 
     EXPECT_EQ(true, isEnhancedSecurityEnabled(webView.get()));
@@ -181,8 +181,8 @@ TEST(EnhancedSecurity, PSONToEnhancedSecuritySamePage)
         finishedNavigation = true;
     };
 
-    NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
-    [webView loadRequest:[NSURLRequest requestWithURL:url]];
+    RetainPtr url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+    [webView loadRequest:[NSURLRequest requestWithURL:url.get()]];
     TestWebKitAPI::Util::run(&finishedNavigation);
     EXPECT_EQ(false, isEnhancedSecurityEnabled(webView.get()));
     EXPECT_STREQ("standard", [webView _webContentProcessVariantForFrame:nil].UTF8String);
@@ -197,8 +197,8 @@ TEST(EnhancedSecurity, PSONToEnhancedSecuritySamePage)
         completionHandler(WKNavigationActionPolicyAllow, preferences);
     };
 
-    NSURL *url2 = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
-    [webView loadRequest:[NSURLRequest requestWithURL:url2]];
+    RetainPtr url2 = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+    [webView loadRequest:[NSURLRequest requestWithURL:url2.get()]];
     TestWebKitAPI::Util::run(&finishedNavigation);
 
     EXPECT_EQ(true, isEnhancedSecurityEnabled(webView.get()));
@@ -235,8 +235,8 @@ TEST(EnhancedSecurity, PSONToEnhancedSecuritySharedProcessPool)
         finishedNavigation = true;
     };
 
-    NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
-    [webView loadRequest:[NSURLRequest requestWithURL:url]];
+    RetainPtr url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+    [webView loadRequest:[NSURLRequest requestWithURL:url.get()]];
     TestWebKitAPI::Util::run(&finishedNavigation);
     EXPECT_EQ(false, isEnhancedSecurityEnabled(webView.get()));
     EXPECT_STREQ("standard", [webView _webContentProcessVariantForFrame:nil].UTF8String);
@@ -253,8 +253,8 @@ TEST(EnhancedSecurity, PSONToEnhancedSecuritySharedProcessPool)
         completionHandler(WKNavigationActionPolicyAllow, preferences);
     };
 
-    NSURL *url2 = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
-    [webView2 loadRequest:[NSURLRequest requestWithURL:url2]];
+    RetainPtr url2 = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+    [webView2 loadRequest:[NSURLRequest requestWithURL:url2.get()]];
     TestWebKitAPI::Util::run(&finishedNavigation);
 
     EXPECT_EQ(true, isEnhancedSecurityEnabled(webView2.get()));
@@ -281,8 +281,8 @@ TEST(EnhancedSecurity, PSONToEnhancedSecuritySharedProcessPoolReverse)
         finishedNavigation = true;
     };
 
-    NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
-    [webView loadRequest:[NSURLRequest requestWithURL:url]];
+    RetainPtr url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+    [webView loadRequest:[NSURLRequest requestWithURL:url.get()]];
     TestWebKitAPI::Util::run(&finishedNavigation);
     EXPECT_EQ(true, isEnhancedSecurityEnabled(webView.get()));
     EXPECT_STREQ("security", [webView _webContentProcessVariantForFrame:nil].UTF8String);
@@ -299,8 +299,8 @@ TEST(EnhancedSecurity, PSONToEnhancedSecuritySharedProcessPoolReverse)
         completionHandler(WKNavigationActionPolicyAllow, preferences);
     };
 
-    NSURL *url2 = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
-    [webView2 loadRequest:[NSURLRequest requestWithURL:url2]];
+    RetainPtr url2 = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+    [webView2 loadRequest:[NSURLRequest requestWithURL:url2.get()]];
     TestWebKitAPI::Util::run(&finishedNavigation);
 
     EXPECT_EQ(false, isEnhancedSecurityEnabled(webView2.get()));
@@ -318,14 +318,14 @@ TEST(EnhancedSecurity, ProcessVariantMatchesConfiguration)
     webViewConfiguration2.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeNone;
     auto webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration2.get()]);
 
-    NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+    RetainPtr url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
 
-    [webView1 loadRequest:[NSURLRequest requestWithURL:url]];
+    [webView1 loadRequest:[NSURLRequest requestWithURL:url.get()]];
     [webView1 _test_waitForDidFinishNavigation];
     EXPECT_EQ(true, isEnhancedSecurityEnabled(webView1.get()));
     EXPECT_STREQ("security", [webView1 _webContentProcessVariantForFrame:nil].UTF8String);
 
-    [webView2 loadRequest:[NSURLRequest requestWithURL:url]];
+    [webView2 loadRequest:[NSURLRequest requestWithURL:url.get()]];
     [webView2 _test_waitForDidFinishNavigation];
     EXPECT_EQ(false, isEnhancedSecurityEnabled(webView2.get()));
     EXPECT_STREQ("standard", [webView2 _webContentProcessVariantForFrame:nil].UTF8String);
@@ -350,8 +350,8 @@ TEST(EnhancedSecurity, ProcessCanLaunch)
     [webView setNavigationDelegate:delegate.get()];
 
     // Wait up to 10 seconds for navigation to complete
-    NSDate *timeout = [NSDate dateWithTimeIntervalSinceNow:10.0];
-    while (!navigationFinished && [timeout timeIntervalSinceNow] > 0)
+    RetainPtr timeout = [NSDate dateWithTimeIntervalSinceNow:10.0];
+    while (!navigationFinished && [timeout.get() timeIntervalSinceNow] > 0)
         [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
 
     if (navigationFinished)
@@ -386,8 +386,8 @@ TEST(EnhancedSecurity, CaptivePortalProcessCanLaunch)
     [webView setNavigationDelegate:delegate.get()];
 
     // Wait up to 10 seconds for navigation to complete
-    NSDate *timeout = [NSDate dateWithTimeIntervalSinceNow:10.0];
-    while (!navigationFinished && [timeout timeIntervalSinceNow] > 0)
+    RetainPtr timeout = [NSDate dateWithTimeIntervalSinceNow:10.0];
+    while (!navigationFinished && [timeout.get() timeIntervalSinceNow] > 0)
         [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
 
     if (navigationFinished)
@@ -858,8 +858,8 @@ TEST(EnhancedSecurity, LockdownModeTakesPrecedenceOverEnhancedSecurity)
     webViewConfiguration.get().defaultWebpagePreferences.lockdownModeEnabled = YES;
 
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 1, 1) configuration:webViewConfiguration.get()]);
-    NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
-    [webView loadRequest:[NSURLRequest requestWithURL:url]];
+    RetainPtr url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+    [webView loadRequest:[NSURLRequest requestWithURL:url.get()]];
     [webView _test_waitForDidFinishNavigation];
 
     EXPECT_EQ(false, isJITEnabled(webView.get()));
@@ -881,8 +881,8 @@ TEST(EnhancedSecurity, EnhancedSecurityRequestedWhenLockdownModeActive)
         finishedNavigation = true;
     };
 
-    NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
-    [webView loadRequest:[NSURLRequest requestWithURL:url]];
+    RetainPtr url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+    [webView loadRequest:[NSURLRequest requestWithURL:url.get()]];
     TestWebKitAPI::Util::run(&finishedNavigation);
 
     EXPECT_EQ(false, isJITEnabled(webView.get()));
@@ -894,8 +894,8 @@ TEST(EnhancedSecurity, EnhancedSecurityRequestedWhenLockdownModeActive)
         completionHandler(WKNavigationActionPolicyAllow, preferences);
     };
 
-    NSURL *url2 = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
-    [webView loadRequest:[NSURLRequest requestWithURL:url2]];
+    RetainPtr url2 = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
+    [webView loadRequest:[NSURLRequest requestWithURL:url2.get()]];
     TestWebKitAPI::Util::run(&finishedNavigation);
 
     EXPECT_EQ(false, isJITEnabled(webView.get()));
@@ -914,8 +914,8 @@ TEST(EnhancedSecurity, SystemLockdownModeEnablesEnhancedSecurityWhenAPIOptsOut)
     webViewConfiguration.get().defaultWebpagePreferences.lockdownModeEnabled = NO;
 
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    NSURL *url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
-    [webView loadRequest:[NSURLRequest requestWithURL:url]];
+    RetainPtr url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+    [webView loadRequest:[NSURLRequest requestWithURL:url.get()]];
     [webView _test_waitForDidFinishNavigation];
 
     EXPECT_EQ(false, isJITEnabled(webView.get()));

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm
@@ -974,14 +974,14 @@ static RetainPtr<NSString> emptyEnhancedSecuritySitesPath()
 {
     NSFileManager *defaultFileManager = NSFileManager.defaultManager;
 
-    NSURL *enhancedSecurityFile = enhancedSecuritySitesPath();
-    NSURL *enhancedSecurityDirectory = [enhancedSecurityFile URLByDeletingLastPathComponent];
+    RetainPtr enhancedSecurityFile = enhancedSecuritySitesPath();
+    NSURL *enhancedSecurityDirectory = [enhancedSecurityFile.get() URLByDeletingLastPathComponent];
 
     [defaultFileManager removeItemAtPath:enhancedSecurityDirectory.path error:nil];
-    EXPECT_FALSE([defaultFileManager fileExistsAtPath:enhancedSecurityFile.path]);
+    EXPECT_FALSE([defaultFileManager fileExistsAtPath:enhancedSecurityFile.get().path]);
     [defaultFileManager createDirectoryAtURL:enhancedSecurityDirectory withIntermediateDirectories:YES attributes:nil error:nil];
 
-    return enhancedSecurityFile.path;
+    return enhancedSecurityFile.get().path;
 }
 
 static void createEnhancedSecuritySitesTable(WebCore::SQLiteDatabase& database)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPage.mm
@@ -123,9 +123,9 @@ TEST(WebKit, FindInPage)
     // Ensure that the generated image has the correct DPI.
     __block bool generateTextImageDone = false;
     [match generateTextImage:^(NSImage *image) {
-        CGImageRef CGImage = [image CGImageForProposedRect:nil context:nil hints:nil];
-        EXPECT_EQ(image.size.width, CGImageGetWidth(CGImage) / 2);
-        EXPECT_EQ(image.size.height, CGImageGetHeight(CGImage) / 2);
+        RetainPtr CGImage = [image CGImageForProposedRect:nil context:nil hints:nil];
+        EXPECT_EQ(image.size.width, CGImageGetWidth(CGImage.get()) / 2);
+        EXPECT_EQ(image.size.height, CGImageGetHeight(CGImage.get()) / 2);
         generateTextImageDone = true;
     }];
     TestWebKitAPI::Util::run(&generateTextImageDone);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IconLoadingDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IconLoadingDelegate.mm
@@ -116,20 +116,20 @@ TEST(IconLoading, DefaultFavicon)
     TestWebKitAPI::Util::run(&doneWithIcons);
     TestWebKitAPI::Util::run(&iconDelegate.get()->receivedFaviconDataCallback);
 
-    auto* faviconParameters = iconDelegate.get()->favicon.get();
-    EXPECT_WK_STREQ(makeString(mainURL, "favicon.ico"_s), faviconParameters.url.absoluteString);
-    EXPECT_EQ(WKLinkIconTypeFavicon, faviconParameters.iconType);
-    EXPECT_EQ(static_cast<unsigned long>(0), faviconParameters.attributes.count);
+    RetainPtr faviconParameters = iconDelegate.get()->favicon.get();
+    EXPECT_WK_STREQ(makeString(mainURL, "favicon.ico"_s), faviconParameters.get().url.absoluteString);
+    EXPECT_EQ(WKLinkIconTypeFavicon, faviconParameters.get().iconType);
+    EXPECT_EQ(static_cast<unsigned long>(0), faviconParameters.get().attributes.count);
 
-    auto* touchParameters = iconDelegate.get()->touch.get();
-    EXPECT_WK_STREQ("http://example.com/my-apple-touch-icon.png", touchParameters.url.absoluteString);
-    EXPECT_EQ(WKLinkIconTypeTouchIcon, touchParameters.iconType);
-    EXPECT_EQ(static_cast<unsigned long>(4), touchParameters.attributes.count);
-    EXPECT_WK_STREQ("apple-touch-icon", [touchParameters.attributes valueForKey:@"rel"]);
-    EXPECT_WK_STREQ("57x57", [touchParameters.attributes valueForKey:@"sizes"]);
-    EXPECT_WK_STREQ("http://example.com/my-apple-touch-icon.png", [touchParameters.attributes valueForKey:@"href"]);
-    EXPECT_TRUE([touchParameters.attributes.allKeys containsObject:@"non-standard-attribute"]);
-    EXPECT_FALSE([touchParameters.attributes.allKeys containsObject:@"nonexistent-attribute"]);
+    RetainPtr touchParameters = iconDelegate.get()->touch.get();
+    EXPECT_WK_STREQ("http://example.com/my-apple-touch-icon.png", touchParameters.get().url.absoluteString);
+    EXPECT_EQ(WKLinkIconTypeTouchIcon, touchParameters.get().iconType);
+    EXPECT_EQ(static_cast<unsigned long>(4), touchParameters.get().attributes.count);
+    EXPECT_WK_STREQ("apple-touch-icon", [touchParameters.get().attributes valueForKey:@"rel"]);
+    EXPECT_WK_STREQ("57x57", [touchParameters.get().attributes valueForKey:@"sizes"]);
+    EXPECT_WK_STREQ("http://example.com/my-apple-touch-icon.png", [touchParameters.get().attributes valueForKey:@"href"]);
+    EXPECT_TRUE([touchParameters.get().attributes.allKeys containsObject:@"non-standard-attribute"]);
+    EXPECT_FALSE([touchParameters.get().attributes.allKeys containsObject:@"nonexistent-attribute"]);
 }
 
 TEST(IconLoading, AlreadyCachedIcon)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ImageAnalysisTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ImageAnalysisTests.mm
@@ -294,12 +294,12 @@ TEST(ImageAnalysisTests, ImageAnalysisPrioritizesVisibleImages)
     [webView _startImageAnalysis:nil target:nil];
     [webView waitForImageAnalysisRequests:2];
 
-    auto firstRequestedImage = [processedRequests().first() image];
-    auto lastRequestedImage = [processedRequests().last() image];
-    EXPECT_EQ(200U, CGImageGetWidth(firstRequestedImage));
-    EXPECT_EQ(150U, CGImageGetHeight(firstRequestedImage));
-    EXPECT_EQ(600U, CGImageGetWidth(lastRequestedImage));
-    EXPECT_EQ(450U, CGImageGetHeight(lastRequestedImage));
+    RetainPtr<CGImageRef> firstRequestedImage = [processedRequests().first() image];
+    RetainPtr<CGImageRef> lastRequestedImage = [processedRequests().last() image];
+    EXPECT_EQ(200U, CGImageGetWidth(firstRequestedImage.get()));
+    EXPECT_EQ(150U, CGImageGetHeight(firstRequestedImage.get()));
+    EXPECT_EQ(600U, CGImageGetWidth(lastRequestedImage.get()));
+    EXPECT_EQ(450U, CGImageGetHeight(lastRequestedImage.get()));
 }
 
 TEST(ImageAnalysisTests, ImageAnalysisWithTransparentImages)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAlternateHTMLString.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAlternateHTMLString.mm
@@ -113,9 +113,9 @@ TEST(WKWebView, LoadAlternateHTMLStringFromProvisionalLoadErrorBackToBack)
         [webView setNavigationDelegate:delegate.get()];
 
         char literal[] = "https://www.example.com<>/";
-        NSURL* targetURL = WTF::URLWithData([NSData dataWithBytes:literal length:strlen(literal)], nil);
-        [webView loadRequest:[NSURLRequest requestWithURL:targetURL]];
-        [webView loadRequest:[NSURLRequest requestWithURL:targetURL]];
+        RetainPtr targetURL = WTF::URLWithData([NSData dataWithBytes:literal length:strlen(literal)], nil);
+        [webView loadRequest:[NSURLRequest requestWithURL:targetURL.get()]];
+        [webView loadRequest:[NSURLRequest requestWithURL:targetURL.get()]];
 
         isDone = false;
         TestWebKitAPI::Util::run(&isDone);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadInvalidURLRequest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadInvalidURLRequest.mm
@@ -119,7 +119,8 @@ TEST(WebKit, LoadInvalidURLRequestNonASCII)
     auto webView = adoptNS([WKWebView new]);
     [webView setNavigationDelegate:delegate.get()];
     const UInt8 bytes[10] = { 'h', 't', 't', 'p', ':', '/', '/', 0xE2, 0x80, 0x80 };
-    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:bridge_cast(adoptCF(CFURLCreateAbsoluteURLWithBytes(nullptr, bytes, 10, kCFStringEncodingUTF8, nullptr, true))).get()];
+    RetainPtr url = bridge_cast(adoptCF(CFURLCreateAbsoluteURLWithBytes(nullptr, bytes, 10, kCFStringEncodingUTF8, nullptr, true)));
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url.get()];
     [request _setProperty:request.URL forKey:@"_kCFHTTPCookiePolicyPropertySiteForCookies"];
     [webView loadRequest:request];
     Util::run(&done);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/LocalStorageClear.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/LocalStorageClear.mm
@@ -138,13 +138,13 @@ TEST(WKWebView, ClearStaleAppCache)
     TestWebKitAPI::Util::run(&readyToContinue);
 
     // Start with a clean slate of Website caches.
-    if (auto *websiteCacheDirectory = defaultWebsiteCacheDirectory()) {
-        NSURL *websiteCacheURL = [NSURL fileURLWithPath:[websiteCacheDirectory stringByExpandingTildeInPath]];
+    if (RetainPtr websiteCacheDirectory = defaultWebsiteCacheDirectory()) {
+        NSURL *websiteCacheURL = [NSURL fileURLWithPath:[websiteCacheDirectory.get() stringByExpandingTildeInPath]];
         [[NSFileManager defaultManager] removeItemAtURL:websiteCacheURL error:nil];
     }
 
-    if (auto *appCacheDirectory = defaultApplicationCacheDirectory()) {
-        NSURL *appCacheURL = [NSURL fileURLWithPath:[appCacheDirectory stringByExpandingTildeInPath]];
+    if (RetainPtr appCacheDirectory = defaultApplicationCacheDirectory()) {
+        NSURL *appCacheURL = [NSURL fileURLWithPath:[appCacheDirectory.get() stringByExpandingTildeInPath]];
         [[NSFileManager defaultManager] removeItemAtURL:appCacheURL error:nil];
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/NowPlaying.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/NowPlaying.mm
@@ -54,12 +54,12 @@ SOFT_LINK_CONSTANT(MediaRemote, kMRMediaRemoteNowPlayingApplicationPIDUserInfoKe
 
 static bool userInfoHasNowPlayingApplicationPID(CFDictionaryRef userInfo, int32_t pid)
 {
-    CFNumberRef nowPlayingPidCF = (CFNumberRef)CFDictionaryGetValue(userInfo, kMRMediaRemoteNowPlayingApplicationPIDUserInfoKey);
+    RetainPtr nowPlayingPidCF = (CFNumberRef)CFDictionaryGetValue(userInfo, kMRMediaRemoteNowPlayingApplicationPIDUserInfoKey);
     if (!nowPlayingPidCF)
         return false;
 
     int32_t nowPlayingPid = 0;
-    if (!CFNumberGetValue(nowPlayingPidCF, kCFNumberSInt32Type, &nowPlayingPid))
+    if (!CFNumberGetValue(nowPlayingPidCF.get(), kCFNumberSInt32Type, &nowPlayingPid))
         return false;
 
     return pid == nowPlayingPid;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteMixedContent.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteMixedContent.mm
@@ -56,13 +56,13 @@ void writeTypesAndDataToPasteboard(id type, ...)
         [types addObject:type];
         va_start(argumentList, type);
         NSUInteger index = 1;
-        id object = va_arg(argumentList, id);
+        RetainPtr object = va_arg(argumentList, id);
         while (object) {
             if (index % 2)
-                [data addObject:object];
+                [data addObject:object.get()];
             else {
-                ASSERT([object isKindOfClass:[NSString class]]);
-                [types addObject:object];
+                ASSERT([object.get() isKindOfClass:[NSString class]]);
+                [types addObject:object.get()];
             }
             ++index;
             object = va_arg(argumentList, id);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteWebArchive.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteWebArchive.mm
@@ -201,9 +201,9 @@ static NSData *msoListMarkupWithoutProperHTMLElement()
 TEST(PasteWebArchive, StripsMSOListWhenMissingMSOHTMLElement)
 {
     auto *url = [NSURL URLWithString:@"file:///some-file.html"];
-    auto *markup = msoListMarkupWithoutProperHTMLElement();
+    RetainPtr markup = msoListMarkupWithoutProperHTMLElement();
 
-    auto mainResource = adoptNS([[WebResource alloc] initWithData:markup URL:url MIMEType:@"text/html" textEncodingName:@"utf-8" frameName:nil]);
+    auto mainResource = adoptNS([[WebResource alloc] initWithData:markup.get() URL:url MIMEType:@"text/html" textEncodingName:@"utf-8" frameName:nil]);
     auto archive = adoptNS([[WebArchive alloc] initWithMainResource:mainResource.get() subresources:nil subframeArchives:nil]);
 
     [[NSPasteboard generalPasteboard] declareTypes:@[WebArchivePboardType] owner:nil];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
@@ -2217,17 +2217,17 @@ static void runClientSideRedirectTest(ShouldEnablePSON shouldEnablePSON)
     clientRedirectDestinationURL = nullptr;
 
     // Validate Back/Forward list.
-    auto* backForwardList = [webView backForwardList];
-    auto* currentItem = backForwardList.currentItem;
-    EXPECT_WK_STREQ(@"pson://www.apple.com/main.html", [currentItem.URL absoluteString]);
-    EXPECT_WK_STREQ(@"pson://www.apple.com/main.html", [currentItem.initialURL absoluteString]);
-    EXPECT_TRUE(!backForwardList.forwardItem);
+    RetainPtr backForwardList = [webView backForwardList];
+    RetainPtr currentItem = [backForwardList.get() currentItem];
+    EXPECT_WK_STREQ(@"pson://www.apple.com/main.html", [currentItem.get().URL absoluteString]);
+    EXPECT_WK_STREQ(@"pson://www.apple.com/main.html", [currentItem.get().initialURL absoluteString]);
+    EXPECT_TRUE(![backForwardList.get() forwardItem]);
 
-    EXPECT_EQ(1U, backForwardList.backList.count);
+    EXPECT_EQ(1U, [backForwardList.get() backList].count);
 
-    auto* backItem = backForwardList.backItem;
-    EXPECT_WK_STREQ(@"pson://www.webkit.org/main.html", [backItem.URL absoluteString]);
-    EXPECT_WK_STREQ(@"pson://www.webkit.org/main.html", [backItem.initialURL absoluteString]);
+    RetainPtr backItem = [backForwardList.get() backItem];
+    EXPECT_WK_STREQ(@"pson://www.webkit.org/main.html", [backItem.get().URL absoluteString]);
+    EXPECT_WK_STREQ(@"pson://www.webkit.org/main.html", [backItem.get().initialURL absoluteString]);
 
     // Navigate back.
     [webView goBack];
@@ -2243,16 +2243,16 @@ static void runClientSideRedirectTest(ShouldEnablePSON shouldEnablePSON)
         EXPECT_EQ(webkitPID, pidAfterBackNavigation);
 
     // Validate Back/Forward list.
-    currentItem = backForwardList.currentItem;
-    EXPECT_WK_STREQ(@"pson://www.webkit.org/main.html", [currentItem.URL absoluteString]);
-    EXPECT_WK_STREQ(@"pson://www.webkit.org/main.html", [currentItem.initialURL absoluteString]);
+    currentItem = [backForwardList.get() currentItem];
+    EXPECT_WK_STREQ(@"pson://www.webkit.org/main.html", [currentItem.get().URL absoluteString]);
+    EXPECT_WK_STREQ(@"pson://www.webkit.org/main.html", [currentItem.get().initialURL absoluteString]);
 
-    EXPECT_TRUE(!backForwardList.backItem);
-    EXPECT_EQ(1U, backForwardList.forwardList.count);
+    EXPECT_TRUE(![backForwardList.get() backItem]);
+    EXPECT_EQ(1U, [backForwardList.get() forwardList].count);
 
-    auto* forwardItem = backForwardList.forwardItem;
-    EXPECT_WK_STREQ(@"pson://www.apple.com/main.html", [forwardItem.URL absoluteString]);
-    EXPECT_WK_STREQ(@"pson://www.apple.com/main.html", [forwardItem.initialURL absoluteString]);
+    RetainPtr forwardItem = [backForwardList.get() forwardItem];
+    EXPECT_WK_STREQ(@"pson://www.apple.com/main.html", [forwardItem.get().URL absoluteString]);
+    EXPECT_WK_STREQ(@"pson://www.apple.com/main.html", [forwardItem.get().initialURL absoluteString]);
 
     // Navigate forward.
     [webView goForward];
@@ -2267,16 +2267,16 @@ static void runClientSideRedirectTest(ShouldEnablePSON shouldEnablePSON)
     EXPECT_EQ(applePID, pidAfterForwardNavigation);
 
     // Validate Back/Forward list.
-    currentItem = backForwardList.currentItem;
-    EXPECT_WK_STREQ(@"pson://www.apple.com/main.html", [currentItem.URL absoluteString]);
-    EXPECT_WK_STREQ(@"pson://www.apple.com/main.html", [currentItem.initialURL absoluteString]);
-    EXPECT_TRUE(!backForwardList.forwardItem);
+    currentItem = [backForwardList.get() currentItem];
+    EXPECT_WK_STREQ(@"pson://www.apple.com/main.html", [currentItem.get().URL absoluteString]);
+    EXPECT_WK_STREQ(@"pson://www.apple.com/main.html", [currentItem.get().initialURL absoluteString]);
+    EXPECT_TRUE(![backForwardList.get() forwardItem]);
 
-    EXPECT_EQ(1U, backForwardList.backList.count);
+    EXPECT_EQ(1U, [backForwardList.get() backList].count);
 
-    backItem = backForwardList.backItem;
-    EXPECT_WK_STREQ(@"pson://www.webkit.org/main.html", [backItem.URL absoluteString]);
-    EXPECT_WK_STREQ(@"pson://www.webkit.org/main.html", [backItem.initialURL absoluteString]);
+    backItem = [backForwardList.get() backItem];
+    EXPECT_WK_STREQ(@"pson://www.webkit.org/main.html", [backItem.get().URL absoluteString]);
+    EXPECT_WK_STREQ(@"pson://www.webkit.org/main.html", [backItem.get().initialURL absoluteString]);
 }
 
 TEST(ProcessSwap, CrossSiteClientSideRedirectWithoutPSON)
@@ -2437,11 +2437,11 @@ static void runNavigationWithLockedHistoryTest(ShouldEnablePSON shouldEnablePSON
     else
         EXPECT_EQ(webkitPID, applePID);
 
-    auto* backForwardList = [webView backForwardList];
-    EXPECT_WK_STREQ(@"pson://www.apple.com/main.html", [backForwardList.currentItem.URL absoluteString]);
-    EXPECT_TRUE(!backForwardList.forwardItem);
-    EXPECT_EQ(1U, backForwardList.backList.count);
-    EXPECT_WK_STREQ(@"pson://www.webkit.org/main.html", [backForwardList.backItem.URL absoluteString]);
+    RetainPtr backForwardList = [webView backForwardList];
+    EXPECT_WK_STREQ(@"pson://www.apple.com/main.html", [[backForwardList.get() currentItem].URL absoluteString]);
+    EXPECT_TRUE(![backForwardList.get() forwardItem]);
+    EXPECT_EQ(1U, [backForwardList.get() backList].count);
+    EXPECT_WK_STREQ(@"pson://www.webkit.org/main.html", [[backForwardList.get() backItem].URL absoluteString]);
 
     receivedMessage = false;
     [webView goBack];
@@ -2451,10 +2451,10 @@ static void runNavigationWithLockedHistoryTest(ShouldEnablePSON shouldEnablePSON
     done = false;
 
     EXPECT_EQ(webkitPID, [webView _webProcessIdentifier]);
-    EXPECT_WK_STREQ(@"pson://www.webkit.org/main.html", [backForwardList.currentItem.URL absoluteString]);
-    EXPECT_TRUE(!backForwardList.backItem);
-    EXPECT_EQ(1U, backForwardList.forwardList.count);
-    EXPECT_WK_STREQ(@"pson://www.apple.com/main.html", [backForwardList.forwardItem.URL absoluteString]);
+    EXPECT_WK_STREQ(@"pson://www.webkit.org/main.html", [[backForwardList.get() currentItem].URL absoluteString]);
+    EXPECT_TRUE(![backForwardList.get() backItem]);
+    EXPECT_EQ(1U, [backForwardList.get() forwardList].count);
+    EXPECT_WK_STREQ(@"pson://www.apple.com/main.html", [[backForwardList.get() forwardItem].URL absoluteString]);
 
     [webView goForward];
     TestWebKitAPI::Util::run(&done);
@@ -2464,10 +2464,10 @@ static void runNavigationWithLockedHistoryTest(ShouldEnablePSON shouldEnablePSON
 
     EXPECT_EQ(applePID, [webView _webProcessIdentifier]);
 
-    EXPECT_WK_STREQ(@"pson://www.apple.com/main.html", [backForwardList.currentItem.URL absoluteString]);
-    EXPECT_TRUE(!backForwardList.forwardItem);
-    EXPECT_EQ(1U, backForwardList.backList.count);
-    EXPECT_WK_STREQ(@"pson://www.webkit.org/main.html", [backForwardList.backItem.URL absoluteString]);
+    EXPECT_WK_STREQ(@"pson://www.apple.com/main.html", [[backForwardList.get() currentItem].URL absoluteString]);
+    EXPECT_TRUE(![backForwardList.get() forwardItem]);
+    EXPECT_EQ(1U, [backForwardList.get() backList].count);
+    EXPECT_WK_STREQ(@"pson://www.webkit.org/main.html", [[backForwardList.get() backItem].URL absoluteString]);
 }
 
 TEST(ProcessSwap, NavigationWithLockedHistoryWithPSON)
@@ -2531,12 +2531,12 @@ static void runQuickBackForwardNavigationTest(ShouldEnablePSON shouldEnablePSON)
     done = false;
 
     Vector<String> backForwardListURLs;
-    auto* backForwardList = [webView backForwardList];
-    for (unsigned i = 0; i < backForwardList.backList.count; ++i)
-        backForwardListURLs.append([backForwardList.backList[i].URL absoluteString]);
-    backForwardListURLs.append([backForwardList.currentItem.URL absoluteString]);
-    for (unsigned i = 0; i < backForwardList.forwardList.count; ++i)
-        backForwardListURLs.append([backForwardList.forwardList[i].URL absoluteString]);
+    RetainPtr backForwardList = [webView backForwardList];
+    for (unsigned i = 0; i < [backForwardList.get() backList].count; ++i)
+        backForwardListURLs.append([[backForwardList.get() backList][i].URL absoluteString]);
+    backForwardListURLs.append([[backForwardList.get() currentItem].URL absoluteString]);
+    for (unsigned i = 0; i < [backForwardList.get() forwardList].count; ++i)
+        backForwardListURLs.append([[backForwardList.get() forwardList][i].URL absoluteString]);
     RELEASE_ASSERT(backForwardListURLs.size() == 3u);
     EXPECT_WK_STREQ("pson://www.webkit.org/main1.html", backForwardListURLs[0]);
     EXPECT_WK_STREQ("pson://www.webkit.org/main2.html", backForwardListURLs[1]);
@@ -2859,12 +2859,12 @@ TEST(ProcessSwap, HistoryItemIDConfusion)
 
     EXPECT_EQ(webkitPID, [webView _webProcessIdentifier]);
 
-    auto* backForwardList = [webView backForwardList];
-    EXPECT_WK_STREQ(@"pson://www.webkit.org/main.html", [backForwardList.currentItem.URL absoluteString]);
-    EXPECT_EQ(2U, backForwardList.forwardList.count);
-    EXPECT_EQ(0U, backForwardList.backList.count);
-    EXPECT_WK_STREQ(@"pson://www.apple.com/main.html", [backForwardList.forwardList[0].URL absoluteString]);
-    EXPECT_WK_STREQ(@"pson://www.google.com/main.html", [backForwardList.forwardList[1].URL absoluteString]);
+    RetainPtr backForwardList = [webView backForwardList];
+    EXPECT_WK_STREQ(@"pson://www.webkit.org/main.html", [[backForwardList.get() currentItem].URL absoluteString]);
+    EXPECT_EQ(2U, [backForwardList.get() forwardList].count);
+    EXPECT_EQ(0U, [backForwardList.get() backList].count);
+    EXPECT_WK_STREQ(@"pson://www.apple.com/main.html", [[backForwardList.get() forwardList][0].URL absoluteString]);
+    EXPECT_WK_STREQ(@"pson://www.google.com/main.html", [[backForwardList.get() forwardList][1].URL absoluteString]);
 }
 
 TEST(ProcessSwap, GoToSecondItemInBackHistory)
@@ -4830,11 +4830,11 @@ TEST(ProcessSwap, ConcurrentHistoryNavigations)
     EXPECT_EQ(webkitPID, [webView _webProcessIdentifier]);
     EXPECT_WK_STREQ(@"pson://www.webkit.org/main.html", [[webView URL] absoluteString]);
 
-    auto* backForwardList = [webView backForwardList];
-    EXPECT_WK_STREQ(@"pson://www.webkit.org/main.html", [backForwardList.currentItem.URL absoluteString]);
-    EXPECT_TRUE(!backForwardList.backItem);
-    EXPECT_EQ(1U, backForwardList.forwardList.count);
-    EXPECT_WK_STREQ(@"pson://www.apple.com/main.html", [backForwardList.forwardItem.URL absoluteString]);
+    RetainPtr backForwardList = [webView backForwardList];
+    EXPECT_WK_STREQ(@"pson://www.webkit.org/main.html", [[backForwardList.get() currentItem].URL absoluteString]);
+    EXPECT_TRUE(![backForwardList.get() backItem]);
+    EXPECT_EQ(1U, [backForwardList.get() forwardList].count);
+    EXPECT_WK_STREQ(@"pson://www.apple.com/main.html", [[backForwardList.get() forwardItem].URL absoluteString]);
 
     // Concurrent requests to go forward, which process swaps.
     [webView goForward];
@@ -4846,10 +4846,10 @@ TEST(ProcessSwap, ConcurrentHistoryNavigations)
     EXPECT_EQ(applePID, [webView _webProcessIdentifier]);
     EXPECT_WK_STREQ(@"pson://www.apple.com/main.html", [[webView URL] absoluteString]);
 
-    EXPECT_WK_STREQ(@"pson://www.apple.com/main.html", [backForwardList.currentItem.URL absoluteString]);
-    EXPECT_TRUE(!backForwardList.forwardItem);
-    EXPECT_EQ(1U, backForwardList.backList.count);
-    EXPECT_WK_STREQ(@"pson://www.webkit.org/main.html", [backForwardList.backItem.URL absoluteString]);
+    EXPECT_WK_STREQ(@"pson://www.apple.com/main.html", [[backForwardList.get() currentItem].URL absoluteString]);
+    EXPECT_TRUE(![backForwardList.get() forwardItem]);
+    EXPECT_EQ(1U, [backForwardList.get() backList].count);
+    EXPECT_WK_STREQ(@"pson://www.webkit.org/main.html", [[backForwardList.get() backItem].URL absoluteString]);
 
     [webView goBack];
     TestWebKitAPI::Util::run(&done);
@@ -4858,10 +4858,10 @@ TEST(ProcessSwap, ConcurrentHistoryNavigations)
     EXPECT_NE(applePID, [webView _webProcessIdentifier]);
     EXPECT_WK_STREQ(@"pson://www.webkit.org/main.html", [[webView URL] absoluteString]);
 
-    EXPECT_WK_STREQ(@"pson://www.webkit.org/main.html", [backForwardList.currentItem.URL absoluteString]);
-    EXPECT_TRUE(!backForwardList.backItem);
-    EXPECT_EQ(1U, backForwardList.forwardList.count);
-    EXPECT_WK_STREQ(@"pson://www.apple.com/main.html", [backForwardList.forwardItem.URL absoluteString]);
+    EXPECT_WK_STREQ(@"pson://www.webkit.org/main.html", [[backForwardList.get() currentItem].URL absoluteString]);
+    EXPECT_TRUE(![backForwardList.get() backItem]);
+    EXPECT_EQ(1U, [backForwardList.get() forwardList].count);
+    EXPECT_WK_STREQ(@"pson://www.apple.com/main.html", [[backForwardList.get() forwardItem].URL absoluteString]);
 }
 
 TEST(ProcessSwap, CookieAccessAfterMultipleRedirects)
@@ -5819,29 +5819,29 @@ TEST(ProcessSwap, NavigateBackAndForth)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    auto* backForwardList = [webView backForwardList];
-    EXPECT_WK_STREQ(@"pson://www.apple.com/main.html", [backForwardList.currentItem.URL absoluteString]);
-    EXPECT_TRUE(!backForwardList.forwardItem);
-    EXPECT_EQ(1U, backForwardList.backList.count);
-    EXPECT_WK_STREQ(@"pson://www.webkit.org/main.html", [backForwardList.backItem.URL absoluteString]);
+    RetainPtr backForwardList = [webView backForwardList];
+    EXPECT_WK_STREQ(@"pson://www.apple.com/main.html", [[backForwardList.get() currentItem].URL absoluteString]);
+    EXPECT_TRUE(![backForwardList.get() forwardItem]);
+    EXPECT_EQ(1U, [backForwardList.get() backList].count);
+    EXPECT_WK_STREQ(@"pson://www.webkit.org/main.html", [[backForwardList.get() backItem].URL absoluteString]);
 
     [webView goBack];
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    EXPECT_WK_STREQ(@"pson://www.webkit.org/main.html", [backForwardList.currentItem.URL absoluteString]);
-    EXPECT_TRUE(!backForwardList.backItem);
-    EXPECT_EQ(1U, backForwardList.forwardList.count);
-    EXPECT_WK_STREQ(@"pson://www.apple.com/main.html", [backForwardList.forwardItem.URL absoluteString]);
+    EXPECT_WK_STREQ(@"pson://www.webkit.org/main.html", [[backForwardList.get() currentItem].URL absoluteString]);
+    EXPECT_TRUE(![backForwardList.get() backItem]);
+    EXPECT_EQ(1U, [backForwardList.get() forwardList].count);
+    EXPECT_WK_STREQ(@"pson://www.apple.com/main.html", [[backForwardList.get() forwardItem].URL absoluteString]);
 
     [webView goForward];
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    EXPECT_WK_STREQ(@"pson://www.apple.com/main.html", [backForwardList.currentItem.URL absoluteString]);
-    EXPECT_TRUE(!backForwardList.forwardItem);
-    EXPECT_EQ(1U, backForwardList.backList.count);
-    EXPECT_WK_STREQ(@"pson://www.webkit.org/main.html", [backForwardList.backItem.URL absoluteString]);
+    EXPECT_WK_STREQ(@"pson://www.apple.com/main.html", [[backForwardList.get() currentItem].URL absoluteString]);
+    EXPECT_TRUE(![backForwardList.get() forwardItem]);
+    EXPECT_EQ(1U, [backForwardList.get() backList].count);
+    EXPECT_WK_STREQ(@"pson://www.webkit.org/main.html", [[backForwardList.get() backItem].URL absoluteString]);
 }
 
 TEST(ProcessSwap, SwapOnLoadHTMLString)
@@ -7421,14 +7421,14 @@ TEST(ProcessSwap, QuickLookRequestsPasswordAfterSwap)
     auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:navigationDelegate.get()];
 
-    auto* request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]];
-    [webView loadRequest:request];
+    RetainPtr request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]];
+    [webView loadRequest:request.get()];
 
     TestWebKitAPI::Util::run(&done);
     done = false;
 
     request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"password-protected" withExtension:@"pages"]];
-    [webView loadRequest:request];
+    [webView loadRequest:request.get()];
 
     TestWebKitAPI::Util::run(&didStartQuickLookLoad);
     didStartQuickLookLoad = false;
@@ -7479,8 +7479,8 @@ TEST(ProcessSwap, PassMinimumDeviceWidthOnNewWebView)
     [preferences _setShouldIgnoreMetaViewport:YES];
     [webView _setMinimumEffectiveDeviceWidth:1024];
 
-    auto* request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]];
-    [webView loadRequest:request];
+    RetainPtr request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]];
+    [webView loadRequest:request.get()];
 
     TestWebKitAPI::Util::run(&done);
     done = false;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/RemoteObjectRegistryPlugIn.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/RemoteObjectRegistryPlugIn.mm
@@ -50,8 +50,8 @@
     _browserContextController = browserContextController;
     _plugInController = plugInController;
 
-    _WKRemoteObjectInterface *interface = remoteObjectInterface();
-    [[_browserContextController _remoteObjectRegistry] registerExportedObject:self interface:interface];
+    RetainPtr interface = remoteObjectInterface();
+    [[_browserContextController _remoteObjectRegistry] registerExportedObject:self interface:interface.get()];
 }
 
 - (void)sayHello:(NSString *)helloString

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadDelegate.mm
@@ -285,12 +285,12 @@ TEST(ResourceLoadDelegate, LoadInfo)
     EXPECT_EQ(loadInfos[6].get().resourceLoadID, loadInfos[8].get().resourceLoadID);
     EXPECT_NE(loadInfos[6].get().resourceLoadID, loadInfos[0].get().resourceLoadID);
     auto checkFrames = ^(size_t index, _WKFrameHandle *expectedFrame, _WKFrameHandle *expectedParent, _WKResourceLoadInfoResourceType expectedType) {
-        _WKResourceLoadInfo *info = loadInfos[index].get();
-        EXPECT_EQ(!!info.frame, !!expectedFrame);
-        EXPECT_EQ(!!info.parentFrame, !!expectedParent);
-        EXPECT_EQ(info.frame.frameID, expectedFrame.frameID);
-        EXPECT_EQ(info.parentFrame.frameID, expectedParent.frameID);
-        EXPECT_EQ(info.resourceType, expectedType);
+        RetainPtr info = loadInfos[index].get();
+        EXPECT_EQ(!!info.get().frame, !!expectedFrame);
+        EXPECT_EQ(!!info.get().parentFrame, !!expectedParent);
+        EXPECT_EQ(info.get().frame.frameID, expectedFrame.frameID);
+        EXPECT_EQ(info.get().parentFrame.frameID, expectedParent.frameID);
+        EXPECT_EQ(info.get().resourceType, expectedType);
     };
     _WKFrameHandle *main = loadInfos[0].get().frame;
     _WKFrameHandle *sub = loadInfos[8].get().frame;
@@ -335,18 +335,18 @@ TEST(ResourceLoadDelegate, LoadInfo)
     EXPECT_WK_STREQ(NSStringFromClass([otherParameters[11] class]), "NSHTTPURLResponse");
     EXPECT_WK_STREQ([otherParameters[11] URL].path, "/fetchTarget");
 
-    _WKResourceLoadInfo *original = loadInfos[0].get();
+    RetainPtr original = loadInfos[0].get();
     NSError *error = nil;
-    NSData *archiveData = [NSKeyedArchiver archivedDataWithRootObject:original requiringSecureCoding:YES error:&error];
+    NSData *archiveData = [NSKeyedArchiver archivedDataWithRootObject:original.get() requiringSecureCoding:YES error:&error];
     EXPECT_FALSE(error);
     _WKResourceLoadInfo *deserialized = [NSKeyedUnarchiver unarchivedObjectOfClass:[_WKResourceLoadInfo class] fromData:archiveData error:&error];
     EXPECT_FALSE(error);
-    EXPECT_TRUE(deserialized.resourceLoadID == original.resourceLoadID);
-    EXPECT_TRUE(deserialized.frame.frameID == original.frame.frameID);
-    EXPECT_TRUE(deserialized.parentFrame.frameID == original.parentFrame.frameID);
-    EXPECT_WK_STREQ(deserialized.originalURL.absoluteString, original.originalURL.absoluteString);
-    EXPECT_WK_STREQ(deserialized.originalHTTPMethod, original.originalHTTPMethod);
-    EXPECT_EQ(deserialized.eventTimestamp.timeIntervalSince1970, original.eventTimestamp.timeIntervalSince1970);
+    EXPECT_TRUE(deserialized.resourceLoadID == original.get().resourceLoadID);
+    EXPECT_TRUE(deserialized.frame.frameID == original.get().frame.frameID);
+    EXPECT_TRUE(deserialized.parentFrame.frameID == original.get().parentFrame.frameID);
+    EXPECT_WK_STREQ(deserialized.originalURL.absoluteString, original.get().originalURL.absoluteString);
+    EXPECT_WK_STREQ(deserialized.originalHTTPMethod, original.get().originalHTTPMethod);
+    EXPECT_EQ(deserialized.eventTimestamp.timeIntervalSince1970, original.get().eventTimestamp.timeIntervalSince1970);
 }
 
 TEST(ResourceLoadDelegate, Challenge)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SafeBrowsing.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SafeBrowsing.mm
@@ -258,13 +258,13 @@ static void checkTitleAndClick(UIButton *button, const char* expectedTitle)
 
 template<typename ViewType> void goBack(ViewType *view, bool mainFrame = true)
 {
-    WKWebView *webView = (WKWebView *)view.superview;
+    RetainPtr webView = (WKWebView *)view.superview;
     auto box = view.subviews.firstObject;
     checkTitleAndClick(box.subviews[3], "Go Back");
     if (mainFrame)
-        EXPECT_EQ([webView _safeBrowsingWarning], nil);
+        EXPECT_EQ([webView.get() _safeBrowsingWarning], nil);
     else
-        EXPECT_NE([webView _safeBrowsingWarning], nil);
+        EXPECT_NE([webView.get() _safeBrowsingWarning], nil);
 }
 
 TEST(SafeBrowsing, GoBack)
@@ -590,11 +590,11 @@ TEST(SafeBrowsing, HangTimeout)
     TestWebKitAPI::HTTPServer server({
         { "/test"_s, { "test"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::HttpsProxy);
-    auto configuration = server.httpsProxyConfiguration();
+    RetainPtr configuration = server.httpsProxyConfiguration();
 
     ClassMethodSwizzler swizzler(getSSBLookupContextClassSingleton(), @selector(sharedLookupContext), [DelayedLookupContext methodForSelector:@selector(sharedLookupContext)]);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView configuration].preferences.fraudulentWebsiteWarningEnabled = YES;
     auto delegate = adoptNS([TestNavigationDelegate new]);
     [delegate allowAnyTLSCertificate];
@@ -611,11 +611,11 @@ TEST(SafeBrowsing, PostResponse)
     TestWebKitAPI::HTTPServer server({
         { "/test"_s, { "test"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::HttpsProxy);
-    auto configuration = server.httpsProxyConfiguration();
+    RetainPtr configuration = server.httpsProxyConfiguration();
 
     ClassMethodSwizzler swizzler(getSSBLookupContextClassSingleton(), @selector(sharedLookupContext), [DelayedLookupContext methodForSelector:@selector(sharedLookupContext)]);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView configuration].preferences.fraudulentWebsiteWarningEnabled = YES;
     auto delegate = adoptNS([TestNavigationDelegate new]);
     [delegate allowAnyTLSCertificate];
@@ -694,11 +694,11 @@ TEST(SafeBrowsing, PostResponseServerSideRedirect)
         { "/safe"_s, { 301, { { "Location"_s, "/redirectTarget"_s } } } },
         { "/redirectTarget"_s, { "hi"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::HttpsProxy);
-    auto configuration = server.httpsProxyConfiguration();
+    RetainPtr configuration = server.httpsProxyConfiguration();
 
     ClassMethodSwizzler swizzler(getSSBLookupContextClassSingleton(), @selector(sharedLookupContext), [DelayedLookupContext methodForSelector:@selector(sharedLookupContext)]);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView configuration].preferences.fraudulentWebsiteWarningEnabled = YES;
     auto delegate = adoptNS([TestNavigationDelegate new]);
     [delegate allowAnyTLSCertificate];
@@ -718,11 +718,11 @@ TEST(SafeBrowsing, MultipleRedirectsFirstPhishing)
         { "/redirectTarget1"_s, { 301, { { "Location"_s, "/redirectTarget2"_s } } } },
         { "/redirectTarget2"_s, { "hi"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::HttpsProxy);
-    auto configuration = server.httpsProxyConfiguration();
+    RetainPtr configuration = server.httpsProxyConfiguration();
 
     ClassMethodSwizzler swizzler(getSSBLookupContextClassSingleton(), @selector(sharedLookupContext), [SimpleLookupContext methodForSelector:@selector(sharedLookupContext)]);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView configuration].preferences.fraudulentWebsiteWarningEnabled = YES;
     auto delegate = adoptNS([TestNavigationDelegate new]);
     [delegate allowAnyTLSCertificate];
@@ -742,11 +742,11 @@ TEST(SafeBrowsing, MultipleRedirectsMiddlePhishing)
         { "/redirectTarget1"_s, { 301, { { "Location"_s, "/redirectTarget2"_s } } } },
         { "/redirectTarget2"_s, { "hi"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::HttpsProxy);
-    auto configuration = server.httpsProxyConfiguration();
+    RetainPtr configuration = server.httpsProxyConfiguration();
 
     ClassMethodSwizzler swizzler(getSSBLookupContextClassSingleton(), @selector(sharedLookupContext), [SimpleLookupContext methodForSelector:@selector(sharedLookupContext)]);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView configuration].preferences.fraudulentWebsiteWarningEnabled = YES;
     auto delegate = adoptNS([TestNavigationDelegate new]);
     [delegate allowAnyTLSCertificate];
@@ -766,11 +766,11 @@ TEST(SafeBrowsing, MultipleRedirectsLastPhishing)
         { "/redirectTarget1"_s, { 301, { { "Location"_s, "/redirectTarget2"_s } } } },
         { "/redirectTarget2"_s, { "hi"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::HttpsProxy);
-    auto configuration = server.httpsProxyConfiguration();
+    RetainPtr configuration = server.httpsProxyConfiguration();
 
     ClassMethodSwizzler swizzler(getSSBLookupContextClassSingleton(), @selector(sharedLookupContext), [SimpleLookupContext methodForSelector:@selector(sharedLookupContext)]);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView configuration].preferences.fraudulentWebsiteWarningEnabled = YES;
     auto delegate = adoptNS([TestNavigationDelegate new]);
     [delegate allowAnyTLSCertificate];
@@ -810,11 +810,11 @@ TEST(SafeBrowsing, PostTimeout)
     TestWebKitAPI::HTTPServer server({
         { "/test"_s, { "test"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::HttpsProxy);
-    auto configuration = server.httpsProxyConfiguration();
+    RetainPtr configuration = server.httpsProxyConfiguration();
 
     ClassMethodSwizzler swizzler(getSSBLookupContextClassSingleton(), @selector(sharedLookupContext), [DelayedLookupContext methodForSelector:@selector(sharedLookupContext)]);
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView configuration].preferences.fraudulentWebsiteWarningEnabled = YES;
     auto delegate = adoptNS([TestNavigationDelegate new]);
     [delegate allowAnyTLSCertificate];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm
@@ -2622,8 +2622,8 @@ static bool isTestServerTrust(SecTrustRef trust)
         return false;
 
     auto chain = adoptCF(SecTrustCopyCertificateChain(trust));
-    auto certificate = checked_cf_cast<SecCertificateRef>(CFArrayGetValueAtIndex(chain.get(), 0));
-    if (![bridge_cast(adoptCF(SecCertificateCopySubjectSummary(certificate)).get()) isEqualToString:@"Me"])
+    RetainPtr certificate = checked_cf_cast<SecCertificateRef>(CFArrayGetValueAtIndex(chain.get(), 0));
+    if (![bridge_cast(adoptCF(SecCertificateCopySubjectSummary(certificate.get())).get()) isEqualToString:@"Me"])
         return false;
 
     return true;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ShouldOpenAppLinks.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ShouldOpenAppLinks.mm
@@ -43,9 +43,9 @@
 {
     [super init];
 
-    __unsafe_unretained ShouldOpenAppLinksTestNavigationDelegate *unretainedSelf = self;
+    RetainPtr unretainedSelf = self;
     self.decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^decisionHandler)(WKNavigationActionPolicy)) {
-        unretainedSelf.lastNavigationAction = action;
+        unretainedSelf.get().lastNavigationAction = action;
         decisionHandler(WKNavigationActionPolicyAllow);
     };
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/VerifyUserGestureFromUIProcess.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/VerifyUserGestureFromUIProcess.mm
@@ -50,12 +50,12 @@ static void testWindowOpenMouseEvent(const String& event, bool expectOpenedWindo
         { "/opened"_s, { ""_s } }
     }, HTTPServer::Protocol::HttpsProxy);
 
-    auto configuration = server.httpsProxyConfiguration();
-    [[configuration preferences] _setVerifyWindowOpenUserGestureFromUIProcess:YES];
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    [[configuration.get() preferences] _setVerifyWindowOpenUserGestureFromUIProcess:YES];
     auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [navigationDelegate allowAnyTLSCertificate];
     auto uiDelegate = adoptNS([TestUIDelegate new]);
-    auto openerWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    auto openerWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [openerWebView setNavigationDelegate:navigationDelegate.get()];
     [openerWebView setUIDelegate:uiDelegate.get()];
 
@@ -119,12 +119,12 @@ TEST(VerifyUserGesture, WindowOpenKeyEvent)
         { "/opened"_s, { ""_s } }
     }, HTTPServer::Protocol::HttpsProxy);
 
-    auto configuration = server.httpsProxyConfiguration();
-    [[configuration preferences] _setVerifyWindowOpenUserGestureFromUIProcess:YES];
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    [[configuration.get() preferences] _setVerifyWindowOpenUserGestureFromUIProcess:YES];
     auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [navigationDelegate allowAnyTLSCertificate];
     auto uiDelegate = adoptNS([TestUIDelegate new]);
-    auto openerWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    auto openerWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [openerWebView setNavigationDelegate:navigationDelegate.get()];
     [openerWebView setUIDelegate:uiDelegate.get()];
 
@@ -162,12 +162,12 @@ TEST(VerifyUserGesture, InvalidateAuthorizationTokensByPage)
         { "/opened"_s, { ""_s } }
     }, HTTPServer::Protocol::HttpsProxy);
 
-    auto configuration = server.httpsProxyConfiguration();
-    [[configuration preferences] _setVerifyWindowOpenUserGestureFromUIProcess:YES];
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    [[configuration.get() preferences] _setVerifyWindowOpenUserGestureFromUIProcess:YES];
     auto openerNavigationDelegate = adoptNS([TestNavigationDelegate new]);
     [openerNavigationDelegate allowAnyTLSCertificate];
     auto openerUIDelegate = adoptNS([TestUIDelegate new]);
-    auto openerWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    auto openerWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [openerWebView setNavigationDelegate:openerNavigationDelegate.get()];
     [openerWebView setUIDelegate:openerUIDelegate.get()];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentExtensionStore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentExtensionStore.mm
@@ -762,11 +762,11 @@ TEST_F(WKContentRuleListStoreTest, ModifyHeaders)
     [[configuration userContentController] addContentRuleList:list.get()];
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"testscheme"];
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
-    auto delegate = navigationDelegateAllowingActiveActionsOnTestHost().unsafeGet();
-    webView.get().navigationDelegate = delegate;
+    RetainPtr delegate = navigationDelegateAllowingActiveActionsOnTestHost().unsafeGet();
+    webView.get().navigationDelegate = delegate.get();
     __block bool receivedActionNotification { false };
     __block Vector<String> urls;
-    delegate.contentRuleListPerformedAction = ^(WKWebView *, NSString *identifier, _WKContentRuleListAction *action, NSURL *url) {
+    delegate.get().contentRuleListPerformedAction = ^(WKWebView *, NSString *identifier, _WKContentRuleListAction *action, NSURL *url) {
         urls.append(url.absoluteString);
         EXPECT_TRUE(action.modifiedHeaders);
         receivedActionNotification = true;
@@ -778,7 +778,7 @@ TEST_F(WKContentRuleListStoreTest, ModifyHeaders)
         "testscheme://testhost/main.html"_s,
         "testscheme://testhost/fetch.txt"_s
     });
-    
+
     // FIXME: Appending to the User-Agent replaces the user agent because we haven't added the user agent yet when processing the request.
 }
 
@@ -848,11 +848,11 @@ TEST_F(WKContentRuleListStoreTest, ModifyHeadersWithCompetingRulesWhereAppendWin
     [[configuration userContentController] addContentRuleList:list.get()];
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"testscheme"];
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
-    auto delegate = navigationDelegateAllowingActiveActionsOnTestHost().unsafeGet();
-    webView.get().navigationDelegate = delegate;
+    RetainPtr delegate = navigationDelegateAllowingActiveActionsOnTestHost().unsafeGet();
+    webView.get().navigationDelegate = delegate.get();
     __block bool receivedActionNotification { false };
     __block Vector<String> urls;
-    delegate.contentRuleListPerformedAction = ^(WKWebView *, NSString *identifier, _WKContentRuleListAction *action, NSURL *url) {
+    delegate.get().contentRuleListPerformedAction = ^(WKWebView *, NSString *identifier, _WKContentRuleListAction *action, NSURL *url) {
         urls.append(url.absoluteString);
         EXPECT_TRUE(action.modifiedHeaders);
         receivedActionNotification = true;
@@ -937,11 +937,11 @@ TEST_F(WKContentRuleListStoreTest, ModifyHeadersWithCompetingRulesWhereSetWins)
     [[configuration userContentController] addContentRuleList:list.get()];
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"testscheme"];
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
-    auto delegate = navigationDelegateAllowingActiveActionsOnTestHost().unsafeGet();
-    webView.get().navigationDelegate = delegate;
+    RetainPtr delegate = navigationDelegateAllowingActiveActionsOnTestHost().unsafeGet();
+    webView.get().navigationDelegate = delegate.get();
     __block bool receivedActionNotification { false };
     __block Vector<String> urls;
-    delegate.contentRuleListPerformedAction = ^(WKWebView *, NSString *identifier, _WKContentRuleListAction *action, NSURL *url) {
+    delegate.get().contentRuleListPerformedAction = ^(WKWebView *, NSString *identifier, _WKContentRuleListAction *action, NSURL *url) {
         urls.append(url.absoluteString);
         EXPECT_TRUE(action.modifiedHeaders);
         receivedActionNotification = true;
@@ -1003,11 +1003,11 @@ TEST_F(WKContentRuleListStoreTest, ModifyHeadersWithCompetingRulesWhereRemoveWin
     [[configuration userContentController] addContentRuleList:list.get()];
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"testscheme"];
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
-    auto delegate = navigationDelegateAllowingActiveActionsOnTestHost().unsafeGet();
-    webView.get().navigationDelegate = delegate;
+    RetainPtr delegate = navigationDelegateAllowingActiveActionsOnTestHost().unsafeGet();
+    webView.get().navigationDelegate = delegate.get();
     __block bool receivedActionNotification { false };
     __block Vector<String> urls;
-    delegate.contentRuleListPerformedAction = ^(WKWebView *, NSString *identifier, _WKContentRuleListAction *action, NSURL *url) {
+    delegate.get().contentRuleListPerformedAction = ^(WKWebView *, NSString *identifier, _WKContentRuleListAction *action, NSURL *url) {
         urls.append(url.absoluteString);
         EXPECT_TRUE(action.modifiedHeaders);
         receivedActionNotification = true;
@@ -1075,11 +1075,11 @@ TEST_F(WKContentRuleListStoreTest, ModifyHeadersWithMultipleRuleLists)
     [[configuration userContentController] addContentRuleList:secondList.get()];
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"testscheme"];
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
-    auto delegate = navigationDelegateAllowingActiveActionsOnTestHost().unsafeGet();
-    webView.get().navigationDelegate = delegate;
+    RetainPtr delegate = navigationDelegateAllowingActiveActionsOnTestHost().unsafeGet();
+    webView.get().navigationDelegate = delegate.get();
     __block bool receivedActionNotification { false };
     __block Vector<String> urls;
-    delegate.contentRuleListPerformedAction = ^(WKWebView *, NSString *identifier, _WKContentRuleListAction *action, NSURL *url) {
+    delegate.get().contentRuleListPerformedAction = ^(WKWebView *, NSString *identifier, _WKContentRuleListAction *action, NSURL *url) {
         urls.append(url.absoluteString);
         EXPECT_TRUE(action.modifiedHeaders);
         receivedActionNotification = true;
@@ -1195,11 +1195,11 @@ TEST_F(WKContentRuleListStoreTest, Redirect)
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"testscheme"];
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"othertestscheme"];
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
-    auto delegate = navigationDelegateAllowingActiveActionsOnTestHost().unsafeGet();
-    webView.get().navigationDelegate = delegate;
+    RetainPtr delegate = navigationDelegateAllowingActiveActionsOnTestHost().unsafeGet();
+    webView.get().navigationDelegate = delegate.get();
     __block bool receivedActionNotification { false };
     __block Vector<String> urlsFromCallback;
-    delegate.contentRuleListPerformedAction = ^(WKWebView *, NSString *identifier, _WKContentRuleListAction *action, NSURL *url) {
+    delegate.get().contentRuleListPerformedAction = ^(WKWebView *, NSString *identifier, _WKContentRuleListAction *action, NSURL *url) {
         urlsFromCallback.append(url.absoluteString);
         EXPECT_TRUE(action.redirected);
         receivedActionNotification = true;
@@ -1245,9 +1245,9 @@ TEST_F(WKContentRuleListStoreTest, MainResourceCrossOriginRedirect)
         } ]
     )JSON");
 
-    auto configuration = server.httpsProxyConfiguration();
-    [[configuration userContentController] addContentRuleList:list.get()];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    [[configuration.get() userContentController] addContentRuleList:list.get()];
+    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
 
     auto delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *, WKWebpagePreferences *preferences, void (^decisionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
@@ -1277,9 +1277,9 @@ TEST_F(WKContentRuleListStoreTest, MainResourceSameOriginRedirect)
         } ]
     )JSON");
 
-    auto configuration = server.httpsProxyConfiguration();
-    [configuration.userContentController addContentRuleList:list.get()];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    [configuration.get().userContentController addContentRuleList:list.get()];
+    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
 
     auto delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *, WKWebpagePreferences *preferences, void (^decisionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
@@ -1313,9 +1313,9 @@ TEST_F(WKContentRuleListStoreTest, MainResourceCrossOriginRedirectFromLoadedPage
         } ]
     )JSON");
 
-    auto configuration = server.httpsProxyConfiguration();
-    [[configuration userContentController] addContentRuleList:list.get()];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration]);
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    [[configuration.get() userContentController] addContentRuleList:list.get()];
+    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect configuration:configuration.get()]);
 
     auto delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *, WKWebpagePreferences *preferences, void (^decisionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKNSDictionaryEmptyDictionaryCrash.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKNSDictionaryEmptyDictionaryCrash.mm
@@ -34,8 +34,8 @@ namespace TestWebKitAPI {
 
 TEST(WebKit, WKNSDictionaryEmptyDictionaryCrash)
 {
-    NSDictionary *dictionary = (NSDictionary *)WKMutableDictionaryCreate();
-    RELEASE_ASSERT([dictionary objectForKey:@"key"] == nil);
+    RetainPtr dictionary = (NSDictionary *)WKMutableDictionaryCreate();
+    RELEASE_ASSERT([dictionary.get() objectForKey:@"key"] == nil);
 }
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKNSNumber.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKNSNumber.mm
@@ -40,15 +40,15 @@ TEST(WebKit, WKNSNumber)
     auto uint64Ref = adoptWK(WKUInt64Create(39));
     auto doubleRef = adoptWK(WKDoubleCreate(-16.2));
 
-    NSNumber *booleanNumber = (NSNumber *)booleanRef.get();
-    NSNumber *uint64Number = (NSNumber *)uint64Ref.get();
-    NSNumber *doubleNumber = (NSNumber *)doubleRef.get();
+    RetainPtr booleanNumber = (NSNumber *)booleanRef.get();
+    RetainPtr uint64Number = (NSNumber *)uint64Ref.get();
+    RetainPtr doubleNumber = (NSNumber *)doubleRef.get();
 
-    EXPECT_EQ(YES, booleanNumber.boolValue);
-    EXPECT_EQ(YES, booleanNumber.charValue);
-    EXPECT_EQ(39UL, uint64Number.unsignedLongLongValue);
-    EXPECT_EQ(39, uint64Number.intValue);
-    EXPECT_EQ(-16.2, doubleNumber.doubleValue);
+    EXPECT_EQ(YES, [booleanNumber.get() boolValue]);
+    EXPECT_EQ(YES, [booleanNumber.get() charValue]);
+    EXPECT_EQ(39UL, [uint64Number.get() unsignedLongLongValue]);
+    EXPECT_EQ(39, [uint64Number.get() intValue]);
+    EXPECT_EQ(-16.2, [doubleNumber.get() doubleValue]);
 }
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKURLSchemeHandler-1.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKURLSchemeHandler-1.mm
@@ -302,24 +302,24 @@ TEST(URLSchemeHandler, BuiltinSchemes)
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     RetainPtr<SchemeHandler> handler = adoptNS([[SchemeHandler alloc] initWithData:nil mimeType:nil]);
 
-    for (NSString *scheme : handledSchemes) {
-        EXPECT_TRUE([WKWebView handlesURLScheme:scheme]);
+    for (RetainPtr scheme : handledSchemes) {
+        EXPECT_TRUE([WKWebView handlesURLScheme:scheme.get()]);
 
         bool exceptionRaised = false;
         @try {
-            [configuration setURLSchemeHandler:handler.get() forURLScheme:scheme];
+            [configuration setURLSchemeHandler:handler.get() forURLScheme:scheme.get()];
         } @catch (NSException *exception) {
             EXPECT_WK_STREQ(NSInvalidArgumentException, exception.name);
             exceptionRaised = true;
         }
         EXPECT_TRUE(exceptionRaised);
     }
-    for (NSString *scheme : notHandledSchemes) {
-        EXPECT_FALSE([WKWebView handlesURLScheme:scheme]);
+    for (RetainPtr scheme : notHandledSchemes) {
+        EXPECT_FALSE([WKWebView handlesURLScheme:scheme.get()]);
 
         bool exceptionRaised = false;
         @try {
-            [configuration setURLSchemeHandler:handler.get() forURLScheme:scheme];
+            [configuration setURLSchemeHandler:handler.get() forURLScheme:scheme.get()];
         } @catch (NSException *exception) {
             exceptionRaised = true;
         }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm
@@ -264,17 +264,17 @@ TEST(WKWebExtension, MultipleIconSizes)
         selector64 = @selector(blackColor);
     }
 
-    auto *icon16 = Util::makePNGData(CGSizeMake(16, 16), selector16);
-    auto *icon32 = Util::makePNGData(CGSizeMake(32, 32), selector32);
-    auto *icon64 = Util::makePNGData(CGSizeMake(64, 64), selector64);
+    RetainPtr icon16 = Util::makePNGData(CGSizeMake(16, 16), selector16);
+    RetainPtr icon32 = Util::makePNGData(CGSizeMake(32, 32), selector32);
+    RetainPtr icon64 = Util::makePNGData(CGSizeMake(64, 64), selector64);
 
     auto *resources = @{
-        @"icon-16.png": icon16,
-        @"icon-32.png": icon32,
-        @"icon-64.png": icon64,
-        @"action-icon-16.png": icon16,
-        @"action-icon-32.png": icon32,
-        @"action-icon-64.png": icon64,
+        @"icon-16.png": icon16.get(),
+        @"icon-32.png": icon32.get(),
+        @"icon-64.png": icon64.get(),
+        @"action-icon-16.png": icon16.get(),
+        @"action-icon-32.png": icon32.get(),
+        @"action-icon-64.png": icon64.get(),
     };
 
     auto testExtension = [[WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary resources:resources];
@@ -321,14 +321,14 @@ TEST(WKWebExtension, IconErrorsOnce)
         }
     };
 
-    auto *icon16 = Util::makePNGData(CGSizeMake(16, 16), @selector(blackColor));
-    auto *icon32 = Util::makePNGData(CGSizeMake(32, 32), @selector(whiteColor));
+    RetainPtr icon16 = Util::makePNGData(CGSizeMake(16, 16), @selector(blackColor));
+    RetainPtr icon32 = Util::makePNGData(CGSizeMake(32, 32), @selector(whiteColor));
 
     auto *resources = @{
-        @"icon-16.png": icon16,
-        @"icon-32.png": icon32,
-        @"action-icon-16.png": icon16,
-        @"action-icon-32.png": icon32,
+        @"icon-16.png": icon16.get(),
+        @"icon-32.png": icon32.get(),
+        @"action-icon-16.png": icon16.get(),
+        @"action-icon-32.png": icon32.get(),
     };
 
     auto testExtension = [[WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary resources:resources];
@@ -444,16 +444,16 @@ TEST(WKWebExtension, MultipleIconVariants)
         ]
     };
 
-    auto *dark16Icon = Util::makePNGData(CGSizeMake(32, 32), @selector(whiteColor));
-    auto *dark32Icon = Util::makePNGData(CGSizeMake(64, 64), @selector(whiteColor));
-    auto *light16Icon = Util::makePNGData(CGSizeMake(32, 32), @selector(blackColor));
-    auto *light32Icon = Util::makePNGData(CGSizeMake(64, 64), @selector(blackColor));
+    RetainPtr dark16Icon = Util::makePNGData(CGSizeMake(32, 32), @selector(whiteColor));
+    RetainPtr dark32Icon = Util::makePNGData(CGSizeMake(64, 64), @selector(whiteColor));
+    RetainPtr light16Icon = Util::makePNGData(CGSizeMake(32, 32), @selector(blackColor));
+    RetainPtr light32Icon = Util::makePNGData(CGSizeMake(64, 64), @selector(blackColor));
 
     auto *resources = @{
-        @"dark-32.png": dark16Icon,
-        @"dark-64.png": dark32Icon,
-        @"light-32.png": light16Icon,
-        @"light-64.png": light32Icon,
+        @"dark-32.png": dark16Icon.get(),
+        @"dark-64.png": dark32Icon.get(),
+        @"light-32.png": light16Icon.get(),
+        @"light-64.png": light32Icon.get(),
     };
 
     auto testExtension = [[WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary resources:resources];
@@ -498,10 +498,10 @@ TEST(WKWebExtension, SingleIconVariant)
         ]
     };
 
-    auto *icon32 = Util::makePNGData(CGSizeMake(32, 32), @selector(whiteColor));
+    RetainPtr icon32 = Util::makePNGData(CGSizeMake(32, 32), @selector(whiteColor));
 
     auto *resources = @{
-        @"icon-32.png": icon32,
+        @"icon-32.png": icon32.get(),
     };
 
     auto testExtension = [[WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary resources:resources];
@@ -586,12 +586,12 @@ TEST(WKWebExtension, IconsAndIconVariantsSpecified)
         ]
     };
 
-    auto *iconLegacy = Util::makePNGData(CGSizeMake(32, 32), @selector(blackColor));
-    auto *iconVariant = Util::makePNGData(CGSizeMake(32, 32), @selector(whiteColor));
+    RetainPtr iconLegacy = Util::makePNGData(CGSizeMake(32, 32), @selector(blackColor));
+    RetainPtr iconVariant = Util::makePNGData(CGSizeMake(32, 32), @selector(whiteColor));
 
     auto *resources = @{
-        @"icon-legacy.png": iconLegacy,
-        @"icon-variant.png": iconVariant,
+        @"icon-legacy.png": iconLegacy.get(),
+        @"icon-variant.png": iconVariant.get(),
     };
 
     auto testExtension = [[WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary resources:resources];
@@ -625,16 +625,16 @@ TEST(WKWebExtension, ActionIconVariantsMultiple)
         }
     };
 
-    auto *dark32Icon = Util::makePNGData(CGSizeMake(32, 32), @selector(whiteColor));
-    auto *dark64Icon = Util::makePNGData(CGSizeMake(64, 64), @selector(whiteColor));
-    auto *light32Icon = Util::makePNGData(CGSizeMake(32, 32), @selector(blackColor));
-    auto *light64Icon = Util::makePNGData(CGSizeMake(64, 64), @selector(blackColor));
+    RetainPtr dark32Icon = Util::makePNGData(CGSizeMake(32, 32), @selector(whiteColor));
+    RetainPtr dark64Icon = Util::makePNGData(CGSizeMake(64, 64), @selector(whiteColor));
+    RetainPtr light32Icon = Util::makePNGData(CGSizeMake(32, 32), @selector(blackColor));
+    RetainPtr light64Icon = Util::makePNGData(CGSizeMake(64, 64), @selector(blackColor));
 
     auto *resources = @{
-        @"action-dark-32.png": dark32Icon,
-        @"action-dark-64.png": dark64Icon,
-        @"action-light-32.png": light32Icon,
-        @"action-light-64.png": light64Icon,
+        @"action-dark-32.png": dark32Icon.get(),
+        @"action-dark-64.png": dark64Icon.get(),
+        @"action-light-32.png": light32Icon.get(),
+        @"action-light-64.png": light64Icon.get(),
     };
 
     auto testExtension = [[WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary resources:resources];
@@ -681,10 +681,10 @@ TEST(WKWebExtension, ActionIconSingleVariant)
         }
     };
 
-    auto *icon32 = Util::makePNGData(CGSizeMake(32, 32), @selector(whiteColor));
+    RetainPtr icon32 = Util::makePNGData(CGSizeMake(32, 32), @selector(whiteColor));
 
     auto *resources = @{
-        @"action-icon-32.png": icon32,
+        @"action-icon-32.png": icon32.get(),
     };
 
     auto testExtension = [[WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary resources:resources];
@@ -771,12 +771,12 @@ TEST(WKWebExtension, ActionIconsAndIconVariantsSpecified)
         }
     };
 
-    auto *iconLegacy = Util::makePNGData(CGSizeMake(32, 32), @selector(blackColor));
-    auto *iconVariant = Util::makePNGData(CGSizeMake(32, 32), @selector(whiteColor));
+    RetainPtr iconLegacy = Util::makePNGData(CGSizeMake(32, 32), @selector(blackColor));
+    RetainPtr iconVariant = Util::makePNGData(CGSizeMake(32, 32), @selector(whiteColor));
 
     auto *resources = @{
-        @"action-icon-legacy.png": iconLegacy,
-        @"action-icon-variant.png": iconVariant,
+        @"action-icon-legacy.png": iconLegacy.get(),
+        @"action-icon-variant.png": iconVariant.get(),
     };
 
     auto testExtension = [[WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary resources:resources];
@@ -908,22 +908,22 @@ TEST(WKWebExtension, ActionParsing)
     EXPECT_NULL(testExtension.displayActionLabel);
     EXPECT_NULL([testExtension actionIconForSize:NSMakeSize(16, 16)]);
 
-    auto *imageData = Util::makePNGData(CGSizeMake(16, 16), @selector(greenColor));
+    RetainPtr imageData = Util::makePNGData(CGSizeMake(16, 16), @selector(greenColor));
 
     testManifestDictionary = @{ @"manifest_version": @3, @"name": @"Test", @"description": @"Test", @"version": @"1.0", @"action": @{ @"default_title": @"Button Title", @"default_icon": @"test.png" } };
-    testExtension = [[WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary resources:@{ @"test.png": imageData }];
+    testExtension = [[WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary resources:@{ @"test.png": imageData.get() }];
     EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
     EXPECT_NS_EQUAL(testExtension.displayActionLabel, @"Button Title");
     EXPECT_NOT_NULL([testExtension actionIconForSize:NSMakeSize(16, 16)]);
 
     testManifestDictionary = @{ @"manifest_version": @3, @"name": @"Test", @"description": @"Test", @"version": @"1.0", @"action": @{ @"default_title": @"Button Title", @"default_icon": @{ @"16": @"test.png" } } };
-    testExtension = [[WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary resources:@{ @"test.png": imageData }];
+    testExtension = [[WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary resources:@{ @"test.png": imageData.get() }];
     EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
     EXPECT_NS_EQUAL(testExtension.displayActionLabel, @"Button Title");
     EXPECT_NOT_NULL([testExtension actionIconForSize:NSMakeSize(16, 16)]);
 
     testManifestDictionary = @{ @"manifest_version": @3, @"name": @"Test", @"description": @"Test", @"version": @"1.0", @"icons": @{ @"16": @"test.png" }, @"action": @{ @"default_title": @"Button Title" } };
-    testExtension = [[WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary resources:@{ @"test.png": imageData }];
+    testExtension = [[WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary resources:@{ @"test.png": imageData.get() }];
     EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
     EXPECT_NS_EQUAL(testExtension.displayActionLabel, @"Button Title");
     EXPECT_NOT_NULL([testExtension actionIconForSize:NSMakeSize(16, 16)]);
@@ -2300,9 +2300,9 @@ TEST(WKWebExtension, LoadFromDirectory)
     [manager load];
     [manager runUntilTestMessage:@"Load Tab"];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -2324,9 +2324,9 @@ TEST(WKWebExtension, LoadFromDirectoryWithoutTrailingSlash)
     [manager load];
     [manager runUntilTestMessage:@"Load Tab"];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -2346,9 +2346,9 @@ TEST(WKWebExtension, LoadFromZipArchiveWithoutParentDirectory)
     [manager load];
     [manager runUntilTestMessage:@"Load Tab"];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -2368,9 +2368,9 @@ TEST(WKWebExtension, LoadFromZipArchiveWithParentDirectory)
     [manager load];
     [manager runUntilTestMessage:@"Load Tab"];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -2390,9 +2390,9 @@ TEST(WKWebExtension, LoadFromChromeExtensionArchive)
     [manager load];
     [manager runUntilTestMessage:@"Load Tab"];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -2415,9 +2415,9 @@ TEST(WKWebExtension, LoadFromMacAppExtensionBundle)
     [manager load];
     [manager runUntilTestMessage:@"Load Tab"];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -2440,9 +2440,9 @@ TEST(WKWebExtension, LoadFromiOSAppExtensionBundle)
     [manager load];
     [manager runUntilTestMessage:@"Load Tab"];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -2459,7 +2459,7 @@ TEST(WKWebExtension, LoadWithBadURL)
 
 TEST(WKWebExtension, ContentScriptImport)
 {
-    static auto *pageScript = Util::constructScript(@[
+    static NeverDestroyed<RetainPtr<NSString>> pageScript = Util::constructScript(@[
         @"const registration = await navigator.serviceWorker.register('./service-worker.js')",
         @"let worker = registration.installing",
 
@@ -2469,7 +2469,7 @@ TEST(WKWebExtension, ContentScriptImport)
         @"})",
     ]);
 
-    static auto *serviceWorkerScript = Util::constructScript(@[
+    static NeverDestroyed<RetainPtr<NSString>> serviceWorkerScript = Util::constructScript(@[
         @"self.addEventListener('install', (event) => self.skipWaiting())",
         @"self.addEventListener('activate', (event) => event.waitUntil(self.clients.claim()))",
 
@@ -2487,8 +2487,8 @@ TEST(WKWebExtension, ContentScriptImport)
 
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, @"<script type='module' src='page.js'></script>" } },
-        { "/page.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, pageScript } },
-        { "/service-worker.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, serviceWorkerScript } },
+        { "/page.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, pageScript->get() } },
+        { "/service-worker.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, serviceWorkerScript->get() } },
         { "/bad.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, badScript } },
         { "/good.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, goodScript } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
@@ -2511,7 +2511,7 @@ TEST(WKWebExtension, ContentScriptImport)
         }]
     };
 
-    static auto *contentScript = Util::constructScript(@[
+    static NeverDestroyed<RetainPtr<NSString>> contentScript = Util::constructScript(@[
         @"window.addEventListener('message', (event) => {",
         @"  browser.test.assertEq(event.data, 'ready', 'Expected message to be ready')",
         [NSString stringWithFormat:@"  import('%@')", server.requestWithLocalhost("/good.js"_s).URL.absoluteString],
@@ -2522,17 +2522,17 @@ TEST(WKWebExtension, ContentScriptImport)
 
     auto *resources = @{
         @"background.js": backgroundScript,
-        @"content.js": contentScript
+        @"content.js": contentScript->get()
     };
 
     auto manager = Util::loadExtension(manifest, resources);
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -2562,11 +2562,11 @@ TEST(WKWebExtension, ContentScriptNotInjectedForExcludedMatchPattern)
         }]
     };
 
-    static auto *contentScript = Util::constructScript(@[
+    static NeverDestroyed<RetainPtr<NSString>> contentScript = Util::constructScript(@[
         @"browser.runtime.sendMessage('Hello from content script')"
     ]);
 
-    static auto *backgroundScript = Util::constructScript(@[
+    static NeverDestroyed<RetainPtr<NSString>> backgroundScript = Util::constructScript(@[
         @"browser.runtime.onMessage.addListener((message, sender) => {",
         @"  browser.test.notifyFail('Content script should not have been injected.')",
         @"})",
@@ -2579,8 +2579,8 @@ TEST(WKWebExtension, ContentScriptNotInjectedForExcludedMatchPattern)
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
-        @"content.js": contentScript
+        @"background.js": backgroundScript->get(),
+        @"content.js": contentScript->get()
     };
 
     auto manager = Util::loadExtension(manifest, resources);
@@ -2618,15 +2618,15 @@ TEST(WKWebExtension, MultipleContentScriptsInjectedWhenMatched)
         }]
     };
 
-    static auto *scriptA = Util::constructScript(@[
+    static NeverDestroyed<RetainPtr<NSString>> scriptA = Util::constructScript(@[
         @"browser.runtime.sendMessage('Script A ran')"
     ]);
 
-    static auto *scriptB = Util::constructScript(@[
+    static NeverDestroyed<RetainPtr<NSString>> scriptB = Util::constructScript(@[
         @"browser.runtime.sendMessage('Script B ran')"
     ]);
 
-    static auto *backgroundScript = Util::constructScript(@[
+    static NeverDestroyed<RetainPtr<NSString>> backgroundScript = Util::constructScript(@[
         @"let seen = new Set()",
 
         @"browser.runtime.onMessage.addListener((message, sender) => {",
@@ -2639,9 +2639,9 @@ TEST(WKWebExtension, MultipleContentScriptsInjectedWhenMatched)
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
-        @"scriptA.js": scriptA,
-        @"scriptB.js": scriptB
+        @"background.js": backgroundScript->get(),
+        @"scriptA.js": scriptA->get(),
+        @"scriptB.js": scriptB->get()
     };
 
     auto manager = Util::loadExtension(manifest, resources);
@@ -2680,15 +2680,15 @@ TEST(WKWebExtension, MultipleContentScriptsNotInjectedWhenNotMatched)
         }]
     };
 
-    static auto *scriptA = Util::constructScript(@[
+    static NeverDestroyed<RetainPtr<NSString>> scriptA = Util::constructScript(@[
         @"browser.runtime.sendMessage('Script A ran')"
     ]);
 
-    static auto *scriptB = Util::constructScript(@[
+    static NeverDestroyed<RetainPtr<NSString>> scriptB = Util::constructScript(@[
         @"browser.runtime.sendMessage('Script B ran')"
     ]);
 
-    static auto *backgroundScript = Util::constructScript(@[
+    static NeverDestroyed<RetainPtr<NSString>> backgroundScript = Util::constructScript(@[
         @"browser.runtime.onMessage.addListener((message, sender) => {",
         @"  browser.test.notifyFail(`No content scripts should have injected, but got: ${message}`)",
         @"})",
@@ -2699,9 +2699,9 @@ TEST(WKWebExtension, MultipleContentScriptsNotInjectedWhenNotMatched)
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
-        @"scriptA.js": scriptA,
-        @"scriptB.js": scriptB
+        @"background.js": backgroundScript->get(),
+        @"scriptA.js": scriptA->get(),
+        @"scriptB.js": scriptB->get()
     };
 
     auto manager = Util::loadExtension(manifest, resources);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm
@@ -65,7 +65,7 @@ static auto *actionPopupManifest = @{
 
 TEST(WKWebExtensionAPIAction, Errors)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.assertThrows(() => browser.action.setTitle({tabId: 'bad', title: 'Test'}), /'tabId' is expected to be a number, but a string was provided/i)",
         @"browser.test.assertThrows(() => browser.action.setTitle({windowId: 'bad', title: 'Test'}), /'windowId' is expected to be a number, but a string was provided/i)",
         @"browser.test.assertThrows(() => browser.action.setIcon({path: 123}), /'path' is expected to be a string or an object or null, but a number was provided/i)",
@@ -104,12 +104,12 @@ TEST(WKWebExtensionAPIAction, Errors)
         @"browser.test.notifyPass()"
     ]);
 
-    Util::loadAndRunExtension(actionPopupManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(actionPopupManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPIAction, ClickedEvent)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.action.setPopup({ popup: '' })",
 
         @"browser.action.onClicked.addListener((tab) => {",
@@ -121,7 +121,7 @@ TEST(WKWebExtensionAPIAction, ClickedEvent)
         @"browser.test.sendMessage('Test Action')"
     ]);
 
-    auto manager = Util::loadExtension(actionPopupManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(actionPopupManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager runUntilTestMessage:@"Test Action"];
 
@@ -134,18 +134,18 @@ TEST(WKWebExtensionAPIAction, PresentPopupForAction)
 {
     auto *popupPage = @"<b>Hello World!</b>";
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.sendMessage('Test Popup Action')"
     ]);
 
-    auto *smallToolbarIcon = Util::makePNGData(CGSizeMake(16, 16), @selector(redColor));
-    auto *largeToolbarIcon = Util::makePNGData(CGSizeMake(32, 32), @selector(blueColor));
+    RetainPtr smallToolbarIcon = Util::makePNGData(CGSizeMake(16, 16), @selector(redColor));
+    RetainPtr largeToolbarIcon = Util::makePNGData(CGSizeMake(32, 32), @selector(blueColor));
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"popup.html": popupPage,
-        @"toolbar-16.png": smallToolbarIcon,
-        @"toolbar-32.png": largeToolbarIcon,
+        @"toolbar-16.png": smallToolbarIcon.get(),
+        @"toolbar-32.png": largeToolbarIcon.get(),
     };
 
     auto manager = Util::loadExtension(actionPopupManifest, resources);
@@ -194,7 +194,7 @@ TEST(WKWebExtensionAPIAction, PresentPopupForAction)
 
 TEST(WKWebExtensionAPIAction, GetCurrentTabAndWindowFromPopupPage)
 {
-    auto *popupScript = Util::constructScript(@[
+    RetainPtr popupScript = Util::constructScript(@[
         @"const tab = await browser.tabs.getCurrent()",
         @"browser.test.assertEq(typeof tab, 'object', 'The tab should be')",
         @"browser.test.assertTrue(tab.active, 'The current tab should be active')",
@@ -206,14 +206,14 @@ TEST(WKWebExtensionAPIAction, GetCurrentTabAndWindowFromPopupPage)
         @"browser.test.notifyPass()"
     ]);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.sendMessage('Test Popup Action')"
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"popup.html": @"<script type='module' src='popup.js'></script>",
-        @"popup.js": popupScript
+        @"popup.js": popupScript.get()
     };
 
     auto manager = Util::loadExtension(actionPopupManifest, resources);
@@ -232,7 +232,7 @@ TEST(WKWebExtensionAPIAction, GetCurrentTabAndWindowFromPopupPage)
 
 TEST(WKWebExtensionAPIAction, UpdateTabFromPopupPage)
 {
-    auto *popupScript = Util::constructScript(@[
+    RetainPtr popupScript = Util::constructScript(@[
         @"const tab = await browser.tabs.getCurrent()",
         @"browser.test.assertEq(typeof tab, 'object', 'The tab should be')",
         @"browser.test.assertTrue(tab.active, 'The current tab should be active')",
@@ -248,14 +248,14 @@ TEST(WKWebExtensionAPIAction, UpdateTabFromPopupPage)
         @"browser.test.notifyPass()"
     ]);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.sendMessage('Test Popup Action')"
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"popup.html": @"<script type='module' src='popup.js'></script>",
-        @"popup.js": popupScript
+        @"popup.js": popupScript.get()
     };
 
     auto manager = Util::loadExtension(actionPopupManifest, resources);
@@ -276,7 +276,7 @@ TEST(WKWebExtensionAPIAction, SetDefaultActionProperties)
 {
     auto *popupPage = @"<b>Hello World!</b>";
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.assertEq(await browser.action.getTitle({ }), 'Test Action', 'Title should be')",
         @"browser.test.assertEq(await browser.action.getPopup({ }), 'popup.html', 'Popup should be')",
         @"browser.test.assertEq(await browser.action.getBadgeText({ }), '', 'Badge text should be')",
@@ -296,12 +296,12 @@ TEST(WKWebExtensionAPIAction, SetDefaultActionProperties)
         @"browser.action.openPopup()"
     ]);
 
-    auto *extraLargeToolbarIcon = Util::makePNGData(CGSizeMake(48, 48), @selector(yellowColor));
+    RetainPtr extraLargeToolbarIcon = Util::makePNGData(CGSizeMake(48, 48), @selector(yellowColor));
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"alt-popup.html": popupPage,
-        @"toolbar-48.png": extraLargeToolbarIcon,
+        @"toolbar-48.png": extraLargeToolbarIcon.get(),
     };
 
     auto manager = Util::loadExtension(actionPopupManifest, resources);
@@ -349,7 +349,7 @@ TEST(WKWebExtensionAPIAction, TabSpecificActionProperties)
     auto *popupPage = @"<b>Hello World!</b>";
     auto *altPopupPage = @"<b>Hello Alternate World!</b>";
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const [currentTab] = await browser.tabs.query({ active: true, currentWindow: true })",
 
         @"browser.test.assertEq(await browser.action.getTitle({ tabId: currentTab.id }), 'Test Action', 'Title should be')",
@@ -371,17 +371,17 @@ TEST(WKWebExtensionAPIAction, TabSpecificActionProperties)
         @"browser.action.openPopup({ windowId: currentTab.windowId })"
     ]);
 
-    auto *smallToolbarIcon = Util::makePNGData(CGSizeMake(16, 16), @selector(redColor));
-    auto *largeToolbarIcon = Util::makePNGData(CGSizeMake(32, 32), @selector(blueColor));
-    auto *extraLargeToolbarIcon = Util::makePNGData(CGSizeMake(48, 48), @selector(yellowColor));
+    RetainPtr smallToolbarIcon = Util::makePNGData(CGSizeMake(16, 16), @selector(redColor));
+    RetainPtr largeToolbarIcon = Util::makePNGData(CGSizeMake(32, 32), @selector(blueColor));
+    RetainPtr extraLargeToolbarIcon = Util::makePNGData(CGSizeMake(48, 48), @selector(yellowColor));
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"popup.html": popupPage,
         @"alt-popup.html": altPopupPage,
-        @"toolbar-16.png": smallToolbarIcon,
-        @"toolbar-32.png": largeToolbarIcon,
-        @"toolbar-48.png": extraLargeToolbarIcon,
+        @"toolbar-16.png": smallToolbarIcon.get(),
+        @"toolbar-32.png": largeToolbarIcon.get(),
+        @"toolbar-48.png": extraLargeToolbarIcon.get(),
     };
 
     auto manager = Util::parseExtension(actionPopupManifest, resources);
@@ -467,7 +467,7 @@ TEST(WKWebExtensionAPIAction, WindowSpecificActionProperties)
     auto *popupPage = @"<b>Hello World!</b>";
     auto *windowPopupPage = @"<b>Window-Specific Popup!</b>";
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const [currentTab] = await browser.tabs.query({ active: true, currentWindow: true })",
         @"const currentWindowId = currentTab.windowId",
 
@@ -487,15 +487,15 @@ TEST(WKWebExtensionAPIAction, WindowSpecificActionProperties)
         @"browser.action.openPopup({ windowId: currentWindowId })"
     ]);
 
-    auto *defaultToolbarIcon = Util::makePNGData(CGSizeMake(32, 32), @selector(redColor));
-    auto *windowToolbarIcon = Util::makePNGData(CGSizeMake(48, 48), @selector(greenColor));
+    RetainPtr defaultToolbarIcon = Util::makePNGData(CGSizeMake(32, 32), @selector(redColor));
+    RetainPtr windowToolbarIcon = Util::makePNGData(CGSizeMake(48, 48), @selector(greenColor));
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"popup.html": popupPage,
         @"window-popup.html": windowPopupPage,
-        @"toolbar-32.png": defaultToolbarIcon,
-        @"window-toolbar-48.png": windowToolbarIcon,
+        @"toolbar-32.png": defaultToolbarIcon.get(),
+        @"window-toolbar-48.png": windowToolbarIcon.get(),
     };
 
     auto manager = Util::parseExtension(actionPopupManifest, resources);
@@ -555,15 +555,15 @@ TEST(WKWebExtensionAPIAction, WindowSpecificActionProperties)
 
 TEST(WKWebExtensionAPIAction, SetIconSinglePath)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"await browser.action.setIcon({ path: 'toolbar-48.png' })",
     ]);
 
-    auto *extraLargeToolbarIcon = Util::makePNGData(CGSizeMake(48, 48), @selector(yellowColor));
+    RetainPtr extraLargeToolbarIcon = Util::makePNGData(CGSizeMake(48, 48), @selector(yellowColor));
 
     auto *resources = @{
-        @"background.js": backgroundScript,
-        @"toolbar-48.png": extraLargeToolbarIcon,
+        @"background.js": backgroundScript.get(),
+        @"toolbar-48.png": extraLargeToolbarIcon.get(),
         @"popup.html": @"Hello world!",
     };
 
@@ -582,16 +582,16 @@ TEST(WKWebExtensionAPIAction, SetIconSinglePath)
 
 TEST(WKWebExtensionAPIAction, SetIconSinglePathRelative)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"await browser.action.setIcon({ path: '../icons/toolbar-48.png' })",
     ]);
 
-    auto *extraLargeToolbarIcon = Util::makePNGData(CGSizeMake(48, 48), @selector(yellowColor));
+    RetainPtr extraLargeToolbarIcon = Util::makePNGData(CGSizeMake(48, 48), @selector(yellowColor));
 
     auto *resources = @{
         @"background/index.html": @"<script type='module' src='script.js'></script>",
-        @"background/script.js": backgroundScript,
-        @"icons/toolbar-48.png": extraLargeToolbarIcon,
+        @"background/script.js": backgroundScript.get(),
+        @"icons/toolbar-48.png": extraLargeToolbarIcon.get(),
         @"popup.html": @"Hello world!",
     };
 
@@ -633,19 +633,19 @@ TEST(WKWebExtensionAPIAction, SetIconSinglePathRelative)
 
 TEST(WKWebExtensionAPIAction, SetIconMultipleSizes)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"await browser.action.setIcon({ path: { '48': 'toolbar-48.png', '96': 'toolbar-96.png', '128': 'toolbar-128.png' } })",
     ]);
 
-    auto *largeToolbarIcon = Util::makePNGData(CGSizeMake(48, 48), @selector(yellowColor));
-    auto *extraLargeToolbarIcon = Util::makePNGData(CGSizeMake(96, 96), @selector(greenColor));
-    auto *superExtraLargeToolbarIcon = Util::makePNGData(CGSizeMake(128, 128), @selector(purpleColor));
+    RetainPtr largeToolbarIcon = Util::makePNGData(CGSizeMake(48, 48), @selector(yellowColor));
+    RetainPtr extraLargeToolbarIcon = Util::makePNGData(CGSizeMake(96, 96), @selector(greenColor));
+    RetainPtr superExtraLargeToolbarIcon = Util::makePNGData(CGSizeMake(128, 128), @selector(purpleColor));
 
     auto *resources = @{
-        @"background.js": backgroundScript,
-        @"toolbar-48.png": largeToolbarIcon,
-        @"toolbar-96.png": extraLargeToolbarIcon,
-        @"toolbar-128.png": superExtraLargeToolbarIcon,
+        @"background.js": backgroundScript.get(),
+        @"toolbar-48.png": largeToolbarIcon.get(),
+        @"toolbar-96.png": extraLargeToolbarIcon.get(),
+        @"toolbar-128.png": superExtraLargeToolbarIcon.get(),
         @"popup.html": @"Hello world!",
     };
 
@@ -673,20 +673,20 @@ TEST(WKWebExtensionAPIAction, SetIconMultipleSizes)
 
 TEST(WKWebExtensionAPIAction, SetIconMultipleSizesRelative)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"await browser.action.setIcon({ path: { '48': '../icons/toolbar-48.png', '96': '../icons/toolbar-96.png', '128': '../icons/toolbar-128.png' } })",
     ]);
 
-    auto *largeToolbarIcon = Util::makePNGData(CGSizeMake(48, 48), @selector(yellowColor));
-    auto *extraLargeToolbarIcon = Util::makePNGData(CGSizeMake(96, 96), @selector(greenColor));
-    auto *superExtraLargeToolbarIcon = Util::makePNGData(CGSizeMake(128, 128), @selector(purpleColor));
+    RetainPtr largeToolbarIcon = Util::makePNGData(CGSizeMake(48, 48), @selector(yellowColor));
+    RetainPtr extraLargeToolbarIcon = Util::makePNGData(CGSizeMake(96, 96), @selector(greenColor));
+    RetainPtr superExtraLargeToolbarIcon = Util::makePNGData(CGSizeMake(128, 128), @selector(purpleColor));
 
     auto *resources = @{
         @"background/index.html": @"<script type='module' src='script.js'></script>",
-        @"background/script.js": backgroundScript,
-        @"icons/toolbar-48.png": largeToolbarIcon,
-        @"icons/toolbar-96.png": extraLargeToolbarIcon,
-        @"icons/toolbar-128.png": superExtraLargeToolbarIcon,
+        @"background/script.js": backgroundScript.get(),
+        @"icons/toolbar-48.png": largeToolbarIcon.get(),
+        @"icons/toolbar-96.png": extraLargeToolbarIcon.get(),
+        @"icons/toolbar-128.png": superExtraLargeToolbarIcon.get(),
         @"popup.html": @"Hello world!",
     };
 
@@ -737,12 +737,12 @@ TEST(WKWebExtensionAPIAction, SetIconMultipleSizesRelative)
 
 TEST(WKWebExtensionAPIAction, SetIconWithBadPath)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"await browser.action.setIcon({ path: 'bad.png' })",
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"popup.html": @"Hello world!",
     };
 
@@ -760,7 +760,7 @@ TEST(WKWebExtensionAPIAction, SetIconWithBadPath)
 
 TEST(WKWebExtensionAPIAction, SetIconWithImageData)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const context = new OffscreenCanvas(48, 48).getContext('2d')",
         @"context.fillStyle = 'green'",
         @"context.fillRect(0, 0, 48, 48)",
@@ -770,7 +770,7 @@ TEST(WKWebExtensionAPIAction, SetIconWithImageData)
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"popup.html": @"Hello world!",
     };
 
@@ -790,18 +790,18 @@ TEST(WKWebExtensionAPIAction, SetIconWithImageData)
 
 TEST(WKWebExtensionAPIAction, SetIconWithBadImageData)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.assertThrows(() => browser.action.setIcon({ imageData: { 16: { data: [ 'bad' ] } } }))",
 
         @"browser.test.notifyPass()"
     ]);
 
-    Util::loadAndRunExtension(actionPopupManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(actionPopupManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPIAction, SetIconWithMultipleImageDataSizes)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const createImageData = (size, color) => {",
         @"  const context = new OffscreenCanvas(size, size).getContext('2d')",
         @"  context.fillStyle = color",
@@ -818,7 +818,7 @@ TEST(WKWebExtensionAPIAction, SetIconWithMultipleImageDataSizes)
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"popup.html": @"Hello world!",
     };
 
@@ -846,7 +846,7 @@ TEST(WKWebExtensionAPIAction, SetIconWithMultipleImageDataSizes)
 
 TEST(WKWebExtensionAPIAction, SetIconWithDataURL)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const canvas = document.createElement('canvas')",
         @"canvas.width = 48",
         @"canvas.height = 48",
@@ -861,7 +861,7 @@ TEST(WKWebExtensionAPIAction, SetIconWithDataURL)
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"popup.html": @"Hello world!",
     };
 
@@ -880,14 +880,14 @@ TEST(WKWebExtensionAPIAction, SetIconWithDataURL)
 
 TEST(WKWebExtensionAPIAction, SetIconWithBadDataURL)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const invalidDataURL = 'data:image/png;base64,INVALIDDATA'",
 
         @"await browser.action.setIcon({ path: invalidDataURL })",
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"popup.html": @"Hello world!",
     };
 
@@ -905,16 +905,16 @@ TEST(WKWebExtensionAPIAction, SetIconWithBadDataURL)
 
 TEST(WKWebExtensionAPIAction, SetIconWithNullPath)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"await browser.action.setIcon({ path: null })",
         @"browser.test.sendMessage('Icon Set')",
     ]);
 
-    auto *largeToolbarIcon = Util::makePNGData(CGSizeMake(32, 32), @selector(blueColor));
+    RetainPtr largeToolbarIcon = Util::makePNGData(CGSizeMake(32, 32), @selector(blueColor));
 
     auto *resources = @{
-        @"background.js": backgroundScript,
-        @"toolbar-32.png": largeToolbarIcon,
+        @"background.js": backgroundScript.get(),
+        @"toolbar-32.png": largeToolbarIcon.get(),
         @"popup.html": @"Hello world!",
     };
 
@@ -930,16 +930,16 @@ TEST(WKWebExtensionAPIAction, SetIconWithNullPath)
 
 TEST(WKWebExtensionAPIAction, SetIconWithNullImageData)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"await browser.action.setIcon({ imageData: null })",
         @"browser.test.sendMessage('Icon Set')",
     ]);
 
-    auto *largeToolbarIcon = Util::makePNGData(CGSizeMake(32, 32), @selector(blueColor));
+    RetainPtr largeToolbarIcon = Util::makePNGData(CGSizeMake(32, 32), @selector(blueColor));
 
     auto *resources = @{
-        @"background.js": backgroundScript,
-        @"toolbar-32.png": largeToolbarIcon,
+        @"background.js": backgroundScript.get(),
+        @"toolbar-32.png": largeToolbarIcon.get(),
         @"popup.html": @"Hello world!",
     };
 
@@ -955,16 +955,16 @@ TEST(WKWebExtensionAPIAction, SetIconWithNullImageData)
 
 TEST(WKWebExtensionAPIAction, SetIconWithNullVariants)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"await browser.action.setIcon({ variants: null })",
         @"browser.test.sendMessage('Icon Set')",
     ]);
 
-    auto *largeToolbarIcon = Util::makePNGData(CGSizeMake(32, 32), @selector(blueColor));
+    RetainPtr largeToolbarIcon = Util::makePNGData(CGSizeMake(32, 32), @selector(blueColor));
 
     auto *resources = @{
-        @"background.js": backgroundScript,
-        @"toolbar-32.png": largeToolbarIcon,
+        @"background.js": backgroundScript.get(),
+        @"toolbar-32.png": largeToolbarIcon.get(),
         @"popup.html": @"Hello world!",
     };
 
@@ -980,7 +980,7 @@ TEST(WKWebExtensionAPIAction, SetIconWithNullVariants)
 
 TEST(WKWebExtensionAPIAction, SetIconWithMultipleDataURLs)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const canvas = document.createElement('canvas')",
 
         @"canvas.width = 48",
@@ -1005,7 +1005,7 @@ TEST(WKWebExtensionAPIAction, SetIconWithMultipleDataURLs)
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"popup.html": @"Hello world!",
     };
 
@@ -1028,11 +1028,11 @@ TEST(WKWebExtensionAPIAction, SetIconWithMultipleDataURLs)
 
 TEST(WKWebExtensionAPIAction, SetIconSymbolSinglePath)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"await browser.action.setIcon({ path: 'symbol:star' })",
     ]);
 
-    auto manager = Util::loadExtension(actionPopupManifest, @{ @"background.js": backgroundScript, @"popup.html": @"Hello world!" });
+    auto manager = Util::loadExtension(actionPopupManifest, @{ @"background.js": backgroundScript.get(), @"popup.html": @"Hello world!" });
 
     manager.get().internalDelegate.didUpdateAction = ^(WKWebExtensionAction *action) {
         auto *icon = [action iconForSize:CGSizeMake(16, 16)];
@@ -1052,11 +1052,11 @@ TEST(WKWebExtensionAPIAction, SetIconSymbolSinglePath)
 
 TEST(WKWebExtensionAPIAction, SetIconSymbolIconsDictionary)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"await browser.action.setIcon({ path: { '16': 'symbol:heart.fill' } })",
     ]);
 
-    auto manager = Util::loadExtension(actionPopupManifest, @{ @"background.js": backgroundScript, @"popup.html": @"Hello world!" });
+    auto manager = Util::loadExtension(actionPopupManifest, @{ @"background.js": backgroundScript.get(), @"popup.html": @"Hello world!" });
 
     manager.get().internalDelegate.didUpdateAction = ^(WKWebExtensionAction *action) {
         auto *icon = [action iconForSize:CGSizeMake(16, 16)];
@@ -1077,7 +1077,7 @@ TEST(WKWebExtensionAPIAction, SetIconSymbolIconsDictionary)
 #if ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
 TEST(WKWebExtensionAPIAction, SetIconWithVariants)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"await browser.test.assertSafeResolve(() => browser.action.setIcon({",
         @"    variants: [",
         @"        { 32: 'action-dark-32.png', 64: 'action-dark-64.png', 'colorSchemes': [ 'dark' ] },",
@@ -1086,18 +1086,18 @@ TEST(WKWebExtensionAPIAction, SetIconWithVariants)
         @"}))",
     ]);
 
-    auto *dark32Icon = Util::makePNGData(CGSizeMake(32, 32), @selector(whiteColor));
-    auto *dark64Icon = Util::makePNGData(CGSizeMake(64, 64), @selector(whiteColor));
-    auto *light32Icon = Util::makePNGData(CGSizeMake(32, 32), @selector(blackColor));
-    auto *light64Icon = Util::makePNGData(CGSizeMake(64, 64), @selector(blackColor));
+    RetainPtr dark32Icon = Util::makePNGData(CGSizeMake(32, 32), @selector(whiteColor));
+    RetainPtr dark64Icon = Util::makePNGData(CGSizeMake(64, 64), @selector(whiteColor));
+    RetainPtr light32Icon = Util::makePNGData(CGSizeMake(32, 32), @selector(blackColor));
+    RetainPtr light64Icon = Util::makePNGData(CGSizeMake(64, 64), @selector(blackColor));
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"popup.html": @"Hello world!",
-        @"action-dark-32.png": dark32Icon,
-        @"action-dark-64.png": dark64Icon,
-        @"action-light-32.png": light32Icon,
-        @"action-light-64.png": light64Icon,
+        @"action-dark-32.png": dark32Icon.get(),
+        @"action-dark-64.png": dark64Icon.get(),
+        @"action-light-32.png": light32Icon.get(),
+        @"action-light-64.png": light64Icon.get(),
     };
 
     auto manager = Util::loadExtension(actionPopupManifest, resources);
@@ -1129,7 +1129,7 @@ TEST(WKWebExtensionAPIAction, SetIconWithVariants)
 
 TEST(WKWebExtensionAPIAction, SetIconWithImageDataAndVariants)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const createImageData = (size, color) => {",
         @"  const context = new OffscreenCanvas(size, size).getContext('2d')",
         @"  context.fillStyle = color",
@@ -1152,7 +1152,7 @@ TEST(WKWebExtensionAPIAction, SetIconWithImageDataAndVariants)
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"popup.html": @"Hello world!",
     };
 
@@ -1186,7 +1186,7 @@ TEST(WKWebExtensionAPIAction, SetIconWithImageDataAndVariants)
 
 TEST(WKWebExtensionAPIAction, SetIconThrowsWithNoValidVariants)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const createImageData = (size, color) => {",
         @"  const context = new OffscreenCanvas(size, size).getContext('2d')",
         @"  context.fillStyle = color",
@@ -1209,7 +1209,7 @@ TEST(WKWebExtensionAPIAction, SetIconThrowsWithNoValidVariants)
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"popup.html": @"Hello world!",
     };
 
@@ -1218,7 +1218,7 @@ TEST(WKWebExtensionAPIAction, SetIconThrowsWithNoValidVariants)
 
 TEST(WKWebExtensionAPIAction, SetIconWithMixedValidAndInvalidVariants)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const createImageData = (size, color) => {",
         @"  const context = new OffscreenCanvas(size, size).getContext('2d')",
         @"  context.fillStyle = color",
@@ -1239,7 +1239,7 @@ TEST(WKWebExtensionAPIAction, SetIconWithMixedValidAndInvalidVariants)
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"popup.html": @"Hello world!",
     };
 
@@ -1267,7 +1267,7 @@ TEST(WKWebExtensionAPIAction, SetIconWithMixedValidAndInvalidVariants)
 
 TEST(WKWebExtensionAPIAction, SetIconWithAnySizeVariantAndSVGDataURL)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const whiteSVGData = 'data:image/svg+xml;base64,' + btoa(`",
         @"  <svg width=\"100\" height=\"100\" xmlns=\"http://www.w3.org/2000/svg\">",
         @"    <rect width=\"100\" height=\"100\" fill=\"white\" />",
@@ -1287,7 +1287,7 @@ TEST(WKWebExtensionAPIAction, SetIconWithAnySizeVariantAndSVGDataURL)
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"popup.html": @"Hello World!",
     };
 
@@ -1315,7 +1315,7 @@ TEST(WKWebExtensionAPIAction, SetIconWithAnySizeVariantAndSVGDataURL)
 
 TEST(WKWebExtensionAPIAction, SetIconWithSymbolVariants)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"await browser.test.assertSafeResolve(() => browser.action.setIcon({",
         @"    variants: [",
         @"        { any: 'symbol:star' }",
@@ -1323,7 +1323,7 @@ TEST(WKWebExtensionAPIAction, SetIconWithSymbolVariants)
         @"}))",
     ]);
 
-    auto manager = Util::loadExtension(actionPopupManifest, @{ @"background.js": backgroundScript, @"popup.html": @"Hello world!" });
+    auto manager = Util::loadExtension(actionPopupManifest, @{ @"background.js": backgroundScript.get(), @"popup.html": @"Hello world!" });
 
     manager.get().internalDelegate.didUpdateAction = ^(WKWebExtensionAction *action) {
         auto *icon = [action iconForSize:CGSizeMake(32, 32)];
@@ -1369,7 +1369,7 @@ TEST(WKWebExtensionAPIAction, BrowserAction)
 
     auto *popupPage = @"<b>Hello World!</b>";
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"await browser.browserAction.setTitle({ title: 'Modified Title' })",
         @"await browser.browserAction.setIcon({ path: 'toolbar-48.png' })",
         @"await browser.browserAction.setPopup({ popup: 'alt-popup.html' })",
@@ -1379,12 +1379,12 @@ TEST(WKWebExtensionAPIAction, BrowserAction)
         @"browser.browserAction.openPopup()"
     ]);
 
-    auto *extraLargeToolbarIcon = Util::makePNGData(CGSizeMake(48, 48), @selector(yellowColor));
+    RetainPtr extraLargeToolbarIcon = Util::makePNGData(CGSizeMake(48, 48), @selector(yellowColor));
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"alt-popup.html": popupPage,
-        @"toolbar-48.png": extraLargeToolbarIcon,
+        @"toolbar-48.png": extraLargeToolbarIcon.get(),
     };
 
     auto manager = Util::loadExtension(browserActionManifest, resources);
@@ -1462,7 +1462,7 @@ TEST(WKWebExtensionAPIAction, PageAction)
 
     auto *popupPage = @"<b>Hello World!</b>";
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"await browser.pageAction.setTitle({ title: 'Modified Title' })",
         @"await browser.pageAction.setIcon({ path: 'toolbar-48.png' })",
         @"await browser.pageAction.setPopup({ popup: 'alt-popup.html' })",
@@ -1472,12 +1472,12 @@ TEST(WKWebExtensionAPIAction, PageAction)
         @"browser.pageAction.openPopup()"
     ]);
 
-    auto *extraLargeToolbarIcon = Util::makePNGData(CGSizeMake(48, 48), @selector(yellowColor));
+    RetainPtr extraLargeToolbarIcon = Util::makePNGData(CGSizeMake(48, 48), @selector(yellowColor));
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"alt-popup.html": popupPage,
-        @"toolbar-48.png": extraLargeToolbarIcon,
+        @"toolbar-48.png": extraLargeToolbarIcon.get(),
     };
 
     auto manager = Util::loadExtension(pageActionManifest, resources);
@@ -1534,7 +1534,7 @@ TEST(WKWebExtensionAPIAction, ClearTabSpecificActionPropertiesOnNavigation)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const [currentTab] = await browser.tabs.query({ active: true, currentWindow: true })",
 
         @"browser.action.setTitle({ title: 'Tab Title', tabId: currentTab.id })",
@@ -1563,45 +1563,45 @@ TEST(WKWebExtensionAPIAction, ClearTabSpecificActionPropertiesOnNavigation)
         @"browser.test.sendMessage('Load Tab')",
     ]);
 
-    auto *smallToolbarIcon = Util::makePNGData(CGSizeMake(16, 16), @selector(redColor));
-    auto *largeToolbarIcon = Util::makePNGData(CGSizeMake(32, 32), @selector(blueColor));
-    auto *extraLargeToolbarIcon = Util::makePNGData(CGSizeMake(48, 48), @selector(yellowColor));
+    RetainPtr smallToolbarIcon = Util::makePNGData(CGSizeMake(16, 16), @selector(redColor));
+    RetainPtr largeToolbarIcon = Util::makePNGData(CGSizeMake(32, 32), @selector(blueColor));
+    RetainPtr extraLargeToolbarIcon = Util::makePNGData(CGSizeMake(48, 48), @selector(yellowColor));
 
     auto *resources = @{
-        @"background.js": backgroundScript,
-        @"toolbar-16.png": smallToolbarIcon,
-        @"toolbar-32.png": largeToolbarIcon,
-        @"toolbar-48.png": extraLargeToolbarIcon,
+        @"background.js": backgroundScript.get(),
+        @"toolbar-16.png": smallToolbarIcon.get(),
+        @"toolbar-32.png": largeToolbarIcon.get(),
+        @"toolbar-48.png": extraLargeToolbarIcon.get(),
     };
 
     auto manager = Util::loadExtension(actionPopupManifest, resources);
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebNavigation];
 
-    auto *localhostRequest = server.requestWithLocalhost();
-    auto *addressRequest = server.request();
+    RetainPtr localhostRequest = server.requestWithLocalhost();
+    RetainPtr addressRequest = server.request();
 
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:localhostRequest.URL];
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:addressRequest.URL];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:localhostRequest.get().URL];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:addressRequest.get().URL];
 
-    [manager.get().defaultTab.webView loadRequest:localhostRequest];
+    [manager.get().defaultTab.webView loadRequest:localhostRequest.get()];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:addressRequest];
+    [manager.get().defaultTab.webView loadRequest:addressRequest.get()];
 
     [manager run];
 }
 
 TEST(WKWebExtensionAPIAction, HasUnreadBadgeText)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"await browser.action.setBadgeText({ text: 'New' })",
 
         @"browser.test.sendMessage('Check Unread Badge Text')"
     ]);
 
-    auto manager = Util::loadExtension(actionPopupManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(actionPopupManifest, @{ @"background.js": backgroundScript.get() });
     [manager runUntilTestMessage:@"Check Unread Badge Text"];
 
     auto *defaultAction = [manager.get().context actionForTab:nil];
@@ -1636,20 +1636,20 @@ TEST(WKWebExtensionAPIAction, NavigationOpensInNewTab)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *localhostRequest = server.requestWithLocalhost();
+    RetainPtr localhostRequest = server.requestWithLocalhost();
 
-    auto *popupScript = Util::constructScript(@[
-        [NSString stringWithFormat:@"document.location.href = '%@'", localhostRequest.URL.absoluteString],
+    RetainPtr popupScript = Util::constructScript(@[
+        [NSString stringWithFormat:@"document.location.href = '%@'", localhostRequest.get().URL.absoluteString],
     ]);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.sendMessage('Open Popup')"
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"popup.html": @"<script type='module' src='popup.js'></script>",
-        @"popup.js": popupScript
+        @"popup.js": popupScript.get()
     };
 
     auto manager = Util::loadExtension(actionPopupManifest, resources);
@@ -1660,7 +1660,7 @@ TEST(WKWebExtensionAPIAction, NavigationOpensInNewTab)
     };
 
     manager.get().internalDelegate.openNewTab = ^(WKWebExtensionTabConfiguration *configuration, WKWebExtensionContext *context, void (^completionHandler)(id<WKWebExtensionTab>, NSError *)) {
-        EXPECT_NS_EQUAL(configuration.url, localhostRequest.URL);
+        EXPECT_NS_EQUAL(configuration.url, localhostRequest.get().URL);
         EXPECT_NS_EQUAL(configuration.window, manager.get().defaultWindow);
         EXPECT_EQ(configuration.index, 1ul);
         EXPECT_EQ(configuration.shouldBeActive, YES);
@@ -1679,20 +1679,20 @@ TEST(WKWebExtensionAPIAction, NavigationOpensInNewTab)
 
 TEST(WKWebExtensionAPIAction, WindowOpenOpensInNewWindow)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.sendMessage('Open Popup')"
     ]);
 
-    auto *popupScript = Util::constructScript(@[
+    RetainPtr popupScript = Util::constructScript(@[
         @"browser.test.runWithUserGesture(() => {",
         @"  window.open('https://example.com/', '_blank', 'popup, width=100, height=50')",
         @"})"
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"popup.html": @"<script type='module' src='popup.js'></script>",
-        @"popup.js": popupScript
+        @"popup.js": popupScript.get()
     };
 
     auto manager = Util::loadExtension(actionPopupManifest, resources);
@@ -1758,7 +1758,7 @@ TEST(WKWebExtensionAPIAction, EmptyAction)
         @"action": @{ }
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"if (browser.action) {",
         @"  browser.test.notifyPass()",
         @"} else {",
@@ -1766,12 +1766,12 @@ TEST(WKWebExtensionAPIAction, EmptyAction)
         @"}"
     ]);
 
-    Util::loadAndRunExtension(actionManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(actionManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPIAction, ClickedEventAndPermissionsRequest)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.action.setPopup({ popup: '' })",
 
         @"browser.action.onClicked.addListener(async (tab) => {",
@@ -1789,7 +1789,7 @@ TEST(WKWebExtensionAPIAction, ClickedEventAndPermissionsRequest)
         @"browser.test.sendMessage('Test Action')"
     ]);
 
-    auto manager = Util::loadExtension(actionPopupManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(actionPopupManifest, @{ @"background.js": backgroundScript.get() });
 
     manager.get().internalDelegate.promptForPermissions = ^(id<WKWebExtensionTab> tab, NSSet<NSString *> *requestedPermissions, void (^callback)(NSSet<NSString *> *, NSDate *)) {
         EXPECT_EQ(requestedPermissions.count, 1lu);
@@ -1810,12 +1810,12 @@ TEST(WKWebExtensionAPIAction, SubframeNavigation)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<script>browser.test.notifyPass()</script>"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.sendMessage('Test Popup Action')"
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"popup.html": [NSString stringWithFormat:@"<iframe src='%@'></iframe>", server.requestWithLocalhost("/"_s).URL],
     };
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAlarms.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAlarms.mm
@@ -45,7 +45,7 @@ static auto *alarmsManifest = @{
 
 TEST(WKWebExtensionAPIAlarms, Errors)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.assertThrows(() => browser.alarms.create(null), /'info' value is invalid, because an object is expected/i)",
         @"browser.test.assertThrows(() => browser.alarms.create(undefined), /'info' value is invalid, because an object is expected/i)",
 
@@ -74,12 +74,12 @@ TEST(WKWebExtensionAPIAlarms, Errors)
         @"browser.test.notifyPass()",
     ]);
 
-    Util::loadAndRunExtension(alarmsManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(alarmsManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPIAlarms, DelaySingleShot)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         // Setup
         @"const startDate = Date.now()",
         @"const delayInMilliseconds = 100",
@@ -113,12 +113,12 @@ TEST(WKWebExtensionAPIAlarms, DelaySingleShot)
         @"}, 500)",
     ]);
 
-    Util::loadAndRunExtension(alarmsManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(alarmsManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPIAlarms, DelayRepeating)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         // Setup
         @"const startDate = Date.now()",
         @"const delayInMilliseconds = 100",
@@ -152,12 +152,12 @@ TEST(WKWebExtensionAPIAlarms, DelayRepeating)
         // The listener firing will indicate that the test passed.
     ]);
 
-    Util::loadAndRunExtension(alarmsManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(alarmsManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPIAlarms, WhenSingleShot)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         // Setup
         @"const startDate = Date.now()",
         @"const delayInMilliseconds = 100",
@@ -191,12 +191,12 @@ TEST(WKWebExtensionAPIAlarms, WhenSingleShot)
         @"}, 500)",
     ]);
 
-    Util::loadAndRunExtension(alarmsManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(alarmsManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPIAlarms, WhenRepeating)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         // Setup
         @"const startDate = Date.now()",
         @"const delayInMilliseconds = 100",
@@ -230,12 +230,12 @@ TEST(WKWebExtensionAPIAlarms, WhenRepeating)
         // The listener firing will indicate that the test passed.
     ]);
 
-    Util::loadAndRunExtension(alarmsManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(alarmsManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPIAlarms, ClearSingleAlarm)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         // Setup
         @"function listener(alarmInfo) {",
         @"  browser.test.assertEq(alarmInfo.name, 'two', 'Should only be called for alarm two.')",
@@ -254,12 +254,12 @@ TEST(WKWebExtensionAPIAlarms, ClearSingleAlarm)
         // The listener firing will indicate that the test passed.
     ]);
 
-    Util::loadAndRunExtension(alarmsManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(alarmsManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPIAlarms, GetSingleAlarm)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         // Test
         @"browser.alarms.create('one', { delayInMinutes: 1 })",
         @"browser.alarms.create('two', { delayInMinutes: 1, periodInMinutes: 1 })",
@@ -280,12 +280,12 @@ TEST(WKWebExtensionAPIAlarms, GetSingleAlarm)
         @"browser.test.notifyPass()",
     ]);
 
-    Util::loadAndRunExtension(alarmsManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(alarmsManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPIAlarms, ClearAllAlarms)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         // Setup
         @"function listener(alarmInfo) {",
         @"  browser.test.notifyFail('This listener should not have been called.')",
@@ -304,12 +304,12 @@ TEST(WKWebExtensionAPIAlarms, ClearAllAlarms)
         @"}, 500)",
     ]);
 
-    Util::loadAndRunExtension(alarmsManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(alarmsManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPIAlarms, GetAllAlarms)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         // Test
         @"browser.alarms.create('one', { delayInMinutes: 1 })",
         @"browser.alarms.create('two', { delayInMinutes: 1, periodInMinutes: 1 })",
@@ -334,12 +334,12 @@ TEST(WKWebExtensionAPIAlarms, GetAllAlarms)
         @"browser.test.notifyPass()",
     ]);
 
-    Util::loadAndRunExtension(alarmsManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(alarmsManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPIAlarms, UnnamedAlarm)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         // Setup
         @"function listener(alarmInfo) {",
         @"  browser.test.assertEq(alarmInfo.name, '', 'Should only be called for alarm with an empty string name.')",
@@ -355,12 +355,12 @@ TEST(WKWebExtensionAPIAlarms, UnnamedAlarm)
         // The listener firing will indicate that the test passed.
     ]);
 
-    Util::loadAndRunExtension(alarmsManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(alarmsManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPIAlarms, RemoveListenerDuringEvent)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"function alarmListener() {",
         @"  browser.alarms.onAlarm.removeListener(alarmListener)",
         @"  browser.test.assertFalse(browser.alarms.onAlarm.hasListener(alarmListener), 'Listener should be removed')",
@@ -374,7 +374,7 @@ TEST(WKWebExtensionAPIAlarms, RemoveListenerDuringEvent)
         @"browser.alarms.create('test-alarm', { delayInMinutes: (500 / 1000 / 60) })"
     ]);
 
-    Util::loadAndRunExtension(alarmsManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(alarmsManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPICommands.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPICommands.mm
@@ -98,7 +98,7 @@ static auto *emptyCommandsManifest = @{
 
 TEST(WKWebExtensionAPICommands, GetAllCommands)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"let commands = await browser.commands.getAll()",
         @"browser.test.assertEq(commands.length, 2, 'Should be two commands.')",
 
@@ -116,12 +116,12 @@ TEST(WKWebExtensionAPICommands, GetAllCommands)
         @"browser.test.notifyPass()",
     ]);
 
-    Util::loadAndRunExtension(commandsManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(commandsManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPICommands, GetAllCommandsEmptyManifest)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"let commands = await browser.commands.getAll()",
         @"browser.test.assertEq(commands.length, 1, 'Should be one command.')",
 
@@ -133,7 +133,7 @@ TEST(WKWebExtensionAPICommands, GetAllCommandsEmptyManifest)
         @"browser.test.notifyPass()",
     ]);
 
-    Util::loadAndRunExtension(emptyCommandsManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(emptyCommandsManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPICommands, GetAllCommandsEmptyManifestNoActionName)
@@ -160,7 +160,7 @@ TEST(WKWebExtensionAPICommands, GetAllCommandsEmptyManifestNoActionName)
         }
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"let commands = await browser.commands.getAll()",
         @"browser.test.assertEq(commands.length, 1, 'Should be one command.')",
 
@@ -172,12 +172,12 @@ TEST(WKWebExtensionAPICommands, GetAllCommandsEmptyManifestNoActionName)
         @"browser.test.notifyPass()",
     ]);
 
-    Util::loadAndRunExtension(emptyCommandsNoActionNameManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(emptyCommandsNoActionNameManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPICommands, CommandEvent)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.commands.onCommand.addListener((command, tab) => {",
         @"  browser.test.assertEq(command, 'test-command', 'The command should be test-command')",
         @"  browser.test.assertEq(typeof tab, 'object', 'The tab should be an object')",
@@ -189,7 +189,7 @@ TEST(WKWebExtensionAPICommands, CommandEvent)
         @"browser.test.sendMessage('Perform Command')"
     ]);
 
-    auto manager = Util::loadExtension(commandsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(commandsManifest, @{ @"background.js": backgroundScript.get() });
     [manager runUntilTestMessage:@"Perform Command"];
 
     auto *predicate = [NSPredicate predicateWithFormat:@"identifier == %@", @"test-command"];
@@ -246,7 +246,7 @@ TEST(WKWebExtensionAPICommands, CommandForEvent)
 
 TEST(WKWebExtensionAPICommands, PerformCommandForEvent)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.commands.onCommand.addListener((command, tab) => {",
         @"  browser.test.assertEq(command, 'test-command', 'The command should be')",
         @"  browser.test.assertEq(typeof tab, 'object', 'The tab should be')",
@@ -258,7 +258,7 @@ TEST(WKWebExtensionAPICommands, PerformCommandForEvent)
         @"browser.test.sendMessage('Test Command Event')"
     ]);
 
-    auto manager = Util::loadExtension(commandsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(commandsManifest, @{ @"background.js": backgroundScript.get() });
     [manager runUntilTestMessage:@"Test Command Event"];
 
     auto *keyCommandEvent = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSZeroPoint modifierFlags:(NSEventModifierFlagCommand | NSEventModifierFlagOption)
@@ -275,7 +275,7 @@ TEST(WKWebExtensionAPICommands, PerformCommandForEvent)
 
 TEST(WKWebExtensionAPICommands, PerformKeyCommand)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.commands.onCommand.addListener((command, tab) => {",
         @"  browser.test.assertEq(command, 'test-command', 'The command should be')",
         @"  browser.test.assertEq(typeof tab, 'object', 'The tab should be')",
@@ -287,7 +287,7 @@ TEST(WKWebExtensionAPICommands, PerformKeyCommand)
         @"browser.test.sendMessage('Test Command Event')"
     ]);
 
-    auto manager = Util::loadExtension(commandsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(commandsManifest, @{ @"background.js": backgroundScript.get() });
     [manager runUntilTestMessage:@"Test Command Event"];
 
     auto *predicate = [NSPredicate predicateWithFormat:@"identifier == %@", @"test-command"];
@@ -305,7 +305,7 @@ TEST(WKWebExtensionAPICommands, PerformKeyCommand)
 
 TEST(WKWebExtensionAPICommands, PerformMenuItem)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.commands.onCommand.addListener((command, tab) => {",
         @"  browser.test.assertEq(command, 'test-command', 'The command should be')",
         @"  browser.test.assertEq(typeof tab, 'object', 'The tab should be')",
@@ -317,7 +317,7 @@ TEST(WKWebExtensionAPICommands, PerformMenuItem)
         @"browser.test.sendMessage('Test Command Event')"
     ]);
 
-    auto manager = Util::loadExtension(commandsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(commandsManifest, @{ @"background.js": backgroundScript.get() });
     [manager runUntilTestMessage:@"Test Command Event"];
 
     auto *predicate = [NSPredicate predicateWithFormat:@"identifier == %@", @"test-command"];
@@ -338,7 +338,7 @@ TEST(WKWebExtensionAPICommands, PerformMenuItem)
 
 TEST(WKWebExtensionAPICommands, ExecuteActionCommand)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.commands.onCommand.addListener((command, tab) => {",
         @"  browser.test.notifyFail('The action command should not fire onCommand')",
         @"})",
@@ -353,7 +353,7 @@ TEST(WKWebExtensionAPICommands, ExecuteActionCommand)
         @"browser.test.sendMessage('Test Execute Action Command')"
     ]);
 
-    auto manager = Util::loadExtension(commandsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(commandsManifest, @{ @"background.js": backgroundScript.get() });
     [manager runUntilTestMessage:@"Test Execute Action Command"];
 
     auto *predicate = [NSPredicate predicateWithFormat:@"identifier == %@", @"_execute_action"];
@@ -367,7 +367,7 @@ TEST(WKWebExtensionAPICommands, ExecuteActionCommand)
 
 TEST(WKWebExtensionAPICommands, ChangedEvent)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.commands.onChanged.addListener((changeInfo) => {",
         @"  browser.test.assertEq(typeof changeInfo, 'object', 'The change should be an object')",
         @"  browser.test.assertEq(changeInfo.name, 'test-command', 'The name should be')",
@@ -380,7 +380,7 @@ TEST(WKWebExtensionAPICommands, ChangedEvent)
         @"browser.test.sendMessage('Test Command Shortcut Change')"
     ]);
 
-    auto manager = Util::loadExtension(commandsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(commandsManifest, @{ @"background.js": backgroundScript.get() });
     [manager runUntilTestMessage:@"Test Command Shortcut Change"];
 
     auto *predicate = [NSPredicate predicateWithFormat:@"identifier == %@", @"test-command"];
@@ -401,7 +401,7 @@ TEST(WKWebExtensionAPICommands, ChangedEvent)
 
 TEST(WKWebExtensionAPICommands, PerformCommandAndPermissionsRequest)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.commands.onCommand.addListener(async (tab) => {",
         @"  try {",
         @"    const result = await browser.permissions.request({ 'permissions': [ 'webNavigation' ] })",
@@ -417,7 +417,7 @@ TEST(WKWebExtensionAPICommands, PerformCommandAndPermissionsRequest)
         @"browser.test.sendMessage('Perform Command')"
     ]);
 
-    auto manager = Util::loadExtension(commandsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(commandsManifest, @{ @"background.js": backgroundScript.get() });
 
     manager.get().internalDelegate.promptForPermissions = ^(id<WKWebExtensionTab> tab, NSSet<NSString *> *requestedPermissions, void (^callback)(NSSet<NSString *> *, NSDate *)) {
         EXPECT_EQ(requestedPermissions.count, 1lu);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPICookies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPICookies.mm
@@ -53,7 +53,7 @@ static auto *cookiesManifest = @{
 
 TEST(WKWebExtensionAPICookies, ErrorsRead)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.assertThrows(() => browser.cookies.get({ url: 123, name: 'Test' }), /'url' is expected to be a string, but a number was provided/i)",
         @"browser.test.assertThrows(() => browser.cookies.get({ url: '', name: 'Test' }), /'url' value is invalid, because it must not be empty/i)",
         @"browser.test.assertThrows(() => browser.cookies.get({ url: 'bad', name: 'Test' }), /'url' value is invalid, because 'bad' is not a valid URL/i)",
@@ -74,12 +74,12 @@ TEST(WKWebExtensionAPICookies, ErrorsRead)
         @"browser.test.notifyPass()",
     ]);
 
-    Util::loadAndRunExtension(cookiesManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(cookiesManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPICookies, ErrorsWrite)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.assertThrows(() => browser.cookies.set({ url: 123 }), /'url' is expected to be a string, but a number was provided/i)",
         @"browser.test.assertThrows(() => browser.cookies.set({ url: '' }), /'url' value is invalid, because it must not be empty/i)",
         @"browser.test.assertThrows(() => browser.cookies.set({ url: 'bad' }), /'url' value is invalid, because 'bad' is not a valid URL/i)",
@@ -103,12 +103,12 @@ TEST(WKWebExtensionAPICookies, ErrorsWrite)
         @"browser.test.notifyPass()",
     ]);
 
-    Util::loadAndRunExtension(cookiesManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(cookiesManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPICookies, GetAllCookieStores)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const cookieStores = await browser.test.assertSafeResolve(() => browser.cookies.getAllCookieStores())",
         @"browser.test.assertEq(cookieStores?.length, 1, 'Should have one cookie store')",
 
@@ -125,7 +125,7 @@ TEST(WKWebExtensionAPICookies, GetAllCookieStores)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::loadExtension(cookiesManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(cookiesManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager openNewWindowUsingPrivateBrowsing:YES];
 
@@ -134,7 +134,7 @@ TEST(WKWebExtensionAPICookies, GetAllCookieStores)
 
 TEST(WKWebExtensionAPICookies, GetAllCookieStoresWithPrivateAccess)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const cookieStores = await browser.test.assertSafeResolve(() => browser.cookies.getAllCookieStores())",
         @"browser.test.assertEq(cookieStores?.length, 2, 'Should have two cookie stores')",
 
@@ -157,7 +157,7 @@ TEST(WKWebExtensionAPICookies, GetAllCookieStoresWithPrivateAccess)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::loadExtension(cookiesManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(cookiesManifest, @{ @"background.js": backgroundScript.get() });
 
     manager.get().context.hasAccessToPrivateData = YES;
 
@@ -168,7 +168,7 @@ TEST(WKWebExtensionAPICookies, GetAllCookieStoresWithPrivateAccess)
 
 TEST(WKWebExtensionAPICookies, GetAll)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const cookies = await browser.test.assertSafeResolve(() => browser.cookies.getAll({ }))",
         @"browser.test.assertTrue(Array.isArray(cookies), 'Cookies should be an array')",
         @"browser.test.assertTrue(cookies?.length >= 2, 'There should be 2 or more cookies')",
@@ -190,7 +190,7 @@ TEST(WKWebExtensionAPICookies, GetAll)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::loadExtension(cookiesManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(cookiesManifest, @{ @"background.js": backgroundScript.get() });
 
     auto *matchPattern = [WKWebExtensionMatchPattern matchPatternWithString:@"*://*.example.com/*"];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:matchPattern];
@@ -236,7 +236,7 @@ TEST(WKWebExtensionAPICookies, GetAll)
 
 TEST(WKWebExtensionAPICookies, GetAllIncognito)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const allCookieStores = await browser.test.assertSafeResolve(() => browser.cookies.getAllCookieStores())",
         @"const incognitoStore = allCookieStores.find(store => store.incognito)",
         @"browser.test.assertEq(incognitoStore, undefined, 'Incognito store should not be found')",
@@ -254,7 +254,7 @@ TEST(WKWebExtensionAPICookies, GetAllIncognito)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::loadExtension(cookiesManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(cookiesManifest, @{ @"background.js": backgroundScript.get() });
 
     auto *matchPattern = [WKWebExtensionMatchPattern matchPatternWithString:@"*://*.private.com/*"];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:matchPattern];
@@ -301,7 +301,7 @@ TEST(WKWebExtensionAPICookies, GetAllIncognito)
 
 TEST(WKWebExtensionAPICookies, GetAllIncognitoWithPrivateAccess)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const allCookieStores = await browser.test.assertSafeResolve(() => browser.cookies.getAllCookieStores())",
         @"const incognitoStore = allCookieStores.find(store => store.incognito)",
         @"browser.test.assertEq(typeof incognitoStore, 'object', 'Incognito store should be found')",
@@ -327,7 +327,7 @@ TEST(WKWebExtensionAPICookies, GetAllIncognitoWithPrivateAccess)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::loadExtension(cookiesManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(cookiesManifest, @{ @"background.js": backgroundScript.get() });
 
     auto *matchPattern = [WKWebExtensionMatchPattern matchPatternWithString:@"*://*.private.com/*"];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:matchPattern];
@@ -376,7 +376,7 @@ TEST(WKWebExtensionAPICookies, GetAllIncognitoWithPrivateAccess)
 
 TEST(WKWebExtensionAPICookies, GetAllWithFilters)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const nameCookies = await browser.test.assertSafeResolve(() => browser.cookies.getAll({ name: 'nameCookie' }))",
         @"browser.test.assertEq(nameCookies?.length, 1, 'Should find one cookie with name `nameCookie`')",
         @"browser.test.assertEq(nameCookies?.[0]?.value, 'nameValue', 'Value of `nameCookie` should be `nameValue`')",
@@ -417,7 +417,7 @@ TEST(WKWebExtensionAPICookies, GetAllWithFilters)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::loadExtension(cookiesManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(cookiesManifest, @{ @"background.js": backgroundScript.get() });
 
     auto *matchPattern = [WKWebExtensionMatchPattern matchPatternWithString:@"*://*.example.com/*"];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:matchPattern];
@@ -492,7 +492,7 @@ TEST(WKWebExtensionAPICookies, GetAllWithFilters)
 
 TEST(WKWebExtensionAPICookies, RemoveCookie)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const removedCookie = await browser.test.assertSafeResolve(() => browser.cookies.remove({ url: 'http://www.example.com/', name: 'testCookie' }))",
         @"browser.test.assertEq(removedCookie?.name, 'testCookie', 'Removed cookie name should be `testCookie`')",
         @"browser.test.assertEq(removedCookie?.value, 'value1', 'Removed cookie value should be `value1`')",
@@ -506,7 +506,7 @@ TEST(WKWebExtensionAPICookies, RemoveCookie)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::loadExtension(cookiesManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(cookiesManifest, @{ @"background.js": backgroundScript.get() });
 
     auto *matchPattern = [WKWebExtensionMatchPattern matchPatternWithString:@"*://*.example.com/*"];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:matchPattern];
@@ -532,7 +532,7 @@ TEST(WKWebExtensionAPICookies, RemoveCookie)
 
 TEST(WKWebExtensionAPICookies, RemoveCookieNotFound)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const removedCookie = await browser.test.assertSafeResolve(() => browser.cookies.remove({ url: 'http://www.example.com/', name: 'notFoundName' }))",
         @"browser.test.assertEq(removedCookie, null)",
 
@@ -543,7 +543,7 @@ TEST(WKWebExtensionAPICookies, RemoveCookieNotFound)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::loadExtension(cookiesManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(cookiesManifest, @{ @"background.js": backgroundScript.get() });
 
     auto *matchPattern = [WKWebExtensionMatchPattern matchPatternWithString:@"*://*.example.com/*"];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:matchPattern];
@@ -569,7 +569,7 @@ TEST(WKWebExtensionAPICookies, RemoveCookieNotFound)
 
 TEST(WKWebExtensionAPICookies, SetCookie)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const initialCookies = await browser.cookies.getAll({ url: 'http://www.example.com/' })",
         @"browser.test.assertTrue(!initialCookies.some(cookie => cookie.name === 'testCookie1' || cookie.name === 'testCookie2'), 'Cookies should not exist initially')",
         @"browser.test.assertTrue(initialCookies.some(cookie => cookie.name === 'replacedCookie'), 'Replaced cookie should exist')",
@@ -590,7 +590,7 @@ TEST(WKWebExtensionAPICookies, SetCookie)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::loadExtension(cookiesManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(cookiesManifest, @{ @"background.js": backgroundScript.get() });
 
     auto *matchPattern = [WKWebExtensionMatchPattern matchPatternWithString:@"*://*.example.com/*"];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:matchPattern];
@@ -616,7 +616,7 @@ TEST(WKWebExtensionAPICookies, SetCookie)
 
 TEST(WKWebExtensionAPICookies, SetCookieWithExpirationDate)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const cookieName = 'token'",
         @"const testUrl = 'http://www.example.com/'",
         @"const expirationDate = Math.floor(Date.now() / 1000) + 2",
@@ -650,7 +650,7 @@ TEST(WKWebExtensionAPICookies, SetCookieWithExpirationDate)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::loadExtension(cookiesManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(cookiesManifest, @{ @"background.js": backgroundScript.get() });
 
     auto *matchPattern = [WKWebExtensionMatchPattern matchPatternWithString:@"*://*.example.com/*"];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:matchPattern];
@@ -660,7 +660,7 @@ TEST(WKWebExtensionAPICookies, SetCookieWithExpirationDate)
 
 TEST(WKWebExtensionAPICookies, GetCookie)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const cookie = await browser.test.assertSafeResolve(() => browser.cookies.get({ url: 'http://www.example.com/', name: 'testGetCookie' }))",
         @"browser.test.assertEq(cookie?.name, 'testGetCookie', 'The cookie name should match')",
         @"browser.test.assertEq(cookie?.value, 'getValue', 'The cookie value should match')",
@@ -673,7 +673,7 @@ TEST(WKWebExtensionAPICookies, GetCookie)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::loadExtension(cookiesManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(cookiesManifest, @{ @"background.js": backgroundScript.get() });
 
     auto *matchPattern = [WKWebExtensionMatchPattern matchPatternWithString:@"*://*.example.com/*"];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:matchPattern];
@@ -699,7 +699,7 @@ TEST(WKWebExtensionAPICookies, GetCookie)
 
 TEST(WKWebExtensionAPICookies, ChangedEvent)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.cookies.onChanged.addListener(() => {",
         @"  browser.test.notifyPass()",
         @"})",
@@ -707,7 +707,7 @@ TEST(WKWebExtensionAPICookies, ChangedEvent)
         @"await browser.test.assertSafeResolve(() => browser.cookies.set({ url: 'http://www.example.com/', name: 'testCookie', value: 'testValue' }))"
     ]);
 
-    auto manager = Util::loadExtension(cookiesManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(cookiesManifest, @{ @"background.js": backgroundScript.get() });
 
     auto *matchPattern = [WKWebExtensionMatchPattern matchPatternWithString:@"*://*.example.com/*"];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:matchPattern];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDOM.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDOM.mm
@@ -52,9 +52,9 @@ TEST(WKWebExtensionAPIDOM, OpenOrClosedShadowRoot)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *urlRequest = server.requestWithLocalhost();
+    RetainPtr urlRequest = server.requestWithLocalhost();
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"const hostOpen = document.createElement('div')",
         @"hostOpen.id = 'host-open'",
         @"document.body.appendChild(hostOpen)",
@@ -84,10 +84,10 @@ TEST(WKWebExtensionAPIDOM, OpenOrClosedShadowRoot)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::loadExtension(domManifest, @{ @"content.js": contentScript });
+    auto manager = Util::loadExtension(domManifest, @{ @"content.js": contentScript.get() });
 
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -98,9 +98,9 @@ TEST(WKWebExtensionAPIDOM, OpenOrClosedShadowRootViaElement)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *urlRequest = server.requestWithLocalhost();
+    RetainPtr urlRequest = server.requestWithLocalhost();
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"const hostOpen = document.createElement('div')",
         @"hostOpen.id = 'host-open'",
         @"document.body.appendChild(hostOpen)",
@@ -130,10 +130,10 @@ TEST(WKWebExtensionAPIDOM, OpenOrClosedShadowRootViaElement)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::loadExtension(domManifest, @{ @"content.js": contentScript });
+    auto manager = Util::loadExtension(domManifest, @{ @"content.js": contentScript.get() });
 
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm
@@ -42,7 +42,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, BlockedLoadTest)
         { "/frame.html"_s, { { { "Content-Type"_s, "text/html"_s } }, "<body style='background-color: blue'></body>"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
@@ -63,7 +63,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, BlockedLoadTest)
 
     auto *rules = @"[ { \"id\" : 1, \"priority\": 1, \"action\" : { \"type\" : \"block\" }, \"condition\" : { \"urlFilter\" : \"frame\" } } ]";
 
-    auto manager = Util::loadExtension(declarativeNetRequestManifest, @{ @"background.js": backgroundScript, @"rules.json": rules  });
+    auto manager = Util::loadExtension(declarativeNetRequestManifest, @{ @"background.js": backgroundScript.get(), @"rules.json": rules  });
 
     // Grant the declarativeNetRequest permission.
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionDeclarativeNetRequest];
@@ -96,7 +96,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, BlockedLoadInPrivateBrowsingTest)
         { "/frame.html"_s, { { { "Content-Type"_s, "text/html"_s } }, "<body style='background-color: blue'></body>"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
@@ -117,7 +117,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, BlockedLoadInPrivateBrowsingTest)
 
     auto *rules = @"[ { \"id\" : 1, \"priority\": 1, \"action\" : { \"type\" : \"block\" }, \"condition\" : { \"urlFilter\" : \"frame\" } } ]";
 
-    auto manager = Util::loadExtension(declarativeNetRequestManifest, @{ @"background.js": backgroundScript, @"rules.json": rules  });
+    auto manager = Util::loadExtension(declarativeNetRequestManifest, @{ @"background.js": backgroundScript.get(), @"rules.json": rules  });
 
     // Grant the declarativeNetRequest permission.
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionDeclarativeNetRequest];
@@ -147,7 +147,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, BlockedLoadInPrivateBrowsingTest)
 
 TEST(WKWebExtensionAPIDeclarativeNetRequest, GetEnabledRulesets)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const enabledRulesets = await browser.declarativeNetRequest.getEnabledRulesets()",
         @"browser.test.assertEq(enabledRulesets.length, 1, 'One ruleset should have been enabled')",
         @"browser.test.assertEq(enabledRulesets[0], 'blockFrame', 'blockFrame should have been enabled')",
@@ -177,7 +177,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, GetEnabledRulesets)
 
     auto *rules = @"[ { \"id\" : 1, \"priority\": 1, \"action\" : { \"type\" : \"block\" }, \"condition\" : { \"urlFilter\" : \"frame\" } } ]";
 
-    auto manager = Util::loadExtension(declarativeNetRequestManifest, @{ @"background.js": backgroundScript, @"rules.json": rules  });
+    auto manager = Util::loadExtension(declarativeNetRequestManifest, @{ @"background.js": backgroundScript.get(), @"rules.json": rules  });
 
     // Grant the declarativeNetRequest permission.
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionDeclarativeNetRequest];
@@ -187,7 +187,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, GetEnabledRulesets)
 
 TEST(WKWebExtensionAPIDeclarativeNetRequest, UpdateEnabledRulesets)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
 
         // Test invalid argument types
         @"browser.test.assertThrows(() => browser.declarativeNetRequest.updateEnabledRulesets({ enableRulesetIds: 5 }), /'options' value is invalid, because 'enableRulesetIds' is expected to be an array of strings/i)",
@@ -240,7 +240,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, UpdateEnabledRulesets)
 
     auto *rules = @"[ { \"id\" : 1, \"priority\": 1, \"action\" : { \"type\" : \"block\" }, \"condition\" : { \"urlFilter\" : \"frame\" } } ]";
 
-    auto manager = Util::loadExtension(declarativeNetRequestManifest, @{ @"background.js": backgroundScript, @"rules.json": rules  });
+    auto manager = Util::loadExtension(declarativeNetRequestManifest, @{ @"background.js": backgroundScript.get(), @"rules.json": rules  });
 
     // Grant the declarativeNetRequest permission.
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionDeclarativeNetRequest];
@@ -255,7 +255,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, UpdateEnabledRulesetsPerformsCompil
         { "/frame.html"_s, { { { "Content-Type"_s, "text/html"_s } }, "<body style='background-color: blue'></body>"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         // Before any modifications
         @"let enabledRulesets = await browser.declarativeNetRequest.getEnabledRulesets()",
         @"browser.test.assertEq(enabledRulesets.length, 0, 'No rulesets should have been enabled')",
@@ -288,7 +288,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, UpdateEnabledRulesetsPerformsCompil
 
     auto *rules = @"[ { \"id\" : 1, \"priority\": 1, \"action\" : { \"type\" : \"block\" }, \"condition\" : { \"urlFilter\" : \"frame\" } } ]";
 
-    auto manager = Util::loadExtension(declarativeNetRequestManifest, @{ @"background.js": backgroundScript, @"rules.json": rules  });
+    auto manager = Util::loadExtension(declarativeNetRequestManifest, @{ @"background.js": backgroundScript.get(), @"rules.json": rules  });
 
     // Grant the declarativeNetRequest permission.
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionDeclarativeNetRequest];
@@ -312,7 +312,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, UpdateEnabledRulesetsPerformsCompil
 
 TEST(WKWebExtensionAPIDeclarativeNetRequest, IsRegexSupported)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         // Invalid arguments
         @"browser.test.assertThrows(() => browser.declarativeNetRequest.isRegexSupported({ }), /'regexOptions' value is invalid, because it is missing required keys: 'regex'/i)",
         @"browser.test.assertThrows(() => browser.declarativeNetRequest.isRegexSupported({ regex: 5 }), /'regexOptions' value is invalid, because 'regex' is expected to be a string/i)",
@@ -342,7 +342,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, IsRegexSupported)
         @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO },
     };
 
-    auto manager = Util::loadExtension(declarativeNetRequestManifest, @{ @"background.js": backgroundScript  });
+    auto manager = Util::loadExtension(declarativeNetRequestManifest, @{ @"background.js": backgroundScript.get()  });
 
     // Grant the declarativeNetRequest permission.
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionDeclarativeNetRequest];
@@ -357,7 +357,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, SetExtensionActionOptions)
         { "/frame.html"_s, { { { "Content-Type"_s, "text/html"_s } }, "<body style='background-color: blue'></body>"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const [currentTab] = await browser.tabs.query({ active: true, currentWindow: true })",
         @"browser.declarativeNetRequest.setExtensionActionOptions({ displayActionCountAsBadgeText: true })",
 
@@ -386,7 +386,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, SetExtensionActionOptions)
 
     auto *rules = @"[ { \"id\" : 1, \"priority\": 1, \"action\" : { \"type\" : \"block\" }, \"condition\" : { \"urlFilter\" : \"frame\" } } ]";
 
-    auto manager = Util::loadExtension(declarativeNetRequestManifest, @{ @"background.js": backgroundScript, @"rules.json": rules  });
+    auto manager = Util::loadExtension(declarativeNetRequestManifest, @{ @"background.js": backgroundScript.get(), @"rules.json": rules  });
 
     // Grant the declarativeNetRequest and tabs permission.
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionDeclarativeNetRequest];
@@ -427,7 +427,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, GetMatchedRules)
         { "/frame.html"_s, { { { "Content-Type"_s, "text/html"_s } }, "<body style='background-color: blue'></body>"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"setTimeout(async () => {",
         @"  const matchedRules = await browser.declarativeNetRequest.getMatchedRules()",
         @"  browser.test.assertEq(matchedRules.rulesMatchedInfo.length, 1)",
@@ -457,20 +457,20 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, GetMatchedRules)
 
     auto *rules = @"[ { \"id\" : 1, \"priority\": 1, \"action\" : { \"type\" : \"block\" }, \"condition\" : { \"urlFilter\" : \"frame\" } } ]";
 
-    auto manager = Util::loadExtension(declarativeNetRequestManifest, @{ @"background.js": backgroundScript, @"rules.json": rules  });
+    auto manager = Util::loadExtension(declarativeNetRequestManifest, @{ @"background.js": backgroundScript.get(), @"rules.json": rules  });
 
     // Grant the declarativeNetRequestFeedback permission.
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionDeclarativeNetRequest];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionDeclarativeNetRequestFeedback];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    NSURL *requestURL = urlRequest.URL;
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    NSURL *requestURL = urlRequest.get().URL;
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:requestURL];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:[requestURL URLByAppendingPathComponent:@"frame.html"]];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -482,7 +482,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, SessionRules)
         { "/frame.html"_s, { { { "Content-Type"_s, "text/html"_s } }, "<body style='background-color: blue'></body>"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"let sessionRules = await browser.declarativeNetRequest.getSessionRules()",
         @"browser.test.assertEq(sessionRules.length, 0)",
         @"await browser.declarativeNetRequest.updateSessionRules({ addRules: [{ id: 1, priority: 1, action: {type: 'block'}, condition: { urlFilter: 'frame' } }] })",
@@ -498,7 +498,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, SessionRules)
         @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO },
     };
 
-    auto manager = Util::loadExtension(declarativeNetRequestManifest, @{ @"background.js": backgroundScript  });
+    auto manager = Util::loadExtension(declarativeNetRequestManifest, @{ @"background.js": backgroundScript.get()  });
 
     // Grant the declarativeNetRequest permission.
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionDeclarativeNetRequest];
@@ -526,7 +526,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, SessionRules)
 
 TEST(WKWebExtensionAPIDeclarativeNetRequest, GetSessionRules)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"let sessionRules = await browser.declarativeNetRequest.getSessionRules()",
         @"browser.test.assertEq(sessionRules.length, 0)",
 
@@ -584,12 +584,12 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, GetSessionRules)
         @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO },
     };
 
-    Util::loadAndRunExtension(declarativeNetRequestManifest, @{ @"background.js": backgroundScript  });
+    Util::loadAndRunExtension(declarativeNetRequestManifest, @{ @"background.js": backgroundScript.get()  });
 }
 
 TEST(WKWebExtensionAPIDeclarativeNetRequest, RemoveSessionRules)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"let sessionRules = await browser.declarativeNetRequest.getSessionRules()",
         @"browser.test.assertEq(sessionRules.length, 0)",
 
@@ -614,7 +614,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, RemoveSessionRules)
         @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO },
     };
 
-    Util::loadAndRunExtension(declarativeNetRequestManifest, @{ @"background.js": backgroundScript  });
+    Util::loadAndRunExtension(declarativeNetRequestManifest, @{ @"background.js": backgroundScript.get()  });
 }
 
 TEST(WKWebExtensionAPIDeclarativeNetRequest, DynamicRules)
@@ -624,7 +624,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, DynamicRules)
         { "/frame.html"_s, { { { "Content-Type"_s, "text/html"_s } }, "<body style='background-color: blue'></body>"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"let dynamicRules = await browser.declarativeNetRequest.getDynamicRules()",
         @"if (dynamicRules.length == 0) {",
         @"  await browser.declarativeNetRequest.updateDynamicRules({ addRules: [{ id: 1, priority: 1, action: {type: 'block'}, condition: { urlFilter: 'frame' } }] })",
@@ -645,7 +645,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, DynamicRules)
         @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO },
     };
 
-    auto manager = Util::parseExtension(declarativeNetRequestManifest, @{ @"background.js": backgroundScript }, WKWebExtensionControllerConfiguration._temporaryConfiguration);
+    auto manager = Util::parseExtension(declarativeNetRequestManifest, @{ @"background.js": backgroundScript.get() }, WKWebExtensionControllerConfiguration._temporaryConfiguration);
 
     // Give the extension a unique identifier so it opts into saving data in the temporary configuration.
     manager.get().context.uniqueIdentifier = @"org.webkit.test.extension (76C788B8)";
@@ -685,7 +685,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, DynamicRules)
 
 TEST(WKWebExtensionAPIDeclarativeNetRequest, GetDynamicRules)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"let dynamicRules = await browser.declarativeNetRequest.getDynamicRules()",
         @"browser.test.assertEq(dynamicRules.length, 0)",
 
@@ -743,12 +743,12 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, GetDynamicRules)
         @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO },
     };
 
-    Util::loadAndRunExtension(declarativeNetRequestManifest, @{ @"background.js": backgroundScript  });
+    Util::loadAndRunExtension(declarativeNetRequestManifest, @{ @"background.js": backgroundScript.get()  });
 }
 
 TEST(WKWebExtensionAPIDeclarativeNetRequest, RemoveDynamicRules)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"let dynamicRules = await browser.declarativeNetRequest.getDynamicRules()",
         @"browser.test.assertEq(dynamicRules.length, 0)",
 
@@ -773,12 +773,12 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, RemoveDynamicRules)
         @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO },
     };
 
-    Util::loadAndRunExtension(declarativeNetRequestManifest, @{ @"background.js": backgroundScript  });
+    Util::loadAndRunExtension(declarativeNetRequestManifest, @{ @"background.js": backgroundScript.get()  });
 }
 
 TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRule)
 {
-    auto *pageScript = Util::constructScript(@[
+    RetainPtr pageScript = Util::constructScript(@[
         @"<script>",
         @"  browser.test.assertTrue(location.href.startsWith('http://127.0.0.1'), 'Final load should be via IP address')",
 
@@ -787,10 +787,10 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRule)
     ]);
 
     TestWebKitAPI::HTTPServer server({
-        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, pageScript } },
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, pageScript.get() } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *urlRequest = server.requestWithLocalhost();
+    RetainPtr urlRequest = server.requestWithLocalhost();
     auto *redirectURL = server.request().URL.absoluteString;
 
     auto *rules = @[ @{
@@ -851,18 +851,18 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRule)
 
     manager.get().defaultTab.webView.navigationDelegate = navigationDelegate.get();
 
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
 
 TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRuleWithoutHostAccessPermission)
 {
-    auto *pageScript = Util::constructScript(@[
+    RetainPtr pageScript = Util::constructScript(@[
         @"<script>",
         @"  browser.test.assertTrue(location.href.startsWith('http://localhost'), 'Final load should be via localhost')",
 
@@ -871,10 +871,10 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRuleWithoutHostAccessPermis
     ]);
 
     TestWebKitAPI::HTTPServer server({
-        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, pageScript } },
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, pageScript.get() } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *urlRequest = server.requestWithLocalhost();
+    RetainPtr urlRequest = server.requestWithLocalhost();
     auto *redirectURL = server.request().URL.absoluteString;
 
     auto *rules = @[ @{
@@ -915,30 +915,30 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRuleWithoutHostAccessPermis
         }
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"rules.json": rules
     };
 
     auto manager = Util::loadExtension(manifest, resources);
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusDeniedExplicitly forPermission:WKWebExtensionPermissionDeclarativeNetRequestWithHostAccess];
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
 
 TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRuleWithoutHostPermission)
 {
-    auto *pageScript = Util::constructScript(@[
+    RetainPtr pageScript = Util::constructScript(@[
         @"<script>",
         @"  browser.test.assertTrue(location.href.startsWith('http://localhost'), 'Final load should be via localhost')",
 
@@ -947,10 +947,10 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRuleWithoutHostPermission)
     ]);
 
     TestWebKitAPI::HTTPServer server({
-        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, pageScript } },
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, pageScript.get() } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *urlRequest = server.requestWithLocalhost();
+    RetainPtr urlRequest = server.requestWithLocalhost();
     auto *redirectURL = server.request().URL.absoluteString;
 
     auto *rules = @[ @{
@@ -991,12 +991,12 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRuleWithoutHostPermission)
         }
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"rules.json": rules
     };
 
@@ -1004,14 +1004,14 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRuleWithoutHostPermission)
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
 
 TEST(WKWebExtensionAPIDeclarativeNetRequest, ModifyHeadersRule)
 {
-    auto *pageScript = Util::constructScript(@[
+    RetainPtr pageScript = Util::constructScript(@[
         @"<script>",
         @"  browser.test.assertEq(document.referrer, 'https://example.com/')",
 
@@ -1020,10 +1020,10 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, ModifyHeadersRule)
     ]);
 
     TestWebKitAPI::HTTPServer server({
-        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, pageScript } },
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, pageScript.get() } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *urlRequest = server.requestWithLocalhost();
+    RetainPtr urlRequest = server.requestWithLocalhost();
 
     auto *rules = @[@{
         @"id": @1,
@@ -1065,29 +1065,29 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, ModifyHeadersRule)
         }
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"rules.json": rules
     };
 
     auto manager = Util::loadExtension(manifest, resources);
 
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
 
 TEST(WKWebExtensionAPIDeclarativeNetRequest, ModifyHeadersRuleWithoutHostAccessPermission)
 {
-    auto *pageScript = Util::constructScript(@[
+    RetainPtr pageScript = Util::constructScript(@[
         @"<script>",
         @"  browser.test.assertEq(document.referrer, '')",
 
@@ -1096,10 +1096,10 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, ModifyHeadersRuleWithoutHostAccessP
     ]);
 
     TestWebKitAPI::HTTPServer server({
-        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, pageScript } },
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, pageScript.get() } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *urlRequest = server.requestWithLocalhost();
+    RetainPtr urlRequest = server.requestWithLocalhost();
 
     auto *rules = @[@{
         @"id": @1,
@@ -1141,30 +1141,30 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, ModifyHeadersRuleWithoutHostAccessP
         }
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"rules.json": rules
     };
 
     auto manager = Util::loadExtension(manifest, resources);
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusDeniedExplicitly forPermission:WKWebExtensionPermissionDeclarativeNetRequestWithHostAccess];
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
 
 TEST(WKWebExtensionAPIDeclarativeNetRequest, ModifyHeadersRuleWithoutHostPermission)
 {
-    auto *pageScript = Util::constructScript(@[
+    RetainPtr pageScript = Util::constructScript(@[
         @"<script>",
         @"  browser.test.assertEq(document.referrer, '')",
 
@@ -1173,10 +1173,10 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, ModifyHeadersRuleWithoutHostPermiss
     ]);
 
     TestWebKitAPI::HTTPServer server({
-        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, pageScript } },
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, pageScript.get() } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *urlRequest = server.requestWithLocalhost();
+    RetainPtr urlRequest = server.requestWithLocalhost();
 
     auto *rules = @[@{
         @"id": @1,
@@ -1218,12 +1218,12 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, ModifyHeadersRuleWithoutHostPermiss
         }
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"rules.json": rules
     };
 
@@ -1231,7 +1231,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, ModifyHeadersRuleWithoutHostPermiss
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -1243,7 +1243,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, MainFrameAllowAllRequests)
         { "/frame.html"_s, { { { "Content-Type"_s, "text/html"_s } }, "<script>browser.test.notifyPass()</script>"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
@@ -1264,7 +1264,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, MainFrameAllowAllRequests)
         }
     };
 
-    auto manager = Util::loadExtension(declarativeNetRequestManifest, @{ @"background.js": backgroundScript, @"rules.json": rules  });
+    auto manager = Util::loadExtension(declarativeNetRequestManifest, @{ @"background.js": backgroundScript.get(), @"rules.json": rules  });
 
     // Grant the declarativeNetRequest permission.
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionDeclarativeNetRequest];
@@ -1273,12 +1273,12 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, MainFrameAllowAllRequests)
 
     auto webView = manager.get().defaultTab.webView;
 
-    auto *urlRequest = server.requestWithLocalhost();
-    NSURL *requestURL = urlRequest.URL;
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    NSURL *requestURL = urlRequest.get().URL;
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:requestURL];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:[requestURL URLByAppendingPathComponent:@"frame.html"]];
 
-    [webView loadRequest:urlRequest];
+    [webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -3894,7 +3894,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, RemoveAllContentRuleListsDoesNotRem
         { "/frame.html"_s, { { { "Content-Type"_s, "text/html"_s } }, "<body style='background-color: blue'></body>"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.sendMessage('Remove RuleLists and Load Tab')"
     ]);
 
@@ -3915,7 +3915,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, RemoveAllContentRuleListsDoesNotRem
 
     auto *rules = @"[ { \"id\" : 1, \"priority\": 1, \"action\" : { \"type\" : \"block\" }, \"condition\" : { \"urlFilter\" : \"frame\" } } ]";
 
-    auto manager = Util::loadExtension(declarativeNetRequestManifest, @{ @"background.js": backgroundScript, @"rules.json": rules });
+    auto manager = Util::loadExtension(declarativeNetRequestManifest, @{ @"background.js": backgroundScript.get(), @"rules.json": rules });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionDeclarativeNetRequest];
 
@@ -3940,7 +3940,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, RemoveAllContentRuleListsDoesNotRem
 
 TEST(WKWebExtensionAPIDeclarativeNetRequest, MigrateDeclarativeNetRequestDataToNewFormat)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"var expectedResults = [{",
         @"  'id': 1,",
         @"  'condition': {",
@@ -3960,7 +3960,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, MigrateDeclarativeNetRequestDataToN
     ]);
 
     static auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
     };
 
     auto *declarativeNetRequestManifest = @{

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDevTools.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDevTools.mm
@@ -56,11 +56,11 @@ TEST(WKWebExtensionAPIDevTools, Basics)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.assertEq(browser?.devtools, undefined, 'browser.devtools should be undefined in background script')",
     ]);
 
-    auto *devToolsScript = Util::constructScript(@[
+    RetainPtr devToolsScript = Util::constructScript(@[
         @"browser.test.assertEq(typeof browser?.devtools, 'object', 'browser.devtools should be available in devtools page script')",
         @"browser.test.assertEq(typeof browser?.devtools?.panels, 'object', 'browser.devtools.panels should be available')",
         @"browser.test.assertEq(typeof browser?.devtools?.network, 'object', 'browser.devtools.network should be available')",
@@ -72,9 +72,9 @@ TEST(WKWebExtensionAPIDevTools, Basics)
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"devtools.html": @"<script type='module' src='devtools.js'></script>",
-        @"devtools.js": devToolsScript
+        @"devtools.js": devToolsScript.get()
     };
 
     auto manager = Util::loadExtension(devToolsManifest, resources);
@@ -92,7 +92,7 @@ TEST(WKWebExtensionAPIDevTools, DISABLED_CreatePanel)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *devToolsScript = Util::constructScript(@[
+    RetainPtr devToolsScript = Util::constructScript(@[
         @"let cachedPanelWindow = null",
 
         @"let panel = await browser.test.assertSafeResolve(() => browser.devtools.panels.create('Test Panel', 'icon.svg', 'panel.html'))",
@@ -114,7 +114,7 @@ TEST(WKWebExtensionAPIDevTools, DISABLED_CreatePanel)
         @"browser.test.sendMessage('Panel Created')",
     ]);
 
-    auto *panelScript = Util::constructScript(@[
+    RetainPtr panelScript = Util::constructScript(@[
         @"browser.test.assertEq(typeof browser?.devtools?.inspectedWindow?.tabId, 'number', 'browser.devtools.inspectedWindow.tabId should be available')",
         @"browser.test.assertTrue(browser?.devtools?.inspectedWindow?.tabId > 0, 'browser.devtools.inspectedWindow.tabId should be a positive value')",
 
@@ -130,9 +130,9 @@ TEST(WKWebExtensionAPIDevTools, DISABLED_CreatePanel)
     auto *resources = @{
         @"background.js": @"// This script is intentionally left blank.",
         @"devtools.html": @"<script type='module' src='devtools.js'></script>",
-        @"devtools.js": devToolsScript,
+        @"devtools.js": devToolsScript.get(),
         @"panel.html": @"<script type='module' src='panel.js'></script>",
-        @"panel.js": panelScript,
+        @"panel.js": panelScript.get(),
         @"icon.svg": iconSVG,
     };
 
@@ -162,7 +162,7 @@ TEST(WKWebExtensionAPIDevTools, DISABLED_InspectedWindowEval)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<title>Test Page</title><script>const secretNumber = 42; window.customTitle = 'Dynamic Title'</script>"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *devToolsScript = Util::constructScript(@[
+    RetainPtr devToolsScript = Util::constructScript(@[
         // Evaluate a simple expression that should succeed
         @"await browser.test.assertSafeResolve(async () => {",
         @"  const [result, exceptionInfo] = await browser.devtools.inspectedWindow.eval('document.title')",
@@ -193,7 +193,7 @@ TEST(WKWebExtensionAPIDevTools, DISABLED_InspectedWindowEval)
     auto *resources = @{
         @"background.js": @"// This script is intentionally left blank.",
         @"devtools.html": @"<script type='module' src='devtools.js'></script>",
-        @"devtools.js": devToolsScript
+        @"devtools.js": devToolsScript.get()
     };
 
     auto manager = Util::loadExtension(devToolsManifest, resources);
@@ -212,7 +212,7 @@ TEST(WKWebExtensionAPIDevTools, InspectedWindowReload)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s }, { "Cache-Control"_s, "max-age=3600"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *devToolsScript = Util::constructScript(@[
+    RetainPtr devToolsScript = Util::constructScript(@[
         @"browser.test.assertSafe(() => browser.devtools.inspectedWindow.reload())",
 
         @"browser.test.sendMessage('Reload Called')",
@@ -221,7 +221,7 @@ TEST(WKWebExtensionAPIDevTools, InspectedWindowReload)
     auto *resources = @{
         @"background.js": @"// This script is intentionally left blank.",
         @"devtools.html": @"<script type='module' src='devtools.js'></script>",
-        @"devtools.js": devToolsScript
+        @"devtools.js": devToolsScript.get()
     };
 
     auto manager = Util::loadExtension(devToolsManifest, resources);
@@ -245,7 +245,7 @@ TEST(WKWebExtensionAPIDevTools, DISABLED_InspectedWindowReloadIgnoringCache)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s }, { "Cache-Control"_s, "max-age=3600"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *devToolsScript = Util::constructScript(@[
+    RetainPtr devToolsScript = Util::constructScript(@[
         @"browser.test.assertSafe(() => browser.devtools.inspectedWindow.reload({ ignoreCache: true }))",
 
         @"browser.test.sendMessage('Reload Called')",
@@ -254,7 +254,7 @@ TEST(WKWebExtensionAPIDevTools, DISABLED_InspectedWindowReloadIgnoringCache)
     auto *resources = @{
         @"background.js": @"// This script is intentionally left blank.",
         @"devtools.html": @"<script type='module' src='devtools.js'></script>",
-        @"devtools.js": devToolsScript
+        @"devtools.js": devToolsScript.get()
     };
 
     auto manager = Util::loadExtension(devToolsManifest, resources);
@@ -276,7 +276,7 @@ TEST(WKWebExtensionAPIDevTools, NetworkNavigatedEvent)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *devToolsScript = Util::constructScript(@[
+    RetainPtr devToolsScript = Util::constructScript(@[
         @"browser.devtools.network.onNavigated.addListener((url) => {",
         @"  browser.test.assertEq(typeof url, 'string', 'url should be a string')",
         @"  browser.test.assertTrue(url?.startsWith('http://127.0.0.1:'), 'url should be local IP address')",
@@ -290,7 +290,7 @@ TEST(WKWebExtensionAPIDevTools, NetworkNavigatedEvent)
     auto *resources = @{
         @"background.js": @"// This script is intentionally left blank.",
         @"devtools.html": @"<script type='module' src='devtools.js'></script>",
-        @"devtools.js": devToolsScript
+        @"devtools.js": devToolsScript.get()
     };
 
     auto manager = Util::loadExtension(devToolsManifest, resources);
@@ -312,7 +312,7 @@ TEST(WKWebExtensionAPIDevTools, PanelsThemeName)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *devToolsScript = Util::constructScript(@[
+    RetainPtr devToolsScript = Util::constructScript(@[
         @"browser.test.assertEq(browser?.devtools?.panels?.themeName, 'light', 'panels.themeName should be light')",
 
         @"browser?.devtools?.panels?.onThemeChanged.addListener((newTheme) => {",
@@ -328,7 +328,7 @@ TEST(WKWebExtensionAPIDevTools, PanelsThemeName)
     auto *resources = @{
         @"background.js": @"// This script is intentionally left blank.",
         @"devtools.html": @"<script type='module' src='devtools.js'></script>",
-        @"devtools.js": devToolsScript
+        @"devtools.js": devToolsScript.get()
     };
 
     // Force light mode for the app, so the switch to dark will trigger the event.
@@ -355,14 +355,14 @@ TEST(WKWebExtensionAPIDevTools, MessagePassingToBackground)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.runtime.onMessage.addListener((message, sender, sendResponse) => {",
         @"  browser.test.assertEq(message, 'Hello from Inspector', 'Should get the correct message from the Inspector script')",
         @"  sendResponse('Acknowledged by background')",
         @"})"
     ]);
 
-    auto *devToolsScript = Util::constructScript(@[
+    RetainPtr devToolsScript = Util::constructScript(@[
         @"const response = await browser.runtime.sendMessage('Hello from Inspector')",
         @"browser.test.assertEq(response, 'Acknowledged by background', 'Should get the correct response from the background script')",
 
@@ -370,9 +370,9 @@ TEST(WKWebExtensionAPIDevTools, MessagePassingToBackground)
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"devtools.html": @"<script type='module' src='devtools.js'></script>",
-        @"devtools.js": devToolsScript
+        @"devtools.js": devToolsScript.get()
     };
 
     auto manager = Util::loadExtension(devToolsManifest, resources);
@@ -389,21 +389,21 @@ TEST(WKWebExtensionAPIDevTools, MessagePassingFromPanelToBackground)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.runtime.onMessage.addListener((message, sender, sendResponse) => {",
         @"  browser.test.assertEq(message, 'Hello from Inspector panel', 'Should get the correct message from the pane script')",
         @"  sendResponse('Acknowledged by Inspector panel')",
         @"})"
     ]);
 
-    auto *devToolsScript = Util::constructScript(@[
+    RetainPtr devToolsScript = Util::constructScript(@[
         @"let panel = await browser.devtools.panels.create('Test Panel', 'icon.svg', 'panel.html')",
         @"browser.test.assertEq(typeof panel, 'object', 'Panel should be created successfully')",
 
         @"browser.test.sendMessage('Panel Created')",
     ]);
 
-    auto *panelScript = Util::constructScript(@[
+    RetainPtr panelScript = Util::constructScript(@[
         @"const response = await browser.runtime.sendMessage('Hello from Inspector panel')",
         @"browser.test.assertEq(response, 'Acknowledged by Inspector panel', 'Should get the correct response from the background script')",
 
@@ -413,11 +413,11 @@ TEST(WKWebExtensionAPIDevTools, MessagePassingFromPanelToBackground)
     auto *iconSVG = @"<svg width='16' height='16' xmlns='http://www.w3.org/2000/svg'><circle cx='8' cy='8' r='8' fill='red' /></svg>";
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"devtools.html": @"<script type='module' src='devtools.js'></script>",
-        @"devtools.js": devToolsScript,
+        @"devtools.js": devToolsScript.get(),
         @"panel.html": @"<script type='module' src='panel.js'></script>",
-        @"panel.js": panelScript,
+        @"panel.js": panelScript.get(),
         @"icon.svg": iconSVG,
     };
 
@@ -442,7 +442,7 @@ TEST(WKWebExtensionAPIDevTools, MessagePassingFromPanelToDevToolsBackground)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *devToolsScript = Util::constructScript(@[
+    RetainPtr devToolsScript = Util::constructScript(@[
         @"let panel = await browser.devtools.panels.create('Test Panel', 'icon.svg', 'panel.html')",
         @"browser.test.assertEq(typeof panel, 'object', 'Panel should be created successfully')",
 
@@ -454,7 +454,7 @@ TEST(WKWebExtensionAPIDevTools, MessagePassingFromPanelToDevToolsBackground)
         @"browser.test.sendMessage('Panel Created')",
     ]);
 
-    auto *panelScript = Util::constructScript(@[
+    RetainPtr panelScript = Util::constructScript(@[
         @"const response = await browser.runtime.sendMessage('Hello from Inspector panel')",
         @"browser.test.assertEq(response, 'Acknowledged by Inspector background', 'Should get the correct response from the Inspector background')",
 
@@ -466,9 +466,9 @@ TEST(WKWebExtensionAPIDevTools, MessagePassingFromPanelToDevToolsBackground)
     auto *resources = @{
         @"background.js": @"// This script is intentionally left blank.",
         @"devtools.html": @"<script type='module' src='devtools.js'></script>",
-        @"devtools.js": devToolsScript,
+        @"devtools.js": devToolsScript.get(),
         @"panel.html": @"<script type='module' src='panel.js'></script>",
-        @"panel.js": panelScript,
+        @"panel.js": panelScript.get(),
         @"icon.svg": iconSVG,
     };
 
@@ -494,7 +494,7 @@ TEST(WKWebExtensionAPIDevTools, DISABLED_PortMessagePassingToBackground)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.runtime.onConnect.addListener(port => {",
         @"  port.onMessage.addListener((message) => {",
         @"    browser.test.assertEq(message, 'Hello from Inspector', 'Should get the correct message from the Inspector script')",
@@ -503,7 +503,7 @@ TEST(WKWebExtensionAPIDevTools, DISABLED_PortMessagePassingToBackground)
         @"})"
     ]);
 
-    auto *devToolsScript = Util::constructScript(@[
+    RetainPtr devToolsScript = Util::constructScript(@[
         @"const port = browser.runtime.connect()",
         @"port.postMessage('Hello from Inspector')",
 
@@ -515,9 +515,9 @@ TEST(WKWebExtensionAPIDevTools, DISABLED_PortMessagePassingToBackground)
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"devtools.html": @"<script type='module' src='devtools.js'></script>",
-        @"devtools.js": devToolsScript,
+        @"devtools.js": devToolsScript.get(),
     };
 
     auto manager = Util::loadExtension(devToolsManifest, resources);
@@ -534,7 +534,7 @@ TEST(WKWebExtensionAPIDevTools, PortMessagePassingFromPanelToBackground)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.runtime.onConnect.addListener(port => {",
         @"  port.onMessage.addListener((message) => {",
         @"    browser.test.assertEq(message, 'Hello from Inspector panel', 'Should get the correct message from the panel script')",
@@ -543,14 +543,14 @@ TEST(WKWebExtensionAPIDevTools, PortMessagePassingFromPanelToBackground)
         @"})"
     ]);
 
-    auto *devToolsScript = Util::constructScript(@[
+    RetainPtr devToolsScript = Util::constructScript(@[
         @"let panel = await browser.devtools.panels.create('Test Panel', 'icon.svg', 'panel.html')",
         @"browser.test.assertEq(typeof panel, 'object', 'Panel should be created successfully')",
 
         @"browser.test.sendMessage('Panel Created')",
     ]);
 
-    auto *panelScript = Util::constructScript(@[
+    RetainPtr panelScript = Util::constructScript(@[
         @"const port = browser.runtime.connect()",
         @"port.postMessage('Hello from Inspector panel')",
         @"port.onMessage.addListener((response) => {",
@@ -563,11 +563,11 @@ TEST(WKWebExtensionAPIDevTools, PortMessagePassingFromPanelToBackground)
     auto *iconSVG = @"<svg width='16' height='16' xmlns='http://www.w3.org/2000/svg'><circle cx='8' cy='8' r='8' fill='red' /></svg>";
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"devtools.html": @"<script type='module' src='devtools.js'></script>",
-        @"devtools.js": devToolsScript,
+        @"devtools.js": devToolsScript.get(),
         @"panel.html": @"<script type='module' src='panel.js'></script>",
-        @"panel.js": panelScript,
+        @"panel.js": panelScript.get(),
         @"icon.svg": iconSVG,
     };
 
@@ -592,7 +592,7 @@ TEST(WKWebExtensionAPIDevTools, PortMessagePassingFromPanelToDevToolsBackground)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *devToolsScript = Util::constructScript(@[
+    RetainPtr devToolsScript = Util::constructScript(@[
         @"let panel = await browser.devtools.panels.create('Test Panel', 'icon.svg', 'panel.html')",
         @"browser.test.assertEq(typeof panel, 'object', 'Panel should be created successfully')",
 
@@ -606,7 +606,7 @@ TEST(WKWebExtensionAPIDevTools, PortMessagePassingFromPanelToDevToolsBackground)
         @"browser.test.sendMessage('Panel Created')",
     ]);
 
-    auto *panelScript = Util::constructScript(@[
+    RetainPtr panelScript = Util::constructScript(@[
         @"const port = browser.runtime.connect()",
         @"port.postMessage('Hello from Inspector panel')",
 
@@ -622,9 +622,9 @@ TEST(WKWebExtensionAPIDevTools, PortMessagePassingFromPanelToDevToolsBackground)
     auto *resources = @{
         @"background.js": @"// This script is intentionally left blank.",
         @"devtools.html": @"<script type='module' src='devtools.js'></script>",
-        @"devtools.js": devToolsScript,
+        @"devtools.js": devToolsScript.get(),
         @"panel.html": @"<script type='module' src='panel.js'></script>",
-        @"panel.js": panelScript,
+        @"panel.js": panelScript.get(),
         @"icon.svg": iconSVG,
     };
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIEvent.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIEvent.mm
@@ -35,7 +35,7 @@ static auto *eventManifest = @{ @"manifest_version": @3, @"background": @{ @"scr
 
 TEST(WKWebExtensionAPIEvent, Errors)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.assertThrows(() => browser.runtime.onStartup.addListener('bad'), /'listener' value is invalid, because a function is expected/i)",
         @"browser.test.assertThrows(() => browser.runtime.onStartup.removeListener('bad'), /'listener' value is invalid, because a function is expected/i)",
         @"browser.test.assertThrows(() => browser.runtime.onStartup.hasListener('bad'), /'listener' value is invalid, because a function is expected/i)",
@@ -43,12 +43,12 @@ TEST(WKWebExtensionAPIEvent, Errors)
         @"browser.test.notifyPass()"
     ]);
 
-    Util::loadAndRunExtension(eventManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(eventManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPIEvent, TestEventListener)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         // Setup
         @"function listener() { }",
         @"browser.test.assertFalse(browser.runtime.onStartup.hasListener(listener), 'Should not have listener')",
@@ -64,7 +64,7 @@ TEST(WKWebExtensionAPIEvent, TestEventListener)
         @"browser.test.notifyPass()"
     ]);
 
-    Util::loadAndRunExtension(eventManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(eventManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIExtension.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIExtension.mm
@@ -76,7 +76,7 @@ TEST(WKWebExtensionAPIExtension, GetURL)
 {
     auto *baseURLString = @"test-extension://76C788B8-3374-400D-8259-40E5B9DF79D3";
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         // Variable Setup
         [NSString stringWithFormat:@"const baseURL = '%@'", baseURLString],
 
@@ -112,7 +112,7 @@ TEST(WKWebExtensionAPIExtension, GetURL)
 
     auto *manifest = @{ @"manifest_version": @2, @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO } };
 
-    auto manager = Util::parseExtension(manifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::parseExtension(manifest, @{ @"background.js": backgroundScript.get() });
 
     // Set a base URL so it is a known value and not the default random one.
     [WKWebExtensionMatchPattern registerCustomURLScheme:@"test-extension"];
@@ -132,12 +132,12 @@ TEST(WKWebExtensionAPIExtension, GetURL)
 
     manifest = @{ @"manifest_version": @3, @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO } };
 
-    Util::loadAndRunExtension(manifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(manifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPIExtension, GetBackgroundPageFromBackground)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"window.notifyTestPass = () => {",
         @"  browser.test.notifyPass()",
         @"}",
@@ -148,12 +148,12 @@ TEST(WKWebExtensionAPIExtension, GetBackgroundPageFromBackground)
         @"browser.test.assertSafe(() => backgroundPage.notifyTestPass())"
     ]);
 
-    Util::loadAndRunExtension(extensionManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(extensionManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPIExtension, GetBackgroundPageFromTab)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"window.notifyTestPass = () => {",
         @"  browser.test.notifyPass()",
         @"}",
@@ -161,7 +161,7 @@ TEST(WKWebExtensionAPIExtension, GetBackgroundPageFromTab)
         @"browser.tabs.create({ url: 'test.html' })"
     ]);
 
-    auto *testScript = Util::constructScript(@[
+    RetainPtr testScript = Util::constructScript(@[
         @"const backgroundPage = browser.extension.getBackgroundPage()",
         @"browser.test.assertSafe(() => backgroundPage.notifyTestPass())",
     ]);
@@ -169,15 +169,15 @@ TEST(WKWebExtensionAPIExtension, GetBackgroundPageFromTab)
     auto *testHTML = @"<script type='module' src='test.js'></script>";
 
     Util::loadAndRunExtension(extensionManifest, @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"test.html": testHTML,
-        @"test.js": testScript
+        @"test.js": testScript.get()
     });
 }
 
 TEST(WKWebExtensionAPIExtension, GetBackgroundPageFromPopup)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"window.notifyTestPass = () => {",
         @"  browser.test.notifyPass()",
         @"}",
@@ -185,7 +185,7 @@ TEST(WKWebExtensionAPIExtension, GetBackgroundPageFromPopup)
         @"browser.action.openPopup()"
     ]);
 
-    auto *popupScript = Util::constructScript(@[
+    RetainPtr popupScript = Util::constructScript(@[
         @"const backgroundPage = browser.extension.getBackgroundPage()",
         @"browser.test.assertSafe(() => backgroundPage.notifyTestPass())"
     ]);
@@ -193,9 +193,9 @@ TEST(WKWebExtensionAPIExtension, GetBackgroundPageFromPopup)
     auto *popupHTML = @"<script type='module' src='popup.js'></script>";
 
     auto resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"popup.html": popupHTML,
-        @"popup.js": popupScript
+        @"popup.js": popupScript.get()
     };
 
     auto manager = Util::loadExtension(extensionManifest, resources);
@@ -209,11 +209,11 @@ TEST(WKWebExtensionAPIExtension, GetBackgroundPageFromPopup)
 
 TEST(WKWebExtensionAPIExtension, GetBackgroundPageForServiceWorker)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.tabs.create({ url: 'test.html' })"
     ]);
 
-    auto *testScript = Util::constructScript(@[
+    RetainPtr testScript = Util::constructScript(@[
         @"const backgroundPage = browser.extension.getBackgroundPage()",
         @"browser.test.assertEq(backgroundPage, null, 'Background page should be null for service workers')",
         @"browser.test.notifyPass()"
@@ -222,15 +222,15 @@ TEST(WKWebExtensionAPIExtension, GetBackgroundPageForServiceWorker)
     auto *testHTML = @"<script type='module' src='test.js'></script>";
 
     Util::loadAndRunExtension(extensionServiceWorkerManifest, @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"test.html": testHTML,
-        @"test.js": testScript
+        @"test.js": testScript.get()
     });
 }
 
 TEST(WKWebExtensionAPIExtension, GetViewsFromBackgroundPage)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"window.notifyTestPass = () => {",
         @"  browser.test.notifyPass()",
         @"}",
@@ -241,12 +241,12 @@ TEST(WKWebExtensionAPIExtension, GetViewsFromBackgroundPage)
         @"browser.test.assertSafe(() => views[0].notifyTestPass())"
     ]);
 
-    Util::loadAndRunExtension(extensionManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(extensionManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPIExtension, GetViewsForBackground)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"window.notifyTestPass = () => {",
         @"  browser.test.notifyPass()",
         @"}",
@@ -254,7 +254,7 @@ TEST(WKWebExtensionAPIExtension, GetViewsForBackground)
         @"browser.tabs.create({ url: 'test.html' })"
     ]);
 
-    auto *testScript = Util::constructScript(@[
+    RetainPtr testScript = Util::constructScript(@[
         @"const views = browser.extension.getViews()",
         @"browser.test.assertEq(views.length, 2)",
 
@@ -269,15 +269,15 @@ TEST(WKWebExtensionAPIExtension, GetViewsForBackground)
     auto *testHTML = @"<script type='module' src='test.js'></script>";
 
     Util::loadAndRunExtension(extensionManifest, @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"test.html": testHTML,
-        @"test.js": testScript
+        @"test.js": testScript.get()
     });
 }
 
 TEST(WKWebExtensionAPIExtension, GetViewsForTab)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.runtime.onMessage.addListener((message, sender, sendResponse) => {",
         @"  browser.test.assertEq(message, 'ready')",
 
@@ -290,7 +290,7 @@ TEST(WKWebExtensionAPIExtension, GetViewsForTab)
         @"browser.tabs.create({ url: 'test.html' })"
     ]);
 
-    auto *testScript = Util::constructScript(@[
+    RetainPtr testScript = Util::constructScript(@[
         @"window.notifyTestPass = () => {",
         @"  browser.test.notifyPass()",
         @"}",
@@ -301,9 +301,9 @@ TEST(WKWebExtensionAPIExtension, GetViewsForTab)
     auto *testHTML = @"<script type='module' src='test.js'></script>";
 
     Util::loadAndRunExtension(extensionManifest, @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"test.html": testHTML,
-        @"test.js": testScript
+        @"test.js": testScript.get()
     });
 }
 
@@ -313,7 +313,7 @@ TEST(WKWebExtensionAPIExtension, GetViewsForMultipleTabs)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"let tabCount = 0",
 
         @"browser.runtime.onMessage.addListener((message, sender, sendResponse) => {",
@@ -335,7 +335,7 @@ TEST(WKWebExtensionAPIExtension, GetViewsForMultipleTabs)
         @"browser.tabs.create({ url: 'test.html' })"
     ]);
 
-    auto *testScript = Util::constructScript(@[
+    RetainPtr testScript = Util::constructScript(@[
         @"window.notifyTestPass = (index) => {",
         @"  if (index === 1)",
         @"    browser.test.notifyPass()",
@@ -347,9 +347,9 @@ TEST(WKWebExtensionAPIExtension, GetViewsForMultipleTabs)
     auto *testHTML = @"<script type='module' src='test.js'></script>";
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"test.html": testHTML,
-        @"test.js": testScript
+        @"test.js": testScript.get()
     };
 
     auto manager = Util::loadExtension(extensionManifest, resources);
@@ -361,7 +361,7 @@ TEST(WKWebExtensionAPIExtension, GetViewsForMultipleTabs)
 
 TEST(WKWebExtensionAPIExtension, GetViewsForPopup)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.runtime.onMessage.addListener((message, sender, sendResponse) => {",
         @"  browser.test.assertEq(message, 'ready')",
 
@@ -374,7 +374,7 @@ TEST(WKWebExtensionAPIExtension, GetViewsForPopup)
         @"browser.action.openPopup()"
     ]);
 
-    auto *popupScript = Util::constructScript(@[
+    RetainPtr popupScript = Util::constructScript(@[
         @"window.notifyTestPass = () => {",
         @"  browser.test.notifyPass()",
         @"}",
@@ -385,9 +385,9 @@ TEST(WKWebExtensionAPIExtension, GetViewsForPopup)
     auto *popupHTML = @"<script type='module' src='popup.js'></script>";
 
     auto resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"popup.html": popupHTML,
-        @"popup.js": popupScript
+        @"popup.js": popupScript.get()
     };
 
     auto manager = Util::loadExtension(extensionManifest, resources);
@@ -401,14 +401,14 @@ TEST(WKWebExtensionAPIExtension, GetViewsForPopup)
 
 TEST(WKWebExtensionAPIExtension, GetViewsExcludesServiceWorkerBackground)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const views = browser.extension.getViews()",
         @"browser.test.assertEq(views.length, 0, 'Background view should not be included for service workers')",
         @"browser.test.notifyPass()"
     ]);
 
     Util::loadAndRunExtension(extensionServiceWorkerManifest, @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
     });
 }
 
@@ -418,24 +418,24 @@ TEST(WKWebExtensionAPIExtension, InIncognitoContext)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.assertFalse(browser.extension.inIncognitoContext, 'Should not be in incognito in background script')"
     ]);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"if (browser.extension.inIncognitoContext)",
         @"  browser.test.sendMessage('Content Script is Incognito')",
         @"else",
         @"  browser.test.sendMessage('Content Script is Not Incognito')"
     ]);
 
-    auto manager = Util::loadExtension(extensionManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
+    auto manager = Util::loadExtension(extensionManifest, @{ @"background.js": backgroundScript.get(), @"content.js": contentScript.get() });
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
     manager.get().context.hasAccessToPrivateData = YES;
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager runUntilTestMessage:@"Content Script is Not Incognito"];
 
@@ -444,7 +444,7 @@ TEST(WKWebExtensionAPIExtension, InIncognitoContext)
     auto *privateWindow = [manager openNewWindowUsingPrivateBrowsing:YES];
     auto *privateTab = privateWindow.tabs.firstObject;
 
-    [privateTab.webView loadRequest:urlRequest];
+    [privateTab.webView loadRequest:urlRequest.get()];
 
     [manager runUntilTestMessage:@"Content Script is Incognito"];
 }
@@ -455,23 +455,23 @@ TEST(WKWebExtensionAPIExtension, InIncognitoContextWithoutPrivateAccess)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.assertFalse(browser.extension.inIncognitoContext, 'Should not be in incognito in background script')"
     ]);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"if (browser.extension.inIncognitoContext)",
         @"  browser.test.sendMessage('Content Script is Incognito')",
         @"else",
         @"  browser.test.sendMessage('Content Script is Not Incognito')"
     ]);
 
-    auto manager = Util::loadExtension(extensionManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
+    auto manager = Util::loadExtension(extensionManifest, @{ @"background.js": backgroundScript.get(), @"content.js": contentScript.get() });
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager runUntilTestMessage:@"Content Script is Not Incognito"];
 
@@ -480,7 +480,7 @@ TEST(WKWebExtensionAPIExtension, InIncognitoContextWithoutPrivateAccess)
     auto *privateWindow = [manager openNewWindowUsingPrivateBrowsing:YES];
     auto *privateTab = privateWindow.tabs.firstObject;
 
-    [privateTab.webView loadRequest:urlRequest];
+    [privateTab.webView loadRequest:urlRequest.get()];
 
     // The content script should not run in the private tab, so timeout after waiting for 3 seconds.
     [manager runForTimeInterval:3];
@@ -488,12 +488,12 @@ TEST(WKWebExtensionAPIExtension, InIncognitoContextWithoutPrivateAccess)
 
 TEST(WKWebExtensionAPIExtension, IsAllowedIncognitoAccess)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const allowed = await browser.extension.isAllowedIncognitoAccess()",
         @"browser.test.sendMessage(allowed ? 'Allowed Incognito Access' : 'Not Allowed Incognito Access')",
     ]);
 
-    auto manager = Util::loadExtension(extensionManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(extensionManifest, @{ @"background.js": backgroundScript.get() });
 
     manager.get().context.hasAccessToPrivateData = YES;
 
@@ -502,24 +502,24 @@ TEST(WKWebExtensionAPIExtension, IsAllowedIncognitoAccess)
 
 TEST(WKWebExtensionAPIExtension, IsAllowedIncognitoAccessWithoutPrivateAccess)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const allowed = await browser.extension.isAllowedIncognitoAccess()",
         @"browser.test.sendMessage(allowed ? 'Allowed Incognito Access' : 'Not Allowed Incognito Access')",
     ]);
 
-    auto manager = Util::loadExtension(extensionManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(extensionManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager runUntilTestMessage:@"Not Allowed Incognito Access"];
 }
 
 TEST(WKWebExtensionAPIExtension, IsAllowedFileSchemeAccess)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const allowed = await browser.extension.isAllowedFileSchemeAccess()",
         @"browser.test.sendMessage(allowed ? 'Allowed File Access' : 'Not Allowed File Access')",
     ]);
 
-    auto manager = Util::loadExtension(extensionManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(extensionManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager runUntilTestMessage:@"Not Allowed File Access"];
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIMenus.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIMenus.mm
@@ -70,7 +70,7 @@ static auto *menusManifest = @{
 
 TEST(WKWebExtensionAPIMenus, Errors)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.assertThrows(() => browser.menus.create({ id: { }, title: 'Test' }), /'id' is expected to be a string or a number, but an object was provided/i)",
         @"browser.test.assertThrows(() => browser.menus.create({ id: '', title: 'Test' }), /'id' value is invalid, because it must not be empty/i)",
         @"browser.test.assertThrows(() => browser.menus.create({ id: NaN, title: 'Test' }), /'id' is expected to be a string or a number, but NaN was provided/i)",
@@ -118,7 +118,7 @@ TEST(WKWebExtensionAPIMenus, Errors)
         @"browser.test.notifyPass()"
     ]);
 
-    Util::loadAndRunExtension(menusManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(menusManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 #if USE(APPKIT)
@@ -144,7 +144,7 @@ static inline void performMenuItemAction(auto *menuItem)
 
 TEST(WKWebExtensionAPIMenus, MenuCreateWithVariousIds)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"let menuItemWithStringId = browser.menus.create({",
         @"  id: 'string-id',",
         @"  title: 'String ID',",
@@ -179,12 +179,12 @@ TEST(WKWebExtensionAPIMenus, MenuCreateWithVariousIds)
         @"browser.test.notifyPass()"
     ]);
 
-    Util::loadAndRunExtension(menusManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(menusManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPIMenus, CreateMenuWithDeprecatedKeys)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr<NSString> backgroundScript = Util::constructScript(@[
         @"const createImageData = (size, color) => {",
         @"  const context = new OffscreenCanvas(size, size).getContext('2d')",
         @"  context.fillStyle = color",
@@ -224,7 +224,7 @@ TEST(WKWebExtensionAPIMenus, CreateMenuWithDeprecatedKeys)
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
     };
 
     auto manager = Util::loadExtension(menusManifest, resources);
@@ -261,7 +261,7 @@ TEST(WKWebExtensionAPIMenus, ActionMenus)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.menus.create({",
         @"  id: 'top-level-1',",
         @"  title: 'Top Level 1',",
@@ -304,7 +304,7 @@ TEST(WKWebExtensionAPIMenus, ActionMenus)
         @"browser.test.sendMessage('Menus Created')"
     ]);
 
-    auto manager = Util::loadExtension(menusManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(menusManifest, @{ @"background.js": backgroundScript.get() });
 
     // Reset activeTab, WKWebExtensionAPIMenus.ActionMenusWithActiveTab tests that.
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusUnknown forPermission:WKWebExtensionPermissionActiveTab];
@@ -332,7 +332,7 @@ TEST(WKWebExtensionAPIMenus, ActionMenus)
 
 TEST(WKWebExtensionAPIMenus, ActionMenusWithActiveTab)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.menus.create({",
         @"  id: 'top-level-1',",
         @"  title: 'Top Level 1',",
@@ -376,7 +376,7 @@ TEST(WKWebExtensionAPIMenus, ActionMenusWithActiveTab)
         @"browser.test.sendMessage('Menus Created')"
     ]);
 
-    auto manager = Util::loadExtension(menusManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(menusManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager runUntilTestMessage:@"Menus Created"];
 
@@ -409,7 +409,7 @@ TEST(WKWebExtensionAPIMenus, ActionMenusWithActiveTab)
 
 TEST(WKWebExtensionAPIMenus, ActionSubmenus)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.menus.create({",
         @"  id: 'top-level-1',",
         @"  title: 'Top Level 1',",
@@ -449,7 +449,7 @@ TEST(WKWebExtensionAPIMenus, ActionSubmenus)
         @"browser.test.sendMessage('Menus Created')",
     ]);
 
-    auto manager = Util::loadExtension(menusManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(menusManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager runUntilTestMessage:@"Menus Created"];
 
@@ -492,7 +492,7 @@ TEST(WKWebExtensionAPIMenus, ActionSubmenus)
 
 TEST(WKWebExtensionAPIMenus, ActionSubmenusUpdate)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.menus.create({",
         @"  id: 'top-level-1',",
         @"  title: 'Top Level 1',",
@@ -551,7 +551,7 @@ TEST(WKWebExtensionAPIMenus, ActionSubmenusUpdate)
         @"browser.test.sendMessage('Menus Created')",
     ]);
 
-    auto manager = Util::loadExtension(menusManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(menusManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager runUntilTestMessage:@"Menus Created"];
 
@@ -598,7 +598,7 @@ TEST(WKWebExtensionAPIMenus, TabMenus)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.menus.create({",
         @"  id: 'tab-item-1',",
         @"  title: 'Tab Item 1',",
@@ -631,7 +631,7 @@ TEST(WKWebExtensionAPIMenus, TabMenus)
         @"browser.test.sendMessage('Menus Created')",
     ]);
 
-    auto manager = Util::loadExtension(menusManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(menusManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager runUntilTestMessage:@"Menus Created"];
 
@@ -665,7 +665,7 @@ TEST(WKWebExtensionAPIMenus, TabMenus)
 
 TEST(WKWebExtensionAPIMenus, MenuItemProperties)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.menus.create({",
         @"  id: 'menu-item-properties',",
         @"  title: 'Menu &Item with Ampersand && More',",
@@ -693,13 +693,13 @@ TEST(WKWebExtensionAPIMenus, MenuItemProperties)
         @"browser.test.sendMessage('Menus Created')",
     ]);
 
-    auto *smallIcon = Util::makePNGData(CGSizeMake(16, 16), @selector(greenColor));
-    auto *largerIcon = Util::makePNGData(CGSizeMake(20, 20), @selector(blueColor));
+    RetainPtr smallIcon = Util::makePNGData(CGSizeMake(16, 16), @selector(greenColor));
+    RetainPtr largerIcon = Util::makePNGData(CGSizeMake(20, 20), @selector(blueColor));
 
     auto *resources = @{
-        @"background.js": backgroundScript,
-        @"icon-16.png": smallIcon,
-        @"icon-20.png": largerIcon,
+        @"background.js": backgroundScript.get(),
+        @"icon-16.png": smallIcon.get(),
+        @"icon-20.png": largerIcon.get(),
     };
 
     auto manager = Util::loadExtension(menusManifest, resources);
@@ -744,7 +744,7 @@ TEST(WKWebExtensionAPIMenus, MenuItemProperties)
 
 TEST(WKWebExtensionAPIMenus, MenuItemPropertiesUpdate)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.menus.create({",
         @"  id: 'menu-item-properties',",
         @"  title: 'Old Title',",
@@ -782,13 +782,13 @@ TEST(WKWebExtensionAPIMenus, MenuItemPropertiesUpdate)
         @"browser.test.sendMessage('Menus Created')",
     ]);
 
-    auto *smallIcon = Util::makePNGData(CGSizeMake(16, 16), @selector(greenColor));
-    auto *largerIcon = Util::makePNGData(CGSizeMake(20, 20), @selector(blueColor));
+    RetainPtr smallIcon = Util::makePNGData(CGSizeMake(16, 16), @selector(greenColor));
+    RetainPtr largerIcon = Util::makePNGData(CGSizeMake(20, 20), @selector(blueColor));
 
     auto *resources = @{
-        @"background.js": backgroundScript,
-        @"icon-16.png": smallIcon,
-        @"icon-20.png": largerIcon,
+        @"background.js": backgroundScript.get(),
+        @"icon-16.png": smallIcon.get(),
+        @"icon-20.png": largerIcon.get(),
     };
 
     auto manager = Util::loadExtension(menusManifest, resources);
@@ -834,7 +834,7 @@ TEST(WKWebExtensionAPIMenus, MenuItemPropertiesUpdate)
 #if ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
 TEST(WKWebExtensionAPIMenus, MenuItemWithIconVariants)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.assertSafe(() => browser.menus.create({",
         @"  id: 'menu-item-with-icon-variants',",
         @"  title: 'Menu Item with Icon Variants',",
@@ -848,13 +848,13 @@ TEST(WKWebExtensionAPIMenus, MenuItemWithIconVariants)
         @"browser.test.sendMessage('Menus Created')",
     ]);
 
-    auto *darkIcon16 = Util::makePNGData(CGSizeMake(16, 16), @selector(whiteColor));
-    auto *lightIcon16 = Util::makePNGData(CGSizeMake(16, 16), @selector(blackColor));
+    RetainPtr darkIcon16 = Util::makePNGData(CGSizeMake(16, 16), @selector(whiteColor));
+    RetainPtr lightIcon16 = Util::makePNGData(CGSizeMake(16, 16), @selector(blackColor));
 
     auto *resources = @{
-        @"background.js": backgroundScript,
-        @"icon-dark-16.png": darkIcon16,
-        @"icon-light-16.png": lightIcon16,
+        @"background.js": backgroundScript.get(),
+        @"icon-dark-16.png": darkIcon16.get(),
+        @"icon-light-16.png": lightIcon16.get(),
     };
 
     auto manager = Util::loadExtension(menusManifest, resources);
@@ -887,7 +887,7 @@ TEST(WKWebExtensionAPIMenus, MenuItemWithIconVariants)
 
 TEST(WKWebExtensionAPIMenus, MenuItemWithImageDataVariants)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const createImageData = (size, color) => {",
         @"  const context = new OffscreenCanvas(size, size).getContext('2d')",
         @"  context.fillStyle = color",
@@ -913,7 +913,7 @@ TEST(WKWebExtensionAPIMenus, MenuItemWithImageDataVariants)
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
     };
 
     auto manager = Util::loadExtension(menusManifest, resources);
@@ -946,7 +946,7 @@ TEST(WKWebExtensionAPIMenus, MenuItemWithImageDataVariants)
 
 TEST(WKWebExtensionAPIMenus, MenuItemWithWithNoValidVariants)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const createImageData = (size, color) => {",
         @"  const context = new OffscreenCanvas(size, size).getContext('2d')",
         @"  context.fillStyle = color",
@@ -981,7 +981,7 @@ TEST(WKWebExtensionAPIMenus, MenuItemWithWithNoValidVariants)
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
     };
 
     Util::loadAndRunExtension(menusManifest, resources);
@@ -989,7 +989,7 @@ TEST(WKWebExtensionAPIMenus, MenuItemWithWithNoValidVariants)
 
 TEST(WKWebExtensionAPIMenus, MenuItemWithMixedValidAndInvalidIconVariants)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const createImageData = (size, color) => {",
         @"  const context = new OffscreenCanvas(size, size).getContext('2d')",
         @"  context.fillStyle = color",
@@ -1015,7 +1015,7 @@ TEST(WKWebExtensionAPIMenus, MenuItemWithMixedValidAndInvalidIconVariants)
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
     };
 
     auto manager = Util::loadExtension(menusManifest, resources);
@@ -1049,7 +1049,7 @@ TEST(WKWebExtensionAPIMenus, MenuItemWithMixedValidAndInvalidIconVariants)
 
 TEST(WKWebExtensionAPIMenus, MenuItemWithAnySizeVariantAndSVGDataURL)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const whiteSVGData = 'data:image/svg+xml;base64,' + btoa(`",
         @"  <svg width=\"100\" height=\"100\" xmlns=\"http://www.w3.org/2000/svg\">",
         @"    <rect width=\"100\" height=\"100\" fill=\"white\" />",
@@ -1074,7 +1074,7 @@ TEST(WKWebExtensionAPIMenus, MenuItemWithAnySizeVariantAndSVGDataURL)
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
     };
 
     auto manager = Util::loadExtension(menusManifest, resources);
@@ -1107,7 +1107,7 @@ TEST(WKWebExtensionAPIMenus, MenuItemWithAnySizeVariantAndSVGDataURL)
 
 TEST(WKWebExtensionAPIMenus, UpdateMenuItemWithIconVariants)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.assertSafe(() => browser.menus.create({",
         @"  id: 'menu-item-without-icon-variants',",
         @"  title: 'Menu Item without Icon Variants',",
@@ -1125,13 +1125,13 @@ TEST(WKWebExtensionAPIMenus, UpdateMenuItemWithIconVariants)
         @"browser.test.sendMessage('Menus Updated')",
     ]);
 
-    auto *darkIcon16 = Util::makePNGData(CGSizeMake(16, 16), @selector(whiteColor));
-    auto *lightIcon16 = Util::makePNGData(CGSizeMake(16, 16), @selector(blackColor));
+    RetainPtr darkIcon16 = Util::makePNGData(CGSizeMake(16, 16), @selector(whiteColor));
+    RetainPtr lightIcon16 = Util::makePNGData(CGSizeMake(16, 16), @selector(blackColor));
 
     auto *resources = @{
-        @"background.js": backgroundScript,
-        @"icon-dark-16.png": darkIcon16,
-        @"icon-light-16.png": lightIcon16,
+        @"background.js": backgroundScript.get(),
+        @"icon-dark-16.png": darkIcon16.get(),
+        @"icon-light-16.png": lightIcon16.get(),
     };
 
     auto manager = Util::loadExtension(menusManifest, resources);
@@ -1164,7 +1164,7 @@ TEST(WKWebExtensionAPIMenus, UpdateMenuItemWithIconVariants)
 
 TEST(WKWebExtensionAPIMenus, ClearMenuItemIconVariantsWithNull)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.assertSafe(() => browser.menus.create({",
         @"  id: 'menu-item-with-icon-variants',",
         @"  title: 'Menu Item with Icon Variants',",
@@ -1183,13 +1183,13 @@ TEST(WKWebExtensionAPIMenus, ClearMenuItemIconVariantsWithNull)
         @"browser.test.sendMessage('Menus Updated')",
     ]);
 
-    auto *darkIcon16 = Util::makePNGData(CGSizeMake(16, 16), @selector(whiteColor));
-    auto *lightIcon16 = Util::makePNGData(CGSizeMake(16, 16), @selector(blackColor));
+    RetainPtr darkIcon16 = Util::makePNGData(CGSizeMake(16, 16), @selector(whiteColor));
+    RetainPtr lightIcon16 = Util::makePNGData(CGSizeMake(16, 16), @selector(blackColor));
 
     auto *resources = @{
-        @"background.js": backgroundScript,
-        @"icon-dark-16.png": darkIcon16,
-        @"icon-light-16.png": lightIcon16,
+        @"background.js": backgroundScript.get(),
+        @"icon-dark-16.png": darkIcon16.get(),
+        @"icon-light-16.png": lightIcon16.get(),
     };
 
     auto manager = Util::loadExtension(menusManifest, resources);
@@ -1211,7 +1211,7 @@ TEST(WKWebExtensionAPIMenus, ClearMenuItemIconVariantsWithNull)
 
 TEST(WKWebExtensionAPIMenus, ClearMenuItemIconVariantsWithEmpty)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.assertSafe(() => browser.menus.create({",
         @"  id: 'menu-item-with-icon-variants',",
         @"  title: 'Menu Item with Icon Variants',",
@@ -1230,13 +1230,13 @@ TEST(WKWebExtensionAPIMenus, ClearMenuItemIconVariantsWithEmpty)
         @"browser.test.sendMessage('Menus Updated')",
     ]);
 
-    auto *darkIcon16 = Util::makePNGData(CGSizeMake(16, 16), @selector(whiteColor));
-    auto *lightIcon16 = Util::makePNGData(CGSizeMake(16, 16), @selector(blackColor));
+    RetainPtr darkIcon16 = Util::makePNGData(CGSizeMake(16, 16), @selector(whiteColor));
+    RetainPtr lightIcon16 = Util::makePNGData(CGSizeMake(16, 16), @selector(blackColor));
 
     auto *resources = @{
-        @"background.js": backgroundScript,
-        @"icon-dark-16.png": darkIcon16,
-        @"icon-light-16.png": lightIcon16,
+        @"background.js": backgroundScript.get(),
+        @"icon-dark-16.png": darkIcon16.get(),
+        @"icon-light-16.png": lightIcon16.get(),
     };
 
     auto manager = Util::loadExtension(menusManifest, resources);
@@ -1258,7 +1258,7 @@ TEST(WKWebExtensionAPIMenus, ClearMenuItemIconVariantsWithEmpty)
 
 TEST(WKWebExtensionAPIMenus, MenuItemWithSymbolImageIconVariants)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.assertSafe(() => browser.menus.create({",
         @"  id: 'menu-item-with-symbol-variants',",
         @"  title: 'Menu Item with Symbol Variants',",
@@ -1271,7 +1271,7 @@ TEST(WKWebExtensionAPIMenus, MenuItemWithSymbolImageIconVariants)
         @"browser.test.sendMessage('Menus Created')",
     ]);
 
-    auto manager = Util::loadExtension(menusManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(menusManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager runUntilTestMessage:@"Menus Created"];
 
@@ -1296,7 +1296,7 @@ TEST(WKWebExtensionAPIMenus, MenuItemWithSymbolImageIconVariants)
 
 TEST(WKWebExtensionAPIMenus, MenuItemWithSymbolImageIcon)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.assertSafe(() => browser.menus.create({",
         @"  id: 'menu-item-with-symbol-icon',",
         @"  title: 'Menu Item with Symbol Icon',",
@@ -1309,7 +1309,7 @@ TEST(WKWebExtensionAPIMenus, MenuItemWithSymbolImageIcon)
         @"browser.test.sendMessage('Menus Created')",
     ]);
 
-    auto manager = Util::loadExtension(menusManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(menusManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager runUntilTestMessage:@"Menus Created"];
 
@@ -1333,7 +1333,7 @@ TEST(WKWebExtensionAPIMenus, MenuItemWithSymbolImageIcon)
 
 TEST(WKWebExtensionAPIMenus, ToggleCheckboxMenuItems)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.menus.create({",
         @"  id: 'checkbox-1',",
         @"  title: 'Checkbox 1',",
@@ -1367,7 +1367,7 @@ TEST(WKWebExtensionAPIMenus, ToggleCheckboxMenuItems)
         @"browser.test.sendMessage('Menus Created')",
     ]);
 
-    auto manager = Util::loadExtension(menusManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(menusManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager runUntilTestMessage:@"Menus Created"];
 
@@ -1417,7 +1417,7 @@ TEST(WKWebExtensionAPIMenus, ToggleCheckboxMenuItems)
 
 TEST(WKWebExtensionAPIMenus, RadioItemGrouping)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.menus.create({",
         @"  id: 'radio-1-group-1',",
         @"  title: 'Radio 1 Group 1',",
@@ -1479,7 +1479,7 @@ TEST(WKWebExtensionAPIMenus, RadioItemGrouping)
         @"browser.test.sendMessage('Menus Created')",
     ]);
 
-    auto manager = Util::loadExtension(menusManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(menusManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager runUntilTestMessage:@"Menus Created"];
 
@@ -1543,7 +1543,7 @@ TEST(WKWebExtensionAPIMenus, RadioItemGrouping)
 
 TEST(WKWebExtensionAPIMenus, OnClick)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.menus.create({",
         @"  id: 'click-item',",
         @"  title: 'Click Item',",
@@ -1560,7 +1560,7 @@ TEST(WKWebExtensionAPIMenus, OnClick)
         @"}, () => browser.test.sendMessage('Menu Item Created'))"
     ]);
 
-    auto manager = Util::loadExtension(menusManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(menusManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager runUntilTestMessage:@"Menu Item Created"];
 
@@ -1574,7 +1574,7 @@ TEST(WKWebExtensionAPIMenus, OnClick)
 
 TEST(WKWebExtensionAPIMenus, OnClickAfterUpdate)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.menus.create({",
         @"  id: 'click-item',",
         @"  title: 'Click Item',",
@@ -1596,7 +1596,7 @@ TEST(WKWebExtensionAPIMenus, OnClickAfterUpdate)
         @"browser.test.sendMessage('Menu Item Created')"
     ]);
 
-    auto manager = Util::loadExtension(menusManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(menusManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager runUntilTestMessage:@"Menu Item Created"];
 
@@ -1610,20 +1610,20 @@ TEST(WKWebExtensionAPIMenus, OnClickAfterUpdate)
 
 TEST(WKWebExtensionAPIMenus, ContextMenusNamespace)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.assertEq(typeof browser.contextMenus, 'object')",
 
         @"browser.test.notifyPass()"
     ]);
 
-    Util::loadAndRunExtension(menusManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(menusManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 #if PLATFORM(MAC)
 
 TEST(WKWebExtensionAPIMenus, MacContextMenuItems)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.menus.create({",
         @"  id: 'context-menu-1',",
         @"  title: 'Context Menu 1'",
@@ -1685,7 +1685,7 @@ TEST(WKWebExtensionAPIMenus, MacContextMenuItems)
         completionHandler(nil);
     };
 
-    auto manager = Util::loadExtension(menusManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(menusManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager runUntilTestMessage:@"Menus Created"];
 
@@ -1695,8 +1695,8 @@ TEST(WKWebExtensionAPIMenus, MacContextMenuItems)
 
     EXPECT_FALSE([manager.get().context hasActiveUserGestureInTab:manager.get().defaultTab]);
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().webExtensionController = manager.get().controller;
@@ -1706,7 +1706,7 @@ TEST(WKWebExtensionAPIMenus, MacContextMenuItems)
 
     manager.get().defaultTab.webView = webView.get();
 
-    [webView synchronouslyLoadRequest:urlRequest];
+    [webView synchronouslyLoadRequest:urlRequest.get()];
     [webView waitForNextPresentationUpdate];
 
     [webView.get().window makeFirstResponder:webView.get()];
@@ -1723,7 +1723,7 @@ TEST(WKWebExtensionAPIMenus, MacContextMenuItems)
 
 TEST(WKWebExtensionAPIMenus, MacActiveTabContextMenuItems)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.menus.create({",
         @"  id: 'context-menu',",
         @"  title: 'Context Menu Item'",
@@ -1771,7 +1771,7 @@ TEST(WKWebExtensionAPIMenus, MacActiveTabContextMenuItems)
         completionHandler(nil);
     };
 
-    auto manager = Util::loadExtension(menusManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(menusManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager runUntilTestMessage:@"Menus Created"];
 
@@ -1806,7 +1806,7 @@ TEST(WKWebExtensionAPIMenus, MacActiveTabContextMenuItems)
 
 TEST(WKWebExtensionAPIMenus, MacURLPatternContextMenuItems)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.menus.create({",
         @"  id: 'url-pattern-menu-item',",
         @"  title: 'URL Pattern Item',",
@@ -1852,8 +1852,8 @@ TEST(WKWebExtensionAPIMenus, MacURLPatternContextMenuItems)
     delegate.get().getContextMenuFromProposedMenu = ^(NSMenu *menu, _WKContextMenuElementInfo *elementInfo, id<NSSecureCoding>, void (^completionHandler)(NSMenu *)) {
         gotContextMenu = true;
 
-        NSMenuItem *urlPatternMenuItem = nil;
-        NSMenuItem *nonMatchingMenuItem = nil;
+        RetainPtr<NSMenuItem> urlPatternMenuItem = nil;
+        RetainPtr<NSMenuItem> nonMatchingMenuItem = nil;
         for (NSMenuItem *menuItem in menu.itemArray) {
             if ([menuItem.title isEqualToString:@"URL Pattern Item"])
                 urlPatternMenuItem = menuItem;
@@ -1861,15 +1861,15 @@ TEST(WKWebExtensionAPIMenus, MacURLPatternContextMenuItems)
                 nonMatchingMenuItem = menuItem;
         }
 
-        EXPECT_NOT_NULL(urlPatternMenuItem);
-        EXPECT_NULL(nonMatchingMenuItem);
+        EXPECT_NOT_NULL(urlPatternMenuItem.get());
+        EXPECT_NULL(nonMatchingMenuItem.get());
 
-        performMenuItemAction(urlPatternMenuItem);
+        performMenuItemAction(urlPatternMenuItem.get());
 
         completionHandler(nil);
     };
 
-    auto manager = Util::loadExtension(menusManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(menusManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager runUntilTestMessage:@"Menus Created"];
 
@@ -1877,8 +1877,8 @@ TEST(WKWebExtensionAPIMenus, MacURLPatternContextMenuItems)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<a href='http://example.com/test' style='font-size: 100px'>Large Example Link</p>"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().webExtensionController = manager.get().controller;
@@ -1888,7 +1888,7 @@ TEST(WKWebExtensionAPIMenus, MacURLPatternContextMenuItems)
 
     manager.get().defaultTab.webView = webView.get();
 
-    [webView synchronouslyLoadRequest:urlRequest];
+    [webView synchronouslyLoadRequest:urlRequest.get()];
     [webView waitForNextPresentationUpdate];
 
     [webView.get().window makeFirstResponder:webView.get()];
@@ -1903,7 +1903,7 @@ TEST(WKWebExtensionAPIMenus, MacURLPatternContextMenuItems)
 
 TEST(WKWebExtensionAPIMenus, MacSelectionContextMenuItems)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.menus.create({",
         @"  id: 'selection-menu-item',",
         @"  title: 'Selected: %s',",
@@ -1953,7 +1953,7 @@ TEST(WKWebExtensionAPIMenus, MacSelectionContextMenuItems)
         completionHandler(nil);
     };
 
-    auto manager = Util::loadExtension(menusManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(menusManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager runUntilTestMessage:@"Menus Created"];
 
@@ -1961,8 +1961,8 @@ TEST(WKWebExtensionAPIMenus, MacSelectionContextMenuItems)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<p style='font-size: 100px'>Selection Example Text</p>"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().webExtensionController = manager.get().controller;
@@ -1972,7 +1972,7 @@ TEST(WKWebExtensionAPIMenus, MacSelectionContextMenuItems)
 
     manager.get().defaultTab.webView = webView.get();
 
-    [webView synchronouslyLoadRequest:urlRequest];
+    [webView synchronouslyLoadRequest:urlRequest.get()];
     [webView waitForNextPresentationUpdate];
 
     [webView.get().window makeFirstResponder:webView.get()];
@@ -1987,7 +1987,7 @@ TEST(WKWebExtensionAPIMenus, MacSelectionContextMenuItems)
 
 TEST(WKWebExtensionAPIMenus, MacLinkContextMenuItems)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.menus.create({",
         @"  id: 'link-menu-item',",
         @"  title: 'Link Item',",
@@ -2038,7 +2038,7 @@ TEST(WKWebExtensionAPIMenus, MacLinkContextMenuItems)
         completionHandler(nil);
     };
 
-    auto manager = Util::loadExtension(menusManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(menusManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager runUntilTestMessage:@"Menus Created"];
 
@@ -2046,8 +2046,8 @@ TEST(WKWebExtensionAPIMenus, MacLinkContextMenuItems)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<a href='http://example.com/test' style='font-size: 100px'>Large Example Link</p>"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().webExtensionController = manager.get().controller;
@@ -2057,7 +2057,7 @@ TEST(WKWebExtensionAPIMenus, MacLinkContextMenuItems)
 
     manager.get().defaultTab.webView = webView.get();
 
-    [webView synchronouslyLoadRequest:urlRequest];
+    [webView synchronouslyLoadRequest:urlRequest.get()];
     [webView waitForNextPresentationUpdate];
 
     [webView.get().window makeFirstResponder:webView.get()];
@@ -2072,7 +2072,7 @@ TEST(WKWebExtensionAPIMenus, MacLinkContextMenuItems)
 
 TEST(WKWebExtensionAPIMenus, MacImageContextMenuItems)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.menus.create({",
         @"  id: 'image-menu-item',",
         @"  title: 'Image Item',",
@@ -2122,7 +2122,7 @@ TEST(WKWebExtensionAPIMenus, MacImageContextMenuItems)
         completionHandler(nil);
     };
 
-    auto manager = Util::loadExtension(menusManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(menusManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager runUntilTestMessage:@"Menus Created"];
 
@@ -2131,8 +2131,8 @@ TEST(WKWebExtensionAPIMenus, MacImageContextMenuItems)
         { "/test.png"_s, [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"400x400-green" withExtension:@"png"]] },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().webExtensionController = manager.get().controller;
@@ -2142,7 +2142,7 @@ TEST(WKWebExtensionAPIMenus, MacImageContextMenuItems)
 
     manager.get().defaultTab.webView = webView.get();
 
-    [webView synchronouslyLoadRequest:urlRequest];
+    [webView synchronouslyLoadRequest:urlRequest.get()];
     [webView waitForNextPresentationUpdate];
 
     [webView.get().window makeFirstResponder:webView.get()];
@@ -2157,7 +2157,7 @@ TEST(WKWebExtensionAPIMenus, MacImageContextMenuItems)
 
 TEST(WKWebExtensionAPIMenus, MacVideoContextMenuItems)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.menus.create({",
         @"  id: 'video-menu-item',",
         @"  title: 'Video Item',",
@@ -2207,7 +2207,7 @@ TEST(WKWebExtensionAPIMenus, MacVideoContextMenuItems)
         completionHandler(nil);
     };
 
-    auto manager = Util::loadExtension(menusManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(menusManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager runUntilTestMessage:@"Menus Created"];
 
@@ -2216,8 +2216,8 @@ TEST(WKWebExtensionAPIMenus, MacVideoContextMenuItems)
         { "/test.mp4"_s, [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"mp4"]] },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().webExtensionController = manager.get().controller;
@@ -2227,7 +2227,7 @@ TEST(WKWebExtensionAPIMenus, MacVideoContextMenuItems)
 
     manager.get().defaultTab.webView = webView.get();
 
-    [webView synchronouslyLoadRequest:urlRequest];
+    [webView synchronouslyLoadRequest:urlRequest.get()];
     [webView waitForNextPresentationUpdate];
 
     [webView.get().window makeFirstResponder:webView.get()];
@@ -2242,7 +2242,7 @@ TEST(WKWebExtensionAPIMenus, MacVideoContextMenuItems)
 
 TEST(WKWebExtensionAPIMenus, MacAudioContextMenuItems)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.menus.create({",
         @"  id: 'audio-menu-item',",
         @"  title: 'Audio Item',",
@@ -2292,7 +2292,7 @@ TEST(WKWebExtensionAPIMenus, MacAudioContextMenuItems)
         completionHandler(nil);
     };
 
-    auto manager = Util::loadExtension(menusManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(menusManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager runUntilTestMessage:@"Menus Created"];
 
@@ -2301,8 +2301,8 @@ TEST(WKWebExtensionAPIMenus, MacAudioContextMenuItems)
         { "/test.m4a"_s, [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"silence-long" withExtension:@"m4a"]] },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().webExtensionController = manager.get().controller;
@@ -2312,7 +2312,7 @@ TEST(WKWebExtensionAPIMenus, MacAudioContextMenuItems)
 
     manager.get().defaultTab.webView = webView.get();
 
-    [webView synchronouslyLoadRequest:urlRequest];
+    [webView synchronouslyLoadRequest:urlRequest.get()];
     [webView waitForNextPresentationUpdate];
 
     [webView.get().window makeFirstResponder:webView.get()];
@@ -2327,7 +2327,7 @@ TEST(WKWebExtensionAPIMenus, MacAudioContextMenuItems)
 
 TEST(WKWebExtensionAPIMenus, MacEditableContextMenuItems)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.menus.create({",
         @"  id: 'editable-menu-item',",
         @"  title: 'Editable Item',",
@@ -2373,7 +2373,7 @@ TEST(WKWebExtensionAPIMenus, MacEditableContextMenuItems)
         completionHandler(nil);
     };
 
-    auto manager = Util::loadExtension(menusManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(menusManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager runUntilTestMessage:@"Menus Created"];
 
@@ -2381,8 +2381,8 @@ TEST(WKWebExtensionAPIMenus, MacEditableContextMenuItems)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<textarea style='font-size: 50px; width: 400px; height: 400px; white-space: nowrap;'>Editable Text Area</textarea>"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().webExtensionController = manager.get().controller;
@@ -2392,7 +2392,7 @@ TEST(WKWebExtensionAPIMenus, MacEditableContextMenuItems)
 
     manager.get().defaultTab.webView = webView.get();
 
-    [webView synchronouslyLoadRequest:urlRequest];
+    [webView synchronouslyLoadRequest:urlRequest.get()];
     [webView waitForNextPresentationUpdate];
 
     [webView.get().window makeFirstResponder:webView.get()];
@@ -2407,7 +2407,7 @@ TEST(WKWebExtensionAPIMenus, MacEditableContextMenuItems)
 
 TEST(WKWebExtensionAPIMenus, MacFrameContextMenuItems)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.menus.create({",
         @"  id: 'frame-menu-item',",
         @"  title: 'Frame Item',",
@@ -2455,7 +2455,7 @@ TEST(WKWebExtensionAPIMenus, MacFrameContextMenuItems)
         completionHandler(nil);
     };
 
-    auto manager = Util::loadExtension(menusManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(menusManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager runUntilTestMessage:@"Menus Created"];
 
@@ -2464,8 +2464,8 @@ TEST(WKWebExtensionAPIMenus, MacFrameContextMenuItems)
         { "/frame.html"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:server.requestWithLocalhost("/frame.html"_s).URL];
 
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
@@ -2476,7 +2476,7 @@ TEST(WKWebExtensionAPIMenus, MacFrameContextMenuItems)
 
     manager.get().defaultTab.webView = webView.get();
 
-    [webView synchronouslyLoadRequest:urlRequest];
+    [webView synchronouslyLoadRequest:urlRequest.get()];
     [webView waitForNextPresentationUpdate];
 
     [webView.get().window makeFirstResponder:webView.get()];
@@ -2491,7 +2491,7 @@ TEST(WKWebExtensionAPIMenus, MacFrameContextMenuItems)
 
 TEST(WKWebExtensionAPIMenus, ClickedMenuItemAndPermissionsRequest)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.menus.create({",
         @"  id: 'click-item',",
         @"  title: 'Click Item',",
@@ -2510,7 +2510,7 @@ TEST(WKWebExtensionAPIMenus, ClickedMenuItemAndPermissionsRequest)
         @"}, () => browser.test.sendMessage('Menu Item Created'))"
     ]);
 
-    auto manager = Util::loadExtension(menusManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(menusManifest, @{ @"background.js": backgroundScript.get() });
 
     manager.get().internalDelegate.promptForPermissions = ^(id<WKWebExtensionTab> tab, NSSet<NSString *> *requestedPermissions, void (^callback)(NSSet<NSString *> *, NSDate *)) {
         EXPECT_EQ(requestedPermissions.count, 1lu);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPINamespace.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPINamespace.mm
@@ -45,12 +45,12 @@ TEST(WKWebExtensionAPINamespace, NoWebNavigationObjectWithoutPermission)
         }
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.assertEq(typeof browser.webNavigation, 'undefined')",
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript.get() });
 
     // Deny the permission, since TestWebKitAPI auto grants all requested permissions.
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusDeniedExplicitly forPermission:WKWebExtensionPermissionWebNavigation];
@@ -70,14 +70,14 @@ TEST(WKWebExtensionAPINamespace, WebNavigationObjectWithPermission)
         }
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.assertEq(typeof browser.webNavigation, 'object')",
         @"browser.test.notifyPass()"
     ]);
 
     // TestWebKitAPI auto grants all requested permissions.
 
-    Util::loadAndRunExtension(manifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(manifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPINamespace, NoNotificationsObjectWithoutPermission)
@@ -92,12 +92,12 @@ TEST(WKWebExtensionAPINamespace, NoNotificationsObjectWithoutPermission)
         }
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.assertEq(typeof browser.notifications, 'undefined')",
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript.get() });
 
     // Deny the permission, since TestWebKitAPI auto grants all requested permissions.
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusDeniedExplicitly forPermission:@"notifications"];
@@ -117,14 +117,14 @@ TEST(WKWebExtensionAPINamespace, NotificationsObjectWithPermission)
         }
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.assertEq(typeof browser.notifications, 'object')",
         @"browser.test.notifyPass()"
     ]);
 
     // TestWebKitAPI auto grants all requested permissions.
 
-    Util::loadAndRunExtension(manifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(manifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPINamespace, NotificationsUnsupported)
@@ -139,13 +139,13 @@ TEST(WKWebExtensionAPINamespace, NotificationsUnsupported)
         }
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.assertEq(browser.notifications, undefined)",
 
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::parseExtension(manifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::parseExtension(manifest, @{ @"background.js": backgroundScript.get() });
 
     manager.get().context.unsupportedAPIs = [NSSet setWithObject:@"browser.notifications"];
 
@@ -165,7 +165,7 @@ TEST(WKWebExtensionAPINamespace, ObjectEquality)
         }
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.assertEq(browser.storage, browser.storage)",
         @"browser.test.assertEq(browser.storage.local, browser.storage.local)",
         @"browser.test.assertEq(browser.storage.session, browser.storage.session)",
@@ -176,7 +176,7 @@ TEST(WKWebExtensionAPINamespace, ObjectEquality)
         @"browser.test.notifyPass()"
     ]);
 
-    Util::loadAndRunExtension(manifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(manifest, @{ @"background.js": backgroundScript.get() });
 }
 
 
@@ -201,25 +201,25 @@ TEST(WKWebExtensionAPINamespace, BrowserNamespaceIsAvailableInContentScripts)
         } ]
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.sendMessage('Background page loaded')"
     ]);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"browser.test.assertEq(typeof browser, 'object')",
         @"browser.test.notifyPass()",
     ]);
 
     auto manager = Util::parseExtension(manifest, @{
-        @"background.js": backgroundScript,
-        @"content.js": contentScript
+        @"background.js": backgroundScript.get(),
+        @"content.js": contentScript.get()
     });
 
-    auto *urlRequest = server.requestWithLocalhost();
+    RetainPtr urlRequest = server.requestWithLocalhost();
 
     // Steps to reproduce:
     // Step 1: Navigate to a page
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
     [manager.get().defaultTab.webView _test_waitForDidFinishNavigation];
 
     // Step 2: Enable the extension
@@ -227,7 +227,7 @@ TEST(WKWebExtensionAPINamespace, BrowserNamespaceIsAvailableInContentScripts)
     [manager runUntilTestMessage:@"Background page loaded"];
 
     // Step 3: Grant it access to the page
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     // Step 4: Disable the extension
     [manager unload];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIPermissions.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIPermissions.mm
@@ -51,7 +51,7 @@ TEST(WKWebExtensionAPIPermissions, Errors)
         @"host_permissions": @[ @"*://*.apple.com/*" ]
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"await browser.test.assertRejects(browser.permissions.remove({ permissions: ['webRequest'] }), /only permissions specified in the manifest may be removed/i)",
         @"await browser.test.assertRejects(browser.permissions.remove({ origins: ['https://example.com/'] }), /only permissions specified in the manifest may be removed/i)",
 
@@ -78,7 +78,7 @@ TEST(WKWebExtensionAPIPermissions, Errors)
         @"browser.test.notifyPass()"
     ]);
 
-    Util::loadAndRunExtension(manifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(manifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPIPermissions, Basics)
@@ -91,7 +91,7 @@ TEST(WKWebExtensionAPIPermissions, Basics)
         @"host_permissions": @[ @"*://*.apple.com/*" ]
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         // contains() should return true for all named permissions and granted match patterns.
         @"browser.test.assertTrue(await browser.permissions.contains({'permissions': ['alarms', 'activeTab']}))",
         @"browser.test.assertTrue(await browser.permissions.contains({'origins': ['*://webkit.org/*']}))",
@@ -117,7 +117,7 @@ TEST(WKWebExtensionAPIPermissions, Basics)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript.get() });
 
     // Grant "permissions" in the manifest.
     for (NSString *permission in manager.get().extension.requestedPermissions)
@@ -143,13 +143,13 @@ TEST(WKWebExtensionAPIPermissions, AcceptPermissionsRequest)
         @"host_permissions": @[ @"*://*.apple.com/*" ]
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.runWithUserGesture(async () => {",
         @"  browser.test.assertTrue(await browser.permissions.request({'permissions': ['declarativeNetRequest'], 'origins': ['*://*.apple.com/*']}))",
         @"})"
     ]);
 
-    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript.get() });
 
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().webExtensionController = manager.get().controller;
@@ -190,13 +190,13 @@ TEST(WKWebExtensionAPIPermissions, DenyPermissionsRequest)
         @"optional_host_permissions": @[ @"*://*.apple.com/*" ]
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.runWithUserGesture(async () => {",
         @"  browser.test.assertFalse(await browser.permissions.request({'permissions': ['declarativeNetRequest'], 'origins': ['*://*.apple.com/*']}))",
         @"})"
     ]);
 
-    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript.get() });
 
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().webExtensionController = manager.get().controller;
@@ -228,13 +228,13 @@ TEST(WKWebExtensionAPIPermissions, AcceptPermissionsDenyMatchPatternsRequest)
         @"optional_host_permissions": @[ @"*://*.apple.com/*" ]
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.runWithUserGesture(async () => {",
         @"  browser.test.assertFalse(await browser.permissions.request({'permissions': ['declarativeNetRequest'], 'origins': ['*://*.apple.com/*']}))",
         @"})"
     ]);
 
-    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript.get() });
 
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().webExtensionController = manager.get().controller;
@@ -267,13 +267,13 @@ TEST(WKWebExtensionAPIPermissions, RequestPermissionsOnly)
         @"optional_host_permissions": @[ @"*://*.apple.com/*" ]
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.runWithUserGesture(async () => {",
         @"  browser.test.assertTrue(await browser.permissions.request({'permissions': ['declarativeNetRequest']}))",
         @"})"
     ]);
 
-    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript.get() });
 
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().webExtensionController = manager.get().controller;
@@ -308,13 +308,13 @@ TEST(WKWebExtensionAPIPermissions, RequestMatchPatternsOnly)
         @"optional_host_permissions": @[ @"*://*.apple.com/*" ]
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.runWithUserGesture(async () => {",
         @"  browser.test.assertTrue(await browser.permissions.request({'origins': ['*://*.apple.com/*']}))",
         @"})"
     ]);
 
-    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript.get() });
 
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().webExtensionController = manager.get().controller;
@@ -348,13 +348,13 @@ TEST(WKWebExtensionAPIPermissions, RequestAllURLsMatchPattern)
         @"optional_host_permissions": @[ @"<all_urls>" ]
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.runWithUserGesture(async () => {",
         @"  browser.test.assertTrue(await browser.permissions.request({'origins': ['<all_urls>']}))",
         @"})"
     ]);
 
-    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript.get() });
 
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().webExtensionController = manager.get().controller;
@@ -389,7 +389,7 @@ TEST(WKWebExtensionAPIPermissions, ImplicitAllHostsAndURLsPermissions)
         @"permissions": @[ @"tabs" ],
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.onMessage.addListener(async (message, data) => {",
         @"  if (message != 'Run test') return",
 
@@ -402,7 +402,7 @@ TEST(WKWebExtensionAPIPermissions, ImplicitAllHostsAndURLsPermissions)
         @"browser.test.sendMessage('Loaded')",
     ]);
 
-    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript.get() });
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:WKWebExtensionMatchPattern.allHostsAndSchemesMatchPattern];
 
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
@@ -422,7 +422,7 @@ TEST(WKWebExtensionAPIPermissions, AllHostsHostPermissions)
         @"host_permissions": @[ @"*://*/*" ],
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.onMessage.addListener(async (message, data) => {",
         @"  if (message != 'Run test') return",
 
@@ -437,7 +437,7 @@ TEST(WKWebExtensionAPIPermissions, AllHostsHostPermissions)
         @"browser.test.sendMessage('Loaded')",
     ]);
 
-    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript.get() });
 
     WKWebExtensionMatchPattern *allHostsMatchPattern = [WKWebExtensionMatchPattern matchPatternWithString:@"*://*/*"];
     WKWebExtensionMatchPattern *allURLsMatchPattern = [WKWebExtensionMatchPattern allURLsMatchPattern];
@@ -467,7 +467,7 @@ TEST(WKWebExtensionAPIPermissions, AllURLsHostPermissions)
         @"host_permissions": @[ @"<all_urls>" ],
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.onMessage.addListener(async (message, data) => {",
         @"  if (message != 'Run test') return",
 
@@ -482,7 +482,7 @@ TEST(WKWebExtensionAPIPermissions, AllURLsHostPermissions)
         @"browser.test.sendMessage('Loaded')",
     ]);
 
-    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript.get() });
 
     WKWebExtensionMatchPattern *allHostsMatchPattern = [WKWebExtensionMatchPattern matchPatternWithString:@"*://*/*"];
     WKWebExtensionMatchPattern *allURLsMatchPattern = [WKWebExtensionMatchPattern allURLsMatchPattern];
@@ -512,7 +512,7 @@ TEST(WKWebExtensionAPIPermissions, AllHostsOptionalHostPermissions)
         @"optional_host_permissions": @[ @"*://*/*" ],
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.onMessage.addListener(async (message, data) => {",
         @"  if (message != 'Run test') return",
 
@@ -527,7 +527,7 @@ TEST(WKWebExtensionAPIPermissions, AllHostsOptionalHostPermissions)
         @"browser.test.sendMessage('Loaded')",
     ]);
 
-    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript.get() });
 
     WKWebExtensionMatchPattern *allHostsMatchPattern = [WKWebExtensionMatchPattern matchPatternWithString:@"*://*/*"];
     WKWebExtensionMatchPattern *allURLsMatchPattern = [WKWebExtensionMatchPattern allURLsMatchPattern];
@@ -557,7 +557,7 @@ TEST(WKWebExtensionAPIPermissions, AllURLsOptionalHostPermissions)
         @"optional_host_permissions": @[ @"<all_urls>" ],
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.onMessage.addListener(async (message, data) => {",
         @"  if (message != 'Run test') return",
 
@@ -572,7 +572,7 @@ TEST(WKWebExtensionAPIPermissions, AllURLsOptionalHostPermissions)
         @"browser.test.sendMessage('Loaded')",
     ]);
 
-    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript.get() });
 
     WKWebExtensionMatchPattern *allHostsMatchPattern = [WKWebExtensionMatchPattern matchPatternWithString:@"*://*/*"];
     WKWebExtensionMatchPattern *allURLsMatchPattern = [WKWebExtensionMatchPattern allURLsMatchPattern];
@@ -602,7 +602,7 @@ TEST(WKWebExtensionAPIPermissions, AllHostsAndURLsHostPermissions)
         @"host_permissions": @[ @"*://*/*", @"<all_urls>" ],
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.onMessage.addListener(async (message, data) => {",
         @"  if (message != 'Run test') return",
 
@@ -617,7 +617,7 @@ TEST(WKWebExtensionAPIPermissions, AllHostsAndURLsHostPermissions)
         @"browser.test.sendMessage('Loaded')",
     ]);
 
-    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript.get() });
 
     WKWebExtensionMatchPattern *allHostsMatchPattern = [WKWebExtensionMatchPattern matchPatternWithString:@"*://*/*"];
     WKWebExtensionMatchPattern *allURLsMatchPattern = [WKWebExtensionMatchPattern allURLsMatchPattern];
@@ -647,7 +647,7 @@ TEST(WKWebExtensionAPIPermissions, AllHostsAndURLsOptionalHostPermissions)
         @"optional_host_permissions": @[ @"*://*/*", @"<all_urls>" ],
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.onMessage.addListener(async (message, data) => {",
         @"  if (message != 'Run test') return",
 
@@ -662,7 +662,7 @@ TEST(WKWebExtensionAPIPermissions, AllHostsAndURLsOptionalHostPermissions)
         @"browser.test.sendMessage('Loaded')",
     ]);
 
-    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript.get() });
 
     WKWebExtensionMatchPattern *allHostsMatchPattern = [WKWebExtensionMatchPattern matchPatternWithString:@"*://*/*"];
     WKWebExtensionMatchPattern *allURLsMatchPattern = [WKWebExtensionMatchPattern allURLsMatchPattern];
@@ -693,7 +693,7 @@ TEST(WKWebExtensionAPIPermissions, AllHostsAndURLsOptionalAndHostPermissions)
         @"optional_host_permissions": @[ @"<all_urls>" ],
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.onMessage.addListener(async (message, data) => {",
         @"  if (message != 'Run test') return",
 
@@ -708,7 +708,7 @@ TEST(WKWebExtensionAPIPermissions, AllHostsAndURLsOptionalAndHostPermissions)
         @"browser.test.sendMessage('Loaded')",
     ]);
 
-    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript.get() });
 
     WKWebExtensionMatchPattern *allHostsMatchPattern = [WKWebExtensionMatchPattern matchPatternWithString:@"*://*/*"];
     WKWebExtensionMatchPattern *allURLsMatchPattern = [WKWebExtensionMatchPattern allURLsMatchPattern];
@@ -739,13 +739,13 @@ TEST(WKWebExtensionAPIPermissions, GrantOnlySomePermissions)
         @"optional_host_permissions": @[ @"*://*.apple.com/*" ]
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.runWithUserGesture(async () => {",
         @"  browser.test.assertFalse(await browser.permissions.request({'permissions': ['alarms', 'declarativeNetRequest']}))",
         @"})"
     ]);
 
-    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript.get() });
 
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().webExtensionController = manager.get().controller;
@@ -780,13 +780,13 @@ TEST(WKWebExtensionAPIPermissions, GrantOnlySomeMatchPatterns)
         @"optional_host_permissions": @[ @"*://*.apple.com/*", @"*://*.example.com/*" ]
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.runWithUserGesture(async () => {",
         @"  browser.test.assertFalse(await browser.permissions.request({'origins': ['*://*.apple.com/*', '*://*.example.com/*']}))",
         @"})"
     ]);
 
-    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript.get() });
 
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().webExtensionController = manager.get().controller;
@@ -820,7 +820,7 @@ TEST(WKWebExtensionAPIPermissions, ValidMatchPatterns)
         @"host_permissions": @[ @"*://*.example.com/*" ]
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         // Supported Schemes
         @"await browser.test.assertSafeResolve(() => browser.permissions.contains({ origins: [ '*://*.example.com/*' ] }))",
         @"await browser.test.assertSafeResolve(() => browser.permissions.contains({ origins: [ 'http://*.example.com/*' ] }))",
@@ -844,7 +844,7 @@ TEST(WKWebExtensionAPIPermissions, ValidMatchPatterns)
     [WKWebExtensionMatchPattern registerCustomURLScheme:@"test-extension"];
     [WKWebExtensionMatchPattern registerCustomURLScheme:@"other-extension"];
 
-    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript.get() });
 
     WKWebExtensionMatchPattern *matchPatternApple = [WKWebExtensionMatchPattern matchPatternWithString:@"*://*.example.com/*"];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:matchPatternApple];
@@ -870,13 +870,13 @@ TEST(WKWebExtensionAPIPermissions, ClipboardWrite)
         @"permissions": @[ @"clipboardWrite" ],
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"await navigator.clipboard.writeText('Test Clipboard Write')",
 
         @"browser.test.sendMessage('Clipboard Written')",
     ]);
 
-    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionClipboardWrite];
 
@@ -907,7 +907,7 @@ TEST(WKWebExtensionAPIPermissions, ClipboardWriteWithoutPermission)
         },
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"try {",
         @"  await navigator.clipboard.writeText('Attempt Without Permission')",
 
@@ -925,7 +925,7 @@ TEST(WKWebExtensionAPIPermissions, ClipboardWriteWithoutPermission)
     auto *clipboardContentBefore = [NSPasteboard.generalPasteboard stringForType:NSPasteboardTypeString];
 #endif
 
-    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript.get() });
 
     [manager run];
 
@@ -956,7 +956,7 @@ TEST(WKWebExtensionAPIPermissions, ClipboardWriteWithRequest)
         @"optional_permissions": @[ @"clipboardWrite" ],
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"try {",
         @"  await navigator.clipboard.writeText('Initial Attempt Without Permission')",
         @"} catch (error) {",
@@ -976,7 +976,7 @@ TEST(WKWebExtensionAPIPermissions, ClipboardWriteWithRequest)
         @"}"
     ]);
 
-    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript.get() });
 
     auto requestDelegate = adoptNS([[TestWebExtensionsDelegate alloc] init]);
 
@@ -1022,7 +1022,7 @@ TEST(WKWebExtensionAPIPermissions, CORSUsingFetchWithPermissions)
         { "/subresource"_s, { {{ "Content-Type"_s, "application/json"_s }, { "headerName"_s, "headerValue"_s }}, "{ \"testKey\": \"testValue\" }"_s } }
     });
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         [NSString stringWithFormat:@"const subresourceURL = 'http://127.0.0.1:%d/subresource'", server.port()],
 
         @"try {",
@@ -1040,10 +1040,10 @@ TEST(WKWebExtensionAPIPermissions, CORSUsingFetchWithPermissions)
         @"}"
     ]);
 
-    auto manager = Util::loadExtension(corsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(corsManifest, @{ @"background.js": backgroundScript.get() });
 
-    auto *urlRequest = server.request();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.request();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager run];
 }
@@ -1056,7 +1056,7 @@ TEST(WKWebExtensionAPIPermissions, CORSUsingFetchWithoutPermissions)
 
     auto *subresourceURL = [NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/subresource", server.port()]];
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         [NSString stringWithFormat:@"const subresourceURL = '%@'", subresourceURL],
 
         @"browser.permissions.onAdded.addListener(async () => {",
@@ -1083,7 +1083,7 @@ TEST(WKWebExtensionAPIPermissions, CORSUsingFetchWithoutPermissions)
         @"}",
     ]);
 
-    auto manager = Util::loadExtension(corsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(corsManifest, @{ @"background.js": backgroundScript.get() });
 
     __block size_t promptCount = 0;
 
@@ -1109,7 +1109,7 @@ TEST(WKWebExtensionAPIPermissions, CORSUsingFetchWithoutGrantingPermission)
 
     auto *subresourceURL = [NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/subresource", server.port()]];
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         [NSString stringWithFormat:@"const subresourceURL = '%@'", subresourceURL],
 
         @"let fetchAttempt = 0",
@@ -1129,7 +1129,7 @@ TEST(WKWebExtensionAPIPermissions, CORSUsingFetchWithoutGrantingPermission)
         @"performFetch()"
     ]);
 
-    auto manager = Util::loadExtension(corsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(corsManifest, @{ @"background.js": backgroundScript.get() });
 
     __block size_t promptCount = 0;
 
@@ -1153,7 +1153,7 @@ TEST(WKWebExtensionAPIPermissions, CORSUsingXHRWithPermissions)
         { "/subresource"_s, { {{ "Content-Type"_s, "application/json"_s }, { "headerName"_s, "headerValue"_s }}, "{ \"testKey\": \"testValue\" }"_s } }
     });
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         [NSString stringWithFormat:@"const subresourceURL = 'http://127.0.0.1:%d/subresource'", server.port()],
 
         @"const xhr = new XMLHttpRequest()",
@@ -1179,10 +1179,10 @@ TEST(WKWebExtensionAPIPermissions, CORSUsingXHRWithPermissions)
         @"xhr.send()"
     ]);
 
-    auto manager = Util::loadExtension(corsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(corsManifest, @{ @"background.js": backgroundScript.get() });
 
-    auto *urlRequest = server.request();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.request();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager run];
 }
@@ -1195,7 +1195,7 @@ TEST(WKWebExtensionAPIPermissions, CORSUsingXHRWithoutPermissions)
 
     auto *subresourceURL = [NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/subresource", server.port()]];
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         [NSString stringWithFormat:@"const subresourceURL = '%@'", subresourceURL],
 
         @"browser.permissions.onAdded.addListener(() => {",
@@ -1234,7 +1234,7 @@ TEST(WKWebExtensionAPIPermissions, CORSUsingXHRWithoutPermissions)
         @"xhr.send()"
     ]);
 
-    auto manager = Util::loadExtension(corsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(corsManifest, @{ @"background.js": backgroundScript.get() });
 
     __block size_t promptCount = 0;
 
@@ -1260,7 +1260,7 @@ TEST(WKWebExtensionAPIPermissions, CORSUsingXHRWithoutGrantingPermission)
 
     auto *subresourceURL = [NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/subresource", server.port()]];
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         [NSString stringWithFormat:@"const subresourceURL = '%@'", subresourceURL],
 
         @"let fetchAttempt = 0",
@@ -1286,7 +1286,7 @@ TEST(WKWebExtensionAPIPermissions, CORSUsingXHRWithoutGrantingPermission)
         @"performXHR()"
     ]);
 
-    auto manager = Util::loadExtension(corsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(corsManifest, @{ @"background.js": backgroundScript.get() });
 
     __block size_t promptCount = 0;
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm
@@ -117,7 +117,7 @@ TEST(WKWebExtensionAPIRuntime, GetURL)
 {
     auto *baseURLString = @"test-extension://76C788B8-3374-400D-8259-40E5B9DF79D3";
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         // Variable Setup
         [NSString stringWithFormat:@"const baseURL = '%@'", baseURLString],
 
@@ -151,7 +151,7 @@ TEST(WKWebExtensionAPIRuntime, GetURL)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::parseExtension(runtimeManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::parseExtension(runtimeManifest, @{ @"background.js": backgroundScript.get() });
 
     // Set a base URL so it is a known value and not the default random one.
     [WKWebExtensionMatchPattern registerCustomURLScheme:@"test-extension"];
@@ -162,7 +162,7 @@ TEST(WKWebExtensionAPIRuntime, GetURL)
 
 TEST(WKWebExtensionAPIRuntime, GetBackgroundPageFromBackground)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"window.notifyTestPass = async () => {",
         @"  browser.test.notifyPass()",
         @"}",
@@ -174,13 +174,13 @@ TEST(WKWebExtensionAPIRuntime, GetBackgroundPageFromBackground)
     ]);
 
     Util::loadAndRunExtension(runtimeManifest, @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
     });
 }
 
 TEST(WKWebExtensionAPIRuntime, GetBackgroundPageFromTab)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"window.notifyTestPass = () => {",
         @"  browser.test.notifyPass()",
         @"}",
@@ -188,7 +188,7 @@ TEST(WKWebExtensionAPIRuntime, GetBackgroundPageFromTab)
         @"browser.tabs.create({ url: 'test.html' })"
     ]);
 
-    auto *testScript = Util::constructScript(@[
+    RetainPtr testScript = Util::constructScript(@[
         @"const backgroundPage = await browser.runtime.getBackgroundPage()",
         @"browser.test.assertSafe(() => backgroundPage.notifyTestPass())",
     ]);
@@ -196,15 +196,15 @@ TEST(WKWebExtensionAPIRuntime, GetBackgroundPageFromTab)
     auto *testHTML = @"<script type='module' src='test.js'></script>";
 
     Util::loadAndRunExtension(runtimeManifest, @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"test.html": testHTML,
-        @"test.js": testScript
+        @"test.js": testScript.get()
     });
 }
 
 TEST(WKWebExtensionAPIRuntime, GetBackgroundPageFromPopup)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"window.notifyTestPass = () => {",
         @"  browser.test.notifyPass()",
         @"}",
@@ -212,7 +212,7 @@ TEST(WKWebExtensionAPIRuntime, GetBackgroundPageFromPopup)
         @"browser.action.openPopup()"
     ]);
 
-    auto *popupScript = Util::constructScript(@[
+    RetainPtr popupScript = Util::constructScript(@[
         @"const backgroundPage = await browser.runtime.getBackgroundPage()",
         @"browser.test.assertSafe(() => backgroundPage.notifyTestPass())"
     ]);
@@ -220,9 +220,9 @@ TEST(WKWebExtensionAPIRuntime, GetBackgroundPageFromPopup)
     auto *popupHTML = @"<script type='module' src='popup.js'></script>";
 
     auto resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"popup.html": popupHTML,
-        @"popup.js": popupScript
+        @"popup.js": popupScript.get()
     };
 
     auto manager = Util::loadExtension(runtimeManifest, resources);
@@ -236,11 +236,11 @@ TEST(WKWebExtensionAPIRuntime, GetBackgroundPageFromPopup)
 
 TEST(WKWebExtensionAPIRuntime, GetBackgroundPageForServiceWorker)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.tabs.create({ url: 'test.html' })"
     ]);
 
-    auto *testScript = Util::constructScript(@[
+    RetainPtr testScript = Util::constructScript(@[
         @"const backgroundPage = await browser.runtime.getBackgroundPage()",
         @"browser.test.assertEq(backgroundPage, null, 'Background page should be null for service workers')",
         @"browser.test.notifyPass()"
@@ -249,21 +249,21 @@ TEST(WKWebExtensionAPIRuntime, GetBackgroundPageForServiceWorker)
     auto *testHTML = @"<script type='module' src='test.js'></script>";
 
     Util::loadAndRunExtension(runtimeServiceWorkerManifest, @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"test.html": testHTML,
-        @"test.js": testScript
+        @"test.js": testScript.get()
     });
 }
 
 TEST(WKWebExtensionAPIRuntime, SetUninstallURL)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.assertSafeResolve(() => browser.runtime.setUninstallURL('https://example.com/uninstall'))",
         @"browser.test.notifyPass()"
     ]);
 
     Util::loadAndRunExtension(runtimeManifest, @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
     });
 }
 
@@ -271,13 +271,13 @@ TEST(WKWebExtensionAPIRuntime, Id)
 {
     auto *uniqueIdentifier = @"org.webkit.test.extension (76C788B8)";
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         [NSString stringWithFormat:@"browser.test.assertEq(browser.runtime.id, '%@')", uniqueIdentifier],
 
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::parseExtension(runtimeManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::parseExtension(runtimeManifest, @{ @"background.js": backgroundScript.get() });
 
     // Set an uniqueIdentifier so it is a known value and not the default random one.
     manager.get().context.uniqueIdentifier = uniqueIdentifier;
@@ -299,13 +299,13 @@ TEST(WKWebExtensionAPIRuntime, GetManifest)
         @"unused" : [NSNull null],
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.assertDeepEq(browser.runtime.getManifest(), { manifest_version: 3, background: { persistent: false, scripts: [ 'background.js' ], type: 'module' }, unused: null })",
 
         @"browser.test.notifyPass()"
     ]);
 
-    Util::loadAndRunExtension(testManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(testManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPIRuntime, GetVersion)
@@ -322,13 +322,13 @@ TEST(WKWebExtensionAPIRuntime, GetVersion)
         }
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.assertEq(browser.runtime.getVersion(), '1.0')",
 
         @"browser.test.notifyPass()"
     ]);
 
-    Util::loadAndRunExtension(testManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(testManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPIRuntime, GetPlatformInfo)
@@ -345,7 +345,7 @@ TEST(WKWebExtensionAPIRuntime, GetPlatformInfo)
     auto *expectedInfo = @"{ os: 'unknown', arch: 'unknown' }";
 #endif
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.assertTrue(browser.runtime.getPlatformInfo() instanceof Promise)",
         [NSString stringWithFormat:@"browser.test.assertDeepEq(await browser.runtime.getPlatformInfo(), %@)", expectedInfo],
         [NSString stringWithFormat:@"browser.test.assertEq(browser.runtime.getPlatformInfo((info) => browser.test.assertDeepEq(info, %@)), undefined)", expectedInfo],
@@ -353,7 +353,7 @@ TEST(WKWebExtensionAPIRuntime, GetPlatformInfo)
         @"browser.test.notifyPass()"
     ]);
 
-    Util::loadAndRunExtension(runtimeManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(runtimeManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPIRuntime, GetFrameId)
@@ -363,13 +363,13 @@ TEST(WKWebExtensionAPIRuntime, GetFrameId)
         { "/subframe"_s, { { { "Content-Type"_s, "text/html"_s } }, "Subframe Content"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *urlRequest = server.requestWithLocalhost();
+    RetainPtr urlRequest = server.requestWithLocalhost();
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"if (window.top === window) {",
         @"  let mainFrameId = browser.runtime.getFrameId(window)",
         @"  browser.test.assertEq(mainFrameId, 0, 'Main frame should have frameId 0')",
@@ -394,20 +394,20 @@ TEST(WKWebExtensionAPIRuntime, GetFrameId)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::loadExtension(runtimeContentScriptManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
+    auto manager = Util::loadExtension(runtimeContentScriptManifest, @{ @"background.js": backgroundScript.get(), @"content.js": contentScript.get() });
 
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
 
 TEST(WKWebExtensionAPIRuntime, LastError)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.assertEq(typeof browser.runtime.lastError, 'object')",
         @"browser.test.assertEq(browser.runtime.lastError, null)",
 
@@ -416,7 +416,7 @@ TEST(WKWebExtensionAPIRuntime, LastError)
         @"browser.test.notifyPass()"
     ]);
 
-    Util::loadAndRunExtension(runtimeManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(runtimeManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPIRuntime, SendMessageFromContentScript)
@@ -425,10 +425,10 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromContentScript)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *urlRequest = server.requestWithLocalhost();
-    auto *urlString = urlRequest.URL.absoluteString;
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    auto *urlString = urlRequest.get().URL.absoluteString;
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         [NSString stringWithFormat:@"const expectedURL = '%@'", urlString],
         [NSString stringWithFormat:@"const expectedOrigin = '%@'", [urlString substringToIndex:urlString.length - 1]],
 
@@ -454,7 +454,7 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromContentScript)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"(async () => {",
         @"  const response = await browser.runtime.sendMessage({ content: 'Hello' })",
 
@@ -464,13 +464,13 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromContentScript)
         @"})()"
     ]);
 
-    auto manager = Util::loadExtension(runtimeContentScriptManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
+    auto manager = Util::loadExtension(runtimeContentScriptManifest, @{ @"background.js": backgroundScript.get(), @"content.js": contentScript.get() });
 
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -481,10 +481,10 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromContentScriptWithAsyncReply)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *urlRequest = server.requestWithLocalhost();
-    auto *urlString = urlRequest.URL.absoluteString;
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    auto *urlString = urlRequest.get().URL.absoluteString;
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         [NSString stringWithFormat:@"const expectedURL = '%@'", urlString],
         [NSString stringWithFormat:@"const expectedOrigin = '%@'", [urlString substringToIndex:urlString.length - 1]],
 
@@ -512,7 +512,7 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromContentScriptWithAsyncReply)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"(async () => {",
         @"  const response = await browser.runtime.sendMessage({ content: 'Hello' })",
 
@@ -522,13 +522,13 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromContentScriptWithAsyncReply)
         @"})()"
     ]);
 
-    auto manager = Util::loadExtension(runtimeContentScriptManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
+    auto manager = Util::loadExtension(runtimeContentScriptManifest, @{ @"background.js": backgroundScript.get(), @"content.js": contentScript.get() });
 
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -539,10 +539,10 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromContentScriptWithPromiseReply)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *urlRequest = server.requestWithLocalhost();
-    auto *urlString = urlRequest.URL.absoluteString;
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    auto *urlString = urlRequest.get().URL.absoluteString;
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         [NSString stringWithFormat:@"const expectedURL = '%@'", urlString],
         [NSString stringWithFormat:@"const expectedOrigin = '%@'", [urlString substringToIndex:urlString.length - 1]],
 
@@ -568,7 +568,7 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromContentScriptWithPromiseReply)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"(async () => {",
         @"  const response = await browser.runtime.sendMessage({ content: 'Hello' })",
 
@@ -578,13 +578,13 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromContentScriptWithPromiseReply)
         @"})()"
     ]);
 
-    auto manager = Util::loadExtension(runtimeContentScriptManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
+    auto manager = Util::loadExtension(runtimeContentScriptManifest, @{ @"background.js": backgroundScript.get(), @"content.js": contentScript.get() });
 
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -595,10 +595,10 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromContentScriptWithAsyncPromiseReply
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *urlRequest = server.requestWithLocalhost();
-    auto *urlString = urlRequest.URL.absoluteString;
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    auto *urlString = urlRequest.get().URL.absoluteString;
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         [NSString stringWithFormat:@"const expectedURL = '%@'", urlString],
         [NSString stringWithFormat:@"const expectedOrigin = '%@'", [urlString substringToIndex:urlString.length - 1]],
 
@@ -626,7 +626,7 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromContentScriptWithAsyncPromiseReply
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"(async () => {",
         @"  const response = await browser.runtime.sendMessage({ content: 'Hello' })",
 
@@ -636,13 +636,13 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromContentScriptWithAsyncPromiseReply
         @"})()"
     ]);
 
-    auto manager = Util::loadExtension(runtimeContentScriptManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
+    auto manager = Util::loadExtension(runtimeContentScriptManifest, @{ @"background.js": backgroundScript.get(), @"content.js": contentScript.get() });
 
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -653,10 +653,10 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromContentScriptWithNoReply)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *urlRequest = server.requestWithLocalhost();
-    auto *urlString = urlRequest.URL.absoluteString;
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    auto *urlString = urlRequest.get().URL.absoluteString;
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         [NSString stringWithFormat:@"const expectedURL = '%@'", urlString],
         [NSString stringWithFormat:@"const expectedOrigin = '%@'", [urlString substringToIndex:urlString.length - 1]],
 
@@ -682,7 +682,7 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromContentScriptWithNoReply)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"(async () => {",
         @"  const response = await browser.runtime.sendMessage({ content: 'Hello' })",
 
@@ -692,13 +692,13 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromContentScriptWithNoReply)
         @"})()"
     ]);
 
-    auto manager = Util::loadExtension(runtimeContentScriptManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
+    auto manager = Util::loadExtension(runtimeContentScriptManifest, @{ @"background.js": backgroundScript.get(), @"content.js": contentScript.get() });
 
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -717,7 +717,7 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromSubframe)
     auto *urlRequestMain = server.requestWithLocalhost("/main"_s);
     auto *urlRequestSubframe = server.request("/subframe"_s);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.runtime.onMessage.addListener((message, sender) => {",
         @"  browser.test.assertEq(message?.content, 'Hello from Subframe', 'Should receive the correct message from the subframe content script')",
         @"  return Promise.resolve({ content: 'Received your message' })",
@@ -726,7 +726,7 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromSubframe)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"(async () => {",
         @"  const response = await browser.runtime.sendMessage({ content: 'Hello from Subframe' })",
         @"  browser.test.assertEq(response?.content, 'Received your message', 'Should get the response from the background script')",
@@ -756,8 +756,8 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromSubframe)
     };
 
     auto *resources = @{
-        @"background.js": backgroundScript,
-        @"content.js": contentScript
+        @"background.js": backgroundScript.get(),
+        @"content.js": contentScript.get()
     };
 
     auto manager = Util::loadExtension(manifest, resources);
@@ -801,7 +801,7 @@ TEST(WKWebExtensionAPIRuntime, SendMessageWithTabFrameAndAsyncReply)
         } ],
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.runtime.onMessage.addListener((message, sender, sendResponse) => {",
         @"  if (message?.content === 'Hello from iframe')",
         @"    setTimeout(() => sendResponse({ content: 'Async reply from background' }), 500)",
@@ -812,7 +812,7 @@ TEST(WKWebExtensionAPIRuntime, SendMessageWithTabFrameAndAsyncReply)
         @"browser.test.sendMessage('Load Tab')",
     ]);
 
-    auto *iframeScript = Util::constructScript(@[
+    RetainPtr iframeScript = Util::constructScript(@[
         @"browser.runtime.onMessage.addListener((message, sender, sendResponse) => {",
         @"  // This listener should not be called since it is in the same frame as the sender,",
         @"  // but having it is needed to verify the background script is the responder.",
@@ -826,7 +826,7 @@ TEST(WKWebExtensionAPIRuntime, SendMessageWithTabFrameAndAsyncReply)
         @"browser.test.notifyPass()",
     ]);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"(function() {",
         @"  const iframe = document.createElement('iframe')",
         @"  iframe.src = browser.runtime.getURL('extension-frame.html')",
@@ -835,20 +835,20 @@ TEST(WKWebExtensionAPIRuntime, SendMessageWithTabFrameAndAsyncReply)
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
-        @"content.js": contentScript,
-        @"extension-frame.js": iframeScript,
+        @"background.js": backgroundScript.get(),
+        @"content.js": contentScript.get(),
+        @"extension-frame.js": iframeScript.get(),
         @"extension-frame.html": @"<script type='module' src='extension-frame.js'></script>",
     };
 
     auto manager = Util::loadExtension(extensionManifest, resources);
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -878,7 +878,7 @@ TEST(WKWebExtensionAPITabs, SendMessageFromBackgroundToOpenedWindow)
         ],
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.runtime.onMessage.addListener(async (message, sender) => {",
         @"  browser.test.assertEq(message, 'Begin Test', 'Message content should match')",
 
@@ -894,13 +894,13 @@ TEST(WKWebExtensionAPITabs, SendMessageFromBackgroundToOpenedWindow)
         @"browser.test.sendMessage('Load Tab')",
     ]);
 
-    auto *mainScript = Util::constructScript(@[
+    RetainPtr mainScript = Util::constructScript(@[
         @"browser.runtime.onMessage.addListener(() => {",
         @"  browser.test.fail('Main page should not receive messages intended for opened window')",
         @"})",
     ]);
 
-    auto *windowScript = Util::constructScript(@[
+    RetainPtr windowScript = Util::constructScript(@[
         @"browser.runtime.onMessage.addListener((message, sender, sendResponse) => {",
         @"  browser.test.assertEq(message, 'Hello, window!', 'Message should be received in the opened window')",
         @"  sendResponse('Message received')",
@@ -910,9 +910,9 @@ TEST(WKWebExtensionAPITabs, SendMessageFromBackgroundToOpenedWindow)
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
-        @"main-script.js": mainScript,
-        @"window-script.js": windowScript,
+        @"background.js": backgroundScript.get(),
+        @"main-script.js": mainScript.get(),
+        @"window-script.js": windowScript.get(),
     };
 
     auto manager = Util::loadExtension(manifest, resources);
@@ -944,9 +944,9 @@ TEST(WKWebExtensionAPIRuntime, SendMessageWithNaNValue)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *urlRequest = server.requestWithLocalhost();
+    RetainPtr urlRequest = server.requestWithLocalhost();
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.runtime.onMessage.addListener((message, sender, sendResponse) => {",
         @"  browser.test.assertEq(message?.value, null, 'The message value should be null')",
 
@@ -956,7 +956,7 @@ TEST(WKWebExtensionAPIRuntime, SendMessageWithNaNValue)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"(async () => {",
         @"  const response = await browser.runtime.sendMessage({ value: NaN })",
 
@@ -967,13 +967,13 @@ TEST(WKWebExtensionAPIRuntime, SendMessageWithNaNValue)
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
-        @"content.js": contentScript
+        @"background.js": backgroundScript.get(),
+        @"content.js": contentScript.get()
     };
 
     auto manager = Util::loadExtension(runtimeContentScriptManifest, resources);
 
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
@@ -993,7 +993,7 @@ TEST(WKWebExtensionAPIRuntime, ConnectFromContentScript)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.runtime?.onConnect.addListener((port) => {",
         @"  browser.test.assertEq(port?.name, 'testPort', 'Port name should be testPort')",
         @"  browser.test.assertEq(port?.error, null, 'Port error should be null')",
@@ -1013,7 +1013,7 @@ TEST(WKWebExtensionAPIRuntime, ConnectFromContentScript)
         @"})"
     ]);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"setTimeout(() => {",
         @"  const port = browser.runtime?.connect({ name: 'testPort' })",
         @"  browser.test.assertEq(typeof port, 'object', 'Port should be an object')",
@@ -1030,11 +1030,11 @@ TEST(WKWebExtensionAPIRuntime, ConnectFromContentScript)
         @"}, 1000)"
     ]);
 
-    auto manager = Util::loadExtension(runtimeContentScriptManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
+    auto manager = Util::loadExtension(runtimeContentScriptManifest, @{ @"background.js": backgroundScript.get(), @"content.js": contentScript.get() });
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -1050,7 +1050,7 @@ TEST(WKWebExtensionAPIRuntime, ConnectFromContentScriptWithImmediateMessage)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.runtime.onConnect.addListener((port) => {",
         @"  browser.test.assertEq(port.name, 'testPort', 'Port name should be testPort')",
         @"  browser.test.assertEq(port.error, null, 'Port error should be null')",
@@ -1061,7 +1061,7 @@ TEST(WKWebExtensionAPIRuntime, ConnectFromContentScriptWithImmediateMessage)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"const port = browser.runtime.connect({ name: 'testPort' })",
         @"browser.test.assertEq(typeof port, 'object', 'Port should be an object')",
         @"browser.test.assertEq(port.name, 'testPort', 'Port name should be testPort')",
@@ -1074,18 +1074,18 @@ TEST(WKWebExtensionAPIRuntime, ConnectFromContentScriptWithImmediateMessage)
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
-        @"content.js": contentScript
+        @"background.js": backgroundScript.get(),
+        @"content.js": contentScript.get()
     };
 
     auto manager = Util::loadExtension(runtimeContentScriptManifest, resources);
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -1104,7 +1104,7 @@ TEST(WKWebExtensionAPIRuntime, ConnectFromSubframe)
     auto *urlRequestMain = server.requestWithLocalhost("/main"_s);
     auto *urlRequestSubframe = server.request("/subframe"_s);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.runtime.onConnect.addListener((port) => {",
         @"  browser.test.assertEq(port.name, 'subframePort', 'Port name should be subframePort')",
 
@@ -1117,7 +1117,7 @@ TEST(WKWebExtensionAPIRuntime, ConnectFromSubframe)
         @"browser.test.sendMessage('Load Tab')",
     ]);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"(async () => {",
         @"  const port = browser.runtime.connect({ name: 'subframePort' })",
         @"  port.postMessage('Hello from Subframe')",
@@ -1151,8 +1151,8 @@ TEST(WKWebExtensionAPIRuntime, ConnectFromSubframe)
     };
 
     auto *resources = @{
-        @"background.js": backgroundScript,
-        @"content.js": contentScript
+        @"background.js": backgroundScript.get(),
+        @"content.js": contentScript.get()
     };
 
     auto manager = Util::loadExtension(manifest, resources);
@@ -1177,7 +1177,7 @@ TEST(WKWebExtensionAPIRuntime, ConnectFromContentScriptWithMultipleListeners)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.runtime?.onConnect.addListener((port) => {",
         @"  browser.test.assertEq(port?.name, 'testPort', 'Port name should be testPort in first listener')",
         @"  browser.test.assertEq(port?.error, null, 'Port error should be null in first listener')",
@@ -1215,7 +1215,7 @@ TEST(WKWebExtensionAPIRuntime, ConnectFromContentScriptWithMultipleListeners)
         @"})"
     ]);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"setTimeout(() => {",
         @"  const port = browser.runtime?.connect({ name: 'testPort' })",
         @"  browser.test.assertEq(typeof port, 'object', 'Port should be an object')",
@@ -1234,11 +1234,11 @@ TEST(WKWebExtensionAPIRuntime, ConnectFromContentScriptWithMultipleListeners)
         @"}, 1000)"
     ]);
 
-    auto manager = Util::loadExtension(runtimeContentScriptManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
+    auto manager = Util::loadExtension(runtimeContentScriptManifest, @{ @"background.js": backgroundScript.get(), @"content.js": contentScript.get() });
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -1254,7 +1254,7 @@ TEST(WKWebExtensionAPIRuntime, PortDisconnectFromContentScript)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.runtime?.onConnect.addListener((port) => {",
         @"  browser.test.assertEq(port?.name, 'testPort', 'Port name should be testPort')",
 
@@ -1270,7 +1270,7 @@ TEST(WKWebExtensionAPIRuntime, PortDisconnectFromContentScript)
         @"})"
     ]);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"setTimeout(() => {",
         @"  const port = browser.runtime?.connect({ name: 'testPort' })",
         @"  browser.test.assertEq(typeof port, 'object', 'Port should be an object')",
@@ -1287,11 +1287,11 @@ TEST(WKWebExtensionAPIRuntime, PortDisconnectFromContentScript)
         @"}, 1000)"
     ]);
 
-    auto manager = Util::loadExtension(runtimeContentScriptManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
+    auto manager = Util::loadExtension(runtimeContentScriptManifest, @{ @"background.js": backgroundScript.get(), @"content.js": contentScript.get() });
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -1307,7 +1307,7 @@ TEST(WKWebExtensionAPIRuntime, PortDisconnectFromContentScriptWithMultipleListen
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.runtime?.onConnect.addListener((port) => {",
         @"  browser.test.assertEq(port?.name, 'testPort', 'Port name should be testPort')",
 
@@ -1330,7 +1330,7 @@ TEST(WKWebExtensionAPIRuntime, PortDisconnectFromContentScriptWithMultipleListen
         @"})"
     ]);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"let messagesReceived = 0",
 
         @"setTimeout(() => {",
@@ -1350,18 +1350,18 @@ TEST(WKWebExtensionAPIRuntime, PortDisconnectFromContentScriptWithMultipleListen
         @"}, 1000)"
     ]);
 
-    auto manager = Util::loadExtension(runtimeContentScriptManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
+    auto manager = Util::loadExtension(runtimeContentScriptManifest, @{ @"background.js": backgroundScript.get(), @"content.js": contentScript.get() });
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
 
 TEST(WKWebExtensionAPIRuntime, ConnectFromPopup)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.runtime?.onConnect.addListener((port) => {",
         @"  port?.onMessage.addListener((message) => {",
         @"    browser.test.assertEq(message, 'Hello from popup', 'Should receive the correct message content')",
@@ -1373,7 +1373,7 @@ TEST(WKWebExtensionAPIRuntime, ConnectFromPopup)
         @"browser.action?.openPopup()"
     ]);
 
-    auto *popupScript = Util::constructScript(@[
+    RetainPtr popupScript = Util::constructScript(@[
         @"const port = browser.runtime?.connect({ name: 'testPort' })",
         @"browser.test.assertEq(typeof port, 'object', 'Port should be an object')",
         @"browser.test.assertEq(port?.name, 'testPort', 'Port name should be testPort')",
@@ -1389,9 +1389,9 @@ TEST(WKWebExtensionAPIRuntime, ConnectFromPopup)
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"popup.html": @"<script type='module' src='popup.js'></script>",
-        @"popup.js": popupScript
+        @"popup.js": popupScript.get()
     };
 
     auto manager = Util::loadExtension(runtimeManifest, resources);
@@ -1405,14 +1405,14 @@ TEST(WKWebExtensionAPIRuntime, ConnectFromPopup)
 
 TEST(WKWebExtensionAPIRuntime, SendNativeMessage)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const response = await browser.test.assertSafeResolve(() => browser.runtime.sendNativeMessage('test', 'Hello'))",
         @"browser.test.assertEq(response, 'Received', 'Should get the response from the native app')",
 
         @"browser.test.notifyPass()",
     ]);
 
-    auto manager = Util::loadExtension(runtimeManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(runtimeManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionNativeMessaging];
 
@@ -1430,13 +1430,13 @@ TEST(WKWebExtensionAPIRuntime, SendNativeMessage)
 
 TEST(WKWebExtensionAPIRuntime, SendNativeMessageWithInvalidReply)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"await browser.test.assertRejects(browser.runtime.sendNativeMessage('test', 'Hello'), /reply message was not JSON-serializable/i)",
 
         @"browser.test.notifyPass()",
     ]);
 
-    auto manager = Util::loadExtension(runtimeManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(runtimeManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionNativeMessaging];
 
@@ -1454,7 +1454,7 @@ TEST(WKWebExtensionAPIRuntime, SendNativeMessageWithInvalidReply)
 
 TEST(WKWebExtensionAPIRuntime, ConnectNative)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const port = browser.runtime?.connectNative('test')",
         @"browser.test.assertEq(typeof port, 'object', 'Port should be an object')",
         @"browser.test.assertEq(port?.name, 'test', 'Port name should be test')",
@@ -1477,7 +1477,7 @@ TEST(WKWebExtensionAPIRuntime, ConnectNative)
         @"port?.postMessage('Hello')"
     ]);
 
-    auto manager = Util::loadExtension(runtimeManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(runtimeManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionNativeMessaging];
 
@@ -1505,12 +1505,12 @@ TEST(WKWebExtensionAPIRuntime, ConnectNative)
 
 TEST(WKWebExtensionAPIRuntime, ConnectNativeWithInvalidMessage)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const port = browser.runtime?.connectNative('test')",
         @"port?.postMessage('Hello')"
     ]);
 
-    auto manager = Util::loadExtension(runtimeManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(runtimeManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionNativeMessaging];
 
@@ -1536,7 +1536,7 @@ TEST(WKWebExtensionAPIRuntime, ConnectNativeWithInvalidMessage)
 
 TEST(WKWebExtensionAPIRuntime, ConnectNativeWithUndefinedMessage)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const port = browser.runtime?.connectNative('test')",
         @"browser.test.assertEq(typeof port, 'object', 'Port should be an object')",
         @"browser.test.assertEq(port?.name, 'test', 'Port name should be test')",
@@ -1551,7 +1551,7 @@ TEST(WKWebExtensionAPIRuntime, ConnectNativeWithUndefinedMessage)
         @"port?.postMessage('Hello')"
     ]);
 
-    auto manager = Util::loadExtension(runtimeManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(runtimeManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionNativeMessaging];
 
@@ -1577,19 +1577,19 @@ TEST(WKWebExtensionAPIRuntime, ConnectNativeWithUndefinedMessage)
 
 TEST(WKWebExtensionAPIRuntime, Reload)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.sendMessage('Loaded')",
         @"browser.runtime.reload()"
     ]);
 
-    auto manager = Util::loadExtension(runtimeManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(runtimeManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager runUntilTestMessage:@"Loaded"];
 }
 
 TEST(WKWebExtensionAPIRuntime, StartupEvent)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.runtime.onStartup.addListener(() => {",
         @"  browser.test.sendMessage('Startup Event Fired')",
         @"})",
@@ -1599,7 +1599,7 @@ TEST(WKWebExtensionAPIRuntime, StartupEvent)
         @"}, 1000)"
     ]);
 
-    auto manager = Util::loadExtension(runtimeManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(runtimeManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager runUntilTestMessage:@"Startup Event Fired"];
 
@@ -1612,7 +1612,7 @@ TEST(WKWebExtensionAPIRuntime, StartupEvent)
 
 TEST(WKWebExtensionAPIRuntime, InstalledEvent)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.runtime.onInstalled.addListener((details) => {",
         @"  browser.test.assertEq(details.reason, 'install')",
 
@@ -1624,7 +1624,7 @@ TEST(WKWebExtensionAPIRuntime, InstalledEvent)
         @"}, 1000)"
     ]);
 
-    auto manager = Util::parseExtension(runtimeManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::parseExtension(runtimeManifest, @{ @"background.js": backgroundScript.get() });
 
     // Wait until after startup event time expires.
     [manager runForTimeInterval:5];
@@ -1641,12 +1641,12 @@ TEST(WKWebExtensionAPIRuntime, InstalledEvent)
 
 TEST(WKWebExtensionAPIRuntime, OpenOptionsPage)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.assertSafeResolve(() => browser.runtime.openOptionsPage())"
     ]);
 
     auto resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"options.html": @"Hello world!"
     };
 
@@ -1672,7 +1672,7 @@ TEST(WKWebExtensionAPIRuntime, ConnectFromWebPage)
 {
     auto *uniqueIdentifier = @"org.webkit.test.extension (76C788B8)";
 
-    auto *webpageScript = Util::constructScript(@[
+    RetainPtr webpageScript = Util::constructScript(@[
         @"<script>",
         @"setTimeout(() => {",
         [NSString stringWithFormat:@"const port = browser?.runtime?.connect('%@', { name: 'testPort' })", uniqueIdentifier],
@@ -1691,12 +1691,12 @@ TEST(WKWebExtensionAPIRuntime, ConnectFromWebPage)
     ]);
 
     TestWebKitAPI::HTTPServer server({
-        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, webpageScript } },
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, webpageScript.get() } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *urlRequest = server.requestWithLocalhost();
+    RetainPtr urlRequest = server.requestWithLocalhost();
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.runtime?.onConnectExternal.addListener((port) => {",
         @"  browser.test.assertEq(port?.name, 'testPort', 'Port name should be testPort')",
         @"  browser.test.assertEq(port?.error, null, 'Port error should be null')",
@@ -1720,9 +1720,9 @@ TEST(WKWebExtensionAPIRuntime, ConnectFromWebPage)
         @"browser.test.sendMessage('Load Tab')",
     ]);
 
-    auto manager = Util::parseExtension(externallyConnectableManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::parseExtension(externallyConnectableManifest, @{ @"background.js": backgroundScript.get() });
 
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     // Set an uniqueIdentifier so it is a known value and not the default random one.
     manager.get().context.uniqueIdentifier = uniqueIdentifier;
@@ -1730,7 +1730,7 @@ TEST(WKWebExtensionAPIRuntime, ConnectFromWebPage)
     [manager load];
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -1739,7 +1739,7 @@ TEST(WKWebExtensionAPIRuntime, ConnectFromWebPageWithImmediateMessage)
 {
     auto *uniqueIdentifier = @"org.webkit.test.extension (76C788B8)";
 
-    auto *webpageScript = Util::constructScript(@[
+    RetainPtr webpageScript = Util::constructScript(@[
         @"<script>",
         @"setTimeout(() => {",
         [NSString stringWithFormat:@"const port = browser?.runtime?.connect('%@', { name: 'testPort' })", uniqueIdentifier],
@@ -1756,12 +1756,12 @@ TEST(WKWebExtensionAPIRuntime, ConnectFromWebPageWithImmediateMessage)
     ]);
 
     TestWebKitAPI::HTTPServer server({
-        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, webpageScript } },
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, webpageScript.get() } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *urlRequest = server.requestWithLocalhost();
+    RetainPtr urlRequest = server.requestWithLocalhost();
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.runtime?.onConnectExternal.addListener((port) => {",
         @"  browser.test.assertEq(port?.name, 'testPort', 'Port name should be testPort')",
         @"  browser.test.assertEq(port?.error, null, 'Port error should be null')",
@@ -1772,9 +1772,9 @@ TEST(WKWebExtensionAPIRuntime, ConnectFromWebPageWithImmediateMessage)
         @"browser.test.sendMessage('Load Tab')",
     ]);
 
-    auto manager = Util::parseExtension(externallyConnectableManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::parseExtension(externallyConnectableManifest, @{ @"background.js": backgroundScript.get() });
 
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     // Set an uniqueIdentifier so it is a known value and not the default random one.
     manager.get().context.uniqueIdentifier = uniqueIdentifier;
@@ -1782,14 +1782,14 @@ TEST(WKWebExtensionAPIRuntime, ConnectFromWebPageWithImmediateMessage)
     [manager load];
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
 
 TEST(WKWebExtensionAPIRuntime, ConnectFromWebPageWithWrongIdentifier)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.runtime.onMessageExternal.addListener((message, sender, sendResponse) => {",
         @"  browser.test.notifyFail('The page should not be able to connect')",
         @"})",
@@ -1797,7 +1797,7 @@ TEST(WKWebExtensionAPIRuntime, ConnectFromWebPageWithWrongIdentifier)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto *webpageScript = Util::constructScript(@[
+    RetainPtr webpageScript = Util::constructScript(@[
         @"<script>",
         @"  const startTime = performance.now()",
 
@@ -1813,18 +1813,18 @@ TEST(WKWebExtensionAPIRuntime, ConnectFromWebPageWithWrongIdentifier)
     ]);
 
     TestWebKitAPI::HTTPServer server({
-        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, webpageScript } },
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, webpageScript.get() } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *urlRequest = server.requestWithLocalhost();
+    RetainPtr urlRequest = server.requestWithLocalhost();
 
-    auto manager = Util::loadExtension(externallyConnectableManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(externallyConnectableManifest, @{ @"background.js": backgroundScript.get() });
 
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -1833,7 +1833,7 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromWebPage)
 {
     auto *uniqueIdentifier = @"org.webkit.test.extension (SendMessageTest)";
 
-    auto *webpageScript = Util::constructScript(@[
+    RetainPtr webpageScript = Util::constructScript(@[
         @"<script>",
         @"setTimeout(() => {",
         [NSString stringWithFormat:@"browser.runtime.sendMessage('%@', 'Hello', (response) => {", uniqueIdentifier],
@@ -1846,12 +1846,12 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromWebPage)
     ]);
 
     TestWebKitAPI::HTTPServer server({
-        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, webpageScript } },
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, webpageScript.get() } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *urlRequest = server.requestWithLocalhost();
+    RetainPtr urlRequest = server.requestWithLocalhost();
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.runtime.onMessageExternal.addListener((message, sender, sendResponse) => {",
         @"  browser.test.assertEq(message, 'Hello', 'Should receive the correct message')",
 
@@ -1875,9 +1875,9 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromWebPage)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::parseExtension(externallyConnectableManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::parseExtension(externallyConnectableManifest, @{ @"background.js": backgroundScript.get() });
 
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     // Set an uniqueIdentifier so it is a known value and not the default random one.
     manager.get().context.uniqueIdentifier = uniqueIdentifier;
@@ -1885,7 +1885,7 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromWebPage)
     [manager load];
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -1920,7 +1920,7 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromWebPageWithTabFrameAndAsyncReply)
         },
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.runtime.onMessageExternal.addListener((message, sender, sendResponse) => {",
         @"  browser.test.assertEq(message?.content, 'Hello from webpage', 'Should receive the correct message from the web page')",
 
@@ -1932,13 +1932,13 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromWebPageWithTabFrameAndAsyncReply)
         @"browser.test.sendMessage('Load Tabs')"
     ]);
 
-    auto *iframeScript = Util::constructScript(@[
+    RetainPtr iframeScript = Util::constructScript(@[
         @"browser.runtime.onMessageExternal.addListener((message, sender, sendResponse) => {",
         @"  browser.test.assertEq(message?.content, 'Hello from webpage', 'Should receive the correct message from the web page')",
         @"})",
     ]);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"(function() {",
         @"  const iframe = document.createElement('iframe')",
         @"  iframe.src = browser.runtime.getURL('extension-frame.html')",
@@ -1946,7 +1946,7 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromWebPageWithTabFrameAndAsyncReply)
         @"})()",
     ]);
 
-    auto *webpageScript = Util::constructScript(@[
+    RetainPtr webpageScript = Util::constructScript(@[
         @"<script>",
         @"setTimeout(() => {",
         @"  browser.runtime.sendMessage('org.webkit.test.extension (SendMessageTest)', { content: 'Hello from webpage' }, (response) => {",
@@ -1959,22 +1959,22 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromWebPageWithTabFrameAndAsyncReply)
     ]);
 
     TestWebKitAPI::HTTPServer server({
-        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, webpageScript } },
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, webpageScript.get() } },
         { "/second-tab.html"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *urlRequest = server.requestWithLocalhost();
+    RetainPtr urlRequest = server.requestWithLocalhost();
 
     auto *resources = @{
-        @"background.js": backgroundScript,
-        @"content.js": contentScript,
-        @"extension-frame.js": iframeScript,
+        @"background.js": backgroundScript.get(),
+        @"content.js": contentScript.get(),
+        @"extension-frame.js": iframeScript.get(),
         @"extension-frame.html": @"<script type='module' src='extension-frame.js'></script>",
     };
 
     auto manager = Util::parseExtension(extensionManifest, resources);
 
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     // Set an uniqueIdentifier so it is a known value and not the default random one.
     manager.get().context.uniqueIdentifier = @"org.webkit.test.extension (SendMessageTest)";
@@ -1982,7 +1982,7 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromWebPageWithTabFrameAndAsyncReply)
     [manager load];
     [manager runUntilTestMessage:@"Load Tabs"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     auto *secondTab = [manager.get().defaultWindow openNewTab];
     [secondTab.webView loadRequest:server.requestWithLocalhost("/second-tab.html"_s)];
@@ -1992,7 +1992,7 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromWebPageWithTabFrameAndAsyncReply)
 
 TEST(WKWebExtensionAPIRuntime, SendMessageFromWebPageWithWrongIdentifier)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.runtime.onMessageExternal.addListener(async (message, sender, sendResponse) => {",
         @"  browser.test.notifyFail('The page should not be able to send a message with a wrong identifier')",
         @"})",
@@ -2000,7 +2000,7 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromWebPageWithWrongIdentifier)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto *webpageScript = Util::constructScript(@[
+    RetainPtr webpageScript = Util::constructScript(@[
         @"<script type='module'>",
         @"  const startTime = performance.now()",
 
@@ -2014,18 +2014,18 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromWebPageWithWrongIdentifier)
     ]);
 
     TestWebKitAPI::HTTPServer server({
-        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, webpageScript } },
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, webpageScript.get() } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *urlRequest = server.requestWithLocalhost();
+    RetainPtr urlRequest = server.requestWithLocalhost();
 
-    auto manager = Util::loadExtension(externallyConnectableManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(externallyConnectableManifest, @{ @"background.js": backgroundScript.get() });
 
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm
@@ -55,7 +55,7 @@ static auto *changeBackgroundFontScript = @"document.body.style.fontSize = '555p
 
 TEST(WKWebExtensionAPIScripting, ErrorsExecuteScript)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.assertThrows(() => browser.scripting.executeScript(), /a required argument is missing/i)",
         @"browser.test.assertThrows(() => browser.scripting.executeScript({}), /missing required keys: 'target'./i)",
         @"browser.test.assertThrows(() => browser.scripting.executeScript({'target' : { }}), /missing required keys: 'tabId'./i)",
@@ -83,12 +83,12 @@ TEST(WKWebExtensionAPIScripting, ErrorsExecuteScript)
         @"browser.test.notifyPass()"
     ]);
 
-    Util::loadAndRunExtension(scriptingManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(scriptingManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPIScripting, ErrorsCSS)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.assertThrows(() => browser.scripting.insertCSS(), /a required argument is missing./i)",
         @"browser.test.assertThrows(() => browser.scripting.insertCSS({}), /missing required keys: 'target'./i)",
         @"browser.test.assertThrows(() => browser.scripting.insertCSS({ target: {} }), /missing required keys: 'tabId'./i)",
@@ -107,12 +107,12 @@ TEST(WKWebExtensionAPIScripting, ErrorsCSS)
         @"browser.test.notifyPass()"
     ]);
 
-    Util::loadAndRunExtension(scriptingManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(scriptingManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPIScripting, ErrorsRegisteredContentScript)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.assertThrows(() => browser.scripting.registerContentScripts(), /a required argument is missing/i)",
         @"browser.test.assertThrows(() => browser.scripting.registerContentScripts({}), /an array is expected/i)",
         @"browser.test.assertThrows(() => browser.scripting.registerContentScripts([{}]), /it is missing required keys: 'id'/i)",
@@ -146,7 +146,7 @@ TEST(WKWebExtensionAPIScripting, ErrorsRegisteredContentScript)
         @"browser.test.notifyPass()"
     ]);
 
-    Util::loadAndRunExtension(scriptingManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(scriptingManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPIScripting, ExecuteScript)
@@ -155,7 +155,7 @@ TEST(WKWebExtensionAPIScripting, ExecuteScript)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } }
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.webNavigation.onCompleted.addListener(async (details) => {",
         @"  const tabId = details.tabId",
 
@@ -209,12 +209,12 @@ TEST(WKWebExtensionAPIScripting, ExecuteScript)
 
     static auto *backgroundColor = @"document.body.style.background = 'pink'";
 
-    static auto *resources = @{ @"background.js": backgroundScript, @"backgroundColor.js": backgroundColor };
+    static auto *resources = @{ @"background.js": backgroundScript.get(), @"backgroundColor.js": backgroundColor };
 
     auto manager = Util::loadExtension(scriptingManifest, resources);
 
-    auto *urlRequest = server.requestWithLocalhost();
-    auto *url = urlRequest.URL;
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    auto *url = urlRequest.get().URL;
 
     auto *matchPattern = [WKWebExtensionMatchPattern matchPatternWithScheme:url.scheme host:url.host path:@"/*"];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebNavigation];
@@ -222,7 +222,7 @@ TEST(WKWebExtensionAPIScripting, ExecuteScript)
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -233,7 +233,7 @@ TEST(WKWebExtensionAPIScripting, ExecuteScriptJSONTypes)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } }
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.webNavigation.onCompleted.addListener(async (details) => {",
         @"  const tabId = details.tabId",
 
@@ -256,15 +256,15 @@ TEST(WKWebExtensionAPIScripting, ExecuteScriptJSONTypes)
         @"browser.test.sendMessage('Load Tab')",
     ]);
 
-    auto manager = Util::loadExtension(scriptingManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(scriptingManifest, @{ @"background.js": backgroundScript.get() });
 
-    auto *urlRequest = server.requestWithLocalhost();
+    RetainPtr urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebNavigation];
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -276,7 +276,7 @@ TEST(WKWebExtensionAPIScripting, ExecuteScriptWithFrameIds)
         { "/frame.html"_s, { { { "Content-Type"_s, "text/html"_s } }, " "_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.runtime.onMessage.addListener(async (message, sender) => {",
         @"  browser.test.assertEq(message, 'Hello from frame')",
 
@@ -322,7 +322,7 @@ TEST(WKWebExtensionAPIScripting, ExecuteScriptWithFrameIds)
     };
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"content.js": contentScript,
     };
 
@@ -344,7 +344,7 @@ TEST(WKWebExtensionAPIScripting, ExecuteScriptWithDocumentIds)
         { "/frame.html"_s, { { { "Content-Type"_s, "text/html"_s } }, "<span>Frame Document</span>"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.runtime.onMessage.addListener(async (message, sender) => {",
         @"  browser.test.assertEq(message, 'Hello from frame')",
 
@@ -394,7 +394,7 @@ TEST(WKWebExtensionAPIScripting, ExecuteScriptWithDocumentIds)
     };
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"content.js": contentScript,
     };
 
@@ -416,7 +416,7 @@ TEST(WKWebExtensionAPIScripting, InsertAndRemoveCSS)
         { "/frame.html"_s, { { { "Content-Type"_s, "text/html"_s } }, "<body style='background-color: blue'></body>"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const pinkValue = 'rgb(255, 192, 203)'",
         @"const blueValue = 'rgb(0, 0, 255)'",
         @"const transparentValue = 'rgba(0, 0, 0, 0)'",
@@ -490,22 +490,22 @@ TEST(WKWebExtensionAPIScripting, InsertAndRemoveCSS)
     static auto *fontSize = @"body { font-size: 104px }";
 
     static auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"backgroundColor.css": backgroundColor,
         @"fontSize.css": fontSize,
     };
 
     auto manager = Util::loadExtension(scriptingManifest, resources);
 
-    auto *urlRequest = server.requestWithLocalhost();
-    auto *url = urlRequest.URL;
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    auto *url = urlRequest.get().URL;
 
     auto *matchPattern = [WKWebExtensionMatchPattern matchPatternWithScheme:url.scheme host:url.host path:@"/*"];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:matchPattern];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -517,7 +517,7 @@ TEST(WKWebExtensionAPIScripting, InsertAndRemoveCSSWithFrameIds)
         { "/frame.html"_s, { { { "Content-Type"_s, "text/html"_s } }, "<body style='background-color: blue'></body>"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const pinkValue = 'rgb(255, 192, 203)'",
         @"const blueValue = 'rgb(0, 0, 255)'",
         @"const transparentValue = 'rgba(0, 0, 0, 0)'",
@@ -563,22 +563,22 @@ TEST(WKWebExtensionAPIScripting, InsertAndRemoveCSSWithFrameIds)
     static auto *fontSize = @"body { font-size: 104px }";
 
     static auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"backgroundColor.css": backgroundColor,
         @"fontSize.css": fontSize,
     };
 
     auto manager = Util::loadExtension(scriptingManifest, resources);
 
-    auto *urlRequest = server.requestWithLocalhost();
-    auto *url = urlRequest.URL;
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    auto *url = urlRequest.get().URL;
 
     auto *matchPattern = [WKWebExtensionMatchPattern matchPatternWithScheme:url.scheme host:url.host path:@"/*"];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:matchPattern];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -589,7 +589,7 @@ TEST(WKWebExtensionAPIScripting, CSSUserOrigin)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<body style='color: red'></body>"_s } }
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {",
         @"  if (tab.status === 'complete') {",
         @"    await browser.test.assertSafeResolve(() => browser.scripting.insertCSS({ target: { tabId }, css: 'body { color: green !important }', origin: 'user' }))",
@@ -605,18 +605,18 @@ TEST(WKWebExtensionAPIScripting, CSSUserOrigin)
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
     };
 
     auto manager = Util::loadExtension(scriptingManifest, resources);
 
-    auto *urlRequest = server.requestWithLocalhost();
+    RetainPtr urlRequest = server.requestWithLocalhost();
 
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -627,7 +627,7 @@ TEST(WKWebExtensionAPIScripting, CSSAuthorOrigin)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<style> body { color: red } </style>"_s } }
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {",
         @"  if (tab.status === 'complete') {",
         @"    await browser.test.assertSafeResolve(() => browser.scripting.insertCSS({ target: { tabId }, css: 'body { color: green !important }', origin: 'author' }))",
@@ -643,18 +643,18 @@ TEST(WKWebExtensionAPIScripting, CSSAuthorOrigin)
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
     };
 
     auto manager = Util::loadExtension(scriptingManifest, resources);
 
-    auto *urlRequest = server.requestWithLocalhost();
+    RetainPtr urlRequest = server.requestWithLocalhost();
 
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -665,7 +665,7 @@ TEST(WKWebExtensionAPIScripting, World)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<script> const world = 'MAIN'; </script>"_s } }
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"function testWorld() {",
         @"  if (world)",
         @"    browser.test.notifyPass()",
@@ -688,18 +688,18 @@ TEST(WKWebExtensionAPIScripting, World)
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
     };
 
     auto manager = Util::loadExtension(scriptingManifest, resources);
 
-    auto *urlRequest = server.requestWithLocalhost();
+    RetainPtr urlRequest = server.requestWithLocalhost();
 
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -710,7 +710,7 @@ TEST(WKWebExtensionAPIScripting, RegisterContentScripts)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } }
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"function getBackgroundColor() { return window.getComputedStyle(document.body).getPropertyValue('background-color') }",
 
         @"function getFontSize() { return window.getComputedStyle(document.body).getPropertyValue('font-size') }",
@@ -754,15 +754,15 @@ TEST(WKWebExtensionAPIScripting, RegisterContentScripts)
     ]);
 
     static auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"changeBackgroundColorScript.js": changeBackgroundColorScript,
         @"changeBackgroundFontScript.js": changeBackgroundFontScript,
     };
 
     auto manager = Util::loadExtension(scriptingManifest, resources);
 
-    auto *urlRequest = server.requestWithLocalhost();
-    auto *url = urlRequest.URL;
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    auto *url = urlRequest.get().URL;
 
     auto *matchPattern = [WKWebExtensionMatchPattern matchPatternWithScheme:url.scheme host:url.host path:@"/*"];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebNavigation];
@@ -770,7 +770,7 @@ TEST(WKWebExtensionAPIScripting, RegisterContentScripts)
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -781,7 +781,7 @@ TEST(WKWebExtensionAPIScripting, RegisterContentScriptsWithCSSUserOrigin)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<body style='color: red'></body>"_s } }
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.webNavigation.onCompleted.addListener(async (details) => {",
         @"  const tabId = details.tabId",
 
@@ -810,19 +810,19 @@ TEST(WKWebExtensionAPIScripting, RegisterContentScriptsWithCSSUserOrigin)
     auto *css = @"body { color: green !important }";
 
     auto resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"changeColor.css": css
     };
 
     auto manager = Util::loadExtension(scriptingManifest, resources);
 
-    auto *urlRequest = server.requestWithLocalhost();
+    RetainPtr urlRequest = server.requestWithLocalhost();
 
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -833,7 +833,7 @@ TEST(WKWebExtensionAPIScripting, RegisterContentScriptsWithCSSAuthorOrigin)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<style> body { color: red } </style>"_s } }
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.webNavigation.onCompleted.addListener(async (details) => {",
         @"  const tabId = details.tabId",
 
@@ -862,19 +862,19 @@ TEST(WKWebExtensionAPIScripting, RegisterContentScriptsWithCSSAuthorOrigin)
     auto *css = @"body { color: green !important }";
 
     auto resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"changeColor.css": css
     };
 
     auto manager = Util::loadExtension(scriptingManifest, resources);
 
-    auto *urlRequest = server.requestWithLocalhost();
+    RetainPtr urlRequest = server.requestWithLocalhost();
 
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -885,7 +885,7 @@ TEST(WKWebExtensionAPIScripting, RegisterContentScriptsMatchOriginAsFallback)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<iframe src='about:blank'></iframe>"_s } }
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"await browser.scripting.registerContentScripts([{",
         @"    id: 'applyStylesAndScript',",
         @"    matches: ['*://localhost/*'],",
@@ -900,7 +900,7 @@ TEST(WKWebExtensionAPIScripting, RegisterContentScriptsMatchOriginAsFallback)
 
     auto *contentStyle = @"body { background-color: green !important }";
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"browser.test.assertEq(document.body.dataset.injected, undefined, 'Script should not have run before')",
         @"document.body.dataset.injected = 'true'",
 
@@ -911,19 +911,19 @@ TEST(WKWebExtensionAPIScripting, RegisterContentScriptsMatchOriginAsFallback)
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
-        @"content.js": contentScript,
+        @"background.js": backgroundScript.get(),
+        @"content.js": contentScript.get(),
         @"applyStyles.css": contentStyle
     };
 
     auto manager = Util::loadExtension(scriptingManifest, resources);
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Scripts Registered"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager runUntilTestMessage:@"Main Frame Injected"];
     [manager runUntilTestMessage:@"Sub-Frame Injected"];
@@ -936,7 +936,7 @@ TEST(WKWebExtensionAPIScripting, UpdateContentScripts)
         { "/frame.html"_s, { { { "Content-Type"_s, "text/html"_s } }, "<body style='background-color: blue'></body>"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"function getBackgroundColor() { return window.getComputedStyle(document.body).getPropertyValue('background-color') }",
 
         @"function getFontSize() { return window.getComputedStyle(document.body).getPropertyValue('font-size') }",
@@ -991,15 +991,15 @@ TEST(WKWebExtensionAPIScripting, UpdateContentScripts)
     ]);
 
     static auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"changeBackgroundColorScript.js": changeBackgroundColorScript,
         @"changeBackgroundFontScript.js": changeBackgroundFontScript,
     };
 
     auto manager = Util::loadExtension(scriptingManifest, resources);
 
-    auto *urlRequest = server.requestWithLocalhost();
-    auto *url = urlRequest.URL;
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    auto *url = urlRequest.get().URL;
 
     auto *matchPattern = [WKWebExtensionMatchPattern matchPatternWithScheme:url.scheme host:url.host path:@"/*"];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebNavigation];
@@ -1007,14 +1007,14 @@ TEST(WKWebExtensionAPIScripting, UpdateContentScripts)
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
 
 TEST(WKWebExtensionAPIScripting, UpdateContentScriptsWithMinimalParametersShouldNotCrash)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"await browser.scripting.registerContentScripts([{ id: '1', matches: ['*://localhost/*'], js: ['script.js'] }])",
         @"await browser.scripting.updateContentScripts([{ id: '1', allFrames: true }])",
 
@@ -1025,7 +1025,7 @@ TEST(WKWebExtensionAPIScripting, UpdateContentScriptsWithMinimalParametersShould
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"script.js": @"document.body.style.backgroundColor = 'red'",
     };
 
@@ -1038,7 +1038,7 @@ TEST(WKWebExtensionAPIScripting, GetContentScripts)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } }
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.webNavigation.onCompleted.addListener(async () => {",
 
         @"  var expectedResults = [{",
@@ -1077,15 +1077,15 @@ TEST(WKWebExtensionAPIScripting, GetContentScripts)
     ]);
 
     static auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"changeBackgroundColorScript.js": changeBackgroundColorScript,
         @"changeBackgroundFontScript.js": changeBackgroundFontScript,
     };
 
     auto manager = Util::loadExtension(scriptingManifest, resources);
 
-    auto *urlRequest = server.requestWithLocalhost();
-    auto *url = urlRequest.URL;
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    auto *url = urlRequest.get().URL;
 
     auto *matchPattern = [WKWebExtensionMatchPattern matchPatternWithScheme:url.scheme host:url.host path:@"/*"];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebNavigation];
@@ -1093,7 +1093,7 @@ TEST(WKWebExtensionAPIScripting, GetContentScripts)
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -1104,7 +1104,7 @@ TEST(WKWebExtensionAPIScripting, UnregisterContentScripts)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } }
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"function getBackgroundColor() { return window.getComputedStyle(document.body).getPropertyValue('background-color') }",
 
         @"  const pinkValue = 'rgb(255, 192, 203)'",
@@ -1149,15 +1149,15 @@ TEST(WKWebExtensionAPIScripting, UnregisterContentScripts)
     ]);
 
     static auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"changeBackgroundColorScript.js": changeBackgroundColorScript,
         @"changeBackgroundFontScript.js": changeBackgroundFontScript,
     };
 
     auto manager = Util::loadExtension(scriptingManifest, resources);
 
-    auto *urlRequest = server.requestWithLocalhost();
-    auto *url = urlRequest.URL;
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    auto *url = urlRequest.get().URL;
 
     auto *matchPattern = [WKWebExtensionMatchPattern matchPatternWithScheme:url.scheme host:url.host path:@"/*"];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebNavigation];
@@ -1165,7 +1165,7 @@ TEST(WKWebExtensionAPIScripting, UnregisterContentScripts)
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -1176,7 +1176,7 @@ TEST(WKWebExtensionAPIScripting, RegisteredScriptIsInjectedAfterContextReloads)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } }
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.webNavigation.onCompleted.addListener(async (details) => {",
         @"  const pinkValue = 'rgb(255, 192, 203)'",
         @"  function getBackgroundColor() { return window.getComputedStyle(document.body).getPropertyValue('background-color') }",
@@ -1203,7 +1203,7 @@ TEST(WKWebExtensionAPIScripting, RegisteredScriptIsInjectedAfterContextReloads)
     ]);
 
     static auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"changeBackgroundColorScript.js": changeBackgroundColorScript,
     };
 
@@ -1228,9 +1228,9 @@ TEST(WKWebExtensionAPIScripting, RegisteredScriptIsInjectedAfterContextReloads)
 
     EXPECT_TRUE(manager.get().context.hasInjectedContent);
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -1241,7 +1241,7 @@ TEST(WKWebExtensionAPIScripting, PersistentRegisteredScriptIsInjectedAfterContex
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } }
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.webNavigation.onCompleted.addListener(async (details) => {",
         @"  const pinkValue = 'rgb(255, 192, 203)'",
         @"  function getBackgroundColor() { return window.getComputedStyle(document.body).getPropertyValue('background-color') }",
@@ -1268,7 +1268,7 @@ TEST(WKWebExtensionAPIScripting, PersistentRegisteredScriptIsInjectedAfterContex
     ]);
 
     static auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"changeBackgroundColorScript.js": changeBackgroundColorScript,
     };
 
@@ -1293,9 +1293,9 @@ TEST(WKWebExtensionAPIScripting, PersistentRegisteredScriptIsInjectedAfterContex
 
     EXPECT_TRUE(manager.get().context.hasInjectedContent);
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -1306,7 +1306,7 @@ TEST(WKWebExtensionAPIScripting, RegisteredScriptExcludeMatches)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } }
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.webNavigation.onCompleted.addListener(async () => {",
 
         @"  var expectedResults = [{",
@@ -1334,7 +1334,7 @@ TEST(WKWebExtensionAPIScripting, RegisteredScriptExcludeMatches)
     ]);
 
     static auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"changeBackgroundColorScript.js": changeBackgroundColorScript,
     };
 
@@ -1345,8 +1345,8 @@ TEST(WKWebExtensionAPIScripting, RegisteredScriptExcludeMatches)
     auto *exampleURL = [NSURL URLWithString:@"https://example.com/"];
     EXPECT_FALSE([testContext hasInjectedContentForURL:exampleURL]);
 
-    auto *urlRequest = server.requestWithLocalhost();
-    auto *url = urlRequest.URL;
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    auto *url = urlRequest.get().URL;
 
     auto *matchPattern = [WKWebExtensionMatchPattern matchPatternWithScheme:url.scheme host:url.host path:@"/*"];
     [testContext setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebNavigation];
@@ -1354,7 +1354,7 @@ TEST(WKWebExtensionAPIScripting, RegisteredScriptExcludeMatches)
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -1378,7 +1378,7 @@ TEST(WKWebExtensionAPIScripting, InjectedOnlyOnce)
         } ]
     };
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"if (document.body.dataset.injected)",
         @"    browser.test.notifyFail('Script injected more than once')",
 
@@ -1388,14 +1388,14 @@ TEST(WKWebExtensionAPIScripting, InjectedOnlyOnce)
     ]);
 
     auto *resources = @{
-        @"content_script.js": contentScript
+        @"content_script.js": contentScript.get()
     };
 
     auto manager = Util::loadExtension(contentScriptsManifest, resources);
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager runUntilTestMessage:@"script-injected"];
 
@@ -1422,7 +1422,7 @@ TEST(WKWebExtensionAPIScripting, MainWorld)
         } ]
     };
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"browser.test.assertEq(window.secretValue, 'This is a secret.')",
 
         // Externally connectable exposes a limited browser but not chrome.
@@ -1434,14 +1434,14 @@ TEST(WKWebExtensionAPIScripting, MainWorld)
     ]);
 
     auto *resources = @{
-        @"content_script.js": contentScript
+        @"content_script.js": contentScript.get()
     };
 
     auto manager = Util::loadExtension(contentScriptsManifest, resources);
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -1466,7 +1466,7 @@ TEST(WKWebExtensionAPIScripting, IsolatedWorld)
         } ]
     };
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"browser.test.assertEq(window.secretValue, undefined)",
 
         // Both chrome and browser should be exposed.
@@ -1477,14 +1477,14 @@ TEST(WKWebExtensionAPIScripting, IsolatedWorld)
     ]);
 
     auto *resources = @{
-        @"content_script.js": contentScript
+        @"content_script.js": contentScript.get()
     };
 
     auto manager = Util::loadExtension(contentScriptsManifest, resources);
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -1513,7 +1513,7 @@ TEST(WKWebExtensionAPIScripting, MatchAboutBlank)
 
     auto *contentStyle = @"body { background-color: red !important; }";
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"browser.test.assertEq(document.body.dataset.injected, undefined, 'Script should not have run before')",
         @"document.body.dataset.injected = 'true'",
 
@@ -1524,15 +1524,15 @@ TEST(WKWebExtensionAPIScripting, MatchAboutBlank)
     ]);
 
     auto *resources = @{
-        @"content.js": contentScript,
+        @"content.js": contentScript.get(),
         @"content.css": contentStyle
     };
 
     auto manager = Util::loadExtension(contentScriptsManifest, resources);
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager runUntilTestMessage:@"Main Frame Injected"];
     [manager runUntilTestMessage:@"Sub-Frame Injected"];
@@ -1562,7 +1562,7 @@ TEST(WKWebExtensionAPIScripting, MatchOriginAsFallbackWithAboutBlank)
 
     auto *contentStyle = @"body { background-color: green !important; }";
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"browser.test.assertEq(document.body.dataset.injected, undefined, 'Script should not have run before')",
         @"document.body.dataset.injected = 'true'",
 
@@ -1573,15 +1573,15 @@ TEST(WKWebExtensionAPIScripting, MatchOriginAsFallbackWithAboutBlank)
     ]);
 
     auto *resources = @{
-        @"content.js": contentScript,
+        @"content.js": contentScript.get(),
         @"content.css": contentStyle
     };
 
     auto manager = Util::loadExtension(contentScriptsManifest, resources);
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager runUntilTestMessage:@"Main Frame Injected"];
     [manager runUntilTestMessage:@"Sub-Frame Injected"];
@@ -1609,7 +1609,7 @@ TEST(WKWebExtensionAPIScripting, MatchOriginAsFallbackWithData)
 
     auto *contentStyle = @"body { background-color: blue !important; }";
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"browser.test.assertEq(document.body.dataset.injected, undefined, 'Script should not have run before')",
         @"document.body.dataset.injected = 'true'",
 
@@ -1620,15 +1620,15 @@ TEST(WKWebExtensionAPIScripting, MatchOriginAsFallbackWithData)
     ]);
 
     auto *resources = @{
-        @"content.js": contentScript,
+        @"content.js": contentScript.get(),
         @"content.css": contentStyle
     };
 
     auto manager = Util::loadExtension(contentScriptsManifest, resources);
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager runUntilTestMessage:@"Main Frame Injected"];
     [manager runUntilTestMessage:@"Sub-Frame Injected"];
@@ -1636,7 +1636,7 @@ TEST(WKWebExtensionAPIScripting, MatchOriginAsFallbackWithData)
 
 TEST(WKWebExtensionAPIScripting, MatchOriginAsFallbackWithBlob)
 {
-    auto *pageScript = Util::constructScript(@[
+    RetainPtr pageScript = Util::constructScript(@[
         @"<script>",
         @"  const blob = new Blob(['<body></body>'], { type: 'text/html' })",
         @"  const blobURL = URL.createObjectURL(blob)",
@@ -1645,7 +1645,7 @@ TEST(WKWebExtensionAPIScripting, MatchOriginAsFallbackWithBlob)
     ]);
 
     TestWebKitAPI::HTTPServer server({
-        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, pageScript } }
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, pageScript.get() } }
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
     auto *contentScriptsManifest = @{
@@ -1666,7 +1666,7 @@ TEST(WKWebExtensionAPIScripting, MatchOriginAsFallbackWithBlob)
 
     auto *contentStyle = @"body { background-color: green !important; }";
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"browser.test.assertEq(document.body.dataset.injected, undefined, 'Script should not have run before')",
         @"document.body.dataset.injected = 'true'",
 
@@ -1677,15 +1677,15 @@ TEST(WKWebExtensionAPIScripting, MatchOriginAsFallbackWithBlob)
     ]);
 
     auto *resources = @{
-        @"content.js": contentScript,
+        @"content.js": contentScript.get(),
         @"content.css": contentStyle
     };
 
     auto manager = Util::loadExtension(contentScriptsManifest, resources);
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager runUntilTestMessage:@"Main Frame Injected"];
     [manager runUntilTestMessage:@"Sub-Frame Injected"];
@@ -1716,28 +1716,28 @@ TEST(WKWebExtensionAPIScripting, RemoveAllUserScriptsDoesNotRemoveWebExtensionSc
         } ]
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.sendMessage('Remove Scripts and Load Tab')"
     ]);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"browser.test.notifyPass()"
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
-        @"content.js": contentScript
+        @"background.js": backgroundScript.get(),
+        @"content.js": contentScript.get()
     };
 
     auto manager = Util::loadExtension(contentScriptsManifest, resources);
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Remove Scripts and Load Tab"];
 
     [manager.get().defaultTab.webView.configuration.userContentController removeAllUserScripts];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -1768,11 +1768,11 @@ TEST(WKWebExtensionAPIScripting, RemoveAllUserStyleSheetsDoesNotRemoveWebExtensi
         } ]
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.sendMessage('Remove StyleSheets and Load Tab')"
     ]);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"const testElement = document.getElementById('test')",
         @"const style = window.getComputedStyle(testElement)",
         @"browser.test.assertEq(style.color, 'rgb(255, 0, 0)', 'CSS should still apply after removing user stylesheets')",
@@ -1781,20 +1781,20 @@ TEST(WKWebExtensionAPIScripting, RemoveAllUserStyleSheetsDoesNotRemoveWebExtensi
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"content.css": @"#test { color: red; }",
-        @"content.js": contentScript
+        @"content.js": contentScript.get()
     };
 
     auto manager = Util::loadExtension(contentScriptsManifest, resources);
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Remove StyleSheets and Load Tab"];
 
     [manager.get().defaultTab.webView.configuration.userContentController _removeAllUserStyleSheets];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -1818,7 +1818,7 @@ TEST(WKWebExtensionAPIScripting, InjectScriptWithTrustedTypesCSP)
         } ]
     };
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"try {",
         @"  document.body.innerHTML = '<p>Injected</p>'",
         @"  browser.test.notifyPass()",
@@ -1827,18 +1827,18 @@ TEST(WKWebExtensionAPIScripting, InjectScriptWithTrustedTypesCSP)
         @"}",
     ]);
 
-    auto manager = Util::loadExtension(manifest, @{ @"content.js": contentScript });
+    auto manager = Util::loadExtension(manifest, @{ @"content.js": contentScript.get() });
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
 
 TEST(WKWebExtensionAPIScripting, MigrateScriptDataToNewFormat)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"var expectedResults = [{",
         @"  id: '1',",
         @"  js: ['content.js'],",
@@ -1859,7 +1859,7 @@ TEST(WKWebExtensionAPIScripting, MigrateScriptDataToNewFormat)
     ]);
 
     static auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"content.js": Util::constructScript(@[]),
     };
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIStorage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIStorage.mm
@@ -56,7 +56,7 @@ static auto *storageManifest = @{
 
 TEST(WKWebExtensionAPIStorage, Errors)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.assertThrows(() => browser?.storage?.local?.get(Date.now()), /'items' value is invalid, because an object or a string or an array of strings or null is expected, but a number was provided/i)",
 
         @"browser.test.assertThrows(() => browser?.storage?.local?.getKeys('invalid'), /'callback' value is invalid, because a function is expected/i)",
@@ -81,12 +81,12 @@ TEST(WKWebExtensionAPIStorage, Errors)
         @"browser.test.notifyPass()"
     ]);
 
-    Util::loadAndRunExtension(storageManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(storageManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPIStorage, UndefinedProperties)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.assertEq(browser?.storage?.local?.setAccessLevel, undefined)",
         @"browser.test.assertEq(browser?.storage?.sync?.setAccessLevel, undefined)",
 
@@ -105,7 +105,7 @@ TEST(WKWebExtensionAPIStorage, UndefinedProperties)
         @"browser.test.notifyPass()"
     ]);
 
-    Util::loadAndRunExtension(storageManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(storageManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 // FIXME rdar://147858640
@@ -119,7 +119,7 @@ TEST(WKWebExtensionAPIStorage, SetAccessLevelTrustedContexts)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } }
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.runtime.onMessage.addListener(async (message, sender, sendResponse) => {",
         @"  browser.test.assertEq(message, 'Ready')",
 
@@ -135,7 +135,7 @@ TEST(WKWebExtensionAPIStorage, SetAccessLevelTrustedContexts)
         @"})"
     ]);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"browser.runtime.onMessage.addListener((message, sender, sendResponse) => {",
         @"  browser.test.assertEq(message?.content, 'Access level set', 'Should receive the correct message content')",
 
@@ -145,11 +145,11 @@ TEST(WKWebExtensionAPIStorage, SetAccessLevelTrustedContexts)
         @"setTimeout(() => browser.runtime.sendMessage('Ready'), 1000)"
     ]);
 
-    auto manager = Util::loadExtension(storageManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
+    auto manager = Util::loadExtension(storageManifest, @{ @"background.js": backgroundScript.get(), @"content.js": contentScript.get() });
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -165,7 +165,7 @@ TEST(WKWebExtensionAPIStorage, SetAccessLevelTrustedAndUntrustedContexts)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } }
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.runtime.onMessage.addListener(async (message, sender, sendResponse) => {",
         @"  browser.test.assertEq(message, 'Ready')",
 
@@ -181,7 +181,7 @@ TEST(WKWebExtensionAPIStorage, SetAccessLevelTrustedAndUntrustedContexts)
         @"})"
     ]);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"browser.runtime.onMessage.addListener((message, sender, sendResponse) => {",
         @"  browser.test.assertEq(message?.content, 'Access level set', 'Should receive the correct message content')",
 
@@ -191,18 +191,18 @@ TEST(WKWebExtensionAPIStorage, SetAccessLevelTrustedAndUntrustedContexts)
         @"setTimeout(() => browser.runtime.sendMessage('Ready'), 1000)"
     ]);
 
-    auto manager = Util::loadExtension(storageManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
+    auto manager = Util::loadExtension(storageManifest, @{ @"background.js": backgroundScript.get(), @"content.js": contentScript.get() });
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
 
 TEST(WKWebExtensionAPIStorage, Set)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const data = { 'string': 'string', 'number': 1, 'boolean': true, 'dictionary': {'key': 'value'}, 'array': [1, true, 'string'], 'null': null, 'undefined': undefined }",
         @"await browser?.storage?.local?.set(data)",
 
@@ -232,12 +232,12 @@ TEST(WKWebExtensionAPIStorage, Set)
         @"browser.test.notifyPass()",
     ]);
 
-    Util::loadAndRunExtension(storageManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(storageManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPIStorage, SetCustomObject)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"class BaseObject {",
         @"  constructor(name) {",
         @"    this.name = name",
@@ -269,12 +269,12 @@ TEST(WKWebExtensionAPIStorage, SetCustomObject)
         @"browser.test.notifyPass()",
     ]);
 
-    Util::loadAndRunExtension(storageManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(storageManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPIStorage, Get)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const data = { 'string': 'string', 'number': 1, 'boolean': true, 'dictionary': {'key': 'value'}, 'array': [1, true, 'string'], 'null': null, 'nan': NaN, '': 'empty' }",
         @"await browser?.storage?.local?.set(data)",
 
@@ -299,12 +299,12 @@ TEST(WKWebExtensionAPIStorage, Get)
         @"browser.test.notifyPass()",
     ]);
 
-    Util::loadAndRunExtension(storageManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(storageManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPIStorage, GetWithDefaultValue)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const data = { 'abc': 123 }",
         @"await browser.storage.local.set(data)",
 
@@ -318,12 +318,12 @@ TEST(WKWebExtensionAPIStorage, GetWithDefaultValue)
         @"browser.test.notifyPass()",
     ]);
 
-    Util::loadAndRunExtension(storageManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(storageManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPIStorage, GetKeys)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const data = { 'string': 'string', 'number': 1, 'boolean': true, 'dictionary': {'key': 'value'}, 'array': [1, true, 'string'], 'null': null }",
         @"await browser?.storage?.local?.set(data)",
 
@@ -348,12 +348,12 @@ TEST(WKWebExtensionAPIStorage, GetKeys)
         @"browser.test.notifyPass()",
     ]);
 
-    Util::loadAndRunExtension(storageManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(storageManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPIStorage, GetBytesInUse)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const data = { 'string': 'string', 'number': 1, 'boolean': true, 'dictionary': {'key': 'value'}, 'array': [1, true, 'string'] }",
         @"await browser?.storage?.local?.set(data)",
 
@@ -377,12 +377,12 @@ TEST(WKWebExtensionAPIStorage, GetBytesInUse)
         @"browser.test.notifyPass()",
     ]);
 
-    Util::loadAndRunExtension(storageManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(storageManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPIStorage, GetBytesInUseWhenEmpty)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"var result = await browser?.storage?.local?.getBytesInUse()",
         @"browser.test.assertEq(result, 0)",
 
@@ -395,12 +395,12 @@ TEST(WKWebExtensionAPIStorage, GetBytesInUseWhenEmpty)
         @"browser.test.notifyPass()",
     ]);
 
-    Util::loadAndRunExtension(storageManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(storageManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPIStorage, Remove)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const data = { 'string': 'string', 'number': 1, 'boolean': true, 'dictionary': {'key': 'value'}, 'array': [1, true, 'string'] }",
         @"await browser?.storage?.local?.set(data)",
 
@@ -418,12 +418,12 @@ TEST(WKWebExtensionAPIStorage, Remove)
         @"browser.test.notifyPass()",
     ]);
 
-    Util::loadAndRunExtension(storageManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(storageManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPIStorage, Clear)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const data = { 'string': 'string', 'number': 1, 'boolean': true, 'dictionary': {'key': 'value'}, 'array': [1, true, 'string'] }",
         @"await browser?.storage?.local?.set(data)",
 
@@ -438,12 +438,12 @@ TEST(WKWebExtensionAPIStorage, Clear)
         @"browser.test.notifyPass()",
     ]);
 
-    Util::loadAndRunExtension(storageManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(storageManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPIStorage, StorageOnChanged)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"let changeCount = 0",
 
         @"browser.storage.onChanged.addListener((changes, areaName) => {",
@@ -510,12 +510,12 @@ TEST(WKWebExtensionAPIStorage, StorageOnChanged)
         @"await browser.storage.local.remove([ 'string', 'number', 'boolean', 'dictionary', 'array' ])"
     ]);
 
-    Util::loadAndRunExtension(storageManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(storageManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPIStorage, StorageAreaOnChanged)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"let changeCount = 0",
 
         @"browser.storage.local.onChanged.addListener((changes, areaName) => {",
@@ -583,7 +583,7 @@ TEST(WKWebExtensionAPIStorage, StorageAreaOnChanged)
         @"await browser.storage.local.remove([ 'string', 'number', 'boolean', 'dictionary', 'array' ])"
     ]);
 
-    Util::loadAndRunExtension(storageManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(storageManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPIStorage, StorageFromSubframe)
@@ -597,10 +597,10 @@ TEST(WKWebExtensionAPIStorage, StorageFromSubframe)
         { "/subframe"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *urlRequestMain = server.requestWithLocalhost("/main"_s);
-    auto *urlRequestSubframe = server.request("/subframe"_s);
+    RetainPtr urlRequestMain = server.requestWithLocalhost("/main"_s);
+    RetainPtr urlRequestSubframe = server.request("/subframe"_s);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"(async () => {",
         @"  await browser.storage.local.set({ key: 'value' })",
         @"  const result = await browser.storage.local.get('key')",
@@ -627,14 +627,14 @@ TEST(WKWebExtensionAPIStorage, StorageFromSubframe)
     };
 
     auto *resources = @{
-        @"content.js": contentScript
+        @"content.js": contentScript.get()
     };
 
     auto manager = Util::loadExtension(manifest, resources);
 
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequestSubframe.URL];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequestSubframe.get().URL];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequestMain];
+    [manager.get().defaultTab.webView loadRequest:urlRequestMain.get()];
 
     [manager run];
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm
@@ -107,7 +107,7 @@ static auto *activeTabManifest = @{
 
 TEST(WKWebExtensionAPITabs, Errors)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.assertThrows(() => browser.tabs.get('bad'), /'tabId' value is invalid, because a number is expected/i)",
         @"browser.test.assertThrows(() => browser.tabs.get(-3), /'tabId' value is invalid, because it is not a tab identifier/i)",
         @"browser.test.assertThrows(() => browser.tabs.duplicate('bad'), /'tabId' value is invalid, because a number is expected/i)",
@@ -169,7 +169,7 @@ TEST(WKWebExtensionAPITabs, Errors)
         @"browser.test.notifyPass()"
     ]);
 
-    Util::loadAndRunExtension(tabsManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(tabsManifest, @{ @"background.js": backgroundScript.get() });
 
     backgroundScript = Util::constructScript(@[
         @"browser.test.assertThrows(() => browser.tabs.executeScript(), /a required argument is missing/i)",
@@ -217,12 +217,12 @@ TEST(WKWebExtensionAPITabs, Errors)
         @"browser.test.notifyPass()"
     ]);
 
-    Util::loadAndRunExtension(tabsManifestV2, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(tabsManifestV2, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPITabs, Create)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const allWindows = await browser.windows.getAll({ populate: true })",
         @"const initialTabsCount = allWindows[0].tabs.length",
 
@@ -236,7 +236,7 @@ TEST(WKWebExtensionAPITabs, Create)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript.get() });
 
     auto *window = manager.get().defaultWindow;
     auto originalOpenNewTab = manager.get().internalDelegate.openNewTab;
@@ -262,7 +262,7 @@ TEST(WKWebExtensionAPITabs, Create)
 
 TEST(WKWebExtensionAPITabs, CreateTabsOverflowIndex)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"var allWindows = await browser.windows.getAll({ populate: true })",
         @"var initialTabsCount = allWindows[0].tabs.length",
         @"var largeIndex = 13000000000000000000000000000000000",
@@ -276,7 +276,7 @@ TEST(WKWebExtensionAPITabs, CreateTabsOverflowIndex)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript.get() });
 
     auto *window = manager.get().defaultWindow;
     auto originalOpenNewTab = manager.get().internalDelegate.openNewTab;
@@ -293,7 +293,7 @@ TEST(WKWebExtensionAPITabs, CreateTabsOverflowIndex)
 
 TEST(WKWebExtensionAPITabs, CreateTabsZeroIndex)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"var allWindows = await browser.windows.getAll({ populate: true })",
         @"var initialTabsCount = allWindows[0].tabs.length",
 
@@ -307,7 +307,7 @@ TEST(WKWebExtensionAPITabs, CreateTabsZeroIndex)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript.get() });
 
     auto *window = manager.get().defaultWindow;
     auto originalOpenNewTab = manager.get().internalDelegate.openNewTab;
@@ -324,7 +324,7 @@ TEST(WKWebExtensionAPITabs, CreateTabsZeroIndex)
 
 TEST(WKWebExtensionAPITabs, CreateWithSpecifiedOptions)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const allWindows = await browser.windows.getAll({ populate: true })",
         @"const initialTabsCount = allWindows[0].tabs.length",
 
@@ -347,7 +347,7 @@ TEST(WKWebExtensionAPITabs, CreateWithSpecifiedOptions)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript.get() });
 
     auto *window = manager.get().defaultWindow;
     auto *tab = manager.get().defaultTab;
@@ -374,7 +374,7 @@ TEST(WKWebExtensionAPITabs, CreateWithSpecifiedOptions)
 
 TEST(WKWebExtensionAPITabs, CreateWithRelativeURL)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const newTab = await browser.tabs.create({",
         @"  url: 'test.html'",
         @"})",
@@ -384,7 +384,7 @@ TEST(WKWebExtensionAPITabs, CreateWithRelativeURL)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript, @"test.html": @"Hello world!" });
+    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript.get(), @"test.html": @"Hello world!" });
 
     auto originalOpenNewTab = manager.get().internalDelegate.openNewTab;
 
@@ -399,7 +399,7 @@ TEST(WKWebExtensionAPITabs, CreateWithRelativeURL)
 
 TEST(WKWebExtensionAPITabs, Duplicate)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const allWindows = await browser.windows.getAll({ populate: true })",
         @"const initialTabsCount = allWindows[0].tabs.length",
 
@@ -413,7 +413,7 @@ TEST(WKWebExtensionAPITabs, Duplicate)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript.get() });
 
     auto *window = manager.get().defaultWindow;
     auto *tab = manager.get().defaultTab;
@@ -440,7 +440,7 @@ TEST(WKWebExtensionAPITabs, Duplicate)
 
 TEST(WKWebExtensionAPITabs, DuplicateWithOptions)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const allWindows = await browser.windows.getAll({ populate: true })",
         @"const initialTabsCount = allWindows[0].tabs.length",
 
@@ -458,7 +458,7 @@ TEST(WKWebExtensionAPITabs, DuplicateWithOptions)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript.get() });
 
     auto *window = manager.get().defaultWindow;
     auto *tab = manager.get().defaultTab;
@@ -485,7 +485,7 @@ TEST(WKWebExtensionAPITabs, DuplicateWithOptions)
 
 TEST(WKWebExtensionAPITabs, Update)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const allWindows = await browser.windows.getAll({ populate: true })",
         @"const secondTab = allWindows[0].tabs[1]",
 
@@ -512,7 +512,7 @@ TEST(WKWebExtensionAPITabs, Update)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().defaultWindow openNewTab];
 
@@ -523,7 +523,7 @@ TEST(WKWebExtensionAPITabs, Update)
 
 TEST(WKWebExtensionAPITabs, UpdateWithoutTabId)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const allWindows = await browser.windows.getAll({ populate: true })",
         @"const activeTab = allWindows[0].tabs[0]",
 
@@ -538,7 +538,7 @@ TEST(WKWebExtensionAPITabs, UpdateWithoutTabId)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript.get() });
 
     EXPECT_EQ(manager.get().defaultWindow.tabs.count, 1lu);
 
@@ -547,7 +547,7 @@ TEST(WKWebExtensionAPITabs, UpdateWithoutTabId)
 
 TEST(WKWebExtensionAPITabs, Get)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const allWindows = await browser.windows.getAll({ populate: true })",
         @"const windowId = allWindows[0].id",
         @"const tabId = allWindows[0].tabs[0].id",
@@ -571,7 +571,7 @@ TEST(WKWebExtensionAPITabs, Get)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().defaultWindow openNewTab];
 
@@ -582,7 +582,7 @@ TEST(WKWebExtensionAPITabs, Get)
 
 TEST(WKWebExtensionAPITabs, GetCurrentFromBackgroundPage)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const [currentTab] = await browser.tabs.query({ active: true, currentWindow: true })",
         @"const tab = await browser.tabs.getCurrent()",
 
@@ -591,7 +591,7 @@ TEST(WKWebExtensionAPITabs, GetCurrentFromBackgroundPage)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().defaultWindow openNewTab];
 
@@ -602,7 +602,7 @@ TEST(WKWebExtensionAPITabs, GetCurrentFromBackgroundPage)
 
 TEST(WKWebExtensionAPITabs, GetCurrentFromOptionsPage)
 {
-    auto *optionsScript = Util::constructScript(@[
+    RetainPtr optionsScript = Util::constructScript(@[
         @"const tab = await browser.tabs.getCurrent()",
 
         @"browser.test.assertEq(typeof tab, 'object', 'The tab should be')",
@@ -614,7 +614,7 @@ TEST(WKWebExtensionAPITabs, GetCurrentFromOptionsPage)
     auto *resources = @{
         @"background.js": @"// Not Used",
         @"options.html": @"<script type='module' src='options.js'></script>",
-        @"options.js": optionsScript
+        @"options.js": optionsScript.get()
     };
 
     auto manager = Util::loadExtension(tabsManifest, resources);
@@ -637,7 +637,7 @@ TEST(WKWebExtensionAPITabs, GetCurrentFromOptionsPage)
 
 TEST(WKWebExtensionAPITabs, GetSelected)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const [selectedTab] = await browser.tabs.query({ active: true, currentWindow: true })",
         @"const tab = await browser.tabs.getSelected()",
 
@@ -646,7 +646,7 @@ TEST(WKWebExtensionAPITabs, GetSelected)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::loadExtension(tabsManifestV2, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(tabsManifestV2, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().defaultWindow openNewTab];
 
@@ -657,7 +657,7 @@ TEST(WKWebExtensionAPITabs, GetSelected)
 
 TEST(WKWebExtensionAPITabs, Query)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const allWindows = await browser.windows.getAll({ populate: true })",
         @"browser.test.assertEq(allWindows?.length, 2, 'There should be 2 windows')",
 
@@ -699,7 +699,7 @@ TEST(WKWebExtensionAPITabs, Query)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::parseExtension(tabsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::parseExtension(tabsManifest, @{ @"background.js": backgroundScript.get() });
 
     auto *windowOne = manager.get().defaultWindow;
     [windowOne openNewTab];
@@ -721,7 +721,7 @@ TEST(WKWebExtensionAPITabs, Query)
 
 TEST(WKWebExtensionAPITabs, QueryWithPrivateAccess)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const allWindows = await browser.windows.getAll({ populate: true })",
         @"const normalWindows = allWindows.filter(window => !window.incognito)",
         @"const incognitoWindows = allWindows.filter(window => window.incognito)",
@@ -770,7 +770,7 @@ TEST(WKWebExtensionAPITabs, QueryWithPrivateAccess)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::parseExtension(tabsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::parseExtension(tabsManifest, @{ @"background.js": backgroundScript.get() });
 
     manager.get().context.hasAccessToPrivateData = YES;
 
@@ -798,7 +798,7 @@ TEST(WKWebExtensionAPITabs, QueryWithAccessPrompt)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const allWindows = await browser.windows.getAll({ populate: true })",
         @"const windowIdOne = allWindows?.[0]?.id",
 
@@ -817,7 +817,7 @@ TEST(WKWebExtensionAPITabs, QueryWithAccessPrompt)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionTabs];
 
@@ -862,7 +862,7 @@ TEST(WKWebExtensionAPITabs, QueryWithAccessPrompt)
 
 TEST(WKWebExtensionAPITabs, QueryWithCurrentWindow)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const tabs = await browser.tabs.query({ windowId: browser.windows.WINDOW_ID_CURRENT })",
         @"browser.test.assertEq(tabs.length, 2, 'Should return exactly two tabs for the current window')",
 
@@ -875,7 +875,7 @@ TEST(WKWebExtensionAPITabs, QueryWithCurrentWindow)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().defaultWindow openNewTab];
 
@@ -890,7 +890,7 @@ TEST(WKWebExtensionAPITabs, QueryWithPermissionBypass)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const allWindows = await browser.windows.getAll({ populate: true })",
         @"const windowIdOne = allWindows?.[0]?.id",
 
@@ -909,7 +909,7 @@ TEST(WKWebExtensionAPITabs, QueryWithPermissionBypass)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionTabs];
 
@@ -934,7 +934,7 @@ TEST(WKWebExtensionAPITabs, QueryWithPermissionBypass)
 
 TEST(WKWebExtensionAPITabs, Zoom)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const allWindows = await browser.windows.getAll({ populate: true })",
         @"const windowId = allWindows[0].id",
         @"const tabId = allWindows[0].tabs[0].id",
@@ -949,12 +949,12 @@ TEST(WKWebExtensionAPITabs, Zoom)
         @"browser.test.notifyPass()"
     ]);
 
-    Util::loadAndRunExtension(tabsManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(tabsManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPITabs, ToggleReaderMode)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const allWindows = await browser.windows.getAll({ populate: true })",
         @"const tabId = allWindows[0].tabs[0].id",
 
@@ -971,7 +971,7 @@ TEST(WKWebExtensionAPITabs, ToggleReaderMode)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript.get() });
 
     __block size_t toggleReaderModeCounter = 0;
 
@@ -990,7 +990,7 @@ TEST(WKWebExtensionAPITabs, DetectLanguage)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const allWindows = await browser.windows.getAll({ populate: true })",
         @"const tabId = allWindows[0].tabs[0].id",
 
@@ -1001,11 +1001,11 @@ TEST(WKWebExtensionAPITabs, DetectLanguage)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript.get() });
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     __block bool detectWebpageLocaleCalled = false;
 
@@ -1021,7 +1021,7 @@ TEST(WKWebExtensionAPITabs, DetectLanguage)
 
 TEST(WKWebExtensionAPITabs, CaptureVisibleTab)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const newTab = await browser.tabs.create({ url: 'http://example.com' })",
 
         @"let dataURLPNG = await browser.tabs.captureVisibleTab(newTab.windowId, { format: 'png' })",
@@ -1033,7 +1033,7 @@ TEST(WKWebExtensionAPITabs, CaptureVisibleTab)
         @"browser.test.notifyPass()",
     ]);
 
-    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:[NSURL URLWithString:@"http://example.com/"]];
 
@@ -1042,7 +1042,7 @@ TEST(WKWebExtensionAPITabs, CaptureVisibleTab)
 
 TEST(WKWebExtensionAPITabs, Reload)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const allWindows = await browser.windows.getAll({ populate: true })",
         @"const tabId = allWindows[0].tabs[0].id",
 
@@ -1052,7 +1052,7 @@ TEST(WKWebExtensionAPITabs, Reload)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript.get() });
 
     __block bool reloadCalled = false;
     __block bool reloadFromOriginCalled = false;
@@ -1072,7 +1072,7 @@ TEST(WKWebExtensionAPITabs, Reload)
 
 TEST(WKWebExtensionAPITabs, GoBack)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const allWindows = await browser.windows.getAll({ populate: true })",
         @"const tabId = allWindows[0].tabs[0].id",
 
@@ -1081,7 +1081,7 @@ TEST(WKWebExtensionAPITabs, GoBack)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript.get() });
 
     __block bool goBackCalled = false;
 
@@ -1096,7 +1096,7 @@ TEST(WKWebExtensionAPITabs, GoBack)
 
 TEST(WKWebExtensionAPITabs, GoForward)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const allWindows = await browser.windows.getAll({ populate: true })",
         @"const tabId = allWindows[0].tabs[0].id",
 
@@ -1105,7 +1105,7 @@ TEST(WKWebExtensionAPITabs, GoForward)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript.get() });
 
     __block bool goForwardCalled = false;
 
@@ -1120,7 +1120,7 @@ TEST(WKWebExtensionAPITabs, GoForward)
 
 TEST(WKWebExtensionAPITabs, Remove)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const allWindows = await browser.windows.getAll({ populate: true })",
         @"const tabIdToRemove = allWindows[0].tabs[1].id",
 
@@ -1135,7 +1135,7 @@ TEST(WKWebExtensionAPITabs, Remove)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().defaultWindow openNewTab];
 
@@ -1146,7 +1146,7 @@ TEST(WKWebExtensionAPITabs, Remove)
 
 TEST(WKWebExtensionAPITabs, RemoveMultipleTabs)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const allWindows = await browser.windows.getAll({ populate: true })",
         @"const tabIdsToRemove = [allWindows[0].tabs[1].id, allWindows[0].tabs[2].id]",
 
@@ -1162,7 +1162,7 @@ TEST(WKWebExtensionAPITabs, RemoveMultipleTabs)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().defaultWindow openNewTab];
     [manager.get().defaultWindow openNewTab];
@@ -1174,7 +1174,7 @@ TEST(WKWebExtensionAPITabs, RemoveMultipleTabs)
 
 TEST(WKWebExtensionAPITabs, CreatedEvent)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.tabs.onCreated.addListener((newTab) => {",
         @"  browser.test.assertFalse(newTab.active, 'The new tab should not be active')",
         @"  browser.test.assertFalse(newTab.pinned, 'The new tab should not be pinned')",
@@ -1187,12 +1187,12 @@ TEST(WKWebExtensionAPITabs, CreatedEvent)
         @"browser.tabs.create({})",
     ]);
 
-    Util::loadAndRunExtension(tabsManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(tabsManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPITabs, UpdatedEvent)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const newTab = await browser.tabs.create({ active: false, muted: false, pinned: false })",
 
         @"let mutedUpdated = false",
@@ -1224,7 +1224,7 @@ TEST(WKWebExtensionAPITabs, UpdatedEvent)
         @"browser.tabs.update(newTab.id, { muted: true, pinned: true })"
     ]);
 
-    Util::loadAndRunExtension(tabsManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(tabsManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPITabs, UpdatedEventWithoutPrivateAccess)
@@ -1233,7 +1233,7 @@ TEST(WKWebExtensionAPITabs, UpdatedEventWithoutPrivateAccess)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {",
         @"  browser.test.notifyFail('tabs.onUpdated should not fire for private tabs when no permission is granted.')",
         @"})",
@@ -1243,7 +1243,7 @@ TEST(WKWebExtensionAPITabs, UpdatedEventWithoutPrivateAccess)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager runUntilTestMessage:@"Load Tab"];
 
@@ -1259,7 +1259,7 @@ TEST(WKWebExtensionAPITabs, UpdatedEventWithPrivateAccess)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {",
         @"  browser.test.notifyPass()",
         @"})",
@@ -1269,7 +1269,7 @@ TEST(WKWebExtensionAPITabs, UpdatedEventWithPrivateAccess)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::parseExtension(tabsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::parseExtension(tabsManifest, @{ @"background.js": backgroundScript.get() });
 
     manager.get().context.hasAccessToPrivateData = YES;
 
@@ -1284,7 +1284,7 @@ TEST(WKWebExtensionAPITabs, UpdatedEventWithPrivateAccess)
 
 TEST(WKWebExtensionAPITabs, RemovedEvent)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const newTab = await browser.tabs.create({})",
 
         @"browser.tabs.onRemoved.addListener((tabId, removeInfo) => {",
@@ -1297,12 +1297,12 @@ TEST(WKWebExtensionAPITabs, RemovedEvent)
         @"browser.tabs.remove(newTab.id)"
     ]);
 
-    Util::loadAndRunExtension(tabsManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(tabsManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPITabs, ReplacedEvent)
 {
-    auto backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"let createdTabId = null",
         @"let removedTabId = null",
 
@@ -1330,7 +1330,7 @@ TEST(WKWebExtensionAPITabs, ReplacedEvent)
         @"browser.test.sendMessage('Replace Tab')"
     ]);
 
-    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager runUntilTestMessage:@"Replace Tab"];
 
@@ -1345,7 +1345,7 @@ TEST(WKWebExtensionAPITabs, ReplacedEvent)
 
 TEST(WKWebExtensionAPITabs, MovedEvent)
 {
-    auto backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.tabs.onMoved.addListener((tabId, moveInfo) => {",
         @"  browser.test.assertEq(tabId, movedTabId, 'Moved tab id should match the provided tab id')",
         @"  browser.test.assertEq(moveInfo.fromIndex, 1, 'Tab should have been moved from index 1')",
@@ -1360,7 +1360,7 @@ TEST(WKWebExtensionAPITabs, MovedEvent)
         @"browser.test.sendMessage('Move Tab')"
     ]);
 
-    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript.get() });
 
     auto *tabToMove = [manager.get().defaultWindow openNewTab];
     [manager.get().defaultWindow openNewTab];
@@ -1374,7 +1374,7 @@ TEST(WKWebExtensionAPITabs, MovedEvent)
 
 TEST(WKWebExtensionAPITabs, DetachedAndAttachedEvent)
 {
-    auto backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"let detachedTabId",
 
         @"const currentWindow = await browser.windows.getCurrent()",
@@ -1401,7 +1401,7 @@ TEST(WKWebExtensionAPITabs, DetachedAndAttachedEvent)
         @"browser.test.sendMessage('Move Tab')"
     ]);
 
-    auto manager = Util::parseExtension(tabsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::parseExtension(tabsManifest, @{ @"background.js": backgroundScript.get() });
 
     auto *tabToMove = [manager.get().defaultWindow openNewTab];
     auto *secondWindow = [manager openNewWindow];
@@ -1422,7 +1422,7 @@ TEST(WKWebExtensionAPITabs, DetachedAndAttachedEvent)
 
 TEST(WKWebExtensionAPITabs, DetachAndAttachToWindowIDNone)
 {
-    auto backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"let detachedTabId",
 
         @"const currentWindow = await browser.windows.getCurrent()",
@@ -1445,7 +1445,7 @@ TEST(WKWebExtensionAPITabs, DetachAndAttachToWindowIDNone)
         @"browser.test.sendMessage('Detach Tab')"
     ]);
 
-    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript.get() });
 
     auto *tabToMove = [manager.get().defaultWindow openNewTab];
 
@@ -1462,7 +1462,7 @@ TEST(WKWebExtensionAPITabs, DetachAndAttachToWindowIDNone)
 
 TEST(WKWebExtensionAPITabs, DetachAndAttachFromWindowIDNone)
 {
-    auto backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"let detachedTabId",
 
         @"const currentWindow = await browser.windows.getCurrent()",
@@ -1485,7 +1485,7 @@ TEST(WKWebExtensionAPITabs, DetachAndAttachFromWindowIDNone)
         @"browser.test.sendMessage('Attach Tab')"
     ]);
 
-    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript.get() });
 
     auto *tabToMove = [manager.get().defaultWindow openNewTab];
 
@@ -1508,7 +1508,7 @@ TEST(WKWebExtensionAPITabs, DetachAndAttachFromWindowIDNone)
 
 TEST(WKWebExtensionAPITabs, ActivatedEvent)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const newTab = await browser.tabs.create({ active: false })",
 
         @"browser.tabs.onActivated.addListener((activeInfo) => {",
@@ -1520,12 +1520,12 @@ TEST(WKWebExtensionAPITabs, ActivatedEvent)
         @"browser.tabs.update(newTab.id, { active: true })"
     ]);
 
-    Util::loadAndRunExtension(tabsManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(tabsManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPITabs, HighlightedEvent)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const initialTabs = await browser.tabs.query({ active: true, currentWindow: true })",
         @"const newTab = await browser.tabs.create({ active: false })",
 
@@ -1543,12 +1543,12 @@ TEST(WKWebExtensionAPITabs, HighlightedEvent)
         @"browser.tabs.update(newTab.id, { active: false, highlighted: true })"
     ]);
 
-    Util::loadAndRunExtension(tabsManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(tabsManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPITabs, HighlightedAlsoActivatesTab)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const newTab = await browser.tabs.create({ active: false })",
 
         @"let tabActivated = false",
@@ -1574,7 +1574,7 @@ TEST(WKWebExtensionAPITabs, HighlightedAlsoActivatesTab)
         @"browser.tabs.update(newTab.id, { highlighted: true })"
     ]);
 
-    Util::loadAndRunExtension(tabsManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(tabsManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 // FIXME rdar://147858640
@@ -1588,7 +1588,7 @@ TEST(WKWebExtensionAPITabs, SendMessage)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.runtime.onMessage.addListener(async (message, sender, sendResponse) => {",
         @"  browser.test.assertEq(message, 'Ready')",
 
@@ -1602,7 +1602,7 @@ TEST(WKWebExtensionAPITabs, SendMessage)
         @"})"
     ]);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"browser.runtime.onMessage.addListener((message, sender, sendResponse) => {",
         @"  browser.test.assertEq(message.content, 'Hello', 'Should receive the correct message content')",
 
@@ -1623,11 +1623,11 @@ TEST(WKWebExtensionAPITabs, SendMessage)
         @"setTimeout(() => browser.runtime.sendMessage('Ready'), 1000)"
     ]);
 
-    auto manager = Util::loadExtension(tabsContentScriptManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
+    auto manager = Util::loadExtension(tabsContentScriptManifest, @{ @"background.js": backgroundScript.get(), @"content.js": contentScript.get() });
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -1643,7 +1643,7 @@ TEST(WKWebExtensionAPITabs, SendMessageWithAsyncReply)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.runtime.onMessage.addListener(async (message, sender, sendResponse) => {",
         @"  browser.test.assertEq(message, 'Ready')",
 
@@ -1657,7 +1657,7 @@ TEST(WKWebExtensionAPITabs, SendMessageWithAsyncReply)
         @"})"
     ]);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"browser.runtime.onMessage.addListener((message, sender, sendResponse) => {",
         @"  browser.test.assertEq(message.content, 'Hello', 'Should receive the correct message content')",
 
@@ -1680,11 +1680,11 @@ TEST(WKWebExtensionAPITabs, SendMessageWithAsyncReply)
         @"setTimeout(() => browser.runtime.sendMessage('Ready'), 1000)"
     ]);
 
-    auto manager = Util::loadExtension(tabsContentScriptManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
+    auto manager = Util::loadExtension(tabsContentScriptManifest, @{ @"background.js": backgroundScript.get(), @"content.js": contentScript.get() });
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -1700,7 +1700,7 @@ TEST(WKWebExtensionAPITabs, SendMessageWithPromiseReply)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.runtime.onMessage.addListener(async (message, sender) => {",
         @"  browser.test.assertEq(message, 'Ready')",
 
@@ -1714,7 +1714,7 @@ TEST(WKWebExtensionAPITabs, SendMessageWithPromiseReply)
         @"})"
     ]);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"browser.runtime.onMessage.addListener((message, sender) => {",
         @"  browser.test.assertEq(message.content, 'Hello', 'Should receive the correct message content')",
 
@@ -1735,11 +1735,11 @@ TEST(WKWebExtensionAPITabs, SendMessageWithPromiseReply)
         @"setTimeout(() => browser.runtime.sendMessage('Ready'), 1000)"
     ]);
 
-    auto manager = Util::loadExtension(tabsContentScriptManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
+    auto manager = Util::loadExtension(tabsContentScriptManifest, @{ @"background.js": backgroundScript.get(), @"content.js": contentScript.get() });
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -1755,7 +1755,7 @@ TEST(WKWebExtensionAPITabs, SendMessageWithAsyncPromiseReply)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.runtime.onMessage.addListener(async (message, sender) => {",
         @"  browser.test.assertEq(message, 'Ready')",
 
@@ -1769,7 +1769,7 @@ TEST(WKWebExtensionAPITabs, SendMessageWithAsyncPromiseReply)
         @"})"
     ]);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"browser.runtime.onMessage.addListener((message, sender) => {",
         @"  browser.test.assertEq(message.content, 'Hello', 'Should receive the correct message content')",
 
@@ -1792,7 +1792,7 @@ TEST(WKWebExtensionAPITabs, SendMessageWithAsyncPromiseReply)
         @"setTimeout(() => browser.runtime.sendMessage('Ready'), 1000)"
     ]);
 
-    auto manager = Util::loadExtension(tabsContentScriptManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
+    auto manager = Util::loadExtension(tabsContentScriptManifest, @{ @"background.js": backgroundScript.get(), @"content.js": contentScript.get() });
 
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
@@ -1812,7 +1812,7 @@ TEST(WKWebExtensionAPITabs, SendMessageWithoutReply)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.runtime.onMessage.addListener(async (message, sender) => {",
         @"  const tabs = await browser.tabs.query({ active: true, currentWindow: true })",
         @"  const tabId = tabs[0].id",
@@ -1824,7 +1824,7 @@ TEST(WKWebExtensionAPITabs, SendMessageWithoutReply)
         @"})"
     ]);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"browser.runtime.onMessage.addListener((message, sender) => {",
         @"  browser.test.assertEq(message.content, 'Hello', 'Should receive the correct message content')",
 
@@ -1845,7 +1845,7 @@ TEST(WKWebExtensionAPITabs, SendMessageWithoutReply)
         @"setTimeout(() => browser.runtime.sendMessage('Ready'), 1000)"
     ]);
 
-    auto manager = Util::loadExtension(tabsContentScriptManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
+    auto manager = Util::loadExtension(tabsContentScriptManifest, @{ @"background.js": backgroundScript.get(), @"content.js": contentScript.get() });
 
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
@@ -1868,7 +1868,7 @@ TEST(WKWebExtensionAPITabs, SendMessageFromBackgroundPageToFullPageExtensionCont
         @"browser.runtime.sendMessage({ content: 'Ready' })",
     ]);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.runtime.onMessage.addListener(async (message, sender, sendResponse) => {",
         @"  browser.test.assertEq(message?.content, 'Ready', 'Should receive the correct message from the options page')",
 
@@ -1884,7 +1884,7 @@ TEST(WKWebExtensionAPITabs, SendMessageFromBackgroundPageToFullPageExtensionCont
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"options.html": @"<script type='module' src='options.js'></script>",
         @"options.js": optionsScript
     };
@@ -1923,7 +1923,7 @@ TEST(WKWebExtensionAPITabs, SendMessageFromBackgroundToSubframe)
     auto *urlRequestMain = server.requestWithLocalhost("/main"_s);
     auto *urlRequestSubframe = server.request("/subframe"_s);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.sendMessage('Load Tab')",
 
         @"await new Promise(resolve => setTimeout(resolve, 1500))",
@@ -1937,7 +1937,7 @@ TEST(WKWebExtensionAPITabs, SendMessageFromBackgroundToSubframe)
         @"browser.test.notifyPass()",
     ]);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"browser.runtime.onMessage.addListener((message, sender) => {",
         @"  browser.test.assertEq(message?.content, 'Hello Subframe', 'Should receive the correct message from the background page')",
         @"  return Promise.resolve({ content: 'Received from subframe' })",
@@ -1965,8 +1965,8 @@ TEST(WKWebExtensionAPITabs, SendMessageFromBackgroundToSubframe)
     };
 
     auto *resources = @{
-        @"background.js": backgroundScript,
-        @"content.js": contentScript
+        @"background.js": backgroundScript.get(),
+        @"content.js": contentScript.get()
     };
 
     auto manager = Util::loadExtension(manifest, resources);
@@ -1987,7 +1987,7 @@ TEST(WKWebExtensionAPITabs, SendMessageFromBackgroundToSpecificFrame)
         { "/frame.html"_s, { { { "Content-Type"_s, "text/html"_s } }, " "_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.runtime.onMessage.addListener(async (message, sender) => {",
         @"  browser.test.assertEq(message, 'Begin Test', 'Message content should match')",
 
@@ -2003,7 +2003,7 @@ TEST(WKWebExtensionAPITabs, SendMessageFromBackgroundToSpecificFrame)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"if (window.top === window) {",
         @"  browser.runtime.onMessage.addListener(() => {",
         @"    browser.test.notifyFail('Main frame should not receive message intended for iframe')",
@@ -2019,8 +2019,8 @@ TEST(WKWebExtensionAPITabs, SendMessageFromBackgroundToSpecificFrame)
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
-        @"content.js": contentScript,
+        @"background.js": backgroundScript.get(),
+        @"content.js": contentScript.get(),
     };
 
     auto manager = Util::loadExtension(tabsContentScriptManifest, resources);
@@ -2042,7 +2042,7 @@ TEST(WKWebExtensionAPITabs, SendMessageFromBackgroundToSpecificDocument)
         { "/frame.html"_s, { { { "Content-Type"_s, "text/html"_s } }, " "_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.runtime.onMessage.addListener(async (message, sender) => {",
         @"  browser.test.assertEq(message, 'Begin Test', 'Message content should match')",
 
@@ -2059,7 +2059,7 @@ TEST(WKWebExtensionAPITabs, SendMessageFromBackgroundToSpecificDocument)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"if (window.top === window) {",
         @"  browser.runtime.onMessage.addListener(() => {",
         @"    browser.test.notifyFail('Main frame should not receive message intended for iframe')",
@@ -2075,8 +2075,8 @@ TEST(WKWebExtensionAPITabs, SendMessageFromBackgroundToSpecificDocument)
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
-        @"content.js": contentScript,
+        @"background.js": backgroundScript.get(),
+        @"content.js": contentScript.get(),
     };
 
     auto manager = Util::loadExtension(tabsContentScriptManifest, resources);
@@ -2098,7 +2098,7 @@ TEST(WKWebExtensionAPITabs, SendMessageBackAndForwardNavigation)
         { "/frame"_s, { { { "Content-Type"_s, "text/html"_s } }, "<p>Frame Content</p>"_s } }
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const expectedHostnames = ['localhost', '127.0.0.1', 'localhost', '127.0.0.1']",
         @"let step = 0",
 
@@ -2128,7 +2128,7 @@ TEST(WKWebExtensionAPITabs, SendMessageBackAndForwardNavigation)
         @"browser.test.sendMessage('Ready')"
     ]);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"browser.runtime.onMessage.addListener((message) => {",
         @"  browser.test.assertEq(message, 'Ping', 'Message content should match')",
         @"  return Promise.resolve(window?.location?.href)",
@@ -2136,8 +2136,8 @@ TEST(WKWebExtensionAPITabs, SendMessageBackAndForwardNavigation)
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
-        @"content.js": contentScript,
+        @"background.js": backgroundScript.get(),
+        @"content.js": contentScript.get(),
     };
 
     auto *manifest = @{
@@ -2210,7 +2210,7 @@ TEST(WKWebExtensionAPITabs, Connect)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.runtime.onMessage.addListener(async (message, sender) => {",
         @"  browser.test.assertEq(message?.readyToConnect, true, 'Should be ready to connect')",
 
@@ -2232,7 +2232,7 @@ TEST(WKWebExtensionAPITabs, Connect)
         @"})"
     ]);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"browser.runtime.onConnect.addListener((port) => {",
         @"  browser.test.assertEq(port.name, 'testPort', 'Port name should be testPort')",
         @"  browser.test.assertEq(port.error, null, 'Port error should be null')",
@@ -2256,7 +2256,7 @@ TEST(WKWebExtensionAPITabs, Connect)
         @"}, 1000)"
     ]);
 
-    auto manager = Util::loadExtension(tabsContentScriptManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
+    auto manager = Util::loadExtension(tabsContentScriptManifest, @{ @"background.js": backgroundScript.get(), @"content.js": contentScript.get() });
 
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
@@ -2272,7 +2272,7 @@ TEST(WKWebExtensionAPITabs, ConnectToSpecificFrame)
         { "/frame.html"_s, { { { "Content-Type"_s, "text/html"_s } }, " "_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.runtime.onMessage.addListener(async (message, sender) => {",
         @"  browser.test.assertEq(message, 'Begin Test', 'Message content should match')",
 
@@ -2293,7 +2293,7 @@ TEST(WKWebExtensionAPITabs, ConnectToSpecificFrame)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"if (window.top === window) {",
         @"  browser.runtime.onConnect.addListener(() => {",
         @"    browser.test.notifyFail('Main frame should not receive connection intended for iframe')",
@@ -2311,8 +2311,8 @@ TEST(WKWebExtensionAPITabs, ConnectToSpecificFrame)
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
-        @"content.js": contentScript,
+        @"background.js": backgroundScript.get(),
+        @"content.js": contentScript.get(),
     };
 
     auto manager = Util::loadExtension(tabsContentScriptManifest, resources);
@@ -2334,7 +2334,7 @@ TEST(WKWebExtensionAPITabs, ConnectToSpecificDocument)
         { "/frame.html"_s, { { { "Content-Type"_s, "text/html"_s } }, " "_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.runtime.onMessage.addListener(async (message, sender) => {",
         @"  browser.test.assertEq(message, 'Begin Test', 'Message content should match')",
 
@@ -2356,7 +2356,7 @@ TEST(WKWebExtensionAPITabs, ConnectToSpecificDocument)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"if (window.top === window) {",
         @"  browser.runtime.onConnect.addListener(() => {",
         @"    browser.test.notifyFail('Main frame should not receive connection intended for iframe')",
@@ -2374,8 +2374,8 @@ TEST(WKWebExtensionAPITabs, ConnectToSpecificDocument)
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
-        @"content.js": contentScript,
+        @"background.js": backgroundScript.get(),
+        @"content.js": contentScript.get(),
     };
 
     auto manager = Util::loadExtension(tabsContentScriptManifest, resources);
@@ -2404,7 +2404,7 @@ TEST(WKWebExtensionAPITabs, ConnectToSubframe)
     auto *urlRequestMain = server.requestWithLocalhost("/main"_s);
     auto *urlRequestSubframe = server.request("/subframe"_s);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.sendMessage('Load Tab')",
 
         @"await new Promise(resolve => setTimeout(resolve, 1500))",
@@ -2424,7 +2424,7 @@ TEST(WKWebExtensionAPITabs, ConnectToSubframe)
         @"port.postMessage('Hello Subframe')"
     ]);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"browser.runtime.onConnect.addListener((port) => {",
         @"  browser.test.assertEq(port.name, 'testPort', 'Port name should be testPort')",
 
@@ -2456,8 +2456,8 @@ TEST(WKWebExtensionAPITabs, ConnectToSubframe)
     };
 
     auto *resources = @{
-        @"background.js": backgroundScript,
-        @"content.js": contentScript
+        @"background.js": backgroundScript.get(),
+        @"content.js": contentScript.get()
     };
 
     auto manager = Util::loadExtension(manifest, resources);
@@ -2482,7 +2482,7 @@ TEST(WKWebExtensionAPITabs, PortDisconnect)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.runtime.onMessage.addListener(async (message, sender) => {",
         @"  browser.test.assertEq(message?.readyToConnect, true, 'Should be ready to connect')",
 
@@ -2504,7 +2504,7 @@ TEST(WKWebExtensionAPITabs, PortDisconnect)
         @"})"
     ]);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"browser.runtime.onConnect.addListener((port) => {",
         @"  port.onMessage.addListener((message) => {",
         @"    browser.test.assertEq(message, 'Hello', 'Should receive the correct message content')",
@@ -2521,7 +2521,7 @@ TEST(WKWebExtensionAPITabs, PortDisconnect)
         @"}, 1000)"
     ]);
 
-    auto manager = Util::loadExtension(tabsContentScriptManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
+    auto manager = Util::loadExtension(tabsContentScriptManifest, @{ @"background.js": backgroundScript.get(), @"content.js": contentScript.get() });
 
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
@@ -2541,7 +2541,7 @@ TEST(WKWebExtensionAPITabs, ConnectWithMultipleListeners)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.runtime.onMessage.addListener(async (message, sender) => {",
         @"  browser.test.assertEq(message?.readyToConnect, true, 'Should be ready to connect')",
 
@@ -2565,7 +2565,7 @@ TEST(WKWebExtensionAPITabs, ConnectWithMultipleListeners)
         @"})"
     ]);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"let firstListenerHandled = false",
         @"let secondListenerHandled = false",
 
@@ -2594,7 +2594,7 @@ TEST(WKWebExtensionAPITabs, ConnectWithMultipleListeners)
         @"}, 1000)"
     ]);
 
-    auto manager = Util::loadExtension(tabsContentScriptManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
+    auto manager = Util::loadExtension(tabsContentScriptManifest, @{ @"background.js": backgroundScript.get(), @"content.js": contentScript.get() });
 
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
@@ -2614,7 +2614,7 @@ TEST(WKWebExtensionAPITabs, PortDisconnectWithMultipleListeners)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.runtime.onMessage.addListener(async (message, sender) => {",
         @"  browser.test.assertEq(message?.readyToConnect, true, 'Should be ready to connect')",
 
@@ -2638,7 +2638,7 @@ TEST(WKWebExtensionAPITabs, PortDisconnectWithMultipleListeners)
         @"})"
     ]);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"browser.runtime.onConnect.addListener((port) => {",
         @"  port.onMessage.addListener((message) => {",
         @"    browser.test.assertEq(message, 'Hello', 'Should receive the correct message content')",
@@ -2659,7 +2659,7 @@ TEST(WKWebExtensionAPITabs, PortDisconnectWithMultipleListeners)
         @"}, 1000)"
     ]);
 
-    auto manager = Util::loadExtension(tabsContentScriptManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
+    auto manager = Util::loadExtension(tabsContentScriptManifest, @{ @"background.js": backgroundScript.get(), @"content.js": contentScript.get() });
 
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
@@ -2677,7 +2677,7 @@ TEST(WKWebExtensionAPITabs, ExecuteScript)
 
     static auto *javaScript = @"document.body.style.background = 'pink'";
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const tabs = await browser.tabs.query({ active: true, currentWindow: true })",
         @"const tabId = tabs[0].id",
 
@@ -2705,7 +2705,7 @@ TEST(WKWebExtensionAPITabs, ExecuteScript)
         @"browser.test.sendMessage('Load Tab')",
     ]);
 
-    auto manager = Util::loadExtension(tabsManifestV2, @{ @"background.js": backgroundScript, @"executeScript.js": javaScript });
+    auto manager = Util::loadExtension(tabsManifestV2, @{ @"background.js": backgroundScript.get(), @"executeScript.js": javaScript });
 
     auto *urlRequest = server.requestWithLocalhost();
     auto *url = urlRequest.URL;
@@ -2726,7 +2726,7 @@ TEST(WKWebExtensionAPITabs, ExecuteScriptWithFrameId)
         { "/frame.html"_s, { { { "Content-Type"_s, "text/html"_s } }, " "_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.runtime.onMessage.addListener(async (message, sender) => {",
         @"  browser.test.assertEq(message, 'Hello from frame')",
 
@@ -2742,7 +2742,7 @@ TEST(WKWebExtensionAPITabs, ExecuteScriptWithFrameId)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"browser.runtime.sendMessage('Hello from frame')",
     ]);
 
@@ -2767,8 +2767,8 @@ TEST(WKWebExtensionAPITabs, ExecuteScriptWithFrameId)
     };
 
     auto *resources = @{
-        @"background.js": backgroundScript,
-        @"content.js": contentScript,
+        @"background.js": backgroundScript.get(),
+        @"content.js": contentScript.get(),
     };
 
     auto manager = Util::loadExtension(manifest, resources);
@@ -2789,7 +2789,7 @@ TEST(WKWebExtensionAPITabs, ExecuteScriptWithDocumentId)
         { "/frame.html"_s, { { { "Content-Type"_s, "text/html"_s } }, "<span>Frame Document</span>"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.runtime.onMessage.addListener(async (message, sender) => {",
         @"  browser.test.assertEq(message, 'Hello from frame')",
 
@@ -2805,7 +2805,7 @@ TEST(WKWebExtensionAPITabs, ExecuteScriptWithDocumentId)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"browser.runtime.sendMessage('Hello from frame')",
     ]);
 
@@ -2829,8 +2829,8 @@ TEST(WKWebExtensionAPITabs, ExecuteScriptWithDocumentId)
     };
 
     auto *resources = @{
-        @"background.js": backgroundScript,
-        @"content.js": contentScript,
+        @"background.js": backgroundScript.get(),
+        @"content.js": contentScript.get(),
     };
 
     auto manager = Util::loadExtension(manifest, resources);
@@ -2850,7 +2850,7 @@ TEST(WKWebExtensionAPITabs, ExecuteScriptJSONTypes)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } }
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {",
         @"  if (tab.status === 'complete') {",
         @"    const expectedResult = { 'boolean': true, 'number': 42, 'string': 'Test String', 'object': { 'key': 'value' }, 'array': [1, 2, 3] };",
@@ -2869,7 +2869,7 @@ TEST(WKWebExtensionAPITabs, ExecuteScriptJSONTypes)
         @"browser.test.sendMessage('Load Tab')",
     ]);
 
-    auto manager = Util::loadExtension(tabsManifestV2, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(tabsManifestV2, @{ @"background.js": backgroundScript.get() });
 
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
@@ -2889,7 +2889,7 @@ TEST(WKWebExtensionAPITabs, InsertAndRemoveCSSInMainFrame)
 
     static auto *css = @"body { background-color: pink !important }";
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const pinkValue = 'rgb(255, 192, 203)'",
         @"const blueValue = 'rgb(0, 0, 255)'",
         @"const transparentValue = 'rgba(0, 0, 0, 0)'",
@@ -2934,7 +2934,7 @@ TEST(WKWebExtensionAPITabs, InsertAndRemoveCSSInMainFrame)
         @"browser.test.sendMessage('Load Tab')",
     ]);
 
-    auto manager = Util::loadExtension(tabsManifestV2, @{ @"background.js": backgroundScript, @"styles.css": css });
+    auto manager = Util::loadExtension(tabsManifestV2, @{ @"background.js": backgroundScript.get(), @"styles.css": css });
 
     auto *urlRequest = server.requestWithLocalhost();
     auto *url = urlRequest.URL;
@@ -2957,7 +2957,7 @@ TEST(WKWebExtensionAPITabs, InsertAndRemoveCSSInAllFrames)
 
     static auto *css = @"body { background-color: pink !important }";
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const pinkValue = 'rgb(255, 192, 203)'",
         @"const blueValue = 'rgb(0, 0, 255)'",
         @"const transparentValue = 'rgba(0, 0, 0, 0)'",
@@ -2985,7 +2985,7 @@ TEST(WKWebExtensionAPITabs, InsertAndRemoveCSSInAllFrames)
         @"browser.test.sendMessage('Load Tab')",
     ]);
 
-    auto manager = Util::loadExtension(tabsManifestV2, @{ @"background.js": backgroundScript, @"styles.css": css });
+    auto manager = Util::loadExtension(tabsManifestV2, @{ @"background.js": backgroundScript.get(), @"styles.css": css });
 
     auto *urlRequest = server.requestWithLocalhost();
     auto *url = urlRequest.URL;
@@ -3005,7 +3005,7 @@ TEST(WKWebExtensionAPITabs, CSSUserOrigin)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<body style='color: red'></body>"_s } }
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {",
         @"  if (changeInfo.status === 'complete') {",
         @"    await browser.test.assertSafeResolve(() => browser.tabs.insertCSS(tabId, { code: 'body { color: green !important }', cssOrigin: 'user' }))",
@@ -3022,7 +3022,7 @@ TEST(WKWebExtensionAPITabs, CSSUserOrigin)
 
     auto *urlRequest = server.requestWithLocalhost();
 
-    auto manager = Util::loadExtension(tabsManifestV2, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(tabsManifestV2, @{ @"background.js": backgroundScript.get() });
 
     [manager runUntilTestMessage:@"Load Tab"];
 
@@ -3037,7 +3037,7 @@ TEST(WKWebExtensionAPITabs, CSSAuthorOrigin)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<style> body { color: red; } </style>"_s } }
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {",
         @"  if (changeInfo.status === 'complete') {",
         @"    await browser.test.assertSafeResolve(() => browser.tabs.insertCSS(tabId, { code: 'body { color: green !important; }', cssOrigin: 'author' }))",
@@ -3054,7 +3054,7 @@ TEST(WKWebExtensionAPITabs, CSSAuthorOrigin)
 
     auto *urlRequest = server.requestWithLocalhost();
 
-    auto manager = Util::loadExtension(tabsManifestV2, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(tabsManifestV2, @{ @"background.js": backgroundScript.get() });
 
     [manager runUntilTestMessage:@"Load Tab"];
 
@@ -3067,7 +3067,7 @@ TEST(WKWebExtensionAPITabs, UnsupportedMV3APIs)
 {
     // Manifest v3 deprecates these APIs, so they should be an undefined property.
 
-    static auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.assertEq(browser.tabs.insertCSS, undefined)",
         @"browser.test.assertEq(browser.tabs.removeCSS, undefined)",
         @"browser.test.assertEq(browser.tabs.executeScript, undefined)",
@@ -3077,7 +3077,7 @@ TEST(WKWebExtensionAPITabs, UnsupportedMV3APIs)
         @"browser.test.notifyPass()"
     ]);
 
-    Util::loadAndRunExtension(tabsManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(tabsManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPITabs, ActiveTab)
@@ -3087,7 +3087,7 @@ TEST(WKWebExtensionAPITabs, ActiveTab)
         { "/next.html"_s, { { { "Content-Type"_s, "text/html"_s } }, "<head><title>Next Title</title></head>"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const [currentTab] = await browser.tabs.query({ active: true, currentWindow: true })",
         @"let updateCount = 0",
 
@@ -3125,7 +3125,7 @@ TEST(WKWebExtensionAPITabs, ActiveTab)
         @"browser.test.sendMessage('Load Localhost')",
     ]);
 
-    auto manager = Util::loadExtension(activeTabManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(activeTabManifest, @{ @"background.js": backgroundScript.get() });
 
     auto *localhostRequest = server.requestWithLocalhost();
     auto *addressRequest = server.request();
@@ -3179,7 +3179,7 @@ TEST(WKWebExtensionAPITabs, UserGestureWithoutActiveTab)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<head><title>Test Title</title></head>"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const [currentTab] = await browser.tabs.query({ active: true, currentWindow: true })",
 
         @"browser.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {",
@@ -3195,7 +3195,7 @@ TEST(WKWebExtensionAPITabs, UserGestureWithoutActiveTab)
         @"browser.test.sendMessage('Load Localhost')"
     ]);
 
-    auto manager = Util::loadExtension(activeTabManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(activeTabManifest, @{ @"background.js": backgroundScript.get() });
 
     // Reset activeTab, WKWebExtensionAPITabs.ActiveTab tests that.
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusUnknown forPermission:WKWebExtensionPermissionActiveTab];
@@ -3229,7 +3229,7 @@ TEST(WKWebExtensionAPITabs, ActiveTabWithDeniedPermissions)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<head><title>Test Title</title></head>"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const [currentTab] = await browser.tabs.query({ active: true, currentWindow: true })",
 
         @"browser.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {",
@@ -3245,7 +3245,7 @@ TEST(WKWebExtensionAPITabs, ActiveTabWithDeniedPermissions)
         @"browser.test.sendMessage('Load Localhost')"
     ]);
 
-    auto manager = Util::loadExtension(activeTabManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(activeTabManifest, @{ @"background.js": backgroundScript.get() });
 
     auto *localhostRequest = server.requestWithLocalhost();
 
@@ -3277,7 +3277,7 @@ TEST(WKWebExtensionAPITabs, ActiveTabRemovedWithDeniedPermissions)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<head><title>Test Title</title></head>"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const [currentTab] = await browser.tabs.query({ active: true, currentWindow: true })",
 
         @"browser.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {",
@@ -3293,7 +3293,7 @@ TEST(WKWebExtensionAPITabs, ActiveTabRemovedWithDeniedPermissions)
         @"browser.test.sendMessage('Load Localhost')"
     ]);
 
-    auto manager = Util::loadExtension(activeTabManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(activeTabManifest, @{ @"background.js": backgroundScript.get() });
 
     auto *localhostRequest = server.requestWithLocalhost();
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWebNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWebNavigation.mm
@@ -39,7 +39,7 @@ static auto *webNavigationManifest = @{ @"manifest_version": @3, @"permissions":
 
 TEST(WKWebExtensionAPIWebNavigation, EventListenerRegistration)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"function listener() { browser.test.notifyFail('This listener should not have been called') }",
         @"browser.test.assertFalse(browser.webNavigation.onBeforeNavigate.hasListener(listener), 'Should not have listener')",
 
@@ -52,7 +52,7 @@ TEST(WKWebExtensionAPIWebNavigation, EventListenerRegistration)
         @"browser.test.notifyPass()"
     ]);
 
-    Util::loadAndRunExtension(webNavigationManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(webNavigationManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPIWebNavigation, BeforeNavigateEvent)
@@ -61,7 +61,7 @@ TEST(WKWebExtensionAPIWebNavigation, BeforeNavigateEvent)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.webNavigation.onBeforeNavigate.addListener((details) => {",
         @"    browser.test.assertEq(details?.frameId, 0, 'details.frameId should be')",
         @"    browser.test.assertEq(details?.parentFrameId, -1, 'details.parentFrameId should be')",
@@ -80,16 +80,16 @@ TEST(WKWebExtensionAPIWebNavigation, BeforeNavigateEvent)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(webNavigationManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(webNavigationManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebNavigation];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -100,7 +100,7 @@ TEST(WKWebExtensionAPIWebNavigation, CommittedEvent)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.webNavigation.onCommitted.addListener((details) => {",
         @"    browser.test.assertEq(details?.frameId, 0, 'details.frameId should be')",
         @"    browser.test.assertEq(details?.parentFrameId, -1, 'details.parentFrameId should be')",
@@ -120,16 +120,16 @@ TEST(WKWebExtensionAPIWebNavigation, CommittedEvent)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(webNavigationManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(webNavigationManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebNavigation];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -140,7 +140,7 @@ TEST(WKWebExtensionAPIWebNavigation, DOMContentLoadedEvent)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.webNavigation.onDOMContentLoaded.addListener((details) => {",
         @"    browser.test.assertEq(details?.frameId, 0, 'details.frameId should be')",
         @"    browser.test.assertEq(details?.parentFrameId, -1, 'details.parentFrameId should be')",
@@ -160,16 +160,16 @@ TEST(WKWebExtensionAPIWebNavigation, DOMContentLoadedEvent)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(webNavigationManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(webNavigationManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebNavigation];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -180,7 +180,7 @@ TEST(WKWebExtensionAPIWebNavigation, CompletedEvent)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.webNavigation.onCompleted.addListener((details) => {",
         @"    browser.test.assertEq(details?.frameId, 0, 'details.frameId should be')",
         @"    browser.test.assertEq(details?.parentFrameId, -1, 'details.parentFrameId should be')",
@@ -200,16 +200,16 @@ TEST(WKWebExtensionAPIWebNavigation, CompletedEvent)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(webNavigationManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(webNavigationManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebNavigation];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -220,7 +220,7 @@ TEST(WKWebExtensionAPIWebNavigation, AllowedFilter)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"function passListener() { browser.test.notifyPass() }",
 
         @"browser.webNavigation.onCommitted.addListener(passListener, { 'url': [ {'hostContains': 'localhost'} ] })",
@@ -228,16 +228,16 @@ TEST(WKWebExtensionAPIWebNavigation, AllowedFilter)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(webNavigationManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(webNavigationManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebNavigation];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -248,7 +248,7 @@ TEST(WKWebExtensionAPIWebNavigation, DeniedFilter)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"function passListener() { browser.test.notifyPass() }",
         @"function failListener() { browser.test.notifyFail('This listener should not have been called') }",
 
@@ -258,16 +258,16 @@ TEST(WKWebExtensionAPIWebNavigation, DeniedFilter)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(webNavigationManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(webNavigationManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebNavigation];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -278,7 +278,7 @@ TEST(WKWebExtensionAPIWebNavigation, AllEventsFired)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"let beforeNavigateEventFired = false",
         @"let onCommittedEventFired = false",
         @"let onDOMContentLoadedEventFired = false",
@@ -303,16 +303,16 @@ TEST(WKWebExtensionAPIWebNavigation, AllEventsFired)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(webNavigationManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(webNavigationManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebNavigation];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -323,7 +323,7 @@ TEST(WKWebExtensionAPIWebNavigation, DocumentIdAcrossEvents)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"let documentId = null",
 
         @"browser.webNavigation.onBeforeNavigate.addListener((details) => {",
@@ -352,16 +352,16 @@ TEST(WKWebExtensionAPIWebNavigation, DocumentIdAcrossEvents)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(webNavigationManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(webNavigationManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebNavigation];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -372,7 +372,7 @@ TEST(WKWebExtensionAPIWebNavigation, RemoveListenerDuringEvent)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"function navigationListener() {",
         @"  browser.webNavigation.onCommitted.removeListener(navigationListener)",
         @"  browser.test.assertFalse(browser.webNavigation.onCommitted.hasListener(navigationListener), 'Listener should be removed')",
@@ -386,16 +386,16 @@ TEST(WKWebExtensionAPIWebNavigation, RemoveListenerDuringEvent)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(webNavigationManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(webNavigationManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebNavigation];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -407,7 +407,7 @@ TEST(WKWebExtensionAPIWebNavigation, ErrorOccurredEventDuringProvisionalLoad)
         { "/frame.html"_s, { HTTPResponse::Behavior::TerminateConnectionAfterReceivingRequest } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"function errorListener(details) {",
         @"  browser.test.assertTrue(details?.frameId != 0)",
 
@@ -422,18 +422,18 @@ TEST(WKWebExtensionAPIWebNavigation, ErrorOccurredEventDuringProvisionalLoad)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(webNavigationManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(webNavigationManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebNavigation];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    NSURL *requestURL = urlRequest.URL;
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    NSURL *requestURL = urlRequest.get().URL;
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:requestURL];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:[requestURL URLByAppendingPathComponent:@"frame.html"]];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -478,7 +478,7 @@ TEST(WKWebExtensionAPIWebNavigation, ErrorOccurredEventDuringLoad)
         }
     });
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"async function errorListener(details) {",
         // This should be a subframe
         @"  browser.test.assertTrue(details.frameId != 0)",
@@ -504,18 +504,18 @@ TEST(WKWebExtensionAPIWebNavigation, ErrorOccurredEventDuringLoad)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(webNavigationManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(webNavigationManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebNavigation];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    NSURL *requestURL = urlRequest.URL;
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    NSURL *requestURL = urlRequest.get().URL;
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:requestURL];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:[requestURL URLByAppendingPathComponent:@"frame.html"]];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -527,7 +527,7 @@ TEST(WKWebExtensionAPIWebNavigation, GetFrameWithMainFrame)
         { "/frame.html"_s, { { { "Content-Type"_s, "text/html"_s } }, "<body style='background-color: blue'></body>"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"function completedListener(details) {",
         @"  if (details?.frameId !== 0)",
         @"    return",
@@ -548,18 +548,18 @@ TEST(WKWebExtensionAPIWebNavigation, GetFrameWithMainFrame)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(webNavigationManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(webNavigationManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebNavigation];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    NSURL *requestURL = urlRequest.URL;
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    NSURL *requestURL = urlRequest.get().URL;
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:requestURL];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:[requestURL URLByAppendingPathComponent:@"frame.html"]];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -571,7 +571,7 @@ TEST(WKWebExtensionAPIWebNavigation, GetFrameWithSubframe)
         { "/frame.html"_s, { { { "Content-Type"_s, "text/html"_s } }, "<body style='background-color: blue'></body>"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"function completedListener(details) {",
         @"  if (details?.frameId === 0)",
         @"    return",
@@ -592,18 +592,18 @@ TEST(WKWebExtensionAPIWebNavigation, GetFrameWithSubframe)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(webNavigationManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(webNavigationManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebNavigation];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    NSURL *requestURL = urlRequest.URL;
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    NSURL *requestURL = urlRequest.get().URL;
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:requestURL];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:[requestURL URLByAppendingPathComponent:@"frame.html"]];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -615,7 +615,7 @@ TEST(WKWebExtensionAPIWebNavigation, GetAllFrames)
         { "/frame.html"_s, { { { "Content-Type"_s, "text/html"_s } }, "<body style='background-color: blue'></body>"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"function completedListener(details) {",
         @"  if (details.frameId !== 0)",
         @"    return",
@@ -647,18 +647,18 @@ TEST(WKWebExtensionAPIWebNavigation, GetAllFrames)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(webNavigationManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(webNavigationManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebNavigation];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    NSURL *requestURL = urlRequest.URL;
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    NSURL *requestURL = urlRequest.get().URL;
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:requestURL];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:[requestURL URLByAppendingPathComponent:@"frame.html"]];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -670,7 +670,7 @@ TEST(WKWebExtensionAPIWebNavigation, ErrorOccurred)
         { "/frame.html"_s, { HTTPResponse::Behavior::TerminateConnectionAfterReceivingRequest } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"function errorListener(details) {",
         // A subframe should have been the one to have the error.
         @"  browser.test.assertFalse(details.frameId == 0)",
@@ -694,18 +694,18 @@ TEST(WKWebExtensionAPIWebNavigation, ErrorOccurred)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(webNavigationManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(webNavigationManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebNavigation];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    NSURL *requestURL = urlRequest.URL;
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    NSURL *requestURL = urlRequest.get().URL;
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:requestURL];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:[requestURL URLByAppendingPathComponent:@"frame.html"]];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -717,7 +717,7 @@ TEST(WKWebExtensionAPIWebNavigation, Errors)
         { "/frame.html"_s, { { { "Content-Type"_s, "text/html"_s } }, "<body style='background-color: blue'></body>"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"async function completedListener(details) {",
         // Only listen for when the main frame loads so we don't call this method more than once.
         @"  if (details.frameId !== 0)",
@@ -735,18 +735,18 @@ TEST(WKWebExtensionAPIWebNavigation, Errors)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(webNavigationManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(webNavigationManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebNavigation];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    NSURL *requestURL = urlRequest.URL;
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    NSURL *requestURL = urlRequest.get().URL;
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:requestURL];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:[requestURL URLByAppendingPathComponent:@"frame.html"]];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWebRequest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWebRequest.mm
@@ -40,7 +40,7 @@ static auto *webRequestManifest = @{ @"manifest_version": @3, @"permissions": @[
 
 TEST(WKWebExtensionAPIWebRequest, ManifestV2Persistent)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.assertEq(typeof browser.webRequest, 'object', 'webRequest should be defined')",
 
         @"browser.test.notifyPass()"
@@ -48,14 +48,14 @@ TEST(WKWebExtensionAPIWebRequest, ManifestV2Persistent)
 
     auto *manifest = @{ @"manifest_version": @2, @"permissions": @[ @"webRequest" ], @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @YES } };
 
-    Util::loadAndRunExtension(manifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(manifest, @{ @"background.js": backgroundScript.get() });
 }
 
 #endif // PLATFORM(MAC)
 
 TEST(WKWebExtensionAPIWebRequest, ManifestV2NonPersistent)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.assertEq(typeof browser.webRequest, 'object', 'webRequest should be defined')",
 
         @"browser.test.notifyPass()"
@@ -63,12 +63,12 @@ TEST(WKWebExtensionAPIWebRequest, ManifestV2NonPersistent)
 
     auto *manifest = @{ @"manifest_version": @2, @"permissions": @[ @"webRequest" ], @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO } };
 
-    Util::loadAndRunExtension(manifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(manifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPIWebRequest, EventListenerRegistration)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"function listener() { browser.test.notifyFail('This listener should not have been called') }",
         @"browser.test.assertFalse(browser.webRequest.onCompleted.hasListener(listener), 'Should not have listener')",
 
@@ -81,7 +81,7 @@ TEST(WKWebExtensionAPIWebRequest, EventListenerRegistration)
         @"browser.test.notifyPass()"
     ]);
 
-    Util::loadAndRunExtension(webRequestManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(webRequestManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPIWebRequest, BeforeRequestEvent)
@@ -90,7 +90,7 @@ TEST(WKWebExtensionAPIWebRequest, BeforeRequestEvent)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.webRequest.onBeforeRequest.addListener((details) => {",
         @"  browser.test.assertEq(typeof details?.requestId, 'string', 'details.requestId should be')",
         @"  browser.test.assertEq(typeof details?.tabId, 'number', 'details.tabId should be')",
@@ -112,16 +112,16 @@ TEST(WKWebExtensionAPIWebRequest, BeforeRequestEvent)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebRequest];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -133,7 +133,7 @@ TEST(WKWebExtensionAPIWebRequest, BeforeRequestEventForSubresource)
         { "/image.png"_s, { { { "Content-Type"_s, "image/png"_s } }, "..."_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.webRequest.onBeforeRequest.addListener((details) => {",
         @"  if (details?.type !== 'image')",
         @"    return",
@@ -157,23 +157,23 @@ TEST(WKWebExtensionAPIWebRequest, BeforeRequestEventForSubresource)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebRequest];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
 
 TEST(WKWebExtensionAPIWebRequest, BeforeRequestEventWithRequestBodyAndFormData)
 {
-    auto *pageScript = Util::constructScript(@[
+    RetainPtr pageScript = Util::constructScript(@[
         @"const formData = new FormData()",
         @"formData.append('username', 'user1')",
         @"formData.append('username', 'user2')",
@@ -195,7 +195,7 @@ TEST(WKWebExtensionAPIWebRequest, BeforeRequestEventWithRequestBodyAndFormData)
         } },
         { "/form.js"_s, {
             { { "Content-Type"_s, "application/javascript"_s } },
-            pageScript
+            pageScript.get()
         } },
         { "/test"_s, {
             { { "Content-Type"_s, "text/plain"_s } },
@@ -203,7 +203,7 @@ TEST(WKWebExtensionAPIWebRequest, BeforeRequestEventWithRequestBodyAndFormData)
         } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.webRequest.onBeforeRequest.addListener((details) => {",
         @"  if (!details.url.includes('/test'))",
         @"    return",
@@ -227,23 +227,23 @@ TEST(WKWebExtensionAPIWebRequest, BeforeRequestEventWithRequestBodyAndFormData)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebRequest];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
 
 TEST(WKWebExtensionAPIWebRequest, BeforeRequestEventWithRequestBodyAndBlob)
 {
-    auto *pageScript = Util::constructScript(@[
+    RetainPtr pageScript = Util::constructScript(@[
         @"const blob = new Blob(['This is some text blob content'], { type: 'text/plain' })",
 
         @"const response = await fetch('/test', {",
@@ -262,7 +262,7 @@ TEST(WKWebExtensionAPIWebRequest, BeforeRequestEventWithRequestBodyAndBlob)
         } },
         { "/blob.js"_s, {
             { { "Content-Type"_s, "application/javascript"_s } },
-            pageScript
+            pageScript.get()
         } },
         { "/test"_s, {
             { { "Content-Type"_s, "text/plain"_s } },
@@ -270,7 +270,7 @@ TEST(WKWebExtensionAPIWebRequest, BeforeRequestEventWithRequestBodyAndBlob)
         } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.webRequest.onBeforeRequest.addListener((details) => {",
         @"  if (!details.url.includes('/test'))",
         @"    return",
@@ -288,23 +288,23 @@ TEST(WKWebExtensionAPIWebRequest, BeforeRequestEventWithRequestBodyAndBlob)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebRequest];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
 
 TEST(WKWebExtensionAPIWebRequest, BeforeRequestEventWithRequestBodyAndJSON)
 {
-    auto *pageScript = Util::constructScript(@[
+    RetainPtr pageScript = Util::constructScript(@[
         @"const response = await fetch('/test', {",
         @"  method: 'POST',",
         @"  headers: { 'Content-Type': 'application/json' },",
@@ -322,7 +322,7 @@ TEST(WKWebExtensionAPIWebRequest, BeforeRequestEventWithRequestBodyAndJSON)
         } },
         { "/fetch.js"_s, {
             { { "Content-Type"_s, "application/javascript"_s } },
-            pageScript
+            pageScript.get()
         } },
         { "/test"_s, {
             { { "Content-Type"_s, "text/plain"_s } },
@@ -330,7 +330,7 @@ TEST(WKWebExtensionAPIWebRequest, BeforeRequestEventWithRequestBodyAndJSON)
         } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.webRequest.onBeforeRequest.addListener((details) => {",
         @"  if (!details.url.includes('/test'))",
         @"    return",
@@ -352,23 +352,23 @@ TEST(WKWebExtensionAPIWebRequest, BeforeRequestEventWithRequestBodyAndJSON)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebRequest];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
 
 TEST(WKWebExtensionAPIWebRequest, BeforeRequestEventWithRequestBodyAndForm)
 {
-    auto *pageScript = Util::constructScript(@[
+    RetainPtr pageScript = Util::constructScript(@[
         @"const form = document.createElement('form')",
         @"form.action = '/test'",
         @"form.method = 'POST'",
@@ -402,7 +402,7 @@ TEST(WKWebExtensionAPIWebRequest, BeforeRequestEventWithRequestBodyAndForm)
         } },
         { "/form.js"_s, {
             { { "Content-Type"_s, "application/javascript"_s } },
-            pageScript
+            pageScript.get()
         } },
         { "/test"_s, {
             { { "Content-Type"_s, "text/plain"_s } },
@@ -410,7 +410,7 @@ TEST(WKWebExtensionAPIWebRequest, BeforeRequestEventWithRequestBodyAndForm)
         } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.webRequest.onBeforeRequest.addListener((details) => {",
         @"  if (!details.url.includes('/test'))",
         @"    return",
@@ -432,16 +432,16 @@ TEST(WKWebExtensionAPIWebRequest, BeforeRequestEventWithRequestBodyAndForm)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebRequest];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -452,7 +452,7 @@ TEST(WKWebExtensionAPIWebRequest, BeforeSendHeadersEvent)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.webRequest.onBeforeSendHeaders.addListener((details) => {",
         @"  browser.test.assertEq(typeof details?.requestId, 'string', 'details.requestId should be')",
         @"  browser.test.assertEq(typeof details?.tabId, 'number', 'details.tabId should be')",
@@ -474,16 +474,16 @@ TEST(WKWebExtensionAPIWebRequest, BeforeSendHeadersEvent)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebRequest];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -494,7 +494,7 @@ TEST(WKWebExtensionAPIWebRequest, BeforeSendHeadersEventWithRequestHeaders)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.webRequest.onBeforeSendHeaders.addListener((details) => {",
         @"  browser.test.assertEq(typeof details?.requestId, 'string', 'details.requestId should be')",
         @"  browser.test.assertEq(typeof details?.tabId, 'number', 'details.tabId should be')",
@@ -517,16 +517,16 @@ TEST(WKWebExtensionAPIWebRequest, BeforeSendHeadersEventWithRequestHeaders)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebRequest];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -538,7 +538,7 @@ TEST(WKWebExtensionAPIWebRequest, BeforeSendHeadersEventForSubresource)
         { "/image.png"_s, { { { "Content-Type"_s, "image/png"_s } }, "..."_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.webRequest.onBeforeSendHeaders.addListener((details) => {",
         @"  if (details?.type !== 'image')",
         @"    return",
@@ -563,16 +563,16 @@ TEST(WKWebExtensionAPIWebRequest, BeforeSendHeadersEventForSubresource)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebRequest];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -583,7 +583,7 @@ TEST(WKWebExtensionAPIWebRequest, SendHeadersEvent)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.webRequest.onSendHeaders.addListener((details) => {",
         @"  browser.test.assertEq(typeof details?.requestId, 'string', 'details.requestId should be')",
         @"  browser.test.assertEq(typeof details?.tabId, 'number', 'details.tabId should be')",
@@ -605,16 +605,16 @@ TEST(WKWebExtensionAPIWebRequest, SendHeadersEvent)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebRequest];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -625,7 +625,7 @@ TEST(WKWebExtensionAPIWebRequest, SendHeadersEventWithRequestHeaders)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.webRequest.onSendHeaders.addListener((details) => {",
         @"  browser.test.assertEq(typeof details?.requestId, 'string', 'details.requestId should be')",
         @"  browser.test.assertEq(typeof details?.tabId, 'number', 'details.tabId should be')",
@@ -648,16 +648,16 @@ TEST(WKWebExtensionAPIWebRequest, SendHeadersEventWithRequestHeaders)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebRequest];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -669,7 +669,7 @@ TEST(WKWebExtensionAPIWebRequest, SendHeadersEventForSubresource)
         { "/image.png"_s, { { { "Content-Type"_s, "image/png"_s } }, "..."_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.webRequest.onSendHeaders.addListener((details) => {",
         @"  if (details?.type !== 'image')",
         @"    return",
@@ -694,16 +694,16 @@ TEST(WKWebExtensionAPIWebRequest, SendHeadersEventForSubresource)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebRequest];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -714,7 +714,7 @@ TEST(WKWebExtensionAPIWebRequest, HeadersReceivedEvent)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.webRequest.onHeadersReceived.addListener((details) => {",
         @"  browser.test.assertEq(typeof details?.requestId, 'string', 'details.requestId should be')",
         @"  browser.test.assertEq(typeof details?.tabId, 'number', 'details.tabId should be')",
@@ -739,16 +739,16 @@ TEST(WKWebExtensionAPIWebRequest, HeadersReceivedEvent)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebRequest];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -759,7 +759,7 @@ TEST(WKWebExtensionAPIWebRequest, HeadersReceivedEventWithResponseHeaders)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.webRequest.onHeadersReceived.addListener((details) => {",
         @"  browser.test.assertEq(typeof details?.requestId, 'string', 'details.requestId should be')",
         @"  browser.test.assertEq(typeof details?.tabId, 'number', 'details.tabId should be')",
@@ -785,16 +785,16 @@ TEST(WKWebExtensionAPIWebRequest, HeadersReceivedEventWithResponseHeaders)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebRequest];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -806,7 +806,7 @@ TEST(WKWebExtensionAPIWebRequest, HeadersReceivedEventForSubresource)
         { "/image.png"_s, { { { "Content-Type"_s, "image/png"_s }, { "Cache-Control"_s, "no-cache"_s } }, "..."_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.webRequest.onHeadersReceived.addListener((details) => {",
         @"  if (details?.type !== 'image')",
         @"    return",
@@ -835,16 +835,16 @@ TEST(WKWebExtensionAPIWebRequest, HeadersReceivedEventForSubresource)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebRequest];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -856,7 +856,7 @@ TEST(WKWebExtensionAPIWebRequest, ErrorOccurredEvent)
         { "/nonexistent.png"_s, { HTTPResponse::Behavior::TerminateConnectionAfterReceivingRequest } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.webRequest.onErrorOccurred.addListener((details) => {",
         @"  browser.test.assertEq(typeof details?.requestId, 'string', 'details.requestId should be')",
         @"  browser.test.assertEq(typeof details?.tabId, 'number', 'details.tabId should be')",
@@ -879,16 +879,16 @@ TEST(WKWebExtensionAPIWebRequest, ErrorOccurredEvent)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebRequest];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -900,7 +900,7 @@ TEST(WKWebExtensionAPIWebRequest, RedirectOccurredEvent)
         { "/target.html"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     });
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.webRequest.onBeforeRedirect.addListener((details) => {",
         @"  browser.test.assertEq(typeof details?.requestId, 'string', 'details.requestId should be')",
         @"  browser.test.assertEq(typeof details?.tabId, 'number', 'details.tabId should be')",
@@ -922,16 +922,16 @@ TEST(WKWebExtensionAPIWebRequest, RedirectOccurredEvent)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebRequest];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -944,7 +944,7 @@ TEST(WKWebExtensionAPIWebRequest, RedirectOccurredEventForSubresource)
         { "/final.png"_s, { { { "Content-Type"_s, "image/png"_s } }, "..."_s } },
     });
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.webRequest.onBeforeRedirect.addListener((details) => {",
         @"  if (details?.type !== 'image')",
         @"    return",
@@ -968,16 +968,16 @@ TEST(WKWebExtensionAPIWebRequest, RedirectOccurredEventForSubresource)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebRequest];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -988,7 +988,7 @@ TEST(WKWebExtensionAPIWebRequest, ResponseStartedEvent)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.webRequest.onResponseStarted.addListener((details) => {",
         @"  browser.test.assertEq(typeof details?.requestId, 'string', 'details.requestId should be')",
         @"  browser.test.assertEq(typeof details?.tabId, 'number', 'details.tabId should be')",
@@ -1013,16 +1013,16 @@ TEST(WKWebExtensionAPIWebRequest, ResponseStartedEvent)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebRequest];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -1033,7 +1033,7 @@ TEST(WKWebExtensionAPIWebRequest, ResponseStartedEventWithResponseHeaders)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.webRequest.onResponseStarted.addListener((details) => {",
         @"  browser.test.assertEq(typeof details?.requestId, 'string', 'details.requestId should be')",
         @"  browser.test.assertEq(typeof details?.tabId, 'number', 'details.tabId should be')",
@@ -1059,16 +1059,16 @@ TEST(WKWebExtensionAPIWebRequest, ResponseStartedEventWithResponseHeaders)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebRequest];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -1080,7 +1080,7 @@ TEST(WKWebExtensionAPIWebRequest, ResponseStartedEventForSubresource)
         { "/image.png"_s, { { { "Content-Type"_s, "image/png"_s } }, "..."_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.webRequest.onResponseStarted.addListener((details) => {",
         @"  if (details?.type !== 'image')",
         @"    return",
@@ -1109,16 +1109,16 @@ TEST(WKWebExtensionAPIWebRequest, ResponseStartedEventForSubresource)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebRequest];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -1129,7 +1129,7 @@ TEST(WKWebExtensionAPIWebRequest, CompletedEvent)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.webRequest.onCompleted.addListener((details) => {",
         @"  browser.test.assertEq(typeof details?.tabId, 'number', 'details.tabId should be')",
         @"  browser.test.assertEq(details?.frameId, 0, 'details.frameId should be')",
@@ -1153,16 +1153,16 @@ TEST(WKWebExtensionAPIWebRequest, CompletedEvent)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebRequest];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -1173,7 +1173,7 @@ TEST(WKWebExtensionAPIWebRequest, CompletedEventWithResponseHeaders)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.webRequest.onCompleted.addListener((details) => {",
         @"  browser.test.assertEq(typeof details?.tabId, 'number', 'details.tabId should be')",
         @"  browser.test.assertEq(details?.frameId, 0, 'details.frameId should be')",
@@ -1198,16 +1198,16 @@ TEST(WKWebExtensionAPIWebRequest, CompletedEventWithResponseHeaders)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebRequest];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -1219,7 +1219,7 @@ TEST(WKWebExtensionAPIWebRequest, CompletedEventForSubresource)
         { "/image.png"_s, { { { "Content-Type"_s, "image/png"_s } }, "..."_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.webRequest.onCompleted.addListener((details) => {",
         @"  if (details?.type !== 'image')",
         @"    return",
@@ -1247,16 +1247,16 @@ TEST(WKWebExtensionAPIWebRequest, CompletedEventForSubresource)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebRequest];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -1267,7 +1267,7 @@ TEST(WKWebExtensionAPIWebRequest, AllowedFilter)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"function passListener() { browser.test.notifyPass() }",
 
         @"browser.webRequest.onCompleted.addListener(passListener, { 'urls': [ '*://*.localhost/*' ] })",
@@ -1275,17 +1275,17 @@ TEST(WKWebExtensionAPIWebRequest, AllowedFilter)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript.get() });
 
     // Grant the webRequest permission.
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebRequest];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -1296,7 +1296,7 @@ TEST(WKWebExtensionAPIWebRequest, DeniedFilter)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"function passListener() { browser.test.notifyPass() }",
         @"function failListener() { browser.test.notifyFail('This listener should not have been called') }",
 
@@ -1306,17 +1306,17 @@ TEST(WKWebExtensionAPIWebRequest, DeniedFilter)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript.get() });
 
     // Grant the webRequest permission.
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebRequest];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -1327,7 +1327,7 @@ TEST(WKWebExtensionAPIWebRequest, AllEventsFired)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"let beforeRequestFired = false",
         @"let beforeSendHeadersFired = false",
         @"let sendHeadersFired = false",
@@ -1355,17 +1355,17 @@ TEST(WKWebExtensionAPIWebRequest, AllEventsFired)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript.get() });
 
     // Grant the webRequest permission.
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebRequest];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -1376,7 +1376,7 @@ TEST(WKWebExtensionAPIWebRequest, DocumentIdAcrossEvents)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"let documentId = null",
 
         @"browser.webRequest.onBeforeRequest.addListener((details) => {",
@@ -1413,16 +1413,16 @@ TEST(WKWebExtensionAPIWebRequest, DocumentIdAcrossEvents)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebRequest];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -1433,7 +1433,7 @@ TEST(WKWebExtensionAPIWebRequest, RemoveListenerDuringEvent)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"function requestListener() {",
         @"  browser.webRequest.onCompleted.removeListener(requestListener)",
         @"  browser.test.assertFalse(browser.webRequest.onCompleted.hasListener(requestListener), 'Listener should be removed')",
@@ -1447,16 +1447,16 @@ TEST(WKWebExtensionAPIWebRequest, RemoveListenerDuringEvent)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebRequest];
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -1532,23 +1532,23 @@ TEST(WKWebExtensionAPIWebRequest, TabIDMatch)
     NSURL *url = [NSURL URLWithString:@"http://example.com/a"];
     _WKWebExtensionWebRequestResourceType type = _WKWebExtensionWebRequestResourceTypeOther;
 
-    auto filter = filterWithDictionary(@{
+    RetainPtr filter = filterWithDictionary(@{
         @"urls": @[ @"http://example.com/*" ],
     });
-    EXPECT_TRUE([filter matchesRequestForResourceOfType:type URL:url tabID:100 windowID:1]);
+    EXPECT_TRUE([filter.get() matchesRequestForResourceOfType:type URL:url tabID:100 windowID:1]);
 
     filter = filterWithDictionary(@{
         @"urls": @[ @"http://example.com/*" ],
         @"tabId": @(-1),
     });
-    EXPECT_TRUE([filter matchesRequestForResourceOfType:type URL:url tabID:100 windowID:1]);
+    EXPECT_TRUE([filter.get() matchesRequestForResourceOfType:type URL:url tabID:100 windowID:1]);
 
     filter = filterWithDictionary(@{
         @"urls": @[ @"http://example.com/*" ],
         @"tabId": @(100),
     });
-    EXPECT_TRUE([filter matchesRequestForResourceOfType:type URL:url tabID:100 windowID:1]);
-    EXPECT_FALSE([filter matchesRequestForResourceOfType:type URL:url tabID:200 windowID:1]);
+    EXPECT_TRUE([filter.get() matchesRequestForResourceOfType:type URL:url tabID:100 windowID:1]);
+    EXPECT_FALSE([filter.get() matchesRequestForResourceOfType:type URL:url tabID:200 windowID:1]);
 }
 
 TEST(WKWebExtensionAPIWebRequest, WindowIDMatch)
@@ -1556,23 +1556,23 @@ TEST(WKWebExtensionAPIWebRequest, WindowIDMatch)
     NSURL *url = [NSURL URLWithString:@"http://example.com/a"];
     _WKWebExtensionWebRequestResourceType type = _WKWebExtensionWebRequestResourceTypeOther;
 
-    auto filter = filterWithDictionary(@{
+    RetainPtr filter = filterWithDictionary(@{
         @"urls": @[ @"http://example.com/*" ],
     });
-    EXPECT_TRUE([filter matchesRequestForResourceOfType:type URL:url tabID:-1 windowID:-1]);
+    EXPECT_TRUE([filter.get() matchesRequestForResourceOfType:type URL:url tabID:-1 windowID:-1]);
 
     filter = filterWithDictionary(@{
         @"urls": @[ @"http://example.com/*" ],
         @"windowId": @(-1),
     });
-    EXPECT_TRUE([filter matchesRequestForResourceOfType:type URL:url tabID:1 windowID:1]);
+    EXPECT_TRUE([filter.get() matchesRequestForResourceOfType:type URL:url tabID:1 windowID:1]);
 
     filter = filterWithDictionary(@{
         @"urls": @[ @"http://example.com/*" ],
         @"windowId": @(100),
     });
-    EXPECT_TRUE([filter matchesRequestForResourceOfType:type URL:url tabID:1 windowID:100]);
-    EXPECT_FALSE([filter matchesRequestForResourceOfType:type URL:url tabID:1 windowID:200]);
+    EXPECT_TRUE([filter.get() matchesRequestForResourceOfType:type URL:url tabID:1 windowID:100]);
+    EXPECT_FALSE([filter.get() matchesRequestForResourceOfType:type URL:url tabID:1 windowID:200]);
 }
 
 TEST(WKWebExtensionAPIWebRequest, URLMatch)
@@ -1581,67 +1581,67 @@ TEST(WKWebExtensionAPIWebRequest, URLMatch)
     NSURL *otherURL = [NSURL URLWithString:@"http://some-other-website.biz/a/b"];
     _WKWebExtensionWebRequestResourceType type = _WKWebExtensionWebRequestResourceTypeOther;
 
-    auto filter = filterWithDictionary(@{
+    RetainPtr filter = filterWithDictionary(@{
         @"urls": @[ ],
     });
-    EXPECT_TRUE([filter matchesRequestForResourceOfType:type URL:url tabID:1 windowID:1]);
-    EXPECT_TRUE([filter matchesRequestForResourceOfType:type URL:otherURL tabID:1 windowID:1]);
+    EXPECT_TRUE([filter.get() matchesRequestForResourceOfType:type URL:url tabID:1 windowID:1]);
+    EXPECT_TRUE([filter.get() matchesRequestForResourceOfType:type URL:otherURL tabID:1 windowID:1]);
 
     filter = filterWithDictionary(@{
         @"urls": @[ @"http://example.com/*" ],
     });
-    EXPECT_TRUE([filter matchesRequestForResourceOfType:type URL:url tabID:1 windowID:1]);
-    EXPECT_FALSE([filter matchesRequestForResourceOfType:type URL:otherURL tabID:1 windowID:1]);
+    EXPECT_TRUE([filter.get() matchesRequestForResourceOfType:type URL:url tabID:1 windowID:1]);
+    EXPECT_FALSE([filter.get() matchesRequestForResourceOfType:type URL:otherURL tabID:1 windowID:1]);
 
     filter = filterWithDictionary(@{
         @"urls": @[ @"http://not-example.com/*", @"http://not-some-other-website.biz/*" ],
     });
-    EXPECT_FALSE([filter matchesRequestForResourceOfType:type URL:url tabID:1 windowID:1]);
+    EXPECT_FALSE([filter.get() matchesRequestForResourceOfType:type URL:url tabID:1 windowID:1]);
 
     filter = filterWithDictionary(@{
         @"urls": @[ @"http://example.com/*", @"http://not-some-other-website.biz/*" ],
     });
-    EXPECT_TRUE([filter matchesRequestForResourceOfType:type URL:url tabID:1 windowID:1]);
-    EXPECT_FALSE([filter matchesRequestForResourceOfType:type URL:otherURL tabID:1 windowID:1]);
+    EXPECT_TRUE([filter.get() matchesRequestForResourceOfType:type URL:url tabID:1 windowID:1]);
+    EXPECT_FALSE([filter.get() matchesRequestForResourceOfType:type URL:otherURL tabID:1 windowID:1]);
 
     filter = filterWithDictionary(@{
         @"urls": @[ @"http://example.com/*/b", @"http://example.com/a/*" ]
     });
 
-    EXPECT_TRUE([filter matchesRequestForResourceOfType:type URL:url tabID:1 windowID:1]);
+    EXPECT_TRUE([filter.get() matchesRequestForResourceOfType:type URL:url tabID:1 windowID:1]);
 }
 
 TEST(WKWebExtensionAPIWebRequest, ResourceTypesMatch)
 {
     NSURL *url = [NSURL URLWithString:@"http://example.com/a/b"];
 
-    auto filter = filterWithDictionary(@{
+    RetainPtr filter = filterWithDictionary(@{
         @"urls": @[ ],
     });
-    EXPECT_TRUE([filter matchesRequestForResourceOfType:_WKWebExtensionWebRequestResourceTypeImage URL:url tabID:1 windowID:1]);
-    EXPECT_TRUE([filter matchesRequestForResourceOfType:_WKWebExtensionWebRequestResourceTypeScript URL:url tabID:1 windowID:1]);
+    EXPECT_TRUE([filter.get() matchesRequestForResourceOfType:_WKWebExtensionWebRequestResourceTypeImage URL:url tabID:1 windowID:1]);
+    EXPECT_TRUE([filter.get() matchesRequestForResourceOfType:_WKWebExtensionWebRequestResourceTypeScript URL:url tabID:1 windowID:1]);
 
     filter = filterWithDictionary(@{
         @"urls": @[ ],
         @"types": @[ ],
     });
-    EXPECT_TRUE([filter matchesRequestForResourceOfType:_WKWebExtensionWebRequestResourceTypeImage URL:url tabID:1 windowID:1]);
-    EXPECT_TRUE([filter matchesRequestForResourceOfType:_WKWebExtensionWebRequestResourceTypeScript URL:url tabID:1 windowID:1]);
+    EXPECT_TRUE([filter.get() matchesRequestForResourceOfType:_WKWebExtensionWebRequestResourceTypeImage URL:url tabID:1 windowID:1]);
+    EXPECT_TRUE([filter.get() matchesRequestForResourceOfType:_WKWebExtensionWebRequestResourceTypeScript URL:url tabID:1 windowID:1]);
 
     filter = filterWithDictionary(@{
         @"urls": @[ ],
         @"types": @[ @"image" ],
     });
-    EXPECT_TRUE([filter matchesRequestForResourceOfType:_WKWebExtensionWebRequestResourceTypeImage URL:url tabID:1 windowID:1]);
-    EXPECT_FALSE([filter matchesRequestForResourceOfType:_WKWebExtensionWebRequestResourceTypeScript URL:url tabID:1 windowID:1]);
+    EXPECT_TRUE([filter.get() matchesRequestForResourceOfType:_WKWebExtensionWebRequestResourceTypeImage URL:url tabID:1 windowID:1]);
+    EXPECT_FALSE([filter.get() matchesRequestForResourceOfType:_WKWebExtensionWebRequestResourceTypeScript URL:url tabID:1 windowID:1]);
 
     filter = filterWithDictionary(@{
         @"urls": @[ ],
         @"types": @[ @"image", @"script" ],
     });
-    EXPECT_TRUE([filter matchesRequestForResourceOfType:_WKWebExtensionWebRequestResourceTypeImage URL:url tabID:1 windowID:1]);
-    EXPECT_TRUE([filter matchesRequestForResourceOfType:_WKWebExtensionWebRequestResourceTypeScript URL:url tabID:1 windowID:1]);
-    EXPECT_FALSE([filter matchesRequestForResourceOfType:_WKWebExtensionWebRequestResourceTypeWebsocket URL:url tabID:1 windowID:1]);
+    EXPECT_TRUE([filter.get() matchesRequestForResourceOfType:_WKWebExtensionWebRequestResourceTypeImage URL:url tabID:1 windowID:1]);
+    EXPECT_TRUE([filter.get() matchesRequestForResourceOfType:_WKWebExtensionWebRequestResourceTypeScript URL:url tabID:1 windowID:1]);
+    EXPECT_FALSE([filter.get() matchesRequestForResourceOfType:_WKWebExtensionWebRequestResourceTypeWebsocket URL:url tabID:1 windowID:1]);
 }
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWindows.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWindows.mm
@@ -57,7 +57,7 @@ static auto *windowsManifest = @{
 
 TEST(WKWebExtensionAPIWindows, Errors)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.assertThrows(() => browser.windows.get('bad'), /'windowId' value is invalid, because a number is expected/i)",
         @"browser.test.assertThrows(() => browser.windows.get(NaN), /'windowId' value is invalid, because a number is expected/i)",
         @"browser.test.assertThrows(() => browser.windows.get(Infinity), /'windowId' value is invalid, because a number is expected/i)",
@@ -97,12 +97,12 @@ TEST(WKWebExtensionAPIWindows, Errors)
         @"browser.test.notifyPass()"
     ]);
 
-    Util::loadAndRunExtension(windowsManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(windowsManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPIWindows, GetCurrent)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const window = await browser.windows.getCurrent();",
 
         @"browser.test.assertEq(typeof window, 'object', 'The window should be an object');",
@@ -120,12 +120,12 @@ TEST(WKWebExtensionAPIWindows, GetCurrent)
         @"browser.test.notifyPass();"
     ]);
 
-    Util::loadAndRunExtension(windowsManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(windowsManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPIWindows, GetCurrentFromOptionsPage)
 {
-    auto *optionsScript = Util::constructScript(@[
+    RetainPtr optionsScript = Util::constructScript(@[
         @"const window = await browser.windows.getCurrent()",
 
         @"browser.test.assertEq(typeof window, 'object', 'The window should be')",
@@ -137,7 +137,7 @@ TEST(WKWebExtensionAPIWindows, GetCurrentFromOptionsPage)
     auto *resources = @{
         @"background.js": @"// Not Used",
         @"options.html": @"<script type='module' src='options.js'></script>",
-        @"options.js": optionsScript
+        @"options.js": optionsScript.get()
     };
 
     auto manager = Util::loadExtension(windowsManifest, resources);
@@ -160,7 +160,7 @@ TEST(WKWebExtensionAPIWindows, GetCurrentFromOptionsPage)
 
 TEST(WKWebExtensionAPIWindows, GetCurrentWindowAfterTabMove)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const initialWindow = await browser.windows.getCurrent()",
         @"browser.test.assertEq(typeof initialWindow, 'object', 'Initial window should be an object')",
         @"browser.test.assertEq(typeof initialWindow.id, 'number', 'Initial window ID should be a number')",
@@ -175,7 +175,7 @@ TEST(WKWebExtensionAPIWindows, GetCurrentWindowAfterTabMove)
         @"browser.test.sendMessage('Move Tab')",
     ]);
 
-    auto manager = Util::loadExtension(windowsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(windowsManifest, @{ @"background.js": backgroundScript.get() });
 
     auto *newTab = [manager.get().defaultWindow openNewTab];
     auto *newWindow = [manager openNewWindow];
@@ -189,7 +189,7 @@ TEST(WKWebExtensionAPIWindows, GetCurrentWindowAfterTabMove)
 
 TEST(WKWebExtensionAPIWindows, GetLastFocused)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const window = await browser.windows.getLastFocused();",
 
         @"browser.test.assertEq(typeof window, 'object', 'The window should be an object');",
@@ -207,7 +207,7 @@ TEST(WKWebExtensionAPIWindows, GetLastFocused)
         @"browser.test.notifyPass();"
     ]);
 
-    auto manager = Util::parseExtension(windowsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::parseExtension(windowsManifest, @{ @"background.js": backgroundScript.get() });
 
     manager.get().internalDelegate.focusedWindow = ^id<WKWebExtensionWindow>(WKWebExtensionContext *) {
         return nil;
@@ -218,7 +218,7 @@ TEST(WKWebExtensionAPIWindows, GetLastFocused)
 
 TEST(WKWebExtensionAPIWindows, GetLastFocusedWithPrivateAccess)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const lastFocusedWindow = await browser.windows.getLastFocused()",
 
         @"browser.test.assertEq(typeof lastFocusedWindow, 'object', 'Last focused window should be an object')",
@@ -227,7 +227,7 @@ TEST(WKWebExtensionAPIWindows, GetLastFocusedWithPrivateAccess)
         @"browser.test.notifyPass()",
     ]);
 
-    auto manager = Util::loadExtension(windowsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(windowsManifest, @{ @"background.js": backgroundScript.get() });
 
     manager.get().context.hasAccessToPrivateData = YES;
 
@@ -239,7 +239,7 @@ TEST(WKWebExtensionAPIWindows, GetLastFocusedWithPrivateAccess)
 
 TEST(WKWebExtensionAPIWindows, GetLastFocusedWithoutPrivateAccess)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const lastFocusedWindow = await browser.windows.getLastFocused()",
 
         @"browser.test.assertEq(typeof lastFocusedWindow, 'object', 'Last focused window should be an object')",
@@ -248,7 +248,7 @@ TEST(WKWebExtensionAPIWindows, GetLastFocusedWithoutPrivateAccess)
         @"browser.test.notifyPass()",
     ]);
 
-    auto manager = Util::loadExtension(windowsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(windowsManifest, @{ @"background.js": backgroundScript.get() });
 
     manager.get().context.hasAccessToPrivateData = NO;
 
@@ -260,7 +260,7 @@ TEST(WKWebExtensionAPIWindows, GetLastFocusedWithoutPrivateAccess)
 
 TEST(WKWebExtensionAPIWindows, GetAll)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const windows = await browser.windows.getAll();",
         @"const windowOne = windows[0];",
 
@@ -281,7 +281,7 @@ TEST(WKWebExtensionAPIWindows, GetAll)
         @"browser.test.notifyPass();"
     ]);
 
-    auto manager = Util::parseExtension(windowsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::parseExtension(windowsManifest, @{ @"background.js": backgroundScript.get() });
 
     EXPECT_FALSE(manager.get().context.hasAccessToPrivateData);
 
@@ -292,7 +292,7 @@ TEST(WKWebExtensionAPIWindows, GetAll)
 
 TEST(WKWebExtensionAPIWindows, GetAllWithPrivateAccess)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const windows = await browser.windows.getAll();",
         @"const windowOne = windows[0];",
         @"const windowTwo = windows[1];",
@@ -330,7 +330,7 @@ TEST(WKWebExtensionAPIWindows, GetAllWithPrivateAccess)
         @"browser.test.notifyPass();"
     ]);
 
-    auto manager = Util::parseExtension(windowsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::parseExtension(windowsManifest, @{ @"background.js": backgroundScript.get() });
 
     manager.get().context.hasAccessToPrivateData = YES;
 
@@ -350,7 +350,7 @@ TEST(WKWebExtensionAPIWindows, GetAllWithPrivateAccess)
 
 TEST(WKWebExtensionAPIWindows, CreatedEvent)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.windows.onCreated.addListener((window) => {",
 
         @"  browser.test.assertEq(typeof window, 'object', 'The window should be an object');",
@@ -372,7 +372,7 @@ TEST(WKWebExtensionAPIWindows, CreatedEvent)
         @"browser.test.sendMessage('Open Window');"
     ]);
 
-    auto manager = Util::loadExtension(windowsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(windowsManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager runUntilTestMessage:@"Open Window"];
 
@@ -382,7 +382,7 @@ TEST(WKWebExtensionAPIWindows, CreatedEvent)
 
 TEST(WKWebExtensionAPIWindows, FocusChangedEvent)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"let focusedTwice = false;",
 
         @"browser.windows.onFocusChanged.addListener((windowId) => {",
@@ -404,7 +404,7 @@ TEST(WKWebExtensionAPIWindows, FocusChangedEvent)
         @"browser.test.sendMessage('Focus Window');"
     ]);
 
-    auto manager = Util::loadExtension(windowsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(windowsManifest, @{ @"background.js": backgroundScript.get() });
 
     auto *windowOne = manager.get().defaultWindow;
     auto *windowTwo = [manager openNewWindow];
@@ -426,7 +426,7 @@ TEST(WKWebExtensionAPIWindows, FocusChangedEvent)
 
 TEST(WKWebExtensionAPIWindows, RemovedEvent)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.windows.onRemoved.addListener((windowId) => {",
         @"  browser.test.assertEq(typeof windowId, 'number', 'The window id should be a number');",
 
@@ -436,7 +436,7 @@ TEST(WKWebExtensionAPIWindows, RemovedEvent)
         @"browser.test.sendMessage('Close Window');"
     ]);
 
-    auto manager = Util::loadExtension(windowsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(windowsManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager openNewWindow];
 
@@ -449,7 +449,7 @@ TEST(WKWebExtensionAPIWindows, RemovedEvent)
 
 TEST(WKWebExtensionAPIWindows, RemoveListenerDuringEvent)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"function windowListener() {",
         @"  browser.windows.onCreated.removeListener(windowListener)",
         @"  browser.test.assertFalse(browser.windows.onCreated.hasListener(windowListener), 'Listener should be removed')",
@@ -463,7 +463,7 @@ TEST(WKWebExtensionAPIWindows, RemoveListenerDuringEvent)
         @"browser.test.sendMessage('Open Window')"
     ]);
 
-    auto manager = Util::loadExtension(windowsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(windowsManifest, @{ @"background.js": backgroundScript.get() });
 
     [manager runUntilTestMessage:@"Open Window"];
 
@@ -477,7 +477,7 @@ TEST(WKWebExtensionAPIWindows, RemoveListenerDuringEvent)
 
 TEST(WKWebExtensionAPIWindows, Create)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const windowOptions = {",
         @"  focused: true,",
         @"  left: 300,",
@@ -510,7 +510,7 @@ TEST(WKWebExtensionAPIWindows, Create)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::loadExtension(windowsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(windowsManifest, @{ @"background.js": backgroundScript.get() });
 
     auto originalOpenNewWindow = manager.get().internalDelegate.openNewWindow;
 
@@ -544,7 +544,7 @@ TEST(WKWebExtensionAPIWindows, Create)
 
 TEST(WKWebExtensionAPIWindows, CreateWithRelativeURL)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const windowOptions = {",
         @"  url: 'test.html'",
         @"}",
@@ -564,7 +564,7 @@ TEST(WKWebExtensionAPIWindows, CreateWithRelativeURL)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::loadExtension(windowsManifest, @{ @"background.js": backgroundScript, @"test.html": @"Hello world!" });
+    auto manager = Util::loadExtension(windowsManifest, @{ @"background.js": backgroundScript.get(), @"test.html": @"Hello world!" });
 
     auto originalOpenNewWindow = manager.get().internalDelegate.openNewWindow;
 
@@ -584,7 +584,7 @@ TEST(WKWebExtensionAPIWindows, CreateWithRelativeURL)
 
 TEST(WKWebExtensionAPIWindows, CreateWithRelativeURLs)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const windowOptions = {",
         @"  url: [ 'one.html', 'two.html' ]",
         @"}",
@@ -610,7 +610,7 @@ TEST(WKWebExtensionAPIWindows, CreateWithRelativeURLs)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::loadExtension(windowsManifest, @{ @"background.js": backgroundScript, @"one.html": @"Hello one!", @"two.html": @"Hello two!" });
+    auto manager = Util::loadExtension(windowsManifest, @{ @"background.js": backgroundScript.get(), @"one.html": @"Hello one!", @"two.html": @"Hello two!" });
 
     auto originalOpenNewWindow = manager.get().internalDelegate.openNewWindow;
 
@@ -631,7 +631,7 @@ TEST(WKWebExtensionAPIWindows, CreateWithRelativeURLs)
 
 TEST(WKWebExtensionAPIWindows, CreateIncognitoWithoutPrivateAccess)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const windowOptions = {",
         @"  focused: true,",
         @"  left: 300,",
@@ -647,7 +647,7 @@ TEST(WKWebExtensionAPIWindows, CreateIncognitoWithoutPrivateAccess)
         @"browser.test.notifyPass();"
     ]);
 
-    auto manager = Util::loadExtension(windowsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(windowsManifest, @{ @"background.js": backgroundScript.get() });
 
     EXPECT_FALSE(manager.get().context.hasAccessToPrivateData);
     EXPECT_EQ(manager.get().windows.count, 1lu);
@@ -659,7 +659,7 @@ TEST(WKWebExtensionAPIWindows, CreateIncognitoWithoutPrivateAccess)
 
 TEST(WKWebExtensionAPIWindows, CreateIncognitoWithPrivateAccess)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const windowOptions = {",
         @"  focused: true,",
         @"  left: 300,",
@@ -691,7 +691,7 @@ TEST(WKWebExtensionAPIWindows, CreateIncognitoWithPrivateAccess)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::loadExtension(windowsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(windowsManifest, @{ @"background.js": backgroundScript.get() });
 
     manager.get().context.hasAccessToPrivateData = YES;
 
@@ -704,7 +704,7 @@ TEST(WKWebExtensionAPIWindows, CreateIncognitoWithPrivateAccess)
 
 TEST(WKWebExtensionAPIWindows, Update)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const newWindow = await browser.windows.create();",
 
         @"browser.test.assertEq(newWindow.top, 50, 'The new window top position should be 50 initially');",
@@ -742,12 +742,12 @@ TEST(WKWebExtensionAPIWindows, Update)
         @"browser.test.notifyPass();"
     ]);
 
-    Util::loadAndRunExtension(windowsManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(windowsManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPIWindows, Remove)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         // Create a new window and verify the count
         @"const initialWindows = await browser.windows.getAll();",
         @"const newWindow = await browser.windows.create();",
@@ -764,18 +764,18 @@ TEST(WKWebExtensionAPIWindows, Remove)
         @"browser.test.notifyPass();"
     ]);
 
-    Util::loadAndRunExtension(windowsManifest, @{ @"background.js": backgroundScript });
+    Util::loadAndRunExtension(windowsManifest, @{ @"background.js": backgroundScript.get() });
 }
 
 TEST(WKWebExtensionAPIWindows, RemoveUnsupported)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.assertEq(browser.windows.remove, undefined)",
 
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::parseExtension(windowsManifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::parseExtension(windowsManifest, @{ @"background.js": backgroundScript.get() });
 
     manager.get().context.unsupportedAPIs = [NSSet setWithObject:@"browser.windows.remove"];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionContext.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionContext.mm
@@ -759,7 +759,7 @@ TEST(WKWebExtensionContext, CommandsParsing)
     EXPECT_NOT_NULL(testContext.commands);
     EXPECT_EQ(testContext.commands.count, 6lu);
 
-    WKWebExtensionCommand *testCommand = nil;
+    RetainPtr<WKWebExtensionCommand> testCommand = nil;
 
     for (WKWebExtensionCommand *command in testContext.commands) {
         if ([command.identifier isEqualToString:@"toggle-feature"]) {
@@ -811,70 +811,70 @@ TEST(WKWebExtensionContext, CommandsParsing)
 
     EXPECT_NOT_NULL(testCommand);
 
-    testCommand.activationKey = nil;
+    testCommand.get().activationKey = nil;
 
-    EXPECT_NULL(testCommand.activationKey);
-    EXPECT_EQ((uint32_t)testCommand.modifierFlags, 0lu);
+    EXPECT_NULL(testCommand.get().activationKey);
+    EXPECT_EQ((uint32_t)testCommand.get().modifierFlags, 0lu);
 
-    testCommand.activationKey = @"\uF70D";
+    testCommand.get().activationKey = @"\uF70D";
 
-    EXPECT_NS_EQUAL(testCommand.activationKey, @"\uF70D");
+    EXPECT_NS_EQUAL(testCommand.get().activationKey, @"\uF70D");
 #if PLATFORM(MAC)
-    EXPECT_EQ(testCommand.modifierFlags, NSEventModifierFlagOption | NSEventModifierFlagShift);
+    EXPECT_EQ(testCommand.get().modifierFlags, NSEventModifierFlagOption | NSEventModifierFlagShift);
 #else
-    EXPECT_EQ(testCommand.modifierFlags, UIKeyModifierAlternate | UIKeyModifierShift);
+    EXPECT_EQ(testCommand.get().modifierFlags, UIKeyModifierAlternate | UIKeyModifierShift);
 #endif
 
-    testCommand.activationKey = @"M";
+    testCommand.get().activationKey = @"M";
 
 #if PLATFORM(MAC)
-    EXPECT_NS_EQUAL(testCommand.activationKey, @"m");
-    EXPECT_EQ(testCommand.modifierFlags, NSEventModifierFlagOption | NSEventModifierFlagShift);
+    EXPECT_NS_EQUAL(testCommand.get().activationKey, @"m");
+    EXPECT_EQ(testCommand.get().modifierFlags, NSEventModifierFlagOption | NSEventModifierFlagShift);
 #else
-    EXPECT_NS_EQUAL(testCommand.activationKey, @"M");
-    EXPECT_EQ(testCommand.modifierFlags, UIKeyModifierAlternate | UIKeyModifierShift);
+    EXPECT_NS_EQUAL(testCommand.get().activationKey, @"M");
+    EXPECT_EQ(testCommand.get().modifierFlags, UIKeyModifierAlternate | UIKeyModifierShift);
 #endif
 
-    testCommand.modifierFlags = 0;
+    testCommand.get().modifierFlags = 0;
 
-    EXPECT_NULL(testCommand.activationKey);
-    EXPECT_EQ((uint32_t)testCommand.modifierFlags, 0lu);
+    EXPECT_NULL(testCommand.get().activationKey);
+    EXPECT_EQ((uint32_t)testCommand.get().modifierFlags, 0lu);
 
 #if PLATFORM(MAC)
-    testCommand.modifierFlags = NSEventModifierFlagCommand | NSEventModifierFlagShift;
+    testCommand.get().modifierFlags = NSEventModifierFlagCommand | NSEventModifierFlagShift;
 #else
-    testCommand.modifierFlags = UIKeyModifierCommand | UIKeyModifierShift;
+    testCommand.get().modifierFlags = UIKeyModifierCommand | UIKeyModifierShift;
 #endif
 
 #if PLATFORM(MAC)
-    EXPECT_NS_EQUAL(testCommand.activationKey, @"m");
-    EXPECT_EQ(testCommand.modifierFlags, NSEventModifierFlagCommand | NSEventModifierFlagShift);
+    EXPECT_NS_EQUAL(testCommand.get().activationKey, @"m");
+    EXPECT_EQ(testCommand.get().modifierFlags, NSEventModifierFlagCommand | NSEventModifierFlagShift);
 #else
-    EXPECT_NS_EQUAL(testCommand.activationKey, @"M");
-    EXPECT_EQ(testCommand.modifierFlags, UIKeyModifierCommand | UIKeyModifierShift);
+    EXPECT_NS_EQUAL(testCommand.get().activationKey, @"M");
+    EXPECT_EQ(testCommand.get().modifierFlags, UIKeyModifierCommand | UIKeyModifierShift);
 #endif
 
     @try {
-        testCommand.activationKey = @"F10";
+        testCommand.get().activationKey = @"F10";
     } @catch (NSException *exception) {
         EXPECT_NS_EQUAL(exception.name, NSInternalInconsistencyException);
     } @finally {
 #if PLATFORM(MAC)
-        EXPECT_NS_EQUAL(testCommand.activationKey, @"m");
+        EXPECT_NS_EQUAL(testCommand.get().activationKey, @"m");
 #else
-        EXPECT_NS_EQUAL(testCommand.activationKey, @"M");
+        EXPECT_NS_EQUAL(testCommand.get().activationKey, @"M");
 #endif
     }
 
     @try {
-        testCommand.modifierFlags = 1 << 16;
+        testCommand.get().modifierFlags = 1 << 16;
     } @catch (NSException *exception) {
         EXPECT_NS_EQUAL(exception.name, NSInternalInconsistencyException);
     } @finally {
 #if PLATFORM(MAC)
-        EXPECT_EQ(testCommand.modifierFlags, NSEventModifierFlagCommand | NSEventModifierFlagShift);
+        EXPECT_EQ(testCommand.get().modifierFlags, NSEventModifierFlagCommand | NSEventModifierFlagShift);
 #else
-        EXPECT_EQ(testCommand.modifierFlags, UIKeyModifierCommand | UIKeyModifierShift);
+        EXPECT_EQ(testCommand.get().modifierFlags, UIKeyModifierCommand | UIKeyModifierShift);
 #endif
     }
 
@@ -945,7 +945,7 @@ TEST(WKWebExtensionContext, LoadNonExistentImage)
         }
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const img = new Image()",
         @"img.src = 'non-existent-image.png'",
 
@@ -954,7 +954,7 @@ TEST(WKWebExtensionContext, LoadNonExistentImage)
         @"}",
     ]);
 
-    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript.get() });
 
     EXPECT_NS_EQUAL(manager.get().context.errors, @[ ]);
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionController.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionController.mm
@@ -282,19 +282,19 @@ TEST(WKWebExtensionController, BackgroundWithServiceWorkerPreferredEnvironment)
         }
     };
 
-    auto *serviceWorkerScript = Util::constructScript(@[
+    RetainPtr serviceWorkerScript = Util::constructScript(@[
         @"browser.test.assertTrue('ServiceWorkerGlobalScope' in self && self instanceof ServiceWorkerGlobalScope, 'Global scope should be ServiceWorkerGlobalScope');",
 
         @"browser.test.notifyPass()"
     ]);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.notifyFail('This background script should not be used')"
     ]);
 
     auto *resources = @{
-        @"service_worker.js": serviceWorkerScript,
-        @"background.js": backgroundScript,
+        @"service_worker.js": serviceWorkerScript.get(),
+        @"background.js": backgroundScript.get(),
         @"background.html": @"<script src='background.js'></script>",
     };
 
@@ -318,24 +318,24 @@ TEST(WKWebExtensionController, BackgroundWithPageDocumentPreferredEnvironment)
         }
     };
 
-    auto *serviceWorkerScript = Util::constructScript(@[
+    RetainPtr serviceWorkerScript = Util::constructScript(@[
         @"browser.test.notifyFail('Service worker should not be used')"
     ]);
 
-    auto *notUsedbackgroundScript = Util::constructScript(@[
+    RetainPtr notUsedbackgroundScript = Util::constructScript(@[
         @"browser.test.notifyFail('This background script should not be used')"
     ]);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.assertTrue('Window' in self && self instanceof Window, 'Global scope should be Window')",
 
         @"browser.test.notifyPass()"
     ]);
 
     auto *resources = @{
-        @"service_worker.js": serviceWorkerScript,
-        @"other-background.js": notUsedbackgroundScript,
-        @"background.js": backgroundScript,
+        @"service_worker.js": serviceWorkerScript.get(),
+        @"other-background.js": notUsedbackgroundScript.get(),
+        @"background.js": backgroundScript.get(),
         @"background.html": @"<script src='background.js'></script>",
     };
 
@@ -357,19 +357,19 @@ TEST(WKWebExtensionController, BackgroundWithScriptsDocumentPreferredEnvironment
         }
     };
 
-    auto *serviceWorkerScript = Util::constructScript(@[
+    RetainPtr serviceWorkerScript = Util::constructScript(@[
         @"browser.test.notifyFail('Service worker should not be used')"
     ]);
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.assertTrue('Window' in self && self instanceof Window, 'Global scope should be Window')",
 
         @"browser.test.notifyPass()"
     ]);
 
     auto *resources = @{
-        @"service_worker.js": serviceWorkerScript,
-        @"background.js": backgroundScript,
+        @"service_worker.js": serviceWorkerScript.get(),
+        @"background.js": backgroundScript.get(),
     };
 
     Util::loadAndRunExtension(manifest, resources);
@@ -391,11 +391,11 @@ TEST(WKWebExtensionController, BackgroundWithMultipleDocumentModuleScripts)
         }
     };
 
-    auto *module1 = Util::constructScript(@[
+    RetainPtr module1 = Util::constructScript(@[
         @"self.testValue = 'Test value set in Module 1';"
     ]);
 
-    auto *module2 = Util::constructScript(@[
+    RetainPtr module2 = Util::constructScript(@[
         @"import { valueFromModule3 } from './module3.js'",
 
         @"browser.test.assertEq(self.testValue, 'Test value set in Module 1', 'Module 1 value should be accessible')",
@@ -404,14 +404,14 @@ TEST(WKWebExtensionController, BackgroundWithMultipleDocumentModuleScripts)
         @"browser.test.notifyPass();"
     ]);
 
-    auto *module3 = Util::constructScript(@[
+    RetainPtr module3 = Util::constructScript(@[
         @"export const valueFromModule3 = 'Value from Module 3';"
     ]);
 
     auto *resources = @{
-        @"module1.js": module1,
-        @"module2.js": module2,
-        @"module3.js": module3,
+        @"module1.js": module1.get(),
+        @"module2.js": module2.get(),
+        @"module3.js": module3.get(),
     };
 
     Util::loadAndRunExtension(manifest, resources);
@@ -432,19 +432,19 @@ TEST(WKWebExtensionController, BackgroundWithMultipleServiceWorkerScripts)
         }
     };
 
-    auto *script1 = Util::constructScript(@[
+    RetainPtr script1 = Util::constructScript(@[
         @"self.testValue = 'Test value set in Script 1'"
     ]);
 
-    auto *script2 = Util::constructScript(@[
+    RetainPtr script2 = Util::constructScript(@[
         @"browser.test.assertEq(self.testValue, 'Test value set in Script 1')",
 
         @"browser.test.notifyPass()"
     ]);
 
     auto *resources = @{
-        @"script1.js": script1,
-        @"script2.js": script2,
+        @"script1.js": script1.get(),
+        @"script2.js": script2.get(),
     };
 
     Util::loadAndRunExtension(manifest, resources);
@@ -466,11 +466,11 @@ TEST(WKWebExtensionController, BackgroundWithMultipleServiceWorkerModuleScripts)
         }
     };
 
-    auto *module1 = Util::constructScript(@[
+    RetainPtr module1 = Util::constructScript(@[
         @"self.testValue = 'Test value set in Module 1'"
     ]);
 
-    auto *module2 = Util::constructScript(@[
+    RetainPtr module2 = Util::constructScript(@[
         @"import { valueFromModule3 } from './module3.js'",
 
         @"browser.test.assertEq(self.testValue, 'Test value set in Module 1')",
@@ -479,14 +479,14 @@ TEST(WKWebExtensionController, BackgroundWithMultipleServiceWorkerModuleScripts)
         @"browser.test.notifyPass()"
     ]);
 
-    auto *module3 = Util::constructScript(@[
+    RetainPtr module3 = Util::constructScript(@[
         @"export const valueFromModule3 = 'Value from Module 3'"
     ]);
 
     auto *resources = @{
-        @"module1.js": module1,
-        @"module2.js": module2,
-        @"module3.js": module3,
+        @"module1.js": module1.get(),
+        @"module2.js": module2.get(),
+        @"module3.js": module3.get(),
     };
 
     Util::loadAndRunExtension(manifest, resources);
@@ -500,7 +500,7 @@ TEST(WKWebExtensionController, ContentScriptLoading)
 
     auto *manifest = @{ @"manifest_version": @3, @"content_scripts": @[ @{ @"js": @[ @"content.js" ], @"matches": @[ @"*://localhost/*" ] } ] };
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         // Exposed to content scripts
         @"browser.test.assertEq(typeof browser.runtime.id, 'string')",
         @"browser.test.assertEq(typeof browser.runtime.getManifest(), 'object')",
@@ -514,7 +514,7 @@ TEST(WKWebExtensionController, ContentScriptLoading)
         @"browser.test.notifyPass()"
     ]);
 
-    auto manager = Util::loadExtension(manifest, @{ @"content.js": contentScript });
+    auto manager = Util::loadExtension(manifest, @{ @"content.js": contentScript.get() });
 
     WKWebExtensionMatchPattern *matchPattern = [WKWebExtensionMatchPattern matchPatternWithString:@"*://localhost/*"];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:matchPattern];
@@ -560,7 +560,7 @@ TEST(WKWebExtensionController, CSSUserOrigin)
 
     auto *styleSheet = @"body { color: green !important }";
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"let computedColor = window.getComputedStyle(document.body).color",
         @"browser.test.assertEq(computedColor, 'rgb(0, 128, 0)', 'Color should be green')",
 
@@ -569,15 +569,15 @@ TEST(WKWebExtensionController, CSSUserOrigin)
 
     auto resources = @{
         @"style.css": styleSheet,
-        @"content.js": contentScript
+        @"content.js": contentScript.get()
     };
 
     auto manager = Util::loadExtension(manifest, resources);
 
-    auto *urlRequest = server.requestWithLocalhost();
+    RetainPtr urlRequest = server.requestWithLocalhost();
 
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -605,7 +605,7 @@ TEST(WKWebExtensionController, CSSAuthorOrigin)
 
     auto *styleSheet = @"body { color: green !important }";
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"let computedColor = getComputedStyle(document.body).color",
         @"browser.test.assertEq(computedColor, 'rgb(0, 128, 0)', 'Color should be green')",
 
@@ -614,15 +614,15 @@ TEST(WKWebExtensionController, CSSAuthorOrigin)
 
     auto resources = @{
         @"style.css": styleSheet,
-        @"content.js": contentScript
+        @"content.js": contentScript.get()
     };
 
     auto manager = Util::loadExtension(manifest, resources);
 
-    auto *urlRequest = server.requestWithLocalhost();
+    RetainPtr urlRequest = server.requestWithLocalhost();
 
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -633,11 +633,11 @@ TEST(WKWebExtensionController, ContentSecurityPolicyV2BlockingImageLoad)
         { "/image.svg"_s, { { { "Content-Type"_s, "image/svg+xml"_s } }, "<svg xmlns='http://www.w3.org/2000/svg'></svg>"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *urlRequest = server.requestWithLocalhost();
+    RetainPtr urlRequest = server.requestWithLocalhost();
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"var img = document.createElement('img')",
-        [NSString stringWithFormat:@"img.src = '%@image.svg'", urlRequest.URL.absoluteString],
+        [NSString stringWithFormat:@"img.src = '%@image.svg'", urlRequest.get().URL.absoluteString],
 
         @"img.onerror = () => {",
         @"  browser.test.notifyPass()",
@@ -666,7 +666,7 @@ TEST(WKWebExtensionController, ContentSecurityPolicyV2BlockingImageLoad)
     };
 
     Util::loadAndRunExtension(manifest, @{
-        @"background.js": backgroundScript
+        @"background.js": backgroundScript.get()
     });
 }
 
@@ -676,11 +676,11 @@ TEST(WKWebExtensionController, ContentSecurityPolicyV3BlockingImageLoad)
         { "/image.svg"_s, { { { "Content-Type"_s, "image/svg+xml"_s } }, "<svg xmlns='http://www.w3.org/2000/svg'></svg>"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *urlRequest = server.requestWithLocalhost();
+    RetainPtr urlRequest = server.requestWithLocalhost();
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"var img = document.createElement('img')",
-        [NSString stringWithFormat:@"img.src = '%@image.svg'", urlRequest.URL.absoluteString],
+        [NSString stringWithFormat:@"img.src = '%@image.svg'", urlRequest.get().URL.absoluteString],
 
         @"img.onerror = () => {",
         @"  browser.test.notifyPass()",
@@ -711,7 +711,7 @@ TEST(WKWebExtensionController, ContentSecurityPolicyV3BlockingImageLoad)
     };
 
     Util::loadAndRunExtension(manifest, @{
-        @"background.js": backgroundScript
+        @"background.js": backgroundScript.get()
     });
 }
 
@@ -721,7 +721,7 @@ TEST(WKWebExtensionController, WebAccessibleResources)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } }
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"var imgGood = document.createElement('img')",
         @"imgGood.src = browser.runtime.getURL('good.svg')",
 
@@ -773,16 +773,16 @@ TEST(WKWebExtensionController, WebAccessibleResources)
     };
 
     auto *resources = @{
-        @"content.js": contentScript,
+        @"content.js": contentScript.get(),
         @"good.svg": @"<svg xmlns='http://www.w3.org/2000/svg'></svg>",
         @"bad.svg": @"<svg xmlns='http://www.w3.org/2000/svg'></svg>"
     };
 
     auto manager = Util::loadExtension(manifest, resources);
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -793,7 +793,7 @@ TEST(WKWebExtensionController, WebAccessibleResourcesWithLeadingSlash)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } }
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"var img = document.createElement('img')",
         @"img.src = browser.runtime.getURL('img.svg')",
 
@@ -826,15 +826,15 @@ TEST(WKWebExtensionController, WebAccessibleResourcesWithLeadingSlash)
     };
 
     auto *resources = @{
-        @"content.js": contentScript,
+        @"content.js": contentScript.get(),
         @"img.svg": @"<svg xmlns='http://www.w3.org/2000/svg'></svg>"
     };
 
     auto manager = Util::loadExtension(manifest, resources);
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -869,15 +869,15 @@ TEST(WKWebExtensionController, WebAccessibleResourceInSubframeFromAboutBlank)
         } ],
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.sendMessage('Load Tab')",
     ]);
 
-    auto *iframeScript = Util::constructScript(@[
+    RetainPtr iframeScript = Util::constructScript(@[
         @"browser.test.notifyPass()",
     ]);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"(function() {",
         @"  const iframe = document.createElement('iframe')",
         @"  document.documentElement.appendChild(iframe)",
@@ -886,20 +886,20 @@ TEST(WKWebExtensionController, WebAccessibleResourceInSubframeFromAboutBlank)
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
-        @"content.js": contentScript,
-        @"extension-frame.js": iframeScript,
+        @"background.js": backgroundScript.get(),
+        @"content.js": contentScript.get(),
+        @"extension-frame.js": iframeScript.get(),
         @"extension-frame.html": @"<script type='module' src='extension-frame.js'></script>",
     };
 
     auto manager = Util::loadExtension(extensionManifest, resources);
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -910,7 +910,7 @@ TEST(WKWebExtensionController, WebAccessibleResourcesV2)
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } }
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"var imgGood = document.createElement('img')",
         @"imgGood.src = browser.runtime.getURL('good.svg')",
 
@@ -959,16 +959,16 @@ TEST(WKWebExtensionController, WebAccessibleResourcesV2)
     };
 
     auto *resources = @{
-        @"content.js": contentScript,
+        @"content.js": contentScript.get(),
         @"good.svg": @"<svg xmlns='http://www.w3.org/2000/svg'></svg>",
         @"bad.svg": @"<svg xmlns='http://www.w3.org/2000/svg'></svg>"
     };
 
     auto manager = Util::loadExtension(manifest, resources);
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionDataRecord.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionDataRecord.mm
@@ -50,14 +50,14 @@ static auto *allDataTypesSet = [NSSet setWithArray:@[ WKWebExtensionDataTypeLoca
 
 TEST(WKWebExtensionDataRecord, GetDataRecords)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const data = { 'string': 'string', 'number': 1, 'boolean': true, 'dictionary': {'key': 'value'}, 'array': [1, true, 'string'] }",
         @"await browser?.storage?.local?.set(data)",
         @"await browser?.storage?.session?.set(data)",
         @"await browser?.storage?.sync?.set(data)",
     ]);
 
-    auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:dataRecordTestManifest resources:@{ @"background.js": backgroundScript  }]);
+    auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:dataRecordTestManifest resources:@{ @"background.js": backgroundScript.get()  }]);
     auto *testController = [[WKWebExtensionController alloc] initWithConfiguration:WKWebExtensionControllerConfiguration._temporaryConfiguration];
 
     auto *context = [[WKWebExtensionContext alloc] initForExtension:extension.get()];
@@ -101,12 +101,12 @@ TEST(WKWebExtensionDataRecord, DISABLED_GetDataRecordsForMultipleContexts)
 TEST(WKWebExtensionDataRecord, GetDataRecordsForMultipleContexts)
 #endif
 {
-    auto *backgroundScriptOne = Util::constructScript(@[
+    RetainPtr backgroundScriptOne = Util::constructScript(@[
         @"const data = { 'string': 'string', 'number': 1, 'boolean': true, 'dictionary': {'key': 'value'}, 'array': [1, true, 'string'] }",
         @"await browser?.storage?.local?.set(data)",
     ]);
 
-    auto *backgroundScriptTwo = Util::constructScript(@[
+    RetainPtr backgroundScriptTwo = Util::constructScript(@[
         @"const data = { 'string': 'string', 'number': 1, 'boolean': true, 'dictionary': {'key': 'value'}, 'array': [1, true, 'string'] }",
         @"await browser?.storage?.session?.set(data)",
         @"await browser?.storage?.sync?.set(data)",
@@ -114,12 +114,12 @@ TEST(WKWebExtensionDataRecord, GetDataRecordsForMultipleContexts)
 
     auto *testController = [[WKWebExtensionController alloc] initWithConfiguration:WKWebExtensionControllerConfiguration._temporaryConfiguration];
 
-    auto *testExtensionOne = [[WKWebExtension alloc] _initWithManifestDictionary:dataRecordTestManifest resources:@{ @"background.js": backgroundScriptOne }];
+    auto *testExtensionOne = [[WKWebExtension alloc] _initWithManifestDictionary:dataRecordTestManifest resources:@{ @"background.js": backgroundScriptOne.get() }];
     auto *testContextOne = [[WKWebExtensionContext alloc] initForExtension:testExtensionOne];
     [testContextOne setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionStorage];
     testContextOne.uniqueIdentifier = @"org.webkit.testOne.extension (76C788B8)";
 
-    auto *testExtensionTwo = [[WKWebExtension alloc] _initWithManifestDictionary:dataRecordTestTwoManifest resources:@{ @"background.js": backgroundScriptTwo }];
+    auto *testExtensionTwo = [[WKWebExtension alloc] _initWithManifestDictionary:dataRecordTestTwoManifest resources:@{ @"background.js": backgroundScriptTwo.get() }];
     auto *testContextTwo = [[WKWebExtensionContext alloc] initForExtension:testExtensionTwo];
     [testContextTwo setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionStorage];
     testContextTwo.uniqueIdentifier = @"org.webkit.testTwo.extension (76C788B8)";
@@ -175,14 +175,14 @@ TEST(WKWebExtensionDataRecord, GetDataRecordsForMultipleContexts)
 // FIXME: rdar://125926932 (Enable the WKWebExtensionDataRecord.RemoveDataRecords test (272236))
 TEST(WKWebExtensionDataRecord, DISABLED_RemoveDataRecords)
 {
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"const data = { 'string': 'string', 'number': 1, 'boolean': true, 'dictionary': {'key': 'value'}, 'array': [1, true, 'string'] }",
         @"await browser?.storage?.local?.set(data)",
         @"await browser?.storage?.session?.set(data)",
         @"await browser?.storage?.sync?.set(data)",
     ]);
 
-    auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:dataRecordTestManifest resources:@{ @"background.js": backgroundScript  }]);
+    auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:dataRecordTestManifest resources:@{ @"background.js": backgroundScript.get()  }]);
     auto *testController = [[WKWebExtensionController alloc] initWithConfiguration:WKWebExtensionControllerConfiguration._temporaryConfiguration];
 
     auto *context = [[WKWebExtensionContext alloc] initForExtension:extension.get()];
@@ -220,24 +220,24 @@ TEST(WKWebExtensionDataRecord, DISABLED_RemoveDataRecords)
 // FIXME: rdar://125926932 (Enable the WKWebExtensionDataRecord.RemoveDataRecords test (272236))
 TEST(WKWebExtensionDataRecord, DISABLED_RemoveDataRecordsForMultipleContexts)
 {
-    auto *backgroundScriptOne = Util::constructScript(@[
+    RetainPtr backgroundScriptOne = Util::constructScript(@[
         @"const data = { 'string': 'string', 'number': 1, 'boolean': true, 'dictionary': {'key': 'value'}, 'array': [1, true, 'string'] }",
         @"await browser?.storage?.local?.set(data)",
     ]);
 
-    auto *backgroundScriptTwo = Util::constructScript(@[
+    RetainPtr backgroundScriptTwo = Util::constructScript(@[
         @"const data = { 'string': 'string', 'number': 1, 'boolean': true, 'dictionary': {'key': 'value'}, 'array': [1, true, 'string'] }",
         @"await browser?.storage?.sync?.set(data)",
     ]);
 
     auto *testController = [[WKWebExtensionController alloc] initWithConfiguration:WKWebExtensionControllerConfiguration._temporaryConfiguration];
 
-    auto *testExtensionOne = [[WKWebExtension alloc] _initWithManifestDictionary:dataRecordTestManifest resources:@{ @"background.js": backgroundScriptOne }];
+    auto *testExtensionOne = [[WKWebExtension alloc] _initWithManifestDictionary:dataRecordTestManifest resources:@{ @"background.js": backgroundScriptOne.get() }];
     auto *testContextOne = [[WKWebExtensionContext alloc] initForExtension:testExtensionOne];
     [testContextOne setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionStorage];
     testContextOne.uniqueIdentifier = @"org.webkit.testOne.extension (76C788B8)";
 
-    auto *testExtensionTwo = [[WKWebExtension alloc] _initWithManifestDictionary:dataRecordTestTwoManifest resources:@{ @"background.js": backgroundScriptTwo }];
+    auto *testExtensionTwo = [[WKWebExtension alloc] _initWithManifestDictionary:dataRecordTestTwoManifest resources:@{ @"background.js": backgroundScriptTwo.get() }];
     auto *testContextTwo = [[WKWebExtensionContext alloc] initForExtension:testExtensionTwo];
     [testContextTwo setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionStorage];
     testContextTwo.uniqueIdentifier = @"org.webkit.testTwo.extension (76C788B8)";

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionMatchPattern.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionMatchPattern.mm
@@ -473,82 +473,82 @@ TEST(WKWebExtensionMatchPattern, PatternCacheAndEquality)
     // They should still be equal, just not via pointer equality.
     {
         NSError *error;
-        auto* a = toPatternAlloc(@"<all_urls>", &error);
-        auto* b = toPatternAlloc(@"<all_urls>");
+        RetainPtr a = toPatternAlloc(@"<all_urls>", &error);
+        RetainPtr b = toPatternAlloc(@"<all_urls>");
 
         EXPECT_NULL(error);
-        EXPECT_NE(a, b);
-        EXPECT_NS_EQUAL(a, b);
+        EXPECT_NE(a.get(), b.get());
+        EXPECT_NS_EQUAL(a.get(), b.get());
     }
 
     {
         NSError *error;
-        auto* a = toPatternAlloc(@"<all_urls>", &error);
-        auto* b = toPattern(@"<all_urls>");
+        RetainPtr a = toPatternAlloc(@"<all_urls>", &error);
+        RetainPtr b = toPattern(@"<all_urls>");
 
         EXPECT_NULL(error);
-        EXPECT_NE(a, b);
-        EXPECT_NS_EQUAL(a, b);
+        EXPECT_NE(a.get(), b.get());
+        EXPECT_NS_EQUAL(a.get(), b.get());
     }
 
     {
         NSError *error;
-        auto* a = toPatternAlloc(@"*://*/*", &error);
-        auto* b = toPatternAlloc(@"*://*/*");
+        RetainPtr a = toPatternAlloc(@"*://*/*", &error);
+        RetainPtr b = toPatternAlloc(@"*://*/*");
 
         EXPECT_NULL(error);
-        EXPECT_NE(a, b);
-        EXPECT_NS_EQUAL(a, b);
+        EXPECT_NE(a.get(), b.get());
+        EXPECT_NS_EQUAL(a.get(), b.get());
     }
 
     {
         NSError *error;
-        auto* a = toPatternAlloc(@"*://*/*", &error);
-        auto* b = toPattern(@"*://*/*");
+        RetainPtr a = toPatternAlloc(@"*://*/*", &error);
+        RetainPtr b = toPattern(@"*://*/*");
 
         EXPECT_NULL(error);
-        EXPECT_NE(a, b);
-        EXPECT_NS_EQUAL(a, b);
+        EXPECT_NE(a.get(), b.get());
+        EXPECT_NS_EQUAL(a.get(), b.get());
     }
 
     {
         NSError *error;
-        auto* a = toPatternAlloc(@"*://*/*", &error);
-        auto* b = toPattern(@"*", @"*", @"/*");
+        RetainPtr a = toPatternAlloc(@"*://*/*", &error);
+        RetainPtr b = toPattern(@"*", @"*", @"/*");
 
         EXPECT_NULL(error);
-        EXPECT_NE(a, b);
-        EXPECT_NS_EQUAL(a, b);
+        EXPECT_NE(a.get(), b.get());
+        EXPECT_NS_EQUAL(a.get(), b.get());
     }
 
     {
         NSError *error;
-        auto* a = toPatternAlloc(@"*://*/*", &error);
-        auto* b = toPatternAlloc(@"*", @"*", @"/*");
+        RetainPtr a = toPatternAlloc(@"*://*/*", &error);
+        RetainPtr b = toPatternAlloc(@"*", @"*", @"/*");
 
         EXPECT_NULL(error);
-        EXPECT_NE(a, b);
-        EXPECT_NS_EQUAL(a, b);
+        EXPECT_NE(a.get(), b.get());
+        EXPECT_NS_EQUAL(a.get(), b.get());
     }
 
     {
         NSError *error;
-        auto* a = toPatternAlloc(@"*", @"*", @"/*", &error);
-        auto* b = toPattern(@"*", @"*", @"/*");
+        RetainPtr a = toPatternAlloc(@"*", @"*", @"/*", &error);
+        RetainPtr b = toPattern(@"*", @"*", @"/*");
 
         EXPECT_NULL(error);
-        EXPECT_NE(a, b);
-        EXPECT_NS_EQUAL(a, b);
+        EXPECT_NE(a.get(), b.get());
+        EXPECT_NS_EQUAL(a.get(), b.get());
     }
 
     {
         NSError *error;
-        auto* a = toPatternAlloc(@"*", @"*", @"/*", &error);
-        auto* b = toPatternAlloc(@"*", @"*", @"/*");
+        RetainPtr a = toPatternAlloc(@"*", @"*", @"/*", &error);
+        RetainPtr b = toPatternAlloc(@"*", @"*", @"/*");
 
         EXPECT_NULL(error);
-        EXPECT_NE(a, b);
-        EXPECT_NS_EQUAL(a, b);
+        EXPECT_NE(a.get(), b.get());
+        EXPECT_NS_EQUAL(a.get(), b.get());
     }
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewDisableSelection.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewDisableSelection.mm
@@ -80,8 +80,8 @@ TEST(WKWebViewDisableSelection, DragDoesNotSelectWhenTextInteractionsAreDisabled
     RetainPtr<TestWKWebView> webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 1000, 400)]);
     [webView synchronouslyLoadTestPageNamed:@"try-text-select-with-disabled-text-interaction"];
 
-    NSString *selectedText = clickAndDragToSelectText(webView.get());
-    EXPECT_WK_STREQ("Hello", selectedText);
+    RetainPtr selectedText = clickAndDragToSelectText(webView.get());
+    EXPECT_WK_STREQ("Hello", selectedText.get());
     
     // Clear the selection by clicking once.
     [webView sendClicksAtPoint:NSMakePoint(200, 200) numberOfClicks:1];
@@ -90,8 +90,8 @@ TEST(WKWebViewDisableSelection, DragDoesNotSelectWhenTextInteractionsAreDisabled
     // Disable text selection then click and drag again. This should result in no text selected.
     [webView configuration].preferences.textInteractionEnabled = NO;
 
-    NSString *selectedText2 = clickAndDragToSelectText(webView.get());
-    EXPECT_WK_STREQ("", selectedText2);
+    RetainPtr selectedText2 = clickAndDragToSelectText(webView.get());
+    EXPECT_WK_STREQ("", selectedText2.get());
 }
 
 #endif // PLATFORM(MAC)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm
@@ -1308,9 +1308,9 @@ TEST(EvaluateJavaScript, Serialization)
     EXPECT_NULL(error);
 
     size_t depth = 0;
-    NSDictionary *nextDictionary = (NSDictionary *)result;
+    RetainPtr nextDictionary = (NSDictionary *)result;
     while (nextDictionary) {
-        nextDictionary = (NSDictionary *)nextDictionary[@"baz"];
+        nextDictionary = (NSDictionary *)nextDictionary.get()[@"baz"];
         ++depth;
     }
     EXPECT_EQ(depth, 40000u);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewGetContents.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewGetContents.mm
@@ -446,17 +446,17 @@ TEST(WKWebView, AttributedStringFromList)
     };
 
     EXPECT_EQ(allTextLists.size(), 8U);
-    auto firstList = allTextLists.first().second;
-    auto secondList = allTextLists.last().second;
+    RetainPtr firstList = allTextLists.first().second;
+    RetainPtr secondList = allTextLists.last().second;
 
-    checkListAtIndex(0, @"1", firstList);
-    checkListAtIndex(1, @"One", firstList);
-    checkListAtIndex(2, @"2", firstList);
-    checkListAtIndex(3, @"Two", firstList);
-    checkListAtIndex(4, @"•", secondList);
-    checkListAtIndex(5, @"Three", secondList);
-    checkListAtIndex(6, @"•", secondList);
-    checkListAtIndex(7, @"Four", secondList);
+    checkListAtIndex(0, @"1", firstList.get());
+    checkListAtIndex(1, @"One", firstList.get());
+    checkListAtIndex(2, @"2", firstList.get());
+    checkListAtIndex(3, @"Two", firstList.get());
+    checkListAtIndex(4, @"•", secondList.get());
+    checkListAtIndex(5, @"Three", secondList.get());
+    checkListAtIndex(6, @"•", secondList.get());
+    checkListAtIndex(7, @"Four", secondList.get());
 }
 
 TEST(WKWebView, AttributedStringFromListWithNegativeStartValue)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewSnapshot.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewSnapshot.mm
@@ -252,9 +252,9 @@ TEST(WKWebView, SnapshotImageEmptyWithOutOfScopeCompletionHandler)
 
     EXPECT_NULL([snapshotWrapper error]);
 
-    auto image = [snapshotWrapper image].unsafeGet();
-    EXPECT_EQ(0UL, CGImageGetWidth(image));
-    EXPECT_EQ(0UL, CGImageGetHeight(image));
+    RetainPtr image = [snapshotWrapper image].unsafeGet();
+    EXPECT_EQ(0UL, CGImageGetWidth(image.get()));
+    EXPECT_EQ(0UL, CGImageGetHeight(image.get()));
 
     EXPECT_EQ(pid, [webView _webProcessIdentifier]); // Make sure the WebProcess did not crash.
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebContentProcessDidTerminate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebContentProcessDidTerminate.mm
@@ -271,7 +271,7 @@ TEST(WKNavigation, ProcessCrashDuringCallback)
     callbackCount = 0;
     calledAllCallbacks = false;
 
-    __block WKWebView *view = webView.get();
+    __block RetainPtr view = webView.get();
     [webView _getContentsAsStringWithCompletionHandler:^(NSString *contents, NSError *error) {
         if (!!error)
             EXPECT_TRUE(error.code == WKErrorWebContentProcessTerminated || error.code == WKErrorWebViewInvalidated);
@@ -289,7 +289,7 @@ TEST(WKNavigation, ProcessCrashDuringCallback)
     [webView _getContentsAsStringWithCompletionHandler:^(NSString *contents, NSError *error) {
         if (!!error)
             EXPECT_TRUE(error.code == WKErrorWebContentProcessTerminated || error.code == WKErrorWebViewInvalidated);
-        [view _close]; // Calling _close will also invalidate all callbacks.
+        [view.get() _close]; // Calling _close will also invalidate all callbacks.
         ++callbackCount;
         if (callbackCount == 6)
             calledAllCallbacks = true;
@@ -587,13 +587,13 @@ TEST(WKNavigation, CrashRecoveryRightAfterLoadRequest)
 
     // Issue a kill and then a loadRequest.
     kill(webProcessPID, 9);
-    auto request = server.request("/index.html"_s);
-    [webView loadRequest:[NSURLRequest requestWithURL:request.URL]];
+    RetainPtr request = server.request("/index.html"_s);
+    [webView loadRequest:[NSURLRequest requestWithURL:request.get().URL]];
 
     // Navigation should complete.
     TestWebKitAPI::Util::run(&finishedLoad);
 
-    EXPECT_WK_STREQ([webView URL].absoluteString, request.URL.absoluteString);
+    EXPECT_WK_STREQ([webView URL].absoluteString, request.get().URL.absoluteString);
     EXPECT_EQ([webView backForwardList].backList.count, 0U);
     EXPECT_EQ([webView backForwardList].forwardList.count, 0U);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm
@@ -719,7 +719,7 @@ TEST(WebTransport, ServerCertificateHashes)
             certificateBytes.append(makeString((unsigned)sha2[i]));
         }
 
-        NSString *html = [NSString stringWithFormat:@""
+        RetainPtr html = [NSString stringWithFormat:@""
             "<script>async function test() {"
             "  try {"
             "    const hashValue = new Uint8Array([%s]);"
@@ -749,7 +749,7 @@ TEST(WebTransport, ServerCertificateHashes)
             completionHandler(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
         };
 
-        [webView loadHTMLString:html baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
+        [webView loadHTMLString:html.get() baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
         NSString *result = [webView _test_waitForAlert];
         EXPECT_FALSE(challenged);
         return result;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm
@@ -1907,9 +1907,9 @@ TEST(WKWebsiteDataStore, FetchAndDeleteMediaKeysData)
     NSURL *customMediaKeysStorageDirectory = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/CustomWebsiteData/MediaKeys" stringByExpandingTildeInPath] isDirectory:YES];
     WebCore::SecurityOriginData origin("https"_s, "webkit.org"_s, 443);
     NSFileManager *fileManager = [NSFileManager defaultManager];
-    NSURL *customWebKitDirectory = [customMediaKeysStorageDirectory URLByAppendingPathComponent:origin.databaseIdentifier().createNSString().get()];
-    [fileManager createDirectoryAtURL:customWebKitDirectory withIntermediateDirectories:YES attributes:nil error:nil];
-    NSURL *customMediaKeysStorageFile = [customWebKitDirectory URLByAppendingPathComponent:@"SecureStop.plist"];
+    RetainPtr customWebKitDirectory = [customMediaKeysStorageDirectory URLByAppendingPathComponent:origin.databaseIdentifier().createNSString().get()];
+    [fileManager createDirectoryAtURL:customWebKitDirectory.get() withIntermediateDirectories:YES attributes:nil error:nil];
+    NSURL *customMediaKeysStorageFile = [customWebKitDirectory.get() URLByAppendingPathComponent:@"SecureStop.plist"];
     [fileManager createFileAtPath:customMediaKeysStorageFile.path contents:nil attributes:nil];
     FileSystem::updateFileModificationTime(customMediaKeysStorageFile.path);
     NSURL *customVersionDirectory = [customMediaKeysStorageDirectory URLByAppendingPathComponent:@"v1"];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
@@ -4023,14 +4023,14 @@ TEST(WritingTools, IntelligenceTextEffectCoordinatorDelegate_RectsForProofreadin
 
     __block RetainPtr<NSArray<NSValue *>> rectValues = nil;
 
-    id<WKIntelligenceTextEffectCoordinatorDelegate> coordinatorDelegate = (id<WKIntelligenceTextEffectCoordinatorDelegate>)webView.get();
+    RetainPtr<id<WKIntelligenceTextEffectCoordinatorDelegate>> coordinatorDelegate = (id<WKIntelligenceTextEffectCoordinatorDelegate>)webView.get();
 
     // FIXME: Figure out how to use `WebKitSwiftSoftLink` within TestWebKitAPI so that an actual instance can be created.
     id<WKIntelligenceTextEffectCoordinating> coordinator = nil;
 
     NSRange subrange = NSMakeRange(18, 43); // "I didn't quite hear him.\n\nWho's over there?"
 
-    [coordinatorDelegate intelligenceTextEffectCoordinator:coordinator rectsForProofreadingSuggestionsInRange:subrange completion:^(NSArray<NSValue *> *values) {
+    [coordinatorDelegate.get() intelligenceTextEffectCoordinator:coordinator rectsForProofreadingSuggestionsInRange:subrange completion:^(NSArray<NSValue *> *values) {
         rectValues = values;
         finished = true;
     }];
@@ -4085,7 +4085,7 @@ TEST(WritingTools, IntelligenceTextEffectCoordinatorDelegate_UpdateTextVisibilit
     TestWebKitAPI::Util::run(&finished);
     finished = false;
 
-    id<WKIntelligenceTextEffectCoordinatorDelegate> coordinatorDelegate = (id<WKIntelligenceTextEffectCoordinatorDelegate>)webView.get();
+    RetainPtr<id<WKIntelligenceTextEffectCoordinatorDelegate>> coordinatorDelegate = (id<WKIntelligenceTextEffectCoordinatorDelegate>)webView.get();
     id<WKIntelligenceTextEffectCoordinating> coordinator = nil;
 
     __auto_type moveSelectionToFirstNode = ^{
@@ -4120,7 +4120,7 @@ TEST(WritingTools, IntelligenceTextEffectCoordinatorDelegate_UpdateTextVisibilit
 
     RetainPtr identifier = [NSUUID UUID];
 
-    [coordinatorDelegate intelligenceTextEffectCoordinator:coordinator updateTextVisibilityForRange:subrange visible:NO identifier:identifier.get() completion:^{
+    [coordinatorDelegate.get() intelligenceTextEffectCoordinator:coordinator updateTextVisibilityForRange:subrange visible:NO identifier:identifier.get() completion:^{
         finished = true;
     }];
 
@@ -4133,7 +4133,7 @@ TEST(WritingTools, IntelligenceTextEffectCoordinatorDelegate_UpdateTextVisibilit
     moveSelectionToSecondNode();
     EXPECT_TRUE([[webView objectByEvaluatingJavaScript:@"internals.hasTransparentContentMarker(0, 19);"] boolValue]);
 
-    [coordinatorDelegate intelligenceTextEffectCoordinator:coordinator updateTextVisibilityForRange:subrange visible:YES identifier:identifier.get() completion:^{
+    [coordinatorDelegate.get() intelligenceTextEffectCoordinator:coordinator updateTextVisibilityForRange:subrange visible:YES identifier:identifier.get() completion:^{
         finished = true;
     }];
 
@@ -4173,13 +4173,13 @@ TEST(WritingTools, IntelligenceTextEffectCoordinatorDelegate_TextPreviewsForRang
 
     NSRange subrange = NSMakeRange(17, 45); // "I didn't quite here him.\n\nWho's over they're."
 
-    id<WKIntelligenceTextEffectCoordinatorDelegate> coordinatorDelegate = (id<WKIntelligenceTextEffectCoordinatorDelegate>)webView.get();
+    RetainPtr<id<WKIntelligenceTextEffectCoordinatorDelegate>> coordinatorDelegate = (id<WKIntelligenceTextEffectCoordinatorDelegate>)webView.get();
     id<WKIntelligenceTextEffectCoordinating> coordinator = nil;
 
 #if PLATFORM(MAC)
     __block RetainPtr<NSArray<_WKTextPreview *>> previews;
 
-    [coordinatorDelegate intelligenceTextEffectCoordinator:coordinator textPreviewsForRange:subrange completion:^(NSArray<_WKTextPreview *> *result) {
+    [coordinatorDelegate.get() intelligenceTextEffectCoordinator:coordinator textPreviewsForRange:subrange completion:^(NSArray<_WKTextPreview *> *result) {
         previews = result;
         finished = true;
     }];
@@ -4206,7 +4206,7 @@ TEST(WritingTools, IntelligenceTextEffectCoordinatorDelegate_TextPreviewsForRang
 #else
     __block RetainPtr<UITargetedPreview> preview;
 
-    [coordinatorDelegate intelligenceTextEffectCoordinator:coordinator textPreviewsForRange:subrange completion:^(UITargetedPreview *result) {
+    [coordinatorDelegate.get() intelligenceTextEffectCoordinator:coordinator textPreviewsForRange:subrange completion:^(UITargetedPreview *result) {
         preview = result;
         finished = true;
     }];

--- a/Tools/TestWebKitAPI/Tests/mac/AttributedString.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/AttributedString.mm
@@ -53,8 +53,8 @@ public:
 template <typename View>
 void AttributedStringTest_CustomFont::runSyncTest(View view)
 {
-    NSAttributedString *attrString = attributedString(view, NSMakeRange(0, 5));
-    EXPECT_WK_STREQ("Lorem", [attrString string]);
+    RetainPtr attrString = attributedString(view, NSMakeRange(0, 5));
+    EXPECT_WK_STREQ("Lorem", [attrString.get() string]);
 }
 
 TEST_F(AttributedStringTest_CustomFont, WebKit)
@@ -77,11 +77,11 @@ public:
 template <typename View>
 void AttributedStringTest_Strikethrough::runSyncTest(View view)
 {
-    NSAttributedString *attrString = attributedString(view, NSMakeRange(0, 5));
+    RetainPtr attrString = attributedString(view, NSMakeRange(0, 5));
 
-    EXPECT_WK_STREQ("Lorem", [attrString string]);
-    
-    NSDictionary *attributes = [attrString attributesAtIndex:0 effectiveRange:0];
+    EXPECT_WK_STREQ("Lorem", [attrString.get() string]);
+
+    NSDictionary *attributes = [attrString.get() attributesAtIndex:0 effectiveRange:0];
     ASSERT_NOT_NULL([attributes objectForKey:NSStrikethroughStyleAttributeName]);
     ASSERT_TRUE([[attributes objectForKey:NSStrikethroughStyleAttributeName] isKindOfClass:[NSNumber class]]);
     ASSERT_EQ(NSUnderlineStyleSingle, [(NSNumber *)[attributes objectForKey:NSStrikethroughStyleAttributeName] intValue]);

--- a/Tools/TestWebKitAPI/Tests/mac/ContextMenuCanCopyURL.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/ContextMenuCanCopyURL.mm
@@ -61,21 +61,21 @@ static void contextMenuCopyLink(WebView* webView, int itemIndex)
     DOMHTMLAnchorElement *anchor = (DOMHTMLAnchorElement *)[[documentElement querySelectorAll:@"a"] item:itemIndex];
 
     NSWindow *window = [webView window];
-    NSEvent *event = [NSEvent mouseEventWithType:NSEventTypeRightMouseDown
+    RetainPtr event = [NSEvent mouseEventWithType:NSEventTypeRightMouseDown
                                         location:NSMakePoint(anchor.offsetLeft + anchor.offsetWidth / 2, window.frame.size.height - (anchor.offsetTop + anchor.offsetHeight / 2))
                                    modifierFlags:0
                                        timestamp:GetCurrentEventTime()
                                     windowNumber:[window windowNumber]
-                                         context:[NSGraphicsContext currentContext] 
+                                         context:[NSGraphicsContext currentContext]
                                      eventNumber:0
                                       clickCount:0
                                         pressure:0.0];
 
-    NSView *subView = [webView hitTest:[event locationInWindow]];
+    NSView *subView = [webView hitTest:[event.get() locationInWindow]];
     if (!subView)
         return;
 
-    NSMenu* menu = [subView menuForEvent:event];
+    NSMenu* menu = [subView menuForEvent:event.get()];
     for (int i = 0; i < [menu numberOfItems]; ++i) {
         NSMenuItem* menuItem = [menu itemAtIndex:i];
         if ([menuItem tag] != WebMenuItemTagCopyLinkToClipboard)

--- a/Tools/TestWebKitAPI/Tests/mac/FullscreenZoomInitialFrame.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/FullscreenZoomInitialFrame.mm
@@ -165,12 +165,12 @@ void FullscreenZoomInitialFrame::runTest(View view)
     sendMouseDownEvent(view, event);
     Util::run(&didGetPageSignalToContinue);
 
-    id windowController = [[view window] windowController];
-    EXPECT_TRUE([windowController respondsToSelector:@selector(initialFrame)]);
-    EXPECT_TRUE([windowController respondsToSelector:@selector(finalFrame)]);
+    RetainPtr windowController = [[view window] windowController];
+    EXPECT_TRUE([windowController.get() respondsToSelector:@selector(initialFrame)]);
+    EXPECT_TRUE([windowController.get() respondsToSelector:@selector(finalFrame)]);
 
-    NSRect initialFrame = [windowController initialFrame];
-    NSRect finalFrame = [windowController finalFrame];
+    NSRect initialFrame = [windowController.get() initialFrame];
+    NSRect finalFrame = [windowController.get() finalFrame];
 
     EXPECT_EQ(300, initialFrame.size.width);
     EXPECT_EQ(300, initialFrame.size.height);

--- a/Tools/TestWebKitAPI/Tests/mac/LegacyDragAndDropTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/LegacyDragAndDropTests.mm
@@ -258,8 +258,8 @@ TEST(LegacyDragAndDropTests, DropUTF8PlainText)
 TEST(LegacyDragAndDropTests, DropJPEG)
 {
     NSPasteboard *pasteboard = [NSPasteboard pasteboardWithUniqueName];
-    NSImage *icon = getTestImage();
-    NSBitmapImageRep *imageRep = [NSBitmapImageRep imageRepWithData:icon.TIFFRepresentation];
+    RetainPtr icon = getTestImage();
+    NSBitmapImageRep *imageRep = [NSBitmapImageRep imageRepWithData:icon.get().TIFFRepresentation];
     [pasteboard setData:[imageRep representationUsingType:NSJPEGFileType properties:@{ NSImageCompressionFactor: @(0.9) }] forType:UTTypeJPEG.identifier];
 
     RetainPtr<WebView> resultingWebView = webViewAfterPerformingDragOperation(pasteboard);

--- a/Tools/TestWebKitAPI/Tests/mac/LoadInvalidURLRequest.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/LoadInvalidURLRequest.mm
@@ -51,8 +51,8 @@ static bool didFailProvisionalLoad;
     EXPECT_EQ(error.code, WebKitErrorCannotShowURL);
 
     static char literal[] = "https://www.example.com$/";
-    NSURL *failedURL = WTF::URLWithData([NSData dataWithBytes:literal length:strlen(literal)], nil);
-    EXPECT_TRUE([error.userInfo[NSURLErrorFailingURLErrorKey] isEqual:failedURL]);
+    RetainPtr failedURL = WTF::URLWithData([NSData dataWithBytes:literal length:strlen(literal)], nil);
+    EXPECT_TRUE([error.userInfo[NSURLErrorFailingURLErrorKey] isEqual:failedURL.get()]);
 
     didFailProvisionalLoad = true;
     didFinishTest = true;

--- a/Tools/TestWebKitAPI/Tests/mac/MediaPlaybackSleepAssertion.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/MediaPlaybackSleepAssertion.mm
@@ -128,14 +128,14 @@ static bool hasAssertionType(CFStringRef type)
 
     auto assertionsByPID = adoptCF(bareAssertionsByPID);
 
-    CFArrayRef assertions = (CFArrayRef)CFDictionaryGetValue(assertionsByPID.get(), cfPid.get());
+    RetainPtr assertions = (CFArrayRef)CFDictionaryGetValue(assertionsByPID.get(), cfPid.get());
     if (!assertions)
         return false;
 
-    for (CFIndex i = 0, count = CFArrayGetCount(assertions); i < count; ++i) {
-        CFDictionaryRef assertion = (CFDictionaryRef)CFArrayGetValueAtIndex(assertions, i);
-        CFStringRef assertionType = (CFStringRef)CFDictionaryGetValue(assertion, kIOPMAssertionTypeKey);
-        if (CFEqual(type, assertionType))
+    for (CFIndex i = 0, count = CFArrayGetCount(assertions.get()); i < count; ++i) {
+        RetainPtr assertion = (CFDictionaryRef)CFArrayGetValueAtIndex(assertions.get(), i);
+        RetainPtr assertionType = (CFStringRef)CFDictionaryGetValue(assertion.get(), kIOPMAssertionTypeKey);
+        if (CFEqual(type, assertionType.get()))
             return true;
     }
     return false;

--- a/Tools/TestWebKitAPI/Tests/mac/MenuTypesForMouseEvents.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/MenuTypesForMouseEvents.mm
@@ -54,9 +54,9 @@ static void buildAndPerformTest(NSEventType buttonEvent, NSEventModifierFlags mo
                                             pressure:0];
 
         if (buttonEvent == NSEventTypeOtherMouseDown) {
-            CGEventRef cgEvent = event.CGEvent;
-            CGEventSetIntegerValueField(cgEvent, kCGMouseEventButtonNumber, 2);
-            event = [NSEvent eventWithCGEvent:cgEvent];
+            RetainPtr<CGEventRef> cgEvent = event.CGEvent;
+            CGEventSetIntegerValueField(cgEvent.get(), kCGMouseEventButtonNumber, 2);
+            event = [NSEvent eventWithCGEvent:cgEvent.get()];
         }
 
         auto pme = WebCore::PlatformEventFactory::createPlatformMouseEvent(event, nil, webView.get());

--- a/Tools/TestWebKitAPI/Tests/mac/ScrollingCoordinatorTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/ScrollingCoordinatorTests.mm
@@ -105,7 +105,7 @@ TEST(ScrollingCoordinatorTests, ScrollingTreeAfterDetachReattach)
 
     [webView waitForNextPresentationUpdate];
 
-    NSString *scrollingTreeBefore = scrollingTreeElidingLastCommittedScrollPosition([webView stringByEvaluatingJavaScript:@"internals.scrollingTreeAsText()"]);
+    RetainPtr scrollingTreeBefore = scrollingTreeElidingLastCommittedScrollPosition([webView stringByEvaluatingJavaScript:@"internals.scrollingTreeAsText()"]);
 
     NSWindow *hostWindow = [webView window];
     [webView removeFromSuperview];
@@ -113,9 +113,9 @@ TEST(ScrollingCoordinatorTests, ScrollingTreeAfterDetachReattach)
     [[hostWindow contentView] addSubview:webView.get()];
     [webView waitForNextPresentationUpdate];
 
-    NSString *scrollingTreeAfter = scrollingTreeElidingLastCommittedScrollPosition([webView stringByEvaluatingJavaScript:@"internals.scrollingTreeAsText()"]);
+    RetainPtr scrollingTreeAfter = scrollingTreeElidingLastCommittedScrollPosition([webView stringByEvaluatingJavaScript:@"internals.scrollingTreeAsText()"]);
 
-    EXPECT_TRUE([scrollingTreeBefore isEqualToString:scrollingTreeAfter]);
+    EXPECT_TRUE([scrollingTreeBefore.get() isEqualToString:scrollingTreeAfter.get()]);
 
     scrollY = waitForScrollEventAndReturnScrollY(webView.get(), [eventLocationInWindow](TestWKWebView *webView) {
         [webView wheelEventAtPoint:eventLocationInWindow wheelDelta:CGSizeMake(0, -101)];

--- a/Tools/TestWebKitAPI/Tests/mac/StartLoadInDidFailProvisionalLoad.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/StartLoadInDidFailProvisionalLoad.mm
@@ -29,7 +29,7 @@
 
 static bool finished = false;
 static bool didFailProvisionalLoad = false;
-static WebView *testView = nullptr;
+static NeverDestroyed<RetainPtr<WebView>> testView;
 
 @interface StartLoadInDidFailProvisionalLoadDelegate : NSObject <WebFrameLoadDelegate>
 @end
@@ -41,7 +41,7 @@ static WebView *testView = nullptr;
     EXPECT_FALSE(didFailProvisionalLoad);
     didFailProvisionalLoad = true;
 
-    [[testView mainFrame] loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple3" withExtension:@"html"]]];
+    [[testView->get() mainFrame] loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple3" withExtension:@"html"]]];
 }
 
 - (void)webView:(WebView *)sender didFinishLoadForFrame:(WebFrame *)frame
@@ -56,7 +56,7 @@ namespace TestWebKitAPI {
 TEST(WebKitLegacy, StartLoadInDidFailProvisionalLoad)
 {
     auto webView = adoptNS([[WebView alloc] init]);
-    testView = webView.get();
+    testView.get() = webView;
     auto frameLoadDelegate = adoptNS([[StartLoadInDidFailProvisionalLoadDelegate alloc] init]);
     webView.get().frameLoadDelegate = frameLoadDelegate.get();
     [[webView mainFrame] loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]]];

--- a/Tools/TestWebKitAPI/Tests/mac/WKWebViewMacEditingTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/WKWebViewMacEditingTests.mm
@@ -264,10 +264,10 @@ TEST(WKWebViewMacEditingTests, DoNotCrashWhenCallingTextInputClientMethodsWhileD
     [webView synchronouslyLoadHTMLString:[NSString stringWithFormat:@"<p>%@</p>", textContent]];
     [webView removeFromSuperview];
 
-    __unsafe_unretained id <NSTextInputClient_Async> inputClient = (id <NSTextInputClient_Async>)webView.get();
-    [inputClient hasMarkedTextWithCompletionHandler:^(BOOL) {
-        [inputClient selectedRangeWithCompletionHandler:^(NSRange) {
-            [inputClient markedRangeWithCompletionHandler:^(NSRange) { }];
+    RetainPtr inputClient = (id <NSTextInputClient_Async>)webView.get();
+    [inputClient.get() hasMarkedTextWithCompletionHandler:^(BOOL) {
+        [inputClient.get() selectedRangeWithCompletionHandler:^(NSRange) {
+            [inputClient.get() markedRangeWithCompletionHandler:^(NSRange) { }];
         }];
     }];
 

--- a/Tools/TestWebKitAPI/Tests/mac/WKWebViewTitlebarSeparatorTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/WKWebViewTitlebarSeparatorTests.mm
@@ -182,8 +182,8 @@ TEST(WKWebViewTitlebarSeparatorTests, ParentWhileScrolled)
     [[window contentView] addSubview:webView.get()];
     [window makeKeyAndOrderFront:nil];
 
-    auto separatorTrackingAdapter = (id<NSScrollViewSeparatorTrackingAdapter>)webView.get();
-    EXPECT_TRUE([separatorTrackingAdapter hasScrolledContentsUnderTitlebar]);
+    RetainPtr separatorTrackingAdapter = (id<NSScrollViewSeparatorTrackingAdapter>)webView.get();
+    EXPECT_TRUE([separatorTrackingAdapter.get() hasScrolledContentsUnderTitlebar]);
 }
 
 #endif // PLATFORM(MAC)

--- a/Tools/TestWebKitAPI/cocoa/TestCocoaImageAndCocoaColor.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestCocoaImageAndCocoaColor.mm
@@ -31,9 +31,9 @@ namespace TestWebKitAPI::Util {
 CocoaColor *pixelColor(CocoaImage *image, CGPoint point)
 {
 #if USE(APPKIT)
-    auto imageRef = [image CGImageForProposedRect:nullptr context:nil hints:nil];
-    auto *bitmap = [[NSBitmapImageRep alloc] initWithCGImage:imageRef];
-    auto *color = [bitmap colorAtX:point.x y:point.y];
+    RetainPtr imageRef = [image CGImageForProposedRect:nullptr context:nil hints:nil];
+    RetainPtr bitmap = adoptNS([[NSBitmapImageRep alloc] initWithCGImage:imageRef.get()]);
+    auto *color = [bitmap.get() colorAtX:point.x y:point.y];
     return color;
 #else
     image = [image.imageAsset imageWithTraitCollection:UITraitCollection.currentTraitCollection];
@@ -65,22 +65,22 @@ CocoaColor *toSRGBColor(CocoaColor *color)
 #endif
 }
 
-bool compareColors(CocoaColor *color1, CocoaColor *color2, float tolerance)
+bool compareColors(CocoaColor *color1Arg, CocoaColor *color2Arg, float tolerance)
 {
-    if (color1 == color2 || [color1 isEqual:color2])
+    if (color1Arg == color2Arg || [color1Arg isEqual:color2Arg])
         return true;
 
-    if (!color1 || !color2)
+    if (!color1Arg || !color2Arg)
         return false;
 
-    color1 = toSRGBColor(color1);
-    color2 = toSRGBColor(color2);
+    RetainPtr color1 = toSRGBColor(color1Arg);
+    RetainPtr color2 = toSRGBColor(color2Arg);
 
     CGFloat red1, green1, blue1, alpha1;
-    [color1 getRed:&red1 green:&green1 blue:&blue1 alpha:&alpha1];
+    [color1.get() getRed:&red1 green:&green1 blue:&blue1 alpha:&alpha1];
 
     CGFloat red2, green2, blue2, alpha2;
-    [color2 getRed:&red2 green:&green2 blue:&blue2 alpha:&alpha2];
+    [color2.get() getRed:&red2 green:&green2 blue:&blue2 alpha:&alpha2];
 
     return fabs(red1 - red2) < tolerance && fabs(green1 - green2) < tolerance && fabs(blue1 - blue2) < tolerance && fabs(alpha1 - alpha2) < tolerance;
 }

--- a/Tools/TestWebKitAPI/cocoa/TestInspectorURLSchemeHandler.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestInspectorURLSchemeHandler.mm
@@ -60,7 +60,7 @@
         _operationQueue.get().maxConcurrentOperationCount = 4;
     }
 
-    NSBlockOperation *operation = [NSBlockOperation blockOperationWithBlock:^{
+    RetainPtr operation = [NSBlockOperation blockOperationWithBlock:^{
         dispatch_async(mainDispatchQueueSingleton(), ^{
             [_fileLoadOperations removeObjectForKey:urlSchemeTask];
         });
@@ -96,9 +96,9 @@
         [urlSchemeTask didReceiveData:fileData];
         [urlSchemeTask didFinish];
     }];
-    
-    [_fileLoadOperations setObject:operation forKey:urlSchemeTask];
-    [_operationQueue addOperation:operation];
+
+    [_fileLoadOperations setObject:operation.get() forKey:urlSchemeTask];
+    [_operationQueue addOperation:operation.get()];
 }
 
 - (void)webView:(WKWebView *)webView stopURLSchemeTask:(id <WKURLSchemeTask>)urlSchemeTask

--- a/Tools/TestWebKitAPI/cocoa/TestProtocol.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestProtocol.mm
@@ -124,7 +124,7 @@ static NSString *contentTypeForFileExtension(NSString *fileExtension)
         return;
     }
 
-    NSString *contentType;
+    RetainPtr<NSString> contentType;
     NSData *data;
     if ([requestURL.host isEqualToString:@"bundle-file"]) {
         NSString *fileName = requestURL.lastPathComponent;
@@ -137,7 +137,7 @@ static NSString *contentTypeForFileExtension(NSString *fileExtension)
     }
 
     NSMutableDictionary *responseHeaders = [NSMutableDictionary dictionaryWithCapacity:2];
-    responseHeaders[@"Content-Type"] = contentType;
+    responseHeaders[@"Content-Type"] = contentType.get();
     responseHeaders[@"Content-Length"] = [NSString stringWithFormat:@"%tu", data.length];
     if (auto& headers = additionalResponseHeaders())
         [responseHeaders addEntriesFromDictionary:headers.get()];

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
@@ -906,9 +906,9 @@ NSEventMask __simulated_forceClickAssociatedEventsMask(id self, SEL _cmd)
     if (simulatePressure)
         modifierFlags |= NSEventMaskPressure;
 
-    NSEvent *event = [NSEvent mouseEventWithType:mouseEventType location:point modifierFlags:modifierFlags timestamp:_webView.eventTimestamp windowNumber:self.windowNumber context:[NSGraphicsContext currentContext] eventNumber:++gEventNumber clickCount:clickCount pressure:simulatePressure];
+    RetainPtr event = [NSEvent mouseEventWithType:mouseEventType location:point modifierFlags:modifierFlags timestamp:_webView.eventTimestamp windowNumber:self.windowNumber context:[NSGraphicsContext currentContext] eventNumber:++gEventNumber clickCount:clickCount pressure:simulatePressure];
     if (!simulatePressure) {
-        [self sendEvent:event];
+        [self sendEvent:event.get()];
         return;
     }
 
@@ -916,7 +916,7 @@ NSEventMask __simulated_forceClickAssociatedEventsMask(id self, SEL _cmd)
     Method associatedEventsMaskMethod = class_getInstanceMethod([NSEvent class], @selector(associatedEventsMask));
     IMP originalAssociatedEventsMaskImpl = method_setImplementation(associatedEventsMaskMethod, simulatedAssociatedEventsMaskImpl);
     @try {
-        [self sendEvent:event];
+        [self sendEvent:event.get()];
     } @finally {
         // In the case where event sending raises an exception, we still want to restore the original implementation
         // to prevent subsequent event sending tests from being affected.
@@ -1805,12 +1805,12 @@ static NSMenuItem *itemMatchingFilter(NSMenu *menu, MenuItemFilter filter)
         if (!activeMenu)
             return;
 
-        auto *item = itemMatchingFilter(activeMenu, filter.get());
+        RetainPtr item = itemMatchingFilter(activeMenu, filter.get());
         if (!item)
             return;
 
-        auto *itemMenu = item.menu;
-        [itemMenu performActionForItemAtIndex:[itemMenu indexOfItem:item]];
+        auto *itemMenu = [item.get() menu];
+        [itemMenu performActionForItemAtIndex:[itemMenu indexOfItem:item.get()]];
         [activeMenu cancelTracking];
         [timer invalidate];
         selectedItem = true;

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
@@ -1010,8 +1010,8 @@ NSData *makePNGData(CGSize size, SEL colorSelector)
 
     [image unlockFocus];
 
-    auto cgImageRef = [image CGImageForProposedRect:NULL context:nil hints:nil];
-    auto newImageRep = adoptNS([[NSBitmapImageRep alloc] initWithCGImage:cgImageRef]);
+    RetainPtr cgImageRef = [image CGImageForProposedRect:NULL context:nil hints:nil];
+    auto newImageRep = adoptNS([[NSBitmapImageRep alloc] initWithCGImage:cgImageRef.get()]);
     newImageRep.get().size = size;
 
     return [newImageRep representationUsingType:NSBitmapImageFileTypePNG properties:@{ }];

--- a/Tools/TestWebKitAPI/mac/DragAndDropSimulatorMac.mm
+++ b/Tools/TestWebKitAPI/mac/DragAndDropSimulatorMac.mm
@@ -457,11 +457,11 @@ static BOOL getFilePathsAndTypeIdentifiers(NSArray<NSURL *> *fileURLs, NSArray<N
 
         int suffix = 1;
         NSString *baseFileName = [provider.delegate filePromiseProvider:provider fileNameForType:provider.fileType];
-        NSString *uniqueFileName = baseFileName;
-        while ([[NSFileManager defaultManager] fileExistsAtPath:[NSTemporaryDirectory() stringByAppendingPathComponent:uniqueFileName]])
+        RetainPtr uniqueFileName = baseFileName;
+        while ([[NSFileManager defaultManager] fileExistsAtPath:[NSTemporaryDirectory() stringByAppendingPathComponent:uniqueFileName.get()]])
             uniqueFileName = [NSString stringWithFormat:@"%@ %d", baseFileName, ++suffix];
 
-        NSURL *destinationURL = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:uniqueFileName]];
+        NSURL *destinationURL = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:uniqueFileName.get()]];
         __block bool done = false;
         [provider.delegate filePromiseProvider:provider writePromiseToURL:destinationURL completionHandler:^(NSError *) {
             done = true;

--- a/Tools/TestWebKitAPI/mac/PlatformWebViewMac.mm
+++ b/Tools/TestWebKitAPI/mac/PlatformWebViewMac.mm
@@ -226,9 +226,9 @@ void PlatformWebView::simulateButtonClick(WKEventMouseButton button, unsigned x,
     if (button == kWKEventMouseButtonMiddleButton
         || button == kWKEventMouseButtonBackButton
         || button == kWKEventMouseButtonForwardButton) {
-        CGEventRef cgEvent = [event CGEvent];
-        CGEventSetIntegerValueField(cgEvent, kCGMouseEventButtonNumber, cgEventField());
-        event = [NSEvent eventWithCGEvent:cgEvent];
+        RetainPtr cgEvent = [event CGEvent];
+        CGEventSetIntegerValueField(cgEvent.get(), kCGMouseEventButtonNumber, cgEventField());
+        event = [NSEvent eventWithCGEvent:cgEvent.get()];
     }
 
     [m_view mouseDown:event.get()];

--- a/Tools/TestWebKitAPI/mac/TestFilePromiseReceiver.mm
+++ b/Tools/TestWebKitAPI/mac/TestFilePromiseReceiver.mm
@@ -116,17 +116,17 @@ static NSURL *copyFile(NSURL *sourceURL, NSURL *destinationDirectory, NSError **
 {
     [queue addOperationWithBlock:^{
         NSError *error = nil;
-        NSURL *destination = nil;
+        RetainPtr<NSURL> destination = nil;
         if ([_promisedFileURL isFileURL])
             destination = copyFile(_promisedFileURL.get(), destinationDirectory, &error);
         else
             destination = writeToWebLoc(_promisedFileURL.get(), destinationDirectory, &error);
         if (destination) {
             dispatch_async(mainDispatchQueueSingleton(), ^{
-                _destinationURL = destination;
+                _destinationURL = destination.get();
             });
         }
-        reader(destination, error);
+        reader(destination.get(), error);
     }];
 }
 

--- a/Tools/WebKitTestRunner/InjectedBundle/cocoa/AccessibilityCommonCocoa.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/cocoa/AccessibilityCommonCocoa.mm
@@ -60,9 +60,9 @@ namespace WTR {
 
 Class webAccessibilityObjectWrapperClassSingleton()
 {
-    static Class cls = objc_getClass("WebAccessibilityObjectWrapper");
-    ASSERT(cls);
-    return cls;
+    static NeverDestroyed<RetainPtr<Class>> cls = objc_getClass("WebAccessibilityObjectWrapper");
+    ASSERT(cls->get());
+    return cls->get();
 }
 
 JSObjectRef makeJSArray(JSContextRef context, NSArray *array)

--- a/Tools/WebKitTestRunner/InjectedBundle/cocoa/InjectedBundlePageCocoa.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/cocoa/InjectedBundlePageCocoa.mm
@@ -62,8 +62,8 @@ uint64_t InjectedBundlePage::responseHeaderCount(WKURLResponseRef response)
     if (![nsURLResponse isKindOfClass:[NSHTTPURLResponse class]])
         return { };
 
-    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)nsURLResponse.get();
-    return [[httpResponse allHeaderFields] count];
+    RetainPtr httpResponse = (NSHTTPURLResponse *)nsURLResponse.get();
+    return [[httpResponse.get() allHeaderFields] count];
 }
 
 } // namespace WTR

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
@@ -285,8 +285,8 @@ static JSRetainPtr<JSStringRef> descriptionOfElements(const Vector<RefPtr<Access
 {
     NSMutableString *allElementString = [NSMutableString string];
     for (auto element : elements) {
-        NSString *attributes = [NSString stringWithJSStringRef:element->allAttributes().get()];
-        [allElementString appendFormat:@"%@\n------------\n", attributes];
+        RetainPtr attributes = [NSString stringWithJSStringRef:element->allAttributes().get()];
+        [allElementString appendFormat:@"%@\n------------\n", attributes.get()];
     }
 
     return [allElementString createJSStringRef];
@@ -593,9 +593,9 @@ void AccessibilityUIElement::elementAtPointResolvingRemoteFrame(JSContextRef con
 unsigned AccessibilityUIElement::indexOfChild(AccessibilityUIElement* element)
 {
     unsigned index;
-    id platformElement = element->platformUIElement();
+    RetainPtr platformElement = element->platformUIElement();
     s_controller->executeOnAXThreadAndWait([&platformElement, &index, this] {
-        index = [m_element accessibilityIndexOfChild:platformElement];
+        index = [m_element accessibilityIndexOfChild:platformElement.get()];
     });
     return index;
 }
@@ -1064,7 +1064,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::stringValue()
 {
     BEGIN_AX_OBJC_EXCEPTIONS
     RetainPtr<id> value;
-    auto role = attributeValue(NSAccessibilityRoleAttribute);
+    RetainPtr role = attributeValue(NSAccessibilityRoleAttribute);
     if ([role isEqualToString:@"AXDateTimeArea"])
         value = attributeValue(@"AXStringValue");
     else
@@ -1484,8 +1484,8 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::boundsForRange(unsigned locatio
         rect = [value rectValue];
 
     // don't return position information because it is platform dependent
-    NSMutableString* boundsDescription = makeBoundsDescription(rect, false /* exposePosition */);
-    return [boundsDescription createJSStringRef];
+    RetainPtr boundsDescription = makeBoundsDescription(rect, false /* exposePosition */);
+    return [boundsDescription.get() createJSStringRef];
     END_AX_OBJC_EXCEPTIONS
 
     return nullptr;
@@ -1500,8 +1500,8 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::boundsForRangeWithPagePosition(
     if ([value isKindOfClass:[NSValue class]])
         rect = [value rectValue];
 
-    NSMutableString* boundsDescription = makeBoundsDescription(rect, true /* exposePosition */);
-    return [boundsDescription createJSStringRef];
+    RetainPtr boundsDescription = makeBoundsDescription(rect, true /* exposePosition */);
+    return [boundsDescription.get() createJSStringRef];
     END_AX_OBJC_EXCEPTIONS
 
     return nullptr;
@@ -1559,8 +1559,8 @@ bool AccessibilityUIElement::attributedStringRangeIsMisspelled(unsigned location
 unsigned AccessibilityUIElement::uiElementCountForSearchPredicate(JSContextRef context, AccessibilityUIElement *startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly)
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    NSDictionary *parameter = searchPredicateForSearchCriteria(context, startElement, nullptr, isDirectionNext, UINT_MAX, searchKey, searchText, visibleOnly, immediateDescendantsOnly);
-    auto value = attributeValueForParameter(@"AXUIElementsForSearchPredicate", parameter);
+    RetainPtr parameter = searchPredicateForSearchCriteria(context, startElement, nullptr, isDirectionNext, UINT_MAX, searchKey, searchText, visibleOnly, immediateDescendantsOnly);
+    auto value = attributeValueForParameter(@"AXUIElementsForSearchPredicate", parameter.get());
     if ([value isKindOfClass:[NSArray class]])
         return [value count];
     END_AX_OBJC_EXCEPTIONS
@@ -1571,8 +1571,8 @@ unsigned AccessibilityUIElement::uiElementCountForSearchPredicate(JSContextRef c
 RefPtr<AccessibilityUIElement> AccessibilityUIElement::uiElementForSearchPredicate(JSContextRef context, AccessibilityUIElement *startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly)
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    NSDictionary *parameter = searchPredicateForSearchCriteria(context, startElement, nullptr, isDirectionNext, 1, searchKey, searchText, visibleOnly, immediateDescendantsOnly);
-    auto searchResults = attributeValueForParameter(@"AXUIElementsForSearchPredicate", parameter);
+    RetainPtr parameter = searchPredicateForSearchCriteria(context, startElement, nullptr, isDirectionNext, 1, searchKey, searchText, visibleOnly, immediateDescendantsOnly);
+    auto searchResults = attributeValueForParameter(@"AXUIElementsForSearchPredicate", parameter.get());
     if (![searchResults isKindOfClass:[NSArray class]] || ![searchResults count])
         return nullptr;
 
@@ -1590,8 +1590,8 @@ RefPtr<AccessibilityUIElement> AccessibilityUIElement::uiElementForSearchPredica
 JSRetainPtr<JSStringRef> AccessibilityUIElement::selectTextWithCriteria(JSContextRef context, JSStringRef ambiguityResolution, JSValueRef searchStrings, JSStringRef replacementString, JSStringRef activity)
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    NSDictionary *parameterizedAttribute = selectTextParameterizedAttributeForCriteria(context, ambiguityResolution, searchStrings, replacementString, activity);
-    auto result = attributeValueForParameter(@"AXSelectTextWithCriteria", parameterizedAttribute);
+    RetainPtr parameterizedAttribute = selectTextParameterizedAttributeForCriteria(context, ambiguityResolution, searchStrings, replacementString, activity);
+    auto result = attributeValueForParameter(@"AXSelectTextWithCriteria", parameterizedAttribute.get());
     if ([result isKindOfClass:[NSString class]])
         return [result.get() createJSStringRef];
     END_AX_OBJC_EXCEPTIONS
@@ -1603,8 +1603,8 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::selectTextWithCriteria(JSContex
 JSValueRef AccessibilityUIElement::searchTextWithCriteria(JSContextRef context, JSValueRef searchStrings, JSStringRef startFrom, JSStringRef direction)
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    NSDictionary *parameterizedAttribute = searchTextParameterizedAttributeForCriteria(context, searchStrings, startFrom, direction);
-    auto result = attributeValueForParameter(@"AXSearchTextWithCriteria", parameterizedAttribute);
+    RetainPtr parameterizedAttribute = searchTextParameterizedAttributeForCriteria(context, searchStrings, startFrom, direction);
+    auto result = attributeValueForParameter(@"AXSearchTextWithCriteria", parameterizedAttribute.get());
     if ([result isKindOfClass:[NSArray class]])
         return makeJSArray(context, makeVector<RefPtr<AccessibilityTextMarkerRange>>(result.get()));
     END_AX_OBJC_EXCEPTIONS
@@ -1615,8 +1615,8 @@ JSValueRef AccessibilityUIElement::searchTextWithCriteria(JSContextRef context, 
 JSValueRef AccessibilityUIElement::performTextOperation(JSContextRef context, JSStringRef operationType, JSValueRef markerRanges, JSValueRef replacementStrings, bool shouldSmartReplace)
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    NSDictionary *parameterizedAttribute = textOperationParameterizedAttribute(context, operationType, markerRanges, replacementStrings, shouldSmartReplace);
-    auto result = attributeValueForParameter(@"AXTextOperation", parameterizedAttribute);
+    RetainPtr parameterizedAttribute = textOperationParameterizedAttribute(context, operationType, markerRanges, replacementStrings, shouldSmartReplace);
+    auto result = attributeValueForParameter(@"AXTextOperation", parameterizedAttribute.get());
     if ([result isKindOfClass:[NSArray class]])
         return makeValueRefForValue(context, result.get());
     END_AX_OBJC_EXCEPTIONS
@@ -1769,8 +1769,8 @@ RefPtr<AccessibilityUIElement> AccessibilityUIElement::horizontalScrollbar() con
         return nullptr;
 
     BEGIN_AX_OBJC_EXCEPTIONS
-    if (id scrollbar = attributeValue(NSAccessibilityHorizontalScrollBarAttribute).unsafeGet())
-        return AccessibilityUIElement::create(scrollbar);
+    if (RetainPtr scrollbar = attributeValue(NSAccessibilityHorizontalScrollBarAttribute).unsafeGet())
+        return AccessibilityUIElement::create(scrollbar.get());
     END_AX_OBJC_EXCEPTIONS
 
     return nullptr;
@@ -1782,8 +1782,8 @@ RefPtr<AccessibilityUIElement> AccessibilityUIElement::verticalScrollbar() const
         return nullptr;
 
     BEGIN_AX_OBJC_EXCEPTIONS
-    if (id scrollbar = attributeValue(NSAccessibilityVerticalScrollBarAttribute).unsafeGet())
-        return AccessibilityUIElement::create(scrollbar);
+    if (RetainPtr scrollbar = attributeValue(NSAccessibilityVerticalScrollBarAttribute).unsafeGet())
+        return AccessibilityUIElement::create(scrollbar.get());
     END_AX_OBJC_EXCEPTIONS
 
     return nullptr;
@@ -2104,8 +2104,8 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::popupValue() const
 RefPtr<AccessibilityUIElement> AccessibilityUIElement::focusableAncestor()
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    if (id ancestor = attributeValue(@"AXFocusableAncestor").unsafeGet())
-        return AccessibilityUIElement::create(ancestor);
+    if (RetainPtr ancestor = attributeValue(@"AXFocusableAncestor").unsafeGet())
+        return AccessibilityUIElement::create(ancestor.get());
     END_AX_OBJC_EXCEPTIONS
 
     return nullptr;
@@ -2114,8 +2114,8 @@ RefPtr<AccessibilityUIElement> AccessibilityUIElement::focusableAncestor()
 RefPtr<AccessibilityUIElement> AccessibilityUIElement::editableAncestor()
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    if (id ancestor = attributeValue(@"AXEditableAncestor").unsafeGet())
-        return AccessibilityUIElement::create(ancestor);
+    if (RetainPtr ancestor = attributeValue(@"AXEditableAncestor").unsafeGet())
+        return AccessibilityUIElement::create(ancestor.get());
     END_AX_OBJC_EXCEPTIONS
 
     return nullptr;
@@ -2124,8 +2124,8 @@ RefPtr<AccessibilityUIElement> AccessibilityUIElement::editableAncestor()
 RefPtr<AccessibilityUIElement> AccessibilityUIElement::highestEditableAncestor()
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    if (id ancestor = attributeValue(@"AXHighestEditableAncestor").unsafeGet())
-        return AccessibilityUIElement::create(ancestor);
+    if (RetainPtr ancestor = attributeValue(@"AXHighestEditableAncestor").unsafeGet())
+        return AccessibilityUIElement::create(ancestor.get());
     END_AX_OBJC_EXCEPTIONS
 
     return nullptr;
@@ -2257,8 +2257,8 @@ RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::styleTextMarkerRang
 RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::textMarkerRangeForSearchPredicate(JSContextRef context, AccessibilityTextMarkerRange *startRange, bool forward, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly)
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    NSDictionary *parameter = searchPredicateForSearchCriteria(context, nullptr, startRange, forward, 1, searchKey, searchText, visibleOnly, immediateDescendantsOnly);
-    auto searchResults = attributeValueForParameter(@"AXRangesForSearchPredicate", parameter);
+    RetainPtr parameter = searchPredicateForSearchCriteria(context, nullptr, startRange, forward, 1, searchKey, searchText, visibleOnly, immediateDescendantsOnly);
+    auto searchResults = attributeValueForParameter(@"AXRangesForSearchPredicate", parameter.get());
     if (![searchResults isKindOfClass:[NSArray class]] || ![searchResults count])
         return nullptr;
 
@@ -2277,8 +2277,8 @@ RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::textMarkerRangeForS
 RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::misspellingTextMarkerRange(AccessibilityTextMarkerRange* start, bool forward)
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    NSDictionary *parameters = misspellingSearchParameterizedAttributeForCriteria(start, forward);
-    auto textMarkerRange = attributeValueForParameter(@"AXMisspellingTextMarkerRange", parameters);
+    RetainPtr parameters = misspellingSearchParameterizedAttributeForCriteria(start, forward);
+    auto textMarkerRange = attributeValueForParameter(@"AXMisspellingTextMarkerRange", parameters.get());
     return AccessibilityTextMarkerRange::create(textMarkerRange.get());
     END_AX_OBJC_EXCEPTIONS
 
@@ -2565,7 +2565,7 @@ static void appendColorDescription(RetainPtr<NSMutableString> string, NSString* 
 static JSRetainPtr<JSStringRef> createJSStringRef(id string, bool includeDidSpellCheck)
 {
     auto mutableString = adoptNS([[NSMutableString alloc] init]);
-    id attributeEnumerationBlock = ^(NSDictionary<NSString *, id> *attributes, NSRange range, BOOL *stop) {
+    RetainPtr<id> attributeEnumerationBlock = ^(NSDictionary<NSString *, id> *attributes, NSRange range, BOOL *stop) {
         [mutableString appendFormat:@"Attributes in range %@:\n", NSStringFromRange(range)];
         BOOL misspelled = [[attributes objectForKey:NSAccessibilityMisspelledTextAttribute] boolValue];
         if (misspelled)
@@ -2615,7 +2615,7 @@ static JSRetainPtr<JSStringRef> createJSStringRef(id string, bool includeDidSpel
         if ([attributes objectForKey:NSAccessibilityTableAttribute])
             [mutableString appendFormat:@"%@: {present}\n", NSAccessibilityTableAttribute];
     };
-    [string enumerateAttributesInRange:NSMakeRange(0, [string length]) options:(NSAttributedStringEnumerationOptions)0 usingBlock:attributeEnumerationBlock];
+    [string enumerateAttributesInRange:NSMakeRange(0, [string length]) options:(NSAttributedStringEnumerationOptions)0 usingBlock:attributeEnumerationBlock.get()];
     [mutableString appendString:[string string]];
     return [mutableString createJSStringRef];
 }
@@ -2653,14 +2653,14 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::attributedStringForTextMarkerRa
     if (!markerRange || !markerRange->platformTextMarkerRange())
         return nullptr;
 
-    id parameter = nil;
+    RetainPtr<id> parameter = nil;
     if (includeSpellCheck)
         parameter = @{ @"AXSpellCheck": includeSpellCheck ? @YES : @NO, @"AXTextMarkerRange": markerRange->platformTextMarkerRange() };
     else
         parameter = markerRange->platformTextMarkerRange();
 
     BEGIN_AX_OBJC_EXCEPTIONS
-    auto string = attributeValueForParameter(@"AXAttributedStringForTextMarkerRangeWithOptions", parameter);
+    auto string = attributeValueForParameter(@"AXAttributedStringForTextMarkerRangeWithOptions", parameter.get());
     if ([string isKindOfClass:[NSAttributedString class]])
         return createJSStringRef(string.get(), /* IncludeDidSpellCheck */ false);
     END_AX_OBJC_EXCEPTIONS

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/TestRunnerMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/TestRunnerMac.mm
@@ -45,10 +45,10 @@ JSRetainPtr<JSStringRef> TestRunner::inspectorTestStubURL()
 #if PLATFORM(IOS_FAMILY)
     return nullptr;
 #else
-    auto inspectorBundle = CFBundleGetBundleWithIdentifier(CFSTR("com.apple.WebInspectorUI"));
+    RetainPtr inspectorBundle = CFBundleGetBundleWithIdentifier(CFSTR("com.apple.WebInspectorUI"));
     if (!inspectorBundle)
         return nullptr;
-    auto resourceURL = adoptCF(CFBundleCopyResourceURL(inspectorBundle, CFSTR("TestStub"), CFSTR("html"), NULL));
+    auto resourceURL = adoptCF(CFBundleCopyResourceURL(inspectorBundle.get(), CFSTR("TestStub"), CFSTR("html"), NULL));
     return resourceURL ? adopt(JSStringCreateWithCFString(CFURLGetString(resourceURL.get()))) : nullptr;
 #endif
 }

--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -465,8 +465,8 @@ void TestController::resetContentExtensions()
     [[WKContentRuleListStore defaultStore] _removeAllContentRuleLists];
 
     if (auto* webView = mainWebView()) {
-        TestRunnerWKWebView *platformView = webView->platformView();
-        [platformView.configuration.userContentController _removeAllUserContentFilters];
+        RetainPtr platformView = webView->platformView();
+        [platformView.get().configuration.userContentController _removeAllUserContentFilters];
     }
 }
 #endif
@@ -492,22 +492,22 @@ void TestController::cocoaResetStateToConsistentValues(const TestOptions& option
 #endif
     m_calendarSwizzler = nullptr;
     m_overriddenCalendarAndLocaleIdentifiers = { nil, nil };
-    
-    if (auto* webView = mainWebView()) {
-        TestRunnerWKWebView *platformView = webView->platformView();
-        platformView._viewScale = 1;
-        platformView._minimumEffectiveDeviceWidth = 0;
-        platformView._editable = NO;
-#if PLATFORM(MAC)
-        platformView.allowsMagnification = NO;
-        [platformView setMagnification:1 centeredAtPoint:CGPointZero];
-#endif
-        [platformView _setContinuousSpellCheckingEnabledForTesting:options.shouldShowSpellCheckingDots()];
-        [platformView _setGrammarCheckingEnabledForTesting:YES];
-        [platformView resetInteractionCallbacks];
-        [platformView _resetNavigationGestureStateForTesting];
 
-        auto configuration = platformView.configuration;
+    if (auto* webView = mainWebView()) {
+        RetainPtr platformView = webView->platformView();
+        platformView.get()._viewScale = 1;
+        platformView.get()._minimumEffectiveDeviceWidth = 0;
+        platformView.get()._editable = NO;
+#if PLATFORM(MAC)
+        platformView.get().allowsMagnification = NO;
+        [platformView.get() setMagnification:1 centeredAtPoint:CGPointZero];
+#endif
+        [platformView.get() _setContinuousSpellCheckingEnabledForTesting:options.shouldShowSpellCheckingDots()];
+        [platformView.get() _setGrammarCheckingEnabledForTesting:YES];
+        [platformView.get() resetInteractionCallbacks];
+        [platformView.get() _resetNavigationGestureStateForTesting];
+
+        auto configuration = platformView.get().configuration;
         configuration.preferences.textInteractionEnabled = options.textInteractionEnabled();
         configuration.preferences._textExtractionEnabled = options.textExtractionEnabled();
     }
@@ -638,7 +638,7 @@ void TestController::addTestKeyToKeychain(const String& privateKeyBase64, const 
     ));
     ASSERT(!errorRef);
 
-    NSDictionary* addQuery = @{
+    RetainPtr addQuery = @{
         (id)kSecValueRef: (id)key.get(),
         (id)kSecClass: (id)kSecClassKey,
         (id)kSecAttrLabel: attrLabel.createNSString().get(),
@@ -646,7 +646,7 @@ void TestController::addTestKeyToKeychain(const String& privateKeyBase64, const 
         (id)kSecAttrAccessible: (id)kSecAttrAccessibleAfterFirstUnlock,
         (id)kSecUseDataProtectionKeychain: @YES
     };
-    OSStatus status = SecItemAdd((__bridge CFDictionaryRef)addQuery, NULL);
+    OSStatus status = SecItemAdd((__bridge CFDictionaryRef)addQuery.get(), NULL);
     ASSERT_UNUSED(status, !status);
 }
 

--- a/Tools/WebKitTestRunner/cocoa/TestWebsiteDataStoreDelegate.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestWebsiteDataStoreDelegate.mm
@@ -90,12 +90,12 @@
     auto configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:dataStore];
     auto* newView = WTR::TestController::singleton().createOtherPlatformWebView(nullptr, (__bridge WKPageConfigurationRef)configuration.get(), nullptr, nullptr);
-    WKWebView *webView = newView->platformView();
-    
-    ASSERT(webView.configuration.websiteDataStore == dataStore);
-    
-    [webView loadRequest:[NSURLRequest requestWithURL:url]];
-    completionHandler(webView);
+    RetainPtr webView = newView->platformView();
+
+    ASSERT(webView.get().configuration.websiteDataStore == dataStore);
+
+    [webView.get() loadRequest:[NSURLRequest requestWithURL:url]];
+    completionHandler(webView.get());
 }
 
 - (void)setBackgroundFetchPermission:(BOOL)shouldAllowBackgroundFetchPermission

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
@@ -165,8 +165,8 @@ void UIScriptControllerCocoa::findString(JSStringRef string, unsigned long optio
 
 JSObjectRef UIScriptControllerCocoa::contentsOfUserInterfaceItem(JSStringRef interfaceItem) const
 {
-    NSDictionary *contentDictionary = [webView() _contentsOfUserInterfaceItem:toWTFString(interfaceItem).createNSString().get()];
-    return JSValueToObject(m_context->jsContext(), [JSValue valueWithObject:contentDictionary inContext:[JSContext contextWithJSGlobalContextRef:m_context->jsContext()]].JSValueRef, nullptr);
+    RetainPtr contentDictionary = [webView() _contentsOfUserInterfaceItem:toWTFString(interfaceItem).createNSString().get()];
+    return JSValueToObject(m_context->jsContext(), [JSValue valueWithObject:contentDictionary.get() inContext:[JSContext contextWithJSGlobalContextRef:m_context->jsContext()]].JSValueRef, nullptr);
 }
 
 void UIScriptControllerCocoa::setDefaultCalendarType(JSStringRef calendarIdentifier, JSStringRef localeIdentifier)
@@ -276,8 +276,8 @@ void UIScriptControllerCocoa::insertAttachmentForFilePath(JSStringRef filePath, 
 {
     unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
     auto testURL = adoptCF(WKURLCopyCFURL(kCFAllocatorDefault, TestController::singleton().currentTestURL()));
-    auto attachmentURL = [NSURL fileURLWithPath:toWTFString(filePath).createNSString().get() relativeToURL:(__bridge NSURL *)testURL.get()];
-    auto fileWrapper = adoptNS([[NSFileWrapper alloc] initWithURL:attachmentURL options:0 error:nil]);
+    RetainPtr attachmentURL = [NSURL fileURLWithPath:toWTFString(filePath).createNSString().get() relativeToURL:(__bridge NSURL *)testURL.get()];
+    auto fileWrapper = adoptNS([[NSFileWrapper alloc] initWithURL:attachmentURL.get() options:0 error:nil]);
     [webView() _insertAttachmentWithFileWrapper:fileWrapper.get() contentType:toWTFString(contentType).createNSString().get() completion:^(BOOL success) {
         if (!m_context)
             return;

--- a/Tools/WebKitTestRunner/mac/EventSenderProxy.mm
+++ b/Tools/WebKitTestRunner/mac/EventSenderProxy.mm
@@ -491,7 +491,7 @@ void EventSenderProxy::mouseForceClick()
         clickCount:m_clickCount
         pressure:0.0];
 
-    NSView *targetView = [m_testController->mainWebView()->platformView() hitTest:[preForceClick.get() locationInWindow]];
+    RetainPtr targetView = [m_testController->mainWebView()->platformView() hitTest:[preForceClick.get() locationInWindow]];
     targetView = targetView ? targetView : m_testController->mainWebView()->platformView();
     ASSERT(targetView);
 
@@ -506,7 +506,7 @@ void EventSenderProxy::mouseForceClick()
     [NSApp _setCurrentEvent:nil];
     // WKView caches the most recent pressure event, so send it a nil event to clear the cache.
     IGNORE_NULL_CHECK_WARNINGS_BEGIN
-    [targetView pressureChangeWithEvent:nil];
+    [targetView.get() pressureChangeWithEvent:nil];
     IGNORE_NULL_CHECK_WARNINGS_END
 }
 
@@ -527,7 +527,7 @@ void EventSenderProxy::startAndCancelMouseForceClick()
         clickCount:m_clickCount
         pressure:0.0];
 
-    NSView *targetView = [m_testController->mainWebView()->platformView() hitTest:[beginPressure.get() locationInWindow]];
+    RetainPtr targetView = [m_testController->mainWebView()->platformView() hitTest:[beginPressure.get() locationInWindow]];
     targetView = targetView ? targetView : m_testController->mainWebView()->platformView();
     ASSERT(targetView);
 
@@ -541,7 +541,7 @@ void EventSenderProxy::startAndCancelMouseForceClick()
     [NSApp _setCurrentEvent:nil];
     // WKView caches the most recent pressure event, so send it a nil event to clear the cache.
     IGNORE_NULL_CHECK_WARNINGS_BEGIN
-    [targetView pressureChangeWithEvent:nil];
+    [targetView.get() pressureChangeWithEvent:nil];
     IGNORE_NULL_CHECK_WARNINGS_END
 }
 
@@ -553,7 +553,7 @@ void EventSenderProxy::mouseForceDown()
     auto preForceClick = pressureChangeEvent(1, PressureChangeDirection::Increasing);
     auto forceMouseDown = pressureChangeEvent(2, PressureChangeDirection::Increasing);
 
-    NSView *targetView = [m_testController->mainWebView()->platformView() hitTest:[beginPressure locationInWindow]];
+    RetainPtr targetView = [m_testController->mainWebView()->platformView() hitTest:[beginPressure locationInWindow]];
     targetView = targetView ? targetView : m_testController->mainWebView()->platformView();
     ASSERT(targetView);
 
@@ -566,7 +566,7 @@ void EventSenderProxy::mouseForceDown()
     [NSApp _setCurrentEvent:nil];
     // WKView caches the most recent pressure event, so send it a nil event to clear the cache.
     IGNORE_NULL_CHECK_WARNINGS_BEGIN
-    [targetView pressureChangeWithEvent:nil];
+    [targetView.get() pressureChangeWithEvent:nil];
     IGNORE_NULL_CHECK_WARNINGS_END
 }
 
@@ -582,14 +582,14 @@ void EventSenderProxy::mouseForceUp()
     [NSApp sendEvent:stageTwoEvent.get()];
     [NSApp sendEvent:stageOneEvent.get()];
 
-    NSView *targetView = [m_testController->mainWebView()->platformView() hitTest:[beginPressure locationInWindow]];
+    RetainPtr targetView = [m_testController->mainWebView()->platformView() hitTest:[beginPressure locationInWindow]];
     targetView = targetView ? targetView : m_testController->mainWebView()->platformView();
     ASSERT(targetView);
 
     [NSApp _setCurrentEvent:nil];
     // WKView caches the most recent pressure event, so send it a nil event to clear the cache.
     IGNORE_NULL_CHECK_WARNINGS_BEGIN
-    [targetView pressureChangeWithEvent:nil];
+    [targetView.get() pressureChangeWithEvent:nil];
     IGNORE_NULL_CHECK_WARNINGS_END
 }
 
@@ -600,7 +600,7 @@ void EventSenderProxy::mouseForceChanged(float force)
     auto beginPressure = beginPressureEvent(stage);
     auto pressureChangedEvent = pressureChangeEvent(stage, pressure, PressureChangeDirection::Increasing);
 
-    NSView *targetView = [m_testController->mainWebView()->platformView() hitTest:[beginPressure locationInWindow]];
+    RetainPtr targetView = [m_testController->mainWebView()->platformView() hitTest:[beginPressure locationInWindow]];
     targetView = targetView ? targetView : m_testController->mainWebView()->platformView();
     ASSERT(targetView);
 
@@ -609,29 +609,29 @@ void EventSenderProxy::mouseForceChanged(float force)
 
     // WKView caches the most recent pressure event, so send it a nil event to clear the cache.
     IGNORE_NULL_CHECK_WARNINGS_BEGIN
-    [targetView pressureChangeWithEvent:nil];
+    [targetView.get() pressureChangeWithEvent:nil];
     IGNORE_NULL_CHECK_WARNINGS_END
 }
 
 void EventSenderProxy::mouseMoveTo(double x, double y, WKStringRef pointerType)
 {
-    NSView *view = m_testController->mainWebView()->platformView();
-    NSPoint newMousePosition = [view convertPoint:NSMakePoint(x, y) toView:nil];
+    RetainPtr view = m_testController->mainWebView()->platformView();
+    NSPoint newMousePosition = [view.get() convertPoint:NSMakePoint(x, y) toView:nil];
     bool isDrag = m_leftMouseButtonDown;
     NSEvent *event = [NSEvent mouseEventWithType:(isDrag ? NSEventTypeLeftMouseDragged : NSEventTypeMouseMoved)
                                         location:newMousePosition
-                                   modifierFlags:0 
+                                   modifierFlags:0
                                        timestamp:absoluteTimeForEventTime(currentEventTime())
-                                    windowNumber:view.window.windowNumber
-                                         context:[NSGraphicsContext currentContext] 
-                                     eventNumber:++m_eventNumber 
-                                      clickCount:(m_leftMouseButtonDown ? m_clickCount : 0) 
+                                    windowNumber:view.get().window.windowNumber
+                                         context:[NSGraphicsContext currentContext]
+                                     eventNumber:++m_eventNumber
+                                      clickCount:(m_leftMouseButtonDown ? m_clickCount : 0)
                                         pressure:0];
 
-    CGEventRef cgEvent = event.CGEvent;
-    CGEventSetIntegerValueField(cgEvent, kCGMouseEventDeltaX, newMousePosition.x - m_position.x);
-    CGEventSetIntegerValueField(cgEvent, kCGMouseEventDeltaY, -1 * (newMousePosition.y - m_position.y));
-    event = [NSEvent eventWithCGEvent:cgEvent];
+    RetainPtr<CGEventRef> cgEvent = event.CGEvent;
+    CGEventSetIntegerValueField(cgEvent.get(), kCGMouseEventDeltaX, newMousePosition.x - m_position.x);
+    CGEventSetIntegerValueField(cgEvent.get(), kCGMouseEventDeltaY, -1 * (newMousePosition.y - m_position.y));
+    event = [NSEvent eventWithCGEvent:cgEvent.get()];
     m_position.x = newMousePosition.x;
     m_position.y = newMousePosition.y;
 
@@ -866,15 +866,15 @@ void EventSenderProxy::sendWheelEvent(EventTimestamp timestamp, double windowX, 
 void EventSenderProxy::smartMagnify()
 {
     auto* mainWebView = m_testController->mainWebView();
-    NSView *platformView = mainWebView->platformView();
+    RetainPtr platformView = mainWebView->platformView();
 
     auto event = adoptNS([[EventSenderSyntheticEvent alloc] initSmartMagnifyEventAtLocation:NSMakePoint(m_position.x, m_position.y)
         globalLocation:([mainWebView->platformWindow() convertRectToScreen:NSMakeRect(m_position.x, m_position.y, 1, 1)].origin)
         time:absoluteTimeForEventTime(currentEventTime())
         eventNumber:++m_eventNumber
-        window:platformView.window]);
+        window:platformView.get().window]);
 
-    if (NSView *targetView = [platformView hitTest:[event locationInWindow]]) {
+    if (NSView *targetView = [platformView.get() hitTest:[event locationInWindow]]) {
         [NSApp _setCurrentEvent:event.get()];
         [targetView smartMagnifyWithEvent:event.get()];
         [NSApp _setCurrentEvent:nil];

--- a/Tools/WebKitTestRunner/mac/PlatformWebViewMac.mm
+++ b/Tools/WebKitTestRunner/mac/PlatformWebViewMac.mm
@@ -160,9 +160,9 @@ void PlatformWebView::addChromeInputField()
     [textField setTag:1];
     [[m_window contentView] addSubview:textField.get()];
 
-    NSView *view = platformView();
-    [textField setNextKeyView:view];
-    [view setNextKeyView:textField.get()];
+    RetainPtr view = platformView();
+    [textField setNextKeyView:view.get()];
+    [view.get() setNextKeyView:textField.get()];
 }
 
 void PlatformWebView::removeChromeInputField()

--- a/Tools/WebKitTestRunner/mac/TestControllerMac.mm
+++ b/Tools/WebKitTestRunner/mac/TestControllerMac.mm
@@ -240,14 +240,14 @@ void TestController::configureContentExtensionForTest(const TestInvocation& test
     __block bool doneFetchingContentExtension = false;
     auto delegate = adoptNS([WKTRSessionDelegate new]);
     NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration] delegate:delegate.get() delegateQueue:[NSOperationQueue mainQueue]];
-    NSURLSessionDataTask *task = [session dataTaskWithRequest:[NSURLRequest requestWithURL:filterURL] completionHandler:^(NSData * data, NSURLResponse *response, NSError *error) {
+    RetainPtr task = [session dataTaskWithRequest:[NSURLRequest requestWithURL:filterURL] completionHandler:^(NSData * data, NSURLResponse *response, NSError *error) {
         ASSERT(data);
         ASSERT(response);
         ASSERT(!error);
         contentExtensionString = adoptNS([[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]);
         doneFetchingContentExtension = true;
     }];
-    [task resume];
+    [task.get() resume];
     platformRunUntil(doneFetchingContentExtension, noTimeout);
 
     __block bool doneCompiling = false;

--- a/Tools/WebKitTestRunner/mac/WebKitTestRunnerPasteboard.mm
+++ b/Tools/WebKitTestRunner/mac/WebKitTestRunnerPasteboard.mm
@@ -225,8 +225,8 @@ static RetainPtr<NSMutableDictionary> localPasteboards WTF_GUARDED_BY_LOCK(local
     auto item = adoptNS([[NSPasteboardItem alloc] init]);
     for (NSString *type in _typesArray.get()) {
         NSPasteboardType modernPasteboardType = [NSPasteboard _modernPasteboardType:type];
-        if (NSData *dataForType = [_dataByType objectForKey:type] ?: [_dataByType objectForKey:modernPasteboardType])
-            [item setData:dataForType forType:modernPasteboardType];
+        if (RetainPtr dataForType = [_dataByType objectForKey:type] ?: [_dataByType objectForKey:modernPasteboardType])
+            [item setData:dataForType.get() forType:modernPasteboardType];
     }
     return @[ item.get() ];
 }

--- a/Tools/WebKitTestRunner/mac/WebKitTestRunnerWindow.mm
+++ b/Tools/WebKitTestRunner/mac/WebKitTestRunnerWindow.mm
@@ -39,9 +39,9 @@ static Vector<WebKitTestRunnerWindow *> allWindows;
 + (WebKitTestRunnerWindow *)_WTR_keyWindow
 {
     ASSERT(isMainThread());
-    for (auto window : allWindows) {
-        if ([window isKeyWindow])
-            return window;
+    for (RetainPtr window : allWindows) {
+        if ([window.get() isKeyWindow])
+            return window.autorelease();
     }
     return nil;
 }


### PR DESCRIPTION
#### ecc187141a27992b96cf6c9a060c8d0e8af04d2d
<pre>
SaferCPP: Fix a large batch of unretained local variables warnings
<a href="https://bugs.webkit.org/show_bug.cgi?id=305305">https://bugs.webkit.org/show_bug.cgi?id=305305</a>
<a href="https://rdar.apple.com/167963564">rdar://167963564</a>

Reviewed by NOBODY (OOPS!).

Mechanical changes dictated by static analysis.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ecc187141a27992b96cf6c9a060c8d0e8af04d2d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138522 "96 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10887 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146630 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91497 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fb2fe883-6a4e-47ea-a003-4177b261699f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140396 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11591 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11042 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106008 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77335 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8c14e7b8-cd9c-4ac7-9b05-709d791f917a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141469 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8720 "Found 26 new test failures: fast/mediastream/mediaStream-with-rotation.html http/wpt/mediarecorder/MediaRecorder-webm-AV-audio-video-dataavailable.html http/wpt/webcodecs/copyTo-same-decoder.html media/media-rvfc-paused-offscreen-webm.html media/media-rvfc-paused-webm.html media/media-rvfc-playing-webm.html media/media-source/media-managedmse-video-with-poster.html media/media-source/media-source-vp8-webm-error-offscreen.html media/media-source/media-source-vp8-webm-error.html media/media-source/media-source-webm-seek-singlekeyframe.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124172 "Found 6 new API test failures: TestWebKitAPI.WebKitLegacy.ContextMenuCanCopyURL, TestWTF.RetainPtr.BridgingAutorelease, TestWTF.TypeCastsOSObjectCF.osObjectCast, TestWebKitAPI.WebKitLegacy.ContextMenuDefaultItemsHaveTags, TestWebKitAPI._WKDownload.DownloadMonitorCancel, TestWebKitAPI._WKDownload.DownloadMonitorReturnToForeground (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86871 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8309 "Found 16 new test failures: imported/w3c/web-platform-tests/css/css-contain/contain-size-replaced-003a.html imported/w3c/web-platform-tests/css/css-contain/contain-size-replaced-003b.html imported/w3c/web-platform-tests/css/css-contain/contain-size-replaced-003c.html imported/w3c/web-platform-tests/webcodecs/audio-encoder-codec-specific.https.any.html imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.html?vp8 imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.html?vp9_p0 imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.html?vp9_p2 imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker.html?vp8 imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker.html?vp9_p0 imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker.html?vp9_p2 ... (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6070 "Found 7 new API test failures: TestWebKitAPI.WebKitLegacy.ContextMenuCanCopyURL, TestWTF.RetainPtr.BridgingAutorelease, TestWTF.TypeCastsOSObjectCF.osObjectCast, TestWebKitAPI.WebKitLegacy.ContextMenuDefaultItemsHaveTags, TestWebKitAPI._WKDownload.DownloadMonitorCancel, TestWebKitAPI._WKDownload.DownloadMonitorReturnToForeground, TestIPC.IPCSerialization.Basic (failure)") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6920 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/130488 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117725 "Found 3 new API test failures: TestWTF.RetainPtr.BridgingAutorelease, TestWTF.TypeCastsOSObjectCF.osObjectCast, TestWebKitAPI._WKDownload.DownloadMonitorCancel (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2 "Found 60 new test failures: accessibility/mac/html-slider-indicator.html accessibility/mac/listbox-hit-test.html editing/input/reveal-contenteditable-on-input-vertically.html editing/mac/attributed-string/attrib-string-range-with-color-filter.html editing/mac/attributed-string/attributed-string-for-typing-with-color-filter.html editing/mac/input/NSBackgroundColor-transparent.html editing/mac/input/crash-for-empty-text-alternative.html editing/mac/input/firstrectforcharacterrange-caret-in-br.html editing/mac/input/firstrectforcharacterrange-vertical.html editing/mac/input/insert-delete-smp-symbol.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149379 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/137114 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10569 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2 "Found 60 new test failures: fast/css/identical-logical-height-decl.html fast/mediastream/mediaStream-with-rotation.html fast/webgpu/nocrash/fuzz-293750.html http/tests/media/cross-origin-webm-video.html http/tests/media/hls/hls-audio-tracks-language.html http/tests/media/hls/hls-webvtt-default.html http/tests/media/hls/hls-webvtt-style.html http/tests/media/hls/range-request-cross-origin.html http/tests/media/hls/track-in-band-multiple-cues.html http/tests/media/hls/track-webvtt-multitracks.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114388 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10586 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8943 "Found 60 new test failures: fast/events/onunload-not-on-body.html fast/mediastream/mediaStream-with-rotation.html fast/scrolling/mac/rubberband-axis-locking.html http/tests/media/cross-origin-webm-video.html http/tests/media/media-source/mediasource-play-then-seek-back-with-remote-control.html http/tests/media/media-source/mediasource-rvfc.html http/tests/media/video-webm-stall-seek.html http/tests/media/video-webm-stall.html http/tests/site-isolation/remote-frame-loaded-while-hidden.html http/tests/workers/service/shownotification-allowed.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114723 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8458 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120460 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65459 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10618 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2 "Found 60 new test failures: accessibility/password-notifications-timing.html compositing/animation/animation-backing.html compositing/backing/animate-into-view-with-descendant.html fast/media/mq-prefers-contrast-live-update.html fast/mediastream/mediaStream-with-rotation.html fast/repaint/fixed-scale.html fast/webgpu/nocrash/fuzz-284937.html http/tests/geolocation/geolocation-get-current-position-does-not-leak.https.html http/tests/geolocation/geolocation-watch-position-does-not-leak.https.html http/tests/media/cross-origin-webm-video.html ... (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/169796 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10352 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74248 "Found 6 new failures in platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp, BindGroup.mm, platform/audio/cocoa/AudioEncoderCocoa.cpp, page/mac/ChromeMac.mm and found 22 fixed files: API/JSWrapperMap.mm, mac/WebCoreSupport/PopupMenuMac.mm, mac/WebView/WebImmediateActionController.mm, mac/WebView/WebFrame.mm, platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp, mac/WebView/WebHTMLView.mm, platform/cf/KeyedDecoderCF.cpp, platform/mediastream/mac/AVVideoCaptureSource.mm, mac/WebCoreSupport/WebChromeClient.mm, mac/WebView/WebVideoFullscreenController.mm ...") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44261 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10556 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10407 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->