### PR TITLE
Remove InlineDisplay::Line::m_contentOverflow

### DIFF
--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLine.h
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLine.h
@@ -61,7 +61,6 @@ public:
     const FloatRect& lineBoxRect() const { return m_lineBoxRect; }
     const FloatRect& lineBoxLogicalRect() const { return m_lineBoxLogicalRect; }
     const FloatRect& scrollableOverflow() const { return m_scrollableOverflow; }
-    const FloatRect& contentOverflow() const { return m_contentOverflow; }
     const FloatRect& inkOverflow() const { return m_inkOverflow; }
 
     FloatRect visibleRectIgnoringBlockDirection() const;
@@ -125,8 +124,6 @@ private:
     FloatRect m_lineBoxRect;
     FloatRect m_lineBoxLogicalRect;
     FloatRect m_scrollableOverflow;
-    // FIXME: Merge this with scrollable overflow (see InlineContentBuilder::updateLineOverflow).
-    FloatRect m_contentOverflow;
     // FIXME: This should be transitioned to spec aligned overflow value.
     FloatRect m_inkOverflow;
     // Enclosing top and bottom includes all inline level boxes (border box) vertically.
@@ -150,10 +147,10 @@ private:
     std::optional<Ellipsis> m_ellipsis { };
 };
 
-inline Line::Line(bool hasInflowBox, bool hasContentfulBox, bool hasBlockLevelBox, const FloatRect& lineBoxLogicalRect, const FloatRect& lineBoxRect, const FloatRect& contentOverflow, EnclosingTopAndBottom enclosingLogicalTopAndBottom, float alignmentBaseline, FontBaseline baselineType, float contentLogicalLeft, float contentLogicalLeftIgnoringInlineDirection, float contentLogicalWidth, bool isLeftToRightDirection, bool isHorizontal, bool isTruncatedInBlockDirection)
+inline Line::Line(bool hasInflowBox, bool hasContentfulBox, bool hasBlockLevelBox, const FloatRect& lineBoxLogicalRect, const FloatRect& lineBoxRect, const FloatRect& scrollableOverflow, EnclosingTopAndBottom enclosingLogicalTopAndBottom, float alignmentBaseline, FontBaseline baselineType, float contentLogicalLeft, float contentLogicalLeftIgnoringInlineDirection, float contentLogicalWidth, bool isLeftToRightDirection, bool isHorizontal, bool isTruncatedInBlockDirection)
     : m_lineBoxRect(lineBoxRect)
     , m_lineBoxLogicalRect(lineBoxLogicalRect)
-    , m_contentOverflow(contentOverflow)
+    , m_scrollableOverflow(scrollableOverflow)
     , m_enclosingLogicalTopAndBottom(enclosingLogicalTopAndBottom)
     , m_alignmentBaseline(alignmentBaseline)
     , m_contentLogicalLeft(contentLogicalLeft)
@@ -178,7 +175,6 @@ inline void Line::moveInBlockDirection(float offset)
 
     m_lineBoxRect.move(physicalOffset);
     m_scrollableOverflow.move(physicalOffset);
-    m_contentOverflow.move(physicalOffset);
     m_inkOverflow.move(physicalOffset);
     if (m_ellipsis)
         m_ellipsis->visualRect.move(physicalOffset);
@@ -197,7 +193,6 @@ inline void Line::shrinkInBlockDirection(float delta)
 
     m_lineBoxRect.contract(physicalDelta);
     m_scrollableOverflow.contract(physicalDelta);
-    m_contentOverflow.contract(physicalDelta);
     m_inkOverflow.contract(physicalDelta);
     if (m_ellipsis)
         m_ellipsis->visualRect.contract(physicalDelta);
@@ -224,7 +219,6 @@ inline void Line::setLineBoxRectForSVGText(const FloatRect& rect)
 {
     m_lineBoxRect = rect;
     m_scrollableOverflow = rect;
-    m_contentOverflow = rect;
     m_inkOverflow = rect;
     m_lineBoxLogicalRect = m_isHorizontal ? rect : rect.transposedRect();
     m_enclosingLogicalTopAndBottom.top = m_lineBoxLogicalRect.y();

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp
@@ -144,7 +144,7 @@ void InlineContentBuilder::adjustDisplayLines(InlineContent& inlineContent, size
 
     for (size_t lineIndex = startIndex; lineIndex < lines.size(); ++lineIndex) {
         auto& line = lines[lineIndex];
-        auto lineScrollableOverflowRect = line.contentOverflow();
+        auto lineScrollableOverflowRect = line.scrollableOverflow();
         auto adjustOverflowLogicalWidthWithBlockFlowQuirk = [&] {
             auto scrollableOverflowLogicalWidth = isHorizontalWritingMode ? lineScrollableOverflowRect.width() : lineScrollableOverflowRect.height();
             if (!isLeftToRightInlineDirection && line.contentLogicalWidth() > scrollableOverflowLogicalWidth) {


### PR DESCRIPTION
#### 44db87e3fd1256667f145e75edcd64cfd37e5578
<pre>
Remove InlineDisplay::Line::m_contentOverflow
<a href="https://bugs.webkit.org/show_bug.cgi?id=305310">https://bugs.webkit.org/show_bug.cgi?id=305310</a>
<a href="https://rdar.apple.com/167972341">rdar://167972341</a>

Reviewed by Alan Baradlay.

It is not really used.

* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLine.h:
(WebCore::InlineDisplay::Line::scrollableOverflow const):
(WebCore::InlineDisplay::Line::Line):
(WebCore::InlineDisplay::Line::moveInBlockDirection):
(WebCore::InlineDisplay::Line::shrinkInBlockDirection):
(WebCore::InlineDisplay::Line::setLineBoxRectForSVGText):
(WebCore::InlineDisplay::Line::contentOverflow const): Deleted.
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp:
(WebCore::LayoutIntegration::InlineContentBuilder::adjustDisplayLines const):

Canonical link: <a href="https://commits.webkit.org/305459@main">https://commits.webkit.org/305459@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2953594898701fb6103f3b0e8aa4fbe1e2c1406a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138462 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10827 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49872 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146546 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91437 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e0b52c1f-17e1-424b-bd85-4dbcc487074a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140336 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11531 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10982 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105948 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77295 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3cc06eb5-c65b-407f-a35e-69c6fd5100e5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141409 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8660 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124126 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86795 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/473eaa86-9f75-4fc0-b557-e60f8cea0e54) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8247 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6018 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6838 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117667 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42325 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149266 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10509 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42882 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114345 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10526 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8885 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114686 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29125 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8349 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120412 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65395 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10557 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38345 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10292 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74163 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10496 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10347 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->