### PR TITLE
Add support for race-network-and-fetch-handler service worker router source

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/static-router-race-network-and-fetch-handler.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/static-router-race-network-and-fetch-handler.https-expected.txt
@@ -1,8 +1,10 @@
 
 PASS Main resource load matched the rule with race-network-and-fetch-handler source, and the fetch handler response is faster than the server response
-FAIL Main resource load matched the rule with race-network-and-fetch-handler source, and the server reseponse is faster than the fetch handler assert_equals: expected "Network with GET request" but got "rrexb"
+FAIL Main resource load matched the rule with race-network-and-fetch-handler source, and the server reseponse is faster than the fetch handler assert_equals: expected "Network with GET request" but got "szkps"
+PASS Main resource load matched the rule with race-network-and-fetch-handler source, and the fetch handler response is faster than the server response while fetch() is triggered inside the fetch handler
+FAIL Main resource load matched the rule with race-network-and-fetch-handler source, and the server reseponse is faster than the fetch handler while fetch() is triggered inside the fetch handler assert_equals: expected "Network with GET request" but got "idomx"
 PASS Subresource load matched the rule with race-network-and-fetch-handler source, and the fetch handler response is faster than the server response
-FAIL Subresource load matched the rule with race-network-and-fetch-handler source, and the server reseponse is faster than the fetch handler assert_equals: expected "Network with GET request" but got "bsmfq"
+FAIL Subresource load matched the rule with race-network-and-fetch-handler source, and the server reseponse is faster than the fetch handler assert_equals: expected "Network with GET request" but got "drtvj"
 FAIL Subresource load matched the rule with race-network-and-fetch-handler source, and the server reseponse with 204 response is faster than the fetch handler assert_equals: expected 204 but got 200
 PASS Subresource load matched the rule with race-network-and-fetch-handler source, and the server reseponse is faster than the fetch handler, but not found
 

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/static-router-subresource.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/static-router-subresource.https-expected.txt
@@ -1,20 +1,20 @@
 
 PASS Subresource load not matched with URLPattern condition
-FAIL Subresource load matched with URLPattern condition assert_equals: expected "Network\n" but got "bodyh"
+FAIL Subresource load matched with URLPattern condition assert_equals: expected "Network\n" but got "arfcy"
 FAIL Subresource cross origin load matched with URLPattern condition via constructed object assert_equals: expected 0 but got 2
-FAIL Subresource load matched with ignoreCase URLPattern condition assert_equals: expected "Network\n" but got "lmsjn"
+FAIL Subresource load matched with ignoreCase URLPattern condition assert_equals: expected "Network\n" but got "ncqdg"
 PASS Subresource load matched without ignoreCase URLPattern condition
-FAIL Subresource load matched with URLPattern condition via URLPatternCompatible assert_equals: expected "Network\n" but got "ccrmz"
+FAIL Subresource load matched with URLPattern condition via URLPatternCompatible assert_equals: expected "Network\n" but got "mkjnr"
 FAIL Subresource cross origin load not matched with URLPattern condition via URLPatternCompatible assert_equals: expected 1 but got 2
-FAIL Subresource load matched with URLPattern condition via string assert_equals: expected "Network\n" but got "hkqxk"
+FAIL Subresource load matched with URLPattern condition via string assert_equals: expected "Network\n" but got "rfdaj"
 FAIL Subresource cross origin load not matched with URLPattern condition via string assert_equals: expected 1 but got 2
-FAIL Subresource load matched with RequestMode condition assert_equals: expected "matched,with,non-url,conditions\n" but got "{\"error\": {\"code\": 404, \"message\": \"404\"}}"
-PASS Subresource load matched with the nested `or` condition
-PASS Subresource load matched with the next `or` condition
-FAIL Subresource load not matched with `or` condition assert_equals: expected "ftazh" but got "{\"error\": {\"code\": 404, \"message\": \"404\"}}"
+PASS Subresource load matched with RequestMode condition
+FAIL Subresource load matched with the nested `or` condition assert_equals: expected "Network\n" but got "ytihv"
+FAIL Subresource load matched with the next `or` condition assert_equals: expected "Network\n" but got "lzkmm"
+PASS Subresource load not matched with `or` condition
 FAIL Subresource load matched with the cache source rule assert_equals: expected "From cache" but got ""
-FAIL Subresource load did not match with the cache and fallback to the network assert_equals: expected "Network\n" but got "fhlly"
+FAIL Subresource load did not match with the cache and fallback to the network assert_equals: expected "Network\n" but got "wytpc"
 FAIL Subresource load matched with the cache source, with specifying the cache name assert_equals: expected "From cache" but got ""
