### PR TITLE
[WPE] WPE Platform: allow to add multiple callbacks to WPEScreenSyncObserver

### DIFF
--- a/Source/WebKit/UIProcess/wpe/DisplayVBlankMonitorWPE.h
+++ b/Source/WebKit/UIProcess/wpe/DisplayVBlankMonitorWPE.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(WPE_PLATFORM)
 #include "DisplayVBlankMonitor.h"
+#include <wtf/Lock.h>
 #include <wtf/glib/GRefPtr.h>
 
 typedef struct _WPEScreenSyncObserver WPEScreenSyncObserver;
@@ -39,7 +40,7 @@ public:
     DisplayVBlankMonitorWPE(unsigned, GRefPtr<WPEScreenSyncObserver>&&);
     virtual ~DisplayVBlankMonitorWPE();
 
-    WPEScreenSyncObserver* observer() const { return m_observer.get(); }
+    WPEScreenSyncObserver* observer() const;
 
 private:
     Type type() const override { return Type::Wpe; }
@@ -49,7 +50,12 @@ private:
     bool isActive() final;
     void invalidate() final;
 
-    GRefPtr<WPEScreenSyncObserver> m_observer;
+    void addCallbackIfNeeded();
+    void removeCallbackIfNeeded();
+
+    mutable Lock m_lock;
+    GRefPtr<WPEScreenSyncObserver> m_observer WTF_GUARDED_BY_LOCK(m_lock);
+    unsigned m_callbackID { 0 };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WPEPlatform/wpe/WPEScreenSyncObserver.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEScreenSyncObserver.h
@@ -43,7 +43,7 @@ WPE_API WPE_DECLARE_DERIVABLE_TYPE (WPEScreenSyncObserver, wpe_screen_sync_obser
  * @observer: a #WPEScreenSyncObserver
  * @user_data: user data
  *
- * Function passed to wpe_screen_sync_observer_add() to be called on
+ * Function passed to wpe_screen_sync_observer_add_callback() to be called on
  * every #WPEScreen sync.
  */
 typedef void (* WPEScreenSyncObserverSyncFunc) (WPEScreenSyncObserver *observer,
@@ -60,13 +60,12 @@ struct _WPEScreenSyncObserverClass
     gpointer padding[32];
 };
 
-WPE_API void     wpe_screen_sync_observer_set_callback (WPEScreenSyncObserver        *observer,
-                                                        WPEScreenSyncObserverSyncFunc sync_func,
-                                                        gpointer                      user_data,
-                                                        GDestroyNotify                destroy_notify);
-WPE_API void     wpe_screen_sync_observer_start        (WPEScreenSyncObserver        *observer);
-WPE_API void     wpe_screen_sync_observer_stop         (WPEScreenSyncObserver        *observer);
-WPE_API gboolean wpe_screen_sync_observer_is_active    (WPEScreenSyncObserver        *observer);
+WPE_API guint    wpe_screen_sync_observer_add_callback    (WPEScreenSyncObserver        *observer,
+                                                           WPEScreenSyncObserverSyncFunc sync_func,
+                                                           gpointer                      user_data,
+                                                           GDestroyNotify                destroy_notify);
+WPE_API void     wpe_screen_sync_observer_remove_callback (WPEScreenSyncObserver        *observer,
+                                                           guint                         id);
 
 G_END_DECLS
 


### PR DESCRIPTION
#### 403f2d9b29d603035152e7e913ed83e1dda1c212
<pre>
[WPE] WPE Platform: allow to add multiple callbacks to WPEScreenSyncObserver
<a href="https://bugs.webkit.org/show_bug.cgi?id=305326">https://bugs.webkit.org/show_bug.cgi?id=305326</a>

Reviewed by Adrian Perez de Castro.

This can happen if there are more than one web context, like when using
the local inspector. There&apos;s just one WPEScreenSyncObserver, since it&apos;s
created per WPEScreen, but multiple DisplayLink objects, since they are
managed by ProcessPool. In that case we need to be able to set a
callback for both DisplayLink objects. This patch replaces the current
API using a single set_callback() method and start() and stop() by new
API based on add_callback() and remove_callback(). The monitor is
automatically started when the first callback is added and stopped when
the last one is removed.

* Source/WebKit/UIProcess/wpe/DisplayVBlankMonitorWPE.cpp:
(WebKit::DisplayVBlankMonitorWPE::DisplayVBlankMonitorWPE):
(WebKit::DisplayVBlankMonitorWPE::~DisplayVBlankMonitorWPE):
(WebKit::DisplayVBlankMonitorWPE::observer const):
(WebKit::DisplayVBlankMonitorWPE::addCallbackIfNeeded):
(WebKit::DisplayVBlankMonitorWPE::removeCallbackIfNeeded):
(WebKit::DisplayVBlankMonitorWPE::start):
(WebKit::DisplayVBlankMonitorWPE::stop):
(WebKit::DisplayVBlankMonitorWPE::invalidate):
(WebKit::DisplayVBlankMonitorWPE::isActive):
* Source/WebKit/UIProcess/wpe/DisplayVBlankMonitorWPE.h:
* Source/WebKit/WPEPlatform/wpe/WPEScreenSyncObserver.cpp:
(ObserverCallback::ObserverCallback):
(ObserverCallback::~ObserverCallback):
(wpeScreenSyncObserverSync):
(wpe_screen_sync_observer_class_init):
(wpe_screen_sync_observer_add_callback):
(wpe_screen_sync_observer_remove_callback):
(wpeScreenSyncObserverDispose): Deleted.
(wpe_screen_sync_observer_set_callback): Deleted.
(wpe_screen_sync_observer_start): Deleted.
(wpe_screen_sync_observer_stop): Deleted.
(wpe_screen_sync_observer_is_active): Deleted.
* Source/WebKit/WPEPlatform/wpe/WPEScreenSyncObserver.h:

Canonical link: <a href="https://commits.webkit.org/305509@main">https://commits.webkit.org/305509@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93d305de63a232fae9f3764df9fa82139ef1df32

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138619 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10984 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/100 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146732 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/91595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11688 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11140 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/106072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/91595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141566 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8805 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/124249 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86936 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8393 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/6160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7023 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117810 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149485 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/137221 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10666 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/87 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/114448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10683 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/9029 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114790 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8604 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120545 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/65563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21350 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10715 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/87 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10450 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/74361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10653 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10504 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->