### PR TITLE
AX: Add more debugging information for scenario where all content is inaccessible to VoiceOver

### DIFF
--- a/Source/WebCore/accessibility/AXGeometryManager.cpp
+++ b/Source/WebCore/accessibility/AXGeometryManager.cpp
@@ -88,7 +88,7 @@ bool AXGeometryManager::cacheRectIfNeeded(AXID axID, IntRect&& rect)
     if (!rectChanged)
         return false;
 
-    RefPtr tree = AXIsolatedTree::treeForFrameID(*m_cache->frameID());
+    RefPtr tree = AXIsolatedTree::treeForFrameID(m_cache->frameID());
     if (!tree)
         return false;
     tree->updateFrame(axID, WTF::move(rect));

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -128,6 +128,17 @@ struct VisiblePositionIndexRange {
 struct AXTreeData {
     String liveTree;
     String isolatedTree;
+    // Captures warnings about the tree state that could result in poor user-facing
+    // behavior. These are gathered while capturing the structural tree data stored
+    // in the other member variables.
+    Vector<String> warnings;
+
+    void dumpToStderr() const
+    {
+        for (const String& warning : warnings)
+            SAFE_FPRINTF(stderr, "%s\n", warning.utf8());
+        SAFE_FPRINTF(stderr, "==AX Trees==\n%s\n%s\n", liveTree.utf8(), isolatedTree.utf8());
+    }
 };
 
 // When this is updated, WebCoreArgumentCoders.serialization.in must be updated as well.
@@ -136,6 +147,7 @@ struct AXDebugInfo {
     bool isAccessibilityThreadInitialized;
     String liveTree;
     String isolatedTree;
+    Vector<String> warnings;
     uint64_t remoteTokenHash;
     uint64_t webProcessLocalTokenHash;
 };
@@ -631,7 +643,7 @@ public:
 
     Document* document() const { return m_document.get(); }
     RefPtr<Document> protectedDocument() const;
-    constexpr const std::optional<FrameIdentifier>& frameID() const { return m_frameID; }
+    FrameIdentifier frameID() const { return m_frameID; }
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     inline void objectBecameIgnored(const AccessibilityObject&);
@@ -870,7 +882,7 @@ private:
     Ref<AccessibilityNodeObject> createFromNode(Node&);
 
     const WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
-    const std::optional<FrameIdentifier> m_frameID; // constant for object's lifetime.
+    const FrameIdentifier m_frameID; // constant for object's lifetime.
     OptionSet<ActivityState> m_pageActivityState;
     HashMap<AXID, Ref<AccessibilityObject>> m_objects;
 

--- a/Source/WebCore/accessibility/AXUtilities.cpp
+++ b/Source/WebCore/accessibility/AXUtilities.cpp
@@ -187,10 +187,8 @@ bool isRowGroup(Node* node)
 
 void dumpAccessibilityTreeToStderr(Document& document)
 {
-    if (CheckedPtr cache = document.existingAXObjectCache()) {
-        AXTreeData data = cache->treeData();
-        SAFE_FPRINTF(stderr, "==AX Trees==\n%s\n%s\n", data.liveTree.utf8(), data.isolatedTree.utf8());
-    }
+    if (CheckedPtr cache = document.existingAXObjectCache())
+        cache->treeData().dumpToStderr();
 }
 
 String roleToString(AccessibilityRole role)

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -443,17 +443,18 @@ public:
     static void removeTreeForFrameID(FrameIdentifier);
 
     // Retrieve the tree for the frame ID of any LocalFrame
-    static RefPtr<AXIsolatedTree> treeForFrameID(std::optional<FrameIdentifier>);
     static RefPtr<AXIsolatedTree> treeForFrameID(FrameIdentifier);
     static RefPtr<AXIsolatedTree> treeForFrameIDAlreadyLocked(FrameIdentifier);
     AXObjectCache* axObjectCache() const;
     constexpr AXGeometryManager* geometryManager() const { return m_geometryManager.get(); }
 
     AXIsolatedObject* rootNode() { ASSERT(!isMainThread()); return m_rootNode.get(); }
+    std::optional<AXID> pendingRootNodeID();
     RefPtr<AXIsolatedObject> rootWebArea();
     std::optional<AXID> focusedNodeID();
     WEBCORE_EXPORT RefPtr<AXIsolatedObject> focusedNode();
 
+    bool unsafeHasObjectForID(AXID axID) const;
     inline AXIsolatedObject* objectForID(AXID axID) const
     {
         AX_DEBUG_ASSERT(!isMainThread());
@@ -735,11 +736,6 @@ inline AXObjectCache* AXIsolatedTree::axObjectCache() const
 {
     AX_DEBUG_ASSERT(isMainThread());
     return m_axObjectCache.get();
-}
-
-inline RefPtr<AXIsolatedTree> AXIsolatedTree::treeForFrameID(std::optional<FrameIdentifier> frameID)
-{
-    return frameID ? treeForFrameID(*frameID) : nullptr;
 }
 
 template<typename U>

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -2530,7 +2530,8 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
             return;
 
         AXTreeData data = cache->treeData({ { AXStreamOptions::IdentifierAttribute, AXStreamOptions::OuterHTML, AXStreamOptions::RendererOrNode } }); // Can specify AXStreamOptions here if needed (e.g., TextRuns)
-        SAFE_FPRINTF(stderr, "==AX Trees==\n%s\n%s\n", data.liveTree.utf8(), data.isolatedTree.utf8());
+
+        data.dumpToStderr();
     });
 }
 

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -1104,6 +1104,11 @@ IntPoint EmptyFrameLoaderClient::accessibilityRemoteFrameOffset()
 void EmptyFrameLoaderClient::setIsolatedTree(Ref<WebCore::AXIsolatedTree>&&)
 {
 }
