### PR TITLE
Build failure: instance method '-buildMenuOfType:' not found

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/AVKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/AVKitSPI.h
@@ -745,57 +745,26 @@ NS_ASSUME_NONNULL_END
 
 #endif // HAVE(AVKIT_CONTENT_SOURCE)
 
-#if USE(APPLE_INTERNAL_SDK)
-
-#if !__has_include(<AVKit/AVLegibleMediaOptionsMenuController.h>)
-
-typedef NS_ENUM(NSInteger, AVLegibleMediaOptionsMenuType) {
-    AVLegibleMediaOptionsMenuTypeDefault,
-    AVLegibleMediaOptionsMenuTypeCaptionAppearance
-} API_AVAILABLE(ios(26.4), macos(26.4), macCatalyst(26.4), visionos(26.4)) API_UNAVAILABLE(tvos, watchos);
-
-typedef NS_ENUM(NSInteger, AVLegibleMediaOptionEnablementState) {
-    AVLegibleMediaOptionEnablementStateOff,
-    AVLegibleMediaOptionEnablementStateOn
-} API_AVAILABLE(ios(26.4), macos(26.4), macCatalyst(26.4), visionos(26.4)) API_UNAVAILABLE(tvos, watchos);
-
-NS_ASSUME_NONNULL_BEGIN
-
-@protocol AVLegibleMediaOptionsMenuControllerDelegate;
-
-API_AVAILABLE(ios(26.4), macos(26.4), macCatalyst(26.4), visionos(26.4)) API_UNAVAILABLE(tvos, watchos)
-@interface AVLegibleMediaOptionsMenuController : NSObject
-
-- (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithPlayer:(nullable AVPlayer *)player NS_DESIGNATED_INITIALIZER;
-
-#if TARGET_OS_OSX && !TARGET_OS_MACCATALYST
-- (nullable NSMenu *)buildMenuOfType:(AVLegibleMediaOptionsMenuType)type;
+// CLEANUP(rdar://164667890)
+#if HAVE(AVLEGIBLEMEDIAOPTIONSMENUCONTROLLER) && USE(APPLE_INTERNAL_SDK) && !__has_feature(modules)
+#if __has_include(<AVKit/AVLegibleMediaOptionsMenuController_Private.h>)
+#import <AVKit/AVLegibleMediaOptionsMenuController_Private.h>
 #else
-#if !__has_feature(modules)
-- (nullable UIMenu *)buildMenuOfType:(AVLegibleMediaOptionsMenuType)type;
+// SDK does not have -menuWithContents:. Redeclare:
+#import <AVKit/AVLegibleMediaOptionsMenuController.h>
+typedef NS_OPTIONS(NSInteger, AVLegibleMediaOptionsMenuContents) {
+    AVLegibleMediaOptionsMenuContentsLegible = 1 << 0,
+    AVLegibleMediaOptionsMenuContentsCaptionAppearance = 1 << 1,
+    AVLegibleMediaOptionsMenuContentsAll = (AVLegibleMediaOptionsMenuContentsLegible | AVLegibleMediaOptionsMenuContentsCaptionAppearance)
+} API_AVAILABLE(ios(26.4), macos(26.4), visionos(26.4)) API_UNAVAILABLE(tvos, watchos);
+
+@interface AVLegibleMediaOptionsMenuController (MenuWithContents)
+#if TARGET_OS_OSX && !TARGET_OS_MACCATALYST
+- (nullable NSMenu *)menuWithContents:(AVLegibleMediaOptionsMenuContents)contents;
+#else
+- (nullable UIMenu *)menuWithContents:(AVLegibleMediaOptionsMenuContents)contents;
 #endif
-#endif
-
-- (void)updatePlayer:(nullable AVPlayer *)player;
-
-@property (nonatomic, weak) id<AVLegibleMediaOptionsMenuControllerDelegate> delegate;
-@property (nonatomic, readonly) AVLegibleMediaOptionEnablementState currentEnablementState;
-
 @end
 
-API_AVAILABLE(ios(26.4), macos(26.4), macCatalyst(26.4), visionos(26.4)) API_UNAVAILABLE(tvos, watchos)
-@protocol AVLegibleMediaOptionsMenuControllerDelegate <NSObject>
-@optional
-
-- (void)legibleMenuController:(AVLegibleMediaOptionsMenuController *)menuController didUpdateEnablementState:(AVLegibleMediaOptionEnablementState)enablementState;
-- (void)legibleMenuController:(AVLegibleMediaOptionsMenuController *)menuController didRequestCaptionPreviewForProfileID:(NSString *)profileID;
-- (void)legibleMenuControllerDidRequestStoppingSubtitleCaptionPreview:(AVLegibleMediaOptionsMenuController *)menuController;
-
-@end
-
-NS_ASSUME_NONNULL_END
-
-#endif
-
-#endif // USE(APPLE_INTERNAL_SDK)
+#endif // __has_include(<AVKit/AVLegibleMediaOptionsMenuController_Private.h>)
+#endif // HAVE(AVLEGIBLEMEDIAOPTIONSMENUCONTROLLER) && USE(APPLE_INTERNAL_SDK)

--- a/Source/WebKit/Configurations/AllowedSPI.toml
+++ b/Source/WebKit/Configurations/AllowedSPI.toml
@@ -263,6 +263,7 @@ classes = [
 ]
 selectors = [
     { name = "buildMenuOfType:", class = "AVLegibleMediaOptionsMenuController" },
+    { name = "menuWithContents:", class = "AVLegibleMediaOptionsMenuController" },
 ]
 requires = ["HAVE_AVLEGIBLEMEDIAOPTIONSMENUCONTROLLER"]
 

--- a/Source/WebKit/UIProcess/ios/_WKCaptionStyleMenuControllerAVKit.mm
+++ b/Source/WebKit/UIProcess/ios/_WKCaptionStyleMenuControllerAVKit.mm
@@ -51,6 +51,12 @@ SOFT_LINK_CLASS_OPTIONAL(AVKit, AVLegibleMediaOptionsMenuController)
 using namespace WebCore;
 using namespace WTF;
 
+// CLEANUP(rdar://164667890)
+@interface AVLegibleMediaOptionsMenuController (WebKitSPI)
+- (nullable UIMenu *)buildMenuOfType:(NSInteger)type;
+- (nullable UIMenu *)menuWithContents:(NSInteger)contents;
+@end
+
 @interface _WKCaptionStyleMenuControllerAVKit () <AVLegibleMediaOptionsMenuControllerDelegate> {
     RetainPtr<AVLegibleMediaOptionsMenuController> _menuController;
 }
@@ -75,7 +81,12 @@ using namespace WTF;
 
 - (void)rebuildMenu
 {
-    self.menu = [_menuController buildMenuOfType:AVLegibleMediaOptionsMenuTypeCaptionAppearance];
+    if ([_menuController respondsToSelector:@selector(menuWithContents:)])
+        self.menu = [_menuController menuWithContents:AVLegibleMediaOptionsMenuContentsCaptionAppearance];
+    else
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+        self.menu = [_menuController buildMenuOfType:AVLegibleMediaOptionsMenuTypeCaptionAppearance];
+ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
 #pragma mark - AVLegibleMediaOptionsMenuControllerDelegate

--- a/Source/WebKit/UIProcess/mac/_WKCaptionStyleMenuControllerAVKitMac.mm
+++ b/Source/WebKit/UIProcess/mac/_WKCaptionStyleMenuControllerAVKitMac.mm
@@ -48,10 +48,10 @@
 SOFTLINK_AVKIT_FRAMEWORK()
 SOFT_LINK_CLASS_OPTIONAL(AVKit, AVLegibleMediaOptionsMenuController)
 
-// Forward declare the method we need from AVKit SPI
+// CLEANUP(rdar://164667890)
 @interface AVLegibleMediaOptionsMenuController (WebKitSPI)
 - (nullable NSMenu *)buildMenuOfType:(NSInteger)type;
-
+- (nullable NSMenu *)menuWithContents:(NSInteger)contents;
 @end
 
 using namespace WebCore;
@@ -81,7 +81,12 @@ using namespace WTF;
 
 - (void)rebuildMenu
 {
-    self.menu = [_menuController buildMenuOfType:AVLegibleMediaOptionsMenuTypeCaptionAppearance];
+    if ([_menuController respondsToSelector:@selector(menuWithContents:)])
+        self.menu = [_menuController menuWithContents:AVLegibleMediaOptionsMenuContentsCaptionAppearance];
+    else
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+        self.menu = [_menuController buildMenuOfType:AVLegibleMediaOptionsMenuTypeCaptionAppearance];
+ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
 - (NSMenu *)captionStyleMenu


### PR DESCRIPTION
#### f8360ae9af3d30e08443d77cee591f3525f02b54
<pre>
Build failure: instance method &apos;-buildMenuOfType:&apos; not found
<a href="https://rdar.apple.com/167994245">rdar://167994245</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=305394">https://bugs.webkit.org/show_bug.cgi?id=305394</a>

Unreviewed build failure fix after SDK change.

* Source/WebCore/PAL/pal/spi/cocoa/AVKitSPI.h:
* Source/WebKit/Configurations/AllowedSPI.toml:
* Source/WebKit/UIProcess/ios/_WKCaptionStyleMenuControllerAVKit.mm:
(-[_WKCaptionStyleMenuControllerAVKit init]):
(-[_WKCaptionStyleMenuControllerAVKit rebuildMenu]):
* Source/WebKit/UIProcess/mac/_WKCaptionStyleMenuControllerAVKitMac.mm:
(-[_WKCaptionStyleMenuControllerAVKitMac rebuildMenu]):

Canonical link: <a href="https://commits.webkit.org/305534@main">https://commits.webkit.org/305534@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3520871f03fa3443f394061bc1356f67e6324d86

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138653 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11019 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/135 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146767 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91628 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/17fbf11c-9733-4e43-bd88-3572441ef522) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140526 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11723 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11173 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106096 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77421 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6fd5df44-6275-4f5d-9c9c-2ba9d1683dde) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141600 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8832 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124283 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86967 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b965b76b-aee1-430e-9ddd-39dc43584c66) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8423 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6186 "Found 3 new API test failures: TestWebKitAPI.WebKit.PreferenceChanges, TestWebKitAPI.WKWebExtensionDataRecord.GetDataRecords, TestWebKitAPI.PermissionsAPI.GeolocationPermissionDeniedFromPromptAndGeolocationRequestedSinceLoad (failure)") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7065 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117842 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/118 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149523 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10701 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/124 "Found 1 new test failure: http/tests/performance/performance-resource-timing-redirection-cross-origin-media.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114482 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10718 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9060 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114821 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8669 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120575 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65596 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21372 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10749 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/119 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10484 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74390 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10687 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10538 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->