### PR TITLE
Use shortest serialization principle for `column-rule` computed values

### DIFF
--- a/LayoutTests/fast/css/getComputedStyle/getComputedStyle-column-rule-expected.txt
+++ b/LayoutTests/fast/css/getComputedStyle/getComputedStyle-column-rule-expected.txt
@@ -12,15 +12,14 @@ PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(1).getStringV
 PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(2).getRGBColorValue().red.getFloatValue(CSSPrimitiveValue.CSS_NUMBER) is 0
 PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(2).getRGBColorValue().green.getFloatValue(CSSPrimitiveValue.CSS_NUMBER) is 0
 PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(2).getRGBColorValue().blue.getFloatValue(CSSPrimitiveValue.CSS_NUMBER) is 0
-PASS computedStyle.getPropertyValue('-webkit-column-rule') is "10px none rgb(255, 0, 0)"
+PASS computedStyle.getPropertyValue('-webkit-column-rule') is "10px rgb(255, 0, 0)"
 PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').toString() is "[object CSSValueList]"
-PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').cssText is "10px none rgb(255, 0, 0)"
-PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').length is 3
+PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').cssText is "10px rgb(255, 0, 0)"
+PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').length is 2
 PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(0).getFloatValue(CSSPrimitiveValue.CSS_PX) is 10
-PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(1).getStringValue() is "none"
-PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(2).getRGBColorValue().red.getFloatValue(CSSPrimitiveValue.CSS_NUMBER) is 255
-PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(2).getRGBColorValue().green.getFloatValue(CSSPrimitiveValue.CSS_NUMBER) is 0
-PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(2).getRGBColorValue().blue.getFloatValue(CSSPrimitiveValue.CSS_NUMBER) is 0
+PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(1).getRGBColorValue().red.getFloatValue(CSSPrimitiveValue.CSS_NUMBER) is 255
+PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(1).getRGBColorValue().green.getFloatValue(CSSPrimitiveValue.CSS_NUMBER) is 0
+PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(1).getRGBColorValue().blue.getFloatValue(CSSPrimitiveValue.CSS_NUMBER) is 0
 PASS computedStyle.getPropertyValue('-webkit-column-rule') is "3px dashed rgb(255, 0, 0)"
 PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').toString() is "[object CSSValueList]"
 PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').cssText is "3px dashed rgb(255, 0, 0)"
@@ -30,15 +29,14 @@ PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(1).getStringV
 PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(2).getRGBColorValue().red.getFloatValue(CSSPrimitiveValue.CSS_NUMBER) is 255
 PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(2).getRGBColorValue().green.getFloatValue(CSSPrimitiveValue.CSS_NUMBER) is 0
 PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(2).getRGBColorValue().blue.getFloatValue(CSSPrimitiveValue.CSS_NUMBER) is 0
-PASS computedStyle.getPropertyValue('-webkit-column-rule') is "10px none rgb(0, 0, 255)"
+PASS computedStyle.getPropertyValue('-webkit-column-rule') is "10px rgb(0, 0, 255)"
 PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').toString() is "[object CSSValueList]"
-PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').cssText is "10px none rgb(0, 0, 255)"
-PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').length is 3
+PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').cssText is "10px rgb(0, 0, 255)"
+PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').length is 2
 PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(0).getFloatValue(CSSPrimitiveValue.CSS_PX) is 10
-PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(1).getStringValue() is "none"
-PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(2).getRGBColorValue().red.getFloatValue(CSSPrimitiveValue.CSS_NUMBER) is 0
-PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(2).getRGBColorValue().green.getFloatValue(CSSPrimitiveValue.CSS_NUMBER) is 0
-PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(2).getRGBColorValue().blue.getFloatValue(CSSPrimitiveValue.CSS_NUMBER) is 255
+PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(1).getRGBColorValue().red.getFloatValue(CSSPrimitiveValue.CSS_NUMBER) is 0
+PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(1).getRGBColorValue().green.getFloatValue(CSSPrimitiveValue.CSS_NUMBER) is 0
+PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').item(1).getRGBColorValue().blue.getFloatValue(CSSPrimitiveValue.CSS_NUMBER) is 255
 PASS computedStyle.getPropertyValue('-webkit-column-rule') is "10px hidden rgb(0, 0, 255)"
 PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').toString() is "[object CSSValueList]"
 PASS computedStyle.getPropertyCSSValue('-webkit-column-rule').cssText is "10px hidden rgb(0, 0, 255)"

