### PR TITLE
Fixed unretained local variable warnings in Tools/TestWebKitAPI

### DIFF
--- a/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
@@ -91,13 +91,13 @@ struct CFHolderForTesting {
 
     CFTypeRef valueAsCFType() const
     {
-        CFTypeRef result;
+        RetainPtr<CFTypeRef> result;
         WTF::switchOn(value, [&] (std::nullptr_t) {
             result = nullptr;
         }, [&](auto&& arg) {
             result = arg.get();
         });
-        return result;
+        return result.autorelease();
     }
 
     using ValueType = Variant<
@@ -418,13 +418,13 @@ struct ObjCHolderForTesting {
 
     id valueAsID() const
     {
-        id result;
+        RetainPtr<id> result;
         WTF::switchOn(value, [&] (std::nullptr_t) {
             result = nil;
         }, [&](auto&& arg) {
             result = arg.get();
         });
-        return result;
+        return result.autorelease();
     }
 
     typedef Variant<
@@ -1232,9 +1232,9 @@ TEST(IPCSerialization, Basic)
     auto items = adoptCF(itemsPtr);
     EXPECT_GT(CFArrayGetCount(items.get()), 0);
 
-    SecKeychainItemRef keychainItemRef = (SecKeychainItemRef)CFArrayGetValueAtIndex(items.get(), 0);
-    EXPECT_NOT_NULL(keychainItemRef);
-    runTestCF({ keychainItemRef });
+    RetainPtr keychainItemRef = (SecKeychainItemRef)CFArrayGetValueAtIndex(items.get(), 0);
+    EXPECT_NOT_NULL(keychainItemRef.get());
+    runTestCF({ keychainItemRef.get() });
 
     CFRelease(certData);
 

--- a/Tools/TestWebKitAPI/Tests/WGSL/TestWGSLAPI.h
+++ b/Tools/TestWebKitAPI/Tests/WGSL/TestWGSLAPI.h
@@ -156,10 +156,10 @@ inline Variant<id<MTLLibrary>, NSError *> metalCompile(const String& msl)
     auto options = [MTLCompileOptions new];
     options.preprocessorMacros = @{ @"__wgslMetalAppleGPUFamily" : [NSString stringWithFormat:@"%u", 8] };
     NSError *error = nil;
-    id<MTLLibrary> library = [device newLibraryWithSource:msl.createNSString().get() options:options error:&error];
+    RetainPtr library = [device newLibraryWithSource:msl.createNSString().get() options:options error:&error];
     if (error != nil)
         return { error };
-    return { library };
+    return { library.get() };
 }
 #endif
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/PreferenceChanges.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/PreferenceChanges.mm
@@ -326,8 +326,8 @@ TEST(WebKit, PreferenceChangesArray)
 
     RetainPtr<NSObject> object;
     for (unsigned i = 0; i < preferenceQueryMaxCount && ![object isEqual:changedArray]; i++) {
-        auto encodedString = preferenceValue();
-        auto encodedData = adoptNS([[NSData alloc] initWithBase64EncodedString:encodedString options:0]);
+        RetainPtr encodedString = preferenceValue();
+        auto encodedData = adoptNS([[NSData alloc] initWithBase64EncodedString:encodedString.get() options:0]);
         ASSERT_TRUE(encodedData);
         NSError *err = nil;
         object = retainPtr([NSKeyedUnarchiver unarchivedObjectOfClass:[NSObject class] fromData:encodedData.get() error:&err]);
@@ -376,8 +376,8 @@ TEST(WebKit, PreferenceChangesDictionary)
 
     RetainPtr<NSObject> object;
     for (unsigned i = 0; i < preferenceQueryMaxCount && ![object isEqual:changedDict]; i++) {
-        auto encodedString = preferenceValue();
-        auto encodedData = adoptNS([[NSData alloc] initWithBase64EncodedString:encodedString options:0]);
+        RetainPtr encodedString = preferenceValue();
+        auto encodedData = adoptNS([[NSData alloc] initWithBase64EncodedString:encodedString.get() options:0]);
         ASSERT_TRUE(encodedData);
         NSError *err = nil;
         object = retainPtr([NSKeyedUnarchiver unarchivedObjectOfClass:[NSObject class] fromData:encodedData.get() error:&err]);
@@ -419,8 +419,8 @@ TEST(WebKit, PreferenceChangesData)
 
     RetainPtr<NSObject> object;
     for (unsigned i = 0; i < preferenceQueryMaxCount && ![object isEqual:changedData]; i++) {
-        auto encodedString = preferenceValue();
-        auto encodedData = adoptNS([[NSData alloc] initWithBase64EncodedString:encodedString options:0]);
+        RetainPtr encodedString = preferenceValue();
+        auto encodedData = adoptNS([[NSData alloc] initWithBase64EncodedString:encodedString.get() options:0]);
         ASSERT_TRUE(encodedData);
         NSError *err = nil;
         object = retainPtr([NSKeyedUnarchiver unarchivedObjectOfClass:[NSObject class] fromData:encodedData.get() error:&err]);
@@ -462,8 +462,8 @@ TEST(WebKit, PreferenceChangesDate)
 
     RetainPtr<NSObject> object;
     for (unsigned i = 0; i < preferenceQueryMaxCount && ![object isEqual:changedDate]; i++) {
-        auto encodedString = preferenceValue();
-        auto encodedData = adoptNS([[NSData alloc] initWithBase64EncodedString:encodedString options:0]);
+        RetainPtr encodedString = preferenceValue();
+        auto encodedData = adoptNS([[NSData alloc] initWithBase64EncodedString:encodedString.get() options:0]);
         ASSERT_TRUE(encodedData);
         NSError *err = nil;
         object = retainPtr([NSKeyedUnarchiver unarchivedObjectOfClass:[NSObject class] fromData:encodedData.get() error:&err]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/CreateWebArchive.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/CreateWebArchive.mm
@@ -184,7 +184,7 @@ TEST(WebArchive, SaveResourcesBasic)
     NSData *scriptData = [@"function notifyTestRunner() { window.webkit.messageHandlers.testHandler.postMessage(\"done\"); }" dataUsingEncoding:NSUTF8StringEncoding];
     NSData *imageData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"400x400-green" withExtension:@"png"]];
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
-        NSData *data = nil;
+        RetainPtr<NSData> data;
         NSString *mimeType = nil;
         if ([task.request.URL.absoluteString isEqualToString:@"webarchivetest://host/main.html"]) {
             mimeType = @"text/html";
@@ -198,9 +198,9 @@ TEST(WebArchive, SaveResourcesBasic)
         } else
             FAIL();
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.length textEncodingName:nil]);
+        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
-        [task didReceiveData:data];
+        [task didReceiveData:data.get()];
         [task didFinish];
     }];
 
@@ -276,7 +276,7 @@ TEST(WebArchive, SaveResourcesIframe)
     NSData *cssData = [NSData dataWithBytes:cssDataBytesForIframe length:strlen(cssDataBytesForIframe)];
     NSData *imageData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"400x400-green" withExtension:@"png"]];
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
-        NSData *data = nil;
+        RetainPtr<NSData> data;
         NSString *mimeType = nil;
         if ([task.request.URL.absoluteString isEqualToString:@"webarchivetest://host/main.html"]) {
             mimeType = @"text/html";
@@ -293,9 +293,9 @@ TEST(WebArchive, SaveResourcesIframe)
         } else
             FAIL();
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.length textEncodingName:nil]);
+        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
-        [task didReceiveData:data];
+        [task didReceiveData:data.get()];
         [task didFinish];
     }];
 
@@ -385,7 +385,7 @@ TEST(WebArchive, SaveResourcesFrame)
     NSData *frameHTMLData = [NSData dataWithBytes:frameHTMLDataBytes length:strlen(frameHTMLDataBytes)];
     NSData *imageData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"400x400-green" withExtension:@"png"]];
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
-        NSData *data = nil;
+        RetainPtr<NSData> data;
         NSString *mimeType = nil;
         if ([task.request.URL.absoluteString isEqualToString:@"webarchivetest://host/main.html"]) {
             mimeType = @"text/html";
@@ -399,9 +399,9 @@ TEST(WebArchive, SaveResourcesFrame)
         } else
             FAIL();
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.length textEncodingName:nil]);
+        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
-        [task didReceiveData:data];
+        [task didReceiveData:data.get()];
         [task didFinish];
     }];
 
@@ -479,7 +479,7 @@ TEST(WebArchive, SaveResourcesValidFileName)
     NSString *cssString = @"img { width: 10px; }";
     NSData *cssData = [cssString dataUsingEncoding:NSUTF8StringEncoding];
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
-        NSData *data = nil;
+        RetainPtr<NSData> data;
         NSString *mimeType = nil;
         if ([task.request.URL.absoluteString isEqualToString:@"webarchivetest://host/main.html"]) {
             mimeType = @"text/html";
@@ -491,9 +491,9 @@ TEST(WebArchive, SaveResourcesValidFileName)
             mimeType = @"image/png";
             data = imageData;
         }
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.length textEncodingName:nil]);
+        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
-        [task didReceiveData:data];
+        [task didReceiveData:data.get()];
         [task didFinish];
     }];
 
