### PR TITLE
[JSC] Loading from bytecode cache does not set threshold for jitting

### DIFF
--- a/Source/JavaScriptCore/runtime/CachedTypes.cpp
+++ b/Source/JavaScriptCore/runtime/CachedTypes.cpp
@@ -2258,6 +2258,7 @@ ALWAYS_INLINE UnlinkedCodeBlock::UnlinkedCodeBlock(Decoder& decoder, Structure* 
     , m_binaryArithProfiles(cachedCodeBlock.numBinaryArithProfiles())
     , m_unaryArithProfiles(cachedCodeBlock.numUnaryArithProfiles())
 {
+    m_llintExecuteCounter.setNewThreshold(thresholdForJIT(Options::thresholdForJITAfterWarmUp()));
 }
 
 template<typename CodeBlockType>


### PR DESCRIPTION
#### e0644034f46ee296707fdcab9dc3b022083156c1
<pre>
[JSC] Loading from bytecode cache does not set threshold for jitting
<a href="https://bugs.webkit.org/show_bug.cgi?id=305335">https://bugs.webkit.org/show_bug.cgi?id=305335</a>
<a href="https://rdar.apple.com/168002124">rdar://168002124</a>

Reviewed by Yusuke Suzuki and Justin Michaud.

When reconstructing UnlinkedCodeBlocks from the bytecode cache we go through
a different constructor in CachedTypes.cpp. That constructor doesn&apos;t need to
do most of the things that the regular constructor does, but it should set
the JIT threshold for the code block. As it is, any function loaded from the
cache will be compiled when it&apos;s first executed.

Test: Source/JavaScriptCore/API/tests/testapi.mm
* Source/JavaScriptCore/API/tests/testapi.mm:
(testBytecodeCachedFunctionsDontJITImmediately):
(testObjectiveCAPI):
* Source/JavaScriptCore/runtime/CachedTypes.cpp:
(JSC::UnlinkedCodeBlock::UnlinkedCodeBlock):

Canonical link: <a href="https://commits.webkit.org/305568@main">https://commits.webkit.org/305568@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61467348fc8b9997f90905842a8a8087b0ac5335

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138516 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10881 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/49926 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146616 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91491 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/de879bd6-4c13-483f-9969-b1ba062b309a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11585 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11036 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106004 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77331 "1 flakes 1 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0f35708f-e268-41b1-b11f-acd649102f69) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141463 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8712 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/49926 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86867 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e3bec2d1-810d-4a56-a271-4647a166727f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8301 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/6063 "Build was cancelled. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6913 "Built successfully") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/130480 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled JSC (warnings); jscore-tests (cancelled)") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/117717 "Build was cancelled. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Running apply-patch; Checked out pull request; run-api-tests (cancelled)") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/49926 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149369 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/137112 "Built successfully and passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/10563 "Build was cancelled. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/49926 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114382 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10580 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8936 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114717 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29212 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8444 "Passed tests") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/49926 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65453 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10612 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/49926 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/169790 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10346 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74241 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/44259 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; jscore-tests (cancelled)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10550 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10401 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->