--- a/LayoutTests/fast/css/getComputedStyle/getComputedStyle-column-rule.html
+++ b/LayoutTests/fast/css/getComputedStyle/getComputedStyle-column-rule.html
@@ -29,15 +29,14 @@ shouldBe("computedStyle.getPropertyCSSValue('-webkit-column-rule').item(2).getRG
 shouldBe("computedStyle.getPropertyCSSValue('-webkit-column-rule').item(2).getRGBColorValue().blue.getFloatValue(CSSPrimitiveValue.CSS_NUMBER)", "0");
 
 e.style.webkitColumnRule="10px red";
-shouldBeEqualToString("computedStyle.getPropertyValue('-webkit-column-rule')", '10px none rgb(255, 0, 0)');
+shouldBeEqualToString("computedStyle.getPropertyValue('-webkit-column-rule')", '10px rgb(255, 0, 0)');
 shouldBeEqualToString("computedStyle.getPropertyCSSValue('-webkit-column-rule').toString()", '[object CSSValueList]');
-shouldBeEqualToString("computedStyle.getPropertyCSSValue('-webkit-column-rule').cssText", '10px none rgb(255, 0, 0)');
-shouldBe("computedStyle.getPropertyCSSValue('-webkit-column-rule').length", "3");
+shouldBeEqualToString("computedStyle.getPropertyCSSValue('-webkit-column-rule').cssText", '10px rgb(255, 0, 0)');
+shouldBe("computedStyle.getPropertyCSSValue('-webkit-column-rule').length", "2");
 shouldBe("computedStyle.getPropertyCSSValue('-webkit-column-rule').item(0).getFloatValue(CSSPrimitiveValue.CSS_PX)", "10");
-shouldBeEqualToString("computedStyle.getPropertyCSSValue('-webkit-column-rule').item(1).getStringValue()", "none");
-shouldBe("computedStyle.getPropertyCSSValue('-webkit-column-rule').item(2).getRGBColorValue().red.getFloatValue(CSSPrimitiveValue.CSS_NUMBER)", "255");
-shouldBe("computedStyle.getPropertyCSSValue('-webkit-column-rule').item(2).getRGBColorValue().green.getFloatValue(CSSPrimitiveValue.CSS_NUMBER)", "0");
-shouldBe("computedStyle.getPropertyCSSValue('-webkit-column-rule').item(2).getRGBColorValue().blue.getFloatValue(CSSPrimitiveValue.CSS_NUMBER)", "0");
+shouldBe("computedStyle.getPropertyCSSValue('-webkit-column-rule').item(1).getRGBColorValue().red.getFloatValue(CSSPrimitiveValue.CSS_NUMBER)", "255");
+shouldBe("computedStyle.getPropertyCSSValue('-webkit-column-rule').item(1).getRGBColorValue().green.getFloatValue(CSSPrimitiveValue.CSS_NUMBER)", "0");
+shouldBe("computedStyle.getPropertyCSSValue('-webkit-column-rule').item(1).getRGBColorValue().blue.getFloatValue(CSSPrimitiveValue.CSS_NUMBER)", "0");
 
 e.style.webkitColumnRuleWidth="medium"
 e.style.webkitColumnRuleStyle="dashed"
@@ -53,15 +52,14 @@ shouldBe("computedStyle.getPropertyCSSValue('-webkit-column-rule').item(2).getRG
 
 e.style.webkitColumnRule="10px dotted blue"
 e.style.webkitColumnRuleStyle="none";
-shouldBeEqualToString("computedStyle.getPropertyValue('-webkit-column-rule')", '10px none rgb(0, 0, 255)');
+shouldBeEqualToString("computedStyle.getPropertyValue('-webkit-column-rule')", '10px rgb(0, 0, 255)');
 shouldBeEqualToString("computedStyle.getPropertyCSSValue('-webkit-column-rule').toString()", '[object CSSValueList]');
-shouldBeEqualToString("computedStyle.getPropertyCSSValue('-webkit-column-rule').cssText", '10px none rgb(0, 0, 255)');
-shouldBe("computedStyle.getPropertyCSSValue('-webkit-column-rule').length", "3");
+shouldBeEqualToString("computedStyle.getPropertyCSSValue('-webkit-column-rule').cssText", '10px rgb(0, 0, 255)');
+shouldBe("computedStyle.getPropertyCSSValue('-webkit-column-rule').length", "2");
 shouldBe("computedStyle.getPropertyCSSValue('-webkit-column-rule').item(0).getFloatValue(CSSPrimitiveValue.CSS_PX)", "10");
-shouldBeEqualToString("computedStyle.getPropertyCSSValue('-webkit-column-rule').item(1).getStringValue()", "none");
-shouldBe("computedStyle.getPropertyCSSValue('-webkit-column-rule').item(2).getRGBColorValue().red.getFloatValue(CSSPrimitiveValue.CSS_NUMBER)", "0");
-shouldBe("computedStyle.getPropertyCSSValue('-webkit-column-rule').item(2).getRGBColorValue().green.getFloatValue(CSSPrimitiveValue.CSS_NUMBER)", "0");
-shouldBe("computedStyle.getPropertyCSSValue('-webkit-column-rule').item(2).getRGBColorValue().blue.getFloatValue(CSSPrimitiveValue.CSS_NUMBER)", "255");
+shouldBe("computedStyle.getPropertyCSSValue('-webkit-column-rule').item(1).getRGBColorValue().red.getFloatValue(CSSPrimitiveValue.CSS_NUMBER)", "0");
+shouldBe("computedStyle.getPropertyCSSValue('-webkit-column-rule').item(1).getRGBColorValue().green.getFloatValue(CSSPrimitiveValue.CSS_NUMBER)", "0");
+shouldBe("computedStyle.getPropertyCSSValue('-webkit-column-rule').item(1).getRGBColorValue().blue.getFloatValue(CSSPrimitiveValue.CSS_NUMBER)", "255");
 
 e.style.webkitColumnRuleStyle="hidden";
 shouldBeEqualToString("computedStyle.getPropertyValue('-webkit-column-rule')", '10px hidden rgb(0, 0, 255)');

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-multicol/parsing/column-rule-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-multicol/parsing/column-rule-computed-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL Property column-rule value '10px' assert_equals: expected "10px rgb(0, 255, 0)" but got "10px none rgb(0, 255, 0)"
+PASS Property column-rule value '10px'
 PASS Property column-rule value 'dotted'
-FAIL Property column-rule value '0px none rgb(255, 0, 255)' assert_equals: expected "0px rgb(255, 0, 255)" but got "0px none rgb(255, 0, 255)"
+PASS Property column-rule value '0px none rgb(255, 0, 255)'
 PASS Property column-rule value '10px dotted rgb(255, 0, 255)'
 PASS Property column-rule value 'medium hidden currentcolor'
 PASS Property column-rule value 'medium solid currentcolor'

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -10020,7 +10020,8 @@
                     "column-rule-style",
                     "column-rule-color"
                 ],
-                "shorthand-pattern": "StandardSpaceSeparated",
+                "shorthand-parser-pattern": "StandardSpaceSeparated",
+                "shorthand-style-extractor-pattern": "StandardSpaceSeparatedOmittingInitialValues",
                 "parser-grammar-unused": "<'column-rule-width'> || <'column-rule-style'> || <'column-rule-color'>",
                 "parser-grammar-unused-reason": "Needs support for shorthand grammars."
             },

