### PR TITLE
Digital Credential: CredentialRequestCoordinator can remain non-Idle if AbortSignal races with picker result

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get.tentative.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get.tentative.https-expected.txt
@@ -10,9 +10,7 @@ PASS navigator.credentials.get() promise is rejected if called with an aborted c
 PASS navigator.credentials.get() promise is rejected if called with an aborted signal in cross-origin iframe.
 PASS navigator.credentials.get() promise is rejected if abort controller is aborted after call to get().
 PASS navigator.credentials.get() promise is rejected if abort controller is aborted after call to get() in cross-origin iframe.
-FAIL Mediation is implicitly required and hence ignored. Request is aborted regardless. promise_rejects_js: function "function() { throw e; }" threw object "InvalidStateError: A credential picker operation is already in progress." ("InvalidStateError") expected instance of function "function Error() {
-    [native code]
-}" ("Error")
+PASS Mediation is implicitly required and hence ignored. Request is aborted regardless.
 PASS Throws TypeError when request data is not JSON stringifiable.
 PASS `requests` field is required in the options object.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/non-fully-active.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/non-fully-active.https-expected.txt
@@ -1,4 +1,5 @@
 
 PASS non-fully active document behavior for CredentialsContainer
 FAIL Promise rejects with DOMException when the document becomes non-fully active promise_rejects_dom: Expect promise to reject if the document becomes non-fully active function "function() { throw e; }" threw object "TypeError: No supported document requests to present." that is not a DOMException AbortError: property "code" is equal to undefined, expected 20
+PASS Aborted Digital Credentials requests do not leave a subsequent request stuck in an invalid state.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/non-fully-active.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/non-fully-active.https.html
@@ -84,4 +84,33 @@
     iframe.remove();
     await p;
   }, "Promise rejects with DOMException when the document becomes non-fully active");
+
+  promise_test(async (t) => {
+    const iframe = await createIframe();
+    t.add_cleanup(() => iframe.remove());
+    const DOMExceptionCtor = iframe.contentWindow.DOMException;
+
+    for (let i = 0; i < 10; ++i) {
+      await test_driver.bless("User activation", null, iframe.contentWindow);
+      await iframe.focus();
+
+      const controller = new iframe.contentWindow.AbortController();
+      const p = iframe.contentWindow.navigator.credentials.get(
+        makeGetOptions({ signal: controller.signal })
+      );
+
+      controller.abort(new Error(`Aborted iteration ${i}`));
+
+      try {
+        await p;
+        assert_unreached("navigator.credentials.get() unexpectedly resolved");
+      } catch (e) {
+        assert_not_equals(
+          e.name,
+          "InvalidStateError",
+          `Iteration ${i}: should not fail with InvalidStateError`
+        );
+      }
+    }
+}, "Aborted Digital Credentials requests do not leave a subsequent request stuck in an invalid state.");
 </script>

--- a/Source/WebCore/Modules/identity/DigitalCredential.cpp
+++ b/Source/WebCore/Modules/identity/DigitalCredential.cpp
@@ -175,7 +175,7 @@ void DigitalCredential::discoverFromExternalSource(const Document& document, Cre
 
 #if HAVE(DIGITAL_CREDENTIALS_UI)
     Ref coordinator = page->credentialRequestCoordinator();
-    coordinator->presentPicker(document, WTF::move(promise), presentationRequestsOrException.releaseReturnValue(), options.signal);
+    coordinator->prepareCredentialRequest(document, WTF::move(promise), presentationRequestsOrException.releaseReturnValue(), options.signal);
 #else
     promise.reject(Exception { ExceptionCode::NotSupportedError, "Digital credentials are not supported."_s });
 #endif

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -4,7 +4,6 @@ Modules/entriesapi/FileSystemDirectoryEntry.cpp
 Modules/entriesapi/FileSystemEntry.cpp
 Modules/entriesapi/FileSystemFileEntry.cpp
 Modules/filesystem/FileSystemFileHandle.cpp
-Modules/identity/CredentialRequestCoordinator.cpp
 Modules/mediasession/MediaMetadata.cpp
 Modules/mediasession/MediaSession.cpp
 [ Mac ] Modules/mediasession/MediaSessionCoordinator.cpp


### PR DESCRIPTION
#### 8a961b3ac7181f8447e9e23cd2e4935669acf629
<pre>
Digital Credential: CredentialRequestCoordinator can remain non-Idle if AbortSignal races with picker result
<a href="https://rdar.apple.com/163295172">rdar://163295172</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=305363">https://bugs.webkit.org/show_bug.cgi?id=305363</a>

Reviewed by Pascoe.

Fix race and crash in CredentialRequestCoordinator by settling promises only after picker teardown and safely handling abort reasons.
Ensure credential requests always settle after the picker UI has fully torn down.

This change:

- Defers promise settlement until the picker dismiss callback fires
- Better handles aborts during presentation and teardown
- Avoids capturing unprotected JSValues across async boundaries
- Keeps coordinator state transitions more consistent (with better checks)

It also more closely follows the spec:
<a href="https://github.com/w3c-fedid/digital-credentials/pull/420">https://github.com/w3c-fedid/digital-credentials/pull/420</a>
<a href="https://github.com/w3c-fedid/digital-credentials/pull/419">https://github.com/w3c-fedid/digital-credentials/pull/419</a>

* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get.tentative.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/non-fully-active.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/non-fully-active.https.html:
* Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp:
(WebCore::CredentialRequestCoordinator::PickerStateGuard::PickerStateGuard):
(WebCore::CredentialRequestCoordinator::PickerStateGuard::~PickerStateGuard):
(WebCore::CredentialRequestCoordinator::setState):
(WebCore::CredentialRequestCoordinator::prepareCredentialRequest):
(WebCore::CredentialRequestCoordinator::handleDigitalCredentialsPickerResult):
(WebCore:: const):
(WebCore::CredentialRequestCoordinator::dismissPickerAndSettle):
(WebCore::CredentialRequestCoordinator::abortPicker):
(WebCore::CredentialRequestCoordinator::contextDestroyed):
(WebCore::CredentialRequestCoordinator::~CredentialRequestCoordinator):
(): Deleted.
(WebCore::CredentialRequestCoordinator::presentPicker): Deleted.
(WebCore::CredentialRequestCoordinator::finalizeDigitalCredential): Deleted.
* Source/WebCore/Modules/identity/CredentialRequestCoordinator.h:
* Source/WebCore/Modules/identity/DigitalCredential.cpp:
(WebCore::DigitalCredential::discoverFromExternalSource):
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/305868@main">https://commits.webkit.org/305868@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d107c27d5e9825d39cbaf1b59f597f8a9e7e54c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139624 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12000 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1128 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147757 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92692 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9ccc2adb-c90c-481e-920f-bc60b1ddbe1b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141497 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12708 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12150 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106910 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77834 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0d9dd9a8-d2ac-464d-8a31-0aee04a47238) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142571 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9762 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125056 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87772 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e00f51e4-9e9e-41a0-866e-14ae4ecd4ad3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9404 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6965 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8050 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118666 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1054 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150539 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11685 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1087 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115312 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11698 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10000 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115623 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29375 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10287 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121514 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66690 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11729 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/999 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11467 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75407 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11664 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11515 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->