### PR TITLE
Stretch images instead of tiling them on macOS as well as iOS

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fill-stroke/paint-order-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fill-stroke/paint-order-001.html
@@ -7,7 +7,7 @@
 <link rel="match" href="reference/paint-order-001-ref.tentative.html">
 <link rel="help" href="https://www.w3.org/TR/fill-stroke-3/#strokes">
 <link rel="help" href="https://compat.spec.whatwg.org/#the-webkit-text-stroke">
-<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-14">
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-15">
 <style>
 span { -webkit-text-stroke: 5px orange; }
 span.i { paint-order: initial; }

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2133,9 +2133,6 @@ webkit.org/b/293761 http/tests/navigation/keyboard-events-during-provisional-nav
 [ Debug ] fast/scrolling/mac/scrollbars/overflow-overlay-scrollbar-reveal.html [ Pass Crash ]
 [ Debug ] fast/scrolling/mac/scrollbars/overlay-scrollbar-reveal.html [ Pass Crash ]
 
-# It fails only on debug build with '0.01%' difference
-[ Debug ] imported/w3c/web-platform-tests/css/css-fill-stroke/paint-order-001.html [ ImageOnlyFailure ]
-
 webkit.org/b/295076 imported/w3c/web-platform-tests/css/css-pseudo/highlight-custom-properties-dynamic-001.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/295226 http/wpt/mediarecorder/MediaRecorder-audio-samplingrate-change.html [ Pass Failure ]

--- a/Source/WebCore/platform/graphics/Image.cpp
+++ b/Source/WebCore/platform/graphics/Image.cpp
@@ -248,9 +248,7 @@ ImageDrawResult Image::drawTiled(GraphicsContext& ctxt, const FloatRect& destRec
         return draw(ctxt, destRect, visibleSrcRect, options);
     }
 
-#if PLATFORM(IOS_FAMILY)
-    // FIXME: We should re-test this and remove this iOS behavior difference if possible.
-    // When using accelerated drawing on iOS, it's faster to stretch an image than to tile it.
+    // When using accelerated drawing, it's faster to stretch an image than to tile it.
     if (ctxt.renderingMode() == RenderingMode::Accelerated) {
         if (size().width() == 1 && intersection(oneTileRect, destRect).height() == destRect.height()) {
             FloatRect visibleSrcRect;
@@ -269,7 +267,6 @@ ImageDrawResult Image::drawTiled(GraphicsContext& ctxt, const FloatRect& destRec
             return draw(ctxt, destRect, visibleSrcRect, options);
         }
     }
-#endif
 
     // Patterned images and gradients can use lots of memory for caching when the
     // tile size is large (<rdar://problem/4691859>, <rdar://problem/6239505>).


### PR DESCRIPTION
#### b828cfef076351dd755274552b0e38b2b52728bf
<pre>
Stretch images instead of tiling them on macOS as well as iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=305360">https://bugs.webkit.org/show_bug.cgi?id=305360</a>
<a href="https://rdar.apple.com/168038941">rdar://168038941</a>

Reviewed by Tim Horton.

Some old iOS code implemented tiling of 1px wide/tall images via a stretch, rather than a tile.
It turns out that this is about 4x faster on modern macOS hardware too, so let&apos;s use it on all
platforms.

* LayoutTests/imported/w3c/web-platform-tests/css/css-fill-stroke/paint-order-001.html: Increase tolerance
by 1 pixel.
* LayoutTests/platform/mac-wk2/TestExpectations: Remove the above test.
* Source/WebCore/platform/graphics/Image.cpp:
(WebCore::Image::drawTiled):

Canonical link: <a href="https://commits.webkit.org/305528@main">https://commits.webkit.org/305528@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fdd7a8e91e163d2001bc8b7c303dca245cb62be2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138678 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11044 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/160 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146792 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91653 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/33594c72-7927-4175-bd8c-ab8aa4571c95) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140551 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11748 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11198 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106115 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/77433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3916f344-7dba-4e9f-97ee-12bab5319043) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141625 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8852 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/124296 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86987 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c940ab01-89f6-4281-b82a-2554be06a83e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8440 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6200 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7090 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117861 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/133 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149548 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10726 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/136 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114501 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10743 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9077 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114839 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/29188 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8683 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120590 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65621 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10774 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/134 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10509 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74415 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10712 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10563 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->