-PASS Subresource load should not match with the not condition
-FAIL Subresource load should match with a file other than not assert_equals: expected "Network\n" but got "boywr"
+FAIL Subresource load should not match with the not condition assert_equals: expected "xirxd" but got "{\"error\": {\"code\": 404, \"message\": \"404\"}}"
+PASS Subresource load should match with a file other than not
 

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/tentative/static-router/static-router-resource-timing.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/tentative/static-router/static-router-resource-timing.https-expected.txt
@@ -1,16 +1,16 @@
 
-FAIL Main resource matched the rule with fetch-event source assert_equals: expected 0 but got 1
+FAIL Main resource matched the rule with fetch-event source assert_equals: fetch-event as source on main resource expected (string) "fetch-event" but got (undefined) undefined
 FAIL Main resource load matched with the condition and resource timing assert_equals: expected 0 but got 1
 FAIL Main resource load not matched with the condition and resource timing assert_equals: no rule matched on main resource expected (string) "" but got (undefined) undefined
 FAIL Main resource load matched with the cache source and resource timing assert_equals: expected 0 but got 1
 FAIL Main resource fallback to the network when there is no cache entry and resource timing assert_equals: expected 0 but got 1
 FAIL Subresource load matched the rule fetch-event source assert_equals: fetch-event as source on sub resource expected (string) "fetch-event" but got (undefined) undefined
 FAIL Subresource load not matched with URLPattern condition assert_equals: no source type matched expected (string) "" but got (undefined) undefined
-FAIL Subresource load matched with URLPattern condition assert_equals: expected "Network\n" but got "imrmg"
+FAIL Subresource load matched with URLPattern condition assert_equals: expected "Network\n" but got "staue"
 FAIL Subresource load matched with the cache source rule assert_equals: expected "From cache" but got ""
-FAIL Subresource load did not match with the cache and fallback to the network assert_equals: expected "Network\n" but got "dpmim"
-FAIL Main resource load matched the rule with race-network-and-fetch-handler source, and the fetch handler response is faster than the server response assert_equals: race as source on main resource, and fetch-event wins expected (string) "race-network-and-fetch" but got (undefined) undefined
-FAIL Main resource load matched the rule with race-network-and-fetch-handler source, and the server reseponse is faster than the fetch handler assert_equals: expected "Network with GET request" but got "rcqfi"
-FAIL Subresource load matched the rule with race-network-and-fetch-handler source, and the fetch handler response is faster than the server response assert_equals: race as source on subresource and fetch wins expected (string) "race-network-and-fetch" but got (undefined) undefined
-FAIL Subresource load matched the rule with race-network-and-fetch-handler source, and the server reseponse is faster than the fetch handler assert_equals: expected "Network with GET request" but got "kmbqk"
+FAIL Subresource load did not match with the cache and fallback to the network assert_equals: expected "Network\n" but got "fpsvl"
+FAIL Main resource load matched the rule with race-network-and-fetch-handler source, and the fetch handler response is faster than the server response assert_equals: race as source on main resource, and fetch-event wins expected (string) "race-network-and-fetch-handler" but got (undefined) undefined
+FAIL Main resource load matched the rule with race-network-and-fetch-handler source, and the server reseponse is faster than the fetch handler assert_equals: expected "Network with GET request" but got "uoflc"
+FAIL Subresource load matched the rule with race-network-and-fetch-handler source, and the fetch handler response is faster than the server response assert_equals: race as source on subresource and fetch wins expected (string) "race-network-and-fetch-handler" but got (undefined) undefined
+FAIL Subresource load matched the rule with race-network-and-fetch-handler source, and the server reseponse is faster than the fetch handler assert_equals: expected "Network with GET request" but got "irkga"
 

--- a/Source/WebCore/workers/service/RouterSourceEnum.h
+++ b/Source/WebCore/workers/service/RouterSourceEnum.h
@@ -27,6 +27,6 @@
 
 namespace WebCore {
 
-enum class RouterSourceEnum : uint8_t { Cache, FetchEvent, Network };
+enum class RouterSourceEnum : uint8_t { Cache, FetchEvent, Network, RaceNetworkAndFetchHandler };
 
 } // namespace WebCore

--- a/Source/WebCore/workers/service/RouterSourceEnum.idl
+++ b/Source/WebCore/workers/service/RouterSourceEnum.idl
@@ -27,4 +27,5 @@ enum RouterSourceEnum {
     "cache",
     "fetch-event",
     "network",
+    "race-network-and-fetch-handler"
 };

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h
@@ -67,7 +67,7 @@ class ServiceWorkerFetchTask : public RefCountedAndCanMakeWeakPtr<ServiceWorkerF
 public:
     static RefPtr<ServiceWorkerFetchTask> fromNavigationPreloader(WebSWServerConnection&, NetworkResourceLoader&, const WebCore::ResourceRequest&, NetworkSession*);
 
