### PR TITLE
Properly implement TYPE_TRAITS for SpeechSynthesisErrorEvent

### DIFF
--- a/Source/WebCore/Modules/indexeddb/IDBVersionChangeEvent.h
+++ b/Source/WebCore/Modules/indexeddb/IDBVersionChangeEvent.h
@@ -55,14 +55,14 @@ public:
 
     std::optional<IDBResourceIdentifier> requestIdentifier() const { return m_requestIdentifier; }
 
-    bool isVersionChangeEvent() const final { return true; }
-
     uint64_t oldVersion() const { return m_oldVersion; }
     std::optional<uint64_t> newVersion() const { return m_newVersion; }
 
 private:
     IDBVersionChangeEvent(std::optional<IDBResourceIdentifier> requestIdentifier, uint64_t oldVersion, uint64_t newVersion, const AtomString& eventType);
     IDBVersionChangeEvent(const AtomString&, const Init&, IsTrusted);
+
+    bool isVersionChangeEvent() const final { return true; }
 
     std::optional<IDBResourceIdentifier> m_requestIdentifier;
     uint64_t m_oldVersion;

--- a/Source/WebCore/Modules/speech/SpeechSynthesisErrorEvent.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisErrorEvent.h
@@ -44,6 +44,8 @@ public:
 private:
     SpeechSynthesisErrorEvent(const AtomString& type, const SpeechSynthesisErrorEventInit&);
 
+    bool isSpeechSynthesisErrorEvent() const final { return true; }
+
     SpeechSynthesisErrorCode m_error;
 };
 

--- a/Source/WebCore/animation/CSSAnimation.h
+++ b/Source/WebCore/animation/CSSAnimation.h
@@ -43,8 +43,6 @@ public:
     static Ref<CSSAnimation> create(const Styleable&, Style::Animation&&, const RenderStyle* oldStyle, const RenderStyle& newStyle, const Style::ResolutionContext&);
     ~CSSAnimation() = default;
 
-    bool isCSSAnimation() const override { return true; }
-
     const String& animationName() const { return m_animationName.name; }
     const Style::ScopedName& scopedAnimationName() const { return m_animationName; }
 
@@ -61,6 +59,8 @@ public:
 
 private:
     CSSAnimation(const Styleable&, Style::ScopedName&&, Style::Animation&&);
+
+    bool isCSSAnimation() const final { return true; }
 
     void syncPropertiesWithBackingAnimation() final;
     AnimationPlayState backingAnimationPlayState() const final;

--- a/Source/WebCore/dom/BeforeTextInsertedEvent.h
+++ b/Source/WebCore/dom/BeforeTextInsertedEvent.h
@@ -44,7 +44,7 @@ public:
 
 private:
     explicit BeforeTextInsertedEvent(const String&);
-    bool isBeforeTextInsertedEvent() const override { return true; }
+    bool isBeforeTextInsertedEvent() const final { return true; }
 
     String m_text;
 };

--- a/Source/WebCore/dom/CompositionEvent.h
+++ b/Source/WebCore/dom/CompositionEvent.h
@@ -63,7 +63,7 @@ private:
     CompositionEvent(const AtomString& type, RefPtr<WindowProxy>&&, const String&);
     CompositionEvent(const AtomString& type, const Init&);
 
-    bool isCompositionEvent() const override;
+    bool isCompositionEvent() const final;
 
     String m_data;
 };

--- a/Source/WebCore/dom/DeviceMotionClient.h
+++ b/Source/WebCore/dom/DeviceMotionClient.h
@@ -46,7 +46,7 @@ public:
     virtual DeviceMotionData* lastMotion() const = 0;
     virtual void deviceMotionControllerDestroyed() = 0;
 
-    bool isDeviceMotionClient() const override { return true; }
+    bool isDeviceMotionClient() const final { return true; }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/ErrorEvent.h
+++ b/Source/WebCore/dom/ErrorEvent.h
@@ -83,7 +83,7 @@ private:
     ErrorEvent(const String& message, const String& fileName, unsigned lineNumber, unsigned columnNumber, JSC::Strong<JSC::Unknown> error);
     ErrorEvent(const AtomString&, const Init&, IsTrusted);
 