--- a/Source/WebCore/css/CSSPropertyInitialValues.cpp
+++ b/Source/WebCore/css/CSSPropertyInitialValues.cpp
@@ -98,6 +98,10 @@ bool isInitialValueForLonghand(CSSPropertyID longhand, const CSSValue& value)
     if (value.isImplicitInitialValue())
         return true;
     switch (longhand) {
+    case CSSPropertyColumnRuleStyle:
+        if (isValueID(value, CSSValueNone))
+            return true;
+        break;
     case CSSPropertyBackgroundSize:
     case CSSPropertyMaskSize:
         if (isValueIDPair(value, CSSValueAuto))

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -40,6 +40,7 @@
 #include "CSSPrimitiveNumericTypes+Serialization.h"
 #include "CSSPrimitiveValue.h"
 #include "CSSProperty.h"
+#include "CSSPropertyInitialValues.h"
 #include "CSSPropertyNames.h"
 #include "CSSPropertyParserConsumer+Anchor.h"
 #include "CSSRegisteredCustomProperty.h"
@@ -1619,6 +1620,30 @@ inline void extractStandardSpaceSeparatedShorthandSerialization(ExtractorState& 
     builder.append(interleave(shorthand, [&](auto& builder, const auto& longhand) {
         ExtractorGenerated::extractValueSerialization(state, builder, context, longhand);
     }, ' '));
+}
+
+inline Ref<CSSValue> extractStandardSpaceSeparatedOmittingInitialValuesShorthand(ExtractorState& state, const StylePropertyShorthand& shorthand)
+{
+    Vector<Ref<CSSValue>> values;
+    values.reserveInitialCapacity(shorthand.length());
+    for (auto longhand : shorthand)
+        values.append(ExtractorGenerated::extractValue(state, longhand).releaseNonNull());
+
+    CSSValueListBuilder list;
+    for (size_t i = 0; i < shorthand.length(); ++i) {
+        if (!isInitialValueForLonghand(shorthand.properties()[i], values[i]))
+            list.append(values[i].copyRef());
+    }
+    if (list.isEmpty()) {
+        for (auto& value : values)
+            list.append(WTF::move(value));
+    }
+    return CSSValueList::createSpaceSeparated(WTF::move(list));
+}
+
+inline void extractStandardSpaceSeparatedOmittingInitialValuesShorthandSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const StylePropertyShorthand& shorthand)
+{
+    builder.append(extractStandardSpaceSeparatedOmittingInitialValuesShorthand(state, shorthand)->cssText(context));
 }
 
 inline Ref<CSSValue> extractStandardSlashSeparatedShorthand(ExtractorState& state, const StylePropertyShorthand& shorthand)


