### PR TITLE
[GStreamer][WebRTC][Rice] Improve support for TCP sockets

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.h
@@ -87,7 +87,8 @@ public:
 
     virtual void send(unsigned, RTCIceProtocol, String&&, String&&, SharedMemory::Handle&&) = 0;
 
-    virtual Vector<String> gatherSocketAddresses(unsigned) = 0;
+    using Socket = std::pair<String, RTCIceProtocol>;
+    virtual HashMap<Socket, String> gatherSocketAddresses(ScriptExecutionContextIdentifier, unsigned) = 0;
     virtual void finalizeStream(unsigned) = 0;
 
 protected:
@@ -102,8 +103,9 @@ protected:
 WebKitGstIceAgent* webkitGstWebRTCCreateIceAgent(const String&, WebCore::ScriptExecutionContext*);
 
 const GRefPtr<RiceAgent>& webkitGstWebRTCIceAgentGetRiceAgent(WebKitGstIceAgent*);
+
 Vector<GRefPtr<RiceTurnConfig>> webkitGstWebRTCIceAgentGetTurnConfigs(WebKitGstIceAgent*);
-Vector<String> webkitGstWebRTCIceAgentGatherSocketAddresses(WebKitGstIceAgent*, unsigned);
+HashMap<std::pair<String, WebCore::RTCIceProtocol>, String> webkitGstWebRTCIceAgentGatherSocketAddresses(WebKitGstIceAgent*, unsigned);
 
 GstWebRTCICETransport *webkitGstWebRTCIceAgentCreateTransport(WebKitGstIceAgent*, GThreadSafeWeakPtr<WebKitGstIceStream>&&, WebCore::RTCIceComponent);
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceStream.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceStream.cpp
@@ -159,14 +159,14 @@ static gboolean webkitGstWebRTCIceStreamGatherCandidates(GstWebRTCICEStream* ice
 
     Vector<GUniquePtr<RiceAddress>> riceAddresses;
     Vector<RiceTransportType> riceTransports;
-    for (const auto& address : addresses) {
-        GUniquePtr<RiceAddress> addr(rice_address_new_from_string(address.ascii().data()));
+    for (const auto& address : addresses.keys()) {
+        auto& [addressString, protocol] = address;
+        GUniquePtr<RiceAddress> addr(rice_address_new_from_string(addressString.ascii().data()));
         if (!addr) [[unlikely]]
             continue;
 
         riceAddresses.append(WTF::move(addr));
-        riceTransports.append(RICE_TRANSPORT_TYPE_UDP);
-        riceTransports.append(RICE_TRANSPORT_TYPE_TCP);
+        riceTransports.append(fromRTCIceProtocol(protocol));
     }
     Vector<const RiceAddress*> riceAddressValues;
     for (const auto& addr : riceAddresses)
@@ -203,15 +203,7 @@ bool webkitGstWebRTCIceStreamGatherCandidates(WebKitGstIceStream* stream)
 
 void webkitGstWebRTCIceStreamHandleIncomingData(const WebKitGstIceStream* stream, WebCore::RTCIceProtocol protocol, String&& from, String&& to, SharedMemory::Handle&& handle)
 {
-    RiceTransportType transport;
-    switch (protocol) {
-    case WebCore::RTCIceProtocol::Tcp:
-        transport = RICE_TRANSPORT_TYPE_TCP;
-        break;
-    case WebCore::RTCIceProtocol::Udp:
-        transport = RICE_TRANSPORT_TYPE_UDP;
-        break;
-    };
+    RiceTransportType transport = fromRTCIceProtocol(protocol);
     auto riceFrom = riceAddressFromString(from);
     auto riceTo = riceAddressFromString(to);
 

--- a/Source/WebCore/platform/rice/RiceUtilities.h
+++ b/Source/WebCore/platform/rice/RiceUtilities.h
@@ -81,6 +81,18 @@ static inline std::optional<SharedMemory::Handle> riceTransmitToSharedMemoryHand
     return SharedMemoryHandle::createCopy(unsafeMakeSpan(transmit->data.ptr, transmit->data.size), SharedMemoryProtection::ReadOnly);
 }
 
+
+static inline RiceTransportType fromRTCIceProtocol(RTCIceProtocol protocol)
+{
+    switch (protocol) {
+    case RTCIceProtocol::Tcp:
+        return RICE_TRANSPORT_TYPE_TCP;
+    case WebCore::RTCIceProtocol::Udp:
+        return RICE_TRANSPORT_TYPE_UDP;
+    };
+    return RICE_TRANSPORT_TYPE_UDP;
+}
+
 static inline RTCIceProtocol riceTransmitTransportToIceProtocol(const RiceTransmit& transmit)
 {
     switch (transmit.transport) {

--- a/Source/WebKit/NetworkProcess/webrtc/rice/RiceBackend.h
+++ b/Source/WebKit/NetworkProcess/webrtc/rice/RiceBackend.h
@@ -31,6 +31,7 @@
 #include <WebCore/GUniquePtrRice.h>
 #include <WebCore/RTCIceComponent.h>
 #include <WebCore/RTCIceProtocol.h>
+#include <WebCore/ScriptExecutionContextIdentifier.h>
 #include <WebCore/SharedMemory.h>
 #include <wtf/Expected.h>
 #include <wtf/Forward.h>
@@ -42,6 +43,7 @@
 #include <wtf/URL.h>
 #include <wtf/URLHash.h>
 #include <wtf/Vector.h>
+#include <wtf/glib/GUniquePtr.h>
 #include <wtf/text/WTFString.h>
 
 namespace IPC {
@@ -77,7 +79,8 @@ public:
     void sendData(unsigned, WebCore::RTCIceProtocol, String, String, WebCore::SharedMemory::Handle&&);
     void finalizeStream(unsigned);
 
-    void gatherSocketAddresses(unsigned, CompletionHandler<void(Vector<String> &&)>&&);
+    using GatherSocketAddressesCallback = CompletionHandler<void(HashMap<std::pair<String, WebCore::RTCIceProtocol>, String>&&)>;
+    void gatherSocketAddresses(WebCore::ScriptExecutionContextIdentifier, unsigned, GatherSocketAddressesCallback&&);
 
     GRefPtr<RiceSockets> getSocketsForStream(unsigned);
     GRefPtr<GSource> getRecvSourceForStream(unsigned);

--- a/Source/WebKit/NetworkProcess/webrtc/rice/RiceBackend.messages.in
+++ b/Source/WebKit/NetworkProcess/webrtc/rice/RiceBackend.messages.in
@@ -23,7 +23,7 @@
     DispatchedTo=Networking
 ]
 messages -> RiceBackend {
-    GatherSocketAddresses(unsigned streamId) -> (Vector<String> addresses) Synchronous
+    GatherSocketAddresses(WebCore::ScriptExecutionContextIdentifier identifier, unsigned streamId) -> (HashMap<std::pair<String, WebCore::RTCIceProtocol>, String> addresses) Synchronous
     SendData(unsigned streamId, enum:uint8_t WebCore::RTCIceProtocol protocol, String from, String to, WebCore::SharedMemory::Handle data);
     FinalizeStream(unsigned streamId);
     ResolveAddress(String address) -> (Expected<String, WebCore::ExceptionData> result)

--- a/Source/WebKit/WebProcess/Network/webrtc/rice/RiceBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/rice/RiceBackendProxy.cpp
@@ -84,11 +84,11 @@ void RiceBackendProxy::resolveAddress(const String& address, RiceBackend::Resolv
     }, messageSenderDestinationID());
 }
 
-Vector<String> RiceBackendProxy::gatherSocketAddresses(unsigned streamId)
+HashMap<WebCore::RiceBackend::Socket, String> RiceBackendProxy::gatherSocketAddresses(WebCore::ScriptExecutionContextIdentifier identifier, unsigned streamId)
 {
-    Vector<String> addresses;
+    HashMap<WebCore::RiceBackend::Socket, String> addresses;
     callOnMainRunLoopAndWait([&] {
-        auto sendResult = m_connection->sendSync(Messages::RiceBackend::GatherSocketAddresses { streamId }, messageSenderDestinationID(), 3_s);
+        auto sendResult = m_connection->sendSync(Messages::RiceBackend::GatherSocketAddresses { identifier, streamId }, messageSenderDestinationID(), 3_s);
         if (!sendResult.succeeded())
             return;
 

--- a/Source/WebKit/WebProcess/Network/webrtc/rice/RiceBackendProxy.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/rice/RiceBackendProxy.h
@@ -59,8 +59,10 @@ private:
 
     // RiceBackend (Web -> Network)
     void resolveAddress(const String&, WebCore::RiceBackend::ResolveAddressCallback&&) final;
+
     void send(unsigned, WebCore::RTCIceProtocol, String&&, String&&, WebCore::SharedMemory::Handle&&) final;
-    Vector<String> gatherSocketAddresses(unsigned) final;
+    HashMap<WebCore::RiceBackend::Socket, String> gatherSocketAddresses(WebCore::ScriptExecutionContextIdentifier, unsigned) final;
+
     void finalizeStream(unsigned) final;
 
     void refRiceBackend() final { ref(); }


### PR DESCRIPTION
#### e96072a85ff975a0891b930be4fd6777882a4e1c
<pre>
[GStreamer][WebRTC][Rice] Improve support for TCP sockets
<a href="https://bugs.webkit.org/show_bug.cgi?id=305321">https://bugs.webkit.org/show_bug.cgi?id=305321</a>

Reviewed by Xabier Rodriguez-Calvar.

Add support for ICE protocol signaling in the IPC used for gathering socket addresses, so that it
can then be taken into account on WebProcess side in the ICE proto agent.

Driving-by, add null promise checks in the AddCandidate function and fix the code that extracts
IPs/hosts from SDP candidates (it wasn&apos;t accounting for space characters).

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.cpp:
(getCandidateAddress):
(webkitGstWebRTCIceAgentAddCandidate):
(webkit_gst_webrtc_ice_backend_class_init):
(webkitGstWebRTCIceAgentGatherSocketAddresses):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceStream.cpp:
(webkitGstWebRTCIceStreamGatherCandidates):
(webkitGstWebRTCIceStreamHandleIncomingData):
* Source/WebCore/platform/rice/RiceUtilities.h:
(WebCore::fromRTCIceProtocol):
* Source/WebKit/NetworkProcess/webrtc/rice/RiceBackend.cpp:
(WebKit::recvSourceDispatch):
(WebKit::recvSourceWakeup):
(WebKit::recvSourceNew):
(WebKit::RiceBackend::sendData):
(WebKit::RiceBackend::gatherSocketAddresses):
* Source/WebKit/NetworkProcess/webrtc/rice/RiceBackend.h:
* Source/WebKit/NetworkProcess/webrtc/rice/RiceBackend.messages.in:
* Source/WebKit/WebProcess/Network/webrtc/rice/RiceBackendProxy.cpp:
(WebKit::RiceBackendProxy::gatherSocketAddresses):
* Source/WebKit/WebProcess/Network/webrtc/rice/RiceBackendProxy.h:

Canonical link: <a href="https://commits.webkit.org/305502@main">https://commits.webkit.org/305502@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ccb3adc6651d528d67cf6cb9de8f99728a3c67d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138483 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10848 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49893 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146584 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91458 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140357 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11552 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11003 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105989 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77310 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141430 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8679 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124143 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86851 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8266 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6034 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6876 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117686 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42342 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149328 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10530 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42899 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114367 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10547 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8901 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114704 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29164 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8389 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120429 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65418 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10579 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38362 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10313 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74189 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10517 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10368 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->