### PR TITLE
[JSC] Apply KnownStorageUse to all storage operands in DFG/FTL

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
@@ -965,7 +965,7 @@ private:
                                         ASSERT(isInlineOffset(knownPolyProtoOffset));
                                         m_insertionSet.insertNode(
                                             indexInBlock + 1, SpecNone, PutByOffset, origin, OpInfo(data),
-                                            Edge(node, KnownCellUse), Edge(node, KnownCellUse), Edge(prototypeNode, UntypedUse));
+                                            Edge(node, KnownStorageUse), Edge(node, KnownCellUse), Edge(prototypeNode, UntypedUse));
                                     }
                                     changed = true;
                                     break;
@@ -1908,6 +1908,7 @@ private:
             propertyStorage = Edge(m_insertionSet.insertNode(
                 indexInBlock, SpecNone, GetButterfly, node->origin, childEdge));
         }
+        propertyStorage.setUseKind(KnownStorageUse);
         
         StorageAccessData& data = *m_graph.m_storageAccessData.add();
         data.offset = offset;
@@ -1960,15 +1961,15 @@ private:
             ASSERT(variant.oldStructureForTransition()->outOfLineCapacity());
             ASSERT(variant.newStructure()->outOfLineCapacity() > variant.oldStructureForTransition()->outOfLineCapacity());
             ASSERT(!isInlineOffset(variant.offset()));
-
+            Node* butterfly = m_insertionSet.insertNode(indexInBlock, SpecNone, GetButterfly, origin, childEdge);
             Node* reallocatePropertyStorage = m_insertionSet.insertNode(
                 indexInBlock, SpecNone, ReallocatePropertyStorage, origin,
                 OpInfo(transition), childEdge,
-                Edge(m_insertionSet.insertNode(
-                    indexInBlock, SpecNone, GetButterfly, origin, childEdge)));
+                Edge(butterfly, KnownStorageUse));
             propertyStorage = Edge(reallocatePropertyStorage);
             didAllocateStorage = true;
         }
+        propertyStorage.setUseKind(KnownStorageUse);
 
         StorageAccessData& data = *m_graph.m_storageAccessData.add();
         data.offset = variant.offset();
@@ -2016,6 +2017,7 @@ private:
         else
             propertyStorage = Edge(m_insertionSet.insertNode(
                 indexInBlock, SpecNone, GetButterfly, origin, node->child1()));
+        propertyStorage.setUseKind(KnownStorageUse);
 
         StorageAccessData& data = *m_graph.m_storageAccessData.add();
         data.offset = variant.offset();

--- a/Source/JavaScriptCore/dfg/DFGEdge.h
+++ b/Source/JavaScriptCore/dfg/DFGEdge.h
@@ -93,7 +93,7 @@ public:
         m_encodedWord = makeWord(useKind, proofStatus(), killStatus());
 #endif
     }
-    
+
     ProofStatus proofStatusUnchecked() const
     {
 #if USE(JSVALUE64)

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -2423,15 +2423,11 @@ private:
         }
 
         case GetGetterSetterByOffset: {
-            if (!node->child1()->hasStorageResult())
-                fixEdge<KnownCellUse>(node->child1());
             fixEdge<KnownCellUse>(node->child2());
             break;
         }
 
         case GetByOffset: {
-            if (!node->child1()->hasStorageResult())
-                fixEdge<KnownCellUse>(node->child1());
             fixEdge<KnownCellUse>(node->child2());
             attemptToMakeDoubleResultForGet(node);
             break;
@@ -2443,8 +2439,6 @@ private:
         }
             
         case PutByOffset: {
-            if (!node->child1()->hasStorageResult())
-                fixEdge<KnownCellUse>(node->child1());
             fixEdge<KnownCellUse>(node->child2());
             if (!attemptToMakeDoubleRepForPut(node, node->child3()))
                 speculateForBarrier(node->child3());
@@ -2934,7 +2928,6 @@ private:
 
         case LoadMapValue:
         case IsEmptyStorage:
-            fixEdge<UntypedUse>(node->child1());
             break;
 
         case MapGet:
@@ -4551,7 +4544,7 @@ private:
             if (!storage)
                 return;
             
-            storageChild = Edge(storage);
+            storageChild = storage->defaultEdge();
             return;
         } }
     }
@@ -4972,7 +4965,7 @@ private:
         if (!storage)
             return;
             
-        node->child2() = Edge(storage);
+        node->child2() = storage->defaultEdge();
     }
 
     void convertToHasIndexedProperty(Node* node)

--- a/Source/JavaScriptCore/dfg/DFGNode.cpp
+++ b/Source/JavaScriptCore/dfg/DFGNode.cpp
@@ -274,7 +274,7 @@ void Node::convertToNewArrayWithButterfly(Graph&, Node* butterfly)
     IndexingType indexingType = this->indexingType();
     setOpAndDefaultFlags(NewArrayWithButterfly);
     ASSERT(child1()->asInt32() < MIN_ARRAY_STORAGE_CONSTRUCTION_LENGTH);
-    children.child2() = Edge(butterfly);
+    children.child2() = Edge(butterfly, KnownStorageUse);
     ASSERT_UNUSED(indexingType, indexingType == this->indexingType());
 }
 

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -693,6 +693,7 @@ public:
         children.setChild3(children.child2());
         children.setChild2(base);
         children.setChild1(storage);