@@ -567,7 +567,7 @@ TEST(WebArchive, SaveResourcesBlobURL)
     NSData *htmlData = [NSData dataWithBytes:htmlDataBytesForBlobURL length:strlen(htmlDataBytesForBlobURL)];
     NSData *imageData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"400x400-green" withExtension:@"png"]];
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
-        NSData *data = nil;
+        RetainPtr<NSData> data;
         NSString *mimeType = nil;
         if ([task.request.URL.absoluteString isEqualToString:@"webarchivetest://host/main.html"]) {
             mimeType = @"text/html";
@@ -578,9 +578,9 @@ TEST(WebArchive, SaveResourcesBlobURL)
         } else
             FAIL();
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.length textEncodingName:nil]);
+        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
-        [task didReceiveData:data];
+        [task didReceiveData:data.get()];
         [task didFinish];
     }];
 
@@ -677,7 +677,7 @@ TEST(WebArchive, SaveResourcesResponsiveImages)
     NSData *htmlData = [NSData dataWithBytes:htmlDataBytesForResponsiveImages length:strlen(htmlDataBytesForResponsiveImages)];
     NSData *imageData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"400x400-green" withExtension:@"png"]];
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
-        NSData *data = nil;
+        RetainPtr<NSData> data;
         NSString *mimeType = nil;
         if ([task.request.URL.absoluteString isEqualToString:@"webarchivetest://host/main.html"]) {
             mimeType = @"text/html";
@@ -688,9 +688,9 @@ TEST(WebArchive, SaveResourcesResponsiveImages)
         } else
             FAIL();
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.length textEncodingName:nil]);
+        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
-        [task didReceiveData:data];
+        [task didReceiveData:data.get()];
         [task didFinish];
     }];
 
@@ -750,7 +750,7 @@ TEST(WebArchive, SaveResourcesDataURL)
     NSData *htmlData = [NSData dataWithBytes:hTMLDataBytesForDataURL length:strlen(hTMLDataBytesForDataURL)];
     NSData *imageData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"400x400-green" withExtension:@"png"]];
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
-        NSData *data = nil;
+        RetainPtr<NSData> data;
         NSString *mimeType = nil;
         if ([task.request.URL.absoluteString isEqualToString:@"webarchivetest://host/main.html"]) {
             mimeType = @"text/html";
@@ -761,9 +761,9 @@ TEST(WebArchive, SaveResourcesDataURL)
         } else
             FAIL();
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.length textEncodingName:nil]);
+        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
-        [task didReceiveData:data];
+        [task didReceiveData:data.get()];
         [task didFinish];
     }];
 
@@ -851,7 +851,7 @@ TEST(WebArchive, SaveResourcesIframeInIframe)
     NSData *iframe1HTMLData = [NSData dataWithBytes:iframe1HTMLDataBytes length:strlen(iframe1HTMLDataBytes)];
     NSData *iframe2HTMLData = [NSData dataWithBytes:iframe2HTMLDataBytes length:strlen(iframe2HTMLDataBytes)];
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
-        NSData *data = nil;
+        RetainPtr<NSData> data;
         NSString *mimeType = nil;
         if ([task.request.URL.absoluteString isEqualToString:@"webarchivetest://host/main.html"]) {
             mimeType = @"text/html";
@@ -865,9 +865,9 @@ TEST(WebArchive, SaveResourcesIframeInIframe)
         } else
             FAIL();
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.length textEncodingName:nil]);
+        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
-        [task didReceiveData:data];
+        [task didReceiveData:data.get()];
         [task didFinish];
     }];
 
@@ -955,7 +955,7 @@ TEST(WebArchive, SaveResourcesIframesWithSameURL)
     NSData *htmlData = [NSData dataWithBytes:htmlDataBytesForIframesWithSameURL length:strlen(htmlDataBytesForIframesWithSameURL)];
     NSData *iframeHTMLData = [NSData dataWithBytes:iframeHTMLDataBytesForIframesWithSameURL length:strlen(iframeHTMLDataBytesForIframesWithSameURL)];
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
-        NSData *data = nil;
+        RetainPtr<NSData> data;
         NSString *mimeType = nil;
         if ([task.request.URL.absoluteString isEqualToString:@"webarchivetest://host/main.html"]) {
             mimeType = @"text/html";
@@ -966,9 +966,9 @@ TEST(WebArchive, SaveResourcesIframesWithSameURL)
         } else
             FAIL();
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.length textEncodingName:nil]);
+        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
-        [task didReceiveData:data];
+        [task didReceiveData:data.get()];
         [task didFinish];
     }];
 
@@ -1045,7 +1045,7 @@ TEST(WebArchive, SaveResourcesShadowDOM)
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webarchivetest"];
     NSData *htmlData = [NSData dataWithBytes:htmlDataBytesForShadowDOM length:strlen(htmlDataBytesForShadowDOM)];
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
-        NSData *data = nil;
+        RetainPtr<NSData> data;
         NSString *mimeType = nil;
         if ([task.request.URL.absoluteString isEqualToString:@"webarchivetest://host/main.html"]) {
             mimeType = @"text/html";
@@ -1053,9 +1053,9 @@ TEST(WebArchive, SaveResourcesShadowDOM)
         } else
             FAIL();
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.length textEncodingName:nil]);
+        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
-        [task didReceiveData:data];
+        [task didReceiveData:data.get()];
         [task didFinish];
     }];
 
@@ -1110,7 +1110,7 @@ TEST(WebArchive, SaveResourcesDeclarativeShadowDOM)
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webarchivetest"];
     NSData *htmlData = [NSData dataWithBytes:htmlDataBytesForDeclarativeShadowDOM length:strlen(htmlDataBytesForDeclarativeShadowDOM)];
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
-        NSData *data = nil;
+        RetainPtr<NSData> data;
         NSString *mimeType = nil;
         if ([task.request.URL.absoluteString isEqualToString:@"webarchivetest://host/main.html"]) {
             mimeType = @"text/html";
@@ -1118,9 +1118,9 @@ TEST(WebArchive, SaveResourcesDeclarativeShadowDOM)
         } else
             FAIL();
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.length textEncodingName:nil]);
+        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
-        [task didReceiveData:data];
+        [task didReceiveData:data.get()];
         [task didFinish];
     }];
 
@@ -1179,7 +1179,7 @@ TEST(WebArchive, SaveResourcesStyle)
     NSData *imageData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"400x400-green" withExtension:@"png"]];
     NSData *fontData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"Ahem-10000A" withExtension:@"ttf"]];
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
-        NSData *data = nil;
+        RetainPtr<NSData> data;
         NSString *mimeType = nil;
         if ([task.request.URL.absoluteString isEqualToString:@"webarchivetest://host/main.html"]) {
             mimeType = @"text/html";
@@ -1193,9 +1193,9 @@ TEST(WebArchive, SaveResourcesStyle)
         } else
             FAIL();
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.length textEncodingName:nil]);
+        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
-        [task didReceiveData:data];
+        [task didReceiveData:data.get()];
         [task didFinish];
     }];
 
@@ -1251,7 +1251,7 @@ TEST(WebArchive, SaveResourcesInlineStyle)
     NSData *htmlData = [NSData dataWithBytes:htmlDataBytesForInlineStyle length:strlen(htmlDataBytesForInlineStyle)];
     NSData *imageData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"400x400-green" withExtension:@"png"]];
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
-        NSData *data = nil;
+        RetainPtr<NSData> data;
         NSString *mimeType = nil;
         if ([task.request.URL.absoluteString isEqualToString:@"webarchivetest://host/main.html"]) {
             mimeType = @"text/html";
@@ -1262,9 +1262,9 @@ TEST(WebArchive, SaveResourcesInlineStyle)
         } else
             FAIL();
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.length textEncodingName:nil]);
+        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
-        [task didReceiveData:data];
+        [task didReceiveData:data.get()];
         [task didFinish];
     }];
 
@@ -1351,7 +1351,7 @@ TEST(WebArchive, SaveResourcesLink)
     NSData *manifestData = [NSData dataWithBytes:manifestDataBytesForLink length:strlen(manifestDataBytesForLink)];
     NSData *fontData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"Ahem-10000A" withExtension:@"ttf"]];
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
-        NSData *data = nil;
+        RetainPtr<NSData> data;
         NSString *mimeType = nil;
         if ([task.request.URL.absoluteString isEqualToString:@"webarchivetest://host/main.html"]) {
             mimeType = @"text/html";
@@ -1370,9 +1370,9 @@ TEST(WebArchive, SaveResourcesLink)
             data = fontData;
         }
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.length textEncodingName:nil]);
+        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
-        [task didReceiveData:data];
+        [task didReceiveData:data.get()];
         [task didFinish];
     }];
 
