### PR TITLE
Refactor TYPE_TRAITS for events

### DIFF
--- a/Source/WebCore/Modules/cookie-store/ExtendableCookieChangeEvent.h
+++ b/Source/WebCore/Modules/cookie-store/ExtendableCookieChangeEvent.h
@@ -47,14 +47,10 @@ public:
 private:
     ExtendableCookieChangeEvent(const AtomString& type, ExtendableCookieChangeEventInit&&, IsTrusted);
 
-    bool isExtendableCookieChangeEvent() const final { return true; }
-
     Vector<CookieListItem> m_changed;
     Vector<CookieListItem> m_deleted;
 };
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ExtendableCookieChangeEvent)
-    static bool isType(const WebCore::ExtendableEvent& event) { return event.isExtendableCookieChangeEvent(); }
-SPECIALIZE_TYPE_TRAITS_END()
+SPECIALIZE_TYPE_TRAITS_EXTENDABLEEVENT(ExtendableCookieChangeEvent)

--- a/Source/WebCore/Modules/indexeddb/IDBVersionChangeEvent.h
+++ b/Source/WebCore/Modules/indexeddb/IDBVersionChangeEvent.h
@@ -62,8 +62,6 @@ private:
     IDBVersionChangeEvent(std::optional<IDBResourceIdentifier> requestIdentifier, uint64_t oldVersion, uint64_t newVersion, const AtomString& eventType);
     IDBVersionChangeEvent(const AtomString&, const Init&, IsTrusted);
 
-    bool isVersionChangeEvent() const final { return true; }
-
     std::optional<IDBResourceIdentifier> m_requestIdentifier;
     uint64_t m_oldVersion;
     std::optional<uint64_t> m_newVersion;
@@ -71,6 +69,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::IDBVersionChangeEvent)
-    static bool isType(const WebCore::Event& event) { return event.isVersionChangeEvent(); }
-SPECIALIZE_TYPE_TRAITS_END()
+SPECIALIZE_TYPE_TRAITS_EVENT(IDBVersionChangeEvent)

--- a/Source/WebCore/Modules/notifications/NotificationEvent.h
+++ b/Source/WebCore/Modules/notifications/NotificationEvent.h
@@ -55,16 +55,12 @@ public:
 private:
     NotificationEvent(const AtomString&, NotificationEventInit&&, Ref<Notification>&&, const String& action, IsTrusted = IsTrusted::No);
 
-    bool isNotificationEvent() const final { return true; }
-
     const Ref<Notification> m_notification;
     String m_action;
 };
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::NotificationEvent)
-    static bool isType(const WebCore::ExtendableEvent& event) { return event.isNotificationEvent(); }
-SPECIALIZE_TYPE_TRAITS_END()
+SPECIALIZE_TYPE_TRAITS_EXTENDABLEEVENT(NotificationEvent)
 
 #endif // ENABLE(NOTIFICATION_EVENT)

--- a/Source/WebCore/Modules/paymentrequest/PaymentMethodChangeEvent.h
+++ b/Source/WebCore/Modules/paymentrequest/PaymentMethodChangeEvent.h
@@ -62,8 +62,6 @@ private:
     PaymentMethodChangeEvent(const AtomString& type, Init&&);
     PaymentMethodChangeEvent(const AtomString& type, const String& methodName, MethodDetailsFunction&&);
 
-    bool isPaymentMethodChangeEvent() const final { return true; }
-
     String m_methodName;
     MethodDetailsType m_methodDetails;
     JSValueInWrappedObject m_cachedMethodDetails;

--- a/Source/WebCore/Modules/push-api/PushEvent.h
+++ b/Source/WebCore/Modules/push-api/PushEvent.h
@@ -62,8 +62,6 @@ public:
 private:
     PushEvent(const AtomString&, ExtendableEventInit&&, std::optional<Vector<uint8_t>>&&, IsTrusted);
 
-    bool isPushEvent() const final { return true; }
-
     RefPtr<PushMessageData> m_data;
 
 #if ENABLE(DECLARATIVE_WEB_PUSH) && ENABLE(NOTIFICATIONS)
@@ -79,6 +77,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::PushEvent)
-    static bool isType(const WebCore::ExtendableEvent& event) { return event.isPushEvent(); }
-SPECIALIZE_TYPE_TRAITS_END()
+SPECIALIZE_TYPE_TRAITS_EXTENDABLEEVENT(PushEvent)

--- a/Source/WebCore/Modules/push-api/PushSubscriptionChangeEvent.h
+++ b/Source/WebCore/Modules/push-api/PushSubscriptionChangeEvent.h
@@ -43,14 +43,10 @@ public:
 private:
     PushSubscriptionChangeEvent(const AtomString&, ExtendableEventInit&&, RefPtr<PushSubscription>&& newSubscription, RefPtr<PushSubscription>&& oldSubscription, IsTrusted);
 
-    bool isPushSubscriptionChangeEvent() const final { return true; }
-
     RefPtr<PushSubscription> m_newSubscription;
     RefPtr<PushSubscription> m_oldSubscription;
 };
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::PushSubscriptionChangeEvent)
-    static bool isType(const WebCore::ExtendableEvent& event) { return event.isPushSubscriptionChangeEvent(); }
-SPECIALIZE_TYPE_TRAITS_END()
+SPECIALIZE_TYPE_TRAITS_EXTENDABLEEVENT(PushSubscriptionChangeEvent)

