### PR TITLE
Unnest JSC and WebCore

### DIFF
--- a/Source/JavaScriptCore/JavaScriptCore_Private.modulemap
+++ b/Source/JavaScriptCore/JavaScriptCore_Private.modulemap
@@ -122,8 +122,6 @@ framework module JavaScriptCore_Private [system] {
         exclude header "MARReportCrashPrivate.h"
         exclude header "PASReportCrashPrivate.h"
 
-        explicit module * {
-            export *
-        }
+        export *
     }
 }

--- a/Source/WebCore/WebCore_Private.modulemap
+++ b/Source/WebCore/WebCore_Private.modulemap
@@ -13,8 +13,6 @@ framework module WebCore_Private [system] {
 
         requires cplusplus
 
-        explicit module * {
-            export *
-        }
+        export *
     }
 }


### PR DESCRIPTION
#### 36e5415a0135b5e1f6891e2c4dd6dde91d4dbf17
<pre>
Unnest JSC and WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=305309">https://bugs.webkit.org/show_bug.cgi?id=305309</a>
<a href="https://rdar.apple.com/166064408">rdar://166064408</a>

Reviewed by NOBODY (OOPS!).

This simply unnests the JSC and WebCore modulemaps such that all of JSC and all
of WebCore are in two larger modules, rather than many small submodules.
Without this, use of Swift in core WebKit fails because it can&apos;t import APIs
that relate to WebCore or JSC types. Example errors are:

&lt;unknown&gt;:0: note: in implicit copy constructor for &apos;WTF::KeyValuePair&lt;unsigned int, JSC::Wasm::BranchHintMap&gt;&apos; first required here
WebKitBuild/Debug/JavaScriptCore.framework/PrivateHeaders/WasmBranchHints.h:39:7: note: definition here is not reachable

This is believed to be because much of the WebKit codebase heavily uses forward
declarations to improve compile time, and therefore we intentionally omit a lot
of #include directives which declare relationships between these submodules.
Without those includes, the Swift importer is unable to identify which
submodules are required.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36e5415a0135b5e1f6891e2c4dd6dde91d4dbf17

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138456 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10821 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49866 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146540 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91431 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/845500f5-9749-4263-99fe-8409c8adbdc1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140330 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11525 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10976 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105941 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77291 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dbaf52a1-0e18-4f3e-b54f-62568006bd7a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141403 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8657 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124122 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86788 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/46351809-aaab-4cd7-aa31-709ee6c43b5f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8244 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6015 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6832 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/130420 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117664 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42321 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149260 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/137045 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10503 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42878 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114340 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10520 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8882 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114681 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8342 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120408 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65389 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10551 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38341 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/169730 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10286 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74155 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44246 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10490 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10341 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->