+        children.child1().setUseKind(KnownStorageUse);
         m_op = PutByOffset;
     }
     

--- a/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
@@ -2562,7 +2562,7 @@ escapeChildren:
                 }
                 case ArrayButterflyPLoc: {
                     Node* butterfly = resolve(block, location);
-                    m_graph.m_varArgChildren[butterflyChild] = Edge(butterfly);
+                    m_graph.m_varArgChildren[butterflyChild] = Edge(butterfly, KnownStorageUse);
 
                     ASSERT(butterfly->op() == NewButterflyWithSize);
                     m_graph.m_varArgChildren[lengthChild] = butterfly->child1();
@@ -2820,7 +2820,7 @@ escapeChildren:
                     PutByOffset,
                     origin.takeValidExit(canExit),
                     OpInfo(data),
-                    Edge(storage, KnownCellUse),
+                    Edge(storage, KnownStorageUse),
                     Edge(base, KnownCellUse),
                     value->defaultEdge());
             }

--- a/Source/JavaScriptCore/dfg/DFGPutStackSinkingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPutStackSinkingPhase.cpp
@@ -485,6 +485,10 @@ public:
 
                         Node* incoming = mapping.operand(operand);
                         DFG_ASSERT(m_graph, node, incoming);
+                        // We shouldn't generate IR that would PutStack a storage operand. That would make it nearly impossible to
+                        // reason about the liveness of the base object. Additionally, bytecode has no notion of storage so such IR
+                        // is seemingly nonsensical anyway.
+                        DFG_ASSERT(m_graph, node, !incoming->hasStorageResult());
                     
                         // If we are sinking a PutStack to before an ExitOK, it
                         // should be ExitInvalid like the other preceding nodes.

--- a/Source/JavaScriptCore/dfg/DFGSSAConversionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSSAConversionPhase.cpp
@@ -415,19 +415,22 @@ public:
                     SSACalculator::Variable* ssaVariable = phiDef->variable();
                     VariableAccessData* variable = m_variableForSSAIndex[ssaVariable->index()];
                     FlushFormat format = variable->flushFormat();
+                    Node* incoming = valueForOperand.operand(variable->operand());
 
                     // We can use an unchecked use kind because the SetLocal was turned into a Check.
                     // We have to use an unchecked use because at least sometimes, the end of the block
                     // is not exitOK.
                     UseKind useKind = uncheckedUseKindFor(format);
+                    // We differentiate between storage and other cells at in FTL lowering so we want to make sure we use the correct
+                    // UseKind to we look up the incoming node from the correct place.
+                    if (incoming->hasStorageResult())
+                        useKind = KnownStorageUse;
 
-                    dataLogLnIf(verbose, "Inserting Upsilon for ", variable->operand(), " propagating ", valueForOperand.operand(variable->operand()), " to ", phiNode);
+                    dataLogLnIf(verbose, "Inserting Upsilon for ", variable->operand(), " propagating ", incoming, " to ", phiNode);
                     
                     m_insertionSet.insertNode(
                         upsilonInsertionPoint, SpecNone, Upsilon, upsilonOrigin,
-                        OpInfo(phiNode), Edge(
-                            valueForOperand.operand(variable->operand()),
-                            useKind));
+                        OpInfo(phiNode), Edge(incoming, useKind));
                 }
             }
             

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -2297,7 +2297,7 @@ public:
         m_edge = edge;
         ASSERT(m_gprOrInvalid == InvalidGPRReg);
         ASSERT(m_jit);
-        ASSERT(edge.useKind() == UntypedUse || edge.useKind() == KnownCellUse);
+        ASSERT(edge.useKind() == KnownStorageUse);
         if (jit->isFilled(node()))
             gpr();
     }


### PR DESCRIPTION
#### 7051d3ac1f34c7f2899f8a5be987a68a0f03da86
<pre>
[JSC] Apply KnownStorageUse to all storage operands in DFG/FTL
<a href="https://bugs.webkit.org/show_bug.cgi?id=305395">https://bugs.webkit.org/show_bug.cgi?id=305395</a>
<a href="https://rdar.apple.com/168068069">rdar://168068069</a>

Reviewed by Justin Michaud.

In 305546@main we added support for KnownStorageUse but only applied it
to Upsilons produced by Object Allocation Sinking for Arrays. This patch
fills out the rest of the storage operands in the DFG/FTL. This
shouldn&apos;t have any behavioral changes but should make it easier to
validate the lifetime of a butterfly pointer.

Canonical link: <a href="https://commits.webkit.org/305615@main">https://commits.webkit.org/305615@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c92fd97cd79f426ff32183528cfd6c7d5e3917b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138881 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11248 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/368 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147000 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/91908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/34372964-0d03-4c5b-adbc-d220684f6af6) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11953 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11404 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106299 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/91908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141828 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9022 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87169 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2ea5ec9e-3425-4ad5-bc46-d471bd515fb7) 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6348 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7301 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/130853 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118030 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/309 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149786 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/137483 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10930 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/316 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114689 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10951 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9245 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115004 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8903 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120762 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65835 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21406 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10979 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/303 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/170154 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10715 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/74629 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44336 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10919 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10766 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->