### PR TITLE
Implement service worker static routing rules limitation checks

### DIFF
--- a/LayoutTests/http/wpt/service-workers/service-worker-routes.html
+++ b/LayoutTests/http/wpt/service-workers/service-worker-routes.html
@@ -16,11 +16,11 @@ promise_test(async test => {
     const worker = registration.installing;
     await waitForState(worker, "installing");
 
-    worker.postMessage(257);
+    worker.postMessage(1024);
     const result = await new Promise(resolve => navigator.serviceWorker.onmessage = e => resolve(e.data));
     worker.postMessage("finish");
 
-    assert_equals(result, "TypeError: Too many routes are registered");
+    assert_equals(result, "TypeError: Router registration limit is hit");
     await waitForState(worker, "redundant");
 }, "Try to register too many routes in one call");
 
@@ -42,8 +42,8 @@ promise_test(async test => {
     }
     worker.postMessage("finish");
 
-    assert_equals(result, "TypeError: Too many routes are registered");
-    assert_equals(counter, 256);
+    assert_equals(result, "TypeError: Router registration limit is hit");
+    assert_equals(counter, 1023);
     // FIXME: We should check that worker state goes to "redundant".
     // await waitForState(worker, "redundant");
 }, "Try to register too many routes incrementally");

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/static-router-invalid-rules.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/static-router-invalid-rules.https-expected.txt
@@ -2,8 +2,8 @@
 PASS addRoutes should raise for invalid ByteString request method.
 PASS addRoutes should raise for invalid HTTP request method.
 PASS addRoutes should raise for forbidden request method.
-FAIL addRoutes should raise if or condition exceeds the depth limit assert_equals: expected 1 but got 0
-FAIL addRoutes should raise if not condition exceeds the depth limit assert_equals: expected 1 but got 0
+PASS addRoutes should raise if or condition exceeds the depth limit
+PASS addRoutes should raise if not condition exceeds the depth limit
 PASS addRoutes should raise if the number of router rules exceeds the length limit
 PASS addRoutes should raise if the conditon does not exist in the rule
 PASS addRoutes should raise if the source does not exiswt in the rule

--- a/Source/WebCore/workers/service/ServiceWorkerRoute.h
+++ b/Source/WebCore/workers/service/ServiceWorkerRoute.h
@@ -81,7 +81,7 @@ struct ServiceWorkerRoute {
     ServiceWorkerRoute isolatedCopy() &&;
 };
 
-size_t computeServiceWorkerRouteConditionCount(const ServiceWorkerRoute&);
+std::optional<size_t> countRouterInnerConditions(const ServiceWorkerRouteCondition&, size_t result, size_t depth);
 std::optional<ExceptionData> validateServiceWorkerRoute(ServiceWorkerRoute&);
 bool matchRouterCondition(const ServiceWorkerRouteCondition&, const FetchOptions&, const ResourceRequest&, bool isServiceWorkerRunning);
 


### PR DESCRIPTION
#### 4e2674966e4eade49288ae334325d148f706ea3a
<pre>
Implement service worker static routing rules limitation checks
<a href="https://rdar.apple.com/167977145">rdar://167977145</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=305316">https://bugs.webkit.org/show_bug.cgi?id=305316</a>

Reviewed by Chris Dumez.

We add a limit to 1024 route conditions and a max depth of 10, as per <a href="https://w3c.github.io/ServiceWorker/#check-router-registration-limit-algorithm.">https://w3c.github.io/ServiceWorker/#check-router-registration-limit-algorithm.</a>
Covered by rebased test.

Canonical link: <a href="https://commits.webkit.org/305501@main">https://commits.webkit.org/305501@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0bd9477195c3c8cc8416fa6d3d919b1ddccd5901

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138481 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10846 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49891 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146586 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91456 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f62d60f2-0aa2-49b2-a1b2-11e0d28288ae) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140355 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11550 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11001 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105991 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77309 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/988aa3aa-e0ae-4f63-9fdc-fe3c18391ba8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141428 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8678 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124141 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86853 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8265 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6033 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6858 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117685 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42340 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149326 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10528 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42897 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114364 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10545 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8900 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114701 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29162 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8383 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120427 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65415 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10576 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38360 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10311 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74186 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10515 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10366 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->