### PR TITLE
[WebXR] Viewports don't get an initial value until getViewport is called

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXRWebGLLayer.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLLayer.cpp
@@ -172,6 +172,7 @@ WebXRWebGLLayer::WebXRWebGLLayer(WebXRSession& session, WebXRRenderingContext&& 
     , m_ignoreDepthValues(ignoreDepthValues)
     , m_isCompositionEnabled(isCompositionEnabled)
 {
+    updateViewports();
 }
 
 WebXRWebGLLayer::~WebXRWebGLLayer()
@@ -245,7 +246,7 @@ ExceptionOr<RefPtr<WebXRViewport>> WebXRWebGLLayer::getViewport(WebXRView& view)
     // 7. Set the view’s viewport modifiable flag to false.
     view.setViewportModifiable(false);
 
-    computeViewports();
+    updateViewports();
 
     // 8. Let viewport be the XRViewport from the list of viewport objects associated with view.
     // 9. Return viewport.
@@ -336,7 +337,7 @@ void WebXRWebGLLayer::canvasResized(CanvasBase&)
 }
 
 // https://immersive-web.github.io/webxr/#xrview-obtain-a-scaled-viewport
-void WebXRWebGLLayer::computeViewports()
+void WebXRWebGLLayer::updateViewports()
 {
     ASSERT(m_session);
 

--- a/Source/WebCore/Modules/webxr/WebXRWebGLLayer.h
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLLayer.h
@@ -97,7 +97,7 @@ private:
 
     bool isWebXRWebGLLayer() const final { return true; }
 
-    void computeViewports();
+    void updateViewports();
     static IntSize computeNativeWebGLFramebufferResolution();
     static IntSize computeRecommendedWebGLFramebufferResolution();
 


### PR DESCRIPTION
#### 8de7eac55bb0942bad22089579f1ad34d375b30c
<pre>
[WebXR] Viewports don&apos;t get an initial value until getViewport is called
<a href="https://bugs.webkit.org/show_bug.cgi?id=305313">https://bugs.webkit.org/show_bug.cgi?id=305313</a>

Reviewed by Fujii Hironori.

Base layer viewports used to be initialized only after calling
getViewport(). That&apos;s fine from the JS point of view. However if the
WebXR application does not call getViewport() (for example if it does
not want to render anything, or for whatever other reason) then the
viewports won&apos;t ever be initialized. That could cause issues with
underlying platforms (like OpenXR) because we&apos;d be asking the compositor
to render a layer with a 0x0 sized viewport.

Other relevant implementations like Blink do also initialize the
viewport before the getViewport() call.

No new tests as this cannot be easily tested. In order to get the
viewport size in JS you have to call getViewport() so the viewports
would get properly initialized. Apart from that we have seen issues
related to that in specific runtimes but others just handle it fine.

* Source/WebCore/Modules/webxr/WebXRWebGLLayer.cpp:
(WebCore::m_isCompositionEnabled):
(WebCore::WebXRWebGLLayer::getViewport):
(WebCore::WebXRWebGLLayer::updateViewports):
(WebCore::WebXRWebGLLayer::computeViewports): Deleted.
* Source/WebCore/Modules/webxr/WebXRWebGLLayer.h:

Canonical link: <a href="https://commits.webkit.org/305565@main">https://commits.webkit.org/305565@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39771eb948fad38bcbf8b4f706b3a2a6151e59ff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138475 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10840 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49885 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146559 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91450 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140349 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11544 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10995 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105958 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77302 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141422 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8674 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124137 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86806 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8261 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6027 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6852 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117681 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42336 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149280 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10522 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42893 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114359 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10539 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8894 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114698 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29209 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8374 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120423 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65408 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10570 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38356 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10305 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74179 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10509 "Built successfully") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10360 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | | 
<!--EWS-Status-Bubble-End-->