### PR TITLE
Expanding review in GitHub is very slow (more :has invalidation)

### DIFF
--- a/PerformanceTests/CSS/ScopeBreakingHasChildChangeInvalidation.html
+++ b/PerformanceTests/CSS/ScopeBreakingHasChildChangeInvalidation.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Scope-Breaking :has() Child Change Invalidation Performance</title>
+    <style>
+        .outer-a:has(:is(.inner .active)) { background: #fff3cd; }
+        .outer-b:has(:is(.nested .selected)) { border-left: 4px solid #007bff; }
+        .outer-c:has(:is(.deep .expanded)) { box-shadow: 0 2px 8px rgba(0,0,0,0.1); }
+        .outer-d:has(:is(.child .opened)) { font-weight: bold; }
+        .outer-e:has(:is(.descendant .highlighted)) { background: #f0f0f0; }
+
+        .container-a:has(:is(.deep .nested .chain)) { color: red; }
+        .container-b:has(:not(.excluded .pattern)) { color: blue; }
+        .container-c:has(:is(.multi, .selector) .descendant) { color: green; }
+        .container-d:has(:is(.another .complex .selector)) { color: purple; }
+        .container-e:has(:is(.final .pattern .here)) { color: orange; }
+    </style>
+</head>
+<body>
+<div id="test-container"></div>
+<script src="../resources/runner.js"></script>
+<script>
+    const container = document.getElementById('test-container');
+
+    const relatedContainers = [];
+    for (let i = 0; i < 10; i++) {
+        const div = document.createElement('div');
+        div.className = i % 5 === 0 ? 'outer-a' :
+                        i % 5 === 1 ? 'outer-b' :
+                        i % 5 === 2 ? 'outer-c' :
+                        i % 5 === 3 ? 'outer-d' : 'outer-e';
+        document.body.appendChild(div);
+        relatedContainers.push(div);
+    }
+
+    const unrelatedContainer = document.createElement('div');
+    unrelatedContainer.className = 'unrelated-mutation-target';
+    container.appendChild(unrelatedContainer);
+
+    PerfTestRunner.measureRunsPerSecond({
+        description: "DOM insertions and removals in unrelated subtree with scope-breaking :has() selectors",
+        run: function() {
+            for (let i = 0; i < 25; i++) {
+                const div = document.createElement('div');
+                div.className = 'test-element';
+                div.innerHTML = '<span>Content</span>';
+                unrelatedContainer.appendChild(div);
+            }
+
+            getComputedStyle(container).opacity;
+
+            for (let i = 0; i < 25; i++) {
+                const div = document.createElement('div');
+                div.className = 'test-element';
+                div.innerHTML = '<span>Content</span>';
+                unrelatedContainer.appendChild(div);
+                div.remove();
+            }
+
+            getComputedStyle(container).opacity;
+
+            unrelatedContainer.innerHTML = '';
+        }
+    });
+</script>
+</body>
+</html>

--- a/Source/WebCore/style/ChildChangeInvalidation.cpp
+++ b/Source/WebCore/style/ChildChangeInvalidation.cpp
@@ -115,8 +115,12 @@ void ChildChangeInvalidation::invalidateForChangedElement(Element& changedElemen
 
 void ChildChangeInvalidation::invalidateForChangeOutsideHasScope()
 {
-    // FIXME: This is a performance footgun. Any mutation will trigger a full document traversal.
-    if (RefPtr invalidationRuleSet = parentElement().styleResolver().ruleSets().scopeBreakingHasPseudoClassInvalidationRuleSet())
+    auto& ruleSets = parentElement().styleResolver().ruleSets();
+
+    if (!ruleSets.couldMutationAffectScopeBreakingHas(parentElement()))
+        return;
+
+    if (RefPtr invalidationRuleSet = ruleSets.scopeBreakingHasPseudoClassInvalidationRuleSet())
         Invalidator::invalidateWithScopeBreakingHasPseudoClassRuleSet(parentElement(), invalidationRuleSet.get());
 }
 

--- a/Source/WebCore/style/StyleScopeRuleSets.cpp
+++ b/Source/WebCore/style/StyleScopeRuleSets.cpp
@@ -34,6 +34,7 @@
 #include "CSSViewTransitionRule.h"
 #include "DeclarationOrigin.h"
 #include "DocumentInlines.h"
+#include "Element.h"
 #include "ExtensionStyleSheets.h"
 #include "FrameLoader.h"
 #include "HTMLNames.h"
@@ -45,11 +46,32 @@
 #include "StyleResolver.h"
 #include "StyleScope.h"
 #include "StyleSheetContents.h"
+#include "TypedElementDescendantIteratorInlines.h"
 #include <JavaScriptCore/ConsoleTypes.h>
 #include <ranges>
 
 namespace WebCore {
 namespace Style {
+
+static bool extractOuterContextPatternsFromSelector(const CSSSelector& selector, HashSet<AtomString>& patterns)
+{
+    bool foundSpecificPattern = false;
+
+    for (const CSSSelector* current = &selector; current; current = current->precedingInComplexSelector()) {
+        if (current->match() == CSSSelector::Match::PseudoClass && current->pseudoClass() == CSSSelector::PseudoClass::Has)
+            continue;
+
+        if (current->match() == CSSSelector::Match::Class) {
+            patterns.add(current->value());
+            foundSpecificPattern = true;
+        } else if (current->match() == CSSSelector::Match::Tag && current->tagLowercaseLocalName() != starAtom()) {
+            patterns.add(current->tagLowercaseLocalName());
+            foundSpecificPattern = true;
+        }
+    }
+
+    return foundSpecificPattern;
+}
 
 ScopeRuleSets::ScopeRuleSets(Resolver& styleResolver)
     : m_authorStyle(RuleSet::create())
@@ -292,6 +314,15 @@ void ScopeRuleSets::collectFeatures() const
 
     m_scopeBreakingHasPseudoClassInvalidationRuleSet = makeRuleSet(m_features.scopeBreakingHasPseudoClassRules);
 
+    m_scopeBreakingHasOuterContextPatterns.clear();
+    m_hasScopeBreakingHasWithUniversalOuterContext = false;
+    m_scopeBreakingHasSubtreeCache.clear();
+
+    for (const auto& ruleAndSelector : m_features.scopeBreakingHasPseudoClassRules) {
+        if (!extractOuterContextPatternsFromSelector(ruleAndSelector.selector(), m_scopeBreakingHasOuterContextPatterns))
+            m_hasScopeBreakingHasWithUniversalOuterContext = true;
+    }
+
     m_idInvalidationRuleSets.clear();
     m_classInvalidationRuleSets.clear();
     m_attributeInvalidationRuleSets.clear();
@@ -442,6 +473,45 @@ bool ScopeRuleSets::hasMatchingUserOrAuthorStyle(NOESCAPE const WTF::Function<bo
     if (RefPtr userStyle = this->userStyle(); userStyle && predicate(*userStyle))
         return true;
 
+    return false;
+}
+
+bool ScopeRuleSets::couldMutationAffectScopeBreakingHas(const Element& mutationParent) const
+{
+    if (!m_scopeBreakingHasPseudoClassInvalidationRuleSet)
+        return false;
+
+    if (m_hasScopeBreakingHasWithUniversalOuterContext)
+        return true;
+
+    if (auto it = m_scopeBreakingHasSubtreeCache.find(mutationParent); it != m_scopeBreakingHasSubtreeCache.end())
+        return it->value;
+
+    auto hasMatchingPattern = [&](const Element& element) {
+        if (element.hasClass()) {
+            for (unsigned i = 0; i < element.classNames().size(); ++i) {
+                if (m_scopeBreakingHasOuterContextPatterns.contains(element.classNames()[i]))
+                    return true;
+            }
+        }
+        return m_scopeBreakingHasOuterContextPatterns.contains(element.localName());
+    };
+
+    for (RefPtr ancestor = mutationParent; ancestor.get(); ancestor = ancestor->parentElement()) {
+        if (hasMatchingPattern(*ancestor)) {
+            m_scopeBreakingHasSubtreeCache.add(mutationParent, true);
+            return true;
+        }
+    }
+
+    for (auto it = descendantsOfType<Element>(mutationParent).begin(); it; it.traverseNext()) {
+        if (hasMatchingPattern(*it)) {
+            m_scopeBreakingHasSubtreeCache.add(mutationParent, true);
+            return true;
+        }
+    }
+
+    m_scopeBreakingHasSubtreeCache.add(mutationParent, false);
     return false;
 }
 

--- a/Source/WebCore/style/StyleScopeRuleSets.h
+++ b/Source/WebCore/style/StyleScopeRuleSets.h
@@ -27,13 +27,16 @@
 #include "UserAgentStyle.h"
 #include <memory>
 #include <wtf/HashMap.h>
+#include <wtf/HashSet.h>
 #include <wtf/RefPtr.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakHashMap.h>
 
 namespace WebCore {
 
 class CSSStyleRule;
 class CSSStyleSheet;
+class Element;
 class ExtensionStyleSheets;
 
 namespace MQ {
@@ -73,6 +76,8 @@ public:
 
     const RuleFeatureSet& features() const;
     RuleSet* scopeBreakingHasPseudoClassInvalidationRuleSet() const { return m_scopeBreakingHasPseudoClassInvalidationRuleSet.get(); }
+
+    bool couldMutationAffectScopeBreakingHas(const Element& mutationParent) const;
 
     const Vector<InvalidationRuleSet>* idInvalidationRuleSets(const AtomString&) const;
     const Vector<InvalidationRuleSet>* classInvalidationRuleSets(const AtomString&) const;
@@ -124,6 +129,11 @@ private:
     Resolver& m_styleResolver;
     mutable RuleFeatureSet m_features;
     mutable RefPtr<RuleSet> m_scopeBreakingHasPseudoClassInvalidationRuleSet;
+
+    mutable HashSet<AtomString> m_scopeBreakingHasOuterContextPatterns;
+    mutable bool m_hasScopeBreakingHasWithUniversalOuterContext { false };
+    mutable WeakHashMap<Element, bool, WeakPtrImplWithEventTargetData> m_scopeBreakingHasSubtreeCache;
+
     mutable HashMap<AtomString, std::unique_ptr<Vector<InvalidationRuleSet>>> m_idInvalidationRuleSets;
     mutable HashMap<AtomString, std::unique_ptr<Vector<InvalidationRuleSet>>> m_classInvalidationRuleSets;
     mutable HashMap<AtomString, std::unique_ptr<Vector<InvalidationRuleSet>>> m_attributeInvalidationRuleSets;


### PR DESCRIPTION
#### 99b9ad1909079994641012e51453af38621f70c1
<pre>
Expanding review in GitHub is very slow (more :has invalidation)
<a href="https://bugs.webkit.org/show_bug.cgi?id=305351">https://bugs.webkit.org/show_bug.cgi?id=305351</a>
<a href="https://rdar.apple.com/163512170">rdar://163512170</a>

Reviewed by NOBODY (OOPS!).

DOM mutations in documents with scope-breaking :has() selectors triggered full
document traversals on every mutation, which caused significant slowdowns on
sites like GitHub when creating comments.

Added couldMutationAffectScopeBreakingHas() to determine if a mutation could
affect any scope-breaking :has() selectors by checking if the mutation
location&apos;s ancestors or descendants match the outer context patterns (classes
and tags appearing before :has() in the selector). If no match is found, the
full document traversal is skipped.

Results are cached per-element to amortize cost across repeated mutations
in the same subtree.

No new tests (OOPS!).

* PerformanceTests/CSS/ScopeBreakingHasChildChangeInvalidation.html: Added.
* Source/WebCore/style/ChildChangeInvalidation.cpp:
(WebCore::Style::ChildChangeInvalidation::invalidateForChangeOutsideHasScope):
* Source/WebCore/style/StyleScopeRuleSets.cpp:
(WebCore::Style::extractOuterContextPatternsFromSelector):
(WebCore::Style::ScopeRuleSets::collectFeatures const):
(WebCore::Style::ScopeRuleSets::couldMutationAffectScopeBreakingHas const):
* Source/WebCore/style/StyleScopeRuleSets.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99b9ad1909079994641012e51453af38621f70c1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138688 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11054 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/170 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146802 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91663 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140561 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11758 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11208 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106123 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77438 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141635 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8859 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124409 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86994 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8447 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6205 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7100 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117868 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/142 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149558 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10736 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/143 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114510 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10753 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9083 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114847 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8699 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120599 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65631 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10784 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/143 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10519 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74425 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10722 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10573 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->