+
+RefPtr<WebCore::AXIsolatedTree> EmptyFrameLoaderClient::isolatedTree() const
+{
+    return nullptr;
+}
 #endif
 
 void EmptyFrameLoaderClient::willCacheResponse(DocumentLoader*, ResourceLoaderIdentifier, NSCachedURLResponse *response, CompletionHandler<void(NSCachedURLResponse *)>&& completionHandler) const

--- a/Source/WebCore/loader/EmptyFrameLoaderClient.h
+++ b/Source/WebCore/loader/EmptyFrameLoaderClient.h
@@ -180,6 +180,7 @@ private:
     IntPoint accessibilityRemoteFrameOffset() final;
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     void setIsolatedTree(Ref<WebCore::AXIsolatedTree>&&) final;
+    RefPtr<WebCore::AXIsolatedTree> isolatedTree() const final;
 #endif
     void willCacheResponse(DocumentLoader*, ResourceLoaderIdentifier, NSCachedURLResponse *, CompletionHandler<void(NSCachedURLResponse *)>&&) const final;
 #endif

--- a/Source/WebCore/loader/LocalFrameLoaderClient.h
+++ b/Source/WebCore/loader/LocalFrameLoaderClient.h
@@ -285,6 +285,7 @@ public:
     virtual IntPoint accessibilityRemoteFrameOffset() = 0;
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     virtual void setIsolatedTree(Ref<WebCore::AXIsolatedTree>&&) = 0;
+    virtual RefPtr<WebCore::AXIsolatedTree> isolatedTree() const = 0;
 #endif
     virtual void willCacheResponse(DocumentLoader*, ResourceLoaderIdentifier, NSCachedURLResponse*, CompletionHandler<void(NSCachedURLResponse *)>&&) const = 0;
     virtual std::optional<double> dataDetectionReferenceDate() { return std::nullopt; }

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -9103,6 +9103,7 @@ header: <WebCore/AXObjectCache.h>
     bool isAccessibilityThreadInitialized;
     String liveTree;
     String isolatedTree;
+    Vector<String> warnings;
     uint64_t remoteTokenHash;
     uint64_t webProcessLocalTokenHash;
 };

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -1817,6 +1817,7 @@ NSDictionary *WebPageProxy::getAccessibilityWebProcessDebugInfo()
         @"axIsThreadInitialized": [NSNumber numberWithBool:result.isAccessibilityThreadInitialized],
         @"axLiveTree": result.liveTree.createNSString().get(),
         @"axIsolatedTree": result.isolatedTree.createNSString().get(),
+        @"warnings": createNSArray(result.warnings).get(),
         @"axWebProcessRemoteHash": [NSNumber numberWithUnsignedInteger:result.remoteTokenHash],
         @"axWebProcessLocalHash": [NSNumber numberWithUnsignedInteger:result.webProcessLocalTokenHash]
     };

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
@@ -236,6 +236,7 @@ private:
     WebCore::IntPoint accessibilityRemoteFrameOffset() final;
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     void setIsolatedTree(Ref<WebCore::AXIsolatedTree>&&) final;
+    RefPtr<WebCore::AXIsolatedTree> isolatedTree() const final;
 #endif
     void willCacheResponse(WebCore::DocumentLoader*, WebCore::ResourceLoaderIdentifier, NSCachedURLResponse*, CompletionHandler<void(NSCachedURLResponse *)>&&) const final;
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/cocoa/WebLocalFrameLoaderClientCocoa.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/cocoa/WebLocalFrameLoaderClientCocoa.mm
@@ -29,6 +29,8 @@
 #import "APIInjectedBundlePageResourceLoadClient.h"
 #import "WebFrame.h"
 