-    bool isErrorEvent() const override;
+    bool isErrorEvent() const final;
 
     String m_message;
     String m_fileName;

--- a/Source/WebCore/dom/PointerEvent.h
+++ b/Source/WebCore/dom/PointerEvent.h
@@ -133,8 +133,6 @@ public:
 
     void receivedTarget() final;
 
-    bool isPointerEvent() const final { return true; }
-
     // https://w3c.github.io/pointerevents/#attributes-and-default-actions
     // Many user agents expose non-standard attributes fromElement and toElement in MouseEvents to
     // support legacy content. In those user agents, the values of those (inherited) attributes in
@@ -154,6 +152,7 @@ protected:
     PointerEvent(const AtomString& type, MouseButton, const MouseEvent&, PointerID, const String& pointerType, CanBubble, IsCancelable, IsComposed);
 
 private:
+    bool isPointerEvent() const final { return true; }
     static bool typeIsEnterOrLeave(const AtomString& type);
     static unsigned short buttonsForType(const AtomString& type)
     {

--- a/Source/WebCore/dom/TemplateContentDocumentFragment.h
+++ b/Source/WebCore/dom/TemplateContentDocumentFragment.h
@@ -48,7 +48,7 @@ public:
 private:
     TemplateContentDocumentFragment(Document&, const HTMLTemplateElement&);
 
-    bool isTemplateContent() const override { return true; }
+    bool isTemplateContent() const final { return true; }
 
     WeakPtr<const HTMLTemplateElement, WeakPtrImplWithEventTargetData> m_host;
 };

--- a/Source/WebCore/dom/TextEvent.h
+++ b/Source/WebCore/dom/TextEvent.h
@@ -75,7 +75,7 @@ namespace WebCore {
         TextEvent(RefPtr<WindowProxy>&&, const String& data, RefPtr<DocumentFragment>&&, TextEventInputType, bool shouldSmartReplace, bool shouldMatchStyle, MailBlockquoteHandling);
         TextEvent(RefPtr<WindowProxy>&&, const String& data, const Vector<DictationAlternative>& dictationAlternatives);
 
-        bool isTextEvent() const override;
+        bool isTextEvent() const final;
 
         TextEventInputType m_inputType;
         String m_data;

--- a/Source/WebCore/dom/TouchEvent.cpp
+++ b/Source/WebCore/dom/TouchEvent.cpp
@@ -61,11 +61,6 @@ TouchEvent::TouchEvent(const AtomString& type, const Init& initializer, IsTruste
 
 TouchEvent::~TouchEvent() = default;
 
-bool TouchEvent::isTouchEvent() const
-{
-    return true;
-}
-
 } // namespace WebCore
 
 #endif // ENABLE(TOUCH_EVENTS)

--- a/Source/WebCore/dom/TouchEvent.h
+++ b/Source/WebCore/dom/TouchEvent.h
@@ -69,13 +69,13 @@ public:
     void setTargetTouches(RefPtr<TouchList>&& targetTouches) { m_targetTouches = targetTouches; }
     void setChangedTouches(RefPtr<TouchList>&& changedTouches) { m_changedTouches = changedTouches; }
 
-    bool isTouchEvent() const override;
-
 private:
     TouchEvent();
     TouchEvent(TouchList* touches, TouchList* targetTouches, TouchList* changedTouches, const AtomString& type,
         RefPtr<WindowProxy>&&, const DoublePoint& globalLocation, OptionSet<Modifier>);
     TouchEvent(const AtomString&, const Init&, IsTrusted);
+
+    bool isTouchEvent() const final { return true; }
 
     RefPtr<TouchList> m_touches;
     RefPtr<TouchList> m_targetTouches;

--- a/Source/WebCore/fileapi/File.h
+++ b/Source/WebCore/fileapi/File.h
@@ -75,8 +75,6 @@ public:
 
     static Ref<File> createWithRelativePath(ScriptExecutionContext*, const String& path, const String& relativePath);
 
-    bool isFile() const override { return true; }
-
     const String& path() const { return m_path; }
     const String& relativePath() const { return m_relativePath; }
     void setRelativePath(const String& relativePath) { m_relativePath = relativePath; }
@@ -94,14 +92,15 @@ public:
     bool isDirectory() const;
 
 private:
-    WEBCORE_EXPORT explicit File(ScriptExecutionContext*, const String& path);
+    WEBCORE_EXPORT File(ScriptExecutionContext*, const String& path);
     File(ScriptExecutionContext*, URL&&, String&& type, String&& path, String&& name);
     File(ScriptExecutionContext&, Vector<BlobPartVariant>&& blobPartVariants, const String& filename, const PropertyBag&);
     File(ScriptExecutionContext*, URL&&, String&& type, String&& path, String&& name, const std::optional<FileSystem::PlatformFileID>&);
     File(ScriptExecutionContext*, const Blob&, const String& name);
     File(ScriptExecutionContext*, const File&, const String& name);
-
     File(DeserializationContructor, ScriptExecutionContext*, const String& path, const URL& srcURL, const String& type, const String& name, const std::optional<int64_t>& lastModified);
+
+    bool isFile() const final { return true; }
 
     static void computeNameAndContentType(const String& path, const String& nameOverride, String& effectiveName, String& effectiveContentType);
 #if ENABLE(FILE_REPLACEMENT)

--- a/Source/WebCore/html/CustomPaintImage.h
+++ b/Source/WebCore/html/CustomPaintImage.h
@@ -42,10 +42,11 @@ public:
     }
 
     virtual ~CustomPaintImage();
