### PR TITLE
Fix FTL lowering of storage phis for ArrayButterfly allocations

### DIFF
--- a/JSTests/stress/array-allocation-sink-escape-materialize-15.js
+++ b/JSTests/stress/array-allocation-sink-escape-materialize-15.js
@@ -1,0 +1,20 @@
+//@ runDefault("--useConcurrentJIT=0", "--thresholdForJITAfterWarmUp=10", "--thresholdForOptimizeAfterWarmUp=100", "--thresholdForOptimizeAfterLongWarmUp=100",  "--thresholdForFTLOptimizeAfterWarmUp=1000")
+
+function compute(x, len) {
+  x[NaN] = len;
+  var w = Array(80);
+  for (var i = 0; i < x.length; i += 16) {
+    for (var j = 0; j < 50; j++) {
+      if (j >= i) {
+        w[j] = w.filter(function(){})[0];
+      }
+      x.splice(len)
+    }
+  }
+}
+
+var arr = Array();
+for (var i = 0; i < 50000; i += 8) {
+  arr[i >> 5] = 1;
+}
+compute(arr, 50000);

--- a/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
@@ -2147,7 +2147,7 @@ escapeChildren:
                     return nullptr;
 
                 Node* phiNode = m_graph.addNode(SpecHeapTop, Phi, block->at(0)->origin.withInvalidExit());
-                phiNode->mergeFlags(NodeResultJS);
+                phiNode->mergeFlags(identifier->op() == NewButterflyWithSize ? NodeResultStorage : NodeResultJS);
                 return phiNode;
             });
 

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -461,6 +461,9 @@ private:
                 case NodeResultJS:
                     type = Int64;
                     break;
+                case NodeResultStorage:
+                    type = Int64;
+                    break;
                 default:
                     DFG_CRASH(m_graph, node, "Bad Phi node result type");
                     break;
@@ -2016,8 +2019,17 @@ private:
             ASSERT(phi->result() == NodeResultJS);
             break;
         case UntypedUse:
-            upsilonValue = lowJSValue(m_node->child1());
-            ASSERT(phi->result() == NodeResultJS);
+            switch (phi->result()) {
+            case NodeResultJS:
+                upsilonValue = lowJSValue(m_node->child1());
+                break;
+            case NodeResultStorage:
+                upsilonValue = lowStorage(m_node->child1());
+                break;
+            default:
+                DFG_CRASH(m_graph, m_node, "Bad result type for UntypedUse");
+                break;
+            }
             break;
         default:
             DFG_CRASH(m_graph, m_node, "Bad use kind");
@@ -2048,6 +2060,9 @@ private:
             break;
         case NodeResultJS:
             setJSValue(phi);
+            break;
+        case NodeResultStorage:
+            setStorage(phi);
             break;
         default:
             DFG_CRASH(m_graph, m_node, "Bad result type");


### PR DESCRIPTION
#### 59a1269a604fd4bbcfd87b414da9f7ef2b7e975e
<pre>
Fix FTL lowering of storage phis for ArrayButterfly allocations
<a href="https://bugs.webkit.org/show_bug.cgi?id=305362">https://bugs.webkit.org/show_bug.cgi?id=305362</a>
<a href="https://rdar.apple.com/165711688">rdar://165711688</a>

Reviewed by NOBODY (OOPS!).

<a href="https://commits.webkit.org/297146@main">297146@main</a> added ArrayButterfly as a sinkable allocation kind, but the allocation SSA always created
phis with NodeResultJS. So, when ArrayButterfly allocations escape and materialize to
NewButterflyWithSize, FTL would fail trying to lower these values because they are storage, not JSValue.

Fix by:
1. Create phis with NodeResultStorage when the allocation identifier is NewButterflyWithSize.
2. Add NodeResultStorage handling to FTL phi creation/lowering.
3. Make compileUpsilon handle storage phis with UntypedUse edges.

Test: JSTests/stress/array-allocation-sink-escape-materialize-15.js
* JSTests/stress/array-allocation-sink-escape-materialize-15.js: Added.
(compute):
* Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::createPhiVariables):
(JSC::FTL::DFG::LowerDFGToB3::compileUpsilon):
(JSC::FTL::DFG::LowerDFGToB3::compilePhi):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59a1269a604fd4bbcfd87b414da9f7ef2b7e975e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138587 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10952 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/68 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146699 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91562 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a8bc6f6d-4964-4cfb-a18b-abb969455aab) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11656 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11108 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106038 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77377 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f55c91c9-897c-4595-a0a3-a5cf706d61dc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141534 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8776 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124220 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86908 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c63b751a-11f4-448b-af57-68e9870a2f20) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8364 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6146 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6991 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/130553 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117781 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/59 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149450 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/137186 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10634 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/89 "Found 1 new test failure: http/tests/performance/performance-resource-timing-redirection-cross-origin-media.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114422 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10651 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9001 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114762 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8557 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120516 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65526 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10683 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/58 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/169861 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10417 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74315 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44286 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10621 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10472 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->