@@ -1516,7 +1516,7 @@ TEST(WebArchive, SaveResourcesLinksWithSameURL)
     NSData *htmlData = [NSData dataWithBytes:htmlDataBytesForLinksWithSameURL length:strlen(htmlDataBytesForLinksWithSameURL)];
     NSData *cssData = [NSData dataWithBytes:cssDataBytesForLinksWithSameURL length:strlen(cssDataBytesForLinksWithSameURL)];
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
-        NSData *data = nil;
+        RetainPtr<NSData> data;
         NSString *mimeType = nil;
         if ([task.request.URL.absoluteString isEqualToString:@"webarchivetest://host/main.html"]) {
             mimeType = @"text/html";
@@ -1526,9 +1526,9 @@ TEST(WebArchive, SaveResourcesLinksWithSameURL)
             data = cssData;
         }
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.length textEncodingName:nil]);
+        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
-        [task didReceiveData:data];
+        [task didReceiveData:data.get()];
         [task didFinish];
     }];
 
@@ -1605,7 +1605,7 @@ TEST(WebArchive, SaveResourcesCSSImportRule)
     NSData *cssData = [NSData dataWithBytes:cssDataBytesForLink length:strlen(cssDataBytesForLink)];
     NSData *imageData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"400x400-green" withExtension:@"png"]];
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
-        NSData *data = nil;
+        RetainPtr<NSData> data;
         NSString *mimeType = nil;
         if ([task.request.URL.absoluteString isEqualToString:@"webarchivetest://host/main.html"]) {
             mimeType = @"text/html";
@@ -1618,9 +1618,9 @@ TEST(WebArchive, SaveResourcesCSSImportRule)
             data = cssData;
         }
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.length textEncodingName:nil]);
+        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
-        [task didReceiveData:data];
+        [task didReceiveData:data.get()];
         [task didFinish];
     }];
 
@@ -1693,7 +1693,7 @@ TEST(WebArchive, SaveResourcesCSSSupportsRule)
     NSData *htmlData = [NSData dataWithBytes:htmlDataBytesForCSSSupportsRule length:strlen(htmlDataBytesForCSSSupportsRule)];
     NSData *imageData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"400x400-green" withExtension:@"png"]];
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
-        NSData *data = nil;
+        RetainPtr<NSData> data;
         NSString *mimeType = nil;
         if ([task.request.URL.absoluteString isEqualToString:@"webarchivetest://host/main.html"]) {
             mimeType = @"text/html";
@@ -1703,9 +1703,9 @@ TEST(WebArchive, SaveResourcesCSSSupportsRule)
             data = imageData;
         }
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.length textEncodingName:nil]);
+        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
-        [task didReceiveData:data];
+        [task didReceiveData:data.get()];
         [task didFinish];
     }];
 
@@ -1846,7 +1846,7 @@ TEST(WebArchive, SaveResourcesCrossOriginLink)
     NSData *htmlData = [NSData dataWithBytes:htmlDataBytesForCrossOriginLink length:strlen(htmlDataBytesForCrossOriginLink)];
     NSData *cssData = [NSData dataWithBytes:cssDataBytesForCrossOriginLink length:strlen(cssDataBytesForCrossOriginLink)];
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
-        NSData *data = nil;
+        RetainPtr<NSData> data;
         NSString *mimeType = nil;
         if ([task.request.URL.absoluteString isEqualToString:@"webarchivetest://host.com/main.html"]) {
             mimeType = @"text/html";
@@ -1856,9 +1856,9 @@ TEST(WebArchive, SaveResourcesCrossOriginLink)
             data = cssData;
         }
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.length textEncodingName:nil]);
+        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
-        [task didReceiveData:data];
+        [task didReceiveData:data.get()];
         [task didFinish];
     }];
 
@@ -1915,7 +1915,7 @@ TEST(WebArchive, SaveResourcesExcludeBaseElement)
     NSData *htmlData = [NSData dataWithBytes:htmlDataBytesForExcludeBaseElement length:strlen(htmlDataBytesForExcludeBaseElement)];
     NSData *imageData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"400x400-green" withExtension:@"png"]];
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
-        NSData *data = nil;
+        RetainPtr<NSData> data;
         NSString *mimeType = nil;
         if ([task.request.URL.absoluteString isEqualToString:@"webarchivetest://host.com/main.html"]) {
             mimeType = @"text/html";
@@ -1925,9 +1925,9 @@ TEST(WebArchive, SaveResourcesExcludeBaseElement)
             data = imageData;
         }
 
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.length textEncodingName:nil]);
+        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
-        [task didReceiveData:data];
+        [task didReceiveData:data.get()];
         [task didFinish];
     }];
 
@@ -1983,17 +1983,17 @@ TEST(WebArchive, SaveResourcesExclusionRules)
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webarchivetest"];
     NSData *htmlData = [NSData dataWithBytes:htmlDataBytesForExclusionRules length:strlen(htmlDataBytesForExclusionRules)];
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
-        NSData *data = nil;
+        RetainPtr<NSData> data;
         NSString *mimeType = nil;
         if ([task.request.URL.absoluteString isEqualToString:@"webarchivetest://host/main.html"]) {
             mimeType = @"text/html";
             data = htmlData;
         }
 
-        EXPECT_TRUE(data);
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.length textEncodingName:nil]);
+        EXPECT_TRUE(data.get());
+        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
-        [task didReceiveData:data];
+        [task didReceiveData:data.get()];
         [task didFinish];
     }];
 
@@ -2057,7 +2057,7 @@ TEST(WebArchive, SaveResourcesExcludeCrossOriginAttribute)
     NSData *scriptData = [NSData dataWithBytes:scriptDataBytesForExcludeCrossOriginAttribute length:strlen(scriptDataBytesForExcludeCrossOriginAttribute)];
     NSData *cssData = [NSData dataWithBytes:cssDataBytesForExcludeCrossOriginAttribute length:strlen(cssDataBytesForExcludeCrossOriginAttribute)];
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
-        NSData *data = nil;
+        RetainPtr<NSData> data;
         NSString *mimeType = nil;
         bool shouldAddAccessControlHeader = false;
         if ([task.request.URL.absoluteString isEqualToString:@"webarchivetest://host/main.html"]) {
@@ -2072,10 +2072,10 @@ TEST(WebArchive, SaveResourcesExcludeCrossOriginAttribute)
             data = cssData;
             shouldAddAccessControlHeader = true;
         }
-        EXPECT_TRUE(data);
+        EXPECT_TRUE(data.get());
 
         RetainPtr<NSMutableDictionary> headerFields = adoptNS(@{
-            @"Content-Length": [NSString stringWithFormat:@"%zu", (size_t)data.length],
+            @"Content-Length": [NSString stringWithFormat:@"%zu", (size_t)data.get().length],
             @"Content-Type": mimeType,
         }.mutableCopy);
         if (shouldAddAccessControlHeader)
@@ -2083,7 +2083,7 @@ TEST(WebArchive, SaveResourcesExcludeCrossOriginAttribute)
 
         auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:task.request.URL statusCode:200 HTTPVersion:nil headerFields:headerFields.get()]);
         [task didReceiveResponse:response.get()];
-        [task didReceiveData:data];
+        [task didReceiveData:data.get()];
         [task didFinish];
     }];
 
@@ -2220,17 +2220,17 @@ TEST(WebArchive, SaveResourcesWithUTF8Encoding)
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webarchivetest"];
     NSData *htmlData = [NSData dataWithBytes:htmlDataBytesForUTF8Encoding length:strlen(htmlDataBytesForUTF8Encoding)];
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
-        NSData *data = nil;
+        RetainPtr<NSData> data;
         NSString *mimeType = nil;
         if ([task.request.URL.absoluteString isEqualToString:@"webarchivetest://host/main.html"]) {
             mimeType = @"text/html";
             data = htmlData;
         }
-        EXPECT_TRUE(data);
+        EXPECT_TRUE(data.get());
 
-        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.length textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.get().length textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
-        [task didReceiveData:data];
+        [task didReceiveData:data.get()];
         [task didFinish];
     }];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurity.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurity.mm
@@ -409,11 +409,11 @@ TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysEnabledAfterSubFrameNaviga
         { "/webkit"_s, { "<html></html>"_s } }
     }, HTTPServer::Protocol::HttpsProxy);
 
