### PR TITLE
Move InlineDisplay::Line::Ellipsis to a side structure

### DIFF
--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.cpp
@@ -445,10 +445,14 @@ InlineRect InlineFormattingContext::createDisplayContentForInlineContent(const L
         }
         auto isLegacyLineClamp = lineClamp && lineClamp->isLegacy;
         auto truncationPolicy = InlineFormattingUtils::lineEndingTruncationPolicy(root().style(), numberOfLinesWithInlineContent, numberOfVisibleLinesAllowed, lineBox.hasContent());
-        InlineDisplayLineBuilder::applyEllipsisIfNeeded(truncationPolicy, displayLine, boxes, isLegacyLineClamp);
-        auto lineHasLegacyLineClamp = isLegacyLineClamp && displayLine.hasEllipsis() && truncationPolicy == LineEndingTruncationPolicy::WhenContentOverflowsInBlockDirection;
-        if (lineHasLegacyLineClamp)
-            inlineLayoutState.setLegacyClampedLineIndex(lineBox.lineIndex());
+        auto ellipsis = InlineDisplayLineBuilder::applyEllipsisIfNeeded(truncationPolicy, displayLine, boxes, isLegacyLineClamp);
+        if (ellipsis) {
+            displayContent.setLineEllipsis(lineBox.lineIndex(), WTF::move(*ellipsis));
+            displayLine.setHasEllipsis();
+            auto lineHasLegacyLineClamp = isLegacyLineClamp && truncationPolicy == LineEndingTruncationPolicy::WhenContentOverflowsInBlockDirection;
+            if (lineHasLegacyLineClamp)
+                inlineLayoutState.setLegacyClampedLineIndex(lineBox.lineIndex());
+        }
     };
     addTrailingEllipsisIfApplicable();
 

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContent.h
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContent.h
@@ -44,8 +44,18 @@ struct Content {
     void insert(Content&& newContent, size_t lineIndex, size_t boxIndex);
     void remove(size_t firstLineIndex, size_t numberOfLines, size_t firstBoxIndex, size_t numberOfBoxes);
 
+    std::optional<Line::Ellipsis> lineEllipsis(size_t) const;
+    void setLineEllipsis(size_t line, Line::Ellipsis&&);
+
+    void moveLineInBlockDirection(size_t, float offset);
+    void shrinkLineInBlockDirection(size_t, float delta);
+
     Lines lines;
     Boxes boxes;
+
+private:
+    using LineEllipses = Vector<std::optional<Line::Ellipsis>>;
+    std::unique_ptr<LineEllipses> lineEllipses;
 };
 
 }

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLineBuilder.h
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLineBuilder.h
@@ -42,7 +42,7 @@ public:
 
     InlineDisplay::Line build(const LineLayoutResult&, const LineBox&, bool lineIsFullyTruncatedInBlockDirection) const;
 
-    static void applyEllipsisIfNeeded(LineEndingTruncationPolicy, InlineDisplay::Line&, InlineDisplay::Boxes&, bool isLegacyLineClamp);
+    static std::optional<InlineDisplay::Line::Ellipsis> applyEllipsisIfNeeded(LineEndingTruncationPolicy, InlineDisplay::Line&, InlineDisplay::Boxes&, bool isLegacyLineClamp);
     static void addLegacyLineClampTrailingLinkBoxIfApplicable(const InlineFormattingContext&, const InlineLayoutState&, InlineDisplay::Content&);
     static bool hasTrailingLineWithBlockContent(const InlineDisplay::Lines&);
 

--- a/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxModernPath.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxModernPath.h
@@ -58,8 +58,8 @@ public:
     float scrollableOverflowBottom() const { return line().scrollableOverflow().maxY(); }
 
     bool hasEllipsis() const { return line().hasEllipsis(); }
