### PR TITLE
[Temporal] Enable all PlainYearMonth test262 tests

### DIFF
--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -31,7 +31,6 @@ skip:
     - test/built-ins/Temporal/PlainDateTime/prototype/toZonedDateTime
     - test/built-ins/Temporal/PlainDateTime/prototype/until
     - test/built-ins/Temporal/PlainDateTime/prototype/withCalendar
-    - test/built-ins/Temporal/PlainYearMonth
     - test/built-ins/Temporal/ZonedDateTime
     - test/intl402/Temporal/Instant/prototype/toZonedDateTimeISO
     - test/intl402/Temporal/Now

--- a/Source/JavaScriptCore/runtime/ISO8601.cpp
+++ b/Source/JavaScriptCore/runtime/ISO8601.cpp
@@ -1106,8 +1106,11 @@ static std::optional<PlainDate> parseDate(StringParsingBuffer<CharacterType>& bu
     } else
         return std::nullopt;
 
-    if (format == TemporalDateFormat::YearMonth && buffer.atEnd())
+    if (format == TemporalDateFormat::YearMonth && buffer.atEnd()) {
+        if (!isYearWithinLimits(year)) [[unlikely]]
+            year = outOfRangeYear;
         return PlainDate(year, month, 1);
+    }
 
     if (*buffer == '-') {
         if (splitByHyphen || format != TemporalDateFormat::Date)

--- a/Source/JavaScriptCore/runtime/TemporalCalendar.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalCalendar.cpp
@@ -262,8 +262,11 @@ ISO8601::PlainDate TemporalCalendar::isoDateFromFields(JSGlobalObject* globalObj
     if (std::holds_alternative<TemporalOverflow>(optionsOrOverflow))
         overflow = std::get<TemporalOverflow>(optionsOrOverflow);
     else {
-        overflow = toTemporalOverflow(globalObject, std::get<JSObject*>(optionsOrOverflow));
-        RETURN_IF_EXCEPTION(scope, { });
+        JSObject* options = std::get<JSObject*>(optionsOrOverflow);
+        if (options) {
+            overflow = toTemporalOverflow(globalObject, options);
+            RETURN_IF_EXCEPTION(scope, { });
+        }
     }
 
     // Check month code if applicable
@@ -355,8 +358,6 @@ ISO8601::PlainDate TemporalCalendar::isoDateFromFields(JSGlobalObject* globalObj
 // https://tc39.es/proposal-temporal/#sec-temporal-calendaryearmonthfromfields
 ISO8601::PlainDate TemporalCalendar::yearMonthFromFields(JSGlobalObject* globalObject, int32_t year, int32_t month, std::optional<ParsedMonthCode> monthCode, TemporalOverflow overflow)
 {
-    // 2. Let firstDayIndex be the 1-based index of the first day of the month described by fields
-    // (i.e., 1 unless the month's first day is skipped by this calendar.)
     return isoDateFromFields(globalObject, TemporalDateFormat::YearMonth, year, month, 1, monthCode, overflow);
 }
 

--- a/Source/JavaScriptCore/runtime/TemporalPlainDate.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDate.cpp
@@ -394,6 +394,13 @@ TemporalPlainDate::toYearMonth(JSGlobalObject* globalObject, JSObject* temporalD
             return { };
         }
 
+        // See step 9(c)(iv) of PrepareCalendarFields
+        // https://tc39.es/proposal-temporal/#sec-temporal-preparecalendarfields
+        if (doubleMonth <= 0) {
+            throwRangeError(globalObject, scope, "month property must be a positive integer"_s);
+            return { };
+        }
+
         if (!isInBounds<int32_t>(doubleMonth)) [[unlikely]] {
             // Later checks will report error
             month = ISO8601::outOfRangeYear;

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTime.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTime.cpp
@@ -109,7 +109,7 @@ TemporalPlainDateTime* TemporalPlainDateTime::tryCreateIfValid(JSGlobalObject* g
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal-totemporaldatetime
-TemporalPlainDateTime* TemporalPlainDateTime::from(JSGlobalObject* globalObject, JSValue itemValue, std::optional<JSObject*> optionsValue)
+TemporalPlainDateTime* TemporalPlainDateTime::from(JSGlobalObject* globalObject, JSValue itemValue, JSObject* options)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -131,8 +131,8 @@ TemporalPlainDateTime* TemporalPlainDateTime::from(JSGlobalObject* globalObject,
         }
 
         Variant<JSObject*, TemporalOverflow> optionsOrOverflow = TemporalOverflow::Constrain;
-        if (optionsValue)
-            optionsOrOverflow = optionsValue.value();
+        if (options)
+            optionsOrOverflow = options;
         auto overflow = TemporalOverflow::Constrain;
         auto plainDate = TemporalCalendar::isoDateFromFields(globalObject, asObject(itemValue), TemporalDateFormat::Date, optionsOrOverflow, overflow);
         RETURN_IF_EXCEPTION(scope, { });
@@ -155,8 +155,8 @@ TemporalPlainDateTime* TemporalPlainDateTime::from(JSGlobalObject* globalObject,
     auto string = itemValue.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
-    if (optionsValue) {
-        toTemporalOverflow(globalObject, optionsValue.value()); // Validate overflow
+    if (options) {
+        toTemporalOverflow(globalObject, options); // Validate overflow
         RETURN_IF_EXCEPTION(scope, { });
     }
 

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTime.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTime.h
@@ -48,7 +48,7 @@ public:
 
     DECLARE_INFO;
 
-    static TemporalPlainDateTime* from(JSGlobalObject*, JSValue, std::optional<JSObject*>);
+    static TemporalPlainDateTime* from(JSGlobalObject*, JSValue, JSObject*);
     static int32_t compare(TemporalPlainDateTime*, TemporalPlainDateTime*);
 
     TemporalCalendar* calendar() { return m_calendar.get(this); }

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTimeConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTimeConstructor.cpp
@@ -138,10 +138,10 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimeConstructorFuncCompare, (JSGlobalO
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* one = TemporalPlainDateTime::from(globalObject, callFrame->argument(0), std::nullopt);
+    auto* one = TemporalPlainDateTime::from(globalObject, callFrame->argument(0), nullptr);
     RETURN_IF_EXCEPTION(scope, { });
 
-    auto* two = TemporalPlainDateTime::from(globalObject, callFrame->argument(1), std::nullopt);
+    auto* two = TemporalPlainDateTime::from(globalObject, callFrame->argument(1), nullptr);
     RETURN_IF_EXCEPTION(scope, { });
 
     return JSValue::encode(jsNumber(TemporalPlainDateTime::compare(one, two)));

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTimePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTimePrototype.cpp
@@ -290,7 +290,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncEquals, (JSGlobalObje
     if (!plainDateTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.equals called on value that's not a PlainDateTime"_s);
 
-    auto* other = TemporalPlainDateTime::from(globalObject, callFrame->argument(0), std::nullopt);
+    auto* other = TemporalPlainDateTime::from(globalObject, callFrame->argument(0), nullptr);
     RETURN_IF_EXCEPTION(scope, { });
 
     if (plainDateTime->plainDate() != other->plainDate() || plainDateTime->plainTime() != other->plainTime())

--- a/Source/JavaScriptCore/runtime/TemporalPlainMonthDay.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainMonthDay.cpp
@@ -121,7 +121,7 @@ String TemporalPlainMonthDay::toString(JSGlobalObject* globalObject, JSValue opt
 
 // https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.from
 // https://tc39.es/proposal-temporal/#sec-temporal-totemporalmonthday
-TemporalPlainMonthDay* TemporalPlainMonthDay::from(JSGlobalObject* globalObject, JSValue itemValue, std::optional<JSValue> optionsValue)
+TemporalPlainMonthDay* TemporalPlainMonthDay::from(JSGlobalObject* globalObject, JSValue itemValue, JSValue optionsValue)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -136,18 +136,17 @@ TemporalPlainMonthDay* TemporalPlainMonthDay::from(JSGlobalObject* globalObject,
         RETURN_IF_EXCEPTION(scope, { });
         // Overflow has to be validated even though it's not used;
         // see step 9 of ToTemporalMonthDay
-        if (optionsValue) {
-            toTemporalOverflow(globalObject, optionsValue.value());
+        if (!optionsValue.isUndefined()) {
+            JSObject* options = intlGetOptionsObject(globalObject, optionsValue);
+            RETURN_IF_EXCEPTION(scope, { });
+            toTemporalOverflow(globalObject, options);
             RETURN_IF_EXCEPTION(scope, { });
         }
         return result;
     }
 
-    std::optional<JSObject*> options;
-    if (optionsValue) {
-        options = intlGetOptionsObject(globalObject, optionsValue.value());
-        RETURN_IF_EXCEPTION(scope, { });
-    }
+    JSObject* options = intlGetOptionsObject(globalObject, optionsValue);
+    RETURN_IF_EXCEPTION(scope, { });
 
     if (itemValue.isObject()) {
         if (itemValue.inherits<TemporalPlainMonthDay>())
@@ -167,7 +166,7 @@ TemporalPlainMonthDay* TemporalPlainMonthDay::from(JSGlobalObject* globalObject,
 
         Variant<JSObject*, TemporalOverflow> optionsOrOverflow = TemporalOverflow::Constrain;
         if (options)
-            optionsOrOverflow = options.value();
+            optionsOrOverflow = options;
         auto overflow = TemporalOverflow::Constrain;
         auto plainMonthDay = TemporalCalendar::isoDateFromFields(globalObject, asObject(itemValue), TemporalDateFormat::MonthDay, optionsOrOverflow, overflow);
         RETURN_IF_EXCEPTION(scope, { });

--- a/Source/JavaScriptCore/runtime/TemporalPlainMonthDay.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainMonthDay.h
@@ -47,7 +47,7 @@ public:
 
     DECLARE_INFO;
 
-    static TemporalPlainMonthDay* from(JSGlobalObject*, JSValue, std::optional<JSValue>);
+    static TemporalPlainMonthDay* from(JSGlobalObject*, JSValue, JSValue);
     static TemporalPlainMonthDay* from(JSGlobalObject*, WTF::String);
 
     TemporalCalendar* calendar() { return m_calendar.get(this); }

--- a/Source/JavaScriptCore/runtime/TemporalPlainMonthDayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainMonthDayPrototype.cpp
@@ -166,7 +166,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainMonthDayPrototypeFuncEquals, (JSGlobalObje
     if (!monthDay) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainMonthDay.prototype.equals called on value that's not a PlainMonthDay"_s);
 
-    auto* other = TemporalPlainMonthDay::from(globalObject, callFrame->argument(0), std::nullopt);
+    auto* other = TemporalPlainMonthDay::from(globalObject, callFrame->argument(0), jsUndefined());
     RETURN_IF_EXCEPTION(scope, { });
 
     if (monthDay->plainMonthDay() != other->plainMonthDay())

--- a/Source/JavaScriptCore/runtime/TemporalPlainYearMonth.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainYearMonth.cpp
@@ -214,7 +214,6 @@ ISO8601::PlainDate TemporalPlainYearMonth::with(JSGlobalObject* globalObject, JS
         return { };
     }
 
-
     auto [optionalMonth, optionalMonthCode, optionalYear] = TemporalPlainDate::toYearMonth(globalObject, temporalYearMonthLike);
     RETURN_IF_EXCEPTION(scope, { });
     if (!optionalMonth && !optionalMonthCode && !optionalYear) [[unlikely]] {
@@ -222,11 +221,20 @@ ISO8601::PlainDate TemporalPlainYearMonth::with(JSGlobalObject* globalObject, JS
         return { };
     }
 
-    TemporalOverflow overflow = toTemporalOverflow(globalObject, optionsValue);
+    int32_t y = optionalYear.value_or(year());
+    int32_t m = 0;
+    if (optionalMonth)
+        m = optionalMonth.value();
+    else if (optionalMonthCode)
+        m = optionalMonthCode->monthNumber;
+    else
+        m = month();
+
+    JSObject* options = intlGetOptionsObject(globalObject, optionsValue);
+    RETURN_IF_EXCEPTION(scope, { });
+    TemporalOverflow overflow = toTemporalOverflow(globalObject, options);
     RETURN_IF_EXCEPTION(scope, { });
 
-    int32_t y = optionalYear.value_or(year());
-    int32_t m = optionalMonth.value_or(month());
     RELEASE_AND_RETURN(scope, TemporalCalendar::yearMonthFromFields(globalObject, y, m, optionalMonthCode, overflow));
 }
 
@@ -250,6 +258,9 @@ ISO8601::Duration TemporalPlainYearMonth::sinceOrUntil(JSGlobalObject* globalObj
 
     auto [smallestUnit, largestUnit, roundingMode, increment] = extractDifferenceOptions(globalObject, optionsValue, UnitGroup::Date, TemporalUnit::Month, TemporalUnit::Year);
     RETURN_IF_EXCEPTION(scope, { });
+
+    if (op == DifferenceOperation::Since)
+        roundingMode = negateTemporalRoundingMode(roundingMode);
 
     RELEASE_AND_RETURN(scope, TemporalCalendar::differenceTemporalPlainYearMonth<op>(globalObject, plainYearMonth(), other->plainYearMonth(), increment, smallestUnit, largestUnit, roundingMode));
 }


### PR DESCRIPTION
#### d865004780e67703ef5fa5c8b421745a8065a38c
<pre>
[Temporal] Enable all PlainYearMonth test262 tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=305156">https://bugs.webkit.org/show_bug.cgi?id=305156</a>

Reviewed by Yusuke Suzuki.

Also fix several bugs that were hidden by PlainYearMonth being
skipped in config.yaml:

* Negate rounding mode when calling PlainYearMonth since method
* Fix bug where negative month should be checked before options
* Fix month code checking bug in with when supplied month code differs
  from existing month

* JSTests/test262/config.yaml:
* Source/JavaScriptCore/runtime/ISO8601.cpp:
(JSC::ISO8601::parseDate):
* Source/JavaScriptCore/runtime/TemporalCalendar.cpp:
(JSC::TemporalCalendar::isoDateFromFields):
(JSC::TemporalCalendar::yearMonthFromFields):
* Source/JavaScriptCore/runtime/TemporalPlainDate.cpp:
(JSC::TemporalPlainDate::toYearMonth):
* Source/JavaScriptCore/runtime/TemporalPlainDateTime.cpp:
(JSC::TemporalPlainDateTime::from):
* Source/JavaScriptCore/runtime/TemporalPlainDateTime.h:
* Source/JavaScriptCore/runtime/TemporalPlainDateTimeConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/TemporalPlainDateTimePrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/TemporalPlainMonthDay.cpp:
(JSC::TemporalPlainMonthDay::from):
* Source/JavaScriptCore/runtime/TemporalPlainMonthDay.h:
* Source/JavaScriptCore/runtime/TemporalPlainMonthDayPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/TemporalPlainYearMonth.cpp:
(JSC::TemporalPlainYearMonth::with):
(JSC::TemporalPlainYearMonth::sinceOrUntil):

Canonical link: <a href="https://commits.webkit.org/305624@main">https://commits.webkit.org/305624@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e9a90bbb05fec94dcf4d0377b3f74d02caeaafd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138700 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11066 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/182 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146814 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91675 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11770 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11220 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106133 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77445 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141647 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8866 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124309 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87003 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8454 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6212 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7112 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/130671 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117875 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/150 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149570 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/137352 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10748 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/151 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114518 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10765 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9092 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114857 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8703 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120607 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/65643 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21412 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10796 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/151 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/169973 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10531 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74437 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44305 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10734 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10585 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->