### PR TITLE
[JSC] FTL Phis need to support storage

### DIFF
--- a/JSTests/stress/array-sink-materialize-butterfly-to-phi.js
+++ b/JSTests/stress/array-sink-materialize-butterfly-to-phi.js
@@ -1,0 +1,15 @@
+function compute(x, len) {
+  x[NaN] = len;
+  var w = Array(80);
+  for (var i = 0; i < x.length; i += 16) {
+    for (var j = 0; j < 50; j++) {
+      w[j] = w.filter(function(){})[0];
+      x.splice(len)
+    }
+  }
+}
+var arr = Array();
+for (var i = 0; i < testLoopCount; i += 8) {
+  arr[i >> 5] = 1;
+}
+compute(arr, 50000);

--- a/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
@@ -2126,6 +2126,9 @@ escapeChildren:
                     return nullptr;
 
                 Node* phiNode = m_graph.addNode(SpecHeapTop, Phi, block->at(0)->origin.withInvalidExit());
+
+                // It shouldn't be possible to get a butterfly here since it should also be a sink candidate.
+                ASSERT(location.kind() != ArrayButterflyPLoc);
                 if (location.kind() == ArrayIndexedPropertyPLoc && hasDouble(allocation.indexingType())) {
                     ASSERT(allocation.kind() == Allocation::Kind::Array);
                     phiNode->mergeFlags(NodeResultDouble);
@@ -2147,7 +2150,7 @@ escapeChildren:
                     return nullptr;
 
                 Node* phiNode = m_graph.addNode(SpecHeapTop, Phi, block->at(0)->origin.withInvalidExit());
-                phiNode->mergeFlags(NodeResultJS);
+                phiNode->mergeFlags(identifier->result());
                 return phiNode;
             });
 

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -99,7 +99,7 @@ public:
         case NeitherDoubleNorHeapBigIntNorStringUse:
         case NeitherDoubleNorHeapBigIntUse:
             return;
-            
+
         case KnownInt32Use:
             if (m_state.forNode(edge).m_type & ~SpecInt32Only)
                 m_result = false;
@@ -109,7 +109,8 @@ public:
             if (m_state.forNode(edge).m_type & ~SpecBoolean)
                 m_result = false;
             return;
-            
+
+        case KnownStorageUse:
         case KnownCellUse:
             if (m_state.forNode(edge).m_type & ~SpecCell)
                 m_result = false;

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -12484,6 +12484,7 @@ void SpeculativeJIT::speculate(Node*, Edge edge)
     case MiscUse:
         speculateMisc(edge);
         break;
+    case KnownStorageUse:
     default:
         RELEASE_ASSERT_NOT_REACHED();
         break;

--- a/Source/JavaScriptCore/dfg/DFGUseKind.cpp
+++ b/Source/JavaScriptCore/dfg/DFGUseKind.cpp
@@ -77,6 +77,9 @@ void printInternal(PrintStream& out, UseKind useKind)
     case KnownCellUse:
         out.print("KnownCell");
         return;
+    case KnownStorageUse:
+        out.print("KnownStorage");
+        return;
     case CellOrOtherUse:
         out.print("CellOrOther");
         return;

--- a/Source/JavaScriptCore/dfg/DFGValidate.cpp
+++ b/Source/JavaScriptCore/dfg/DFGValidate.cpp
@@ -274,6 +274,7 @@ public:
                     case DoubleRepUse:
                     case BooleanUse:
                     case KnownBooleanUse:
+                    case KnownStorageUse:
                         break;
                     default:
                         VALIDATE((node), !"Bad use kind");

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -567,6 +567,7 @@ CapabilityLevel canCompile(Graph& graph)
                 case KnownBooleanUse:
                 case CellUse:
                 case KnownCellUse:
+                case KnownStorageUse:
                 case CellOrOtherUse:
                 case ObjectUse:
                 case ArrayUse:


### PR DESCRIPTION
#### 00c0add58ec35e0f557a57b1f3918e97ff979c64
<pre>
[JSC] FTL Phis need to support storage
<a href="https://bugs.webkit.org/show_bug.cgi?id=305393">https://bugs.webkit.org/show_bug.cgi?id=305393</a>
<a href="https://rdar.apple.com/165711688">rdar://165711688</a>

Reviewed by Justin Michaud.

When we redesigned Array allocation sinking Phis were not properly
changed to support storage. Prior to sinking, there was no way to
construct a graph that had storage Phis. The main reason we didn&apos;t
support Phis for storage was that it is somewhat risky with the
constraints of our GC. In particular, it would be invalid to have a
storage pointer without also retaining the base object. The GC won&apos;t
scan the butterfly without the base as it doesn&apos;t know the indexing type.

This patch simply fixes Upsilons/Phis for butterflies materialized by
Array allocation sinking. In a follow up patch I&apos;ll add a more
comprehensive fix that applies the new KnownStorageUse to all other
storage consuming Nodes.

Test: JSTests/stress/array-sink-materialize-butterfly-to-phi.js
Canonical link: <a href="https://commits.webkit.org/305546@main">https://commits.webkit.org/305546@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/85e38c4a47b11e016509804c538ca54d3083f723

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138644 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11010 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/126 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146758 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91619 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/529bfadd-b6d8-4d7d-851d-4b4be2385177) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11714 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11164 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106090 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77417 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/63b636b6-f3ce-4593-9c0f-301866d81e97) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141591 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8829 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124274 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86960 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/df8fbede-2dcd-4ea2-a994-08628d5b8a85) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8420 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6177 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7056 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/130615 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117839 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/109 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149514 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/137245 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10692 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/117 "Found 1 new test failure: http/tests/performance/performance-resource-timing-redirection-cross-origin-media.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114474 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10709 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9051 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114814 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29193 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8644 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120566 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65587 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10740 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/110 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/169917 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10475 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74381 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44297 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10678 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10529 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->