### PR DESCRIPTION
#### 09b933e0472bd1bc9ec91cdc44d1a55ed5859c02
<pre>
Use shortest serialization principle for `column-rule` computed values
<a href="https://bugs.webkit.org/show_bug.cgi?id=294284">https://bugs.webkit.org/show_bug.cgi?id=294284</a>

Reviewed by NOBODY (OOPS!).

The computed WPT test for column-rule was failing because the implementation was not applying the shortest-serialization principle when column-rule-width is zero.
This patch fixes the issue by introducing a custom serialization for the column-rule shorthand property.
The test contained also incorrect passes in expectation:

&quot;
  PASS Property column-rule value &apos;medium hidden currentcolor&apos;
  PASS Property column-rule value &apos;medium solid currentcolor&apos;
&quot;

* LayoutTests/fast/css/getComputedStyle/getComputedStyle-column-rule-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-multicol/parsing/column-rule-computed-expected.txt:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/style/StyleExtractorCustom.h:
(WebCore::Style::extractColumnRuleShorthand):
(WebCore::Style::extractColumnRuleShorthandSerialization):
(WebCore::Style::ExtractorCustom::extractColumnRuleShorthand):
(WebCore::Style::ExtractorCustom::extractColumnRuleShorthandSerialization):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09b933e0472bd1bc9ec91cdc44d1a55ed5859c02

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174316 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48249 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42030 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183891 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132184 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176181 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49541 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47931 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135594 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95674 "3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177274 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39027 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156387 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116072 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37668 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36040 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32374 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148091 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35880 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186318 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39518 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40237 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144505 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47916 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155942 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144363 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48595 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32500 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114135 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39266 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120527 "Build is in progress. Recent messages:OS: Tahoe (26.3.1), Xcode: 26.2; Checked out pull request; Found 28185 issues") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47101 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10844 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46504 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46735 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46562 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->