### PR TITLE
Remove remaining std::variant usage and add style check

### DIFF
--- a/Source/WebCore/Modules/identity/protocols/UnvalidatedDigitalCredentialRequest.h
+++ b/Source/WebCore/Modules/identity/protocols/UnvalidatedDigitalCredentialRequest.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#include <variant>
-
 namespace WebCore {
 
 struct MobileDocumentRequest;
@@ -34,4 +32,3 @@ struct MobileDocumentRequest;
 using UnvalidatedDigitalCredentialRequest = MobileDocumentRequest;
 
 } // namespace WebCore
-

--- a/Source/WebCore/platform/MediaSample.h
+++ b/Source/WebCore/platform/MediaSample.h
@@ -28,11 +28,11 @@
 #include <WebCore/FloatSize.h>
 #include <WebCore/MediaPlayerEnums.h>
 #include <functional>
-#include <variant>
 #include <wtf/MediaTime.h>
 #include <wtf/Platform.h>
 #include <wtf/PrintStream.h>
 #include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/Variant.h>
 #include <wtf/text/AtomString.h>
 
 typedef struct opaqueCMSampleBuffer *CMSampleBufferRef;
@@ -51,7 +51,7 @@ using TrackID = uint64_t;
 
 class PlatformSample {
 public:
-    using VariantType = std::variant<const MockSampleBox*
+    using VariantType = Variant<const MockSampleBox*
 #if PLATFORM(COCOA)
         , RetainPtr<CMSampleBufferRef>
 #elif USE(GSTREAMER)

--- a/Source/WebCore/platform/SharedBuffer.h
+++ b/Source/WebCore/platform/SharedBuffer.h
@@ -29,7 +29,6 @@
 #include <JavaScriptCore/Forward.h>
 #include <span>
 #include <utility>
-#include <variant>
 #include <wtf/FileSystem.h>
 #include <wtf/Forward.h>
 #include <wtf/Function.h>

--- a/Source/WebCore/platform/graphics/Path.h
+++ b/Source/WebCore/platform/graphics/Path.h
@@ -32,9 +32,9 @@
 #include <WebCore/PathSegment.h>
 #include <WebCore/PlatformPath.h>
 #include <WebCore/WindRule.h>
-#include <variant>
 #include <wtf/DataRef.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/Variant.h>
 
 namespace WebCore {
 

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -5942,6 +5942,54 @@ class WebKitStyleTest(CppStyleTestBase):
             "  [build/using_std] [4]",
             'foo.mm')
 
+    def test_variant_usage(self):
+        # Test detection of <variant> include
+        self.assert_lint(
+            '#include <variant>',
+            "Use '#include <wtf/Variant.h>' and 'WTF::Variant' instead of '#include <variant>' and 'std::variant'."
+            "  [build/variant] [4]",
+            'foo.cpp')
+
+        # Test detection of std::variant usage
+        self.assert_lint(
+            'using MyVariant = std::variant<int, double>;',
+            "Use 'WTF::Variant' instead of 'std::variant'. WTF::Variant provides better code size and performance."
+            "  [build/variant] [4]",
+            'foo.cpp')
+
+        self.assert_lint(
+            'std::variant<Foo, Bar> m_data;',
+            "Use 'WTF::Variant' instead of 'std::variant'. WTF::Variant provides better code size and performance."
+            "  [build/variant] [4]",
+            'foo.h')
+
+        # Test that WTF::Variant is acceptable
+        self.assert_lint(
+            'using MyVariant = Variant<int, double>;',
+            '',
+            'foo.cpp')
+
+        self.assert_lint(
+            '#include <wtf/Variant.h>',
+            '',
+            'foo.cpp')
+
+        self.assert_lint(
+            'Variant<Foo, Bar> m_data;',
+            '',
+            'foo.h')
+
+        # Test that the check doesn't apply to C files
+        self.assert_lint(
+            '#include <variant>',
+            '',
+            'foo.c')
+
+        self.assert_lint(
+            'std::variant<int, double> data;',
+            '',
+            'foo.c')
+
     def test_using_namespace(self):
         self.assert_lint(
             'using namespace foo;',


### PR DESCRIPTION
#### a9e262a7bac3911b82f1454cd42850d14ab29f37
<pre>
Remove remaining std::variant usage and add style check
<a href="https://bugs.webkit.org/show_bug.cgi?id=305322">https://bugs.webkit.org/show_bug.cgi?id=305322</a>

Reviewed by Chris Dumez.

As per 299791@main this is what we want. Let&apos;s make it clearer for
people adding new code.

Canonical link: <a href="https://commits.webkit.org/305499@main">https://commits.webkit.org/305499@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21021a713b6d61e489bd2bf2daf6df911fcaf7f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138488 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10853 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49898 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146582 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91463 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a3427a0e-f4a1-47af-a2d8-e9f306c34858) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140362 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11557 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11008 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/105998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77314 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b2a6bfde-ca8a-49ce-a21a-1f39771c719b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141435 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8683 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124148 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86860 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d8e04af1-608b-41d8-a159-b141fe935fe4) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/137836 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8270 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6039 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6877 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117690 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42347 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149333 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10535 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42904 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114365 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10552 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8906 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114702 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8400 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120434 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65424 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21341 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10584 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38367 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10318 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74195 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10522 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10373 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->