### PR TITLE
[threaded-animations] merlyndesignworks.co.uk page crashes repeatedly (invalid message: RemoteLayerTreeDrawingAreaProxy_CommitLayerTree)

### DIFF
--- a/LayoutTests/webanimations/threaded-animations/filter-animation-crash-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/filter-animation-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if this does not crash.

--- a/LayoutTests/webanimations/threaded-animations/filter-animation-crash.html
+++ b/LayoutTests/webanimations/threaded-animations/filter-animation-crash.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ThreadedTimeBasedAnimationsEnabled=true ] -->
+<style>
+
+@keyframes anim {
+    from { opacity: 0; filter: blur(4px) drop-shadow(rgba(255, 255, 255, 0) 0px 0px 0px) }
+    to   { opacity: 0; filter: blur(0px) drop-shadow(rgb(235, 235, 235) 0px 0px 7px) }
+}
+
+div {
+    width: 100px;
+    height: 100px;
+    background-color: black;
+	animation: anim 1s;
+    filter: blur(4px) drop-shadow(rgba(255, 255, 255, 0) 0px 0px 0px)
+}
+
+</style>
+
+<div>PASS if this does not crash.</div>
+
+<script>
+
+window.testRunner?.dumpAsText();
+
+</script>

--- a/Source/WebCore/platform/animation/AcceleratedEffect.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.cpp
@@ -66,6 +66,14 @@ AcceleratedEffect::Keyframe::Keyframe(double offset, AcceleratedEffectValues&& v
 void AcceleratedEffect::Keyframe::clearProperty(AcceleratedEffectProperty property)
 {
     m_animatedProperties.remove({ property });
+
+    // If a filter property is removed, it's because it cannot be represented remotely,
+    // so we must ensure we reset it in the base values so that we don't attempt to encode
+    // an unsupported filter operation.
+    if (property == AcceleratedEffectProperty::Filter)
+        m_values.filter = { };
+    if (property == AcceleratedEffectProperty::BackdropFilter)
+        m_values.backdropFilter = { };
 }
 
 bool AcceleratedEffect::Keyframe::animatesProperty(KeyframeInterpolation::Property property) const
@@ -502,9 +510,13 @@ void AcceleratedEffect::validateFilters(const AcceleratedEffectValues& baseValue
         // We need to make sure that the longest filter, if it contains a drop-shadow() operation,
         // has it as its final operation since it will be applied by a separate CALayer property
         // from the other filter operations and it will be applied to the layer as the last filer.
+        // However, drop-shadow() operations with a style color are never supported, see
+        // PlatformCAFilters::setFiltersOnLayer().
         ASSERT(longestFilterList);
         for (auto& operation : *longestFilterList) {
-            if ((operation->type() == FilterOperation::Type::DropShadow || operation->type() == FilterOperation::Type::DropShadowWithStyleColor) && operation != longestFilterList->last())
+            if (operation->type() == FilterOperation::Type::DropShadowWithStyleColor)
+                return false;
+            if (operation->type() == FilterOperation::Type::DropShadow && operation != longestFilterList->last())
                 return false;
         }
 
@@ -515,10 +527,8 @@ void AcceleratedEffect::validateFilters(const AcceleratedEffectValues& baseValue
         if (isValidProperty(property))
             return;
         disallowedProperties.add({ property });
-        m_animatedProperties.remove({ property });
         m_disallowedProperties.add({ property });
-        for (auto& keyframe : m_keyframes)
-            keyframe.clearProperty(property);
+        clearProperty(property);
     };
 
     if (m_animatedProperties.contains(AcceleratedEffectProperty::Filter))
@@ -567,6 +577,14 @@ bool AcceleratedEffect::isPropertyAdditiveOrCumulative(KeyframeInterpolation::Pr
         ASSERT_NOT_REACHED();
         return false;
     });
+}
+
+void AcceleratedEffect::clearProperty(AcceleratedEffectProperty property)
+{
+    m_animatedProperties.remove({ property });
+
+    for (auto& keyframe : m_keyframes)
+        keyframe.clearProperty(property);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/animation/AcceleratedEffect.h
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.h
@@ -85,6 +85,8 @@ public:
     WEBCORE_EXPORT void apply(AcceleratedEffectValues&, WebAnimationTime timelineTime, std::optional<WebAnimationTime> timelineDuration) const;
     WEBCORE_EXPORT ResolvedEffectTiming resolvedTimingForTesting(WebAnimationTime timelineTime, std::optional<WebAnimationTime> timelineDuration) const;
 
+    void clearProperty(AcceleratedEffectProperty);
+
     // Encoding and decoding support
     const AnimationEffectTiming& timing() const { return m_timing; }
     const RefPtr<AcceleratedTimeline>& timeline() const { return m_timeline; }


### PR DESCRIPTION
#### b7aad8b68633d1284f317daf81a5f78c842a383c
<pre>
[threaded-animations] merlyndesignworks.co.uk page crashes repeatedly (invalid message: RemoteLayerTreeDrawingAreaProxy_CommitLayerTree)
<a href="https://bugs.webkit.org/show_bug.cgi?id=305396">https://bugs.webkit.org/show_bug.cgi?id=305396</a>
<a href="https://rdar.apple.com/167992456">rdar://167992456</a>

Reviewed by Simon Fraser.

There were several issues with our filter validation approach under `AcceleratedEffect::validateFilters()`:

- while it would correctly catch the case where a `drop-shadow()` filter was used anywhere but
  as the last filter and mark that property as disallowed, it would not clear the `filter` or
  `backdropFilter` value in the keyframes,
- disallowing a property also did not ensure that we would clear the base values,
- it wouldn&apos;t either clear base values of any previous effect,
- we wouldn&apos;t catch the case where `drop-shadow()` contained a color which is entirely not supported.

We now correctly catch such situations.

Test: webanimations/threaded-animations/filter-animation-crash.html

* LayoutTests/webanimations/threaded-animations/filter-animation-crash-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/filter-animation-crash.html: Added.
* Source/WebCore/platform/animation/AcceleratedEffect.cpp:
(WebCore::AcceleratedEffect::Keyframe::clearProperty):
(WebCore::AcceleratedEffect::validateFilters):
(WebCore::AcceleratedEffect::clearProperty):
* Source/WebCore/platform/animation/AcceleratedEffect.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateAcceleratedEffectsAndBaseValues):

Canonical link: <a href="https://commits.webkit.org/305530@main">https://commits.webkit.org/305530@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d513c8698545487973145c44519400c8fdc80ea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138654 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11020 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/136 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146768 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91629 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8e477529-f825-4585-baea-47a55bc11bfc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140527 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11724 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11174 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106097 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77422 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/105c36bf-0748-48e0-8848-0a0de0caa21f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141601 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8837 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124285 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86968 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f43252bf-f989-460b-9be5-4a386cbd1c75) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8427 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6187 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7066 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117847 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/120 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149524 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10702 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/126 "Found 1 new test failure: http/tests/performance/performance-resource-timing-redirection-cross-origin-media.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114483 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10719 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9061 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114822 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8656 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120577 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65597 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21369 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10750 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/121 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10485 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74391 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10688 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10539 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->