-    auto webViewConfiguration = server.httpsProxyConfiguration();
-    [webViewConfiguration.processPool _setObject:@"WebProcessPlugInWithInternals" forBundleParameter:TestWebKitAPI::Util::TestPlugInClassNameParameter];
-    webViewConfiguration.defaultWebpagePreferences._enhancedSecurityEnabled = YES;
+    RetainPtr webViewConfiguration = server.httpsProxyConfiguration();
+    [webViewConfiguration.get().processPool _setObject:@"WebProcessPlugInWithInternals" forBundleParameter:TestWebKitAPI::Util::TestPlugInClassNameParameter];
+    webViewConfiguration.get().defaultWebpagePreferences._enhancedSecurityEnabled = YES;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration]);
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
     auto delegate = adoptNS([TestNavigationDelegate new]);
     [delegate allowAnyTLSCertificate];
 
@@ -455,11 +455,11 @@ TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysEnabledAfterSubFrameNaviga
         { "/webkit"_s, { "<html></html>"_s } }
     }, HTTPServer::Protocol::HttpsProxy);
 
-    auto webViewConfiguration = server.httpsProxyConfiguration();
-    [webViewConfiguration.processPool _setObject:@"WebProcessPlugInWithInternals" forBundleParameter:TestWebKitAPI::Util::TestPlugInClassNameParameter];
-    webViewConfiguration.defaultWebpagePreferences._enhancedSecurityEnabled = YES;
+    RetainPtr webViewConfiguration = server.httpsProxyConfiguration();
+    [webViewConfiguration.get().processPool _setObject:@"WebProcessPlugInWithInternals" forBundleParameter:TestWebKitAPI::Util::TestPlugInClassNameParameter];
+    webViewConfiguration.get().defaultWebpagePreferences._enhancedSecurityEnabled = YES;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration]);
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
     auto delegate = adoptNS([TestNavigationDelegate new]);
     [delegate allowAnyTLSCertificate];
 
@@ -501,11 +501,11 @@ TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysDisabledAfterSubFrameNavig
         { "/webkit"_s, { "<html></html>"_s } }
     }, HTTPServer::Protocol::HttpsProxy);
 
-    auto webViewConfiguration = server.httpsProxyConfiguration();
-    [webViewConfiguration.processPool _setObject:@"WebProcessPlugInWithInternals" forBundleParameter:TestWebKitAPI::Util::TestPlugInClassNameParameter];
-    webViewConfiguration.defaultWebpagePreferences._enhancedSecurityEnabled = NO;
+    RetainPtr webViewConfiguration = server.httpsProxyConfiguration();
+    [webViewConfiguration.get().processPool _setObject:@"WebProcessPlugInWithInternals" forBundleParameter:TestWebKitAPI::Util::TestPlugInClassNameParameter];
+    webViewConfiguration.get().defaultWebpagePreferences._enhancedSecurityEnabled = NO;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration]);
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
     auto delegate = adoptNS([TestNavigationDelegate new]);
     [delegate allowAnyTLSCertificate];
 
@@ -547,11 +547,11 @@ TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysDisabledAfterSubFrameNavig
         { "/webkit"_s, { "<html></html>"_s } }
     }, HTTPServer::Protocol::HttpsProxy);
 
-    auto webViewConfiguration = server.httpsProxyConfiguration();
-    [webViewConfiguration.processPool _setObject:@"WebProcessPlugInWithInternals" forBundleParameter:TestWebKitAPI::Util::TestPlugInClassNameParameter];
-    webViewConfiguration.defaultWebpagePreferences._enhancedSecurityEnabled = NO;
+    RetainPtr webViewConfiguration = server.httpsProxyConfiguration();
+    [webViewConfiguration.get().processPool _setObject:@"WebProcessPlugInWithInternals" forBundleParameter:TestWebKitAPI::Util::TestPlugInClassNameParameter];
+    webViewConfiguration.get().defaultWebpagePreferences._enhancedSecurityEnabled = NO;
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration]);
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
     auto delegate = adoptNS([TestNavigationDelegate new]);
     [delegate allowAnyTLSCertificate];
 
@@ -590,11 +590,11 @@ TEST(EnhancedSecurity, WindowOpenWithNoopenerFromEnhancedSecurityPage)
         { "/webkit"_s, { "hi"_s } },
     }, HTTPServer::Protocol::HttpsProxy);
 
-    auto webViewConfiguration = server.httpsProxyConfiguration();
-    webViewConfiguration.defaultWebpagePreferences._enhancedSecurityEnabled = YES;
-    webViewConfiguration.preferences.javaScriptCanOpenWindowsAutomatically = YES;
+    RetainPtr webViewConfiguration = server.httpsProxyConfiguration();
+    webViewConfiguration.get().defaultWebpagePreferences._enhancedSecurityEnabled = YES;
+    webViewConfiguration.get().preferences.javaScriptCanOpenWindowsAutomatically = YES;
 
-    auto openerWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration]);
+    auto openerWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
     auto openerDelegate = adoptNS([TestNavigationDelegate new]);
     [openerDelegate allowAnyTLSCertificate];
     [openerWebView setNavigationDelegate:openerDelegate.get()];
@@ -630,11 +630,11 @@ TEST(EnhancedSecurity, WindowOpenWithOpenerFromEnhancedSecurityPage)
         { "/webkit"_s, { "hi"_s } },
     }, HTTPServer::Protocol::HttpsProxy);
 
-    auto webViewConfiguration = server.httpsProxyConfiguration();
-    webViewConfiguration.defaultWebpagePreferences._enhancedSecurityEnabled = YES;
-    webViewConfiguration.preferences.javaScriptCanOpenWindowsAutomatically = YES;
+    RetainPtr webViewConfiguration = server.httpsProxyConfiguration();
+    webViewConfiguration.get().defaultWebpagePreferences._enhancedSecurityEnabled = YES;
+    webViewConfiguration.get().preferences.javaScriptCanOpenWindowsAutomatically = YES;
 
-    auto openerWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration]);
+    auto openerWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
     auto openerDelegate = adoptNS([TestNavigationDelegate new]);
     [openerDelegate allowAnyTLSCertificate];
     [openerWebView setNavigationDelegate:openerDelegate.get()];
@@ -671,12 +671,12 @@ TEST(EnhancedSecurity, WindowOpenNoopenerFromEnhancedSecurityInheritsEnhancedSec
     auto processPoolConfiguration = psonProcessPoolConfiguration();
     auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto standardConfig = server.httpsProxyConfiguration();
-    [standardConfig setProcessPool:processPool.get()];
-    standardConfig.defaultWebpagePreferences._enhancedSecurityEnabled = NO;
-    standardConfig.preferences.javaScriptCanOpenWindowsAutomatically = YES;
+    RetainPtr standardConfig = server.httpsProxyConfiguration();
+    [standardConfig.get() setProcessPool:processPool.get()];
+    standardConfig.get().defaultWebpagePreferences._enhancedSecurityEnabled = NO;
+    standardConfig.get().preferences.javaScriptCanOpenWindowsAutomatically = YES;
 
-    auto standardWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:standardConfig]);
+    auto standardWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:standardConfig.get()]);
     auto standardDelegate = adoptNS([TestNavigationDelegate new]);
     [standardDelegate allowAnyTLSCertificate];
     [standardWebView setNavigationDelegate:standardDelegate.get()];
@@ -689,12 +689,12 @@ TEST(EnhancedSecurity, WindowOpenNoopenerFromEnhancedSecurityInheritsEnhancedSec
     pid_t standardPid = [standardWebView _webProcessIdentifier];
     EXPECT_NE(standardPid, 0);
 
-    auto enhancedConfig = server.httpsProxyConfiguration();
-    [enhancedConfig setProcessPool:processPool.get()];
-    enhancedConfig.defaultWebpagePreferences._enhancedSecurityEnabled = YES;
-    enhancedConfig.preferences.javaScriptCanOpenWindowsAutomatically = YES;
+    RetainPtr enhancedConfig = server.httpsProxyConfiguration();
+    [enhancedConfig.get() setProcessPool:processPool.get()];
+    enhancedConfig.get().defaultWebpagePreferences._enhancedSecurityEnabled = YES;
+    enhancedConfig.get().preferences.javaScriptCanOpenWindowsAutomatically = YES;
 
-    auto openerWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 1, 1) configuration:enhancedConfig]);
+    auto openerWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 1, 1) configuration:enhancedConfig.get()]);
     auto openerDelegate = adoptNS([TestNavigationDelegate new]);
     [openerDelegate allowAnyTLSCertificate];
     [openerWebView setNavigationDelegate:openerDelegate.get()];