+#import <WebCore/AXIsolatedTree.h>
+
 namespace WebKit {
 
 WebCore::IntPoint WebLocalFrameLoaderClient::accessibilityRemoteFrameOffset()
@@ -52,6 +54,12 @@ void WebLocalFrameLoaderClient::setIsolatedTree(Ref<WebCore::AXIsolatedTree>&& t
     ASSERT(isMainRunLoop());
     if (RefPtr webPage = m_frame->page())
         webPage->setIsolatedTree(WTF::move(tree));
+}
+
+RefPtr<AXIsolatedTree> WebLocalFrameLoaderClient::isolatedTree() const
+{
+    RefPtr webPage = m_frame->page();
+    return webPage ? webPage->isolatedTree() : nullptr;
 }
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -564,19 +564,16 @@ void WebPage::getAccessibilityWebProcessDebugInfo(CompletionHandler<void(WebCore
         return;
     }
 
-    if (auto treeData = protectedCorePage()->accessibilityTreeData(IncludeDOMInfo::No)) {
+    bool isAXThreadInitialized = false;
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-        completionHandler({ WebCore::AXObjectCache::accessibilityEnabled(), WebCore::AXObjectCache::isAXThreadInitialized(), treeData->liveTree, treeData->isolatedTree, [m_mockAccessibilityElement remoteTokenHash], [accessibilityRemoteTokenData() hash] });
-#else
-        completionHandler({ WebCore::AXObjectCache::accessibilityEnabled(), false, treeData->liveTree, treeData->isolatedTree, [m_mockAccessibilityElement remoteTokenHash], [accessibilityRemoteTokenData() hash] });
+    isAXThreadInitialized = WebCore::AXObjectCache::isAXThreadInitialized();
 #endif
+
+    if (std::optional treeData = protectedCorePage()->accessibilityTreeData(IncludeDOMInfo::No)) {
+        completionHandler({ WebCore::AXObjectCache::accessibilityEnabled(), isAXThreadInitialized, WTF::move(treeData->liveTree), WTF::move(treeData->isolatedTree), WTF::move(treeData->warnings), [m_mockAccessibilityElement remoteTokenHash], [accessibilityRemoteTokenData() hash] });
         return;
     }
-#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-    completionHandler({ WebCore::AXObjectCache::accessibilityEnabled(), WebCore::AXObjectCache::isAXThreadInitialized(), { }, { }, 0, 0 });
-#else
-    completionHandler({ WebCore::AXObjectCache::accessibilityEnabled(), false, { }, { }, 0, 0 });
-#endif
+    completionHandler({ WebCore::AXObjectCache::accessibilityEnabled(), isAXThreadInitialized, emptyString(), emptyString(), { }, 0, 0 });
 }
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1265,6 +1265,7 @@ public:
     void cacheAXPosition(const WebCore::FloatPoint&);
     void cacheAXSize(const WebCore::IntSize&);
     void setIsolatedTree(Ref<WebCore::AXIsolatedTree>&&);
+    RefPtr<WebCore::AXIsolatedTree> isolatedTree() const;
 #endif
     NSObject *accessibilityObjectForMainFramePlugin();
     bool shouldFallbackToWebContentAXObjectForMainFramePlugin() const;

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.h
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.h
@@ -68,6 +68,7 @@ class AXIsolatedTree;
 - (void)setPosition:(const WebCore::FloatPoint&)point;
 - (void)setSize:(const WebCore::IntSize&)size;
 - (void)setIsolatedTree:(Ref<WebCore::AXIsolatedTree>&&)tree;
+- (RefPtr<WebCore::AXIsolatedTree>)isolatedTree;
 - (void)setWindow:(id)window;
 - (void)_buildIsolatedTreeIfNeeded;
 #endif

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm
@@ -218,6 +218,11 @@ namespace ax = WebCore::Accessibility;
     m_isolatedTree = tree.get();
 }
 
+- (RefPtr<WebCore::AXIsolatedTree>)isolatedTree
+{
+    return m_isolatedTree.get();
+}
+
 - (void)setWindow:(id)window
 {
     ASSERT(isMainRunLoop());

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -517,6 +517,11 @@ void WebPage::setIsolatedTree(Ref<WebCore::AXIsolatedTree>&& tree)
 {
     [m_mockAccessibilityElement setIsolatedTree:WTF::move(tree)];
 }
+
+RefPtr<AXIsolatedTree> WebPage::isolatedTree() const
+{
+    return [m_mockAccessibilityElement isolatedTree];
+}
 #endif
 
 bool WebPage::platformCanHandleRequest(const WebCore::ResourceRequest& request)

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.h
@@ -213,6 +213,7 @@ private:
     WebCore::IntPoint accessibilityRemoteFrameOffset() final { return { }; }
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     void setIsolatedTree(Ref<WebCore::AXIsolatedTree>&&) final { }
+    RefPtr<WebCore::AXIsolatedTree> isolatedTree() const final { return nullptr; }
 #endif
 
     RetainPtr<WebFramePolicyListener> setUpPolicyListener(WebCore::FramePolicyFunction&&, WebCore::PolicyAction defaultPolicy, NSURL *appLinkURL, NSURL* referrerURL);


### PR DESCRIPTION
#### 2e1aa9ba4fc417f1dda845b0059d27efbd4a7c03
<pre>
AX: Add more debugging information for scenario where all content is inaccessible to VoiceOver
<a href="https://bugs.webkit.org/show_bug.cgi?id=305357">https://bugs.webkit.org/show_bug.cgi?id=305357</a>
<a href="https://rdar.apple.com/168035786">rdar://168035786</a>

Reviewed by Joshua Hoffman.

Sometimes, all web content is entirely inaccessible to VoiceOver. There have been several variants of this issue, and
in one, our debugging information tells us there is no isolated tree. This commit improves on this debugging information
on several ways:

  - AXObjectCache::m_frameID being std::nullopt would&apos;ve been one reason an isolated tree couldn&apos;t be returned. However,
    it should never actually be possible for it to be nullopt, thus the optional typing is removed to make it truly
    impossible at compile-time. This has the nice benefit of eliminating branches in many places.

  - The old logging didn&apos;t differentiate between there being no tree, and having a tree with no root. This is an important
    distinction, and the new logging makes it clear.

  - We now log a warning if the webpage doesn&apos;t have an isolated tree set, which could be one cause of these issues that
    we previously had no visibility into. This is added alongside a general-purpose warning infrastructure that we can
    add to over time.

  - We now log if isolated tree mode was off entirely.

  - We now log if the reason we don&apos;t have a root node is because we have a AXIsolatedTree::m_pendingRootNodeID and
    whether it can or cannot be hydrated into an actual object.

* Source/WebCore/accessibility/AXGeometryManager.cpp:
(WebCore::AXGeometryManager::cacheRectIfNeeded):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::AXObjectCache):
(WebCore::AXObjectCache::~AXObjectCache):
(WebCore::AXObjectCache::getOrCreateIsolatedTree):
(WebCore::AXObjectCache::buildIsolatedTree):
(WebCore::AXObjectCache::updateLoadingProgress):
(WebCore::AXObjectCache::onPageActivityStateChange):
(WebCore::AXObjectCache::onScrollbarFrameRectChange):
(WebCore::AXObjectCache::updateIsolatedTree):
(WebCore::AXObjectCache::onPaint const):
(WebCore::AXObjectCache::onPaint):
(WebCore::AXObjectCache::treeData):
* Source/WebCore/accessibility/AXObjectCache.h:
(WebCore::AXTreeData::dumpToStderr const):
* Source/WebCore/accessibility/AXUtilities.cpp:
(WebCore::dumpAccessibilityTreeToStderr):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::storeTree):
(WebCore::AXIsolatedTree::unsafeHasObjectForID const):
(WebCore::AXIsolatedTree::pendingRootNodeID):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
(WebCore::AXIsolatedTree::treeForFrameID): Deleted.
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper _accessibilityPrintTrees]):
* Source/WebCore/loader/LocalFrameLoaderClient.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::getAccessibilityWebProcessDebugInfo):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/cocoa/WebLocalFrameLoaderClientCocoa.mm:
(WebKit::WebLocalFrameLoaderClient::isolatedTree const):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::getAccessibilityWebProcessDebugInfo):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.h:
* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm:
(-[WKAccessibilityWebPageObjectBase isolatedTree]):
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::isolatedTree const):

Canonical link: <a href="https://commits.webkit.org/305525@main">https://commits.webkit.org/305525@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c80ebc31d8d773edc8ea097c46e22eb65b1b23c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138582 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10947 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/63 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146694 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91557 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3eccd4ac-1269-4428-9d30-279658cadf3f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140456 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11651 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11102 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106033 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77372 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/026ad2af-df37-4d25-9e73-a3c97e4a107d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141529 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8771 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124214 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86903 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8ec8f6b8-f180-4912-ae78-fc49e182d1fd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8359 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6119 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6986 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117776 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/53 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149445 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10629 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/49 "Found 1 new test failure: http/tests/performance/performance-resource-timing-redirection-cross-origin-media.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114417 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10646 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8997 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114757 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29176 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8551 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120510 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65521 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10678 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/52 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10412 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74310 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10616 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10467 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->