### PR TITLE
[AutoFill Debugging] Add support for text extraction from client-requested cross-origin frames

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2299,6 +2299,7 @@ page/scrolling/ThreadedScrollingCoordinator.cpp
 page/scrolling/ThreadedScrollingTree.cpp
 page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.cpp
 page/text-extraction/TextExtraction.cpp
+page/text-extraction/TextExtractionTypes.cpp
 platform/AudioDecoder.cpp
 platform/AudioEncoder.cpp
 platform/BoxExtents.cpp

--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TextExtractionTypes.h"
+
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore::TextExtraction {
+
+WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(Item);
+
+static void collateItemsRecursive(Item& item, HashMap<FrameIdentifier, UniqueRef<Item>>& subFrameItems)
+{
+    if (subFrameItems.isEmpty())
+        return;
+
+    if (auto iframe = item.dataAs<IFrameData>(); iframe && item.children.isEmpty()) {
+        if (auto subFrameRoot = subFrameItems.take(iframe->identifier))
+            item.children = WTF::move(subFrameRoot->children);
+    }
+
+    for (auto& child : item.children)
+        collateItemsRecursive(child, subFrameItems);
+}
+
+Item collatePageItems(PageItems&& items)
+{
+    collateItemsRecursive(items.mainFrameItem, items.subFrameItems);
+    return WTF::move(items.mainFrameItem);
+}
+
+} // namespace WebCore::TextExtraction

