### PR TITLE
[Cocoa] Update NowPlayingUpdatesThrottled API test to make timeouts easier to diagnose

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/large-video-test-now-playing.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/large-video-test-now-playing.html
@@ -83,6 +83,16 @@
             }, 0);
         }
 
+        function canplaythrough() {
+            setTimeout(function() {
+                try {
+                    window.webkit.messageHandlers.testHandler.postMessage("canplaythrough");
+                } catch(e) {
+                    console.debug(`error: ${e}`);
+                }
+            }, 0);
+        }
+
         function setMediaSessionMetadata() {
             navigator.mediaSession.metadata = new MediaMetadata({
                 title: "bar",
@@ -108,7 +118,9 @@
     </script>
 </head>
 <body>
-    <video autoplay title="foo" onmousedown=mousedown() onplaying=playing() onpause=stopped() onseeked=seeked() onended=handleEnded()><source src="large-video-with-audio.mp4"></video>
+    <video autoplay title="foo" onmousedown=mousedown() onplaying=playing() onpause=stopped() onseeked=seeked() onended=handleEnded() oncanplaythrough=canplaythrough()>
+        <source src="large-video-with-audio.mp4">
+    </video>
     <button onclick="console.log(removeVideoElement())">Stop!</button>
 </body>
 <html>


### PR DESCRIPTION
#### 0ad51b0438ee15733d2f3721612247859f3b2894
<pre>
[Cocoa] Update NowPlayingUpdatesThrottled API test to make timeouts easier to diagnose
<a href="https://bugs.webkit.org/show_bug.cgi?id=305338">https://bugs.webkit.org/show_bug.cgi?id=305338</a>
<a href="https://rdar.apple.com/168010422">rdar://168010422</a>

Reviewed by Jean-Yves Avenard.

Use a timeout while waiting for media events so test failures can be diagnosed
more easily.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/NowPlayingControlsTests.mm:
(TestWebKitAPI::TEST(NowPlayingControlsTests, NowPlayingUpdatesThrottled)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/large-video-test-now-playing.html:

Canonical link: <a href="https://commits.webkit.org/305599@main">https://commits.webkit.org/305599@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae5371ed2ef517c915cbf01a2dcc91b2770559fa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138560 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10925 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146670 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91535 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c5cb8ff8-ee0a-4fb1-81ba-76e7afe236da) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140434 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11629 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11080 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106020 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77358 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/187cb0a3-1331-4ac6-9d45-f6fe6eabd3c7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141507 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8755 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124198 "Found 1 new API test failure: TestWebKitAPI.ContextMenuTests.ContextMenuElementInfoContainsQRCodePayloadString (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86886 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/43efd79f-1fe1-48fd-9ff4-1678f657e205) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8343 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6099 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6962 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117760 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/35 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149419 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10607 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32 "Found 1 new test failure: http/tests/performance/performance-resource-timing-redirection-cross-origin-media.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114414 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10624 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8977 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114737 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29230 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8513 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120492 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65497 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10656 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10390 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10594 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10445 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->