### PR TITLE
[TestWebKitAPI][GLib] GInputStream is leaked in WebKitImage test

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitImage.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitImage.cpp
@@ -33,16 +33,16 @@ public:
         auto* test = static_cast<WebKitImageTest*>(userData);
         GUniqueOutPtr<char> type;
         GUniqueOutPtr<GError> error;
-        GInputStream* stream = g_loadable_icon_load_finish(G_LOADABLE_ICON(source),
-        result, &type.outPtr(), &error.outPtr());
+        GRefPtr<GInputStream> stream = adoptGRef(g_loadable_icon_load_finish(G_LOADABLE_ICON(source),
+        result, &type.outPtr(), &error.outPtr()));
 
         g_assert_no_error(error.get());
-        g_assert_nonnull(stream);
+        g_assert_nonnull(stream.get());
         g_assert_cmpstr(type.get(), ==, "image/png");
 
         gsize bytes_read;
         unsigned char buffer[8];
-        gboolean success = g_input_stream_read_all(stream, buffer, sizeof(buffer),
+        gboolean success = g_input_stream_read_all(stream.get(), buffer, sizeof(buffer),
             &bytes_read, nullptr, &error.outPtr());
 
         g_assert_no_error(error.get());


### PR DESCRIPTION
#### 683ec4746c285e52f5ee423b175f3b2f52c2c5d5
<pre>
[TestWebKitAPI][GLib] GInputStream is leaked in WebKitImage test
<a href="https://bugs.webkit.org/show_bug.cgi?id=305375">https://bugs.webkit.org/show_bug.cgi?id=305375</a>

Reviewed by Carlos Garcia Campos.

Adopt the GInputStream into a GRefPtr to ensure it is properly disposed
of.

* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitImage.cpp:
(WebKitImageTest::asyncLoadFinishedCallback):

Canonical link: <a href="https://commits.webkit.org/305566@main">https://commits.webkit.org/305566@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f6e279df4f818adc29486c19d03c44ae95ea7ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138655 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11021 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/137 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146769 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91630 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140528 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11725 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11175 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106098 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77423 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141602 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8834 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124286 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86969 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8425 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6188 "Found 1 new API test failure: TestWebKitAPI.NowPlayingControlsTests.NowPlayingUpdatesThrottled (failure)") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7067 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117844 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/121 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149525 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10703 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/127 "Found 1 new test failure: http/tests/performance/performance-resource-timing-redirection-cross-origin-media.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114484 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10720 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9062 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114856 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29210 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8660 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120578 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65598 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10751 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/122 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10486 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10689 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10540 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->