@@ -735,12 +735,12 @@ TEST(EnhancedSecurity, WindowOpenNoopenerFromStandardWithEnhancedSecurityViaDele
     auto processPoolConfiguration = psonProcessPoolConfiguration();
     auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto standardConfig = server.httpsProxyConfiguration();
-    [standardConfig setProcessPool:processPool.get()];
-    standardConfig.defaultWebpagePreferences._enhancedSecurityEnabled = NO;
-    standardConfig.preferences.javaScriptCanOpenWindowsAutomatically = YES;
+    RetainPtr standardConfig = server.httpsProxyConfiguration();
+    [standardConfig.get() setProcessPool:processPool.get()];
+    standardConfig.get().defaultWebpagePreferences._enhancedSecurityEnabled = NO;
+    standardConfig.get().preferences.javaScriptCanOpenWindowsAutomatically = YES;
 
-    auto openerWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:standardConfig]);
+    auto openerWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:standardConfig.get()]);
     auto openerDelegate = adoptNS([TestNavigationDelegate new]);
     [openerDelegate allowAnyTLSCertificate];
     [openerWebView setNavigationDelegate:openerDelegate.get()];
@@ -801,12 +801,12 @@ TEST(EnhancedSecurity, WindowOpenNoopenerFromEnhancedSecurityWithStandardViaDele
     auto processPoolConfiguration = psonProcessPoolConfiguration();
     auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto enhancedConfig = server.httpsProxyConfiguration();
-    [enhancedConfig setProcessPool:processPool.get()];
-    enhancedConfig.defaultWebpagePreferences._enhancedSecurityEnabled = YES;
-    enhancedConfig.preferences.javaScriptCanOpenWindowsAutomatically = YES;
+    RetainPtr enhancedConfig = server.httpsProxyConfiguration();
+    [enhancedConfig.get() setProcessPool:processPool.get()];
+    enhancedConfig.get().defaultWebpagePreferences._enhancedSecurityEnabled = YES;
+    enhancedConfig.get().preferences.javaScriptCanOpenWindowsAutomatically = YES;
 
-    auto openerWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:enhancedConfig]);
+    auto openerWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:enhancedConfig.get()]);
     auto openerDelegate = adoptNS([TestNavigationDelegate new]);
     [openerDelegate allowAnyTLSCertificate];
     [openerWebView setNavigationDelegate:openerDelegate.get()];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
@@ -8578,9 +8578,9 @@ TEST(ProcessSwap, ClientRedirectAfterCOOPIframeIgnored)
         { "/check-opener.html"_s, { "<script>try { alert(window.opener) } catch (e) { alert(e) }</script>"_s } }
     }, HTTPServer::Protocol::HttpsProxy);
 
-    auto configuration = server.httpsProxyConfiguration();
-    configuration.preferences.javaScriptCanOpenWindowsAutomatically = YES;
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    configuration.get().preferences.javaScriptCanOpenWindowsAutomatically = YES;
+    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
     __block RetainPtr<WKWebView> opened;
     auto uiDelegate = adoptNS([TestUIDelegate new]);
     auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
@@ -9848,10 +9848,10 @@ TEST(ProcessSwap, CrossSiteWindowOpenNoOpenerUsesNewProcess)
         { "/opened.html"_s, { "opened page"_s } }
     }, HTTPServer::Protocol::HttpsProxy);
 
-    auto configuration = server.httpsProxyConfiguration();
-    configuration.preferences.javaScriptCanOpenWindowsAutomatically = YES;
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    configuration.get().preferences.javaScriptCanOpenWindowsAutomatically = YES;
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
     __block RetainPtr<WKWebView> openedWebView;
     __block RetainPtr<TestNavigationDelegate> openedNavigationDelegate;
     __block bool openedPageLoaded = false;
@@ -9894,10 +9894,10 @@ TEST(ProcessSwap, CrossSiteLinkTargetBlankNoOpenerUsesNewProcess)
         { "/opened.html"_s, { "opened page"_s } }
     }, HTTPServer::Protocol::HttpsProxy);
 
-    auto configuration = server.httpsProxyConfiguration();
-    configuration.preferences.javaScriptCanOpenWindowsAutomatically = YES;
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    configuration.get().preferences.javaScriptCanOpenWindowsAutomatically = YES;
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
     __block RetainPtr<WKWebView> openedWebView;
     __block RetainPtr<TestNavigationDelegate> openedNavigationDelegate;
     __block bool openedPageLoaded = false;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/RemoteObjectRegistry.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/RemoteObjectRegistry.mm
@@ -57,8 +57,8 @@ TEST(RemoteObjectRegistry, Basic)
 
         isDone = false;
 
-        _WKRemoteObjectInterface *interface = remoteObjectInterface();
-        id <RemoteObjectProtocol> object = [[webView _remoteObjectRegistry] remoteObjectProxyWithInterface:interface];
+        RetainPtr interface = remoteObjectInterface();
+        id <RemoteObjectProtocol> object = [[webView _remoteObjectRegistry] remoteObjectProxyWithInterface:interface.get()];
 
         [object sayHello:@"Hello, World!"];
 
@@ -234,8 +234,8 @@ TEST(RemoteObjectRegistry, CallReplyBlockAfterOriginatingWebViewDeallocates)
         auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
         weakWebViewPtr = webView.get();
 
-        _WKRemoteObjectInterface *interface = remoteObjectInterface();
-        id <RemoteObjectProtocol> object = [[webView _remoteObjectRegistry] remoteObjectProxyWithInterface:interface];
+        RetainPtr interface = remoteObjectInterface();
+        id <RemoteObjectProtocol> object = [[webView _remoteObjectRegistry] remoteObjectProxyWithInterface:interface.get()];
 
         [[webView _remoteObjectRegistry] registerExportedObject:localObject.get() interface:localObjectInterface()];
 
@@ -286,8 +286,8 @@ TEST(RemoteObjectRegistry, CallReplyBlockWithInvalidTypeSignature)
     [[webView _remoteObjectRegistry] registerExportedObject:completedReplyObject.get() interface:localObjectInterface()];
     [[webView _remoteObjectRegistry] registerExportedObject:stringReplyObject.get() interface:stringReplyObjectInterface()];
 
-    _WKRemoteObjectInterface *interface = remoteObjectInterface();
-    id<RemoteObjectProtocol> object = [[webView _remoteObjectRegistry] remoteObjectProxyWithInterface:interface];
+    RetainPtr interface = remoteObjectInterface();
+    id<RemoteObjectProtocol> object = [[webView _remoteObjectRegistry] remoteObjectProxyWithInterface:interface.get()];
 
     [object callUIProcessMethodWithInvalidTypeSignature];
     [object callUIProcessMethodWithReplyBlock];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm
@@ -831,12 +831,12 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRule)
         }
     };
 
