### PR TITLE
[TestWebKitAPI][GLib] g_assert_cmpstr: warning: temporary whose address is used as value of local variable '__s2' will be destroyed at the end of the full-expression [-Wdangling]

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestAutomationSession.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestAutomationSession.cpp
@@ -296,14 +296,14 @@ const SocketConnection::MessageHandlers AutomationTest::s_messageHandlers = {
 
 static void testAutomationSessionRequestSession(AutomationTest* test, gconstpointer)
 {
-    String sessionID = createVersion4UUIDString();
+    CString sessionID = createVersion4UUIDString().utf8();
     // WebKitAutomationSession::automation-started is never emitted if automation is not enabled.
     g_assert_false(webkit_web_context_is_automation_allowed(test->m_webContext.get()));
 #if ENABLE(2022_GLIB_API)
     // Network session for automation is nullptr if automation is not enabled.
     g_assert_null(webkit_web_context_get_network_session_for_automation(test->m_webContext.get()));
 #endif
-    auto* session = test->requestSession(sessionID.utf8().data());
+    auto* session = test->requestSession(sessionID.data());
     g_assert_null(session);
 
     webkit_web_context_set_automation_allowed(test->m_webContext.get(), TRUE);
@@ -323,10 +323,10 @@ static void testAutomationSessionRequestSession(AutomationTest* test, gconstpoin
     Test::addLogFatalFlag(G_LOG_LEVEL_WARNING);
     g_assert_false(webkit_web_context_is_automation_allowed(otherContext.get()));
 
-    session = test->requestSession(sessionID.utf8().data());
-    g_assert_cmpstr(webkit_automation_session_get_id(session), ==, sessionID.utf8().data());
+    session = test->requestSession(sessionID.data());
+    g_assert_cmpstr(webkit_automation_session_get_id(session), ==, sessionID.data());
     g_assert_cmpuint(test->m_target.id, >, 0);
-    ASSERT_CMP_CSTRING(test->m_target.name, ==, sessionID.utf8());
+    ASSERT_CMP_CSTRING(test->m_target.name, ==, sessionID);
     g_assert_false(test->m_target.isPaired);
 
     // Will fail to create a browsing context when not creating a web view (or not handling the signal).

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitPolicyClient.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitPolicyClient.cpp
@@ -192,7 +192,7 @@ static void testNavigationPolicy(PolicyClientTest* test, gconstpointer)
     g_assert_true(webkit_navigation_action_is_redirect(navigationAction));
     g_assert_null(webkit_navigation_action_get_frame_name(navigationAction));
     request = webkit_navigation_action_get_request(navigationAction);
-    g_assert_cmpstr(webkit_uri_request_get_uri(request), ==, kServer->getURIForPath("/").data());
+    ASSERT_CMP_CSTRING(webkit_uri_request_get_uri(request), ==, kServer->getURIForPath("/"));
 
     // If we are waiting until load completion, it will never complete if we ignore the
     // navigation. So we tell the main loop to quit sometime later.


### PR DESCRIPTION
#### a3aa44e96f032ef315fb1a42c7313704162389bf
<pre>
[TestWebKitAPI][GLib] g_assert_cmpstr: warning: temporary whose address is used as value of local variable &apos;__s2&apos; will be destroyed at the end of the full-expression [-Wdangling]
<a href="https://bugs.webkit.org/show_bug.cgi?id=305348">https://bugs.webkit.org/show_bug.cgi?id=305348</a>

Reviewed by Carlos Garcia Campos.

Because g_assert_cmpstr is a macro not a function, the following code doesn&apos;t
retain the life time of a CString returned by str.utf8() by the end of the
macro.

&gt; g_assert_cmpstr(str.utf8().data(), ==, &quot;xyz&quot;);

Use ASSERT_CMP_CSTRING and CString to fix the problems.

* Tools/TestWebKitAPI/Tests/WebKitGLib/TestAutomationSession.cpp:
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitPolicyClient.cpp:
(testNavigationPolicy):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebXR.cpp:
(testWebKitXRPermissionRequest):
(testWebKitXRHitTest):

Canonical link: <a href="https://commits.webkit.org/305503@main">https://commits.webkit.org/305503@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/069c711f7ed738dd3beb95cf4eb9403c0ed8551a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138599 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10964 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/80 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146712 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/91574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140473 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11668 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11120 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/106046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/91574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141546 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8783 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124229 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86917 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8371 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6131 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7003 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117788 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/68 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149462 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10646 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/64 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/114430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10663 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9009 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114771 "Passed tests") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/8581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120525 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65540 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21343 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10695 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/67 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10430 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10633 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10484 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->