### PR TITLE
Move from RefPtr to Ref in WebCore/platform/graphics

### DIFF
--- a/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
@@ -371,7 +371,7 @@ GlyphData FontCascadeFonts::glyphDataForSystemFallback(char32_t character, const
 
     StringBuilder stringBuilder;
     stringBuilder.append(character);
-    auto systemFallbackFont = font->systemFallbackFontForCharacterCluster(stringBuilder, description, resolvedEmojiPolicy, m_isForPlatformFont ? IsForPlatformFont::Yes : IsForPlatformFont::No);
+    RefPtr systemFallbackFont = font->systemFallbackFontForCharacterCluster(stringBuilder, description, resolvedEmojiPolicy, m_isForPlatformFont ? IsForPlatformFont::Yes : IsForPlatformFont::No);
     if (!systemFallbackFont)
         return GlyphData();
 
@@ -394,7 +394,7 @@ GlyphData FontCascadeFonts::glyphDataForSystemFallback(char32_t character, const
 
     // Keep the system fallback fonts we use alive.
     if (fallbackGlyphData.isValid())
-        m_systemFallbackFontSet.add(WTF::move(systemFallbackFont));
+        m_systemFallbackFontSet.add(systemFallbackFont.releaseNonNull());
 
     return fallbackGlyphData;
 }

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.h
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.h
@@ -115,7 +115,7 @@ private:
 
     EnumeratedArray<ResolvedEmojiPolicy, HashMap<unsigned, GlyphPageCacheEntry, IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>>, ResolvedEmojiPolicy::RequireEmoji> m_cachedPages;
 
-    HashSet<RefPtr<Font>> m_systemFallbackFontSet;
+    HashSet<Ref<Font>> m_systemFallbackFontSet;
 
     SingleThreadWeakPtr<const Font> m_cachedPrimaryFont;
 

--- a/Source/WebCore/platform/graphics/avfoundation/MediaSelectionGroupAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaSelectionGroupAVFObjC.h
@@ -78,7 +78,7 @@ public:
 
     void updateOptions(const Vector<String>& characteristics);
 
-    using OptionContainer = HashMap<CFTypeRef, RefPtr<MediaSelectionOptionAVFObjC>>;
+    using OptionContainer = HashMap<CFTypeRef, Ref<MediaSelectionOptionAVFObjC>>;
     typename OptionContainer::ValuesIteratorRange options() { return m_options.values(); }
 
     AVMediaSelectionGroup *avMediaSelectionGroup() const { return m_mediaSelectionGroup.get(); }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateAVFObjC.h
@@ -47,19 +47,19 @@ class AudioTrackPrivateAVFObjC : public AudioTrackPrivateAVF {
     WTF_MAKE_TZONE_ALLOCATED(AudioTrackPrivateAVFObjC);
     WTF_MAKE_NONCOPYABLE(AudioTrackPrivateAVFObjC)
 public:
-    static RefPtr<AudioTrackPrivateAVFObjC> create(AVPlayerItemTrack* track)
+    static Ref<AudioTrackPrivateAVFObjC> create(AVPlayerItemTrack* track)
     {
-        return adoptRef(new AudioTrackPrivateAVFObjC(track));
+        return adoptRef(*new AudioTrackPrivateAVFObjC(track));
     }
 
-    static RefPtr<AudioTrackPrivateAVFObjC> create(AVAssetTrack* track)
+    static Ref<AudioTrackPrivateAVFObjC> create(AVAssetTrack* track)
     {
-        return adoptRef(new AudioTrackPrivateAVFObjC(track));
+        return adoptRef(*new AudioTrackPrivateAVFObjC(track));
     }
 
-    static RefPtr<AudioTrackPrivateAVFObjC> create(MediaSelectionOptionAVFObjC& option)
+    static Ref<AudioTrackPrivateAVFObjC> create(MediaSelectionOptionAVFObjC& option)
     {
-        return adoptRef(new AudioTrackPrivateAVFObjC(option));
+        return adoptRef(*new AudioTrackPrivateAVFObjC(option));
     }
 
     virtual ~AudioTrackPrivateAVFObjC();

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
@@ -424,15 +424,15 @@ private:
     std::unique_ptr<PixelBufferConformerCV> m_pixelBufferConformer;
 
     friend class WebCoreAVFResourceLoader;
-    HashMap<RetainPtr<CFTypeRef>, RefPtr<WebCoreAVFResourceLoader>> m_resourceLoaderMap;
+    HashMap<RetainPtr<CFTypeRef>, Ref<WebCoreAVFResourceLoader>> m_resourceLoaderMap;
     const RetainPtr<WebCoreAVFLoaderDelegate> m_loaderDelegate;
     MemoryCompactRobinHoodHashMap<String, RetainPtr<AVAssetResourceLoadingRequest>> m_keyURIToRequestMap;
     MemoryCompactRobinHoodHashMap<String, RetainPtr<AVAssetResourceLoadingRequest>> m_sessionIDToRequestMap;
 
     RetainPtr<AVPlayerItemLegibleOutput> m_legibleOutput;
 
-    Vector<RefPtr<AudioTrackPrivateAVFObjC>> m_audioTracks;
-    Vector<RefPtr<VideoTrackPrivateAVFObjC>> m_videoTracks;
+    Vector<Ref<AudioTrackPrivateAVFObjC>> m_audioTracks;
+    Vector<Ref<VideoTrackPrivateAVFObjC>> m_videoTracks;
     RefPtr<MediaSelectionGroupAVFObjC> m_audibleGroup;
     RefPtr<MediaSelectionGroupAVFObjC> m_visualGroup;
 
@@ -442,7 +442,7 @@ private:
     RefPtr<InbandMetadataTextTrackPrivateAVF> m_metadataTrack;
 #endif
 
-    MemoryCompactRobinHoodHashMap<String, RefPtr<InbandChapterTrackPrivateAVFObjC>> m_chapterTracks;
+    MemoryCompactRobinHoodHashMap<String, Ref<InbandChapterTrackPrivateAVFObjC>> m_chapterTracks;
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET) && PLATFORM(MAC)
     RetainPtr<AVOutputContext> m_outputContext;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -2472,10 +2472,10 @@ void determineChangedTracksFromNewTracksAndOldItems(NSArray* tracks, NSString* t
 
     if (player) {
         for (auto& removedItem : removedItems)
-            (player.get()->*removedFunction)(*removedItem);
+            (player.get()->*removedFunction)(removedItem.get());
 
         for (auto& addedItem : addedItems)
-            (player.get()->*addedFunction)(*addedItem);
+            (player.get()->*addedFunction)(addedItem.get());
     }
 }
 
@@ -2484,32 +2484,30 @@ void determineChangedTracksFromNewTracksAndOldItems(MediaSelectionGroupAVFObjC* 
 {
     group->updateOptions(characteristics);
 
-    ListHashSet<RefPtr<MediaSelectionOptionAVFObjC>> newSelectionOptions;
+    ListHashSet<Ref<MediaSelectionOptionAVFObjC>> newSelectionOptions;
     for (auto& option : group->options()) {
-        if (!option)
-            continue;
         RetainPtr avOption = option->avMediaSelectionOption();
         if (!avOption)
             continue;
         newSelectionOptions.add(option);
     }
 
-    ListHashSet<RefPtr<MediaSelectionOptionAVFObjC>> oldSelectionOptions;
+    ListHashSet<Ref<MediaSelectionOptionAVFObjC>> oldSelectionOptions;
     for (auto& oldItem : oldItems) {
         if (RefPtr option = oldItem->mediaSelectionOption())
-            oldSelectionOptions.add(WTF::move(option));
+            oldSelectionOptions.add(option.releaseNonNull());
     }
 
     // Find the added & removed AVMediaSelectionOptions:
-    ListHashSet<RefPtr<MediaSelectionOptionAVFObjC>> removedSelectionOptions;
+    ListHashSet<Ref<MediaSelectionOptionAVFObjC>> removedSelectionOptions;
     for (auto& oldOption : oldSelectionOptions) {
-        if (!newSelectionOptions.contains(oldOption))
+        if (!newSelectionOptions.contains(oldOption.ptr()))
             removedSelectionOptions.add(oldOption);
     }
 
-    ListHashSet<RefPtr<MediaSelectionOptionAVFObjC>> addedSelectionOptions;
+    ListHashSet<Ref<MediaSelectionOptionAVFObjC>> addedSelectionOptions;
     for (auto& newOption : newSelectionOptions) {
-        if (!oldSelectionOptions.contains(newOption))
+        if (!oldSelectionOptions.contains(newOption.ptr()))
             addedSelectionOptions.add(newOption);
     }
 
@@ -2527,17 +2525,17 @@ void determineChangedTracksFromNewTracksAndOldItems(MediaSelectionGroupAVFObjC* 
     }
 
     for (auto& option : addedSelectionOptions)
-        addedItems.append(itemFactory(*option.get()));
+        addedItems.append(itemFactory(option));
 
     replacementItems.appendVector(addedItems);
     oldItems.swap(replacementItems);
 
     if (player) {
         for (auto& removedItem : removedItems)
-            (player.get()->*removedFunction)(*removedItem);
+            (player.get()->*removedFunction)(removedItem.get());
 
         for (auto& addedItem : addedItems)
-            (player.get()->*addedFunction)(*addedItem);
+            (player.get()->*addedFunction)(addedItem.get());
     }
 }
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateAVFObjC.h
@@ -47,19 +47,19 @@ class VideoTrackPrivateAVFObjC final : public VideoTrackPrivateAVF {
     WTF_MAKE_TZONE_ALLOCATED(VideoTrackPrivateAVFObjC);
     WTF_MAKE_NONCOPYABLE(VideoTrackPrivateAVFObjC)
 public:
-    static RefPtr<VideoTrackPrivateAVFObjC> create(AVPlayerItemTrack* track)
+    static Ref<VideoTrackPrivateAVFObjC> create(AVPlayerItemTrack* track)
     {
-        return adoptRef(new VideoTrackPrivateAVFObjC(track));
+        return adoptRef(*new VideoTrackPrivateAVFObjC(track));
     }
 
-    static RefPtr<VideoTrackPrivateAVFObjC> create(AVAssetTrack* track)
+    static Ref<VideoTrackPrivateAVFObjC> create(AVAssetTrack* track)
     {
-        return adoptRef(new VideoTrackPrivateAVFObjC(track));
+        return adoptRef(*new VideoTrackPrivateAVFObjC(track));
     }
 
-    static RefPtr<VideoTrackPrivateAVFObjC> create(MediaSelectionOptionAVFObjC& option)
+    static Ref<VideoTrackPrivateAVFObjC> create(MediaSelectionOptionAVFObjC& option)
     {
-        return adoptRef(new VideoTrackPrivateAVFObjC(option));
+        return adoptRef(*new VideoTrackPrivateAVFObjC(option));
     }
 
     void setSelected(bool) override;

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -3456,7 +3456,7 @@ void GraphicsLayerCA::updateAnimations()
     auto infiniteDuration = std::numeric_limits<double>::max();
     auto currentTime = Seconds(CACurrentMediaTime());
 
-    auto addAnimationGroup = [&](AnimatedProperty property, const Vector<RefPtr<PlatformCAAnimation>>& animations) {
+    auto addAnimationGroup = [&](AnimatedProperty property, const Vector<Ref<PlatformCAAnimation>>& animations) {
         auto caAnimationGroup = createPlatformCAAnimation(PlatformCAAnimation::AnimationType::Group, PlatformCAAnimation::makeGroupKeyPath());
         caAnimationGroup->setDuration(infiniteDuration);
         caAnimationGroup->setAnimations(animations);
@@ -3613,7 +3613,7 @@ void GraphicsLayerCA::updateAnimations()
             }
 
             LayerPropertyAnimation* earliestAnimation = nullptr;
-            Vector<RefPtr<PlatformCAAnimation>> caAnimations;
+            Vector<Ref<PlatformCAAnimation>> caAnimations;
             for (auto* animation : animations | std::views::reverse) {
                 if (!animation->m_beginTime)
                     animation->m_beginTime = currentTime - animationGroupBeginTime;
@@ -3629,7 +3629,7 @@ void GraphicsLayerCA::updateAnimations()
             // we must create a non-interpolating animation to set the current value for this transform-related property
             // until that animation begins.
             if (earliestAnimation) {
-                auto fillMode = Ref { *earliestAnimation->m_animation }->fillMode();
+                auto fillMode = earliestAnimation->m_animation->fillMode();
                 if (fillMode != PlatformCAAnimation::FillModeType::Backwards && fillMode != PlatformCAAnimation::FillModeType::Both) {
                     Seconds earliestBeginTime = *earliestAnimation->computedBeginTime() + animationGroupBeginTime;
                     if (earliestBeginTime > currentTime) {
@@ -3671,7 +3671,7 @@ void GraphicsLayerCA::setAnimationOnLayer(LayerPropertyAnimation& animation)
     auto property = animation.m_property;
     RefPtr layer = animatedLayer(property);
 
-    Ref caAnim = *animation.m_animation;
+    Ref caAnim = animation.m_animation;
 
     if (auto beginTime = animation.computedBeginTime())
         caAnim->setBeginTime(beginTime->seconds());
@@ -4641,7 +4641,7 @@ void GraphicsLayerCA::dumpAnimations(WTF::TextStream& textStream, ASCIILiteral c
         textStream << indent << '(' << animation.m_name;
         {
             TextStream::IndentScope indentScope(textStream);
-            textStream.dumpProperty("CA animation"_s, animation.m_animation.get());
+            textStream.dumpProperty("CA animation"_s, animation.m_animation.ptr());
             textStream.dumpProperty("property"_s, animation.m_property);
             textStream.dumpProperty("index"_s, animation.m_index);
             textStream.dumpProperty("time offset"_s, animation.m_timeOffset);

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -591,7 +591,7 @@ private:
             return std::nullopt;
         }
 
-        RefPtr<PlatformCAAnimation> m_animation;
+        const Ref<PlatformCAAnimation> m_animation;
         String m_name;
         AnimatedProperty m_property;
         int m_index;

--- a/Source/WebCore/platform/graphics/ca/LayerPool.cpp
+++ b/Source/WebCore/platform/graphics/ca/LayerPool.cpp
@@ -75,14 +75,14 @@ LayerPool::LayerList& LayerPool::listOfLayersWithSize(const IntSize& size, Acces
     return it->value;
 }
 
-void LayerPool::addLayer(const RefPtr<PlatformCALayer>& layer)
+void LayerPool::addLayer(PlatformCALayer& layer)
 {
     RELEASE_ASSERT(isMainThread());
-    IntSize layerSize(expandedIntSize(layer->bounds().size()));
+    IntSize layerSize(expandedIntSize(layer.bounds().size()));
     if (!canReuseLayerWithSize(layerSize))
         return;
 
-    listOfLayersWithSize(layerSize).prepend(layer);
+    listOfLayersWithSize(layerSize).prepend(Ref { layer });
     m_totalBytes += backingStoreBytesForSize(layerSize);
     
     m_lastAddTime = MonotonicTime::now();

--- a/Source/WebCore/platform/graphics/ca/LayerPool.h
+++ b/Source/WebCore/platform/graphics/ca/LayerPool.h
@@ -49,7 +49,7 @@ public:
 
     static HashSet<CheckedPtr<LayerPool>>& allLayerPools();
     
-    void addLayer(const RefPtr<PlatformCALayer>&);
+    void addLayer(PlatformCALayer&);
     RefPtr<PlatformCALayer> takeLayerWithSize(const IntSize&);
 
     void drain();
@@ -58,7 +58,7 @@ public:
     unsigned capacity() const { return m_maxBytesForPool; }
 
 private:
-    typedef Deque<RefPtr<PlatformCALayer>> LayerList;
+    typedef Deque<Ref<PlatformCALayer>> LayerList;
 
     unsigned decayedCapacity() const;
 

--- a/Source/WebCore/platform/graphics/ca/PlatformCAAnimation.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCAAnimation.h
@@ -150,7 +150,7 @@ public:
     virtual void copyTimingFunctionsFrom(const PlatformCAAnimation&) = 0;
 
     // Animation group properties.
-    virtual void setAnimations(const Vector<RefPtr<PlatformCAAnimation>>&) = 0;
+    virtual void setAnimations(const Vector<Ref<PlatformCAAnimation>>&) = 0;
     virtual void copyAnimationsFrom(const PlatformCAAnimation&) = 0;
 
     void setActualStartTimeIfNeeded(CFTimeInterval t)

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayer.mm
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayer.mm
@@ -205,7 +205,7 @@ void PlatformCALayer::moveToLayerPool()
 {
     ASSERT(!superlayer());
     if (auto pool = layerPool())
-        pool->addLayer(this);
+        pool->addLayer(*this);
 }
 
 LayerPool* PlatformCALayer::layerPool()

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.h
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.h
@@ -124,7 +124,7 @@ public:
     void copyTimingFunctionsFrom(const PlatformCAAnimation&) override;
 
     // Animation group properties.
-    void setAnimations(const Vector<RefPtr<PlatformCAAnimation>>&) final;
+    void setAnimations(const Vector<Ref<PlatformCAAnimation>>&) final;
     void copyAnimationsFrom(const PlatformCAAnimation&) final;
 
 private:

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
@@ -574,7 +574,7 @@ void PlatformCAAnimationCocoa::copyTimingFunctionsFrom(const PlatformCAAnimation
     [static_cast<CAKeyframeAnimation *>(m_animation.get()) setTimingFunctions:[other timingFunctions]];
 }
 
-void PlatformCAAnimationCocoa::setAnimations(const Vector<RefPtr<PlatformCAAnimation>>& value)
+void PlatformCAAnimationCocoa::setAnimations(const Vector<Ref<PlatformCAAnimation>>& value)
 {
     ASSERT(animationType() == AnimationType::Group);
     ASSERT([static_cast<CAAnimation *>(m_animation.get()) isKindOfClass:[CAAnimationGroup class]]);

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.h
@@ -115,7 +115,7 @@ public:
     void copyTimingFunctionsFrom(const WebCore::PlatformCAAnimation&) override;
 
     // Animation group properties.
-    void setAnimations(const Vector<RefPtr<PlatformCAAnimation>>&) final;
+    void setAnimations(const Vector<Ref<PlatformCAAnimation>>&) final;
     void copyAnimationsFrom(const PlatformCAAnimation&) final;
 
     AnimationType animationType() const { return m_properties.animationType; }

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm
@@ -458,10 +458,10 @@ void PlatformCAAnimationRemote::copyTimingFunctionsFrom(const PlatformCAAnimatio
     m_properties.reverseTimingFunctions = other.m_properties.reverseTimingFunctions;
 }
 
-void PlatformCAAnimationRemote::setAnimations(const Vector<RefPtr<PlatformCAAnimation>>& values)
+void PlatformCAAnimationRemote::setAnimations(const Vector<Ref<PlatformCAAnimation>>& values)
 {
     m_properties.animations = values.map([](auto& value) {
-        return downcast<PlatformCAAnimationRemote>(value.get())->properties();
+        return downcast<PlatformCAAnimationRemote>(value)->properties();
     });
 }
 


### PR DESCRIPTION
#### 7b91aa7b96e5ce75dd448cd1152c996035f19d20
<pre>
Move from RefPtr to Ref in WebCore/platform/graphics
<a href="https://bugs.webkit.org/show_bug.cgi?id=305364">https://bugs.webkit.org/show_bug.cgi?id=305364</a>

Reviewed by Tim Nguyen.

Improve code clarity.

Canonical link: <a href="https://commits.webkit.org/305517@main">https://commits.webkit.org/305517@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b65ebe1628c3100f5b0f693f32a04ff89548a81d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138590 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10955 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/71 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146702 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91565 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4efea4fb-946a-49cf-b1f0-f1c1ff340bdf) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140464 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11659 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11111 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106042 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77379 "layout-tests (failure)") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141537 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8780 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124223 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86912 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0a2d3c3a-0559-4150-9ac2-510d2222485f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8368 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6127 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6994 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117785 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/62 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149453 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10637 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/94 "Found 1 new test failure: http/tests/performance/performance-resource-timing-redirection-cross-origin-media.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114426 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10654 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9005 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114767 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8563 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120519 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65530 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21357 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10686 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/61 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10420 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74318 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10624 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10475 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->