-    static Ref<ServiceWorkerFetchTask> create(WebSWServerConnection&, NetworkResourceLoader&, WebCore::ResourceRequest&&, WebCore::SWServerConnectionIdentifier, WebCore::ServiceWorkerIdentifier, WebCore::SWServerRegistration&, NetworkSession*, bool isWorkerReady);
+    static Ref<ServiceWorkerFetchTask> create(WebSWServerConnection&, NetworkResourceLoader&, WebCore::ResourceRequest&&, WebCore::SWServerConnectionIdentifier, WebCore::ServiceWorkerIdentifier, WebCore::SWServerRegistration&, NetworkSession*, bool isWorkerReady, bool shouldRaceNetworkAndFetchHandler);
     static Ref<ServiceWorkerFetchTask> create(WebSWServerConnection&, NetworkResourceLoader&, RefPtr<ServiceWorkerNavigationPreloader>&&);
 
     ~ServiceWorkerFetchTask();
@@ -94,7 +94,7 @@ public:
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
 
 private:
-    ServiceWorkerFetchTask(WebSWServerConnection&, NetworkResourceLoader&, WebCore::ResourceRequest&&, WebCore::SWServerConnectionIdentifier, WebCore::ServiceWorkerIdentifier, WebCore::SWServerRegistration&, NetworkSession*, bool isWorkerReady);
+    ServiceWorkerFetchTask(WebSWServerConnection&, NetworkResourceLoader&, WebCore::ResourceRequest&&, WebCore::SWServerConnectionIdentifier, WebCore::ServiceWorkerIdentifier, WebCore::SWServerRegistration&, NetworkSession*, bool isWorkerReady, bool shouldRaceNetworkAndFetchHandler);
     ServiceWorkerFetchTask(WebSWServerConnection&, NetworkResourceLoader&, RefPtr<ServiceWorkerNavigationPreloader>&&);
 
     enum class ShouldSetSource : bool { No, Yes };
@@ -130,6 +130,7 @@ private:
     void sendNavigationPreloadUpdate();
 
     RefPtr<ServiceWorkerNavigationPreloader> protectedPreloader();
+    void processPreloadResponse();
 
     WeakPtr<WebSWServerConnection> m_swServerConnection;
     WeakPtr<NetworkResourceLoader> m_loader;
@@ -141,6 +142,7 @@ private:
     std::unique_ptr<WebCore::Timer> m_timeoutTimer;
     Markable<WebCore::ServiceWorkerRegistrationIdentifier> m_serviceWorkerRegistrationIdentifier;
     RefPtr<ServiceWorkerNavigationPreloader> m_preloader;
+    const bool m_shouldRaceNetworkAndFetchHandler { false };
     bool m_wasHandled { false };
     bool m_isDone { false };
     bool m_shouldSoftUpdate { false };

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -5290,7 +5290,8 @@ struct WebCore::RouterSourceDict {
 enum class WebCore::RouterSourceEnum : uint8_t {
     Cache,
     FetchEvent,
-    Network
+    Network,
+    RaceNetworkAndFetchHandler
 };
 
 enum class WebCore::RunningStatus : bool


### PR DESCRIPTION
#### 4e7754ef16e98b6e1d826786245b97bdf9e9e734
<pre>
Add support for race-network-and-fetch-handler service worker router source
<a href="https://rdar.apple.com/167982454">rdar://167982454</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=305324">https://bugs.webkit.org/show_bug.cgi?id=305324</a>

Reviewed by Chris Dumez.

We reuse the service worker preloader to implement race-network-and-fetch-handler.
When receiving a response from the preloader, we use it and stop listening to the fetch event handler.
Conversely, when receiving a response from the fetch event handler, we cancel the preloader.
This allows to select the fastest route.

We update InstallEvent::addRoutes to check for fetch event registration in case of race-network-and-fetch-handler route, and fix a potential use-after-move.

We update the IDL to accept race-network-and-fetch-handler and we update InstallEvent::addRoutes according the spec.
Covered by existing WPT tests.

Canonical link: <a href="https://commits.webkit.org/305631@main">https://commits.webkit.org/305631@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b37980ff9f3381d1f61e9fcd30e84e2fb19032a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138836 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11202 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/323 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146955 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91811 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eeb32dbb-c735-4f3f-9bd7-e3874e3c7f5b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140709 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11929 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11358 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106265 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77526 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/294f462c-478c-4ea8-9501-cb55fe325069) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141783 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9011 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124404 "Found 1 new API test failure: TestWebKitAPI.ContextMenuTests.ContextMenuElementInfoContainsQRCodePayloadString (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87134 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9950c385-c0fe-4d87-886e-6e770edea160) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8590 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6318 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7253 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118019 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/269 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149741 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10884 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/277 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114653 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10905 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9210 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114969 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29245 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8854 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120723 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65790 "Built successfully") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/11157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/269 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10670 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74584 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10900 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10779 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->