### PR TITLE
Remove duplicate enum serializers

### DIFF
--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPU.serialization.in
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPU.serialization.in
@@ -185,13 +185,6 @@ enum class WebCore::WebGPU::VertexFormat : uint8_t {
 };
 
 header: <WebCore/WebGPUShaderStage.h>
-enum class WebCore::WebGPU::ShaderStage : uint8_t {
-    Vertex,
-    Fragment,
-    Compute,
-};
-
-header: <WebCore/WebGPUShaderStage.h>
 [OptionSet] enum class WebCore::WebGPU::ShaderStage : uint8_t {
     Vertex,
     Fragment,
@@ -326,15 +319,6 @@ enum class WebCore::WebGPU::BufferUsage : uint16_t {
     Storage,
     Indirect,
     QueryResolve,
-};
-
-header: <WebCore/WebGPUTextureUsage.h>
-enum class WebCore::WebGPU::TextureUsage : uint8_t {
-    CopySource,
-    CopyDestination,
-    TextureBinding,
-    StorageBinding,
-    RenderAttachment,
 };
 
 header: <WebCore/WebGPUTextureUsage.h>


### PR DESCRIPTION
#### ce28630c8108552ee450889f9c7cc55f8be74856
<pre>
Remove duplicate enum serializers
<a href="https://bugs.webkit.org/show_bug.cgi?id=305345">https://bugs.webkit.org/show_bug.cgi?id=305345</a>
<a href="https://rdar.apple.com/168019265">rdar://168019265</a>

Reviewed by Alex Christensen.

These enums were defined twice, which does not seem to be required
for OptionSet serializers any longer.

* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPU.serialization.in:

Canonical link: <a href="https://commits.webkit.org/305521@main">https://commits.webkit.org/305521@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c88ad3f22e556588194682fb396adf5fbeb7e2f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138540 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10905 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146644 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91515 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6c6d05ee-fd2a-4989-9776-90c0fbb35adf) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140414 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11609 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11060 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106012 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77348 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/48c91e3b-d258-4eaf-ac66-e771d4d87447) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141487 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8731 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124183 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86876 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4ab40207-fa2e-4304-aacd-ebb01f1838fe) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8320 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6085 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6941 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117736 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149399 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10587 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13 "Found 1 new test failure: http/tests/performance/performance-resource-timing-redirection-cross-origin-media.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114394 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10604 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8958 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114730 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/29180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8481 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120471 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65477 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21362 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10636 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/13 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10370 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74267 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10574 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10425 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->