--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -32,7 +32,9 @@
 #include <WebCore/NodeIdentifier.h>
 #include <WebCore/WebKitJSHandle.h>
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/URL.h>
+#include <wtf/UniqueRef.h>
 
 namespace WebCore {
 
@@ -183,6 +185,8 @@ enum class ContainerType : uint8_t {
 using ItemData = Variant<ContainerType, TextItemData, ScrollableItemData, ImageItemData, SelectData, ContentEditableData, TextFormControlData, FormData, LinkItemData, IFrameData>;
 
 struct Item {
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED_EXPORT(Item, WEBCORE_EXPORT);
+
     ItemData data;
     FloatRect rectInRootView;
     Vector<Item> children;
@@ -208,6 +212,13 @@ struct Item {
         return std::nullopt;
     }
 };
+
+struct PageItems {
+    Item mainFrameItem;
+    HashMap<FrameIdentifier, UniqueRef<Item>> subFrameItems;
+};
+
+WEBCORE_EXPORT Item collatePageItems(PageItems&&);
 
 struct FilterRuleData {
     String name;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
@@ -29,6 +29,7 @@
 
 NS_HEADER_AUDIT_BEGIN(nullability, sendability)
 
+@class WKFrameInfo;
 @class WKWebView;
 @class _WKJSHandle;
 
@@ -130,6 +131,13 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
  The default value is an empty array.
  */
 @property (nonatomic, copy) NSArray<_WKJSHandle *> *nodesToSkip;
+
+/*!
+ If specified, text extraction includes content from these frames in addition to
+ content in the main frame and same-origin subframes (which are included by default).
+ The default value is an empty array.
+ */
+@property (nonatomic, copy, null_resettable) NSArray<WKFrameInfo *> *additionalFrames;
 
 /*!
  Client-specified attributes and values to add when extracting DOM nodes.

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
@@ -37,6 +37,7 @@
     HashMap<RetainPtr<NSString>, HashMap<RetainPtr<_WKJSHandle>, RetainPtr<NSString>>> _clientNodeAttributes;
     RetainPtr<NSDictionary<NSString *, NSString *>> _replacementStrings;
     RetainPtr<NSArray<_WKJSHandle *>> _nodesToSkip;
+    RetainPtr<NSArray<WKFrameInfo *>> _additionalFrames;
 }
 
 - (instancetype)init
@@ -85,6 +86,16 @@
 - (void)setNodesToSkip:(NSArray<_WKJSHandle *> *)nodesToSkip
 {
     _nodesToSkip = adoptNS([nodesToSkip copy]);
+}
+
+- (NSArray<WKFrameInfo *> *)additionalFrames
+{
+    return _additionalFrames.get() ?: @[ ];
+}
+
+- (void)setAdditionalFrames:(NSArray<WKFrameInfo *> *)frames
+{
+    _additionalFrames = adoptNS([frames copy]);
 }
 
 - (void)addClientAttribute:(NSString *)attributeName value:(NSString *)attributeValue forNode:(_WKJSHandle *)node

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -665,7 +665,17 @@ Ref<FrameTreeSyncData> WebFrameProxy::calculateFrameTreeSyncData() const
     bool isSecureForPaymentSession = false;
 #endif
 
-    return FrameTreeSyncData::create(isSecureForPaymentSession, WebCore::SecurityOrigin::create(url()), url().protocol().toString(), IntRect { });
+    return FrameTreeSyncData::create(isSecureForPaymentSession, securityOrigin(), url().protocol().toString(), IntRect { });
+}
+
+Ref<SecurityOrigin> WebFrameProxy::securityOrigin() const
+{
+    return SecurityOrigin::create(url());
+}
+
+bool WebFrameProxy::isSameOriginAs(const WebFrameProxy& frame) const
+{
+    return &frame == this || securityOrigin()->isSameOriginAs(frame.securityOrigin());
 }
 
 void WebFrameProxy::broadcastFrameTreeSyncData(Ref<FrameTreeSyncData>&& data)

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -62,6 +62,7 @@ class Decoder;
 namespace WebCore {
 class FrameTreeSyncData;
 class ResourceRequest;
+class SecurityOrigin;
 class SecurityOriginData;
 class ShareableBitmapHandle;
 class TextIndicator;
@@ -173,6 +174,8 @@ public:
     const WebCore::CertificateInfo& certificateInfo() const { return m_certificateInfo; }
 
     bool canProvideSource() const;
+
+    bool isSameOriginAs(const WebFrameProxy&) const;
 
     bool isDisplayingStandaloneImageDocument() const;
     bool isDisplayingStandaloneMediaDocument() const;
@@ -305,6 +308,7 @@ private:
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
 
     std::optional<WebCore::PageIdentifier> pageIdentifier() const;
+    Ref<WebCore::SecurityOrigin> securityOrigin() const;
 
     RefPtr<WebFrameProxy> deepLastChild();
     WebFrameProxy* firstChild() const;


### PR DESCRIPTION
#### df2042dcc84871042dcc9587c926bdf215726abc
<pre>
[AutoFill Debugging] Add support for text extraction from client-requested cross-origin frames
<a href="https://bugs.webkit.org/show_bug.cgi?id=305339">https://bugs.webkit.org/show_bug.cgi?id=305339</a>
<a href="https://rdar.apple.com/165929292">rdar://165929292</a>

Reviewed by Abrar Rahman Protyasha.

Complete support for extracting text from subframes — this adds support for an `additionalFrames`
property on the extraction configuration, which allows the WebKit client to specify a list of
additional `WKFrameInfo`s, from which WebKit will extract text (in addition to the main frame and
all same-origin subframes under the main frame).

See below for more details.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/page/text-extraction/TextExtractionTypes.cpp: Added.
(WebCore::TextExtraction::collateItemsRecursive):
(WebCore::TextExtraction::collatePageItems):

Add a helper method that takes `PageItems` (the main frame&apos;s `Item` along with a dictionary mapping
subframe IDs to their root `Item`s) and recursively collates all item data into a single `Item`
rooted in the main frame.

* Source/WebCore/page/text-extraction/TextExtractionTypes.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(jsHandleIdentifierInFrame):
(extractHandleIdentifiersOfNodesToSkip):
(extractClientNodeAttributes):

Augment these helper methods to take a target frame, so that identifiers can be filtered out unless
they identify a node within the target frame.

(-[WKWebView _requestTextExtractionInternal:completion:]):

Currently, this method only requests text extraction from the main frame; we now extend it to
extract items from the combination of frames specified via `-additionalFrames` and the main frame.

(mainFrameJSHandleIdentifier): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm:
(-[_WKTextExtractionConfiguration setNodesToSkip:]):
(-[_WKTextExtractionConfiguration additionalFrames]):
(-[_WKTextExtractionConfiguration setAdditionalFrames:]):

Add the new property.

* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::calculateFrameTreeSyncData const):
(WebKit::WebFrameProxy::securityOrigin const):
(WebKit::WebFrameProxy::isSameOriginAs const):
* Source/WebKit/UIProcess/WebFrameProxy.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm:
(TestWebKitAPI::mainFrameMarkup):
(TestWebKitAPI::subFrameMarkup):

Adjust this API test to include both same-origin and cross-origin subframes.

(TestWebKitAPI::TEST(TextExtractionTests, SubframeInteractions)):
(): Deleted.
(TestWebKitAPI::addEventListener): Deleted.
(TestWebKitAPI::(TextExtractionTests, SubframeInteractions)): Deleted.

Canonical link: <a href="https://commits.webkit.org/305512@main">https://commits.webkit.org/305512@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34c015522257bcd8e0771ff9dc642635246356cd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138577 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10942 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/58 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146687 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91552 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d72697bb-3c4a-4937-813d-c425a4a768ac) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140451 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11646 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11097 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106029 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77369 "8 flakes 4 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c74eb92e-9277-4751-ac61-ec4b300bb34a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141524 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8768 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124210 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86897 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e9d738b4-306f-4675-b4ff-ee4e042b3651) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8356 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6114 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6979 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117773 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/49 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149440 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10624 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44 "Found 1 new test failure: http/tests/performance/performance-resource-timing-redirection-cross-origin-media.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114412 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10641 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8992 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114751 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29163 "Found 1 new test failure: http/tests/performance/performance-resource-timing-redirection-cross-origin-media.html (failure)") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8532 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120506 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65514 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21352 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10673 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/48 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10407 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74305 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10611 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10462 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->