-    FloatRect ellipsisVisualRectIgnoringBlockDirection() const { return line().ellipsis()->visualRect; }
-    TextRun ellipsisText() const { return TextRun { line().ellipsis()->text.string() }; }
+    FloatRect ellipsisVisualRectIgnoringBlockDirection() const { return lineEllipsis().visualRect; }
+    TextRun ellipsisText() const { return TextRun { lineEllipsis().text.string() }; }
 
     float contentLogicalTopAdjustedForPrecedingLineBox() const
     {
@@ -142,6 +142,7 @@ private:
 
     const InlineDisplay::Lines& lines() const { return m_inlineContent->displayContent().lines; }
     const InlineDisplay::Line& line() const { return lines()[m_lineIndex]; }
+    InlineDisplay::Line::Ellipsis lineEllipsis() const { return *m_inlineContent->displayContent().lineEllipsis(m_lineIndex); }
 
     WeakPtr<const LayoutIntegration::InlineContent> m_inlineContent;
     size_t m_lineIndex { 0 };

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationPagination.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationPagination.cpp
@@ -170,7 +170,7 @@ void adjustLinePositionsForPagination(InlineContent& inlineContent, const Vector
     for (size_t lineIndex = 0; lineIndex < displayContent.lines.size(); ++lineIndex) {
         auto& line = displayContent.lines[lineIndex];
         auto& adjustment = adjustments[lineIndex];
-        line.moveInBlockDirection(adjustment.offset);
+        displayContent.moveLineInBlockDirection(lineIndex, adjustment.offset);
         if (adjustment.isFirstAfterPageBreak)
             line.setIsFirstAfterPageBreak();
     }


### PR DESCRIPTION
#### 27bd238f9e476cd70845f5976581d6df0dd28aad
<pre>
Move InlineDisplay::Line::Ellipsis to a side structure
<a href="https://bugs.webkit.org/show_bug.cgi?id=305327">https://bugs.webkit.org/show_bug.cgi?id=305327</a>
<a href="https://rdar.apple.com/167984446">rdar://167984446</a>

Reviewed by Alan Baradlay.

Shrink the popular Line struct by moving this rare optional struct to a separate vector in Content.

* Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.cpp:
(WebCore::Layout::InlineFormattingContext::createDisplayContentForInlineContent):
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContent.cpp:
(WebCore::InlineDisplay::Content::set):
(WebCore::InlineDisplay::Content::append):
(WebCore::InlineDisplay::Content::insert):
(WebCore::InlineDisplay::Content::remove):
(WebCore::InlineDisplay::Content::setLineEllipsis):
(WebCore::InlineDisplay::Content::lineEllipsis const):

Ellipses are kept in a Vector that is constructed on demand and is sized to fit the highest line index
with an ellipsis.

(WebCore::InlineDisplay::Content::moveLineInBlockDirection):
(WebCore::InlineDisplay::Content::shrinkLineInBlockDirection):

Add some line mutation functions for things that affect ellipses.

* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContent.h:
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLine.h:
(WebCore::InlineDisplay::Line::hasEllipsis const):
(WebCore::InlineDisplay::Line::setHasEllipsis):
(WebCore::InlineDisplay::Line::moveInBlockDirection):
(WebCore::InlineDisplay::Line::shrinkInBlockDirection):
(WebCore::InlineDisplay::Line::setEllipsis): Deleted.
(WebCore::InlineDisplay::Line::ellipsis const): Deleted.
(WebCore::InlineDisplay::Line::visibleRectIgnoringBlockDirection const): Deleted.
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLineBuilder.cpp:
(WebCore::Layout::makeRoomForLinkBoxOnClampedLineIfNeeded):
(WebCore::Layout::moveDisplayBoxToClampedLine):
(WebCore::Layout::InlineDisplayLineBuilder::addLegacyLineClampTrailingLinkBoxIfApplicable):
(WebCore::Layout::InlineDisplayLineBuilder::applyEllipsisIfNeeded):
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLineBuilder.h:
* Source/WebCore/layout/integration/inline/InlineIteratorLineBoxModernPath.h:
(WebCore::InlineIterator::LineBoxIteratorModernPath::ellipsisVisualRectIgnoringBlockDirection const):
(WebCore::InlineIterator::LineBoxIteratorModernPath::ellipsisText const):
(WebCore::InlineIterator::LineBoxIteratorModernPath::lineEllipsis const):
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::hasEllipsisInBlockDirectionOnLastFormattedLine const):
(WebCore::LayoutIntegration::LineLayout::hitTest):
(WebCore::LayoutIntegration::LineLayout::shiftLinesBy):
* Source/WebCore/layout/integration/inline/LayoutIntegrationPagination.cpp:
(WebCore::LayoutIntegration::adjustLinePositionsForPagination):

Canonical link: <a href="https://commits.webkit.org/305467@main">https://commits.webkit.org/305467@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2fbdfe24e4a420f2544a2146be53e668d70662c5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138490 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10855 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49900 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/146585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/91465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/30f83192-fca9-4eb5-84ae-3121c2780d19) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140364 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11559 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11010 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/146585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/91465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0a92dc2a-97fb-45c9-8118-814740df9682) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141437 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8688 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124149 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/146585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5c8dd859-a3e1-430e-abc7-c05aacc61533) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8275 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6040 "Passed tests") | [  ~~🛠 wpe-cairo-libwebrtc~~](https://ews-build.webkit.org/#/builders/166/builds/6880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117695 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42348 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/149335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10537 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42905 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/149335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10554 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8907 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/149335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29131 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8406 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120435 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65426 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10586 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38368 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10320 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74197 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10524 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10375 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->