### PR TITLE
REGRESSION (305166@main): [ macOS ] http/tests/lists/list-new-parent-no-sibling-append.html is a flaky crash

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2419,8 +2419,6 @@ webkit.org/b/304851 imported/w3c/web-platform-tests/workers/worker-performance.w
 
 webkit.org/b/304995 [ Release ] imported/w3c/web-platform-tests/largest-contentful-paint/video-poster.html [ Pass Failure ]
 
-webkit.org/b/305069 http/tests/lists/list-new-parent-no-sibling-append.html [ Pass Crash ]
-
 webkit.org/b/305086 [ arm64 ] imported/w3c/web-platform-tests/media-source/mediasource-changetype-play-without-codecs-parameter.html [ Pass Failure ]
 
 webkit.org/b/305403 [ Sequoia ] http/tests/performance/performance-resource-timing-redirection-cross-origin-media.html [ Failure ]

--- a/Source/WebCore/inspector/WebInjectedScriptManager.cpp
+++ b/Source/WebCore/inspector/WebInjectedScriptManager.cpp
@@ -68,8 +68,10 @@ void WebInjectedScriptManager::removeClient()
 {
     ASSERT(m_clientCount > 0);
     --m_clientCount;
-    if (!m_clientCount)
-        disconnect();
+    if (!m_clientCount) {
+        // FIXME <https://webkit.org/b/305415>: Figure out why the commandLineAPIHost may still be used after the last client disconnects, and call disconnect here instead.
+        discardInjectedScripts();
+    }
 }
 
 void WebInjectedScriptManager::connect()


### PR DESCRIPTION
#### 9ad018d8745abfa94d8def9d4bded127e9d6e690
<pre>
REGRESSION (305166@main): [ macOS ] http/tests/lists/list-new-parent-no-sibling-append.html is a flaky crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=305069">https://bugs.webkit.org/show_bug.cgi?id=305069</a>
<a href="https://rdar.apple.com/problem/167718210">rdar://problem/167718210</a>

Reviewed by BJ Burg.

Summary: Restore to the original behavior of discarding injected scripts
instead of deallocating the commandLineAPIHost when the last client
disconnects. Fix the timing bug that prevents deallocation from working
in a follow-up.

Originally, this is how the PageInspectorController handled its
InjectedScriptManager (ISM) while being the sole owner:
1. When the first frontend connects, call ISM-&gt;connect to create the
   commandLineAPIHost.
2. When the last frontend disconnects, call ISM-&gt;discardInjectedScripts
   as a clean up but keeping the API host alive.
3. When the page is destroyed while there&apos;s connected frontend, call
   ISM-&gt;disconnect to clean up and also destroy the API host.

Given the presence of frame targets, which in the case of remote frames
may exist without a page target to manage the ISM, in 305166@main we
introduce a client-counting strategy for ISM. That patch mostly retained
the above original behavior, except in case 2 we called ISM-&gt;disconnect
instead. The expectation was that all inspector agents should be
notified about the connection closing and will cease using the ISM
again.

However that wasn&apos;t the case: in the event of a cross-origin navigation
and PSON triggered, local debugging shows the console agent from a frame
target may still use the ISM unexpectedly after being reported the
frontend disconnection.

To prioritize addressing an observable regression in the build, restore
case 2 to the original behavior. Filed <a href="https://webkit.org/b/305415">https://webkit.org/b/305415</a> as
the follow-up to fix this remaining timing issue and make calling
ISM-&gt;disconnect work as intended.

The test list-new-parent-no-sibling-append.html should now progress.

* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/inspector/WebInjectedScriptManager.cpp:
(WebCore::WebInjectedScriptManager::removeClient):

Canonical link: <a href="https://commits.webkit.org/305619@main">https://commits.webkit.org/305619@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1714409755e72597a2a3a897c659de733fd9bd9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138851 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11218 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/338 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146970 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/91835 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7573fa15-fb28-4bd2-9865-236bc20f7322) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140724 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11922 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11374 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106278 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/91835 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4c632cf2-d081-4082-828c-4070506a5ec3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141798 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9006 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/124413 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87155 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/81e91f61-9c21-413b-8115-4a43fc41d182) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8585 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6329 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7268 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118014 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/284 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149756 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10899 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/292 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114665 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10921 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9224 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114981 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8872 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120738 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65805 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21409 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10948 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/281 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10685 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74599 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10888 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10736 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->