### PR TITLE
Fix animation repaint artifacts for SVG images with object-fit

### DIFF
--- a/LayoutTests/fast/repaint/svg-image-object-fit-animation-repaint-expected.html
+++ b/LayoutTests/fast/repaint/svg-image-object-fit-animation-repaint-expected.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Reference: Animated SVG with intrinsic dimensions and object-fit: cover</title>
+<style>
+    body {
+        margin: 0;
+    }
+    .container {
+        width: 200px;
+        height: 200px;
+        overflow: hidden;
+        background: white;
+    }
+    .image {
+        height: 100%;
+        width: 100%;
+        object-fit: cover;
+    }
+</style>
+</head>
+<body>
+<p>You should see a green rectangle on white with no artifacts.</p>
+<div class="container">
+    <img class="image" src="data:image/svg+xml,
+        <svg xmlns='http://www.w3.org/2000/svg' width='500' height='200'>
+            <rect x='200' y='50' width='100' height='100' fill='green' transform='rotate(10, 250, 100)'/>
+        </svg>">
+</div>
+</body>
+</html>

--- a/LayoutTests/fast/repaint/svg-image-object-fit-animation-repaint.html
+++ b/LayoutTests/fast/repaint/svg-image-object-fit-animation-repaint.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Animated SVG with intrinsic dimensions and object-fit: cover should not leave artifacts</title>
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-1" />
+<script src="../../resources/ui-helper.js"></script>
+<style>
+    body {
+        margin: 0;
+    }
+    .container {
+        width: 200px;
+        height: 200px;
+        overflow: hidden;
+        background: white;
+    }
+    .image {
+        height: 100%;
+        width: 100%;
+        object-fit: cover;
+    }
+</style>
+</head>
+<body>
+<p>You should see a green rectangle on white with no artifacts.</p>
+<div class="container">
+    <img class="image" src="data:image/svg+xml,
+        <svg xmlns='http://www.w3.org/2000/svg' width='500' height='200'>
+            <style>
+                @keyframes rotate {
+                    0% { transform: rotate(0deg); }
+                    100% { transform: rotate(10deg); }
+                }
+                .animated {
+                    transform-origin: 250px 100px;
+                    animation: rotate 50ms linear forwards;
+                }
+            </style>
+            <rect class='animated' x='200' y='50' width='100' height='100' fill='green'/>
+        </svg>">
+</div>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dontForceRepaint();
+}
+
+window.addEventListener('load', async () => {
+    await UIHelper.renderingUpdate();
+    await new Promise(r => setTimeout(r, 60));
+    await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
+    window.testRunner?.notifyDone();
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -405,7 +405,7 @@ void RenderImage::repaintOrMarkForLayout(ImageSizeChangeType imageSizeChange, co
     }
 
     if (parent()) {
-        auto repaintRect = contentBoxRect();
+        auto repaintRect = replacedContentRect();
         if (rect) {
             // The image changed rect is in source image coordinates (pre-zooming),
             // so map from the bounds of the image to the contentsBox.


### PR DESCRIPTION
#### 1b0c248d6d1d8c885102f2348229fb46e78c5f97
<pre>
Fix animation repaint artifacts for SVG images with object-fit
<a href="https://bugs.webkit.org/show_bug.cgi?id=284625">https://bugs.webkit.org/show_bug.cgi?id=284625</a>
<a href="https://rdar.apple.com/141815698">rdar://141815698</a>

Reviewed by Simon Fraser.

This is a follow-up to 305490@main which fixed dimensionless SVGs
in object-fit context.

For SVG images with intrinsic dimensions displayed with object-fit caused
animation artifacts because the repaint wasn&apos;t covering the actual
painted content area.

Fixed by using replacedContentRect for the repaint rect.

Test: fast/repaint/svg-image-object-fit-animation-repaint.html

* LayoutTests/fast/repaint/svg-image-object-fit-animation-repaint-expected.html: Added.
* LayoutTests/fast/repaint/svg-image-object-fit-animation-repaint.html: Added.
* Source/WebCore/rendering/RenderImage.cpp:
(WebCore::RenderImage::repaintOrMarkForLayout):

Canonical link: <a href="https://commits.webkit.org/305542@main">https://commits.webkit.org/305542@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6dc78d7bbbe8d45e1472e500386d833b67a7661

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138692 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11058 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/174 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146806 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91667 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140565 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11762 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11212 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106126 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/77439 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141639 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8862 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/124304 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86996 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8450 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/6208 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7104 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117871 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/144 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149562 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10740 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/145 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114512 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10757 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9087 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114849 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29196 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8694 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120601 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65635 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10788 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/145 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10523 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74429 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10726 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10577 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->