--- a/Source/WebCore/Modules/speech/SpeechSynthesisErrorEvent.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisErrorEvent.h
@@ -44,8 +44,6 @@ public:
 private:
     SpeechSynthesisErrorEvent(const AtomString& type, const SpeechSynthesisErrorEventInit&);
 
-    bool isSpeechSynthesisErrorEvent() const final { return true; }
-
     SpeechSynthesisErrorCode m_error;
 };
 

--- a/Source/WebCore/animation/AnimationEventBase.h
+++ b/Source/WebCore/animation/AnimationEventBase.h
@@ -37,10 +37,6 @@ class AnimationEventBase : public Event {
 public:
     virtual ~AnimationEventBase();
 
-    virtual bool isAnimationPlaybackEvent() const { return false; }
-    virtual bool isCSSAnimationEvent() const { return false; }
-    virtual bool isCSSTransitionEvent() const { return false; }
-
     WebAnimation* animation() const { return m_animation.get(); }
     std::optional<Seconds> scheduledTime() const { return m_scheduledTime; }
 
@@ -49,14 +45,8 @@ protected:
     AnimationEventBase(enum EventInterfaceType, const AtomString&, const EventInit&, IsTrusted);
 
 private:
-    RefPtr<WebAnimation> m_animation;
+    const RefPtr<WebAnimation> m_animation;
     Markable<Seconds> m_scheduledTime;
 };
 
-}
-
-#define SPECIALIZE_TYPE_TRAITS_ANIMATION_EVENT_BASE(ToValueTypeName, predicate) \
-SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ToValueTypeName) \
-static bool isType(const WebCore::AnimationEventBase& value) { return value.predicate; } \
-SPECIALIZE_TYPE_TRAITS_END()
-
+} // namespace WebCore

--- a/Source/WebCore/animation/AnimationPlaybackEvent.h
+++ b/Source/WebCore/animation/AnimationPlaybackEvent.h
@@ -47,8 +47,6 @@ public:
 
     virtual ~AnimationPlaybackEvent();
 
-    bool isAnimationPlaybackEvent() const final { return true; }
-
     std::optional<WebAnimationTime> timelineTime() const { return m_timelineTime; }
     std::optional<WebAnimationTime> currentTime() const { return m_currentTime; }
 
@@ -60,6 +58,6 @@ private:
     std::optional<WebAnimationTime> m_currentTime;
 };
 
-}
+} // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_ANIMATION_EVENT_BASE(AnimationPlaybackEvent, isAnimationPlaybackEvent())
+SPECIALIZE_TYPE_TRAITS_EVENT(AnimationPlaybackEvent)

--- a/Source/WebCore/animation/CSSAnimationEvent.h
+++ b/Source/WebCore/animation/CSSAnimationEvent.h
@@ -50,8 +50,6 @@ public:
 
     virtual ~CSSAnimationEvent();
 
-    bool isCSSAnimationEvent() const final { return true; }
-
     const String& animationName() const { return m_animationName; }
 
 private:
@@ -63,4 +61,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_ANIMATION_EVENT_BASE(CSSAnimationEvent, isCSSAnimationEvent())
+SPECIALIZE_TYPE_TRAITS_EVENT(CSSAnimationEvent)

--- a/Source/WebCore/animation/CSSTransitionEvent.h
+++ b/Source/WebCore/animation/CSSTransitionEvent.h
@@ -51,8 +51,6 @@ public:
 
     virtual ~CSSTransitionEvent();
 
-    bool isCSSTransitionEvent() const final { return true; }
-
     const String& propertyName() const { return m_propertyName; }
 
 private:
@@ -64,4 +62,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_ANIMATION_EVENT_BASE(CSSTransitionEvent, isCSSTransitionEvent())
+SPECIALIZE_TYPE_TRAITS_EVENT(CSSTransitionEvent)

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -30,8 +30,10 @@
 #include "AnimationPlaybackEvent.h"
 #include "AnimationTimeline.h"
 #include "ContainerNodeInlines.h"
+#include "CSSAnimationEvent.h"
 #include "CSSSerializationContext.h"
 #include "CSSStyleProperties.h"
+#include "CSSTransitionEvent.h"
 #include "CSSUnitValue.h"
 #include "CSSUnits.h"
 #include "CSSValuePool.h"
