### PR TITLE
Fix typo in InlineContentBuilder::handlePartialDisplayContentUpdate()

### DIFF
--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp
@@ -287,17 +287,17 @@ FloatRect InlineContentBuilder::handlePartialDisplayContentUpdate(Layout::Inline
         auto& displayContentFromPreviousLayout = inlineContent.displayContent();
         if (!lineDamage || !lineDamage->layoutStartPosition() || !displayContentFromPreviousLayout.lines.size())
             return { };
-        auto canidateLineIndex = lineDamage->layoutStartPosition()->lineIndex;
-        if (canidateLineIndex >= displayContentFromPreviousLayout.lines.size()) {
+        auto candidateLineIndex = lineDamage->layoutStartPosition()->lineIndex;
+        if (candidateLineIndex >= displayContentFromPreviousLayout.lines.size()) {
             ASSERT_NOT_REACHED();
             return { };
         }
-        if (layoutResult.displayContent.boxes.size() && canidateLineIndex > layoutResult.displayContent.boxes[0].lineIndex()) {
+        if (layoutResult.displayContent.boxes.size() && candidateLineIndex > layoutResult.displayContent.boxes[0].lineIndex()) {
             // We should never generate lines _before_ the damaged line.
             ASSERT_NOT_REACHED();
             return { };
         }
-        return { canidateLineIndex };
+        return { candidateLineIndex };
     }();
 
     auto firstDamagedBoxIndex = [&]() -> std::optional<size_t> {
@@ -310,15 +310,15 @@ FloatRect InlineContentBuilder::handlePartialDisplayContentUpdate(Layout::Inline
             return { };
         auto& displayContentFromPreviousLayout = inlineContent.displayContent();
         ASSERT(layoutResult.range != Layout::InlineLayoutResult::Range::Full);
-        auto canidateLineCount = layoutResult.range == Layout::InlineLayoutResult::Range::FullFromDamage
+        auto candidateLineCount = layoutResult.range == Layout::InlineLayoutResult::Range::FullFromDamage
             ? displayContentFromPreviousLayout.lines.size() - *firstDamagedLineIndex
             : layoutResult.displayContent.lines.size();
 
-        if (*firstDamagedLineIndex + canidateLineCount > displayContentFromPreviousLayout.lines.size()) {
+        if (*firstDamagedLineIndex + candidateLineCount > displayContentFromPreviousLayout.lines.size()) {
             ASSERT_NOT_REACHED();
             return { };
         }
-        return { canidateLineCount };
+        return { candidateLineCount };
     }();
 
     auto numberOfDamagedBoxes = [&]() -> std::optional<size_t> {


### PR DESCRIPTION
#### 6dd68b7b2c68b29a0f10396c9f3d4333326953b5
<pre>
Fix typo in InlineContentBuilder::handlePartialDisplayContentUpdate()
<a href="https://bugs.webkit.org/show_bug.cgi?id=305308">https://bugs.webkit.org/show_bug.cgi?id=305308</a>

Reviewed by Adrian Perez de Castro.

* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp:
(WebCore::LayoutIntegration::InlineContentBuilder::handlePartialDisplayContentUpdate const):

Canonical link: <a href="https://commits.webkit.org/305485@main">https://commits.webkit.org/305485@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88a3423a8d736c1de09beec44874c595066046db

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138454 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10819 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49864 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146538 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91429 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ae6dcc0c-e5f0-4297-b161-9a9deeaeaf1e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140328 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11523 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10974 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105940 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77289 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/277d56ac-b765-4cc7-b25c-715cd7f83304) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141401 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8650 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124119 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86787 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8237 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6013 "Found 1 new API test failure: TestWebKitAPI.NowPlayingControlsTests.NowPlayingUpdatesThrottled (failure)") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6830 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117657 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42318 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149258 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/137042 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10501 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42875 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114337 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10518 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8880 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114678 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29148 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8334 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120405 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65387 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10549 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38338 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10284 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74153 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10488 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10339 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->