-    auto *backgroundScript = Util::constructScript(@[
+    RetainPtr backgroundScript = Util::constructScript(@[
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
     auto *resources = @{
-        @"background.js": backgroundScript,
+        @"background.js": backgroundScript.get(),
         @"rules.json": rules
     };
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm
@@ -714,8 +714,8 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromSubframe)
         { "/subframe"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *urlRequestMain = server.requestWithLocalhost("/main"_s);
-    auto *urlRequestSubframe = server.request("/subframe"_s);
+    RetainPtr urlRequestMain = server.requestWithLocalhost("/main"_s);
+    RetainPtr urlRequestSubframe = server.request("/subframe"_s);
 
     auto *backgroundScript = Util::constructScript(@[
         @"browser.runtime.onMessage.addListener((message, sender) => {",
@@ -762,11 +762,11 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromSubframe)
 
     auto manager = Util::loadExtension(manifest, resources);
 
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequestSubframe.URL];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequestSubframe.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequestMain];
+    [manager.get().defaultTab.webView loadRequest:urlRequestMain.get()];
 
     [manager run];
 }
@@ -1101,8 +1101,8 @@ TEST(WKWebExtensionAPIRuntime, ConnectFromSubframe)
         { "/subframe"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *urlRequestMain = server.requestWithLocalhost("/main"_s);
-    auto *urlRequestSubframe = server.request("/subframe"_s);
+    RetainPtr urlRequestMain = server.requestWithLocalhost("/main"_s);
+    RetainPtr urlRequestSubframe = server.request("/subframe"_s);
 
     auto *backgroundScript = Util::constructScript(@[
         @"browser.runtime.onConnect.addListener((port) => {",
@@ -1157,11 +1157,11 @@ TEST(WKWebExtensionAPIRuntime, ConnectFromSubframe)
 
     auto manager = Util::loadExtension(manifest, resources);
 
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequestSubframe.URL];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequestSubframe.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequestMain];
+    [manager.get().defaultTab.webView loadRequest:urlRequestMain.get()];
 
     [manager run];
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm
@@ -296,7 +296,7 @@ TEST(WKWebExtensionAPIScripting, ExecuteScriptWithFrameIds)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"browser.runtime.sendMessage('Hello from frame')",
     ]);
 
@@ -323,7 +323,7 @@ TEST(WKWebExtensionAPIScripting, ExecuteScriptWithFrameIds)
 
     auto *resources = @{
         @"background.js": backgroundScript,
-        @"content.js": contentScript,
+        @"content.js": contentScript.get(),
     };
 
     auto manager = Util::loadExtension(manifest, resources);
@@ -368,7 +368,7 @@ TEST(WKWebExtensionAPIScripting, ExecuteScriptWithDocumentIds)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto *contentScript = Util::constructScript(@[
+    RetainPtr contentScript = Util::constructScript(@[
         @"browser.runtime.sendMessage('Hello from frame')",
     ]);
 
@@ -395,7 +395,7 @@ TEST(WKWebExtensionAPIScripting, ExecuteScriptWithDocumentIds)
 
     auto *resources = @{
         @"background.js": backgroundScript,
-        @"content.js": contentScript,
+        @"content.js": contentScript.get(),
     };
 
     auto manager = Util::loadExtension(manifest, resources);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm
@@ -1003,9 +1003,9 @@ TEST(WKWebExtensionAPITabs, DetectLanguage)
 
     auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript });
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     __block bool detectWebpageLocaleCalled = false;
 
@@ -1625,9 +1625,9 @@ TEST(WKWebExtensionAPITabs, SendMessage)
 
     auto manager = Util::loadExtension(tabsContentScriptManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -1682,9 +1682,9 @@ TEST(WKWebExtensionAPITabs, SendMessageWithAsyncReply)
 
     auto manager = Util::loadExtension(tabsContentScriptManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -1737,9 +1737,9 @@ TEST(WKWebExtensionAPITabs, SendMessageWithPromiseReply)
 
     auto manager = Util::loadExtension(tabsContentScriptManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -1794,9 +1794,9 @@ TEST(WKWebExtensionAPITabs, SendMessageWithAsyncPromiseReply)
 
     auto manager = Util::loadExtension(tabsContentScriptManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -1847,16 +1847,16 @@ TEST(WKWebExtensionAPITabs, SendMessageWithoutReply)
 
     auto manager = Util::loadExtension(tabsContentScriptManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
 
 TEST(WKWebExtensionAPITabs, SendMessageFromBackgroundPageToFullPageExtensionContent)
 {
-    auto *optionsScript = Util::constructScript(@[
+    RetainPtr optionsScript = Util::constructScript(@[
         @"browser.runtime.onMessage.addListener((message, sender, sendResponse) => {",
         @"  browser.test.assertEq(message?.content, 'Hello', 'Should receive the correct message from the background page')",
 
@@ -1886,7 +1886,7 @@ TEST(WKWebExtensionAPITabs, SendMessageFromBackgroundPageToFullPageExtensionCont
     auto *resources = @{
         @"background.js": backgroundScript,
         @"options.html": @"<script type='module' src='options.js'></script>",
-        @"options.js": optionsScript
+        @"options.js": optionsScript.get()
     };
 
     auto manager = Util::loadExtension(tabsManifest, resources);
@@ -1920,8 +1920,8 @@ TEST(WKWebExtensionAPITabs, SendMessageFromBackgroundToSubframe)
         { "/subframe"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *urlRequestMain = server.requestWithLocalhost("/main"_s);
-    auto *urlRequestSubframe = server.request("/subframe"_s);
+    RetainPtr urlRequestMain = server.requestWithLocalhost("/main"_s);
+    RetainPtr urlRequestSubframe = server.request("/subframe"_s);
 
     auto *backgroundScript = Util::constructScript(@[
         @"browser.test.sendMessage('Load Tab')",
@@ -1971,11 +1971,11 @@ TEST(WKWebExtensionAPITabs, SendMessageFromBackgroundToSubframe)
 
     auto manager = Util::loadExtension(manifest, resources);
 
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequestSubframe.URL];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequestSubframe.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequestMain];
+    [manager.get().defaultTab.webView loadRequest:urlRequestMain.get()];
 
     [manager run];
 }
@@ -2164,24 +2164,24 @@ TEST(WKWebExtensionAPITabs, SendMessageBackAndForwardNavigation)
 
     auto manager = Util::loadExtension(manifest, resources);
 
-    auto *localhostRequest = server.requestWithLocalhost();
-    auto *altHostRequest = server.request();
+    RetainPtr localhostRequest = server.requestWithLocalhost();
+    RetainPtr altHostRequest = server.request();
 
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:localhostRequest.URL];
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:altHostRequest.URL];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:localhostRequest.get().URL];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:altHostRequest.get().URL];
 
     [manager runUntilTestMessage:@"Ready"];
 
     auto *webView = manager.get().defaultTab.webView;
 
     // Load localhost page.
-    [webView synchronouslyLoadRequest:localhostRequest];
+    [webView synchronouslyLoadRequest:localhostRequest.get()];
 
     [manager sendTestMessage:@"Go"];
     [manager runUntilTestMessage:@"Messages Sent"];
 
     // Load 127.0.0.1 page.
-    [webView synchronouslyLoadRequest:altHostRequest];
+    [webView synchronouslyLoadRequest:altHostRequest.get()];
 
     [manager sendTestMessage:@"Go"];
     [manager runUntilTestMessage:@"Messages Sent"];
@@ -2258,9 +2258,9 @@ TEST(WKWebExtensionAPITabs, Connect)
 
     auto manager = Util::loadExtension(tabsContentScriptManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -2401,8 +2401,8 @@ TEST(WKWebExtensionAPITabs, ConnectToSubframe)
         { "/subframe"_s, { { { "Content-Type"_s, "text/html"_s } }, "<p>Subframe content</p>"_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
-    auto *urlRequestMain = server.requestWithLocalhost("/main"_s);
-    auto *urlRequestSubframe = server.request("/subframe"_s);
+    RetainPtr urlRequestMain = server.requestWithLocalhost("/main"_s);
+    RetainPtr urlRequestSubframe = server.request("/subframe"_s);
 
     auto *backgroundScript = Util::constructScript(@[
         @"browser.test.sendMessage('Load Tab')",
@@ -2462,11 +2462,11 @@ TEST(WKWebExtensionAPITabs, ConnectToSubframe)
 
     auto manager = Util::loadExtension(manifest, resources);
 
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequestSubframe.URL];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequestSubframe.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequestMain];
+    [manager.get().defaultTab.webView loadRequest:urlRequestMain.get()];
 
     [manager run];
 }
@@ -2523,9 +2523,9 @@ TEST(WKWebExtensionAPITabs, PortDisconnect)
 
     auto manager = Util::loadExtension(tabsContentScriptManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -2596,9 +2596,9 @@ TEST(WKWebExtensionAPITabs, ConnectWithMultipleListeners)
 
     auto manager = Util::loadExtension(tabsContentScriptManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -2661,9 +2661,9 @@ TEST(WKWebExtensionAPITabs, PortDisconnectWithMultipleListeners)
 
     auto manager = Util::loadExtension(tabsContentScriptManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -2707,14 +2707,14 @@ TEST(WKWebExtensionAPITabs, ExecuteScript)
 
     auto manager = Util::loadExtension(tabsManifestV2, @{ @"background.js": backgroundScript, @"executeScript.js": javaScript });
 
-    auto *urlRequest = server.requestWithLocalhost();
-    auto *url = urlRequest.URL;
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    auto *url = urlRequest.get().URL;
     auto *matchPattern = [WKWebExtensionMatchPattern matchPatternWithScheme:url.scheme host:url.host path:@"/*"];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:matchPattern];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -2871,12 +2871,12 @@ TEST(WKWebExtensionAPITabs, ExecuteScriptJSONTypes)
 
     auto manager = Util::loadExtension(tabsManifestV2, @{ @"background.js": backgroundScript });
 
-    auto *urlRequest = server.requestWithLocalhost();
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -2936,14 +2936,14 @@ TEST(WKWebExtensionAPITabs, InsertAndRemoveCSSInMainFrame)
 
     auto manager = Util::loadExtension(tabsManifestV2, @{ @"background.js": backgroundScript, @"styles.css": css });
 
-    auto *urlRequest = server.requestWithLocalhost();
-    auto *url = urlRequest.URL;
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    auto *url = urlRequest.get().URL;
     auto *matchPattern = [WKWebExtensionMatchPattern matchPatternWithScheme:url.scheme host:url.host path:@"/*"];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:matchPattern];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -2987,14 +2987,14 @@ TEST(WKWebExtensionAPITabs, InsertAndRemoveCSSInAllFrames)
 
     auto manager = Util::loadExtension(tabsManifestV2, @{ @"background.js": backgroundScript, @"styles.css": css });
 
-    auto *urlRequest = server.requestWithLocalhost();
-    auto *url = urlRequest.URL;
+    RetainPtr urlRequest = server.requestWithLocalhost();
+    auto *url = urlRequest.get().URL;
     auto *matchPattern = [WKWebExtensionMatchPattern matchPatternWithScheme:url.scheme host:url.host path:@"/*"];
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:matchPattern];
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -3020,13 +3020,13 @@ TEST(WKWebExtensionAPITabs, CSSUserOrigin)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto *urlRequest = server.requestWithLocalhost();
+    RetainPtr urlRequest = server.requestWithLocalhost();
 
     auto manager = Util::loadExtension(tabsManifestV2, @{ @"background.js": backgroundScript });
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -3052,13 +3052,13 @@ TEST(WKWebExtensionAPITabs, CSSAuthorOrigin)
         @"browser.test.sendMessage('Load Tab')"
     ]);
 
-    auto *urlRequest = server.requestWithLocalhost();
+    RetainPtr urlRequest = server.requestWithLocalhost();
 
     auto manager = Util::loadExtension(tabsManifestV2, @{ @"background.js": backgroundScript });
 
     [manager runUntilTestMessage:@"Load Tab"];
 
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
+    [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
@@ -3127,50 +3127,50 @@ TEST(WKWebExtensionAPITabs, ActiveTab)
 
     auto manager = Util::loadExtension(activeTabManifest, @{ @"background.js": backgroundScript });
 
-    auto *localhostRequest = server.requestWithLocalhost();
-    auto *addressRequest = server.request();
+    RetainPtr localhostRequest = server.requestWithLocalhost();
+    RetainPtr addressRequest = server.request();
 
     [manager runUntilTestMessage:@"Load Localhost"];
 
-    [manager.get().defaultTab.webView loadRequest:localhostRequest];
+    [manager.get().defaultTab.webView loadRequest:localhostRequest.get()];
 
     [manager runUntilTestMessage:@"Perform User Gesture"];
 
     EXPECT_FALSE([manager.get().context hasPermission:WKWebExtensionPermissionTabs inTab:manager.get().defaultTab]);
-    EXPECT_FALSE([manager.get().context hasAccessToURL:localhostRequest.URL inTab:manager.get().defaultTab]);
-    EXPECT_FALSE([manager.get().context hasAccessToURL:addressRequest.URL inTab:manager.get().defaultTab]);
-    EXPECT_FALSE([manager.get().context hasAccessToURL:localhostRequest.URL]);
-    EXPECT_FALSE([manager.get().context hasAccessToURL:addressRequest.URL]);
+    EXPECT_FALSE([manager.get().context hasAccessToURL:localhostRequest.get().URL inTab:manager.get().defaultTab]);
+    EXPECT_FALSE([manager.get().context hasAccessToURL:addressRequest.get().URL inTab:manager.get().defaultTab]);
+    EXPECT_FALSE([manager.get().context hasAccessToURL:localhostRequest.get().URL]);
+    EXPECT_FALSE([manager.get().context hasAccessToURL:addressRequest.get().URL]);
 
     [manager.get().context userGesturePerformedInTab:manager.get().defaultTab];
 
     EXPECT_TRUE([manager.get().context hasPermission:WKWebExtensionPermissionTabs inTab:manager.get().defaultTab]);
-    EXPECT_TRUE([manager.get().context hasAccessToURL:localhostRequest.URL inTab:manager.get().defaultTab]);
-    EXPECT_FALSE([manager.get().context hasAccessToURL:addressRequest.URL inTab:manager.get().defaultTab]);
-    EXPECT_FALSE([manager.get().context hasAccessToURL:localhostRequest.URL]);
-    EXPECT_FALSE([manager.get().context hasAccessToURL:addressRequest.URL]);
+    EXPECT_TRUE([manager.get().context hasAccessToURL:localhostRequest.get().URL inTab:manager.get().defaultTab]);
+    EXPECT_FALSE([manager.get().context hasAccessToURL:addressRequest.get().URL inTab:manager.get().defaultTab]);
+    EXPECT_FALSE([manager.get().context hasAccessToURL:localhostRequest.get().URL]);
+    EXPECT_FALSE([manager.get().context hasAccessToURL:addressRequest.get().URL]);
 
     [manager runUntilTestMessage:@"Load Next Page"];
 
     EXPECT_TRUE([manager.get().context hasPermission:WKWebExtensionPermissionTabs inTab:manager.get().defaultTab]);
-    EXPECT_TRUE([manager.get().context hasAccessToURL:localhostRequest.URL inTab:manager.get().defaultTab]);
-    EXPECT_FALSE([manager.get().context hasAccessToURL:addressRequest.URL inTab:manager.get().defaultTab]);
-    EXPECT_FALSE([manager.get().context hasAccessToURL:localhostRequest.URL]);
-    EXPECT_FALSE([manager.get().context hasAccessToURL:addressRequest.URL]);
+    EXPECT_TRUE([manager.get().context hasAccessToURL:localhostRequest.get().URL inTab:manager.get().defaultTab]);
+    EXPECT_FALSE([manager.get().context hasAccessToURL:addressRequest.get().URL inTab:manager.get().defaultTab]);
+    EXPECT_FALSE([manager.get().context hasAccessToURL:localhostRequest.get().URL]);
+    EXPECT_FALSE([manager.get().context hasAccessToURL:addressRequest.get().URL]);
 
     [manager.get().defaultTab.webView loadRequest:server.requestWithLocalhost("/next.html"_s)];
 
     [manager runUntilTestMessage:@"Load IP Address"];
 
-    [manager.get().defaultTab.webView loadRequest:addressRequest];
+    [manager.get().defaultTab.webView loadRequest:addressRequest.get()];
 
     [manager run];
 
     EXPECT_FALSE([manager.get().context hasPermission:WKWebExtensionPermissionTabs inTab:manager.get().defaultTab]);
-    EXPECT_FALSE([manager.get().context hasAccessToURL:localhostRequest.URL]);
-    EXPECT_FALSE([manager.get().context hasAccessToURL:addressRequest.URL]);
-    EXPECT_FALSE([manager.get().context hasAccessToURL:localhostRequest.URL inTab:manager.get().defaultTab]);
-    EXPECT_FALSE([manager.get().context hasAccessToURL:addressRequest.URL inTab:manager.get().defaultTab]);
+    EXPECT_FALSE([manager.get().context hasAccessToURL:localhostRequest.get().URL]);
+    EXPECT_FALSE([manager.get().context hasAccessToURL:addressRequest.get().URL]);
+    EXPECT_FALSE([manager.get().context hasAccessToURL:localhostRequest.get().URL inTab:manager.get().defaultTab]);
+    EXPECT_FALSE([manager.get().context hasAccessToURL:addressRequest.get().URL inTab:manager.get().defaultTab]);
 }
 
 TEST(WKWebExtensionAPITabs, UserGestureWithoutActiveTab)
@@ -3203,12 +3203,12 @@ TEST(WKWebExtensionAPITabs, UserGestureWithoutActiveTab)
     EXPECT_FALSE([manager.get().context hasPermission:WKWebExtensionPermissionActiveTab]);
     EXPECT_FALSE([manager.get().context hasPermission:WKWebExtensionPermissionTabs]);
 
-    auto *localhostRequest = server.requestWithLocalhost();
-    auto *addressRequest = server.request();
+    RetainPtr localhostRequest = server.requestWithLocalhost();
+    RetainPtr addressRequest = server.request();
 
     [manager runUntilTestMessage:@"Load Localhost"];
 
-    [manager.get().defaultTab.webView loadRequest:localhostRequest];
+    [manager.get().defaultTab.webView loadRequest:localhostRequest.get()];
 
     [manager runUntilTestMessage:@"Perform User Gesture"];
 
@@ -3217,10 +3217,10 @@ TEST(WKWebExtensionAPITabs, UserGestureWithoutActiveTab)
     EXPECT_FALSE([manager.get().context hasPermission:WKWebExtensionPermissionActiveTab]);
     EXPECT_FALSE([manager.get().context hasPermission:WKWebExtensionPermissionTabs]);
     EXPECT_FALSE([manager.get().context hasPermission:WKWebExtensionPermissionTabs inTab:manager.get().defaultTab]);
-    EXPECT_FALSE([manager.get().context hasAccessToURL:localhostRequest.URL]);
-    EXPECT_FALSE([manager.get().context hasAccessToURL:addressRequest.URL]);
-    EXPECT_FALSE([manager.get().context hasAccessToURL:localhostRequest.URL inTab:manager.get().defaultTab]);
-    EXPECT_FALSE([manager.get().context hasAccessToURL:addressRequest.URL inTab:manager.get().defaultTab]);
+    EXPECT_FALSE([manager.get().context hasAccessToURL:localhostRequest.get().URL]);
+    EXPECT_FALSE([manager.get().context hasAccessToURL:addressRequest.get().URL]);
+    EXPECT_FALSE([manager.get().context hasAccessToURL:localhostRequest.get().URL inTab:manager.get().defaultTab]);
+    EXPECT_FALSE([manager.get().context hasAccessToURL:addressRequest.get().URL inTab:manager.get().defaultTab]);
 }
 
 TEST(WKWebExtensionAPITabs, ActiveTabWithDeniedPermissions)
@@ -3247,18 +3247,18 @@ TEST(WKWebExtensionAPITabs, ActiveTabWithDeniedPermissions)
 
     auto manager = Util::loadExtension(activeTabManifest, @{ @"background.js": backgroundScript });
 
-    auto *localhostRequest = server.requestWithLocalhost();
+    RetainPtr localhostRequest = server.requestWithLocalhost();
 
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusDeniedExplicitly forURL:localhostRequest.URL];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusDeniedExplicitly forURL:localhostRequest.get().URL];
 
     EXPECT_TRUE([manager.get().context hasPermission:WKWebExtensionPermissionActiveTab]);
     EXPECT_FALSE([manager.get().context hasPermission:WKWebExtensionPermissionTabs]);
-    EXPECT_FALSE([manager.get().context hasAccessToURL:localhostRequest.URL]);
-    EXPECT_FALSE([manager.get().context hasAccessToURL:localhostRequest.URL inTab:manager.get().defaultTab]);
+    EXPECT_FALSE([manager.get().context hasAccessToURL:localhostRequest.get().URL]);
+    EXPECT_FALSE([manager.get().context hasAccessToURL:localhostRequest.get().URL inTab:manager.get().defaultTab]);
 
     [manager runUntilTestMessage:@"Load Localhost"];
 
-    [manager.get().defaultTab.webView loadRequest:localhostRequest];
+    [manager.get().defaultTab.webView loadRequest:localhostRequest.get()];
 
     [manager runUntilTestMessage:@"Perform User Gesture"];
 
@@ -3267,8 +3267,8 @@ TEST(WKWebExtensionAPITabs, ActiveTabWithDeniedPermissions)
     EXPECT_TRUE([manager.get().context hasPermission:WKWebExtensionPermissionActiveTab]);
     EXPECT_FALSE([manager.get().context hasPermission:WKWebExtensionPermissionTabs]);
     EXPECT_FALSE([manager.get().context hasPermission:WKWebExtensionPermissionTabs inTab:manager.get().defaultTab]);
-    EXPECT_FALSE([manager.get().context hasAccessToURL:localhostRequest.URL]);
-    EXPECT_FALSE([manager.get().context hasAccessToURL:localhostRequest.URL inTab:manager.get().defaultTab]);
+    EXPECT_FALSE([manager.get().context hasAccessToURL:localhostRequest.get().URL]);
+    EXPECT_FALSE([manager.get().context hasAccessToURL:localhostRequest.get().URL inTab:manager.get().defaultTab]);
 }
 
 TEST(WKWebExtensionAPITabs, ActiveTabRemovedWithDeniedPermissions)
@@ -3295,38 +3295,38 @@ TEST(WKWebExtensionAPITabs, ActiveTabRemovedWithDeniedPermissions)
 
     auto manager = Util::loadExtension(activeTabManifest, @{ @"background.js": backgroundScript });
 
-    auto *localhostRequest = server.requestWithLocalhost();
+    RetainPtr localhostRequest = server.requestWithLocalhost();
 
     EXPECT_TRUE([manager.get().context hasPermission:WKWebExtensionPermissionActiveTab]);
     EXPECT_FALSE([manager.get().context hasPermission:WKWebExtensionPermissionTabs]);
-    EXPECT_FALSE([manager.get().context hasAccessToURL:localhostRequest.URL]);
-    EXPECT_FALSE([manager.get().context hasAccessToURL:localhostRequest.URL inTab:manager.get().defaultTab]);
+    EXPECT_FALSE([manager.get().context hasAccessToURL:localhostRequest.get().URL]);
+    EXPECT_FALSE([manager.get().context hasAccessToURL:localhostRequest.get().URL inTab:manager.get().defaultTab]);
 
     [manager runUntilTestMessage:@"Load Localhost"];
 
-    [manager.get().defaultTab.webView loadRequest:localhostRequest];
+    [manager.get().defaultTab.webView loadRequest:localhostRequest.get()];
 
     [manager runUntilTestMessage:@"Perform User Gesture"];
 
     EXPECT_TRUE([manager.get().context hasPermission:WKWebExtensionPermissionActiveTab]);
     EXPECT_FALSE([manager.get().context hasPermission:WKWebExtensionPermissionTabs inTab:manager.get().defaultTab]);
-    EXPECT_FALSE([manager.get().context hasAccessToURL:localhostRequest.URL inTab:manager.get().defaultTab]);
-    EXPECT_FALSE([manager.get().context hasAccessToURL:localhostRequest.URL]);
+    EXPECT_FALSE([manager.get().context hasAccessToURL:localhostRequest.get().URL inTab:manager.get().defaultTab]);
+    EXPECT_FALSE([manager.get().context hasAccessToURL:localhostRequest.get().URL]);
 
     [manager.get().context userGesturePerformedInTab:manager.get().defaultTab];
 
     EXPECT_TRUE([manager.get().context hasPermission:WKWebExtensionPermissionActiveTab]);
     EXPECT_TRUE([manager.get().context hasPermission:WKWebExtensionPermissionTabs inTab:manager.get().defaultTab]);
-    EXPECT_TRUE([manager.get().context hasAccessToURL:localhostRequest.URL inTab:manager.get().defaultTab]);
-    EXPECT_FALSE([manager.get().context hasAccessToURL:localhostRequest.URL]);
+    EXPECT_TRUE([manager.get().context hasAccessToURL:localhostRequest.get().URL inTab:manager.get().defaultTab]);
+    EXPECT_FALSE([manager.get().context hasAccessToURL:localhostRequest.get().URL]);
 
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusDeniedExplicitly forURL:localhostRequest.URL];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusDeniedExplicitly forURL:localhostRequest.get().URL];
 
     EXPECT_TRUE([manager.get().context hasPermission:WKWebExtensionPermissionActiveTab]);
     EXPECT_FALSE([manager.get().context hasPermission:WKWebExtensionPermissionTabs]);
     EXPECT_FALSE([manager.get().context hasPermission:WKWebExtensionPermissionTabs inTab:manager.get().defaultTab]);
-    EXPECT_FALSE([manager.get().context hasAccessToURL:localhostRequest.URL]);
-    EXPECT_FALSE([manager.get().context hasAccessToURL:localhostRequest.URL inTab:manager.get().defaultTab]);
+    EXPECT_FALSE([manager.get().context hasAccessToURL:localhostRequest.get().URL]);
+    EXPECT_FALSE([manager.get().context hasAccessToURL:localhostRequest.get().URL inTab:manager.get().defaultTab]);
 }
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/mac/AttributedString.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/AttributedString.mm
@@ -81,10 +81,10 @@ void AttributedStringTest_Strikethrough::runSyncTest(View view)
 
     EXPECT_WK_STREQ("Lorem", [attrString string]);
     
-    NSDictionary *attributes = [attrString attributesAtIndex:0 effectiveRange:0];
-    ASSERT_NOT_NULL([attributes objectForKey:NSStrikethroughStyleAttributeName]);
-    ASSERT_TRUE([[attributes objectForKey:NSStrikethroughStyleAttributeName] isKindOfClass:[NSNumber class]]);
-    ASSERT_EQ(NSUnderlineStyleSingle, [(NSNumber *)[attributes objectForKey:NSStrikethroughStyleAttributeName] intValue]);
+    RetainPtr attributes = [attrString attributesAtIndex:0 effectiveRange:0];
+    ASSERT_NOT_NULL([attributes.get() objectForKey:NSStrikethroughStyleAttributeName]);
+    ASSERT_TRUE([[attributes.get() objectForKey:NSStrikethroughStyleAttributeName] isKindOfClass:[NSNumber class]]);
+    ASSERT_EQ(NSUnderlineStyleSingle, [(NSNumber *)[attributes.get() objectForKey:NSStrikethroughStyleAttributeName] intValue]);
 }
 
 TEST_F(AttributedStringTest_Strikethrough, WebKit)


### PR DESCRIPTION
#### 41d41676ec211bc01c0d565c31af0c9ce4e9fe0b
<pre>
Fixed unretained local variable warnings in Tools/TestWebKitAPI
<a href="https://bugs.webkit.org/show_bug.cgi?id=305408">https://bugs.webkit.org/show_bug.cgi?id=305408</a>
<a href="https://rdar.apple.com/168081614">rdar://168081614</a>

Reviewed by Ryosuke Niwa.

Mechanical application of SaferCPP bot output.

Canonical link: <a href="https://commits.webkit.org/305545@main">https://commits.webkit.org/305545@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/319f904e5f51f5bfa9a24553fd6a055cc98dca4f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138684 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11050 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/166 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146798 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91659 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/79791275-2498-4a45-a5a9-efee0650c7a1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140557 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11754 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11204 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106121 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77436 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141631 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8860 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124298 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86992 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2904d853-3108-41ac-a487-efb3ad9687dc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8448 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6204 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7096 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117869 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/138 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149554 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10732 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/139 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114507 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10749 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9081 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114844 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8692 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120595 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65627 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21377 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10780 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/139 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10515 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10718 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10569 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->