@@ -917,7 +919,7 @@ void WebAnimation::enqueueAnimationEvent(Ref<AnimationEventBase>&& event)
         timeline->enqueueAnimationEvent(WTF::move(event));
     } else {
         // Otherwise, queue a task to dispatch event at animation. The task source for this task is the DOM manipulation task source.
-        if (event->isCSSAnimationEvent() || event->isCSSTransitionEvent()) {
+        if (is<CSSAnimationEvent>(event) || is<CSSTransitionEvent>(event)) {
             if (RefPtr element = dynamicDowncast<Element>(event->target())) {
                 element->queueTaskToDispatchEvent(TaskSource::DOMManipulation, WTF::move(event));
                 return;

--- a/Source/WebCore/dom/BeforeTextInsertedEvent.h
+++ b/Source/WebCore/dom/BeforeTextInsertedEvent.h
@@ -44,6 +44,7 @@ public:
 
 private:
     explicit BeforeTextInsertedEvent(const String&);
+
     bool isBeforeTextInsertedEvent() const final { return true; }
 
     String m_text;
@@ -51,4 +52,5 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_EVENT(BeforeTextInsertedEvent)
+// Technically not a polymorphic Event class, but it requires the same infrastructure as it's not in EventInterfaces.in.
+SPECIALIZE_TYPE_TRAITS_EVENT_POLYMORPHIC(BeforeTextInsertedEvent)

--- a/Source/WebCore/dom/BeforeUnloadEvent.cpp
+++ b/Source/WebCore/dom/BeforeUnloadEvent.cpp
@@ -40,9 +40,4 @@ BeforeUnloadEvent::BeforeUnloadEvent(ForBindingsFlag)
 {
 }
 
-bool BeforeUnloadEvent::isBeforeUnloadEvent() const
-{
-    return true;
-}
-
 } // namespace WebCore

--- a/Source/WebCore/dom/BeforeUnloadEvent.h
+++ b/Source/WebCore/dom/BeforeUnloadEvent.h
@@ -47,9 +47,7 @@ public:
 private:
     enum ForBindingsFlag { ForBindings };
     BeforeUnloadEvent();
-    BeforeUnloadEvent(ForBindingsFlag);
-
-    bool isBeforeUnloadEvent() const final;
+    explicit BeforeUnloadEvent(ForBindingsFlag);
 
     String m_returnValue;
 };

--- a/Source/WebCore/dom/ClipboardEvent.cpp
+++ b/Source/WebCore/dom/ClipboardEvent.cpp
@@ -44,9 +44,4 @@ ClipboardEvent::ClipboardEvent(const AtomString& type, const Init& init)
 
 ClipboardEvent::~ClipboardEvent() = default;
 
-bool ClipboardEvent::isClipboardEvent() const
-{
-    return true;
-}
-
 } // namespace WebCore

--- a/Source/WebCore/dom/ClipboardEvent.h
+++ b/Source/WebCore/dom/ClipboardEvent.h
@@ -54,9 +54,7 @@ private:
     ClipboardEvent(const AtomString& type, Ref<DataTransfer>&&);
     ClipboardEvent(const AtomString& type, const Init&);
 
-    bool isClipboardEvent() const final;
-
-    RefPtr<DataTransfer> m_clipboardData;
+    const RefPtr<DataTransfer> m_clipboardData;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/CommandEvent.cpp
+++ b/Source/WebCore/dom/CommandEvent.cpp
@@ -58,11 +58,6 @@ Ref<CommandEvent> CommandEvent::createForBindings()
     return adoptRef(*new CommandEvent);
 }
 
-bool CommandEvent::isCommandEvent() const
-{
-    return true;
-}
-
 RefPtr<Element> CommandEvent::source() const
 {
     if (!m_source)
@@ -70,12 +65,12 @@ RefPtr<Element> CommandEvent::source() const
 
     if (RefPtr target = dynamicDowncast<Node>(currentTarget())) {
         Ref treeScope = target->treeScope();
-        Ref node = treeScope->retargetToScope(*m_source.get());
+        Ref node = treeScope->retargetToScope(*m_source);
         return &downcast<Element>(node).get();
     }
 
     Ref treeScope = m_source->treeScope().documentScope();
-    Ref node = treeScope->retargetToScope(*m_source.get());
+    Ref node = treeScope->retargetToScope(*m_source);
     return &downcast<Element>(node).get();
 }
 

--- a/Source/WebCore/dom/CommandEvent.h
+++ b/Source/WebCore/dom/CommandEvent.h
@@ -54,9 +54,7 @@ private:
     CommandEvent();
     CommandEvent(const AtomString& type, const Init&, IsTrusted = IsTrusted::No);
 
-    bool isCommandEvent() const final;
-
-    RefPtr<Element> m_source;
+    const RefPtr<Element> m_source;
     String m_command;
 };
 

--- a/Source/WebCore/dom/CompositionEvent.cpp
+++ b/Source/WebCore/dom/CompositionEvent.cpp
@@ -62,9 +62,4 @@ void CompositionEvent::initCompositionEvent(const AtomString& type, bool canBubb
     m_data = data;
 }
 
-bool CompositionEvent::isCompositionEvent() const
-{
-    return true;
-}
-
 } // namespace WebCore

--- a/Source/WebCore/dom/CompositionEvent.h
+++ b/Source/WebCore/dom/CompositionEvent.h
@@ -63,8 +63,6 @@ private:
     CompositionEvent(const AtomString& type, RefPtr<WindowProxy>&&, const String&);
     CompositionEvent(const AtomString& type, const Init&);
 
-    bool isCompositionEvent() const final;
-
     String m_data;
 };
 

--- a/Source/WebCore/dom/DragEvent.h
+++ b/Source/WebCore/dom/DragEvent.h
@@ -38,7 +38,7 @@ struct DragEventInit : public MouseEventInit {
     RefPtr<DataTransfer> dataTransfer;
 };
 