-    bool isCustomPaintImage() const override { return true; }
 
 private:
     CustomPaintImage(PaintDefinition&, const FloatSize&, const RenderElement&, const Vector<String>& arguments);
+
+    bool isCustomPaintImage() const final { return true; }
 
     ImageDrawResult doCustomPaint(GraphicsContext&, const FloatSize&);
 

--- a/Source/WebCore/html/HTMLTablePartElement.h
+++ b/Source/WebCore/html/HTMLTablePartElement.h
@@ -36,7 +36,6 @@ class HTMLTablePartElement : public HTMLElement {
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLTablePartElement);
 public:
     RefPtr<const HTMLTableElement> findParentTable() const;
-    bool isHTMLTablePartElement() const override { return true; }
 
 protected:
     HTMLTablePartElement(const QualifiedName& tagName, Document& document)
@@ -46,6 +45,9 @@ protected:
 
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const override;
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) override;
+
+private:
+    bool isHTMLTablePartElement() const final { return true; }
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### ee8c90c7dd8337e0e936c8591eb599ef3a18409a
<pre>
Properly implement TYPE_TRAITS for SpeechSynthesisErrorEvent
<a href="https://bugs.webkit.org/show_bug.cgi?id=305306">https://bugs.webkit.org/show_bug.cgi?id=305306</a>

Reviewed by Chris Dumez.

Normally event class wrappers are created through
EventFactory::toJSNewlyCreated(Ref&lt;Event&gt;&amp;&amp;) which uses interfaceType()
instead of the TYPE_TRAITS mechanism.

However, there&apos;s another code path generated by the bindings for
subclasses if there&apos;s no longer a cached wrapper which is why
SpeechSynthesisErrorEvent needs TYPE_TRAITS. I could not figure out
with Claude AI how to test that code path however, but it seems better
if it ends up doing the correct thing.

I discovered this while making more of the TYPE_TRAITS isX() methods
private and final, which explains the other changes made here.

Canonical link: <a href="https://commits.webkit.org/305441@main">https://commits.webkit.org/305441@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/041b1016d6541282bbf4a95b65f7d98daba3aaff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138445 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10810 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49855 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146529 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91420 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3ef0766d-8065-48c6-bae8-47cce10f0db3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140319 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11514 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10965 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105931 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77281 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ab3ab333-ca03-4888-8796-395984fe41ec) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141392 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8647 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124111 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86778 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ab6b9a6f-139f-424d-8016-1499c6410972) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8234 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/6003 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6821 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117654 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42310 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149249 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10492 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42867 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114331 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10509 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8871 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114672 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8322 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120397 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65378 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21319 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10540 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38330 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10274 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74142 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10479 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10330 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->