### PR TITLE
Add support for DOMCache service worker router source

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/static-router-main-resource.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/static-router-main-resource.https-expected.txt
@@ -4,7 +4,7 @@ FAIL Main resource load matched with the ignore case condition assert_equals: ex
 PASS Main resource load matched without the ignore case condition
 PASS Main resource load not matched with the condition
 FAIL Main resource load matched with the cache source assert_equals: expected 0 but got 1
-FAIL Main resource fallback to the network when there is no cache entry assert_equals: expected 0 but got 1
+PASS Main resource fallback to the network when there is no cache entry
 FAIL Main resource load matched with the cache source, with specifying the cache name assert_equals: expected 0 but got 1
 FAIL Main resource load should not match the condition with not assert_equals: expected 1 but got 0
 PASS Main resource load should match the condition without not

--- a/Source/WebCore/loader/CrossOriginEmbedderPolicy.h
+++ b/Source/WebCore/loader/CrossOriginEmbedderPolicy.h
@@ -67,7 +67,7 @@ struct CrossOriginEmbedderPolicy {
     String reportOnlyReportingEndpoint;
 
     CrossOriginEmbedderPolicy isolatedCopy() const &;
-    CrossOriginEmbedderPolicy isolatedCopy() &&;
+    WEBCORE_EXPORT CrossOriginEmbedderPolicy isolatedCopy() &&;
     void encode(WTF::Persistence::Encoder&) const;
     static std::optional<CrossOriginEmbedderPolicy> decode(WTF::Persistence::Decoder &);
 

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageCache.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageCache.h
@@ -60,6 +60,9 @@ public:
     void removeAllRecords();
     void close();
 
+    Vector<CacheStorageRecordInformation> findRecords(const WebCore::RetrieveRecordsOptions&);
+    void retrieveRecords(const Vector<CacheStorageRecordInformation>&, WebCore::RetrieveRecordsOptions&&, WebCore::DOMCacheEngine::CrossThreadRecordsCallback&&);
+
 private:
     CacheStorageCache(CacheStorageManager&, const String& name, const String& uniqueName, const String& path, Ref<WorkQueue>&&);
     CacheStorageRecordInformation* findExistingRecord(const WebCore::ResourceRequest&, std::optional<uint64_t> = std::nullopt);

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageManager.h
@@ -37,6 +37,7 @@ class CacheStorageManager;
 
 namespace WebCore {
 struct ClientOrigin;
+struct RetrieveRecordsOptions;
 }
 
 namespace WebKit {
@@ -76,6 +77,8 @@ public:
     void sizeIncreased(uint64_t amount);
     void sizeDecreased(uint64_t amount);
     void reset();
+
+    void query(WebCore::RetrieveRecordsOptions&&, String&&, CompletionHandler<void(std::optional<WebCore::DOMCacheEngine::CrossThreadRecord>&&)>&&);
 
 private:
     CacheStorageManager(const String& path, CacheStorageRegistry&, const std::optional<WebCore::ClientOrigin>&, QuotaCheckFunction&&, Ref<WorkQueue>&&);

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -65,6 +65,10 @@ namespace IDBServer {
 class UniqueIDBDatabaseTransaction;
 }
 
+namespace DOMCacheEngine {
+struct Record;
+}
+
 class IDBCursorInfo;
 class IDBKeyData;
 class IDBIndexInfo;
@@ -151,6 +155,8 @@ public:
     void updateServiceWorkerRegistrations(Vector<WebCore::ServiceWorkerContextData>&&, Vector<WebCore::ServiceWorkerRegistrationKey>&&, CompletionHandler<void(std::optional<Vector<WebCore::ServiceWorkerScripts>>)>&&);
     const String& path() const { return m_pathNormalizedMainThread; }
     const String& customIDBStoragePath() const { return m_customIDBStoragePathNormalizedMainThread; }
+
+    void queryCacheStorage(WebCore::ClientOrigin&&, WebCore::RetrieveRecordsOptions&&, String&&, CompletionHandler<void(std::optional<WebCore::DOMCacheEngine::Record>&&)>&&);
 
 private:
     NetworkStorageManager(NetworkProcess&, PAL::SessionID, Markable<WTF::UUID>, std::optional<IPC::Connection::UniqueID>, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, const String& customServiceWorkerStoragePath, uint64_t defaultOriginQuota, std::optional<double> originQuotaRatio, std::optional<double> totalQuotaRatio, std::optional<uint64_t> standardVolumeCapacity, std::optional<uint64_t> volumeCapacityOverride, UnifiedOriginStorageLevel, bool storageSiteValidationEnabled);


### PR DESCRIPTION
#### f2761152bf0337ba2f4bc9daca0e7da0ec38df33
<pre>
Add support for DOMCache service worker router source
<a href="https://rdar.apple.com/167981904">rdar://167981904</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=305323">https://bugs.webkit.org/show_bug.cgi?id=305323</a>

Reviewed by Chris Dumez.

We update NetworkStorageManager to allow get a response from DOMCache as per <a href="https://w3c.github.io/ServiceWorker/#ref-for-dom-routersourceenum-cache.">https://w3c.github.io/ServiceWorker/#ref-for-dom-routersourceenum-cache.</a>
To fully implement DOMCache service worker route, we update ServiceWorkerFetchTask, the main entry point being ServiceWorkerFetchTask::fromCache.

Covered by existing rebased WPT tests.

Canonical link: <a href="https://commits.webkit.org/305632@main">https://commits.webkit.org/305632@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3dda1d0ca81b46d62dda5bdc9bd3c191122030e0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138991 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11358 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/478 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147110 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fce31bbf-9c05-4907-970d-f3649e4d2a8f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140864 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12066 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11514 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106389 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7989fab8-55e0-4667-98a0-cc4747cccf6b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141938 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9108 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/124505 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87263 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/73cb2005-217a-40e7-93f8-18da5d45bd1f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8670 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6431 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7411 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118109 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/403 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149896 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11042 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/409 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114782 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11061 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9336 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115101 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29246 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8986 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120854 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65945 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11089 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/387 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10826 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74739 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11029 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10877 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->