-class DragEvent : public MouseEvent {
+class DragEvent final : public MouseEvent {
     WTF_MAKE_TZONE_ALLOCATED(DragEvent);
 public:
     using Init = DragEventInit;
@@ -60,9 +60,7 @@ private:
         EventTarget* relatedTarget, double force, SyntheticClickType, DataTransfer*, IsSimulated, IsTrusted);
     DragEvent();
 
-    bool isDragEvent() const final { return true; }
-
-    RefPtr<DataTransfer> m_dataTransfer;
+    const RefPtr<DataTransfer> m_dataTransfer;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/ErrorEvent.cpp
+++ b/Source/WebCore/dom/ErrorEvent.cpp
@@ -91,15 +91,11 @@ JSValue ErrorEvent::error(JSGlobalObject& globalObject)
 RefPtr<SerializedScriptValue> ErrorEvent::trySerializeError(JSGlobalObject& exec)
 {
     if (!m_serializedError && !m_triedToSerialize) {
-        m_serializedError = SerializedScriptValue::create(exec, m_error.getValue(), SerializationForStorage::No, SerializationErrorMode::NonThrowing);
+        if (RefPtr error = SerializedScriptValue::create(exec, m_error.getValue(), SerializationForStorage::No, SerializationErrorMode::NonThrowing))
+            lazyInitialize(m_serializedError, error.releaseNonNull());
         m_triedToSerialize = true;
     }
     return m_serializedError;
-}
-
-bool ErrorEvent::isErrorEvent() const
-{
-    return true;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/ErrorEvent.h
+++ b/Source/WebCore/dom/ErrorEvent.h
@@ -83,14 +83,12 @@ private:
     ErrorEvent(const String& message, const String& fileName, unsigned lineNumber, unsigned columnNumber, JSC::Strong<JSC::Unknown> error);
     ErrorEvent(const AtomString&, const Init&, IsTrusted);
 
-    bool isErrorEvent() const final;
-
     String m_message;
     String m_fileName;
     unsigned m_lineNumber;
     unsigned m_columnNumber;
     JSValueInWrappedObject m_error;
-    RefPtr<SerializedScriptValue> m_serializedError;
+    const RefPtr<SerializedScriptValue> m_serializedError;
     bool m_triedToSerialize { false };
 };
 

--- a/Source/WebCore/dom/Event.h
+++ b/Source/WebCore/dom/Event.h
@@ -110,29 +110,9 @@ public:
     void setLegacyReturnValue(bool);
 
     virtual bool isBeforeTextInsertedEvent() const { return false; }
-    virtual bool isBeforeUnloadEvent() const { return false; }
-    virtual bool isClipboardEvent() const { return false; }
-    virtual bool isCommandEvent() const { return false; }
-    virtual bool isCompositionEvent() const { return false; }
-    virtual bool isDragEvent() const { return false; }
-    virtual bool isErrorEvent() const { return false; }
-    virtual bool isFocusEvent() const { return false; }
-    virtual bool isGestureEvent() const { return false; }
-    virtual bool isInputEvent() const { return false; }
-    virtual bool isKeyboardEvent() const { return false; }
     virtual bool isMouseEvent() const { return false; }
-    virtual bool isPaymentMethodChangeEvent() const { return false; }
-    virtual bool isPointerEvent() const { return false; }
-    virtual bool isSpeechSynthesisErrorEvent() const { return false; }
-    virtual bool isSubmitEvent() const { return false; }
-    virtual bool isTextEvent() const { return false; }
-    virtual bool isToggleEvent() const { return false; }
-    virtual bool isTouchEvent() const { return false; }
     virtual bool isUIEvent() const { return false; }
     virtual bool isUIEventWithKeyState() const { return false; }
-    virtual bool isVersionChangeEvent() const { return false; }
-    virtual bool isWheelEvent() const { return false; }
-    virtual bool isXMLHttpRequestProgressEvent() const { return false; }
 
     bool propagationStopped() const { return m_propagationStopped || m_immediatePropagationStopped; }
     bool immediatePropagationStopped() const { return m_immediatePropagationStopped; }
@@ -254,6 +234,11 @@ WTF::TextStream& operator<<(WTF::TextStream&, const Event&);
 } // namespace WebCore
 
 #define SPECIALIZE_TYPE_TRAITS_EVENT(ToValueTypeName) \
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ToValueTypeName) \
+    static bool isType(const WebCore::Event& event) { return event.interfaceType() == WebCore::EventInterfaceType::ToValueTypeName; } \
+SPECIALIZE_TYPE_TRAITS_END()
+
+#define SPECIALIZE_TYPE_TRAITS_EVENT_POLYMORPHIC(ToValueTypeName) \
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ToValueTypeName) \
     static bool isType(const WebCore::Event& event) { return event.is##ToValueTypeName(); } \
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/dom/EventPath.cpp
+++ b/Source/WebCore/dom/EventPath.cpp
@@ -27,6 +27,7 @@
 #include "Event.h"
 #include "EventContext.h"
 #include "EventNames.h"
+#include "FocusEvent.h"
 #include "HTMLSlotElement.h"
 #include "LocalDOMWindow.h"
 #include "MouseEvent.h"
@@ -88,7 +89,7 @@ EventPath::EventPath(Node& originalTarget, Event& event)
 void EventPath::buildPath(Node& originalTarget, Event& event)
 {
     EventContext::Type contextType = [&]() {
-        if (is<MouseEvent>(event) || event.isFocusEvent())
+        if (is<MouseEvent>(event) || is<FocusEvent>(event))
             return EventContext::Type::MouseOrFocus;
 #if ENABLE(TOUCH_EVENTS)
         if (is<TouchEvent>(event))

--- a/Source/WebCore/dom/FocusEvent.cpp
+++ b/Source/WebCore/dom/FocusEvent.cpp
@@ -34,11 +34,6 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(FocusEvent);
 
-bool FocusEvent::isFocusEvent() const
-{
-    return true;
-}
-
 FocusEvent::FocusEvent()
     : UIEvent(EventInterfaceType::FocusEvent)
 {

--- a/Source/WebCore/dom/FocusEvent.h
+++ b/Source/WebCore/dom/FocusEvent.h
@@ -65,8 +65,6 @@ private:
     FocusEvent(const AtomString& type, CanBubble, IsCancelable, RefPtr<WindowProxy>&&, int, RefPtr<EventTarget>&&);
     FocusEvent(const AtomString& type, const Init&);
 
-    bool isFocusEvent() const final;
-
     void setRelatedTarget(RefPtr<EventTarget>&& relatedTarget) final { m_relatedTarget = WTF::move(relatedTarget); }
 
     RefPtr<EventTarget> m_relatedTarget;

--- a/Source/WebCore/dom/InputEvent.cpp
+++ b/Source/WebCore/dom/InputEvent.cpp
@@ -47,7 +47,7 @@ InputEvent::InputEvent(const AtomString& eventType, const String& inputType, IsC
     : UIEvent(EventInterfaceType::InputEvent, eventType, CanBubble::Yes, cancelable, IsComposed::Yes, WTF::move(view), detail)
     , m_inputType(inputType)
     , m_data(data)
-    , m_dataTransfer(dataTransfer)
+    , m_dataTransfer(WTF::move(dataTransfer))
     , m_targetRanges(targetRanges)
     , m_isInputMethodComposing(isInputMethodComposing == IsInputMethodComposing::Yes)
 {
@@ -63,9 +63,9 @@ InputEvent::InputEvent(const AtomString& eventType, const Init& initializer)
 
 InputEvent::~InputEvent() = default;
 
-RefPtr<DataTransfer> InputEvent::dataTransfer() const
+DataTransfer* InputEvent::dataTransfer() const
 {
-    return m_dataTransfer;
+    return m_dataTransfer.get();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/InputEvent.h
+++ b/Source/WebCore/dom/InputEvent.h
@@ -56,7 +56,7 @@ public:
 
     const String& inputType() const { return m_inputType; }
     const String& data() const { return m_data; }
-    RefPtr<DataTransfer> dataTransfer() const;
+    DataTransfer* dataTransfer() const;
     const Vector<Ref<StaticRange>>& getTargetRanges() { return m_targetRanges; }
     bool isInputMethodComposing() const { return m_isInputMethodComposing; }
 
@@ -65,11 +65,9 @@ private:
         const String& data, RefPtr<DataTransfer>&&, const Vector<Ref<StaticRange>>& targetRanges, int detail, IsInputMethodComposing);
     InputEvent(const AtomString& eventType, const Init&);
 
-    bool isInputEvent() const final { return true; }
-
     String m_inputType;
     String m_data;
-    RefPtr<DataTransfer> m_dataTransfer;
+    const RefPtr<DataTransfer> m_dataTransfer;
     Vector<Ref<StaticRange>> m_targetRanges;
     bool m_isInputMethodComposing;
 };

--- a/Source/WebCore/dom/KeyboardEvent.cpp
+++ b/Source/WebCore/dom/KeyboardEvent.cpp
@@ -242,11 +242,6 @@ int KeyboardEvent::charCode() const
     return m_underlyingPlatformEvent->text().characterStartingAt(0);
 }
 
-bool KeyboardEvent::isKeyboardEvent() const
-{
-    return true;
-}
-
 unsigned KeyboardEvent::which() const
 {
     // Netscape's "which" returns a virtual key code for keydown and keyup, and a character code for keypress.

--- a/Source/WebCore/dom/KeyboardEvent.h
+++ b/Source/WebCore/dom/KeyboardEvent.h
@@ -87,7 +87,6 @@ public:
     int keyCodeForKeyDown() const; // key code for the keydown that matches the keypress
     WEBCORE_EXPORT int charCode() const; // character code for keypress, 0 for keydown and keyup
 
-    bool isKeyboardEvent() const final;
     unsigned which() const final;
 
     bool isComposing() const { return m_isComposing; }

--- a/Source/WebCore/dom/MouseEvent.cpp
+++ b/Source/WebCore/dom/MouseEvent.cpp
@@ -94,7 +94,6 @@ Ref<MouseEvent> MouseEvent::create(const AtomString& eventType, CanBubble canBub
     return adoptRef(*new MouseEvent(EventInterfaceType::MouseEvent, eventType, canBubble, isCancelable, isComposed, timestamp, WTF::move(view), detail, { screenX, screenY }, { clientX, clientY }, 0, 0, modifiers, button, buttons, syntheticClickType, relatedTarget));
 }
 
-
 Ref<MouseEvent> MouseEvent::createForBindings()
 {
     return adoptRef(*new MouseEvent(EventInterfaceType::MouseEvent));
@@ -174,11 +173,6 @@ void MouseEvent::initMouseEvent(const AtomString& type, bool canBubble, bool can
     initCoordinates({ clientX, clientY });
 
     setIsSimulated(false);
-}
-
-bool MouseEvent::isMouseEvent() const
-{
-    return true;
 }
 
 bool MouseEvent::canTriggerActivationBehavior(const Event& event)

--- a/Source/WebCore/dom/MouseEvent.h
+++ b/Source/WebCore/dom/MouseEvent.h
@@ -107,10 +107,10 @@ protected:
 
     MouseEvent(enum EventInterfaceType, const AtomString& type, const MouseEventInit&, IsTrusted);
 
-    MouseEvent(enum EventInterfaceType);
+    explicit MouseEvent(enum EventInterfaceType);
 
 private:
-    bool isMouseEvent() const final;
+    bool isMouseEvent() const final { return true; }
 
     void setRelatedTarget(RefPtr<EventTarget>&&) final;
 
@@ -126,4 +126,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_EVENT(MouseEvent)
+SPECIALIZE_TYPE_TRAITS_EVENT_POLYMORPHIC(MouseEvent)

--- a/Source/WebCore/dom/PointerEvent.h
+++ b/Source/WebCore/dom/PointerEvent.h
@@ -152,7 +152,6 @@ protected:
     PointerEvent(const AtomString& type, MouseButton, const MouseEvent&, PointerID, const String& pointerType, CanBubble, IsCancelable, IsComposed);
 
 private:
-    bool isPointerEvent() const final { return true; }
     static bool typeIsEnterOrLeave(const AtomString& type);
     static unsigned short buttonsForType(const AtomString& type)
     {
@@ -226,4 +225,5 @@ inline bool PointerEvent::typeRequiresResolvedButton(const AtomString& type)
 
 } // namespace WebCore
 
+// Technically a polymorphic Event class because of SimulatedPointerEvent, but that uses the same type.
 SPECIALIZE_TYPE_TRAITS_EVENT(PointerEvent)

--- a/Source/WebCore/dom/TextEvent.cpp
+++ b/Source/WebCore/dom/TextEvent.cpp
@@ -126,9 +126,4 @@ void TextEvent::initTextEvent(const AtomString& type, bool canBubble, bool cance
     m_dictationAlternatives = { };
 }
 
-bool TextEvent::isTextEvent() const
-{
-    return true;
-}
-
 } // namespace WebCore

--- a/Source/WebCore/dom/TextEvent.h
+++ b/Source/WebCore/dom/TextEvent.h
@@ -75,8 +75,6 @@ namespace WebCore {
         TextEvent(RefPtr<WindowProxy>&&, const String& data, RefPtr<DocumentFragment>&&, TextEventInputType, bool shouldSmartReplace, bool shouldMatchStyle, MailBlockquoteHandling);
         TextEvent(RefPtr<WindowProxy>&&, const String& data, const Vector<DictationAlternative>& dictationAlternatives);
 
-        bool isTextEvent() const final;
-
         TextEventInputType m_inputType;
         String m_data;
 

--- a/Source/WebCore/dom/ToggleEvent.h
+++ b/Source/WebCore/dom/ToggleEvent.h
@@ -50,8 +50,6 @@ private:
     ToggleEvent(const AtomString&, const Init&, Event::IsCancelable);
     ToggleEvent(const AtomString&, const Init&);
 
-    bool isToggleEvent() const final { return true; }
-
     String m_oldState;
     String m_newState;
 };

--- a/Source/WebCore/dom/TouchEvent.h
+++ b/Source/WebCore/dom/TouchEvent.h
@@ -75,8 +75,6 @@ private:
         RefPtr<WindowProxy>&&, const DoublePoint& globalLocation, OptionSet<Modifier>);
     TouchEvent(const AtomString&, const Init&, IsTrusted);
 
-    bool isTouchEvent() const final { return true; }
-
     RefPtr<TouchList> m_touches;
     RefPtr<TouchList> m_targetTouches;
     RefPtr<TouchList> m_changedTouches;

--- a/Source/WebCore/dom/UIEvent.cpp
+++ b/Source/WebCore/dom/UIEvent.cpp
@@ -71,11 +71,6 @@ void UIEvent::initUIEvent(const AtomString& typeArg, bool canBubbleArg, bool can
     m_detail = detailArg;
 }
 
-bool UIEvent::isUIEvent() const
-{
-    return true;
-}
-
 int UIEvent::layerX()
 {
     return 0;

--- a/Source/WebCore/dom/UIEvent.h
+++ b/Source/WebCore/dom/UIEvent.h
@@ -78,7 +78,7 @@ protected:
     UIEvent(enum EventInterfaceType, const AtomString&, const UIEventInit&, IsTrusted = IsTrusted::No);
 
 private:
-    bool isUIEvent() const final;
+    bool isUIEvent() const final { return true; }
 
     RefPtr<WindowProxy> m_view;
     int m_detail;
@@ -87,4 +87,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_EVENT(UIEvent)
+SPECIALIZE_TYPE_TRAITS_EVENT_POLYMORPHIC(UIEvent)

--- a/Source/WebCore/dom/UIEventWithKeyState.cpp
+++ b/Source/WebCore/dom/UIEventWithKeyState.cpp
@@ -21,6 +21,8 @@
 #include "config.h"
 #include "UIEventWithKeyState.h"
 
+#include "KeyboardEvent.h"
+#include "MouseEvent.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -78,7 +80,7 @@ void UIEventWithKeyState::setModifierKeys(bool ctrlKey, bool altKey, bool shiftK
 RefPtr<UIEventWithKeyState> findEventWithKeyState(Event* event)
 {
     for (RefPtr e = event; e; e = e->underlyingEvent()) {
-        if (e->isKeyboardEvent() || e->isMouseEvent())
+        if (is<KeyboardEvent>(*e) || is<MouseEvent>(*e))
             return downcast<UIEventWithKeyState>(WTF::move(e));
     }
     return nullptr;

--- a/Source/WebCore/dom/UIEventWithKeyState.h
+++ b/Source/WebCore/dom/UIEventWithKeyState.h
@@ -84,4 +84,4 @@ RefPtr<UIEventWithKeyState> findEventWithKeyState(Event*);
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_EVENT(UIEventWithKeyState)
+SPECIALIZE_TYPE_TRAITS_EVENT_POLYMORPHIC(UIEventWithKeyState)

--- a/Source/WebCore/dom/WheelEvent.cpp
+++ b/Source/WebCore/dom/WheelEvent.cpp
@@ -89,9 +89,4 @@ Ref<WheelEvent> WheelEvent::create(const AtomString& type, const Init& initializ
     return adoptRef(*new WheelEvent(type, initializer));
 }
 
-bool WheelEvent::isWheelEvent() const
-{
-    return true;
-}
-
 } // namespace WebCore

--- a/Source/WebCore/dom/WheelEvent.h
+++ b/Source/WebCore/dom/WheelEvent.h
@@ -77,8 +77,6 @@ private:
     WheelEvent(const AtomString&, const Init&);
     WheelEvent(const PlatformWheelEvent&, RefPtr<WindowProxy>&&, IsCancelable);
 
-    bool isWheelEvent() const final;
-
     IntPoint m_wheelDelta;
     double m_deltaX { 0 };
     double m_deltaY { 0 };

--- a/Source/WebCore/html/BaseDateAndTimeInputType.cpp
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.cpp
@@ -331,7 +331,7 @@ void BaseDateAndTimeInputType::handleDOMActivateEvent(Event& event)
     if (!element()->renderer() || !protectedElement()->isMutable() || !UserGestureIndicator::processingUserGesture())
         return;
 
-    m_pickerWasActivatedByKeyboard = event.isKeyboardEvent();
+    m_pickerWasActivatedByKeyboard = is<KeyboardEvent>(event);
 
     if (m_dateTimeChooser)
         return;

--- a/Source/WebCore/html/SubmitEvent.cpp
+++ b/Source/WebCore/html/SubmitEvent.cpp
@@ -54,9 +54,4 @@ SubmitEvent::SubmitEvent(RefPtr<HTMLElement>&& submitter)
     , m_submitter(WTF::move(submitter))
 { }
 
-bool SubmitEvent::isSubmitEvent() const
-{
-    return true;
-}
-
 } // namespace WebCore

--- a/Source/WebCore/html/SubmitEvent.h
+++ b/Source/WebCore/html/SubmitEvent.h
@@ -33,7 +33,7 @@ namespace WebCore {
 
 class HTMLElement;
 
-class SubmitEvent : public Event {
+class SubmitEvent final : public Event {
     WTF_MAKE_TZONE_ALLOCATED(SubmitEvent);
 public:
     struct Init : EventInit {
@@ -49,9 +49,7 @@ private:
     SubmitEvent(const AtomString& type, Init&&);
     explicit SubmitEvent(RefPtr<HTMLElement>&& submitter);
 
-    bool isSubmitEvent() const final;
-
-    RefPtr<HTMLElement> m_submitter;
+    const RefPtr<HTMLElement> m_submitter;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -2583,13 +2583,13 @@ EventTimingInteractionID LocalDOMWindow::computeInteractionID(Event& event, Even
     }
     case EventType::click: {
         auto clickEvent = downcast<MouseEvent>(&event);
-        bool isBeingSimulatedDuringDefaultDispatch = clickEvent->isSimulated() && clickEvent->underlyingEvent() && clickEvent->underlyingEvent()->isKeyboardEvent();
-        if (isBeingSimulatedDuringDefaultDispatch) {
-            auto keyboardEvent = downcast<KeyboardEvent>(clickEvent->underlyingEvent());
-            if (keyboardEvent->interactionID().isUnassigned())
-                keyboardEvent->setInteractionID(generateInteractionID());
+        if (clickEvent->isSimulated()) {
+            if (auto* keyboardEvent = dynamicDowncast<KeyboardEvent>(clickEvent->underlyingEvent())) {
+                if (keyboardEvent->interactionID().isUnassigned())
+                    keyboardEvent->setInteractionID(generateInteractionID());
 
-            return keyboardEvent->interactionID();
+                return keyboardEvent->interactionID();
+            }
         }
 
         if (m_pointerMap.isUnassigned())

--- a/Source/WebCore/workers/service/ExtendableEvent.h
+++ b/Source/WebCore/workers/service/ExtendableEvent.h
@@ -50,14 +50,6 @@ public:
     WEBCORE_EXPORT void whenAllExtendLifetimePromisesAreSettled(Function<void(HashSet<Ref<DOMPromise>>&&)>&&);
 
     virtual bool isBackgroundFetchEvent() const { return false; }
-    virtual bool isBackgroundFetchUpdateUIEvent() const { return false; }
-    virtual bool isExtendableCookieChangeEvent() const { return false; }
-    virtual bool isExtendableMessageEvent() const { return false; }
-    virtual bool isFetchEvent() const { return false; }
-    virtual bool isInstallEvent() const { return false; }
-    virtual bool isNotificationEvent() const { return false; }
-    virtual bool isPushEvent() const { return false; }
-    virtual bool isPushSubscriptionChangeEvent() const { return false; }
 
 protected:
     WEBCORE_EXPORT ExtendableEvent(enum EventInterfaceType, const AtomString&, const ExtendableEventInit&, IsTrusted);
@@ -74,3 +66,13 @@ private:
 };
 
 } // namespace WebCore
+
+#define SPECIALIZE_TYPE_TRAITS_EXTENDABLEEVENT(ToValueTypeName) \
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ToValueTypeName) \
+    static bool isType(const WebCore::ExtendableEvent& event) { return event.interfaceType() == WebCore::EventInterfaceType::ToValueTypeName; } \
+SPECIALIZE_TYPE_TRAITS_END()
+
+#define SPECIALIZE_TYPE_TRAITS_EXTENDABLEEVENT_POLYMORPHIC(ToValueTypeName) \
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ToValueTypeName) \
+    static bool isType(const WebCore::ExtendableEvent& event) { return event.is##ToValueTypeName(); } \
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/workers/service/ExtendableMessageEvent.h
+++ b/Source/WebCore/workers/service/ExtendableMessageEvent.h
@@ -80,8 +80,6 @@ private:
     ExtendableMessageEvent(const AtomString&, const Init&, IsTrusted);
     ExtendableMessageEvent(const AtomString&, Ref<SecurityOrigin>&&, const String& lastEventId, std::optional<ExtendableMessageEventSource>&&, Vector<Ref<MessagePort>>&&);
 
-    bool isExtendableMessageEvent() const final { return true; }
-
     JSValueInWrappedObject m_data;
     const Variant<String, Ref<SecurityOrigin>> m_origin;
     String m_lastEventId;
@@ -92,6 +90,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ExtendableMessageEvent)
-    static bool isType(const WebCore::ExtendableEvent& event) { return event.isExtendableMessageEvent(); }
-SPECIALIZE_TYPE_TRAITS_END()
+SPECIALIZE_TYPE_TRAITS_EXTENDABLEEVENT(ExtendableMessageEvent)

--- a/Source/WebCore/workers/service/FetchEvent.h
+++ b/Source/WebCore/workers/service/FetchEvent.h
@@ -89,8 +89,6 @@ private:
     void processResponse(Expected<Ref<FetchResponse>, std::optional<ResourceError>>&&);
     void respondWithError(ResourceError&&);
 
-    bool isFetchEvent() const final { return true; }
-
     const Ref<FetchRequest> m_request;
     String m_clientId;
     String m_resultingClientId;
@@ -115,6 +113,4 @@ inline void FetchEvent::setNavigationPreloadIdentifier(FetchIdentifier identifie
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::FetchEvent)
-    static bool isType(const WebCore::ExtendableEvent& event) { return event.isFetchEvent(); }
-SPECIALIZE_TYPE_TRAITS_END()
+SPECIALIZE_TYPE_TRAITS_EXTENDABLEEVENT(FetchEvent)

--- a/Source/WebCore/workers/service/InstallEvent.h
+++ b/Source/WebCore/workers/service/InstallEvent.h
@@ -51,12 +51,8 @@ public:
 
 private:
     WEBCORE_EXPORT InstallEvent(const AtomString&, ExtendableEventInit&&, IsTrusted);
-
-    bool isInstallEvent() const final { return true; }
 };
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::InstallEvent)
-    static bool isType(const WebCore::ExtendableEvent& event) { return event.isInstallEvent(); }
-SPECIALIZE_TYPE_TRAITS_END()
+SPECIALIZE_TYPE_TRAITS_EXTENDABLEEVENT(InstallEvent)

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchEvent.h
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchEvent.h
@@ -51,6 +51,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::BackgroundFetchEvent)
-    static bool isType(const WebCore::ExtendableEvent& event) { return event.isBackgroundFetchEvent(); }
-SPECIALIZE_TYPE_TRAITS_END()
+SPECIALIZE_TYPE_TRAITS_EXTENDABLEEVENT_POLYMORPHIC(BackgroundFetchEvent)

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchUpdateUIEvent.h
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchUpdateUIEvent.h
@@ -44,12 +44,8 @@ public:
 
 private:
     BackgroundFetchUpdateUIEvent(const AtomString&, ExtendableEventInit&&, Ref<BackgroundFetchRegistration>&&, IsTrusted);
-
-    bool isBackgroundFetchUpdateUIEvent() const final { return true; }
 };
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::BackgroundFetchUpdateUIEvent)
-    static bool isType(const WebCore::ExtendableEvent& event) { return event.isBackgroundFetchUpdateUIEvent(); }
-SPECIALIZE_TYPE_TRAITS_END()
+SPECIALIZE_TYPE_TRAITS_EXTENDABLEEVENT(BackgroundFetchUpdateUIEvent)

--- a/Source/WebCore/xml/XMLHttpRequestProgressEvent.h
+++ b/Source/WebCore/xml/XMLHttpRequestProgressEvent.h
@@ -46,8 +46,6 @@ private:
         : ProgressEvent(EventInterfaceType::XMLHttpRequestProgressEvent, type, lengthComputable, loaded, total)
     {
     }
-
-    bool isXMLHttpRequestProgressEvent() const final { return true; }
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 26fdde367412b4923cf8cf86e179de3ff90b9bfa
<pre>
Refactor TYPE_TRAITS for events
<a href="https://bugs.webkit.org/show_bug.cgi?id=305312">https://bugs.webkit.org/show_bug.cgi?id=305312</a>
<a href="https://rdar.apple.com/167973075">rdar://167973075</a>

Reviewed by Chris Dumez.

All final event classes that are also in EventInterfaces.in can use
interfaceType(). SPECIALIZE_TYPE_TRAITS_EVENT implements this. This
obsoletes the need for SPECIALIZE_TYPE_TRAITS_ANIMATION_EVENT_BASE as
well.

SPECIALIZE_TYPE_TRAITS_EVENT_POLYMORPHIC is for event classes that can
have subclasses with their own interfaceType(), such as UIEvent.

This introduces an analogous setup for ExtendableEvent.

Canonical link: <a href="https://commits.webkit.org/305460@main">https://commits.webkit.org/305460@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf336d5a4856483b78ccf2d3941c26b02a612235

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138476 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10841 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49886 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146560 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91451 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e7953af0-ade3-4f85-87f8-09dd83a8b147) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140350 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11545 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10996 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105959 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77305 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/209d348f-0cb4-49ff-b7fb-05f121df6188) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141423 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8672 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124136 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86807 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c6682f45-4878-445c-a625-88f8dc2ba34e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8259 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6028 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6853 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117679 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42335 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149281 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10523 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42892 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/114362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10540 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8895 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114699 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8376 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120422 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65409 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21327 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10571 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38355 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10306 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74180 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10510 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10361 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->