### PR TITLE
Make toJS() interface conversions require correct nullness and subtyping

### DIFF
--- a/Source/WebCore/Modules/WebGPU/NavigatorGPU.idl
+++ b/Source/WebCore/Modules/WebGPU/NavigatorGPU.idl
@@ -29,5 +29,6 @@
     EnabledBySetting=WebGPUEnabled,
 ]
 interface mixin NavigatorGPU {
-    [SameObject, SecureContext] readonly attribute GPU gpu;
+    // FIXME: `gpu` should not be nullable.
+    [SameObject, SecureContext] readonly attribute GPU? gpu;
 };

--- a/Source/WebCore/Modules/async-clipboard/NavigatorClipboard.cpp
+++ b/Source/WebCore/Modules/async-clipboard/NavigatorClipboard.cpp
@@ -42,16 +42,16 @@ NavigatorClipboard::NavigatorClipboard(Navigator& navigator)
 
 NavigatorClipboard::~NavigatorClipboard() = default;
 
-RefPtr<Clipboard> NavigatorClipboard::clipboard(Navigator& navigator)
+Ref<Clipboard> NavigatorClipboard::clipboard(Navigator& navigator)
 {
     return NavigatorClipboard::from(navigator)->clipboard();
 }
 
-RefPtr<Clipboard> NavigatorClipboard::clipboard()
+Ref<Clipboard> NavigatorClipboard::clipboard()
 {
     if (!m_clipboard)
         lazyInitialize(m_clipboard, Clipboard::create(m_navigator.get()));
-    return m_clipboard;
+    return *m_clipboard;
 }
 
 NavigatorClipboard* NavigatorClipboard::from(Navigator& navigator)

--- a/Source/WebCore/Modules/async-clipboard/NavigatorClipboard.h
+++ b/Source/WebCore/Modules/async-clipboard/NavigatorClipboard.h
@@ -41,8 +41,8 @@ public:
     explicit NavigatorClipboard(Navigator&);
     ~NavigatorClipboard();
 
-    static RefPtr<Clipboard> clipboard(Navigator&);
-    RefPtr<Clipboard> clipboard();
+    static Ref<Clipboard> clipboard(Navigator&);
+    Ref<Clipboard> clipboard();
 
 private:
     static NavigatorClipboard* from(Navigator&);

--- a/Source/WebCore/Modules/audiosession/NavigatorAudioSession.cpp
+++ b/Source/WebCore/Modules/audiosession/NavigatorAudioSession.cpp
@@ -41,12 +41,12 @@ NavigatorAudioSession::NavigatorAudioSession() = default;
 
 NavigatorAudioSession::~NavigatorAudioSession() = default;
 
-RefPtr<DOMAudioSession> NavigatorAudioSession::audioSession(Navigator& navigator)
+Ref<DOMAudioSession> NavigatorAudioSession::audioSession(Navigator& navigator)
 {
     auto* navigatorAudioSession = NavigatorAudioSession::from(navigator);
     if (!navigatorAudioSession->m_audioSession)
-        navigatorAudioSession->m_audioSession = DOMAudioSession::create(navigator.protectedScriptExecutionContext().get());
-    return navigatorAudioSession->m_audioSession;
+        lazyInitialize(navigatorAudioSession->m_audioSession, DOMAudioSession::create(navigator.protectedScriptExecutionContext().get()));
+    return *navigatorAudioSession->m_audioSession;
 }
 
 NavigatorAudioSession* NavigatorAudioSession::from(Navigator& navigator)

--- a/Source/WebCore/Modules/audiosession/NavigatorAudioSession.h
+++ b/Source/WebCore/Modules/audiosession/NavigatorAudioSession.h
@@ -42,14 +42,14 @@ public:
     NavigatorAudioSession();
     ~NavigatorAudioSession();
 
-    static RefPtr<DOMAudioSession> audioSession(Navigator&);
+    static Ref<DOMAudioSession> audioSession(Navigator&);
 
 private:
     static NavigatorAudioSession* from(Navigator&);
     static ASCIILiteral supplementName() { return "NavigatorAudioSession"_s; }
     bool isNavigatorAudioSession() const final { return true; }
 
-    RefPtr<DOMAudioSession> m_audioSession;
+    const RefPtr<DOMAudioSession> m_audioSession;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/cache/WindowOrWorkerGlobalScope+Caches.idl
+++ b/Source/WebCore/Modules/cache/WindowOrWorkerGlobalScope+Caches.idl
@@ -28,5 +28,6 @@
     EnabledBySetting=CacheAPIEnabled,
     ImplementedBy=WindowOrWorkerGlobalScopeCaches
 ] partial interface mixin WindowOrWorkerGlobalScope {
-    [CallWith=CurrentScriptExecutionContext, SecureContext, SameObject] readonly attribute DOMCacheStorage caches;
+    // FIXME: `caches` should not be nullable.
+    [CallWith=CurrentScriptExecutionContext, SecureContext, SameObject] readonly attribute DOMCacheStorage? caches;
 };

--- a/Source/WebCore/Modules/contact-picker/NavigatorContacts.cpp
+++ b/Source/WebCore/Modules/contact-picker/NavigatorContacts.cpp
@@ -42,16 +42,16 @@ NavigatorContacts::NavigatorContacts(Navigator& navigator)
 
 NavigatorContacts::~NavigatorContacts() = default;
 
-RefPtr<ContactsManager> NavigatorContacts::contacts(Navigator& navigator)
+Ref<ContactsManager> NavigatorContacts::contacts(Navigator& navigator)
 {
     return NavigatorContacts::from(navigator)->contacts();
 }
 
-RefPtr<ContactsManager> NavigatorContacts::contacts()
+Ref<ContactsManager> NavigatorContacts::contacts()
 {
     if (!m_contactsManager)
-        lazyInitialize(m_contactsManager, ContactsManager::create(Ref { m_navigator.get() }));
-    return m_contactsManager;
+        lazyInitialize(m_contactsManager, ContactsManager::create(m_navigator.get()));
+    return *m_contactsManager;
 }
 
 NavigatorContacts* NavigatorContacts::from(Navigator& navigator)

--- a/Source/WebCore/Modules/contact-picker/NavigatorContacts.h
+++ b/Source/WebCore/Modules/contact-picker/NavigatorContacts.h
@@ -41,15 +41,15 @@ public:
     explicit NavigatorContacts(Navigator&);
     ~NavigatorContacts();
 
-    static RefPtr<ContactsManager> contacts(Navigator&);
-    RefPtr<ContactsManager> contacts();
+    static Ref<ContactsManager> contacts(Navigator&);
+    Ref<ContactsManager> contacts();
 
 private:
     static NavigatorContacts* from(Navigator&);
     static ASCIILiteral supplementName() { return "NavigatorContacts"_s; }
     bool isNavigatorContacts() const final { return true; }
 
-    RefPtr<ContactsManager> m_contactsManager;
+    const RefPtr<ContactsManager> m_contactsManager;
     const CheckedRef<Navigator> m_navigator;
 };
 

--- a/Source/WebCore/Modules/credentialmanagement/Navigator+Credentials.idl
+++ b/Source/WebCore/Modules/credentialmanagement/Navigator+Credentials.idl
@@ -25,10 +25,10 @@
  */
 
 // https://w3c.github.io/webappsec-credential-management/#framework-credential-management
-
 [
     EnabledByQuirk=shouldExposeCredentialsContainer,
     ImplementedBy=NavigatorCredentials
 ] partial interface Navigator {
-    [SecureContext, SameObject] readonly attribute CredentialsContainer credentials;
+    // FIXME: `credentials` should not be nullable.
+    [SecureContext, SameObject] readonly attribute CredentialsContainer? credentials;
 };

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.idl
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.idl
@@ -29,7 +29,7 @@
     EnabledBySetting=LegacyEncryptedMediaAPIEnabled,
     Exposed=Window
 ] interface WebKitMediaKeySession : EventTarget {
-    readonly attribute WebKitMediaKeyError error;
+    readonly attribute WebKitMediaKeyError? error;
 
     readonly attribute DOMString keySystem;
     readonly attribute DOMString sessionId;

--- a/Source/WebCore/Modules/geolocation/Navigator+Geolocation.idl
+++ b/Source/WebCore/Modules/geolocation/Navigator+Geolocation.idl
@@ -23,6 +23,7 @@
     EnabledBySetting=GeolocationAPIEnabled,
     ImplementedBy=NavigatorGeolocation
 ] partial interface Navigator {
-    readonly attribute Geolocation geolocation;
+    // FIXME: `geolocation` should not be nullable.
+    readonly attribute Geolocation? geolocation;
 };
 

--- a/Source/WebCore/Modules/indexeddb/IDBCursor.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBCursor.idl
@@ -23,6 +23,7 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/IndexedDB/#idbcursor
 [
     EnabledBySetting=IndexedDBAPIEnabled,
     JSCustomMarkFunction,
@@ -33,7 +34,8 @@
     readonly attribute IDBCursorDirection direction;
     [CustomGetter] readonly attribute any key;
     [CustomGetter] readonly attribute any primaryKey;
-    [SameObject] readonly attribute IDBRequest request;
+    // FIXME: `request` should not be nullable.
+    [SameObject] readonly attribute IDBRequest? request;
 
     undefined advance([EnforceRange] unsigned long count);
     [CallWith=CurrentGlobalObject, ImplementedAs=continueFunction] undefined continue(optional any key);

--- a/Source/WebCore/Modules/indexeddb/IDBRequest.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBRequest.idl
@@ -38,7 +38,7 @@
     [CustomGetter] readonly attribute (IDBCursor or IDBDatabase or any) result;
     readonly attribute DOMException? error;
     readonly attribute (IDBObjectStore or IDBIndex or IDBCursor)? source;
-    readonly attribute IDBTransaction transaction;
+    readonly attribute IDBTransaction? transaction;
     readonly attribute IDBRequestReadyState readyState;
 
     // Event handlers:

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
@@ -138,10 +138,10 @@ Ref<DOMStringList> IDBTransaction::objectStoreNames() const
     return objectStoreNames;
 }
 
-IDBDatabase* IDBTransaction::db()
+IDBDatabase& IDBTransaction::db()
 {
     ASSERT(canCurrentThreadAccessThreadLocalData(m_database->originThread()));
-    return m_database.ptr();
+    return m_database;
 }
 
 DOMException* IDBTransaction::error() const

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.h
@@ -83,7 +83,7 @@ public:
     Ref<DOMStringList> objectStoreNames() const;
     IDBTransactionMode mode() const { return m_info.mode(); }
     IDBTransactionDurability durability() const { return m_info.durability(); }
-    IDBDatabase* db();
+    IDBDatabase& db();
     DOMException* error() const;
     ExceptionOr<Ref<IDBObjectStore>> objectStore(const String& name);
     ExceptionOr<void> abort();

--- a/Source/WebCore/Modules/indexeddb/WindowOrWorkerGlobalScope+IndexedDatabase.idl
+++ b/Source/WebCore/Modules/indexeddb/WindowOrWorkerGlobalScope+IndexedDatabase.idl
@@ -29,8 +29,9 @@
     EnabledBySetting=IndexedDBAPIEnabled,
     ImplementedBy=WindowOrWorkerGlobalScopeIndexedDatabase
 ] partial interface mixin WindowOrWorkerGlobalScope {
-    [SameObject] readonly attribute IDBFactory indexedDB;
-    
+    // FIXME: `indexedDB` should not be nullable.
+    [SameObject] readonly attribute IDBFactory? indexedDB;
+
     // Non-standard.
-    [Exposed=Window, ImplementedAs=indexedDB] readonly attribute IDBFactory webkitIndexedDB;
+    [Exposed=Window, ImplementedAs=indexedDB] readonly attribute IDBFactory? webkitIndexedDB;
 };

--- a/Source/WebCore/Modules/mediacontrols/DOMWindow+MediaControls.idl
+++ b/Source/WebCore/Modules/mediacontrols/DOMWindow+MediaControls.idl
@@ -28,5 +28,5 @@
     ImplementedBy=LocalDOMWindowMediaControls,
     EnabledForWorld=isMediaControls,
 ] partial interface DOMWindow {
-    [CallWith=CurrentDocument] readonly attribute MediaControlsUtils utils;
+    [CallWith=CurrentDocument] readonly attribute MediaControlsUtils? utils;
 };

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.idl
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.idl
@@ -57,7 +57,7 @@ enum DeviceType {
     readonly attribute TextTrack captionMenuOnItem;
     readonly attribute DOMString captionDisplayMode;
     undefined setSelectedTextTrack(TextTrack? track);
-    readonly attribute HTMLElement textTrackContainer;
+    readonly attribute Element? textTrackContainer;
     readonly attribute boolean allowsInlineMediaPlayback;
     readonly attribute boolean supportsFullscreen;
     readonly attribute boolean isVideoLayerInline;

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsUtils.idl
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsUtils.idl
@@ -29,5 +29,5 @@
     EnabledForWorld=isMediaControls,
 ] interface MediaControlsUtils {
     DOMString formattedStringForDuration(unrestricted double durationInSeconds);
-    HTMLImageElement createImageForIconNameAndType(DOMString iconName, DOMString iconType);
+    HTMLImageElement? createImageForIconNameAndType(DOMString iconName, DOMString iconType);
 };

--- a/Source/WebCore/Modules/mediasource/BufferedChangeEvent.idl
+++ b/Source/WebCore/Modules/mediasource/BufferedChangeEvent.idl
@@ -40,6 +40,6 @@ dictionary BufferedChangeEventInit : EventInit {
 ]
 interface BufferedChangeEvent : Event {
   constructor([AtomString] DOMString type, BufferedChangeEventInit eventInitDict);
-  [SameObject] readonly attribute TimeRanges addedRanges;
-  [SameObject] readonly attribute TimeRanges removedRanges;
+  [SameObject] readonly attribute TimeRanges? addedRanges;
+  [SameObject] readonly attribute TimeRanges? removedRanges;
 };

--- a/Source/WebCore/Modules/mediasource/SourceBufferList.idl
+++ b/Source/WebCore/Modules/mediasource/SourceBufferList.idl
@@ -36,7 +36,7 @@
     Exposed=Window
 ] interface SourceBufferList : EventTarget {
     readonly attribute unsigned long length;
-    getter SourceBuffer item(unsigned long index);
+    getter SourceBuffer? item(unsigned long index);
 
     attribute EventHandler onaddsourcebuffer;
     attribute EventHandler onremovesourcebuffer;

--- a/Source/WebCore/Modules/mediastream/MediaStream.idl
+++ b/Source/WebCore/Modules/mediastream/MediaStream.idl
@@ -22,6 +22,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/mediacapture-main/#dom-mediastream
 [
     ActiveDOMObject,
     Conditional=MEDIA_STREAM,
@@ -39,12 +40,13 @@
     sequence<MediaStreamTrack> getAudioTracks();
     sequence<MediaStreamTrack> getVideoTracks();
     [PrivateIdentifier, PublicIdentifier] sequence<MediaStreamTrack> getTracks();
-    MediaStreamTrack getTrackById(DOMString trackId);
+    MediaStreamTrack? getTrackById(DOMString trackId);
 
     undefined addTrack(MediaStreamTrack track);
     undefined removeTrack(MediaStreamTrack track);
 
-    MediaStream clone();
+    // FIXME: `clone` should not return a nullable type.
+    MediaStream? clone();
 
     readonly attribute boolean active;
 

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.idl
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.idl
@@ -25,6 +25,7 @@
 
 enum MediaStreamTrackState { "live", "ended" };
 
+// https://w3c.github.io/mediacapture-main/#dom-mediastreamtrack
 [
     ActiveDOMObject,
     Conditional=MEDIA_STREAM,
@@ -45,7 +46,8 @@ enum MediaStreamTrackState { "live", "ended" };
     readonly attribute MediaStreamTrackState readyState;
     attribute EventHandler onended;
 
-    MediaStreamTrack clone();
+    // FIXME: `clone` should not return a nullable type.
+    MediaStreamTrack? clone();
     [ImplementedAs=stopTrack] undefined stop();
 
     MediaTrackCapabilities getCapabilities();

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrackEvent.idl
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrackEvent.idl
@@ -22,13 +22,14 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/mediacapture-main/#dom-mediastreamtrackevent
 [
     Conditional=MEDIA_STREAM,
     Exposed=Window
 ] interface MediaStreamTrackEvent : Event {
     constructor([AtomString] DOMString type, MediaStreamTrackEventInit eventInitDict);
-
-    [SameObject] readonly attribute MediaStreamTrack track;
+    // FIXME: `track` should not be nullable.
+    [SameObject] readonly attribute MediaStreamTrack? track;
 };
 
 dictionary MediaStreamTrackEventInit : EventInit {

--- a/Source/WebCore/Modules/mediastream/Navigator+MediaDevices.idl
+++ b/Source/WebCore/Modules/mediastream/Navigator+MediaDevices.idl
@@ -29,12 +29,15 @@
  */
 
 // https://w3c.github.io/mediacapture-main/#navigator-interface-extensions
-// https://w3c.github.io/mediacapture-main/#legacy-interface-extensions
 [
     Conditional=MEDIA_STREAM,
     EnabledBySetting=MediaDevicesEnabled,
     ImplementedBy=NavigatorMediaDevices
 ] partial interface Navigator {
-    [SameObject, SecureContext, ContextAllowsMediaDevices] readonly attribute MediaDevices mediaDevices;
+    // FIXME: `mediaDevices` should not be nullable.
+    [SameObject, SecureContext, ContextAllowsMediaDevices] readonly attribute MediaDevices? mediaDevices;
+
+    // https://w3c.github.io/mediacapture-main/#legacy-getusermedia-interface
+    // FIXME: Move this to its own IDL file Navigator+LegacyGetUserMedia.idl.
     [Custom, SecureContext, EnabledByQuirk=shouldEnableLegacyGetUserMedia] undefined getUserMedia(object constraints, object? successCallback, object? errorCallback);
 };

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp
@@ -262,17 +262,17 @@ ExceptionOr<void> RTCRtpSFrameTransform::createStreams()
     return { };
 }
 
-ExceptionOr<RefPtr<ReadableStream>> RTCRtpSFrameTransform::readable()
+ExceptionOr<Ref<ReadableStream>> RTCRtpSFrameTransform::readable()
 {
     if (!m_readable) {
         auto result = createStreams();
         if (result.hasException())
             return result.releaseException();
     }
-    return m_readable.copyRef();
+    return m_readable.releaseNonNull();
 }
 
-ExceptionOr<RefPtr<WritableStream>> RTCRtpSFrameTransform::writable()
+ExceptionOr<Ref<WritableStream>> RTCRtpSFrameTransform::writable()
 {
     if (!m_writable) {
         auto result = createStreams();
@@ -281,7 +281,7 @@ ExceptionOr<RefPtr<WritableStream>> RTCRtpSFrameTransform::writable()
     }
 
     m_hasWritable = true;
-    return m_writable.copyRef();
+    return m_writable.releaseNonNull();
 }
 
 bool RTCRtpSFrameTransform::virtualHasPendingActivity() const

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.h
@@ -71,8 +71,8 @@ public:
     WEBCORE_EXPORT uint64_t counterForTesting() const;
     WEBCORE_EXPORT uint64_t keyIdForTesting() const;
 
-    ExceptionOr<RefPtr<ReadableStream>> readable();
-    ExceptionOr<RefPtr<WritableStream>> writable();
+    ExceptionOr<Ref<ReadableStream>> readable();
+    ExceptionOr<Ref<WritableStream>> writable();
 
     bool hasKey(uint64_t) const;
 

--- a/Source/WebCore/Modules/mediastream/RTCTrackEvent.idl
+++ b/Source/WebCore/Modules/mediastream/RTCTrackEvent.idl
@@ -28,17 +28,20 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/webrtc-pc/#dom-rtctrackevent
 [
     Conditional=WEB_RTC,
     EnabledBySetting=PeerConnectionEnabled,
     Exposed=Window
 ] interface RTCTrackEvent : Event {
     constructor([AtomString] DOMString type, RTCTrackEventInit eventInitDict);
-
-    readonly attribute RTCRtpReceiver receiver;
-    readonly attribute MediaStreamTrack track;
+    // FIXME: `receiver` should not be nullable.
+    readonly attribute RTCRtpReceiver? receiver;
+    // FIXME: `track` should not be nullable.
+    readonly attribute MediaStreamTrack? track;
     [CachedAttribute, SameObject] readonly attribute FrozenArray<MediaStream> streams;
-    readonly attribute RTCRtpTransceiver transceiver;
+    // FIXME: `transceiver` should not be nullable.
+    readonly attribute RTCRtpTransceiver? transceiver;
 };
 
 dictionary RTCTrackEventInit : EventInit {

--- a/Source/WebCore/Modules/notifications/NotificationEvent.idl
+++ b/Source/WebCore/Modules/notifications/NotificationEvent.idl
@@ -31,7 +31,8 @@
 interface NotificationEvent : ExtendableEvent {
     constructor([AtomString] DOMString type, NotificationEventInit eventInitDict);
 
-    readonly attribute Notification notification;
+    // FIXME: `notification` should not be nullable.
+    readonly attribute Notification? notification;
     readonly attribute DOMString action;
 };
 

--- a/Source/WebCore/Modules/speech/DOMWindow+SpeechSynthesis.idl
+++ b/Source/WebCore/Modules/speech/DOMWindow+SpeechSynthesis.idl
@@ -23,10 +23,12 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://webaudio.github.io/web-speech-api/#ref-for-window
 [
     EnabledBySetting=SpeechSynthesisAPIEnabled,
     Conditional=SPEECH_SYNTHESIS,
     ImplementedBy=LocalDOMWindowSpeechSynthesis
 ] partial interface DOMWindow {
-    [SameObject] readonly attribute SpeechSynthesis speechSynthesis;
+    // FIXME: `speechSynthesis` should not be nullable.
+    [SameObject] readonly attribute SpeechSynthesis? speechSynthesis;
 };

--- a/Source/WebCore/Modules/speech/SpeechRecognitionEvent.idl
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionEvent.idl
@@ -23,6 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://webaudio.github.io/web-speech-api/#speechrecognitionevent
 [
     EnabledBySetting=SpeechRecognitionEnabled,
     SecureContext,
@@ -30,7 +31,8 @@
 ] interface SpeechRecognitionEvent : Event {
     constructor([AtomString] DOMString type, SpeechRecognitionEventInit eventInitDict);
     readonly attribute unsigned long resultIndex;
-    readonly attribute SpeechRecognitionResultList results;
+    // FIXME: `results` should not be nullable.
+    readonly attribute SpeechRecognitionResultList? results;
 };
 
 dictionary SpeechRecognitionEventInit : EventInit {

--- a/Source/WebCore/Modules/speech/SpeechRecognitionResult.idl
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionResult.idl
@@ -29,6 +29,6 @@
     Exposed=Window
 ] interface SpeechRecognitionResult {
     readonly attribute unsigned long length;
-    getter SpeechRecognitionAlternative item(unsigned long index);
+    getter SpeechRecognitionAlternative? item(unsigned long index);
     readonly attribute boolean isFinal;
 };

--- a/Source/WebCore/Modules/speech/SpeechRecognitionResultList.idl
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionResultList.idl
@@ -28,5 +28,5 @@
     Exposed=Window
 ] interface SpeechRecognitionResultList {
     readonly attribute unsigned long length;
-    getter SpeechRecognitionResult item(unsigned long index);
+    getter SpeechRecognitionResult? item(unsigned long index);
 };

--- a/Source/WebCore/Modules/speech/SpeechSynthesisEvent.idl
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisEvent.idl
@@ -31,7 +31,8 @@
 ] interface SpeechSynthesisEvent : Event {
     constructor([AtomString] DOMString type, SpeechSynthesisEventInit eventInitDict);
 
-    readonly attribute SpeechSynthesisUtterance utterance;
+    // FIXME: `utterance` should not be nullable.
+    readonly attribute SpeechSynthesisUtterance? utterance;
     readonly attribute unsigned long charIndex;
     readonly attribute unsigned long charLength;
     readonly attribute unrestricted float elapsedTime;

--- a/Source/WebCore/Modules/streams/ReadableStreamReadRequest.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStreamReadRequest.cpp
@@ -46,12 +46,12 @@ private:
 
     void runChunkSteps(JSC::JSValue value) final
     {
-        m_promise->resolve<IDLDictionary<ReadableStreamReadResult>>({ value, false });
+        m_promise->resolve<IDLDictionary<ReadableStreamReadResult>>(ReadableStreamReadResult { value, false });
     }
 
     void runCloseSteps() final
     {
-        m_promise->resolve<IDLDictionary<ReadableStreamReadResult>>({ JSC::jsUndefined(), true });
+        m_promise->resolve<IDLDictionary<ReadableStreamReadResult>>(ReadableStreamReadResult { JSC::jsUndefined(), true });
     }
 
     void runErrorSteps(JSC::JSValue value) final
@@ -86,12 +86,12 @@ private:
 
     void runChunkSteps(JSC::JSValue value) final
     {
-        m_promise->resolve<IDLDictionary<ReadableStreamReadResult>>({ value, false });
+        m_promise->resolve<IDLDictionary<ReadableStreamReadResult>>(ReadableStreamReadResult { value, false });
     }
 
     void runCloseSteps(JSC::JSValue value) final
     {
-        m_promise->resolve<IDLDictionary<ReadableStreamReadResult>>({ value, true });
+        m_promise->resolve<IDLDictionary<ReadableStreamReadResult>>(ReadableStreamReadResult { value, true });
     }
 
     void runErrorSteps(JSC::JSValue value) final

--- a/Source/WebCore/Modules/webaudio/AudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioContext.cpp
@@ -551,10 +551,11 @@ static bool hasPlayBackAudioSession(Document* document)
     RefPtr window = document ? document->window() : nullptr;
 
     RefPtr navigator = window ? window->optionalNavigator() : nullptr;
-    RefPtr audioSession = navigator ? NavigatorAudioSession::audioSession(*navigator) : nullptr;
+    if (!navigator)
+        return false;
 
-    auto audioSessionType = audioSession ? audioSession->type() : DOMAudioSessionType::Auto;
-    return audioSessionType == DOMAudioSessionType::Playback || audioSessionType == DOMAudioSessionType::PlayAndRecord;
+    Ref audioSession = NavigatorAudioSession::audioSession(*navigator);
+    return audioSession->type() == DOMAudioSessionType::Playback || audioSession->type() == DOMAudioSessionType::PlayAndRecord;
 #else
     UNUSED_PARAM(document);
     return false;

--- a/Source/WebCore/Modules/webaudio/AudioProcessingEvent.idl
+++ b/Source/WebCore/Modules/webaudio/AudioProcessingEvent.idl
@@ -22,6 +22,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://webaudio.github.io/web-audio-api/#dom-audioprocessingevent-audioprocessingevent
 [
     Conditional=WEB_AUDIO,
     EnabledBySetting=WebAudioEnabled,
@@ -29,6 +30,8 @@
 ] interface AudioProcessingEvent : Event {
     [EnabledBySetting=WebAudioEnabled] constructor ([AtomString] DOMString type, AudioProcessingEventInit eventInitDict);
     readonly attribute double playbackTime;
-    readonly attribute AudioBuffer inputBuffer;
-    readonly attribute AudioBuffer outputBuffer; 
+    // FIXME: `inputBuffer` should not be nullable.
+    readonly attribute AudioBuffer? inputBuffer;
+    // FIXME: `outputBuffer` should not be nullable.
+    readonly attribute AudioBuffer? outputBuffer;
 };

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredential.h
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredential.h
@@ -59,7 +59,7 @@ public:
     static Ref<PublicKeyCredential> create(Ref<AuthenticatorResponse>&&);
 
     ArrayBuffer* rawId() const;
-    AuthenticatorResponse* response() const { return m_response.ptr(); }
+    AuthenticatorResponse& response() const { return m_response; }
     AuthenticatorAttachment authenticatorAttachment() const;
     AuthenticationExtensionsClientOutputs getClientExtensionResults() const;
     PublicKeyCredentialJSON toJSON();

--- a/Source/WebCore/Modules/webtransport/WebTransport.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransport.cpp
@@ -613,12 +613,12 @@ void WebTransport::createUnidirectionalStream(ScriptExecutionContext& context, W
         } ();
         if (stream.hasException())
             return promise->reject(stream.releaseException());
-        auto sendStream = stream.releaseReturnValue();
+        Ref sendStream = stream.releaseReturnValue();
         sink->setStream(sendStream.get());
         protectedThis->m_sendStreams.add(sendStream);
         ASSERT(!protectedThis->m_sendStreamSinks.contains(*identifier));
         protectedThis->m_sendStreamSinks.add(*identifier, WTF::move(sink));
-        promise->resolveWithNewlyCreated<IDLInterface<WebTransportSendStream>>(sendStream);
+        promise->resolveWithNewlyCreated<IDLInterface<WebTransportSendStream>>(WTF::move(sendStream));
     });
 }
 

--- a/Source/WebCore/Modules/webtransport/WebTransportDatagramDuplexStream.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransportDatagramDuplexStream.cpp
@@ -54,7 +54,7 @@ void WebTransportDatagramDuplexStream::attachTo(WebTransport& transport)
     m_transport = transport;
 }
 
-ExceptionOr<Ref<WritableStream>> WebTransportDatagramDuplexStream::createWritable(ScriptExecutionContext& context, WebTransportSendOptions&& options)
+ExceptionOr<Ref<WebTransportDatagramsWritable>> WebTransportDatagramDuplexStream::createWritable(ScriptExecutionContext& context, WebTransportSendOptions&& options)
 {
     return WebTransportDatagramsWritable::create(context, m_transport.get(), WTF::move(options));
 }

--- a/Source/WebCore/Modules/webtransport/WebTransportDatagramDuplexStream.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportDatagramDuplexStream.h
@@ -39,8 +39,8 @@ class DOMPromise;
 class ReadableStream;
 class ScriptExecutionContext;
 class WebTransport;
+class WebTransportDatagramsWritable;
 class WebTransportSession;
-class WritableStream;
 struct WebTransportSendOptions;
 template<typename> class ExceptionOr;
 
@@ -50,7 +50,7 @@ public:
     ~WebTransportDatagramDuplexStream();
 
     ReadableStream& readable() { return m_readable; }
-    ExceptionOr<Ref<WritableStream>> createWritable(ScriptExecutionContext&, WebTransportSendOptions&&);
+    ExceptionOr<Ref<WebTransportDatagramsWritable>> createWritable(ScriptExecutionContext&, WebTransportSendOptions&&);
     unsigned maxDatagramSize() const { return std::numeric_limits<uint16_t>::max(); }
     std::optional<double> incomingMaxAge() const { return m_incomingMaxAge; }
     std::optional<double> outgoingMaxAge() const { return m_outgoingMaxAge; }

--- a/Source/WebCore/Modules/webtransport/WebTransportDatagramsWritable.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransportDatagramsWritable.cpp
@@ -34,7 +34,7 @@
 
 namespace WebCore {
 
-ExceptionOr<Ref<WritableStream>> WebTransportDatagramsWritable::create(ScriptExecutionContext& context, RefPtr<WebTransport>&& transport, WebTransportSendOptions&& options)
+ExceptionOr<Ref<WebTransportDatagramsWritable>> WebTransportDatagramsWritable::create(ScriptExecutionContext& context, RefPtr<WebTransport>&& transport, WebTransportSendOptions&& options)
 {
     RefPtr sendGroup = options.sendGroup;
     if (sendGroup && sendGroup->transport().get() != transport.get())

--- a/Source/WebCore/Modules/webtransport/WebTransportDatagramsWritable.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportDatagramsWritable.h
@@ -37,7 +37,7 @@ struct WebTransportSendOptions;
 
 class WebTransportDatagramsWritable : public WritableStream {
 public:
-    static ExceptionOr<Ref<WritableStream>> create(ScriptExecutionContext&, RefPtr<WebTransport>&&, WebTransportSendOptions&&);
+    static ExceptionOr<Ref<WebTransportDatagramsWritable>> create(ScriptExecutionContext&, RefPtr<WebTransport>&&, WebTransportSendOptions&&);
     ~WebTransportDatagramsWritable();
 
     const RefPtr<WebTransportSendGroup>& sendGroup();

--- a/Source/WebCore/Modules/webxr/WebXRHand.idl
+++ b/Source/WebCore/Modules/webxr/WebXRHand.idl
@@ -23,6 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://immersive-web.github.io/webxr-hand-input/#xrhand
 [
     Conditional=WEBXR_HANDS,
     EnabledBySetting=WebXREnabled&WebXRHandInputModuleEnabled,
@@ -31,8 +32,10 @@
     Exposed=Window,
     InterfaceName=XRHand
 ] interface WebXRHand {
-    iterable<XRHandJoint, WebXRJointSpace>;
+    // FIXME: iterable value should not be nullable.
+    iterable<XRHandJoint, WebXRJointSpace?>;
 
     readonly attribute unsigned long size;
-    WebXRJointSpace get(XRHandJoint key);
+    // FIXME: `get` should not return a nullable type.
+    WebXRJointSpace? get(XRHandJoint key);
 };

--- a/Source/WebCore/Modules/webxr/WebXRWebGLLayer.idl
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLLayer.idl
@@ -43,7 +43,7 @@ typedef (WebGLRenderingContext or WebGL2RenderingContext) WebXRWebGLRenderingCon
     // FIXME: Support 'fixedFoveation'.
     // attribute float? fixedFoveation;
 
-    [SameObject] readonly attribute WebGLFramebuffer framebuffer;
+    [SameObject] readonly attribute WebGLFramebuffer? framebuffer;
     readonly attribute unsigned long framebufferWidth;
     readonly attribute unsigned long framebufferHeight;
 

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -45,7 +45,7 @@ bindings/js/JSCustomElementInterface.cpp
 bindings/js/JSDOMBindingSecurity.cpp
 bindings/js/JSDOMBindingSecurity.h
 bindings/js/JSDOMConvertBase.h
-bindings/js/JSDOMConvertInterface.h
+bindings/js/JSDOMConvertNullable.h
 bindings/js/JSDOMGlobalObject.cpp
 bindings/js/JSDOMPromiseDeferred.cpp
 bindings/js/JSDOMWindowBase.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -107,7 +107,7 @@ bindings/js/JSDOMConvertBase.h
 bindings/js/JSDOMConvertBufferSource.h
 bindings/js/JSDOMConvertCallbacks.h
 bindings/js/JSDOMConvertEventListener.h
-bindings/js/JSDOMConvertInterface.h
+bindings/js/JSDOMConvertNullable.h
 bindings/js/JSDOMGlobalObject.cpp
 bindings/js/JSDOMIterator.h
 bindings/js/JSDOMMapLike.h
@@ -175,6 +175,7 @@ bindings/js/ScheduledAction.cpp
 bindings/js/ScriptBufferSourceProvider.h
 bindings/js/ScriptCachedFrameData.cpp
 bindings/js/ScriptModuleLoader.cpp
+bindings/js/SerializedScriptValue.cpp
 bindings/js/WebAssemblyScriptBufferSourceProvider.h
 bindings/js/WebCoreJSClientData.cpp
 bindings/js/WebCoreTypedArrayController.cpp

--- a/Source/WebCore/animation/ViewTimeline.idl
+++ b/Source/WebCore/animation/ViewTimeline.idl
@@ -23,12 +23,14 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://drafts.csswg.org/scroll-animations/#viewtimeline
 [
     EnabledBySetting=ScrollDrivenAnimationsEnabled,
     Exposed=Window
 ] interface ViewTimeline : ScrollTimeline {
     [CallWith=CurrentDocument] constructor(optional ViewTimelineOptions options = {});
-    readonly attribute Element subject;
+    // FIXME: `subject` should not be nullable.
+    readonly attribute Element? subject;
     readonly attribute CSSNumericValue startOffset;
     readonly attribute CSSNumericValue endOffset;
 };

--- a/Source/WebCore/bindings/js/JSCustomElementInterface.cpp
+++ b/Source/WebCore/bindings/js/JSCustomElementInterface.cpp
@@ -380,7 +380,7 @@ void JSCustomElementInterface::invokeAttributeChangedCallback(Element& element, 
 void JSCustomElementInterface::invokeFormAssociatedCallback(Element& element, HTMLFormElement* associatedForm)
 {
     invokeCallback(element, m_formAssociatedCallback.get(), [&](JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, MarkedArgumentBuffer& args) {
-        args.append(toJS(lexicalGlobalObject, globalObject, associatedForm));
+        args.append(associatedForm ? toJS(lexicalGlobalObject, globalObject, *associatedForm) : jsNull());
     });
 }
 

--- a/Source/WebCore/bindings/js/JSDOMConvertInterface.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertInterface.h
@@ -80,16 +80,76 @@ template<typename T> struct JSConverter<IDLInterface<T>> {
     static constexpr bool needsState = true;
     static constexpr bool needsGlobalObject = true;
 
-    template <typename U>
-    static JSC::JSValue convert(JSC::JSGlobalObject& lexicalGlobalObject, JSDOMGlobalObject& globalObject, const U& value)
+    template<std::derived_from<T> U>
+    static JSC::JSValue convert(JSC::JSGlobalObject& lexicalGlobalObject, JSDOMGlobalObject& globalObject, U& value)
     {
-        return toJS(&lexicalGlobalObject, &globalObject, Detail::getPtrOrRef(value));
+        return toJS(&lexicalGlobalObject, &globalObject, Ref<T>(value));
     }
 
-    template<typename U>
-    static JSC::JSValue convertNewlyCreated(JSC::JSGlobalObject& lexicalGlobalObject, JSDOMGlobalObject& globalObject, U&& value)
+    template<std::derived_from<T> U>
+    static JSC::JSValue convert(JSC::JSGlobalObject& lexicalGlobalObject, JSDOMGlobalObject& globalObject, const U& value)
     {
-        return toJSNewlyCreated(&lexicalGlobalObject, &globalObject, std::forward<U>(value));
+        return toJS(&lexicalGlobalObject, &globalObject, Ref<T>(const_cast<U&>(value)));
+    }
+
+    template<std::derived_from<T> U>
+    static JSC::JSValue convert(JSC::JSGlobalObject& lexicalGlobalObject, JSDOMGlobalObject& globalObject, std::reference_wrapper<U> value)
+    {
+        return toJS(&lexicalGlobalObject, &globalObject, Ref<T>(value.get()));
+    }
+
+    template<std::derived_from<T> U>
+    static JSC::JSValue convert(JSC::JSGlobalObject& lexicalGlobalObject, JSDOMGlobalObject& globalObject, Ref<U>& value)
+    {
+        return toJS(&lexicalGlobalObject, &globalObject, value);
+    }
+
+    template<std::derived_from<T> U>
+    static JSC::JSValue convert(JSC::JSGlobalObject& lexicalGlobalObject, JSDOMGlobalObject& globalObject, const Ref<U>& value)
+    {
+        return toJS(&lexicalGlobalObject, &globalObject, const_cast<Ref<U>&>(value));
+    }
+
+    template<std::derived_from<T> U>
+    static JSC::JSValue convert(JSC::JSGlobalObject& lexicalGlobalObject, JSDOMGlobalObject& globalObject, Ref<U>&& value)
+    {
+        return toJS(&lexicalGlobalObject, &globalObject, WTF::move(value));
+    }
+
+    template<std::derived_from<T> U>
+    static JSC::JSValue convertNewlyCreated(JSC::JSGlobalObject& lexicalGlobalObject, JSDOMGlobalObject& globalObject, U& value)
+    {
+        return toJSNewlyCreated(&lexicalGlobalObject, &globalObject, Ref<T>(value));
+    }
+
+    template<std::derived_from<T> U>
+    static JSC::JSValue convertNewlyCreated(JSC::JSGlobalObject& lexicalGlobalObject, JSDOMGlobalObject& globalObject, const U& value)
+    {
+        return toJSNewlyCreated(&lexicalGlobalObject, &globalObject, Ref<T>(const_cast<U&>(value)));
+    }
+
+    template<std::derived_from<T> U>
+    static JSC::JSValue convertNewlyCreated(JSC::JSGlobalObject& lexicalGlobalObject, JSDOMGlobalObject& globalObject, std::reference_wrapper<U> value)
+    {
+        return toJSNewlyCreated(&lexicalGlobalObject, &globalObject, Ref<T>(value.get()));
+    }
+
+    template<std::derived_from<T> U>
+    static JSC::JSValue convertNewlyCreated(JSC::JSGlobalObject& lexicalGlobalObject, JSDOMGlobalObject& globalObject, Ref<U>& value)
+    {
+        return toJSNewlyCreated(&lexicalGlobalObject, &globalObject, value);
+    }
+
+    template<std::derived_from<T> U>
+    static JSC::JSValue convertNewlyCreated(JSC::JSGlobalObject& lexicalGlobalObject, JSDOMGlobalObject& globalObject, const Ref<U>& value)
+    {
+        return toJSNewlyCreated(&lexicalGlobalObject, &globalObject, const_cast<Ref<U>&>(value));
+    }
+
+    template<std::derived_from<T> U>
+    static JSC::JSValue convertNewlyCreated(JSC::JSGlobalObject& lexicalGlobalObject, JSDOMGlobalObject& globalObject, Ref<U>&& value)
+    {
+        return toJSNewlyCreated(&lexicalGlobalObject, &globalObject, WTF::move(value));
     }
 };
 

--- a/Source/WebCore/bindings/js/JSDOMConvertNullable.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertNullable.h
@@ -88,12 +88,10 @@ template<typename IDL> struct Converter<IDLNullable<IDL>> : DefaultConverter<IDL
 };
 
 template<typename IDL> struct JSConverter<IDLNullable<IDL>> {
-    using ImplementationType = typename IDLNullable<IDL>::ImplementationType;
-
     static constexpr bool needsState = JSConverter<IDL>::needsState;
     static constexpr bool needsGlobalObject = JSConverter<IDL>::needsGlobalObject;
 
-    template<std::convertible_to<ImplementationType> U>
+    template<typename U>
     static JSC::JSValue convert(U&& value)
     {
         if (IDL::isNullValue(value))
@@ -101,7 +99,7 @@ template<typename IDL> struct JSConverter<IDLNullable<IDL>> {
         return toJS<IDL>(IDL::extractValueFromNullable(std::forward<U>(value)));
     }
 
-    template<std::convertible_to<ImplementationType> U>
+    template<typename U>
     static JSC::JSValue convert(const U& value)
     {
         if (IDL::isNullValue(value))
@@ -109,7 +107,7 @@ template<typename IDL> struct JSConverter<IDLNullable<IDL>> {
         return toJS<IDL>(IDL::extractValueFromNullable(value));
     }
 
-    template<std::convertible_to<ImplementationType> U>
+    template<typename U>
     static JSC::JSValue convert(JSC::JSGlobalObject& lexicalGlobalObject, U&& value)
     {
         if (IDL::isNullValue(value))
@@ -117,7 +115,7 @@ template<typename IDL> struct JSConverter<IDLNullable<IDL>> {
         return toJS<IDL>(lexicalGlobalObject, IDL::extractValueFromNullable(std::forward<U>(value)));
     }
 
-    template<std::convertible_to<ImplementationType> U>
+    template<typename U>
     static JSC::JSValue convert(JSC::JSGlobalObject& lexicalGlobalObject, const U& value)
     {
         if (IDL::isNullValue(value))
@@ -125,7 +123,7 @@ template<typename IDL> struct JSConverter<IDLNullable<IDL>> {
         return toJS<IDL>(lexicalGlobalObject, IDL::extractValueFromNullable(value));
     }
 
-    template<std::convertible_to<ImplementationType> U>
+    template<typename U>
     static JSC::JSValue convert(JSC::JSGlobalObject& lexicalGlobalObject, JSDOMGlobalObject& globalObject, U&& value)
     {
         if (IDL::isNullValue(value))
@@ -133,7 +131,7 @@ template<typename IDL> struct JSConverter<IDLNullable<IDL>> {
         return toJS<IDL>(lexicalGlobalObject, globalObject, IDL::extractValueFromNullable(std::forward<U>(value)));
     }
 
-    template<std::convertible_to<ImplementationType> U>
+    template<typename U>
     static JSC::JSValue convert(JSC::JSGlobalObject& lexicalGlobalObject, JSDOMGlobalObject& globalObject, const U& value)
     {
         if (IDL::isNullValue(value))
@@ -141,7 +139,7 @@ template<typename IDL> struct JSConverter<IDLNullable<IDL>> {
         return toJS<IDL>(lexicalGlobalObject, globalObject, IDL::extractValueFromNullable(value));
     }
 
-    template<std::convertible_to<ImplementationType> U>
+    template<typename U>
     static JSC::JSValue convertNewlyCreated(JSC::JSGlobalObject& lexicalGlobalObject, JSDOMGlobalObject& globalObject, U&& value)
     {
         if (IDL::isNullValue(value))

--- a/Source/WebCore/bindings/js/JSDOMConvertPromise.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertPromise.h
@@ -74,14 +74,9 @@ template<typename T> struct JSConverter<IDLPromise<T>> {
     static constexpr bool needsState = true;
     static constexpr bool needsGlobalObject = true;
 
-    static JSC::JSValue convert(JSC::JSGlobalObject&, JSDOMGlobalObject&, DOMPromise& promise)
+    static JSC::JSValue convert(JSC::JSGlobalObject&, JSDOMGlobalObject&, const DOMPromise& promise)
     {
         return promise.guardedObject();
-    }
-
-    static JSC::JSValue convert(JSC::JSGlobalObject&, JSDOMGlobalObject&, const RefPtr<DOMPromise>& promise)
-    {
-        return promise->guardedObject();
     }
 
     static JSC::JSValue convert(JSC::JSGlobalObject&, JSDOMGlobalObject&, const Ref<DOMPromise>& promise)
@@ -97,12 +92,12 @@ template<typename T> struct JSConverter<IDLPromise<T>> {
 };
 
 template<typename T> struct JSConverter<IDLPromiseIgnoringSuspension<T>> : public JSConverter<IDLPromise<T>> {
-    static JSC::JSValue convert(JSC::JSGlobalObject&, JSDOMGlobalObject&, DOMPromise& promise)
+    static JSC::JSValue convert(JSC::JSGlobalObject&, JSDOMGlobalObject&, const DOMPromise& promise)
     {
         return promise.guardedObject();
     }
 
-    static JSC::JSValue convert(JSC::JSGlobalObject&, JSDOMGlobalObject&, const RefPtr<DOMPromise>& promise)
+    static JSC::JSValue convert(JSC::JSGlobalObject&, JSDOMGlobalObject&, const Ref<DOMPromise>& promise)
     {
         return promise->guardedObject();
     }

--- a/Source/WebCore/bindings/js/JSDOMConvertUnion.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertUnion.h
@@ -406,6 +406,11 @@ template<typename... T> struct Converter<IDLUnion<T...>> : DefaultConverter<IDLU
     }
 };
 
+// FIXME: This is needed to work around unions storing non-nullable interfaces using RefPtr rather than Ref<>.
+// See "Support using Ref for IDLInterfaces in IDL unions (https://bugs.webkit.org/show_bug.cgi?id=274729)".
+template<typename T> struct AddNullableIfInterface { using type = T; };
+template<typename T> struct AddNullableIfInterface<IDLInterface<T>> { using type = IDLNullable<IDLInterface<T>>; };
+
 template<typename... T> struct JSConverter<IDLUnion<T...>> {
     using Type = IDLUnion<T...>;
     using TypeList = typename Type::TypeList;
@@ -424,7 +429,7 @@ template<typename... T> struct JSConverter<IDLUnion<T...>> {
         forEach<Sequence>([&]<typename I>() {
             if (I::value == index) {
                 ASSERT(!returnValue);
-                returnValue = toJS<brigand::at<TypeList, I>>(lexicalGlobalObject, globalObject, std::get<I::value>(variant));
+                returnValue = toJS<typename AddNullableIfInterface<brigand::at<TypeList, I>>::type>(lexicalGlobalObject, globalObject, std::get<I::value>(variant));
             }
         });
 

--- a/Source/WebCore/bindings/js/JSDOMConvertWebGL.cpp
+++ b/Source/WebCore/bindings/js/JSDOMConvertWebGL.cpp
@@ -157,87 +157,98 @@ using namespace JSC;
 JSValue convertToJSValue(JSGlobalObject& lexicalGlobalObject, JSDOMGlobalObject& globalObject, const WebGLAny& any)
 {
     return WTF::switchOn(any,
-        [] (std::nullptr_t) -> JSValue {
+        [](std::nullptr_t) -> JSValue {
             return jsNull();
-        }, [] (bool value) -> JSValue {
+        },
+        [](bool value) -> JSValue {
             return jsBoolean(value);
-        }, [] (int value) -> JSValue {
+        },
+        [](int value) -> JSValue {
             return jsNumber(value);
-        }, [] (unsigned value) -> JSValue {
+        },
+        [](unsigned value) -> JSValue {
             return jsNumber(value);
-        }, [] (long long value) -> JSValue {
+        },
+        [](long long value) -> JSValue {
             return jsNumber(value);
-        }, [] (unsigned long long value) -> JSValue {
+        },
+        [](unsigned long long value) -> JSValue {
             return jsNumber(value);
-        }, [] (float value) -> JSValue {
+        },
+        [](float value) -> JSValue {
             return jsNumber(purifyNaN(value));
-        }, [&] (const String& value) -> JSValue {
+        },
+        [&](const String& value) -> JSValue {
             return jsStringWithCache(lexicalGlobalObject.vm(), value);
-        }, [&] (const Vector<bool>& values) -> JSValue {
+        },
+        [&](const Vector<bool>& values) -> JSValue {
             MarkedArgumentBuffer list;
             list.ensureCapacity(values.size());
             for (auto& value : values)
                 list.append(jsBoolean(value));
             RELEASE_ASSERT(!list.hasOverflowed());
             return constructArray(&globalObject, static_cast<JSC::ArrayAllocationProfile*>(nullptr), list);
-        }, [&] (const Vector<int>& values) -> JSValue {
+        },
+        [&](const Vector<int>& values) -> JSValue {
             MarkedArgumentBuffer list;
             list.ensureCapacity(values.size());
             for (auto& value : values)
                 list.append(jsNumber(value));
             RELEASE_ASSERT(!list.hasOverflowed());
             return constructArray(&globalObject, static_cast<JSC::ArrayAllocationProfile*>(nullptr), list);
-        }, [&] (const Vector<unsigned>& values) -> JSValue {
+        },
+        [&](const Vector<unsigned>& values) -> JSValue {
             MarkedArgumentBuffer list;
             list.ensureCapacity(values.size());
             for (auto& value : values)
                 list.append(jsNumber(value));
             RELEASE_ASSERT(!list.hasOverflowed());
             return constructArray(&globalObject, static_cast<JSC::ArrayAllocationProfile*>(nullptr), list);
-        }, [&] (const RefPtr<Float32Array>& array) {
+        },
+        [&](const RefPtr<Float32Array>& array) -> JSValue {
             return toJS(&lexicalGlobalObject, &globalObject, array.get());
         },
-        [&] (const RefPtr<Int32Array>& array) {
+        [&](const RefPtr<Int32Array>& array) -> JSValue {
             return toJS(&lexicalGlobalObject, &globalObject, array.get());
         },
-        [&] (const RefPtr<Uint8Array>& array) {
+        [&](const RefPtr<Uint8Array>& array) -> JSValue {
             return toJS(&lexicalGlobalObject, &globalObject, array.get());
         },
-        [&] (const RefPtr<Uint32Array>& array) {
+        [&](const RefPtr<Uint32Array>& array) -> JSValue {
             return toJS(&lexicalGlobalObject, &globalObject, array.get());
         },
-        [&] (const RefPtr<WebGLBuffer>& buffer) {
-            return toJS(&lexicalGlobalObject, &globalObject, buffer.get());
+        [&](const RefPtr<WebGLBuffer>& buffer) -> JSValue {
+            return buffer ? toJS(&lexicalGlobalObject, &globalObject, *buffer) : jsNull();
         },
-        [&] (const RefPtr<WebGLFramebuffer>& buffer) {
-            return toJS(&lexicalGlobalObject, &globalObject, buffer.get());
+        [&](const RefPtr<WebGLFramebuffer>& buffer) -> JSValue {
+            return buffer ? toJS(&lexicalGlobalObject, &globalObject, *buffer) : jsNull();
         },
-        [&] (const RefPtr<WebGLProgram>& program) {
-            return toJS(&lexicalGlobalObject, &globalObject, program.get());
+        [&](const RefPtr<WebGLProgram>& program) -> JSValue {
+            return program ? toJS(&lexicalGlobalObject, &globalObject, *program) : jsNull();
         },
-        [&] (const RefPtr<WebGLRenderbuffer>& buffer) {
-            return toJS(&lexicalGlobalObject, &globalObject, buffer.get());
+        [&](const RefPtr<WebGLRenderbuffer>& buffer) -> JSValue {
+            return buffer ? toJS(&lexicalGlobalObject, &globalObject, *buffer) : jsNull();
         },
-        [&] (const RefPtr<WebGLTexture>& texture) {
-            return toJS(&lexicalGlobalObject, &globalObject, texture.get());
+        [&](const RefPtr<WebGLTexture>& texture) -> JSValue {
+            return texture ? toJS(&lexicalGlobalObject, &globalObject, *texture) : jsNull();
         },
-        [&] (const RefPtr<WebGLTimerQueryEXT>& query) {
-            return toJS(&lexicalGlobalObject, &globalObject, query.get());
+        [&](const RefPtr<WebGLTimerQueryEXT>& query) -> JSValue {
+            return query ? toJS(&lexicalGlobalObject, &globalObject, *query) : jsNull();
         },
-        [&] (const RefPtr<WebGLVertexArrayObjectOES>& array) {
-            return toJS(&lexicalGlobalObject, &globalObject, array.get());
+        [&](const RefPtr<WebGLVertexArrayObjectOES>& array) -> JSValue {
+            return array ? toJS(&lexicalGlobalObject, &globalObject, *array) : jsNull();
         },
-        [&] (const RefPtr<WebGLQuery>& query) {
-            return toJS(&lexicalGlobalObject, &globalObject, query.get());
+        [&](const RefPtr<WebGLQuery>& query) -> JSValue {
+            return query ? toJS(&lexicalGlobalObject, &globalObject, *query) : jsNull();
         },
-        [&] (const RefPtr<WebGLSampler>& sampler) {
-            return toJS(&lexicalGlobalObject, &globalObject, sampler.get());
+        [&](const RefPtr<WebGLSampler>& sampler) -> JSValue {
+            return sampler ? toJS(&lexicalGlobalObject, &globalObject, *sampler) : jsNull();
         },
-        [&] (const RefPtr<WebGLTransformFeedback>& transformFeedback) {
-            return toJS(&lexicalGlobalObject, &globalObject, transformFeedback.get());
+        [&](const RefPtr<WebGLTransformFeedback>& transformFeedback) -> JSValue {
+            return transformFeedback ? toJS(&lexicalGlobalObject, &globalObject, *transformFeedback) : jsNull();
         },
-        [&] (const RefPtr<WebGLVertexArrayObject>& array) {
-            return toJS(&lexicalGlobalObject, &globalObject, array.get());
+        [&](const RefPtr<WebGLVertexArrayObject>& array) -> JSValue {
+            return array ? toJS(&lexicalGlobalObject, &globalObject, *array) : jsNull();
         }
     );
 }

--- a/Source/WebCore/bindings/js/JSDOMIterator.h
+++ b/Source/WebCore/bindings/js/JSDOMIterator.h
@@ -183,7 +183,7 @@ template<typename IteratorValue, typename T> inline EnableIfSet<T, JSC::JSValue>
     ASSERT(value);
 
     auto globalObject = this->globalObject();
-    auto result = toJS<typename Traits::ValueType>(lexicalGlobalObject, *globalObject, value);
+    auto result = toJS<IDLNullable<typename Traits::ValueType>>(lexicalGlobalObject, *globalObject, value);
 
     switch (m_kind) {
     case IterationKind::Keys:
@@ -207,7 +207,7 @@ template<typename JSIterator, typename IteratorValue> EnableIfMap<typename JSIte
 template<typename JSIterator, typename IteratorValue> EnableIfSet<typename JSIterator::Traits> appendForEachArguments(JSC::JSGlobalObject& lexicalGlobalObject, JSDOMGlobalObject& globalObject, JSC::MarkedArgumentBuffer& arguments, IteratorValue& value)
 {
     ASSERT(value);
-    auto argument = toJS<typename JSIterator::Traits::ValueType>(lexicalGlobalObject, globalObject, value);
+    auto argument = toJS<IDLNullable<typename JSIterator::Traits::ValueType>>(lexicalGlobalObject, globalObject, value);
     arguments.append(argument);
     arguments.append(argument);
 }

--- a/Source/WebCore/bindings/js/JSDOMWindowBase.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWindowBase.cpp
@@ -172,7 +172,8 @@ void JSDOMWindowBase::updateDocument()
     bool shouldThrowReadOnlyError = false;
     bool ignoreReadOnlyErrors = true;
     bool putResult = false;
-    symbolTablePutTouchWatchpointSet(this, lexicalGlobalObject, builtinNames(vm).documentPublicName(), toJS(lexicalGlobalObject, this, m_wrapped->documentIfLocal()), shouldThrowReadOnlyError, ignoreReadOnlyErrors, putResult);
+    RefPtr document = m_wrapped->documentIfLocal();
+    symbolTablePutTouchWatchpointSet(this, lexicalGlobalObject, builtinNames(vm).documentPublicName(), document ? toJS(lexicalGlobalObject, this, document.releaseNonNull()) : jsNull(), shouldThrowReadOnlyError, ignoreReadOnlyErrors, putResult);
     EXCEPTION_ASSERT_UNUSED(scope, !scope.exception());
 }
 
@@ -303,8 +304,9 @@ void JSDOMWindowBase::queueMicrotaskToEventLoop(JSGlobalObject& object, QueuedTa
 
 JSC::JSObject* JSDOMWindowBase::currentScriptExecutionOwner(JSGlobalObject* object)
 {
-    JSDOMWindowBase* thisObject = static_cast<JSDOMWindowBase*>(object);
-    return jsCast<JSObject*>(toJS(thisObject, thisObject, thisObject->wrapped().documentIfLocal()));
+    auto* thisObject = static_cast<JSDOMWindowBase*>(object);
+    RefPtr document = thisObject->wrapped().documentIfLocal();
+    return jsCast<JSObject*>(document ? toJS(thisObject, thisObject, document.releaseNonNull()) : jsNull());
 }
 
 JSC::ScriptExecutionStatus JSDOMWindowBase::scriptExecutionStatus(JSC::JSGlobalObject*, JSC::JSObject* owner)

--- a/Source/WebCore/bindings/js/JSDOMWindowCustom.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWindowCustom.cpp
@@ -97,7 +97,8 @@ JSC_DEFINE_CUSTOM_GETTER(jsDOMWindow_webkit, (JSGlobalObject* lexicalGlobalObjec
     RefPtr localDOMWindow = dynamicDowncast<LocalDOMWindow>(castedThis->wrapped());
     if (!localDOMWindow)
         return JSValue::encode(jsUndefined());
-    return JSValue::encode(toJS(lexicalGlobalObject, castedThis->globalObject(), localDOMWindow->webkitNamespace()));
+    RefPtr webkitNamespace = localDOMWindow->webkitNamespace();
+    return JSValue::encode(webkitNamespace ? toJS(lexicalGlobalObject, castedThis->globalObject(), webkitNamespace.releaseNonNull()) : jsNull());
 }
 #endif
 
@@ -469,7 +470,7 @@ JSValue JSDOMWindow::event(JSGlobalObject& lexicalGlobalObject) const
     Event* event = currentEvent();
     if (!event)
         return jsUndefined();
-    return toJS(&lexicalGlobalObject, const_cast<JSDOMWindow*>(this), event);
+    return toJS(&lexicalGlobalObject, const_cast<JSDOMWindow*>(this), *event);
 }
 
 // Custom functions

--- a/Source/WebCore/bindings/js/JSDOMWindowProperties.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWindowProperties.cpp
@@ -66,7 +66,7 @@ static bool jsDOMWindowPropertiesGetOwnPropertySlotNamedItemGetter(JSDOMWindowPr
                 ASSERT(collection->length() > 1);
                 namedItem = toJS(lexicalGlobalObject, thisObject->globalObject(), collection);
             } else
-                namedItem = toJS(lexicalGlobalObject, thisObject->globalObject(), htmlDocument->windowNamedItem(atomPropertyName).get());
+                namedItem = toJS(lexicalGlobalObject, thisObject->globalObject(), *htmlDocument->windowNamedItem(atomPropertyName));
             slot.setValue(thisObject, enumToUnderlyingType(PropertyAttribute::DontEnum), namedItem);
             return true;
         }

--- a/Source/WebCore/bindings/js/JSIDBRequestCustom.cpp
+++ b/Source/WebCore/bindings/js/JSIDBRequestCustom.cpp
@@ -55,11 +55,11 @@ JSC::JSValue JSIDBRequest::result(JSC::JSGlobalObject& lexicalGlobalObject) cons
         return toJS<IDLUnsignedLongLong>(number);
     }, [&] (const RefPtr<IDBCursor>& cursor) {
         return cachedPropertyValue(throwScope, lexicalGlobalObject, *this, resultWrapper, [&](JSC::ThrowScope& throwScope) {
-            return toJS<IDLInterface<IDBCursor>>(lexicalGlobalObject, *jsCast<JSDOMGlobalObject*>(&lexicalGlobalObject), throwScope, cursor.get());
+            return toJS<IDLInterface<IDBCursor>>(lexicalGlobalObject, *jsCast<JSDOMGlobalObject*>(&lexicalGlobalObject), throwScope, *cursor);
         });
     }, [&] (const RefPtr<IDBDatabase>& database) {
         return cachedPropertyValue(throwScope, lexicalGlobalObject, *this, resultWrapper, [&](JSC::ThrowScope& throwScope) {
-            return toJS<IDLInterface<IDBDatabase>>(lexicalGlobalObject, *jsCast<JSDOMGlobalObject*>(&lexicalGlobalObject), throwScope, database.get());
+            return toJS<IDLInterface<IDBDatabase>>(lexicalGlobalObject, *jsCast<JSDOMGlobalObject*>(&lexicalGlobalObject), throwScope, *database);
         });
     }, [&] (const IDBKeyData& keyData) {
         return cachedPropertyValue(throwScope, lexicalGlobalObject, *this, resultWrapper, [&](JSC::ThrowScope&) {

--- a/Source/WebCore/bindings/js/JSXMLHttpRequestCustom.cpp
+++ b/Source/WebCore/bindings/js/JSXMLHttpRequestCustom.cpp
@@ -96,7 +96,7 @@ JSValue JSXMLHttpRequest::response(JSGlobalObject& lexicalGlobalObject) const
     case XMLHttpRequest::ResponseType::Document: {
         auto document = wrapped().responseXML();
         ASSERT(!document.hasException());
-        value = toJS<IDLInterface<Document>>(lexicalGlobalObject, *globalObject(), document.releaseReturnValue());
+        value = toJS<IDLNullable<IDLInterface<Document>>>(lexicalGlobalObject, *globalObject(), document.releaseReturnValue());
         break;
     }
 
@@ -105,7 +105,7 @@ JSValue JSXMLHttpRequest::response(JSGlobalObject& lexicalGlobalObject) const
         break;
 
     case XMLHttpRequest::ResponseType::Arraybuffer:
-        value = toJS<IDLInterface<ArrayBuffer>>(lexicalGlobalObject, *globalObject(), wrapped().createResponseArrayBuffer());
+        value = toJS<IDLNullable<IDLInterface<ArrayBuffer>>>(lexicalGlobalObject, *globalObject(), wrapped().createResponseArrayBuffer());
         break;
     }
 

--- a/Source/WebCore/bindings/js/ScriptController.cpp
+++ b/Source/WebCore/bindings/js/ScriptController.cpp
@@ -567,7 +567,7 @@ JSObject* ScriptController::jsObjectForPluginElement(HTMLPlugInElement* plugin)
     // Create a JSObject bound to this element
     auto* globalObj = globalObject(pluginWorldSingleton());
     // FIXME: is normal okay? - used for NP plugins?
-    JSValue jsElementValue = toJS(globalObj, globalObj, plugin);
+    JSValue jsElementValue = plugin ? toJS(globalObj, globalObj, *plugin) : jsNull();
     if (!jsElementValue || !jsElementValue.isObject())
         return nullptr;
     

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -831,7 +831,7 @@ sub GenerateIndexedGetter
     
     my $itemGetterCondition;
     my $nativeToJSConversion;
-    if ( $indexedGetterOperation->extendedAttributes->{RaisesException}) {
+    if ($indexedGetterOperation->extendedAttributes->{RaisesException}) {
         $itemGetterCondition = "$indexExpression < thisObject->wrapped().length()";
         $nativeToJSConversion = NativeToJSValueUsingPointers($indexedGetterOperation, $interface, "thisObject->wrapped().${indexedGetterFunctionName}(${indexExpression})", "*thisObject->globalObject()");
     } else {
@@ -839,7 +839,9 @@ sub GenerateIndexedGetter
         # We can thus call item() right away and do a null check instead of first checking if `index < length` and then calling
         # item(). This avoids duplicates bounds check, which is especially useful when `length()` is virtual, like on NodeList.
         $itemGetterCondition = "auto item = thisObject->wrapped().${indexedGetterFunctionName}(${indexExpression}); !!item";
-        $nativeToJSConversion = NativeToJSValueUsingPointers($indexedGetterOperation, $interface, "WTF::move(item)", "*thisObject->globalObject()");
+        my $IDLType = GetIDLType($interface, $indexedGetterOperation->type);
+        my $extract = "${IDLType}::extractValueFromNullable(WTF::move(item))";
+        $nativeToJSConversion = NativeToJSValueUsingPointers($indexedGetterOperation, $interface, $extract, "*thisObject->globalObject()");
     }
     return ($itemGetterCondition, $nativeToJSConversion, StringifyJSCAttributes(\@attributes));
 }
@@ -873,7 +875,7 @@ sub GenerateNamedGetter
     my @attributes = ();
     push(@attributes, "JSC::PropertyAttribute::ReadOnly") if !GetNamedSetterOperation($interface) && !$interface->extendedAttributes->{Plugin};
     push(@attributes, "JSC::PropertyAttribute::DontEnum") if $interface->extendedAttributes->{LegacyUnenumerableNamedProperties};
-    
+
     my $nativeToJSConversion = NativeToJSValueUsingPointers($namedGetterOperation, $interface, $namedPropertyExpression, "*thisObject->globalObject()");
     
     return ($nativeToJSConversion, StringifyJSCAttributes(\@attributes));
@@ -966,7 +968,7 @@ sub GenerateGetOwnPropertySlot
         push(@$outputArray, "        if (auto namedProperty = accessVisibleNamedProperty<${overrideBuiltin}>(*lexicalGlobalObject, *thisObject, propertyName, getterFunctor)) {\n");
         
         # NOTE: GenerateNamedGetter implements steps 2.1 - 2.10.
-        
+
         my ($nativeToJSConversion, $attributeString) = GenerateNamedGetter($interface, $namedGetterOperation, "WTF::move(namedProperty.value())");
         
         push(@$outputArray, "            auto value = ${nativeToJSConversion};\n");
@@ -3028,7 +3030,9 @@ sub GenerateDictionaryImplementationContent
                     $result .= "${indent}        result->putDirect(vm, JSC::Identifier::fromString(vm, \"${key}\"_s), ${key}Value);\n";
                     $result .= "${indent}    }\n";
                 } else {
-                    my $conversionExpression = NativeToJSValueUsingReferences($member, $typeScope, $valueExpression, "globalObject");
+                    # FIXME: The `WrappingInterfacesInNullable` variant is needed to work around dictionaries storing non-nullable interfaces using RefPtr<> rather than Ref<>.
+                    # See "Support using Ref for IDLInterfaces in IDL dictionaries (https://bugs.webkit.org/show_bug.cgi?id=305410)".
+                    my $conversionExpression = NativeToJSValueUsingReferencesWrappingInterfacesInNullable($member, $typeScope, $valueExpression, "globalObject");
 
                     $result .= "${indent}    auto ${key}Value = ${conversionExpression};\n";
                     $result .= "${indent}    RETURN_IF_EXCEPTION(throwScope, { });\n";
@@ -3571,11 +3575,9 @@ sub GenerateHeader
         } else {
             push(@headerContent, $exportMacro."JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, $implType&);\n");
         }
-        push(@headerContent, "inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, $implType* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }\n");
 
         push(@headerContent, "JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<$implType>&&);\n");
         push(@headerContent, "ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, $implType& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }\n");
-        push(@headerContent, "inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<$implType>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }\n");
    }
 
     push(@headerContent, "\n");
@@ -7924,11 +7926,20 @@ sub NativeToJSValueDOMConvertNeedsGlobalObject
     return 0;
 }
 
+# FIXME: This is needed to work around dictionaries storing non-nullable interfaces using RefPtr rather than Ref<>.
+# See "Support using Ref for IDLInterfaces in IDL dictionaries (https://bugs.webkit.org/show_bug.cgi?id=305410)".
+sub NativeToJSValueUsingReferencesWrappingInterfacesInNullable
+{
+    my ($context, $interface, $value, $globalObjectReference) = @_;
+
+    return NativeToJSValue($context, $interface, $value, "lexicalGlobalObject", $globalObjectReference, 1);
+}
+
 sub NativeToJSValueUsingReferences
 {
     my ($context, $interface, $value, $globalObjectReference) = @_;
 
-    return NativeToJSValue($context, $interface, $value, "lexicalGlobalObject", $globalObjectReference);
+    return NativeToJSValue($context, $interface, $value, "lexicalGlobalObject", $globalObjectReference, 0);
 }
 
 # FIXME: We should remove NativeToJSValueUsingPointers and combine NativeToJSValueUsingReferences and NativeToJSValue
@@ -7936,7 +7947,7 @@ sub NativeToJSValueUsingPointers
 {
     my ($context, $interface, $value, $globalObjectReference) = @_;
 
-    return NativeToJSValue($context, $interface, $value, "*lexicalGlobalObject", $globalObjectReference);
+    return NativeToJSValue($context, $interface, $value, "*lexicalGlobalObject", $globalObjectReference, 0);
 }
 
 sub IsValidContextForNativeToJSValue
@@ -7954,7 +7965,7 @@ sub NativeToJSValueMayThrow
 
 sub NativeToJSValue
 {
-    my ($context, $interface, $value, $lexicalGlobalObjectReference, $globalObjectReference) = @_;
+    my ($context, $interface, $value, $lexicalGlobalObjectReference, $globalObjectReference, $wrapInterfaceInNullable) = @_;
 
     assert("Invalid context type") if !IsValidContextForNativeToJSValue($context);
 
@@ -7978,6 +7989,11 @@ sub NativeToJSValue
     }
 
     my $IDLType = GetIDLType($interface, $type);
+
+    # FIXME: This is a hack used by the dictionary code while storing interfaces via Ref<> is not supported. Once that is supported, this should be removed.
+    if ($wrapInterfaceInNullable and $codeGenerator->IsInterfaceType($type) and !$type->isNullable) {
+        $IDLType = "IDLNullable<" . $IDLType . ">";
+    }
 
     # FIXME: Not all promise types require the functor wrapping (some attribute getters actually return a value)
     # but wrapping is a no-op, so fixing this would purely be a stylistic / compile time fix.

--- a/Source/WebCore/bindings/scripts/test/JS/JSExposedStar.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSExposedStar.h
@@ -73,10 +73,8 @@ protected:
 };
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, ExposedStar&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, ExposedStar* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<ExposedStar>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, ExposedStar& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<ExposedStar>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<ExposedStar> {
     using WrapperClass = JSExposedStar;

--- a/Source/WebCore/bindings/scripts/test/JS/JSExposedToWorkerAndWindow.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSExposedToWorkerAndWindow.h
@@ -83,10 +83,8 @@ inline void* wrapperKey(ExposedToWorkerAndWindow* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, ExposedToWorkerAndWindow&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, ExposedToWorkerAndWindow* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<ExposedToWorkerAndWindow>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, ExposedToWorkerAndWindow& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<ExposedToWorkerAndWindow>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<ExposedToWorkerAndWindow> {
     using WrapperClass = JSExposedToWorkerAndWindow;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncIterable.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncIterable.h
@@ -82,10 +82,8 @@ inline void* wrapperKey(TestAsyncIterable* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestAsyncIterable&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestAsyncIterable* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestAsyncIterable>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestAsyncIterable& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestAsyncIterable>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestAsyncIterable> {
     using WrapperClass = JSTestAsyncIterable;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncIterableWithoutFlags.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncIterableWithoutFlags.h
@@ -82,10 +82,8 @@ inline void* wrapperKey(TestAsyncIterableWithoutFlags* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestAsyncIterableWithoutFlags&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestAsyncIterableWithoutFlags* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestAsyncIterableWithoutFlags>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestAsyncIterableWithoutFlags& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestAsyncIterableWithoutFlags>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestAsyncIterableWithoutFlags> {
     using WrapperClass = JSTestAsyncIterableWithoutFlags;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncKeyValueIterable.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncKeyValueIterable.h
@@ -82,10 +82,8 @@ inline void* wrapperKey(TestAsyncKeyValueIterable* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestAsyncKeyValueIterable&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestAsyncKeyValueIterable* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestAsyncKeyValueIterable>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestAsyncKeyValueIterable& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestAsyncKeyValueIterable>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestAsyncKeyValueIterable> {
     using WrapperClass = JSTestAsyncKeyValueIterable;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCEReactions.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCEReactions.h
@@ -82,10 +82,8 @@ inline void* wrapperKey(TestCEReactions* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestCEReactions&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestCEReactions* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestCEReactions>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestCEReactions& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestCEReactions>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestCEReactions> {
     using WrapperClass = JSTestCEReactions;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCEReactionsStringifier.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCEReactionsStringifier.h
@@ -82,10 +82,8 @@ inline void* wrapperKey(TestCEReactionsStringifier* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestCEReactionsStringifier&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestCEReactionsStringifier* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestCEReactionsStringifier>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestCEReactionsStringifier& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestCEReactionsStringifier>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestCEReactionsStringifier> {
     using WrapperClass = JSTestCEReactionsStringifier;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallTracer.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallTracer.h
@@ -82,10 +82,8 @@ inline void* wrapperKey(TestCallTracer* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestCallTracer&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestCallTracer* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestCallTracer>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestCallTracer& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestCallTracer>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestCallTracer> {
     using WrapperClass = JSTestCallTracer;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestClassWithJSBuiltinConstructor.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestClassWithJSBuiltinConstructor.h
@@ -82,10 +82,8 @@ inline void* wrapperKey(TestClassWithJSBuiltinConstructor* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestClassWithJSBuiltinConstructor&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestClassWithJSBuiltinConstructor* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestClassWithJSBuiltinConstructor>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestClassWithJSBuiltinConstructor& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestClassWithJSBuiltinConstructor>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestClassWithJSBuiltinConstructor> {
     using WrapperClass = JSTestClassWithJSBuiltinConstructor;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestConditional.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestConditional.h
@@ -82,10 +82,8 @@ inline void* wrapperKey(TestConditional* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestConditional&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestConditional* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestConditional>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestConditional& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestConditional>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestConditional> {
     using WrapperClass = JSTestConditional;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestConditionalIncludes.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestConditionalIncludes.h
@@ -95,10 +95,8 @@ inline void* wrapperKey(TestConditionalIncludes* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestConditionalIncludes&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestConditionalIncludes* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestConditionalIncludes>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestConditionalIncludes& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestConditionalIncludes>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestConditionalIncludes> {
     using WrapperClass = JSTestConditionalIncludes;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestConditionallyReadWrite.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestConditionallyReadWrite.h
@@ -84,10 +84,8 @@ inline void* wrapperKey(TestConditionallyReadWrite* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestConditionallyReadWrite&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestConditionallyReadWrite* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestConditionallyReadWrite>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestConditionallyReadWrite& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestConditionallyReadWrite>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestConditionallyReadWrite> {
     using WrapperClass = JSTestConditionallyReadWrite;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDOMJIT.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDOMJIT.h
@@ -72,10 +72,8 @@ protected:
 };
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestDOMJIT&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestDOMJIT* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestDOMJIT>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestDOMJIT& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestDOMJIT>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 // DOM JIT Attributes
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSON.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSON.h
@@ -82,10 +82,8 @@ inline void* wrapperKey(TestDefaultToJSON* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestDefaultToJSON&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestDefaultToJSON* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestDefaultToJSON>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestDefaultToJSON& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestDefaultToJSON>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestDefaultToJSON> {
     using WrapperClass = JSTestDefaultToJSON;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONFilteredByExposed.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONFilteredByExposed.h
@@ -82,10 +82,8 @@ inline void* wrapperKey(TestDefaultToJSONFilteredByExposed* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestDefaultToJSONFilteredByExposed&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestDefaultToJSONFilteredByExposed* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestDefaultToJSONFilteredByExposed>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestDefaultToJSONFilteredByExposed& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestDefaultToJSONFilteredByExposed>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestDefaultToJSONFilteredByExposed> {
     using WrapperClass = JSTestDefaultToJSONFilteredByExposed;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONIndirectInheritance.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONIndirectInheritance.h
@@ -71,10 +71,8 @@ protected:
 };
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestDefaultToJSONIndirectInheritance&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestDefaultToJSONIndirectInheritance* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestDefaultToJSONIndirectInheritance>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestDefaultToJSONIndirectInheritance& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestDefaultToJSONIndirectInheritance>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestDefaultToJSONIndirectInheritance> {
     using WrapperClass = JSTestDefaultToJSONIndirectInheritance;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONInherit.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONInherit.h
@@ -71,10 +71,8 @@ protected:
 };
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestDefaultToJSONInherit&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestDefaultToJSONInherit* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestDefaultToJSONInherit>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestDefaultToJSONInherit& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestDefaultToJSONInherit>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestDefaultToJSONInherit> {
     using WrapperClass = JSTestDefaultToJSONInherit;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONInheritFinal.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONInheritFinal.h
@@ -71,10 +71,8 @@ protected:
 };
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestDefaultToJSONInheritFinal&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestDefaultToJSONInheritFinal* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestDefaultToJSONInheritFinal>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestDefaultToJSONInheritFinal& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestDefaultToJSONInheritFinal>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestDefaultToJSONInheritFinal> {
     using WrapperClass = JSTestDefaultToJSONInheritFinal;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDelegateToSharedSyntheticAttribute.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDelegateToSharedSyntheticAttribute.h
@@ -82,10 +82,8 @@ inline void* wrapperKey(TestDelegateToSharedSyntheticAttribute* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestDelegateToSharedSyntheticAttribute&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestDelegateToSharedSyntheticAttribute* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestDelegateToSharedSyntheticAttribute>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestDelegateToSharedSyntheticAttribute& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestDelegateToSharedSyntheticAttribute>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestDelegateToSharedSyntheticAttribute> {
     using WrapperClass = JSTestDelegateToSharedSyntheticAttribute;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDomainSecurity.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDomainSecurity.h
@@ -84,10 +84,8 @@ inline void* wrapperKey(TestDomainSecurity* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestDomainSecurity&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestDomainSecurity* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestDomainSecurity>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestDomainSecurity& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestDomainSecurity>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestDomainSecurity> {
     using WrapperClass = JSTestDomainSecurity;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestEnabledBySetting.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestEnabledBySetting.h
@@ -84,10 +84,8 @@ inline void* wrapperKey(TestEnabledBySetting* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestEnabledBySetting&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestEnabledBySetting* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestEnabledBySetting>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestEnabledBySetting& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestEnabledBySetting>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestEnabledBySetting> {
     using WrapperClass = JSTestEnabledBySetting;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestEnabledForContext.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestEnabledForContext.h
@@ -84,10 +84,8 @@ inline void* wrapperKey(TestEnabledForContext* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestEnabledForContext&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestEnabledForContext* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestEnabledForContext>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestEnabledForContext& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestEnabledForContext>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestEnabledForContext> {
     using WrapperClass = JSTestEnabledForContext;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestEventConstructor.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestEventConstructor.h
@@ -72,10 +72,8 @@ protected:
 };
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestEventConstructor&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestEventConstructor* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestEventConstructor>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestEventConstructor& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestEventConstructor>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestEventConstructor> {
     using WrapperClass = JSTestEventConstructor;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestEventTarget.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestEventTarget.cpp
@@ -165,7 +165,7 @@ bool JSTestEventTarget::legacyPlatformObjectGetOwnProperty(JSObject* object, JSG
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     if (auto index = parseIndex(propertyName)) {
         if (auto item = thisObject->wrapped().item(index.value()); !!item) [[likely]] {
-            auto value = toJS<IDLInterface<Node>>(*lexicalGlobalObject, *thisObject->globalObject(), throwScope, WTF::move(item));
+            auto value = toJS<IDLInterface<Node>>(*lexicalGlobalObject, *thisObject->globalObject(), throwScope, IDLInterface<Node>::extractValueFromNullable(WTF::move(item)));
             RETURN_IF_EXCEPTION(throwScope, false);
             slot.setValue(thisObject, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly), value);
             return true;
@@ -201,7 +201,7 @@ bool JSTestEventTarget::getOwnPropertySlotByIndex(JSObject* object, JSGlobalObje
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     if (index <= MAX_ARRAY_INDEX) [[likely]] {
         if (auto item = thisObject->wrapped().item(index); !!item) [[likely]] {
-            auto value = toJS<IDLInterface<Node>>(*lexicalGlobalObject, *thisObject->globalObject(), throwScope, WTF::move(item));
+            auto value = toJS<IDLInterface<Node>>(*lexicalGlobalObject, *thisObject->globalObject(), throwScope, IDLInterface<Node>::extractValueFromNullable(WTF::move(item)));
             RETURN_IF_EXCEPTION(throwScope, false);
             slot.setValue(thisObject, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly), value);
             return true;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestEventTarget.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestEventTarget.h
@@ -85,10 +85,8 @@ protected:
 };
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestEventTarget&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestEventTarget* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestEventTarget>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestEventTarget& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestEventTarget>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestEventTarget> {
     using WrapperClass = JSTestEventTarget;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestException.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestException.h
@@ -83,10 +83,8 @@ inline void* wrapperKey(TestException* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestException&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestException* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestException>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestException& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestException>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestException> {
     using WrapperClass = JSTestException;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestGenerateAddOpaqueRoot.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestGenerateAddOpaqueRoot.h
@@ -84,10 +84,8 @@ inline void* wrapperKey(TestGenerateAddOpaqueRoot* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestGenerateAddOpaqueRoot&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestGenerateAddOpaqueRoot* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestGenerateAddOpaqueRoot>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestGenerateAddOpaqueRoot& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestGenerateAddOpaqueRoot>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestGenerateAddOpaqueRoot> {
     using WrapperClass = JSTestGenerateAddOpaqueRoot;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestGenerateIsReachable.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestGenerateIsReachable.h
@@ -82,10 +82,8 @@ inline void* wrapperKey(TestGenerateIsReachable* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestGenerateIsReachable&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestGenerateIsReachable* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestGenerateIsReachable>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestGenerateIsReachable& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestGenerateIsReachable>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestGenerateIsReachable> {
     using WrapperClass = JSTestGenerateIsReachable;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterNoIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterNoIdentifier.cpp
@@ -159,7 +159,7 @@ bool JSTestIndexedSetterNoIdentifier::legacyPlatformObjectGetOwnProperty(JSObjec
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     if (auto index = parseIndex(propertyName)) {
         if (auto item = thisObject->wrapped().item(index.value()); !!item) [[likely]] {
-            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, WTF::move(item));
+            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, IDLDOMString::extractValueFromNullable(WTF::move(item)));
             RETURN_IF_EXCEPTION(throwScope, false);
             slot.setValue(thisObject, 0, value);
             return true;
@@ -182,7 +182,7 @@ bool JSTestIndexedSetterNoIdentifier::getOwnPropertySlotByIndex(JSObject* object
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     if (index <= MAX_ARRAY_INDEX) [[likely]] {
         if (auto item = thisObject->wrapped().item(index); !!item) [[likely]] {
-            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, WTF::move(item));
+            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, IDLDOMString::extractValueFromNullable(WTF::move(item)));
             RETURN_IF_EXCEPTION(throwScope, false);
             slot.setValue(thisObject, 0, value);
             return true;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterNoIdentifier.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterNoIdentifier.h
@@ -93,10 +93,8 @@ inline void* wrapperKey(TestIndexedSetterNoIdentifier* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestIndexedSetterNoIdentifier&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestIndexedSetterNoIdentifier* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestIndexedSetterNoIdentifier>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestIndexedSetterNoIdentifier& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestIndexedSetterNoIdentifier>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestIndexedSetterNoIdentifier> {
     using WrapperClass = JSTestIndexedSetterNoIdentifier;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterThrowingException.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterThrowingException.cpp
@@ -159,7 +159,7 @@ bool JSTestIndexedSetterThrowingException::legacyPlatformObjectGetOwnProperty(JS
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     if (auto index = parseIndex(propertyName)) {
         if (auto item = thisObject->wrapped().item(index.value()); !!item) [[likely]] {
-            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, WTF::move(item));
+            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, IDLDOMString::extractValueFromNullable(WTF::move(item)));
             RETURN_IF_EXCEPTION(throwScope, false);
             slot.setValue(thisObject, 0, value);
             return true;
@@ -182,7 +182,7 @@ bool JSTestIndexedSetterThrowingException::getOwnPropertySlotByIndex(JSObject* o
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     if (index <= MAX_ARRAY_INDEX) [[likely]] {
         if (auto item = thisObject->wrapped().item(index); !!item) [[likely]] {
-            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, WTF::move(item));
+            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, IDLDOMString::extractValueFromNullable(WTF::move(item)));
             RETURN_IF_EXCEPTION(throwScope, false);
             slot.setValue(thisObject, 0, value);
             return true;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterThrowingException.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterThrowingException.h
@@ -93,10 +93,8 @@ inline void* wrapperKey(TestIndexedSetterThrowingException* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestIndexedSetterThrowingException&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestIndexedSetterThrowingException* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestIndexedSetterThrowingException>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestIndexedSetterThrowingException& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestIndexedSetterThrowingException>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestIndexedSetterThrowingException> {
     using WrapperClass = JSTestIndexedSetterThrowingException;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterWithIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterWithIdentifier.cpp
@@ -168,7 +168,7 @@ bool JSTestIndexedSetterWithIdentifier::legacyPlatformObjectGetOwnProperty(JSObj
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     if (auto index = parseIndex(propertyName)) {
         if (auto item = thisObject->wrapped().item(index.value()); !!item) [[likely]] {
-            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, WTF::move(item));
+            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, IDLDOMString::extractValueFromNullable(WTF::move(item)));
             RETURN_IF_EXCEPTION(throwScope, false);
             slot.setValue(thisObject, 0, value);
             return true;
@@ -191,7 +191,7 @@ bool JSTestIndexedSetterWithIdentifier::getOwnPropertySlotByIndex(JSObject* obje
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     if (index <= MAX_ARRAY_INDEX) [[likely]] {
         if (auto item = thisObject->wrapped().item(index); !!item) [[likely]] {
-            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, WTF::move(item));
+            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, IDLDOMString::extractValueFromNullable(WTF::move(item)));
             RETURN_IF_EXCEPTION(throwScope, false);
             slot.setValue(thisObject, 0, value);
             return true;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterWithIdentifier.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterWithIdentifier.h
@@ -93,10 +93,8 @@ inline void* wrapperKey(TestIndexedSetterWithIdentifier* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestIndexedSetterWithIdentifier&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestIndexedSetterWithIdentifier* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestIndexedSetterWithIdentifier>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestIndexedSetterWithIdentifier& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestIndexedSetterWithIdentifier>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestIndexedSetterWithIdentifier> {
     using WrapperClass = JSTestIndexedSetterWithIdentifier;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestInterface.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestInterface.h
@@ -110,10 +110,8 @@ inline void* wrapperKey(TestInterface* wrappableObject)
 }
 
 WEBCORE_EXPORT JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestInterface&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestInterface* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestInterface>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestInterface& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestInterface>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestInterface> {
     using WrapperClass = JSTestInterface;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestInterfaceLeadingUnderscore.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestInterfaceLeadingUnderscore.h
@@ -82,10 +82,8 @@ inline void* wrapperKey(TestInterfaceLeadingUnderscore* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestInterfaceLeadingUnderscore&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestInterfaceLeadingUnderscore* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestInterfaceLeadingUnderscore>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestInterfaceLeadingUnderscore& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestInterfaceLeadingUnderscore>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestInterfaceLeadingUnderscore> {
     using WrapperClass = JSTestInterfaceLeadingUnderscore;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestIterable.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestIterable.h
@@ -82,10 +82,8 @@ inline void* wrapperKey(TestIterable* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestIterable&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestIterable* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestIterable>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestIterable& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestIterable>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestIterable> {
     using WrapperClass = JSTestIterable;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyFactoryFunction.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyFactoryFunction.h
@@ -83,10 +83,8 @@ inline void* wrapperKey(TestLegacyFactoryFunction* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestLegacyFactoryFunction&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestLegacyFactoryFunction* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestLegacyFactoryFunction>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestLegacyFactoryFunction& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestLegacyFactoryFunction>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestLegacyFactoryFunction> {
     using WrapperClass = JSTestLegacyFactoryFunction;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyNoInterfaceObject.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyNoInterfaceObject.h
@@ -90,10 +90,8 @@ inline void* wrapperKey(TestLegacyNoInterfaceObject* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestLegacyNoInterfaceObject&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestLegacyNoInterfaceObject* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestLegacyNoInterfaceObject>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestLegacyNoInterfaceObject& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestLegacyNoInterfaceObject>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestLegacyNoInterfaceObject> {
     using WrapperClass = JSTestLegacyNoInterfaceObject;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyOverrideBuiltIns.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyOverrideBuiltIns.h
@@ -93,10 +93,8 @@ inline void* wrapperKey(TestLegacyOverrideBuiltIns* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestLegacyOverrideBuiltIns&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestLegacyOverrideBuiltIns* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestLegacyOverrideBuiltIns>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestLegacyOverrideBuiltIns& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestLegacyOverrideBuiltIns>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestLegacyOverrideBuiltIns> {
     using WrapperClass = JSTestLegacyOverrideBuiltIns;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestMapLike.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestMapLike.h
@@ -82,10 +82,8 @@ inline void* wrapperKey(TestMapLike* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestMapLike&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestMapLike* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestMapLike>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestMapLike& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestMapLike>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestMapLike> {
     using WrapperClass = JSTestMapLike;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestMapLikeWithOverriddenOperations.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestMapLikeWithOverriddenOperations.h
@@ -82,10 +82,8 @@ inline void* wrapperKey(TestMapLikeWithOverriddenOperations* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestMapLikeWithOverriddenOperations&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestMapLikeWithOverriddenOperations* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestMapLikeWithOverriddenOperations>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestMapLikeWithOverriddenOperations& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestMapLikeWithOverriddenOperations>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestMapLikeWithOverriddenOperations> {
     using WrapperClass = JSTestMapLikeWithOverriddenOperations;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterNoIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterNoIdentifier.cpp
@@ -159,7 +159,7 @@ bool JSTestNamedAndIndexedSetterNoIdentifier::legacyPlatformObjectGetOwnProperty
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     if (auto index = parseIndex(propertyName)) {
         if (auto item = thisObject->wrapped().item(index.value()); !!item) [[likely]] {
-            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, WTF::move(item));
+            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, IDLDOMString::extractValueFromNullable(WTF::move(item)));
             RETURN_IF_EXCEPTION(throwScope, false);
             slot.setValue(thisObject, 0, value);
             return true;
@@ -195,7 +195,7 @@ bool JSTestNamedAndIndexedSetterNoIdentifier::getOwnPropertySlotByIndex(JSObject
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     if (index <= MAX_ARRAY_INDEX) [[likely]] {
         if (auto item = thisObject->wrapped().item(index); !!item) [[likely]] {
-            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, WTF::move(item));
+            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, IDLDOMString::extractValueFromNullable(WTF::move(item)));
             RETURN_IF_EXCEPTION(throwScope, false);
             slot.setValue(thisObject, 0, value);
             return true;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterNoIdentifier.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterNoIdentifier.h
@@ -93,10 +93,8 @@ inline void* wrapperKey(TestNamedAndIndexedSetterNoIdentifier* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestNamedAndIndexedSetterNoIdentifier&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestNamedAndIndexedSetterNoIdentifier* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestNamedAndIndexedSetterNoIdentifier>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestNamedAndIndexedSetterNoIdentifier& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestNamedAndIndexedSetterNoIdentifier>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestNamedAndIndexedSetterNoIdentifier> {
     using WrapperClass = JSTestNamedAndIndexedSetterNoIdentifier;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterThrowingException.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterThrowingException.cpp
@@ -159,7 +159,7 @@ bool JSTestNamedAndIndexedSetterThrowingException::legacyPlatformObjectGetOwnPro
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     if (auto index = parseIndex(propertyName)) {
         if (auto item = thisObject->wrapped().item(index.value()); !!item) [[likely]] {
-            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, WTF::move(item));
+            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, IDLDOMString::extractValueFromNullable(WTF::move(item)));
             RETURN_IF_EXCEPTION(throwScope, false);
             slot.setValue(thisObject, 0, value);
             return true;
@@ -195,7 +195,7 @@ bool JSTestNamedAndIndexedSetterThrowingException::getOwnPropertySlotByIndex(JSO
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     if (index <= MAX_ARRAY_INDEX) [[likely]] {
         if (auto item = thisObject->wrapped().item(index); !!item) [[likely]] {
-            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, WTF::move(item));
+            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, IDLDOMString::extractValueFromNullable(WTF::move(item)));
             RETURN_IF_EXCEPTION(throwScope, false);
             slot.setValue(thisObject, 0, value);
             return true;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterThrowingException.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterThrowingException.h
@@ -93,10 +93,8 @@ inline void* wrapperKey(TestNamedAndIndexedSetterThrowingException* wrappableObj
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestNamedAndIndexedSetterThrowingException&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestNamedAndIndexedSetterThrowingException* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestNamedAndIndexedSetterThrowingException>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestNamedAndIndexedSetterThrowingException& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestNamedAndIndexedSetterThrowingException>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestNamedAndIndexedSetterThrowingException> {
     using WrapperClass = JSTestNamedAndIndexedSetterThrowingException;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterWithIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterWithIdentifier.cpp
@@ -170,7 +170,7 @@ bool JSTestNamedAndIndexedSetterWithIdentifier::legacyPlatformObjectGetOwnProper
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     if (auto index = parseIndex(propertyName)) {
         if (auto item = thisObject->wrapped().item(index.value()); !!item) [[likely]] {
-            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, WTF::move(item));
+            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, IDLDOMString::extractValueFromNullable(WTF::move(item)));
             RETURN_IF_EXCEPTION(throwScope, false);
             slot.setValue(thisObject, 0, value);
             return true;
@@ -206,7 +206,7 @@ bool JSTestNamedAndIndexedSetterWithIdentifier::getOwnPropertySlotByIndex(JSObje
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     if (index <= MAX_ARRAY_INDEX) [[likely]] {
         if (auto item = thisObject->wrapped().item(index); !!item) [[likely]] {
-            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, WTF::move(item));
+            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, IDLDOMString::extractValueFromNullable(WTF::move(item)));
             RETURN_IF_EXCEPTION(throwScope, false);
             slot.setValue(thisObject, 0, value);
             return true;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterWithIdentifier.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterWithIdentifier.h
@@ -93,10 +93,8 @@ inline void* wrapperKey(TestNamedAndIndexedSetterWithIdentifier* wrappableObject
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestNamedAndIndexedSetterWithIdentifier&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestNamedAndIndexedSetterWithIdentifier* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestNamedAndIndexedSetterWithIdentifier>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestNamedAndIndexedSetterWithIdentifier& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestNamedAndIndexedSetterWithIdentifier>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestNamedAndIndexedSetterWithIdentifier> {
     using WrapperClass = JSTestNamedAndIndexedSetterWithIdentifier;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterNoIdentifier.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterNoIdentifier.h
@@ -93,10 +93,8 @@ inline void* wrapperKey(TestNamedDeleterNoIdentifier* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestNamedDeleterNoIdentifier&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestNamedDeleterNoIdentifier* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestNamedDeleterNoIdentifier>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestNamedDeleterNoIdentifier& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestNamedDeleterNoIdentifier>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestNamedDeleterNoIdentifier> {
     using WrapperClass = JSTestNamedDeleterNoIdentifier;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterThrowingException.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterThrowingException.h
@@ -93,10 +93,8 @@ inline void* wrapperKey(TestNamedDeleterThrowingException* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestNamedDeleterThrowingException&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestNamedDeleterThrowingException* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestNamedDeleterThrowingException>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestNamedDeleterThrowingException& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestNamedDeleterThrowingException>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestNamedDeleterThrowingException> {
     using WrapperClass = JSTestNamedDeleterThrowingException;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterWithIdentifier.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterWithIdentifier.h
@@ -93,10 +93,8 @@ inline void* wrapperKey(TestNamedDeleterWithIdentifier* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestNamedDeleterWithIdentifier&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestNamedDeleterWithIdentifier* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestNamedDeleterWithIdentifier>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestNamedDeleterWithIdentifier& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestNamedDeleterWithIdentifier>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestNamedDeleterWithIdentifier> {
     using WrapperClass = JSTestNamedDeleterWithIdentifier;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterWithIndexedGetter.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterWithIndexedGetter.cpp
@@ -159,7 +159,7 @@ bool JSTestNamedDeleterWithIndexedGetter::legacyPlatformObjectGetOwnProperty(JSO
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     if (auto index = parseIndex(propertyName)) {
         if (auto item = thisObject->wrapped().item(index.value()); !!item) [[likely]] {
-            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, WTF::move(item));
+            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, IDLDOMString::extractValueFromNullable(WTF::move(item)));
             RETURN_IF_EXCEPTION(throwScope, false);
             slot.setValue(thisObject, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly), value);
             return true;
@@ -195,7 +195,7 @@ bool JSTestNamedDeleterWithIndexedGetter::getOwnPropertySlotByIndex(JSObject* ob
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     if (index <= MAX_ARRAY_INDEX) [[likely]] {
         if (auto item = thisObject->wrapped().item(index); !!item) [[likely]] {
-            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, WTF::move(item));
+            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, IDLDOMString::extractValueFromNullable(WTF::move(item)));
             RETURN_IF_EXCEPTION(throwScope, false);
             slot.setValue(thisObject, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly), value);
             return true;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterWithIndexedGetter.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterWithIndexedGetter.h
@@ -93,10 +93,8 @@ inline void* wrapperKey(TestNamedDeleterWithIndexedGetter* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestNamedDeleterWithIndexedGetter&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestNamedDeleterWithIndexedGetter* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestNamedDeleterWithIndexedGetter>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestNamedDeleterWithIndexedGetter& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestNamedDeleterWithIndexedGetter>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestNamedDeleterWithIndexedGetter> {
     using WrapperClass = JSTestNamedDeleterWithIndexedGetter;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterCallWith.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterCallWith.h
@@ -93,10 +93,8 @@ inline void* wrapperKey(TestNamedGetterCallWith* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestNamedGetterCallWith&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestNamedGetterCallWith* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestNamedGetterCallWith>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestNamedGetterCallWith& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestNamedGetterCallWith>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestNamedGetterCallWith> {
     using WrapperClass = JSTestNamedGetterCallWith;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterNoIdentifier.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterNoIdentifier.h
@@ -93,10 +93,8 @@ inline void* wrapperKey(TestNamedGetterNoIdentifier* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestNamedGetterNoIdentifier&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestNamedGetterNoIdentifier* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestNamedGetterNoIdentifier>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestNamedGetterNoIdentifier& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestNamedGetterNoIdentifier>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestNamedGetterNoIdentifier> {
     using WrapperClass = JSTestNamedGetterNoIdentifier;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterWithIdentifier.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterWithIdentifier.h
@@ -93,10 +93,8 @@ inline void* wrapperKey(TestNamedGetterWithIdentifier* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestNamedGetterWithIdentifier&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestNamedGetterWithIdentifier* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestNamedGetterWithIdentifier>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestNamedGetterWithIdentifier& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestNamedGetterWithIdentifier>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestNamedGetterWithIdentifier> {
     using WrapperClass = JSTestNamedGetterWithIdentifier;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterNoIdentifier.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterNoIdentifier.h
@@ -93,10 +93,8 @@ inline void* wrapperKey(TestNamedSetterNoIdentifier* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestNamedSetterNoIdentifier&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestNamedSetterNoIdentifier* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestNamedSetterNoIdentifier>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestNamedSetterNoIdentifier& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestNamedSetterNoIdentifier>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestNamedSetterNoIdentifier> {
     using WrapperClass = JSTestNamedSetterNoIdentifier;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterThrowingException.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterThrowingException.h
@@ -93,10 +93,8 @@ inline void* wrapperKey(TestNamedSetterThrowingException* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestNamedSetterThrowingException&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestNamedSetterThrowingException* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestNamedSetterThrowingException>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestNamedSetterThrowingException& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestNamedSetterThrowingException>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestNamedSetterThrowingException> {
     using WrapperClass = JSTestNamedSetterThrowingException;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIdentifier.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIdentifier.h
@@ -93,10 +93,8 @@ inline void* wrapperKey(TestNamedSetterWithIdentifier* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestNamedSetterWithIdentifier&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestNamedSetterWithIdentifier* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestNamedSetterWithIdentifier>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestNamedSetterWithIdentifier& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestNamedSetterWithIdentifier>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestNamedSetterWithIdentifier> {
     using WrapperClass = JSTestNamedSetterWithIdentifier;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIndexedGetter.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIndexedGetter.cpp
@@ -170,7 +170,7 @@ bool JSTestNamedSetterWithIndexedGetter::legacyPlatformObjectGetOwnProperty(JSOb
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     if (auto index = parseIndex(propertyName)) {
         if (auto item = thisObject->wrapped().indexedSetter(index.value()); !!item) [[likely]] {
-            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, WTF::move(item));
+            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, IDLDOMString::extractValueFromNullable(WTF::move(item)));
             RETURN_IF_EXCEPTION(throwScope, false);
             slot.setValue(thisObject, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly), value);
             return true;
@@ -206,7 +206,7 @@ bool JSTestNamedSetterWithIndexedGetter::getOwnPropertySlotByIndex(JSObject* obj
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     if (index <= MAX_ARRAY_INDEX) [[likely]] {
         if (auto item = thisObject->wrapped().indexedSetter(index); !!item) [[likely]] {
-            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, WTF::move(item));
+            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, IDLDOMString::extractValueFromNullable(WTF::move(item)));
             RETURN_IF_EXCEPTION(throwScope, false);
             slot.setValue(thisObject, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly), value);
             return true;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIndexedGetter.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIndexedGetter.h
@@ -93,10 +93,8 @@ inline void* wrapperKey(TestNamedSetterWithIndexedGetter* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestNamedSetterWithIndexedGetter&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestNamedSetterWithIndexedGetter* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestNamedSetterWithIndexedGetter>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestNamedSetterWithIndexedGetter& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestNamedSetterWithIndexedGetter>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestNamedSetterWithIndexedGetter> {
     using WrapperClass = JSTestNamedSetterWithIndexedGetter;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIndexedGetterAndSetter.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIndexedGetterAndSetter.cpp
@@ -170,7 +170,7 @@ bool JSTestNamedSetterWithIndexedGetterAndSetter::legacyPlatformObjectGetOwnProp
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     if (auto index = parseIndex(propertyName)) {
         if (auto item = thisObject->wrapped().indexedSetter(index.value()); !!item) [[likely]] {
-            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, WTF::move(item));
+            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, IDLDOMString::extractValueFromNullable(WTF::move(item)));
             RETURN_IF_EXCEPTION(throwScope, false);
             slot.setValue(thisObject, 0, value);
             return true;
@@ -206,7 +206,7 @@ bool JSTestNamedSetterWithIndexedGetterAndSetter::getOwnPropertySlotByIndex(JSOb
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     if (index <= MAX_ARRAY_INDEX) [[likely]] {
         if (auto item = thisObject->wrapped().indexedSetter(index); !!item) [[likely]] {
-            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, WTF::move(item));
+            auto value = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, IDLDOMString::extractValueFromNullable(WTF::move(item)));
             RETURN_IF_EXCEPTION(throwScope, false);
             slot.setValue(thisObject, 0, value);
             return true;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIndexedGetterAndSetter.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIndexedGetterAndSetter.h
@@ -93,10 +93,8 @@ inline void* wrapperKey(TestNamedSetterWithIndexedGetterAndSetter* wrappableObje
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestNamedSetterWithIndexedGetterAndSetter&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestNamedSetterWithIndexedGetterAndSetter* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestNamedSetterWithIndexedGetterAndSetter>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestNamedSetterWithIndexedGetterAndSetter& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestNamedSetterWithIndexedGetterAndSetter>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestNamedSetterWithIndexedGetterAndSetter> {
     using WrapperClass = JSTestNamedSetterWithIndexedGetterAndSetter;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyOverrideBuiltIns.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyOverrideBuiltIns.h
@@ -93,10 +93,8 @@ inline void* wrapperKey(TestNamedSetterWithLegacyOverrideBuiltIns* wrappableObje
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestNamedSetterWithLegacyOverrideBuiltIns&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestNamedSetterWithLegacyOverrideBuiltIns* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestNamedSetterWithLegacyOverrideBuiltIns>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestNamedSetterWithLegacyOverrideBuiltIns& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestNamedSetterWithLegacyOverrideBuiltIns>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestNamedSetterWithLegacyOverrideBuiltIns> {
     using WrapperClass = JSTestNamedSetterWithLegacyOverrideBuiltIns;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyUnforgeableProperties.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyUnforgeableProperties.h
@@ -93,10 +93,8 @@ inline void* wrapperKey(TestNamedSetterWithLegacyUnforgeableProperties* wrappabl
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestNamedSetterWithLegacyUnforgeableProperties&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestNamedSetterWithLegacyUnforgeableProperties* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestNamedSetterWithLegacyUnforgeableProperties>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestNamedSetterWithLegacyUnforgeableProperties& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestNamedSetterWithLegacyUnforgeableProperties>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestNamedSetterWithLegacyUnforgeableProperties> {
     using WrapperClass = JSTestNamedSetterWithLegacyUnforgeableProperties;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns.h
@@ -93,10 +93,8 @@ inline void* wrapperKey(TestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyO
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns> {
     using WrapperClass = JSTestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNode.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNode.h
@@ -71,10 +71,8 @@ protected:
 };
 
 WEBCORE_EXPORT JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestNode&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestNode* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestNode>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestNode& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestNode>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestNode> {
     using WrapperClass = JSTestNode;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
@@ -3152,7 +3152,7 @@ bool JSTestObj::legacyPlatformObjectGetOwnProperty(JSObject* object, JSGlobalObj
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     if (auto index = parseIndex(propertyName)) {
         if (auto item = thisObject->wrapped().nullableStringSpecialMethod(index.value()); !!item) [[likely]] {
-            auto value = toJS<IDLNullable<IDLDOMString>>(*lexicalGlobalObject, throwScope, WTF::move(item));
+            auto value = toJS<IDLNullable<IDLDOMString>>(*lexicalGlobalObject, throwScope, IDLNullable<IDLDOMString>::extractValueFromNullable(WTF::move(item)));
             RETURN_IF_EXCEPTION(throwScope, false);
             slot.setValue(thisObject, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly), value);
             return true;
@@ -3175,7 +3175,7 @@ bool JSTestObj::getOwnPropertySlotByIndex(JSObject* object, JSGlobalObject* lexi
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     if (index <= MAX_ARRAY_INDEX) [[likely]] {
         if (auto item = thisObject->wrapped().nullableStringSpecialMethod(index); !!item) [[likely]] {
-            auto value = toJS<IDLNullable<IDLDOMString>>(*lexicalGlobalObject, throwScope, WTF::move(item));
+            auto value = toJS<IDLNullable<IDLDOMString>>(*lexicalGlobalObject, throwScope, IDLNullable<IDLDOMString>::extractValueFromNullable(WTF::move(item)));
             RETURN_IF_EXCEPTION(throwScope, false);
             slot.setValue(thisObject, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly), value);
             return true;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestObj.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestObj.h
@@ -114,10 +114,8 @@ inline void* wrapperKey(TestObj* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestObj&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestObj* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestObj>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestObj& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestObj>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestObj> {
     using WrapperClass = JSTestObj;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestOperationConditional.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestOperationConditional.h
@@ -84,10 +84,8 @@ inline void* wrapperKey(TestOperationConditional* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestOperationConditional&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestOperationConditional* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestOperationConditional>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestOperationConditional& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestOperationConditional>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestOperationConditional> {
     using WrapperClass = JSTestOperationConditional;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestOverloadedConstructors.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestOverloadedConstructors.h
@@ -82,10 +82,8 @@ inline void* wrapperKey(TestOverloadedConstructors* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestOverloadedConstructors&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestOverloadedConstructors* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestOverloadedConstructors>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestOverloadedConstructors& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestOverloadedConstructors>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestOverloadedConstructors> {
     using WrapperClass = JSTestOverloadedConstructors;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestOverloadedConstructorsWithSequence.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestOverloadedConstructorsWithSequence.h
@@ -82,10 +82,8 @@ inline void* wrapperKey(TestOverloadedConstructorsWithSequence* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestOverloadedConstructorsWithSequence&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestOverloadedConstructorsWithSequence* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestOverloadedConstructorsWithSequence>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestOverloadedConstructorsWithSequence& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestOverloadedConstructorsWithSequence>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestOverloadedConstructorsWithSequence> {
     using WrapperClass = JSTestOverloadedConstructorsWithSequence;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestPluginInterface.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestPluginInterface.h
@@ -94,10 +94,8 @@ inline void* wrapperKey(TestPluginInterface* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestPluginInterface&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestPluginInterface* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestPluginInterface>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestPluginInterface& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestPluginInterface>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestPluginInterface> {
     using WrapperClass = JSTestPluginInterface;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestPromiseRejectionEvent.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestPromiseRejectionEvent.h
@@ -72,10 +72,8 @@ protected:
 };
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestPromiseRejectionEvent&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestPromiseRejectionEvent* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestPromiseRejectionEvent>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestPromiseRejectionEvent& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestPromiseRejectionEvent>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestPromiseRejectionEvent> {
     using WrapperClass = JSTestPromiseRejectionEvent;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestReadOnlyMapLike.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestReadOnlyMapLike.h
@@ -82,10 +82,8 @@ inline void* wrapperKey(TestReadOnlyMapLike* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestReadOnlyMapLike&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestReadOnlyMapLike* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestReadOnlyMapLike>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestReadOnlyMapLike& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestReadOnlyMapLike>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestReadOnlyMapLike> {
     using WrapperClass = JSTestReadOnlyMapLike;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestReadOnlySetLike.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestReadOnlySetLike.h
@@ -82,10 +82,8 @@ inline void* wrapperKey(TestReadOnlySetLike* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestReadOnlySetLike&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestReadOnlySetLike* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestReadOnlySetLike>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestReadOnlySetLike& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestReadOnlySetLike>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestReadOnlySetLike> {
     using WrapperClass = JSTestReadOnlySetLike;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestReportExtraMemoryCost.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestReportExtraMemoryCost.h
@@ -85,10 +85,8 @@ inline void* wrapperKey(TestReportExtraMemoryCost* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestReportExtraMemoryCost&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestReportExtraMemoryCost* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestReportExtraMemoryCost>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestReportExtraMemoryCost& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestReportExtraMemoryCost>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestReportExtraMemoryCost> {
     using WrapperClass = JSTestReportExtraMemoryCost;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestScheduledAction.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestScheduledAction.h
@@ -82,10 +82,8 @@ inline void* wrapperKey(TestScheduledAction* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestScheduledAction&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestScheduledAction* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestScheduledAction>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestScheduledAction& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestScheduledAction>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestScheduledAction> {
     using WrapperClass = JSTestScheduledAction;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestSerializedScriptValueInterface.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestSerializedScriptValueInterface.h
@@ -88,10 +88,8 @@ inline void* wrapperKey(TestSerializedScriptValueInterface* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestSerializedScriptValueInterface&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestSerializedScriptValueInterface* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestSerializedScriptValueInterface>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestSerializedScriptValueInterface& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestSerializedScriptValueInterface>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestSerializedScriptValueInterface> {
     using WrapperClass = JSTestSerializedScriptValueInterface;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestSetLike.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestSetLike.h
@@ -82,10 +82,8 @@ inline void* wrapperKey(TestSetLike* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestSetLike&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestSetLike* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestSetLike>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestSetLike& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestSetLike>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestSetLike> {
     using WrapperClass = JSTestSetLike;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestSetLikeWithOverriddenOperations.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestSetLikeWithOverriddenOperations.h
@@ -82,10 +82,8 @@ inline void* wrapperKey(TestSetLikeWithOverriddenOperations* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestSetLikeWithOverriddenOperations&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestSetLikeWithOverriddenOperations* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestSetLikeWithOverriddenOperations>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestSetLikeWithOverriddenOperations& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestSetLikeWithOverriddenOperations>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestSetLikeWithOverriddenOperations> {
     using WrapperClass = JSTestSetLikeWithOverriddenOperations;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifier.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifier.h
@@ -82,10 +82,8 @@ inline void* wrapperKey(TestStringifier* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestStringifier&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestStringifier* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestStringifier>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestStringifier& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestStringifier>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestStringifier> {
     using WrapperClass = JSTestStringifier;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierAnonymousOperation.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierAnonymousOperation.h
@@ -82,10 +82,8 @@ inline void* wrapperKey(TestStringifierAnonymousOperation* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestStringifierAnonymousOperation&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestStringifierAnonymousOperation* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestStringifierAnonymousOperation>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestStringifierAnonymousOperation& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestStringifierAnonymousOperation>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestStringifierAnonymousOperation> {
     using WrapperClass = JSTestStringifierAnonymousOperation;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierNamedOperation.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierNamedOperation.h
@@ -82,10 +82,8 @@ inline void* wrapperKey(TestStringifierNamedOperation* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestStringifierNamedOperation&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestStringifierNamedOperation* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestStringifierNamedOperation>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestStringifierNamedOperation& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestStringifierNamedOperation>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestStringifierNamedOperation> {
     using WrapperClass = JSTestStringifierNamedOperation;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierOperationImplementedAs.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierOperationImplementedAs.h
@@ -82,10 +82,8 @@ inline void* wrapperKey(TestStringifierOperationImplementedAs* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestStringifierOperationImplementedAs&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestStringifierOperationImplementedAs* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestStringifierOperationImplementedAs>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestStringifierOperationImplementedAs& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestStringifierOperationImplementedAs>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestStringifierOperationImplementedAs> {
     using WrapperClass = JSTestStringifierOperationImplementedAs;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierOperationNamedToString.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierOperationNamedToString.h
@@ -82,10 +82,8 @@ inline void* wrapperKey(TestStringifierOperationNamedToString* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestStringifierOperationNamedToString&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestStringifierOperationNamedToString* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestStringifierOperationNamedToString>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestStringifierOperationNamedToString& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestStringifierOperationNamedToString>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestStringifierOperationNamedToString> {
     using WrapperClass = JSTestStringifierOperationNamedToString;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierReadOnlyAttribute.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierReadOnlyAttribute.h
@@ -82,10 +82,8 @@ inline void* wrapperKey(TestStringifierReadOnlyAttribute* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestStringifierReadOnlyAttribute&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestStringifierReadOnlyAttribute* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestStringifierReadOnlyAttribute>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestStringifierReadOnlyAttribute& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestStringifierReadOnlyAttribute>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestStringifierReadOnlyAttribute> {
     using WrapperClass = JSTestStringifierReadOnlyAttribute;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierReadWriteAttribute.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierReadWriteAttribute.h
@@ -82,10 +82,8 @@ inline void* wrapperKey(TestStringifierReadWriteAttribute* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestStringifierReadWriteAttribute&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestStringifierReadWriteAttribute* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestStringifierReadWriteAttribute>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestStringifierReadWriteAttribute& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestStringifierReadWriteAttribute>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestStringifierReadWriteAttribute> {
     using WrapperClass = JSTestStringifierReadWriteAttribute;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestTaggedWrapper.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestTaggedWrapper.h
@@ -83,10 +83,8 @@ inline void* wrapperKey(TestTaggedWrapper* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestTaggedWrapper&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestTaggedWrapper* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestTaggedWrapper>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestTaggedWrapper& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestTaggedWrapper>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestTaggedWrapper> {
     using WrapperClass = JSTestTaggedWrapper;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestTypedefs.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestTypedefs.h
@@ -84,10 +84,8 @@ inline void* wrapperKey(TestTypedefs* wrappableObject)
 }
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TestTypedefs&);
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestTypedefs* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TestTypedefs>&&);
 ALWAYS_INLINE JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TestTypedefs& impl) { return toJSNewlyCreated(lexicalGlobalObject, globalObject, Ref { impl }); }
-inline JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, RefPtr<TestTypedefs>&& impl) { return impl ? toJSNewlyCreated(lexicalGlobalObject, globalObject, impl.releaseNonNull()) : JSC::jsNull(); }
 
 template<> struct JSDOMWrapperConverterTraits<TestTypedefs> {
     using WrapperClass = JSTestTypedefs;

--- a/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
+++ b/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
@@ -170,7 +170,7 @@ CSSRule* CSSComputedStyleDeclaration::parentRule() const
     return nullptr;
 }
 
-CSSRule* CSSComputedStyleDeclaration::cssRules() const
+CSSRuleList* CSSComputedStyleDeclaration::cssRules() const
 {
     return nullptr;
 }

--- a/Source/WebCore/css/CSSComputedStyleDeclaration.h
+++ b/Source/WebCore/css/CSSComputedStyleDeclaration.h
@@ -57,7 +57,7 @@ private:
 
     // CSSOM functions. Don't make these public.
     CSSRule* parentRule() const final;
-    CSSRule* cssRules() const final;
+    CSSRuleList* cssRules() const final;
     unsigned length() const final;
     String item(unsigned index) const final;
     RefPtr<DeprecatedCSSOMValue> getPropertyCSSValue(const String& propertyName) final;

--- a/Source/WebCore/css/CSSMediaRule.cpp
+++ b/Source/WebCore/css/CSSMediaRule.cpp
@@ -75,11 +75,11 @@ String CSSMediaRule::conditionText() const
     return builder.toString();
 }
 
-MediaList* CSSMediaRule::media() const
+MediaList& CSSMediaRule::media() const
 {
     if (!m_mediaCSSOMWrapper)
         m_mediaCSSOMWrapper = MediaList::create(const_cast<CSSMediaRule*>(this));
-    return m_mediaCSSOMWrapper.get();
+    return *m_mediaCSSOMWrapper;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSMediaRule.h
+++ b/Source/WebCore/css/CSSMediaRule.h
@@ -39,7 +39,7 @@ public:
     static Ref<CSSMediaRule> create(StyleRuleMedia& rule, CSSStyleSheet* sheet) { return adoptRef(*new CSSMediaRule(rule, sheet)); }
     virtual ~CSSMediaRule();
 
-    WEBCORE_EXPORT MediaList* media() const;
+    WEBCORE_EXPORT MediaList& media() const;
 
 private:
     friend class MediaList;

--- a/Source/WebCore/css/CSSRuleList.idl
+++ b/Source/WebCore/css/CSSRuleList.idl
@@ -31,7 +31,6 @@
     SkipVTableValidation,
     Exposed=Window
 ] interface CSSRuleList {
-    // FIXME: `getter` below should be nullable.
-    getter CSSRule item(unsigned long index);
+    getter CSSRule? item(unsigned long index);
     readonly attribute unsigned long length;
 };

--- a/Source/WebCore/css/CSSStyleDeclaration.h
+++ b/Source/WebCore/css/CSSStyleDeclaration.h
@@ -29,6 +29,7 @@
 namespace WebCore {
 
 class CSSRule;
+class CSSRuleList;
 class CSSStyleSheet;
 class CSSValue;
 class DeprecatedCSSOMValue;
@@ -56,7 +57,7 @@ public:
 
     virtual StyledElement* parentElement() const { return nullptr; }
     virtual CSSRule* parentRule() const = 0;
-    virtual CSSRule* cssRules() const = 0;
+    virtual CSSRuleList* cssRules() const = 0;
     virtual String cssText() const = 0;
     virtual ExceptionOr<void> setCssText(const String&) = 0;
     virtual unsigned length() const = 0;

--- a/Source/WebCore/css/CSSStyleDeclaration.idl
+++ b/Source/WebCore/css/CSSStyleDeclaration.idl
@@ -31,7 +31,8 @@ typedef USVString CSSOMString;
     Exposed=Window,
 ] interface CSSStyleDeclaration {
     [CEReactions=Needed] attribute CSSOMString cssText;
-    readonly attribute CSSRuleList cssRules;
+    // FIXME: This is non-standard and always returns null. It should be removed.
+    readonly attribute CSSRuleList? cssRules;
     readonly attribute unsigned long length;
     getter CSSOMString item(unsigned long index);
     CSSOMString getPropertyValue(CSSOMString property);

--- a/Source/WebCore/css/CSSStyleProperties.h
+++ b/Source/WebCore/css/CSSStyleProperties.h
@@ -101,7 +101,7 @@ protected:
 private:
     CSSRule* parentRule() const override { return nullptr; }
     // FIXME: To implement.
-    CSSRule* cssRules() const override { return nullptr; }
+    CSSRuleList* cssRules() const override { return nullptr; }
     unsigned length() const final;
     String item(unsigned index) const final;
     RefPtr<DeprecatedCSSOMValue> getPropertyCSSValue(const String& propertyName) final;

--- a/Source/WebCore/css/CSSStyleSheet.idl
+++ b/Source/WebCore/css/CSSStyleSheet.idl
@@ -26,20 +26,20 @@
 ] interface CSSStyleSheet : StyleSheet {
     [CallWith=CurrentDocument] constructor(optional CSSStyleSheetInit options = {});
 
-    // FIXME: `ownerRule` should be nullable.
-    readonly attribute CSSRule ownerRule;
+    readonly attribute CSSRule? ownerRule;
     // FIXME: Add [SameObject] below after https://webkit.org/b/163414
     [ImplementedAs=cssRulesForBindings] readonly attribute CSSRuleList cssRules;
     unsigned long insertRule(DOMString rule, optional unsigned long index = 0);
     undefined deleteRule(unsigned long index);
 
-    // Non-standard.
+    Promise<CSSStyleSheet> replace(USVString text);
+    undefined replaceSync(USVString text);
+
+    // https://drafts.csswg.org/cssom/#legacy-css-style-sheet-members.
+    // FIXME: Move these to their own IDL file CSSStyleSheet+Deprecated.idl.
     readonly attribute CSSRuleList rules;
     long addRule(optional DOMString selector = "undefined", optional DOMString style = "undefined", optional unsigned long index);
     undefined removeRule(optional unsigned long index = 0);
-
-    Promise<CSSStyleSheet> replace(USVString text);
-    undefined replaceSync(USVString text);
 };
 
 dictionary CSSStyleSheetInit {

--- a/Source/WebCore/css/DeprecatedCSSOMRect.h
+++ b/Source/WebCore/css/DeprecatedCSSOMRect.h
@@ -37,10 +37,10 @@ public:
         return adoptRef(*new DeprecatedCSSOMRect(rect, owner));
     }
 
-    DeprecatedCSSOMPrimitiveValue* top() const { return m_top.ptr(); }
-    DeprecatedCSSOMPrimitiveValue* right() const { return m_right.ptr(); }
-    DeprecatedCSSOMPrimitiveValue* bottom() const { return m_bottom.ptr(); }
-    DeprecatedCSSOMPrimitiveValue* left() const { return m_left.ptr(); }
+    DeprecatedCSSOMPrimitiveValue& top() const { return m_top; }
+    DeprecatedCSSOMPrimitiveValue& right() const { return m_right; }
+    DeprecatedCSSOMPrimitiveValue& bottom() const { return m_bottom; }
+    DeprecatedCSSOMPrimitiveValue& left() const { return m_left; }
 
 private:
     DeprecatedCSSOMRect(const Rect& rect, CSSStyleDeclaration& owner)

--- a/Source/WebCore/css/DeprecatedCSSOMValueList.idl
+++ b/Source/WebCore/css/DeprecatedCSSOMValueList.idl
@@ -29,6 +29,6 @@
     Exposed=Window
 ] interface DeprecatedCSSOMValueList : DeprecatedCSSOMValue {
     readonly attribute unsigned long length;
-    getter DeprecatedCSSOMValue item(unsigned long index);
+    getter DeprecatedCSSOMValue? item(unsigned long index);
 };
 

--- a/Source/WebCore/css/PropertySetCSSDescriptors.h
+++ b/Source/WebCore/css/PropertySetCSSDescriptors.h
@@ -56,7 +56,7 @@ protected:
     CSSStyleSheet* parentStyleSheet() const final;
     CSSRule* parentRule() const final;
     // FIXME: To implement.
-    CSSRule* cssRules() const override { return nullptr; }
+    CSSRuleList* cssRules() const override { return nullptr; }
     unsigned length() const final;
     String item(unsigned index) const final;
     RefPtr<DeprecatedCSSOMValue> getPropertyCSSValue(const String& propertyName) final;

--- a/Source/WebCore/css/StyleSheet.idl
+++ b/Source/WebCore/css/StyleSheet.idl
@@ -30,11 +30,12 @@
     // FIXME: `type` should not be nullable.
     readonly attribute DOMString? type;
     readonly attribute USVString? href;
-    // FIXME: Update 'ownerNode' to have (Element or ProcessingInstruction)? as per web specification.
-    readonly attribute Node ownerNode;
-    // FIXME: `parentStyleSheet` should be nullable.
-    readonly attribute StyleSheet parentStyleSheet;
+    // FIXME: `ownerNode` should be a `(Element or ProcessingInstruction)?`.
+    readonly attribute Node? ownerNode;
+    // FIXME: `parentStyleSheet` should be a `CSSStyleSheet?`.
+    readonly attribute StyleSheet? parentStyleSheet;
     readonly attribute DOMString? title;
-    [SameObject, PutForwards=mediaText] readonly attribute MediaList media;
+    // FIXME: `media` should not be nullable.
+    [SameObject, PutForwards=mediaText] readonly attribute MediaList? media;
     attribute boolean disabled;
 };

--- a/Source/WebCore/css/typedom/StylePropertyMapReadOnly.idl
+++ b/Source/WebCore/css/typedom/StylePropertyMapReadOnly.idl
@@ -29,9 +29,11 @@
     SkipVTableValidation,
     JSCustomMarkFunction
 ] interface StylePropertyMapReadOnly {
-    iterable<USVString, sequence<CSSStyleValue>>;
+    // FIXME: iterable value should be `sequence<CSSStyleValue>`.
+    iterable<USVString, sequence<CSSStyleValue?>>;
     [CallWith=CurrentScriptExecutionContext] (undefined or CSSStyleValue) get([AtomString] USVString property);
-    [CallWith=CurrentScriptExecutionContext] sequence<CSSStyleValue> getAll([AtomString] USVString property);
+    // FIXME: `getAll` should return `sequence<CSSStyleValue>`.
+    [CallWith=CurrentScriptExecutionContext] sequence<CSSStyleValue?> getAll([AtomString] USVString property);
     [CallWith=CurrentScriptExecutionContext] boolean has([AtomString] USVString property);
 
     readonly attribute unsigned long size;

--- a/Source/WebCore/css/typedom/color/CSSOMColor.cpp
+++ b/Source/WebCore/css/typedom/color/CSSOMColor.cpp
@@ -32,7 +32,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSOMColor);
 
-void CSSOMColor::setColorSpace(CSSKeywordish)
+void CSSOMColor::setColorSpace(std::optional<CSSKeywordish>)
 {
     // FIXME: Implement.
 }

--- a/Source/WebCore/css/typedom/color/CSSOMColor.h
+++ b/Source/WebCore/css/typedom/color/CSSOMColor.h
@@ -34,7 +34,7 @@ class CSSOMColor final : public CSSOMColorValue {
 public:
     template<typename... Args> static Ref<CSSOMColor> create(Args&&... args) { return adoptRef(*new CSSOMColor(std::forward<Args>(args)...)); }
 
-    void setColorSpace(CSSKeywordish);
+    void setColorSpace(std::optional<CSSKeywordish>);
 
     const CSSNumberish& alpha() const { return m_alpha; }
     void setAlpha(CSSNumberish alpha) { m_alpha = WTF::move(alpha); }

--- a/Source/WebCore/css/typedom/color/CSSOMColor.idl
+++ b/Source/WebCore/css/typedom/color/CSSOMColor.idl
@@ -35,7 +35,8 @@ typedef (CSSNumberish or CSSKeywordish) CSSColorPercent;
     JSGenerateToNativeObject,
 ] interface CSSOMColor : CSSOMColorValue {
     constructor(CSSKeywordish colorSpace, sequence<CSSColorPercent> channels, optional CSSNumberish alpha = 1.0);
-    attribute CSSKeywordish colorSpace;
+    // FIXME: `colorSpace` should not be nullable.
+    attribute CSSKeywordish? colorSpace;
     // FIXME: Add support for ObservableArray and add this.
     // https://bugs.webkit.org/show_bug.cgi?id=238281
     // attribute ObservableArray<CSSColorPercent> channels;

--- a/Source/WebCore/css/typedom/color/CSSOMColorValue.idl
+++ b/Source/WebCore/css/typedom/color/CSSOMColorValue.idl
@@ -32,7 +32,9 @@ typedef (DOMString or CSSKeywordValue) CSSKeywordish;
     Exposed=(Window,Worker,PaintWorklet/*,LayoutWorklet*/),
     JSGenerateToNativeObject,
 ] interface CSSOMColorValue : CSSStyleValue {
-    readonly attribute CSSKeywordValue colorSpace;
-    CSSOMColorValue to(CSSKeywordish colorSpace);
+    // FIXME: `colorSpace` should not exist on this type.
+    readonly attribute CSSKeywordValue? colorSpace;
+    // FIXME: `to` should not exist on this type.
+    CSSOMColorValue? to(CSSKeywordish colorSpace);
     [Exposed=Window] static (CSSOMColorValue or CSSStyleValue) parse(USVString cssText);
 };

--- a/Source/WebCore/css/typedom/transform/CSSMatrixComponent.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSMatrixComponent.cpp
@@ -46,16 +46,16 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSMatrixComponent);
 
-Ref<CSSTransformComponent> CSSMatrixComponent::create(Ref<DOMMatrixReadOnly>&& matrix, CSSMatrixComponentOptions&& options)
+Ref<CSSMatrixComponent> CSSMatrixComponent::create(Ref<DOMMatrixReadOnly>&& matrix, CSSMatrixComponentOptions&& options)
 {
     // https://drafts.css-houdini.org/css-typed-om/#dom-cssmatrixcomponent-cssmatrixcomponent
     auto is2D = options.is2D.value_or(matrix->is2D());
     return adoptRef(*new CSSMatrixComponent(WTF::move(matrix), is2D ? Is2D::Yes : Is2D::No));
 }
 
-ExceptionOr<Ref<CSSTransformComponent>> CSSMatrixComponent::create(Ref<const CSSFunctionValue> cssFunctionValue, Document& document)
+ExceptionOr<Ref<CSSMatrixComponent>> CSSMatrixComponent::create(Ref<const CSSFunctionValue> cssFunctionValue, Document& document)
 {
-    auto makeMatrix = [&](NOESCAPE const Function<Ref<CSSTransformComponent>(Vector<double>&&)>& create, size_t expectedNumberOfComponents) -> ExceptionOr<Ref<CSSTransformComponent>> {
+    auto makeMatrix = [&](NOESCAPE const Function<Ref<CSSMatrixComponent>(Vector<double>&&)>& create, size_t expectedNumberOfComponents) -> ExceptionOr<Ref<CSSMatrixComponent>> {
         Vector<double> components;
         for (Ref componentCSSValue : cssFunctionValue.get()) {
             auto valueOrException = CSSStyleValueFactory::reifyValue(document, componentCSSValue.get(), std::nullopt);

--- a/Source/WebCore/css/typedom/transform/CSSMatrixComponent.h
+++ b/Source/WebCore/css/typedom/transform/CSSMatrixComponent.h
@@ -39,8 +39,8 @@ template<typename> class ExceptionOr;
 class CSSMatrixComponent : public CSSTransformComponent {
     WTF_MAKE_TZONE_ALLOCATED(CSSMatrixComponent);
 public:
-    static Ref<CSSTransformComponent> create(Ref<DOMMatrixReadOnly>&&, CSSMatrixComponentOptions&& = { });
-    static ExceptionOr<Ref<CSSTransformComponent>> create(Ref<const CSSFunctionValue>, Document&);
+    static Ref<CSSMatrixComponent> create(Ref<DOMMatrixReadOnly>&&, CSSMatrixComponentOptions&& = { });
+    static ExceptionOr<Ref<CSSMatrixComponent>> create(Ref<const CSSFunctionValue>, Document&);
 
     ~CSSMatrixComponent();
 

--- a/Source/WebCore/dom/Attr.idl
+++ b/Source/WebCore/dom/Attr.idl
@@ -33,5 +33,5 @@
 
     readonly attribute boolean specified; // Useless; always returns true.
 
-    [EnabledByDeprecatedGlobalSetting=AttrStyleEnabled] readonly attribute CSSStyleProperties style;
+    [EnabledByDeprecatedGlobalSetting=AttrStyleEnabled] readonly attribute CSSStyleProperties? style;
 };

--- a/Source/WebCore/dom/CaretPosition.idl
+++ b/Source/WebCore/dom/CaretPosition.idl
@@ -23,13 +23,15 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://drafts.csswg.org/cssom-view/#caretposition
 [
     EnabledBySetting=CaretPositionFromPointEnabled,
     ExportMacro=WEBCORE_EXPORT,
     Exposed=(Window),
     TaggedWrapper,
 ] interface CaretPosition {
-    readonly attribute Node offsetNode;
+    // FIXME: `offsetNode` should not be nullable.
+    readonly attribute Node? offsetNode;
     readonly attribute unsigned long offset;
     [NewObject] DOMRect? getClientRect();
 };

--- a/Source/WebCore/dom/DOMRectList.idl
+++ b/Source/WebCore/dom/DOMRectList.idl
@@ -23,10 +23,11 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://drafts.csswg.org/geometry/#domrectlist
 [
     ExportMacro=WEBCORE_EXPORT,
     Exposed=Window
 ] interface DOMRectList {
     readonly attribute unsigned long length;
-    getter DOMRect item(unsigned long index);
+    getter DOMRect? item(unsigned long index);
 };

--- a/Source/WebCore/dom/DataTransferItem.idl
+++ b/Source/WebCore/dom/DataTransferItem.idl
@@ -29,15 +29,15 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://html.spec.whatwg.org/multipage/dnd.html#datatransferitem
 [
     EnabledBySetting=DataTransferItemsEnabled,
     Exposed=Window
 ] interface DataTransferItem {
     readonly attribute DOMString kind;
     readonly attribute DOMString type;
-
     [CallWith=CurrentDocument] undefined getAsString(StringCallback? callback);
-    File getAsFile();
+    File? getAsFile();
 
     // https://wicg.github.io/entries-api/#html-data
     [CallWith=CurrentScriptExecutionContext, ImplementedAs=getAsEntry] FileSystemEntry? webkitGetAsEntry();

--- a/Source/WebCore/dom/DataTransferItemList.idl
+++ b/Source/WebCore/dom/DataTransferItemList.idl
@@ -29,13 +29,15 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://html.spec.whatwg.org/multipage/dnd.html#datatransferitemlist
 [
     EnabledBySetting=DataTransferItemsEnabled,
     JSGenerateToNativeObject,
     Exposed=Window
 ] interface DataTransferItemList {
     readonly attribute long length;
-    getter DataTransferItem item(unsigned long index);
+    // FIXME: The spec says this should be anonymous. If the name gets removed, the nullable annotation should also be removed, as it is implicit for anonymous getters.
+    getter DataTransferItem? item(unsigned long index);
 
     [CallWith=CurrentDocument] DataTransferItem? add(DOMString data, DOMString type);
     DataTransferItem? add(File file);

--- a/Source/WebCore/dom/Document+Fullscreen.idl
+++ b/Source/WebCore/dom/Document+Fullscreen.idl
@@ -46,6 +46,6 @@
     // Legacy Mozilla versions.
     readonly attribute boolean webkitIsFullScreen;
     readonly attribute boolean webkitFullScreenKeyboardInputAllowed;
-    [ImplementedAs=webkitFullscreenElement] readonly attribute Element webkitCurrentFullScreenElement;
+    [ImplementedAs=webkitFullscreenElement] readonly attribute Element? webkitCurrentFullScreenElement;
     undefined webkitCancelFullScreen();
 };

--- a/Source/WebCore/dom/Document+HTML.idl
+++ b/Source/WebCore/dom/Document+HTML.idl
@@ -59,7 +59,7 @@ partial interface Document {
     // that the caller document matches those semantics. It is possible we should replace it with
     // the existing 'incumbent document' concept.
     [CEReactions=Needed, CallWith=EntryDocument, ImplementedAs=openForBindings] Document open(optional DOMString unused1, optional DOMString unused2); // both arguments are ignored.
-    [CallWith=ActiveWindow&FirstWindow, ImplementedAs=openForBindings] WindowProxy open(USVString url, [AtomString] DOMString name, DOMString features);
+    [CallWith=ActiveWindow&FirstWindow, ImplementedAs=openForBindings] WindowProxy? open(USVString url, [AtomString] DOMString name, DOMString features);
     [CEReactions=Needed, ImplementedAs=closeForBindings] undefined close();
     [CEReactions=Needed, CallWith=EntryDocument] undefined write((TrustedHTML or DOMString)... text);
     [CEReactions=Needed, CallWith=EntryDocument] undefined writeln((TrustedHTML or DOMString)... text);

--- a/Source/WebCore/dom/Document+ViewTransition.idl
+++ b/Source/WebCore/dom/Document+ViewTransition.idl
@@ -23,7 +23,9 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://drafts.csswg.org/css-view-transitions/#additions-to-document-api
 partial interface Document {
-    [EnabledBySetting=ViewTransitionsEnabled] ViewTransition startViewTransition(optional (ViewTransitionUpdateCallback or StartViewTransitionOptions) callbackOptions = {});
+    // FIXME: startViewTransition() should not be nullable.
+    [EnabledBySetting=ViewTransitionsEnabled] ViewTransition? startViewTransition(optional (ViewTransitionUpdateCallback or StartViewTransitionOptions) callbackOptions = {});
     [EnabledBySetting=ViewTransitionsEnabled] readonly attribute ViewTransition? activeViewTransition;
 };

--- a/Source/WebCore/dom/Document.idl
+++ b/Source/WebCore/dom/Document.idl
@@ -89,7 +89,7 @@ typedef (HTMLScriptElement or SVGScriptElement) HTMLOrSVGScriptElement;
     attribute boolean xmlStandalone;
 
     // Non standard: It has been superseeded by caretPositionFromPoint which we do not implement yet.
-    Range caretRangeFromPoint(optional long x = 0, optional long y = 0);
+    Range? caretRangeFromPoint(optional long x = 0, optional long y = 0);
 
     // Non standard: It has been dropped from Blink already.
     RenderingContext? getCSSCanvasContext(DOMString contextId, DOMString name, long width, long height);

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -6228,15 +6228,15 @@ FormAssociatedCustomElement& Element::formAssociatedCustomElementUnsafe() const
     return *customElement;
 }
 
-StylePropertyMapReadOnly* Element::computedStyleMap()
+StylePropertyMapReadOnly& Element::computedStyleMap()
 {
     auto& rareData = ensureElementRareData();
     if (auto* map = rareData.computedStyleMap())
-        return map;
+        return *map;
 
     auto map = ComputedStylePropertyMapReadOnly::create(*this);
     rareData.setComputedStyleMap(WTF::move(map));
-    return rareData.computedStyleMap();
+    return *rareData.computedStyleMap();
 }
 
 bool Element::hasDuplicateAttribute() const

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -894,7 +894,7 @@ public:
 
     virtual void updateUserAgentShadowTree() { }
 
-    StylePropertyMapReadOnly* computedStyleMap();
+    StylePropertyMapReadOnly& computedStyleMap();
 
     ExplicitlySetAttrElementsMap& explicitlySetAttrElementsMap();
     ExplicitlySetAttrElementsMap* explicitlySetAttrElementsMapIfExists() const;

--- a/Source/WebCore/dom/ElementInternals.cpp
+++ b/Source/WebCore/dom/ElementInternals.cpp
@@ -86,10 +86,10 @@ ExceptionOr<bool> ElementInternals::willValidate() const
     return Exception { ExceptionCode::NotSupportedError };
 }
 
-ExceptionOr<RefPtr<ValidityState>> ElementInternals::validity()
+ExceptionOr<Ref<ValidityState>> ElementInternals::validity()
 {
     if (RefPtr element = elementAsFormAssociatedCustom())
-        return element->validity();
+        return Ref { element->validity() };
     return Exception { ExceptionCode::NotSupportedError };
 }
 

--- a/Source/WebCore/dom/ElementInternals.h
+++ b/Source/WebCore/dom/ElementInternals.h
@@ -57,7 +57,7 @@ public:
 
     ExceptionOr<void> setValidity(ValidityStateFlags, String&& message, HTMLElement* validationAnchor);
     ExceptionOr<bool> willValidate() const;
-    ExceptionOr<RefPtr<ValidityState>> validity();
+    ExceptionOr<Ref<ValidityState>> validity();
     ExceptionOr<String> validationMessage() const;
     ExceptionOr<bool> reportValidity();
     ExceptionOr<bool> checkValidity();

--- a/Source/WebCore/dom/ElementInternals.idl
+++ b/Source/WebCore/dom/ElementInternals.idl
@@ -23,6 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://html.spec.whatwg.org/multipage/custom-elements.html#elementinternals
 [
     GenerateIsReachable=ImplElementRoot,
     GenerateAddOpaqueRoot=element,
@@ -41,7 +42,8 @@
     boolean checkValidity();
     boolean reportValidity();
 
-    readonly attribute NodeList labels;
+    // FIXME: `labels` should not be nullable.
+    readonly attribute NodeList? labels;
 
     [SameObject] readonly attribute CustomStateSet states;
 

--- a/Source/WebCore/dom/Event.idl
+++ b/Source/WebCore/dom/Event.idl
@@ -56,6 +56,6 @@ typedef double DOMHighResTimeStamp;
     undefined initEvent([AtomString] DOMString type, optional boolean bubbles = false, optional boolean cancelable = false); // Historical.
 
     // IE extensions that may get standardized (https://github.com/whatwg/dom/issues/334).
-    [ImplementedAs=target] readonly attribute EventTarget srcElement;
+    [ImplementedAs=target] readonly attribute EventTarget? srcElement;
     [ImplementedAs=legacyReturnValue] attribute boolean returnValue;
 };

--- a/Source/WebCore/dom/MutationObserver.cpp
+++ b/Source/WebCore/dom/MutationObserver.cpp
@@ -143,10 +143,9 @@ void MutationObserver::observationEnded(MutationObserverRegistration& registrati
 void MutationObserver::enqueueMutationRecord(Ref<MutationRecord>&& mutation)
 {
     ASSERT(isMainThread());
-    ASSERT(mutation->target());
-    Ref document = mutation->target()->document();
+    Ref document = mutation->target().document();
 
-    m_pendingTargets.add(*mutation->target());
+    m_pendingTargets.add(mutation->target());
     m_records.append(WTF::move(mutation));
 
     Ref eventLoop = document->windowEventLoop();

--- a/Source/WebCore/dom/MutationRecord.cpp
+++ b/Source/WebCore/dom/MutationRecord.cpp
@@ -66,30 +66,26 @@ public:
 
 private:
     const AtomString& type() override;
-    Node* target() override { return m_target.ptr(); }
-    NodeList* addedNodes() override { return m_addedNodes.get(); }
-    NodeList* removedNodes() override { return m_removedNodes.get(); }
+    Node& target() override { return m_target; }
+    NodeList& addedNodes() override { return m_addedNodes; }
+    NodeList& removedNodes() override { return m_removedNodes; }
     Node* previousSibling() override { return m_previousSibling.get(); }
     Node* nextSibling() override { return m_nextSibling.get(); }
 
     void visitNodesConcurrently(JSC::AbstractSlotVisitor& visitor) const final
     {
         addWebCoreOpaqueRoot(visitor, m_target.get());
-        if (m_addedNodes) {
-            // We cannot ref m_addedNodes here as this function may get called from the GC thread.
-            SUPPRESS_UNRETAINED_ARG visitNodeList(visitor, *m_addedNodes);
-        }
-        if (m_removedNodes) {
-            // We cannot ref m_removedNodes here as this function may get called from the GC thread.
-            SUPPRESS_UNRETAINED_ARG visitNodeList(visitor, *m_removedNodes);
-        }
+        // We cannot ref m_addedNodes here as this function may get called from the GC thread.
+        SUPPRESS_UNRETAINED_ARG visitNodeList(visitor, m_addedNodes.get());
+        // We cannot ref m_removedNodes here as this function may get called from the GC thread.
+        SUPPRESS_UNRETAINED_ARG visitNodeList(visitor, m_removedNodes.get());
     }
     
     const Ref<ContainerNode> m_target;
-    RefPtr<NodeList> m_addedNodes;
-    RefPtr<NodeList> m_removedNodes;
-    RefPtr<Node> m_previousSibling;
-    RefPtr<Node> m_nextSibling;
+    const Ref<NodeList> m_addedNodes;
+    const Ref<NodeList> m_removedNodes;
+    const RefPtr<Node> m_previousSibling;
+    const RefPtr<Node> m_nextSibling;
 };
 
 class RecordWithEmptyNodeLists : public MutationRecord {
@@ -101,16 +97,16 @@ public:
     }
 
 private:
-    Node* target() override { return m_target.ptr(); }
+    Node& target() override { return m_target; }
     String oldValue() override { return m_oldValue; }
-    NodeList* addedNodes() override { return lazilyInitializeEmptyNodeList(m_addedNodes); }
-    NodeList* removedNodes() override { return lazilyInitializeEmptyNodeList(m_removedNodes); }
+    NodeList& addedNodes() override { return lazilyInitializeEmptyNodeList(m_addedNodes); }
+    NodeList& removedNodes() override { return lazilyInitializeEmptyNodeList(m_removedNodes); }
 
-    static NodeList* lazilyInitializeEmptyNodeList(RefPtr<NodeList>& nodeList)
+    static NodeList& lazilyInitializeEmptyNodeList(RefPtr<NodeList>& nodeList)
     {
         if (!nodeList)
             nodeList = StaticNodeList::create();
-        return nodeList.get();
+        return *nodeList;
     }
 
     void visitNodesConcurrently(JSC::AbstractSlotVisitor& visitor) const final
@@ -162,9 +158,9 @@ public:
 
 private:
     const AtomString& type() override { return m_record->type(); }
-    Node* target() override { return m_record->target(); }
-    NodeList* addedNodes() override { return m_record->addedNodes(); }
-    NodeList* removedNodes() override { return m_record->removedNodes(); }
+    Node& target() override { return m_record->target(); }
+    NodeList& addedNodes() override { return m_record->addedNodes(); }
+    NodeList& removedNodes() override { return m_record->removedNodes(); }
     Node* previousSibling() override { return m_record->previousSibling(); }
     Node* nextSibling() override { return m_record->nextSibling(); }
     const AtomString& attributeName() override { return m_record->attributeName(); }

--- a/Source/WebCore/dom/MutationRecord.h
+++ b/Source/WebCore/dom/MutationRecord.h
@@ -61,10 +61,10 @@ public:
     virtual ~MutationRecord();
 
     virtual const AtomString& type() = 0;
-    virtual Node* target() = 0;
+    virtual Node& target() = 0;
 
-    virtual NodeList* addedNodes() = 0;
-    virtual NodeList* removedNodes() = 0;
+    virtual NodeList& addedNodes() = 0;
+    virtual NodeList& removedNodes() = 0;
     virtual Node* previousSibling() { return 0; }
     virtual Node* nextSibling() { return 0; }
 

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -495,7 +495,7 @@ ExceptionOr<void> Node::setNodeValue(const String&)
     return { };
 }
 
-RefPtr<NodeList> Node::childNodes()
+Ref<NodeList> Node::childNodes()
 {
     if (auto* containerNode = dynamicDowncast<ContainerNode>(*this))
         return ensureRareData().ensureNodeLists().ensureChildNodeList(*containerNode);

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -175,7 +175,7 @@ public:
     Node* nextSibling() const { return m_next.get(); }
     RefPtr<Node> protectedNextSibling() const { return m_next.get(); }
     static constexpr ptrdiff_t nextSiblingMemoryOffset() { return OBJECT_OFFSETOF(Node, m_next); }
-    WEBCORE_EXPORT RefPtr<NodeList> childNodes();
+    WEBCORE_EXPORT Ref<NodeList> childNodes();
     inline Node* firstChild() const;
     inline RefPtr<Node> protectedFirstChild() const;
     inline Node* lastChild() const;

--- a/Source/WebCore/dom/NodeIterator.idl
+++ b/Source/WebCore/dom/NodeIterator.idl
@@ -25,7 +25,8 @@
     Exposed=Window
 ] interface NodeIterator {
     [SameObject] readonly attribute Node root;
-    readonly attribute Node referenceNode;
+    // FIXME: `referenceNode` should not be nullable.
+    readonly attribute Node? referenceNode;
     readonly attribute boolean pointerBeforeReferenceNode;
     readonly attribute unsigned long whatToShow;
     readonly attribute NodeFilter? filter;

--- a/Source/WebCore/dom/Range.idl
+++ b/Source/WebCore/dom/Range.idl
@@ -18,6 +18,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
+// https://dom.spec.whatwg.org/#interface-range
 [
     GenerateIsReachable=ReachableFromDOMWindow,
     ExportMacro=WEBCORE_EXPORT,
@@ -27,7 +28,8 @@
 ] interface Range : AbstractRange {
     [CallWith=CurrentDocument] constructor();
 
-    readonly attribute Node commonAncestorContainer;
+    // FIXME: `commonAncestorContainer` should not be nullable.
+    readonly attribute Node? commonAncestorContainer;
 
     undefined setStart(Node node, unsigned long offset);
     undefined setEnd(Node node, unsigned long offset);

--- a/Source/WebCore/dom/ShadowRoot.idl
+++ b/Source/WebCore/dom/ShadowRoot.idl
@@ -34,7 +34,8 @@
     [ImplementedAs=slotAssignmentMode] readonly attribute SlotAssignmentMode slotAssignment;
     [ImplementedAs=isClonable] readonly attribute boolean clonable;
     readonly attribute boolean serializable;
-    readonly attribute Element host;
+    // FIXME: `host` should not be nullable.
+    readonly attribute Element? host;
     [EnabledBySetting=ScopedCustomElementRegistryEnabled, ImplementedAs=registryForBindings] readonly attribute CustomElementRegistry? customElementRegistry;
     [EnabledBySetting=ShadowRootReferenceTargetEnabled] attribute [AtomString] DOMString referenceTarget;
     attribute EventHandler onslotchange;

--- a/Source/WebCore/dom/Touch.idl
+++ b/Source/WebCore/dom/Touch.idl
@@ -35,7 +35,8 @@
     readonly attribute double              screenY;
     readonly attribute double              pageX;
     readonly attribute double              pageY;
-    readonly attribute EventTarget         target;
+    // FIXME: `target` should not be nullable.
+    readonly attribute EventTarget?        target;
     readonly attribute long                identifier;
     readonly attribute double              webkitRadiusX;
     readonly attribute double              webkitRadiusY;

--- a/Source/WebCore/dom/TouchEvent.idl
+++ b/Source/WebCore/dom/TouchEvent.idl
@@ -31,9 +31,12 @@
 ] interface TouchEvent : UIEvent {
     constructor([AtomString] DOMString type, optional TouchEventInit eventInitDict);
 
-    readonly attribute TouchList touches;
-    readonly attribute TouchList targetTouches;
-    readonly attribute TouchList changedTouches;
+    // FIXME: `touches` should not be nullable.
+    readonly attribute TouchList? touches;
+    // FIXME: `targetTouches` should not be nullable.
+    readonly attribute TouchList? targetTouches;
+    // FIXME: `changedTouches` should not be nullable.
+    readonly attribute TouchList? changedTouches;
     readonly attribute boolean ctrlKey;
     readonly attribute boolean shiftKey;
     readonly attribute boolean altKey;

--- a/Source/WebCore/dom/WindowOrWorkerGlobalScope+TrustedTypes.idl
+++ b/Source/WebCore/dom/WindowOrWorkerGlobalScope+TrustedTypes.idl
@@ -27,5 +27,6 @@
     EnabledBySetting=TrustedTypesEnabled,
     ImplementedBy=WindowOrWorkerGlobalScopeTrustedTypes
 ] partial interface mixin WindowOrWorkerGlobalScope {
-    [SameObject] readonly attribute TrustedTypePolicyFactory trustedTypes;
+    // FIXME: `trustedTypes` should not be nullable.
+    [SameObject] readonly attribute TrustedTypePolicyFactory? trustedTypes;
 };

--- a/Source/WebCore/fileapi/FileList.idl
+++ b/Source/WebCore/fileapi/FileList.idl
@@ -23,10 +23,11 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+// https://w3c.github.io/FileAPI/#dfn-filelist
 [
     Exposed=(Window,Worker),
 ] interface FileList {
     readonly attribute unsigned long length;
-    getter File item(unsigned long index);
+    getter File? item(unsigned long index);
 };
 

--- a/Source/WebCore/html/FTPDirectoryDocument.cpp
+++ b/Source/WebCore/html/FTPDirectoryDocument.cpp
@@ -32,6 +32,7 @@
 #include "HTMLDocumentParser.h"
 #include "HTMLTableCellElement.h"
 #include "HTMLTableElement.h"
+#include "HTMLTableRowElement.h"
 #include "LocalizedStrings.h"
 #include "Logging.h"
 #include "FTPDirectoryParser.h"

--- a/Source/WebCore/html/FormListedElement.h
+++ b/Source/WebCore/html/FormListedElement.h
@@ -46,7 +46,7 @@ class FormListedElement : public FormAssociatedElement, public CanMakeWeakPtr<Fo
 public:
     virtual ~FormListedElement();
 
-    ValidityState* validity();
+    ValidityState& validity();
 
     virtual bool isValidatedFormListedElement() const = 0;
     virtual bool isEnumeratable() const = 0;

--- a/Source/WebCore/html/HTMLButtonElement.idl
+++ b/Source/WebCore/html/HTMLButtonElement.idl
@@ -22,7 +22,7 @@
     Exposed=Window
 ] interface HTMLButtonElement : HTMLElement {
     [CEReactions=NotNeeded, Reflect] attribute boolean disabled;
-    [ImplementedAs=formForBindings] readonly attribute HTMLFormElement form;
+    [ImplementedAs=formForBindings] readonly attribute HTMLFormElement? form;
     [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] USVString formAction;
 
     [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] DOMString formEnctype;
@@ -45,7 +45,8 @@
     [EnabledBySetting=InteractiveFormValidationEnabled] boolean reportValidity();
     undefined setCustomValidity(DOMString error);
 
-    readonly attribute NodeList labels;
+    // FIXME: `labels` should not be nullable.
+    readonly attribute NodeList? labels;
 };
 
 HTMLButtonElement includes PopoverInvokerElement;

--- a/Source/WebCore/html/HTMLFieldSetElement.idl
+++ b/Source/WebCore/html/HTMLFieldSetElement.idl
@@ -21,7 +21,7 @@
     Exposed=Window
 ] interface HTMLFieldSetElement : HTMLElement {
     [CEReactions=Needed, Reflect] attribute boolean disabled;
-    [ImplementedAs=formForBindings] readonly attribute HTMLFormElement form;
+    [ImplementedAs=formForBindings] readonly attribute HTMLFormElement? form;
     [CEReactions=NotNeeded, Reflect] attribute DOMString name;
 
     readonly attribute DOMString type;

--- a/Source/WebCore/html/HTMLFrameElement.idl
+++ b/Source/WebCore/html/HTMLFrameElement.idl
@@ -19,7 +19,6 @@
  */
 
 // https://html.spec.whatwg.org/#htmlframeelement
-
 [
     Exposed=Window
 ] interface HTMLFrameElement : HTMLElement {
@@ -29,8 +28,8 @@
     [CEReactions=NotNeeded, Reflect] attribute DOMString frameBorder;
     [CEReactions=NotNeeded, ReflectURL] attribute USVString longDesc;
     [CEReactions=NotNeeded, Reflect] attribute boolean noResize;
-    [CheckSecurityForNode] readonly attribute Document contentDocument;
-    readonly attribute WindowProxy contentWindow;
+    [CheckSecurityForNode] readonly attribute Document? contentDocument;
+    readonly attribute WindowProxy? contentWindow;
 
     [CEReactions=NotNeeded, Reflect] attribute [LegacyNullToEmptyString] DOMString marginHeight;
     [CEReactions=NotNeeded, Reflect] attribute [LegacyNullToEmptyString] DOMString marginWidth;

--- a/Source/WebCore/html/HTMLInputElement.idl
+++ b/Source/WebCore/html/HTMLInputElement.idl
@@ -48,7 +48,7 @@ enum AutofillButtonType {
     [EnabledBySetting=InputTypeColorEnhancementsEnabled, CEReactions=NotNeeded] attribute [AtomString] DOMString colorSpace;
     [CEReactions=NotNeeded, Reflect] attribute DOMString dirName;
     [CEReactions=NotNeeded, Reflect] attribute boolean disabled;
-    [ImplementedAs=formForBindings] readonly attribute HTMLFormElement form;
+    [ImplementedAs=formForBindings] readonly attribute HTMLFormElement? form;
     [ImplementedAs=filesForBindings] attribute FileList? files;
     [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] USVString formAction;
 
@@ -59,7 +59,7 @@ enum AutofillButtonType {
     [CEReactions=NotNeeded, Reflect] attribute DOMString formTarget;
     [CEReactions=NotNeeded, ReflectSetter] attribute unsigned long height;
     attribute boolean indeterminate;
-    readonly attribute HTMLElement list;
+    readonly attribute HTMLElement? list;
     [CEReactions=NotNeeded, Reflect] attribute DOMString max;
     [CEReactions=NotNeeded] attribute long minLength;
     [CEReactions=NotNeeded] attribute long maxLength;
@@ -92,7 +92,7 @@ enum AutofillButtonType {
     [EnabledBySetting=InteractiveFormValidationEnabled] boolean reportValidity();
     undefined setCustomValidity(DOMString error);
 
-    readonly attribute NodeList labels;
+    readonly attribute NodeList? labels;
 
     undefined select();
     [ImplementedAs=selectionStartForBindings] attribute unsigned long? selectionStart;

--- a/Source/WebCore/html/HTMLLabelElement.idl
+++ b/Source/WebCore/html/HTMLLabelElement.idl
@@ -21,8 +21,8 @@
 [
     Exposed=Window
 ] interface HTMLLabelElement : HTMLElement {
-    [ImplementedAs=formForBindings] readonly attribute HTMLFormElement form;
+    [ImplementedAs=formForBindings] readonly attribute HTMLFormElement? form;
     [CEReactions=NotNeeded, Reflect="for"] attribute DOMString htmlFor;
-    [ImplementedAs=controlForBindings] readonly attribute HTMLElement control;
+    [ImplementedAs=controlForBindings] readonly attribute HTMLElement? control;
 };
 

--- a/Source/WebCore/html/HTMLLegendElement.idl
+++ b/Source/WebCore/html/HTMLLegendElement.idl
@@ -21,7 +21,7 @@
 [
     Exposed=Window
 ] interface HTMLLegendElement : HTMLElement {
-    [ImplementedAs=formForBindings] readonly attribute HTMLFormElement form;
+    [ImplementedAs=formForBindings] readonly attribute HTMLFormElement? form;
     [CEReactions=NotNeeded, Reflect] attribute DOMString align;
 };
 

--- a/Source/WebCore/html/HTMLLinkElement.idl
+++ b/Source/WebCore/html/HTMLLinkElement.idl
@@ -19,34 +19,37 @@
  * Boston, MA 02110-1301, USA.
  */
 
+// https://html.spec.whatwg.org/multipage/semantics.html#htmllinkelement
 [
     ExportMacro=WEBCORE_EXPORT,
     JSGenerateToNativeObject,
     Exposed=Window
 ] interface HTMLLinkElement : HTMLElement {
-    [Reflect] attribute boolean disabled;
-    [CEReactions=NotNeeded, Reflect] attribute DOMString charset;
     [CEReactions=NotNeeded, ReflectURL] attribute USVString href;
-    [CEReactions=NotNeeded, Conditional=WEB_PAGE_SPATIAL_BACKDROP, EnabledBySetting=WebPageSpatialBackdropEnabled, ReflectURL] attribute USVString environmentMap;
-    [CEReactions=NotNeeded, Reflect] attribute DOMString hreflang;
-    [CEReactions=NotNeeded, Reflect] attribute DOMString media;
-    [CEReactions=NotNeeded, Reflect] attribute DOMString rel;
-    [CEReactions=NotNeeded, Reflect] attribute DOMString rev;
-    [PutForwards=value] readonly attribute DOMTokenList sizes;
-    [CEReactions=NotNeeded, Reflect] attribute DOMString target;
-    [CEReactions=NotNeeded, Reflect] attribute DOMString type;
-    [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] DOMString as;
     [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] DOMString? crossOrigin;
+    [CEReactions=NotNeeded, Reflect] attribute DOMString rel;
+    [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] DOMString as;
+    [PutForwards=value] readonly attribute DOMTokenList relList;
+    [CEReactions=NotNeeded, Reflect] attribute DOMString media;
+    [CEReactions=NotNeeded, Reflect] attribute DOMString integrity;
+    [CEReactions=NotNeeded, Reflect] attribute DOMString hreflang;
+    [CEReactions=NotNeeded, Reflect] attribute DOMString type;
+    [PutForwards=value] readonly attribute DOMTokenList sizes;
     [CEReactions=NotNeeded, Reflect] attribute DOMString imageSrcset;
     [CEReactions=NotNeeded, Reflect] attribute DOMString imageSizes;
     [CEReactions=NotNeeded, ImplementedAs=referrerPolicyForBindings, ReflectSetter] attribute [AtomString] DOMString referrerPolicy;
     [PutForwards=value] readonly attribute DOMTokenList blocking;
+    [Reflect] attribute boolean disabled;
     [CEReactions=NotNeeded, ImplementedAs=fetchPriorityForBindings, ReflectSetter] attribute [AtomString] DOMString fetchPriority;
 
-    readonly attribute StyleSheet sheet;
+    // Non-standard.
+    [CEReactions=NotNeeded, Conditional=WEB_PAGE_SPATIAL_BACKDROP, EnabledBySetting=WebPageSpatialBackdropEnabled, ReflectURL] attribute USVString environmentMap;
 
-    [PutForwards=value] readonly attribute DOMTokenList relList;
-
-    [CEReactions=NotNeeded, Reflect] attribute DOMString integrity;
+    // https://html.spec.whatwg.org/multipage/obsolete.html#HTMLLinkElement-partial
+    // FIXME: Move these to their own IDL file HTMLLinkElement+Obsolete.idl.
+    [CEReactions=NotNeeded, Reflect] attribute DOMString charset;
+    [CEReactions=NotNeeded, Reflect] attribute DOMString rev;
+    [CEReactions=NotNeeded, Reflect] attribute DOMString target;
 };
 
+HTMLLinkElement includes LinkStyle;

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -8788,7 +8788,7 @@ void HTMLMediaElement::updateRateChangeRestrictions()
         mediaSession->removeBehaviorRestriction(MediaElementSession::RequireUserGestureForAudioRateChange);
 }
 
-RefPtr<VideoPlaybackQuality> HTMLMediaElement::getVideoPlaybackQuality() const
+Ref<VideoPlaybackQuality> HTMLMediaElement::getVideoPlaybackQuality() const
 {
     RefPtr window = document().window();
     double timestamp = window ? window->nowTimestamp().milliseconds() : 0;

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -572,7 +572,7 @@ public:
     void mediaLoadingFailed(MediaPlayer::NetworkState);
     void mediaLoadingFailedFatally(MediaPlayer::NetworkState);
 
-    RefPtr<VideoPlaybackQuality> getVideoPlaybackQuality() const;
+    Ref<VideoPlaybackQuality> getVideoPlaybackQuality() const;
 
     MediaPlayer::Preload preloadValue() const { return m_preload; }
     MediaPlayer::Preload effectivePreloadValue() const;

--- a/Source/WebCore/html/HTMLMediaElement.idl
+++ b/Source/WebCore/html/HTMLMediaElement.idl
@@ -107,9 +107,12 @@ typedef (
     [Conditional=MEDIA_STATISTICS] readonly attribute unsigned long webkitAudioDecodedByteCount;
     [Conditional=MEDIA_STATISTICS] readonly attribute unsigned long webkitVideoDecodedByteCount;
 
-    [Conditional=LEGACY_ENCRYPTED_MEDIA, EnabledBySetting=LegacyEncryptedMediaAPIEnabled] readonly attribute WebKitMediaKeys webkitKeys;
+    [Conditional=LEGACY_ENCRYPTED_MEDIA, EnabledBySetting=LegacyEncryptedMediaAPIEnabled] readonly attribute WebKitMediaKeys? webkitKeys;
     [Conditional=LEGACY_ENCRYPTED_MEDIA, EnabledBySetting=LegacyEncryptedMediaAPIEnabled] undefined webkitSetMediaKeys(WebKitMediaKeys? mediaKeys);
-    [Conditional=ENCRYPTED_MEDIA, EnabledBySetting=EncryptedMediaAPIEnabled, DisabledByQuirk=hasBrokenEncryptedMediaAPISupport] readonly attribute MediaKeys mediaKeys;
+
+    // https://w3c.github.io/encrypted-media/#webidl-1869224078
+    // FIXME: Move these to their own IDL file HTMLMediaElement+EncryptedMedia.idl.
+    [Conditional=ENCRYPTED_MEDIA, EnabledBySetting=EncryptedMediaAPIEnabled, DisabledByQuirk=hasBrokenEncryptedMediaAPISupport] readonly attribute MediaKeys? mediaKeys;
     [Conditional=ENCRYPTED_MEDIA, EnabledBySetting=EncryptedMediaAPIEnabled, DisabledByQuirk=hasBrokenEncryptedMediaAPISupport] attribute EventHandler onencrypted;
     [Conditional=ENCRYPTED_MEDIA, EnabledBySetting=EncryptedMediaAPIEnabled, DisabledByQuirk=hasBrokenEncryptedMediaAPISupport] attribute EventHandler onwaitingforkey;
     [Conditional=ENCRYPTED_MEDIA, EnabledBySetting=EncryptedMediaAPIEnabled, DisabledByQuirk=hasBrokenEncryptedMediaAPISupport] Promise<undefined> setMediaKeys(MediaKeys? mediaKeys);

--- a/Source/WebCore/html/HTMLMeterElement.idl
+++ b/Source/WebCore/html/HTMLMeterElement.idl
@@ -26,5 +26,6 @@
     [CEReactions=NotNeeded, ReflectSetter] attribute double low;
     [CEReactions=NotNeeded, ReflectSetter] attribute double high;
     [CEReactions=NotNeeded, ReflectSetter] attribute double optimum;
-    readonly attribute NodeList labels;
+    // FIXME: labels() is not supposed to be nullable.
+    readonly attribute NodeList? labels;
 };

--- a/Source/WebCore/html/HTMLObjectElement.idl
+++ b/Source/WebCore/html/HTMLObjectElement.idl
@@ -19,28 +19,20 @@
  */
 
 // https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmlobjectelement
-
 [
     Plugin,
     Exposed=Window
 ] interface HTMLObjectElement : HTMLElement {
-    [ImplementedAs=formForBindings] readonly attribute HTMLFormElement form;
-    [CEReactions=NotNeeded, Reflect] attribute DOMString code;
-    [CEReactions=NotNeeded, Reflect] attribute DOMString align;
-    [CEReactions=NotNeeded, Reflect] attribute DOMString archive;
-    [CEReactions=NotNeeded, Reflect] attribute [LegacyNullToEmptyString] DOMString border;
-    [CEReactions=NotNeeded, ReflectURL] attribute USVString codeBase;
-    [CEReactions=NotNeeded, Reflect] attribute DOMString codeType;
     [CEReactions=NotNeeded, ReflectURL] attribute USVString data;
-    [CEReactions=NotNeeded, Reflect] attribute boolean declare;
-    [CEReactions=NotNeeded, Reflect] attribute DOMString height;
-    [CEReactions=NotNeeded, Reflect] attribute unsigned long hspace;
-    [CEReactions=NotNeeded, Reflect] attribute DOMString name;
-    [CEReactions=NotNeeded, Reflect] attribute DOMString standby;
     [CEReactions=NotNeeded, Reflect] attribute DOMString type;
-    [CEReactions=NotNeeded, Reflect] attribute DOMString useMap;
-    [CEReactions=NotNeeded, Reflect] attribute unsigned long vspace;
+    [CEReactions=NotNeeded, Reflect] attribute DOMString name;
+    [ImplementedAs=formForBindings] readonly attribute HTMLFormElement? form;
     [CEReactions=NotNeeded, Reflect] attribute DOMString width;
+    [CEReactions=NotNeeded, Reflect] attribute DOMString height;
+    [CheckSecurityForNode] readonly attribute Document? contentDocument;
+    readonly attribute WindowProxy? contentWindow;
+    [CheckSecurityForNode] Document? getSVGDocument();
+
     readonly attribute boolean willValidate;
     readonly attribute ValidityState validity;
     readonly attribute DOMString validationMessage;
@@ -48,8 +40,17 @@
     [EnabledBySetting=InteractiveFormValidationEnabled] boolean reportValidity();
     undefined setCustomValidity(DOMString error);
 
-    [CheckSecurityForNode] readonly attribute Document contentDocument;
-    readonly attribute WindowProxy contentWindow;
-
-    [CheckSecurityForNode] Document? getSVGDocument();
+    // https://html.spec.whatwg.org/multipage/obsolete.html#HTMLObjectElement-partial
+    // FIXME: Move these to their own IDL file HTMLObjectElement+Obsolete.idl.
+    [CEReactions=NotNeeded, Reflect] attribute DOMString align;
+    [CEReactions=NotNeeded, Reflect] attribute DOMString archive;
+    [CEReactions=NotNeeded, Reflect] attribute DOMString code;
+    [CEReactions=NotNeeded, Reflect] attribute boolean declare;
+    [CEReactions=NotNeeded, Reflect] attribute unsigned long hspace;
+    [CEReactions=NotNeeded, Reflect] attribute DOMString standby;
+    [CEReactions=NotNeeded, Reflect] attribute unsigned long vspace;
+    [CEReactions=NotNeeded, ReflectURL] attribute USVString codeBase;
+    [CEReactions=NotNeeded, Reflect] attribute DOMString codeType;
+    [CEReactions=NotNeeded, Reflect] attribute DOMString useMap;
+    [CEReactions=NotNeeded, Reflect] attribute [LegacyNullToEmptyString] DOMString border;
 };

--- a/Source/WebCore/html/HTMLOptionElement.idl
+++ b/Source/WebCore/html/HTMLOptionElement.idl
@@ -25,7 +25,7 @@
     LegacyFactoryFunction=Option(optional DOMString text = "", optional [AtomString] DOMString value, optional boolean defaultSelected = false, optional boolean selected = false),
 ] interface HTMLOptionElement : HTMLElement {
     [CEReactions=NotNeeded, Reflect] attribute boolean disabled;
-    [ImplementedAs=formForBindings] readonly attribute HTMLFormElement form;
+    [ImplementedAs=formForBindings] readonly attribute HTMLFormElement? form;
     [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] DOMString label;
     [CEReactions=NotNeeded, Reflect="selected"] attribute boolean defaultSelected;
     attribute boolean selected;

--- a/Source/WebCore/html/HTMLOutputElement.idl
+++ b/Source/WebCore/html/HTMLOutputElement.idl
@@ -43,5 +43,6 @@
     [EnabledBySetting=InteractiveFormValidationEnabled] boolean reportValidity();
     undefined setCustomValidity(DOMString error);
 
-    readonly attribute NodeList labels;
+    // FIXME: labels() should not be nullable.
+    readonly attribute NodeList? labels;
 };

--- a/Source/WebCore/html/HTMLProgressElement.idl
+++ b/Source/WebCore/html/HTMLProgressElement.idl
@@ -23,5 +23,6 @@
     [CEReactions=NotNeeded, ReflectSetter] attribute double value;
     [CEReactions=NotNeeded] attribute double max;
     readonly attribute double position;
-    readonly attribute NodeList labels;
+    // FIXME: `labels` should not be nullable.
+    readonly attribute NodeList? labels;
 };

--- a/Source/WebCore/html/HTMLSelectElement.idl
+++ b/Source/WebCore/html/HTMLSelectElement.idl
@@ -54,5 +54,6 @@
     undefined setCustomValidity(DOMString error);
     [EnabledBySetting=SelectShowPickerEnabled] undefined showPicker();
 
-    readonly attribute NodeList labels;
+    // FIXME: `labels` should not be nullable.
+    readonly attribute NodeList? labels;
 };

--- a/Source/WebCore/html/HTMLTableElement.cpp
+++ b/Source/WebCore/html/HTMLTableElement.cpp
@@ -191,7 +191,7 @@ HTMLTableSectionElement* HTMLTableElement::lastBody() const
     return nullptr;
 }
 
-ExceptionOr<Ref<HTMLElement>> HTMLTableElement::insertRow(int index)
+ExceptionOr<Ref<HTMLTableRowElement>> HTMLTableElement::insertRow(int index)
 {
     if (index < -1)
         return Exception { ExceptionCode::IndexSizeError };
@@ -228,7 +228,7 @@ ExceptionOr<Ref<HTMLElement>> HTMLTableElement::insertRow(int index)
             auto result = appendChild(newBody);
             if (result.hasException())
                 return result.releaseException();
-            return Ref<HTMLElement> { WTF::move(newRow) };
+            return newRow;
         }
     }
 
@@ -236,7 +236,7 @@ ExceptionOr<Ref<HTMLElement>> HTMLTableElement::insertRow(int index)
     auto result = parent->insertBefore(newRow, WTF::move(row));
     if (result.hasException())
         return result.releaseException();
-    return Ref<HTMLElement> { WTF::move(newRow) };
+    return newRow;
 }
 
 ExceptionOr<void> HTMLTableElement::deleteRow(int index)

--- a/Source/WebCore/html/HTMLTableElement.h
+++ b/Source/WebCore/html/HTMLTableElement.h
@@ -58,7 +58,7 @@ public:
     WEBCORE_EXPORT Ref<HTMLTableSectionElement> createTBody();
     WEBCORE_EXPORT Ref<HTMLTableCaptionElement> createCaption();
     WEBCORE_EXPORT void deleteCaption();
-    WEBCORE_EXPORT ExceptionOr<Ref<HTMLElement>> insertRow(int index = -1);
+    WEBCORE_EXPORT ExceptionOr<Ref<HTMLTableRowElement>> insertRow(int index = -1);
     WEBCORE_EXPORT ExceptionOr<void> deleteRow(int index);
 
     WEBCORE_EXPORT Ref<HTMLCollection> rows();

--- a/Source/WebCore/html/HTMLTextAreaElement.idl
+++ b/Source/WebCore/html/HTMLTextAreaElement.idl
@@ -26,7 +26,7 @@
 ] interface HTMLTextAreaElement : HTMLElement {
     [CEReactions=NotNeeded, Reflect] attribute DOMString dirName;
     [CEReactions=NotNeeded, Reflect] attribute boolean disabled;
-    [ImplementedAs=formForBindings] readonly attribute HTMLFormElement form;
+    [ImplementedAs=formForBindings] readonly attribute HTMLFormElement? form;
     [CEReactions=NotNeeded] attribute long minLength;
     [CEReactions=NotNeeded] attribute long maxLength;
     [CEReactions=NotNeeded, Reflect] attribute DOMString name;
@@ -49,7 +49,8 @@
     [EnabledBySetting=InteractiveFormValidationEnabled] boolean reportValidity();
     undefined setCustomValidity(DOMString error);
 
-    readonly attribute NodeList labels;
+    // FIXME: `labels` should not be nullable.
+    readonly attribute NodeList? labels;
 
     undefined select();
     attribute unsigned long selectionStart;

--- a/Source/WebCore/html/OffscreenCanvas.idl
+++ b/Source/WebCore/html/OffscreenCanvas.idl
@@ -64,7 +64,8 @@ enum OffscreenRenderingContextType
     [CallTracer=InspectorCanvasCallTracer] attribute [EnforceRange] unsigned long height;
 
     [CallWith=CurrentGlobalObject] OffscreenRenderingContext? getContext(OffscreenRenderingContextType contextType, any... arguments);
-    ImageBitmap transferToImageBitmap();
+    // FIXME: `transferToImageBitmap` should not return a nullable type.
+    ImageBitmap? transferToImageBitmap();
     Promise<Blob> convertToBlob(optional ImageEncodeOptions options);
 
 };

--- a/Source/WebCore/html/ValidityState.h
+++ b/Source/WebCore/html/ValidityState.h
@@ -37,11 +37,11 @@ public:
     Node* opaqueRootConcurrently() { return &asHTMLElement(); }
 };
 
-inline ValidityState* FormListedElement::validity()
+inline ValidityState& FormListedElement::validity()
 {
     // Because ValidityState adds nothing to FormListedElement, we rely on it being safe
     // to cast a FormListedElement like this, even though it's not actually a ValidityState.
-    return static_cast<ValidityState*>(this);
+    return static_cast<ValidityState&>(*this);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/GPUCanvasContext.h
+++ b/Source/WebCore/html/canvas/GPUCanvasContext.h
@@ -60,7 +60,7 @@ public:
     virtual ExceptionOr<void> configure(GPUCanvasConfiguration&&) = 0;
     virtual void unconfigure() = 0;
     virtual std::optional<GPUCanvasConfiguration> getConfiguration() const = 0;
-    virtual ExceptionOr<RefPtr<GPUTexture>> getCurrentTexture() = 0;
+    virtual ExceptionOr<Ref<GPUTexture>> getCurrentTexture() = 0;
 
 protected:
     GPUCanvasContext(CanvasBase&);

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
@@ -49,12 +49,6 @@ class GPUDisplayBufferDisplayDelegate;
 class GPUCanvasContextCocoa final : public GPUCanvasContext {
     WTF_MAKE_TZONE_ALLOCATED(GPUCanvasContextCocoa);
 public:
-#if ENABLE(OFFSCREEN_CANVAS)
-    using CanvasType = Variant<RefPtr<HTMLCanvasElement>, RefPtr<OffscreenCanvas>>;
-#else
-    using CanvasType = Variant<RefPtr<HTMLCanvasElement>>;
-#endif
-
     static std::unique_ptr<GPUCanvasContextCocoa> create(CanvasBase&, GPU&, Document*);
 
     DestinationColorSpace colorSpace() const override;
@@ -73,7 +67,7 @@ public:
     ExceptionOr<void> configure(GPUCanvasConfiguration&&) override;
     void unconfigure() override;
     std::optional<GPUCanvasConfiguration> getConfiguration() const override;
-    ExceptionOr<RefPtr<GPUTexture>> getCurrentTexture() override;
+    ExceptionOr<Ref<GPUTexture>> getCurrentTexture() override;
     RefPtr<ImageBuffer> transferToImageBuffer() override;
 
 #if HAVE(SUPPORT_HDR_DISPLAY) && ENABLE(PIXEL_FORMAT_RGBA16F)

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
@@ -157,7 +157,7 @@ static GPUIntegerCoordinate getCanvasHeight(const GPUCanvasContext::CanvasType& 
     );
 }
 
-GPUCanvasContextCocoa::CanvasType GPUCanvasContextCocoa::htmlOrOffscreenCanvas() const
+GPUCanvasContext::CanvasType GPUCanvasContextCocoa::htmlOrOffscreenCanvas() const
 {
     if (RefPtr canvas = htmlCanvas())
         return canvas;
@@ -493,19 +493,19 @@ std::optional<GPUCanvasConfiguration> GPUCanvasContextCocoa::getConfiguration() 
     return configuration;
 }
 
-ExceptionOr<RefPtr<GPUTexture>> GPUCanvasContextCocoa::getCurrentTexture()
+ExceptionOr<Ref<GPUTexture>> GPUCanvasContextCocoa::getCurrentTexture()
 {
     if (!isConfigured())
         return Exception { ExceptionCode::InvalidStateError, "GPUCanvasContextCocoa::getCurrentTexture: canvas is not configured"_s };
 
     RefPtr currentTexture = m_currentTexture;
     if (currentTexture)
-        return currentTexture;
+        return currentTexture.releaseNonNull();
 
     markContextChangedAndNotifyCanvasObservers();
     m_currentTexture = m_presentationContext->getCurrentTexture(m_configuration->frameCount);
     currentTexture = m_currentTexture;
-    return currentTexture;
+    return currentTexture.releaseNonNull();
 }
 
 PixelFormat GPUCanvasContextCocoa::pixelFormat() const

--- a/Source/WebCore/html/canvas/OESVertexArrayObject.idl
+++ b/Source/WebCore/html/canvas/OESVertexArrayObject.idl
@@ -30,7 +30,8 @@
 ] interface OESVertexArrayObject {
     const unsigned long VERTEX_ARRAY_BINDING_OES = 0x85B5;
 
-    WebGLVertexArrayObjectOES createVertexArrayOES();
+    // FIXME: https://github.com/KhronosGroup/WebGL/issues/3754.
+    WebGLVertexArrayObjectOES? createVertexArrayOES();
     undefined deleteVertexArrayOES(optional WebGLVertexArrayObjectOES? arrayObject = null);
     boolean isVertexArrayOES(optional WebGLVertexArrayObjectOES? arrayObject = null);
     undefined bindVertexArrayOES(optional WebGLVertexArrayObjectOES? arrayObject = null);

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.idl
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.idl
@@ -520,12 +520,12 @@ typedef (HTMLCanvasElement) WebGLCanvas;
     undefined copyTexImage2D(GLenum target, GLint level, GLenum internalformat, GLint x, GLint y, GLsizei width, GLsizei height, GLint border);
     undefined copyTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint x, GLint y, GLsizei width, GLsizei height);
 
-    WebGLBuffer createBuffer();
-    WebGLFramebuffer createFramebuffer();
-    WebGLProgram createProgram();
-    WebGLRenderbuffer createRenderbuffer();
-    WebGLShader createShader(GLenum type);
-    WebGLTexture createTexture();
+    WebGLBuffer? createBuffer();
+    WebGLFramebuffer? createFramebuffer();
+    WebGLProgram? createProgram();
+    WebGLRenderbuffer? createRenderbuffer();
+    WebGLShader? createShader(GLenum type);
+    WebGLTexture? createTexture();
 
     undefined cullFace(GLenum mode);
 
@@ -554,8 +554,8 @@ typedef (HTMLCanvasElement) WebGLCanvas;
     undefined frontFace(GLenum mode);
     undefined generateMipmap(GLenum target);
     
-    WebGLActiveInfo getActiveAttrib(WebGLProgram program, GLuint index);
-    WebGLActiveInfo getActiveUniform(WebGLProgram program, GLuint index);
+    WebGLActiveInfo? getActiveAttrib(WebGLProgram program, GLuint index);
+    WebGLActiveInfo? getActiveUniform(WebGLProgram program, GLuint index);
 
     // FIXME: The spec says this should not take a nullable WebGLProgram.
     sequence<WebGLShader>? getAttachedShaders(WebGLProgram program);
@@ -580,7 +580,7 @@ typedef (HTMLCanvasElement) WebGLCanvas;
 
     DOMString? getShaderInfoLog(WebGLShader shader);
 
-    WebGLShaderPrecisionFormat getShaderPrecisionFormat(GLenum shadertype, GLenum precisiontype);
+    WebGLShaderPrecisionFormat? getShaderPrecisionFormat(GLenum shadertype, GLenum precisiontype);
 
     DOMString? getShaderSource(WebGLShader shader);
 
@@ -588,7 +588,7 @@ typedef (HTMLCanvasElement) WebGLCanvas;
 
     [OverrideIDLType=IDLWebGLAny] any getUniform(WebGLProgram program, WebGLUniformLocation location);
 
-    WebGLUniformLocation getUniformLocation(WebGLProgram program, DOMString name);
+    WebGLUniformLocation? getUniformLocation(WebGLProgram program, DOMString name);
 
     [OverrideIDLType=IDLWebGLAny] any getVertexAttrib(GLuint index, GLenum pname);
 

--- a/Source/WebCore/html/track/AudioTrackList.idl
+++ b/Source/WebCore/html/track/AudioTrackList.idl
@@ -34,8 +34,8 @@
 ] interface AudioTrackList : EventTarget {
     readonly attribute unsigned long length;
 
-    // FIXME: Remove 'item' from below to align with the specification. See: https://bugs.webkit.org/show_bug.cgi?id=260763
-    [ImplementedAs=itemForBindings] getter AudioTrack item(unsigned long index);
+    // FIXME: Remove item() and nullability. See: https://bugs.webkit.org/show_bug.cgi?id=260763
+    [ImplementedAs=itemForBindings] getter AudioTrack? item(unsigned long index);
     AudioTrack? getTrackById([AtomString] DOMString id);
 
     attribute EventHandler onchange;

--- a/Source/WebCore/html/track/TextTrackCue.idl
+++ b/Source/WebCore/html/track/TextTrackCue.idl
@@ -45,7 +45,7 @@
     attribute EventHandler onenter;
     attribute EventHandler onexit;
 
-    // FIXME: Add 'unrestricted' to 'endTime' to align with the specification. See: https://bugs.webkit.org/show_bug.cgi?id=260765
+    // FIXME: This constructor and getCueAsHTML() are not standardized.
     [CallWith=CurrentDocument] constructor(double startTime, double endTime, DocumentFragment cueNode);
-    [EnabledBySetting=GenericCueAPIEnabled] DocumentFragment getCueAsHTML();
+    [EnabledBySetting=GenericCueAPIEnabled] DocumentFragment? getCueAsHTML();
 };

--- a/Source/WebCore/html/track/TextTrackCueList.idl
+++ b/Source/WebCore/html/track/TextTrackCueList.idl
@@ -30,8 +30,7 @@
     Exposed=Window
 ] interface TextTrackCueList {
     readonly attribute unsigned long length;
-    // FIXME: Remove 'item' from below to align with the specification. See: https://bugs.webkit.org/show_bug.cgi?id=260763
-    getter TextTrackCue item(unsigned long index);
+    // FIXME: Remove item() and make non-nullable. See: https://bugs.webkit.org/show_bug.cgi?id=260763
+    getter TextTrackCue? item(unsigned long index);
     TextTrackCue? getCueById(DOMString id);
 };
-

--- a/Source/WebCore/html/track/TextTrackList.idl
+++ b/Source/WebCore/html/track/TextTrackList.idl
@@ -33,12 +33,11 @@
     Exposed=Window
 ] interface TextTrackList : EventTarget {
     readonly attribute unsigned long length;
-    // FIXME: Remove 'item' from below to align with the specification. See: https://bugs.webkit.org/show_bug.cgi?id=260763
-    getter TextTrack item(unsigned long index);
+    // FIXME: Remove item() and make non-nullable. See: https://bugs.webkit.org/show_bug.cgi?id=260763
+    getter TextTrack? item(unsigned long index);
     TextTrack? getTrackById([AtomString] DOMString id);
 
     attribute EventHandler onaddtrack;
     attribute EventHandler onchange;
     attribute EventHandler onremovetrack;
 };
-

--- a/Source/WebCore/html/track/VTTCue.idl
+++ b/Source/WebCore/html/track/VTTCue.idl
@@ -51,5 +51,6 @@ enum AlignSetting { "start", "center", "end", "left", "right" };
     attribute double size;
     attribute AlignSetting align;
     attribute DOMString text;
-    DocumentFragment getCueAsHTML();
+    // FIXME: getCueAsHTML() is defined as non-nullable.
+    DocumentFragment? getCueAsHTML();
 };

--- a/Source/WebCore/html/track/VideoTrackList.idl
+++ b/Source/WebCore/html/track/VideoTrackList.idl
@@ -34,7 +34,7 @@
 ] interface VideoTrackList : EventTarget {
     readonly attribute unsigned long length;
     // FIXME: Remove 'item' from below to align with the specification. See: https://bugs.webkit.org/show_bug.cgi?id=260763
-    [ImplementedAs=itemForBindings] getter VideoTrack item(unsigned long index);
+    [ImplementedAs=itemForBindings] getter VideoTrack? item(unsigned long index);
     VideoTrack? getTrackById([AtomString] DOMString id);
     readonly attribute long selectedIndex;
 
@@ -42,4 +42,3 @@
     attribute EventHandler onaddtrack;
     attribute EventHandler onremovetrack;
 };
-

--- a/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
@@ -375,7 +375,7 @@ Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::Runtime::RemoteObjec
         JSC::JSLockHolder lock(state);
 
         auto* globalObject = deprecatedGlobalObjectForPrototype(state);
-        value = toJS(state, globalObject, animation.get());
+        value = toJS(state, globalObject, *animation);
     }
 
     if (!value) {

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -3175,7 +3175,9 @@ Node* InspectorDOMAgent::scriptValueAsNode(JSC::JSValue value)
 JSC::JSValue InspectorDOMAgent::nodeAsScriptValue(JSC::JSGlobalObject& state, Node* node)
 {
     JSC::JSLockHolder lock(&state);
-    return toJS(&state, deprecatedGlobalObjectForPrototype(&state), BindingSecurity::checkSecurityForNode(state, node));
+    if (auto* checked = BindingSecurity::checkSecurityForNode(state, node))
+        return toJS(&state, deprecatedGlobalObjectForPrototype(&state), *checked);
+    return JSC::jsNull();
 }
 
 Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::setAllowEditingUserAgentShadowTrees(bool allow)
@@ -3226,14 +3228,13 @@ Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::DOM::MediaStats>> In
 
     auto stats = Inspector::Protocol::DOM::MediaStats::create().release();
 
-    if (auto quality = mediaElement->getVideoPlaybackQuality()) {
-        auto jsonQuality = Inspector::Protocol::DOM::VideoPlaybackQuality::create()
-            .setTotalVideoFrames(quality->totalVideoFrames())
-            .setDroppedVideoFrames(quality->droppedVideoFrames())
-            .setDisplayCompositedVideoFrames(quality->displayCompositedVideoFrames())
-            .release();
-        stats->setQuality(WTF::move(jsonQuality));
-    }
+    auto quality = mediaElement->getVideoPlaybackQuality();
+    auto jsonQuality = Inspector::Protocol::DOM::VideoPlaybackQuality::create()
+        .setTotalVideoFrames(quality->totalVideoFrames())
+        .setDroppedVideoFrames(quality->droppedVideoFrames())
+        .setDisplayCompositedVideoFrames(quality->displayCompositedVideoFrames())
+        .release();
+    stats->setQuality(WTF::move(jsonQuality));
 
     auto sourceType = mediaElement->localizedSourceType();
     if (!sourceType.isEmpty())

--- a/Source/WebCore/page/DOMWindow+CSSOMView.idl
+++ b/Source/WebCore/page/DOMWindow+CSSOMView.idl
@@ -27,7 +27,8 @@ typedef USVString CSSOMString;
 
 // https://drafts.csswg.org/cssom-view/#extensions-to-the-window-interface
 partial interface DOMWindow {
-    [NewObject] MediaQueryList matchMedia(CSSOMString query);
+    // FIXME: matchMedia() should not return a nullable.
+    [NewObject] MediaQueryList? matchMedia(CSSOMString query);
     [SameObject, Replaceable] readonly attribute Screen screen;
 
     // browsing context

--- a/Source/WebCore/page/DOMWindow.idl
+++ b/Source/WebCore/page/DOMWindow.idl
@@ -24,6 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#window
 [
     CheckSecurity,
     CustomDefineOwnProperty,
@@ -63,7 +64,8 @@
     [DoNotCheckSecurityOnGetter, Replaceable] readonly attribute WindowProxy? parent;
 
     // the current browsing context
-    [LegacyUnforgeable] readonly attribute Document document;
+    // FIXME: `document` should not be nullable.
+    [LegacyUnforgeable] readonly attribute Document? document;
     attribute [AtomString] DOMString name;
     readonly attribute History history;
     [EnabledBySetting=NavigationAPIEnabled, Replaceable] readonly attribute Navigation navigation;
@@ -111,11 +113,11 @@
     [NotEnumerable, Conditional=IOS_GESTURE_EVENTS] attribute EventHandler ongesturestart;
 
     // Non-standard: For now we expose this to user worlds since Safari is using it, but we plan to remove it.
-    [EnabledForWorld=isUser] CSSRuleList getMatchedCSSRules(optional Element? element = null, optional DOMString? pseudoElement = null);
+    [EnabledForWorld=isUser] CSSRuleList? getMatchedCSSRules(optional Element? element = null, optional DOMString? pseudoElement = null);
 
     // Non-standard: Blink has already dropped these (https://bugs.chromium.org/p/chromium/issues/detail?id=398352).
-    WebKitPoint webkitConvertPointFromPageToNode(optional Node? node = null, optional WebKitPoint? p = null);
-    WebKitPoint webkitConvertPointFromNodeToPage(optional Node? node = null, optional WebKitPoint? p = null);
+    WebKitPoint? webkitConvertPointFromPageToNode(optional Node? node = null, optional WebKitPoint? p = null);
+    WebKitPoint? webkitConvertPointFromNodeToPage(optional Node? node = null, optional WebKitPoint? p = null);
 
     // Internal operations, not exposed to the Web.
     [EnabledForWorld=shadowRootIsAlwaysOpen] NodeList collectMatchingElementsInFlatTree(Node scope, DOMString selectors);

--- a/Source/WebCore/page/IntersectionObserverEntry.idl
+++ b/Source/WebCore/page/IntersectionObserverEntry.idl
@@ -23,10 +23,9 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// https://wicg.github.io/IntersectionObserver/
-
 typedef double DOMHighResTimeStamp;
 
+// https://w3c.github.io/IntersectionObserver/#intersectionobserverentry
 [
     JSCustomMarkFunction,
     Exposed=Window
@@ -35,13 +34,17 @@ typedef double DOMHighResTimeStamp;
 
     readonly attribute DOMHighResTimeStamp time;
     readonly attribute DOMRectReadOnly? rootBounds;
-    readonly attribute DOMRectReadOnly boundingClientRect;
-    readonly attribute DOMRectReadOnly intersectionRect;
+    // FIXME: `boundingClientRect` should not be nullable.
+    readonly attribute DOMRectReadOnly? boundingClientRect;
+    // FIXME: `intersectionRect` should not be nullable.
+    readonly attribute DOMRectReadOnly? intersectionRect;
     readonly attribute boolean isIntersecting;
     readonly attribute double intersectionRatio;
-    readonly attribute Element target;
+    // FIXME: `target` should not be nullable.
+    readonly attribute Element? target;
 };
 
+// https://w3c.github.io/IntersectionObserver/#dictdef-intersectionobserverentryinit
 dictionary IntersectionObserverEntryInit {
     required DOMHighResTimeStamp time;
     required DOMRectInit? rootBounds;

--- a/Source/WebCore/page/NavigateEvent.idl
+++ b/Source/WebCore/page/NavigateEvent.idl
@@ -34,11 +34,13 @@
   constructor([AtomString] DOMString type, NavigateEventInit eventInitDict);
 
   readonly attribute NavigationNavigationType navigationType;
-  readonly attribute NavigationDestination destination;
+  // FIXME: `destination` should not be nullable.
+  readonly attribute NavigationDestination? destination;
   readonly attribute boolean canIntercept;
   readonly attribute boolean userInitiated;
   readonly attribute boolean hashChange;
-  readonly attribute AbortSignal signal;
+  // FIXME: `signal` should not be nullable.
+  readonly attribute AbortSignal? signal;
   readonly attribute DOMFormData? formData;
   readonly attribute DOMString? downloadRequest;
   readonly attribute any info;

--- a/Source/WebCore/page/NavigationCurrentEntryChangeEvent.idl
+++ b/Source/WebCore/page/NavigationCurrentEntryChangeEvent.idl
@@ -32,7 +32,8 @@
   constructor([AtomString] DOMString type, NavigationCurrentEntryChangeEventInit eventInitDict);
 
   readonly attribute NavigationNavigationType? navigationType;
-  readonly attribute NavigationHistoryEntry from;
+  // FIXME: `from` should not be nullable.
+  readonly attribute NavigationHistoryEntry? from;
 };
 
 dictionary NavigationCurrentEntryChangeEventInit : EventInit {

--- a/Source/WebCore/page/NavigationTransition.cpp
+++ b/Source/WebCore/page/NavigationTransition.cpp
@@ -55,14 +55,14 @@ void NavigationTransition::rejectPromise(JSC::JSValue exceptionObject)
     m_finished->reject<IDLAny>(exceptionObject, RejectAsHandled::Yes);
 }
 
-DOMPromise* NavigationTransition::finished()
+DOMPromise& NavigationTransition::finished()
 {
     if (!m_finishedDOMPromise) {
         auto& promise = *jsCast<JSC::JSPromise*>(m_finished->promise());
         m_finishedDOMPromise = DOMPromise::create(*m_finished->globalObject(), promise);
     }
 
-    return m_finishedDOMPromise.get();
+    return *m_finishedDOMPromise;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/NavigationTransition.h
+++ b/Source/WebCore/page/NavigationTransition.h
@@ -42,7 +42,7 @@ public:
 
     NavigationNavigationType navigationType() { return m_navigationType; };
     NavigationHistoryEntry& from() { return m_from; };
-    DOMPromise* finished();
+    DOMPromise& finished();
 
     void resolvePromise();
     void rejectPromise(Exception&, JSC::JSValue exceptionObject);

--- a/Source/WebCore/page/Performance.cpp
+++ b/Source/WebCore/page/Performance.cpp
@@ -151,47 +151,45 @@ ScriptExecutionContext* Performance::scriptExecutionContext() const
     return ContextDestructionObserver::scriptExecutionContext();
 }
 
-EventCounts* Performance::eventCounts()
+EventCounts& Performance::eventCounts()
 {
-    if (!is<Document>(scriptExecutionContext()))
-        return nullptr;
-
+    ASSERT(is<Document>(scriptExecutionContext()));
     ASSERT(isMainThread());
+
     // FIXME: stop lazy-initializing m_eventCounts after event
     // timing stops being gated by a flag:
     if (!m_eventCounts)
         lazyInitialize(m_eventCounts, makeUniqueWithoutRefCountedCheck<EventCounts>(this));
 
-    return m_eventCounts.get();
+    return *m_eventCounts;
 }
 
 uint64_t Performance::interactionCount()
 {
     ASSERT(is<Document>(scriptExecutionContext()));
     ASSERT(isMainThread());
+
     return downcast<Document>(*scriptExecutionContext()).window()->interactionCount();
 }
 
-PerformanceNavigation* Performance::navigation()
+PerformanceNavigation& Performance::navigation()
 {
-    if (!is<Document>(scriptExecutionContext()))
-        return nullptr;
-
+    ASSERT(is<Document>(scriptExecutionContext()));
     ASSERT(isMainThread());
+
     if (!m_navigation)
         m_navigation = PerformanceNavigation::create(downcast<Document>(*scriptExecutionContext()).window());
-    return m_navigation.get();
+    return *m_navigation;
 }
 
-PerformanceTiming* Performance::timing()
+PerformanceTiming& Performance::timing()
 {
-    if (!is<Document>(scriptExecutionContext()))
-        return nullptr;
-
+    ASSERT(is<Document>(scriptExecutionContext()));
     ASSERT(isMainThread());
+
     if (!m_timing)
         m_timing = PerformanceTiming::create(downcast<Document>(*scriptExecutionContext()).window());
-    return m_timing.get();
+    return *m_timing;
 }
 
 Vector<Ref<PerformanceEntry>> Performance::getEntries() const
@@ -317,7 +315,7 @@ void Performance::appendBufferedEntriesByType(const String& entryType, Vector<Re
 void Performance::countEvent(EventType type)
 {
     ASSERT(isMainThread());
-    eventCounts()->add(type);
+    eventCounts().add(type);
 }
 
 void Performance::processEventEntry(const PerformanceEventTimingCandidate& candidate)

--- a/Source/WebCore/page/Performance.h
+++ b/Source/WebCore/page/Performance.h
@@ -90,9 +90,9 @@ public:
     DOMHighResTimeStamp timeOrigin() const;
     ReducedResolutionSeconds nowInReducedResolutionSeconds() const;
 
-    PerformanceNavigation* navigation();
-    PerformanceTiming* timing();
-    EventCounts* eventCounts();
+    PerformanceNavigation& navigation();
+    PerformanceTiming& timing();
+    EventCounts& eventCounts();
 
     uint64_t interactionCount();
 

--- a/Source/WebCore/page/PerformanceUserTiming.cpp
+++ b/Source/WebCore/page/PerformanceUserTiming.cpp
@@ -136,11 +136,10 @@ ExceptionOr<double> PerformanceUserTiming::convertMarkToTimestamp(const String& 
             if (*function == &PerformanceTiming::navigationStart)
                 return 0.0;
 
-            // PerformanceTiming should always be non-null for the Document ScriptExecutionContext.
-            ASSERT(m_performance->timing());
-            RefPtr timing = m_performance->timing();
+            // PerformanceTiming is only available for the Document ScriptExecutionContext.
+            Ref timing = m_performance->timing();
             auto startTime = timing->navigationStart();
-            auto endTime = ((*timing).*(*function))();
+            auto endTime = ((timing.get()).*(*function))();
             if (!endTime)
                 return Exception { ExceptionCode::InvalidAccessError };
             return endTime - startTime;

--- a/Source/WebCore/page/ResizeObserverEntry.h
+++ b/Source/WebCore/page/ResizeObserverEntry.h
@@ -45,9 +45,9 @@ public:
         return adoptRef(*new ResizeObserverEntry(WTF::move(target), contentRect, borderBoxSize, contentBoxSize));
     }
 
-    Element& target() const { return m_target.get(); }
-    DOMRectReadOnly* contentRect() const { return m_contentRect.ptr(); }
-    
+    Element& target() const { return m_target; }
+    DOMRectReadOnly& contentRect() const { return m_contentRect; }
+
     const Vector<Ref<ResizeObserverSize>>& borderBoxSize() const { return m_borderBoxSizes; }
     const Vector<Ref<ResizeObserverSize>>& contentBoxSize() const { return m_contentBoxSizes; }
 

--- a/Source/WebCore/page/WebKitNamespace.idl
+++ b/Source/WebCore/page/WebKitNamespace.idl
@@ -30,7 +30,7 @@
     Conditional=USER_MESSAGE_HANDLERS,
     Exposed=Window
 ] interface WebKitNamespace {
-    readonly attribute UserMessageHandlersNamespace messageHandlers;
+    readonly attribute UserMessageHandlersNamespace? messageHandlers;
     readonly attribute WebKitBufferNamespace buffers;
     [EnabledForGlobalObject=allowsJSHandleCreation] WebKitJSHandle createJSHandle(object object);
     [EnabledForWorld=allowNodeSerialization] WebKitSerializedNode serializeNode(Node node, optional WebKitSerializedNodeInit init);

--- a/Source/WebCore/page/WindowLocalStorage.idl
+++ b/Source/WebCore/page/WindowLocalStorage.idl
@@ -25,5 +25,6 @@
 
 // https://html.spec.whatwg.org/multipage/webstorage.html#the-localstorage-attribute
 interface mixin WindowLocalStorage {
-    [EnabledBySetting=LocalStorageEnabled] readonly attribute Storage localStorage;
+    // FIXME: `localStorage` should not be nullable.
+    [EnabledBySetting=LocalStorageEnabled] readonly attribute Storage? localStorage;
 };

--- a/Source/WebCore/page/WindowSessionStorage.idl
+++ b/Source/WebCore/page/WindowSessionStorage.idl
@@ -25,5 +25,6 @@
 
 // https://html.spec.whatwg.org/multipage/webstorage.html#windowsessionstorage
 interface mixin WindowSessionStorage {
-    [EnabledBySetting=SessionStorageEnabled] readonly attribute Storage sessionStorage;
+    // FIXME: `sessionStorage` should not be nullable.
+    [EnabledBySetting=SessionStorageEnabled] readonly attribute Storage? sessionStorage;
 };

--- a/Source/WebCore/plugins/DOMMimeType.idl
+++ b/Source/WebCore/plugins/DOMMimeType.idl
@@ -18,6 +18,7 @@
     Boston, MA 02110-1301, USA.
 */
 
+// https://html.spec.whatwg.org/multipage/system-state.html#mimetype
 [
     InterfaceName=MimeType,
     GenerateIsReachable=ReachableFromNavigator,
@@ -26,6 +27,6 @@
     readonly attribute DOMString type;
     readonly attribute DOMString suffixes;
     readonly attribute DOMString description;
-    readonly attribute DOMPlugin enabledPlugin;
+    // FIXME: `enabledPlugin` should not be nullable.
+    readonly attribute DOMPlugin? enabledPlugin;
 };
-

--- a/Source/WebCore/svg/SVGGraphicsElement.idl
+++ b/Source/WebCore/svg/SVGGraphicsElement.idl
@@ -23,17 +23,24 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://svgwg.org/svg2-draft/types.html#InterfaceSVGGraphicsElement
 [
     Exposed=Window
 ] interface SVGGraphicsElement : SVGElement {
-    readonly attribute SVGAnimatedTransformList transform;
+    [SameObject] readonly attribute SVGAnimatedTransformList transform;
 
-    readonly attribute SVGElement nearestViewportElement;
-    readonly attribute SVGElement farthestViewportElement;
-
+    // FIXME: `getBBox` should return a `DOMRect`.
+    // FIXME: `getBBox` should take an `optional SVGBoundingBoxOptions` as a parameter.
     [ImplementedAs=getBBoxForBindings, NewObject] SVGRect getBBox();
-    [ImplementedAs=getCTMForBindings, NewObject] SVGMatrix getCTM();
-    [ImplementedAs=getScreenCTMForBindings, NewObject] SVGMatrix getScreenCTM();
+    // FIXME: `getCTM` should return a `DOMMatrix?`.
+    [ImplementedAs=getCTMForBindings, NewObject] SVGMatrix? getCTM();
+    // FIXME: `getScreenCTM` should return a `DOMMatrix?`.
+    [ImplementedAs=getScreenCTMForBindings, NewObject] SVGMatrix? getScreenCTM();
+
+    // Non-standard.
+    // FIXME: These have been removed from SVG2.
+    readonly attribute SVGElement? nearestViewportElement;
+    readonly attribute SVGElement? farthestViewportElement;
 };
 
 SVGGraphicsElement includes SVGTests;

--- a/Source/WebCore/svg/SVGPathElement.h
+++ b/Source/WebCore/svg/SVGPathElement.h
@@ -95,8 +95,8 @@ public:
 
     FloatRect getBBox(StyleUpdateStrategy = AllowStyleUpdate) final;
 
-    Ref<SVGPathSegList>& pathSegList() { return m_pathSegList->baseVal(); }
-    RefPtr<SVGPathSegList>& animatedPathSegList() { return m_pathSegList->animVal(); }
+    SVGPathSegList& pathSegList() { return m_pathSegList->baseVal(); }
+    SVGPathSegList& animatedPathSegList() { return m_pathSegList->animVal(); }
 
     const SVGPathByteStream& pathByteStream() const;
     Path path() const;

--- a/Source/WebCore/svg/SVGPathElement.idl
+++ b/Source/WebCore/svg/SVGPathElement.idl
@@ -98,7 +98,8 @@
     SVGPathSegCurvetoQuadraticSmoothRel createSVGPathSegCurvetoQuadraticSmoothRel(optional unrestricted float x = NaN,
                                                                                   optional unrestricted float y = NaN);
 
-    // FIXME: these are removed from SVG2
+    // Non-standard.
+    // FIXME: These have been removed from SVG2.
     readonly attribute SVGPathSegList pathSegList;
     readonly attribute SVGPathSegList animatedPathSegList;
 };

--- a/Source/WebCore/svg/SVGPolyElement.h
+++ b/Source/WebCore/svg/SVGPolyElement.h
@@ -34,7 +34,7 @@ public:
     const SVGPointList& points() const { return m_points->currentValue(); }
 
     SVGPointList& points() { return m_points->baseVal(); }
-    SVGPointList& animatedPoints() { return *m_points->animVal(); }
+    SVGPointList& animatedPoints() { return m_points->animVal(); }
 
     size_t approximateMemoryCost() const override;
 

--- a/Source/WebCore/svg/SVGTransformList.idl
+++ b/Source/WebCore/svg/SVGTransformList.idl
@@ -40,5 +40,5 @@
     setter undefined (unsigned long index, SVGTransform newItem);
 
     [NewObject] SVGTransform createSVGTransformFromMatrix(optional DOMMatrix2DInit matrix);
-    SVGTransform consolidate();
+    SVGTransform? consolidate();
 };

--- a/Source/WebCore/svg/SVGViewSpec.idl
+++ b/Source/WebCore/svg/SVGViewSpec.idl
@@ -31,7 +31,8 @@
     Exposed=Window
 ] interface SVGViewSpec {
     readonly attribute SVGTransformList transform;
-    readonly attribute SVGElement viewTarget;
+    // FIXME: `viewTarget` should not be nullable.
+    readonly attribute SVGElement? viewTarget;
     readonly attribute DOMString viewBoxString;
     readonly attribute DOMString preserveAspectRatioString;
     readonly attribute DOMString transformString;

--- a/Source/WebCore/svg/properties/SVGAnimatedPrimitiveProperty.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedPrimitiveProperty.h
@@ -146,11 +146,11 @@ protected:
     {
     }
 
-    RefPtr<SVGSharedPrimitiveProperty<PropertyType>>& ensureAnimVal()
+    SVGSharedPrimitiveProperty<PropertyType>& ensureAnimVal()
     {
         if (!m_animVal)
             m_animVal = SVGSharedPrimitiveProperty<PropertyType>::create(m_baseVal->value());
-        return m_animVal;
+        return *m_animVal;
     }
 
     const Ref<SVGSharedPrimitiveProperty<PropertyType>> m_baseVal;

--- a/Source/WebCore/svg/properties/SVGAnimatedPropertyAnimatorImpl.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedPropertyAnimatorImpl.h
@@ -57,7 +57,7 @@ public:
 private:
     void animate(SVGElement& targetElement, float progress, unsigned repeatCount) final
     {
-        m_function.animate(targetElement, progress, repeatCount, m_animated->animVal()->value());
+        m_function.animate(targetElement, progress, repeatCount, m_animated->animVal().value());
     }
 };
 
@@ -145,7 +145,7 @@ public:
 private:
     void animate(SVGElement& targetElement, float progress, unsigned repeatCount) final
     {
-        m_function.animate(targetElement, progress, repeatCount, m_animated->animVal()->value());
+        m_function.animate(targetElement, progress, repeatCount, m_animated->animVal().value());
     }
 };
 
@@ -223,8 +223,8 @@ public:
 private:
     void animate(SVGElement& targetElement, float progress, unsigned repeatCount) final
     {
-        m_animated->animVal()->pathByteStreamWillChange();
-        m_function.animate(targetElement, progress, repeatCount, m_animated->animVal()->pathByteStream());
+        m_animated->animVal().pathByteStreamWillChange();
+        m_function.animate(targetElement, progress, repeatCount, m_animated->animVal().pathByteStream());
     }
 };
 
@@ -282,7 +282,7 @@ public:
 private:
     void animate(SVGElement& targetElement, float progress, unsigned repeatCount) final
     {
-        SVGPreserveAspectRatioValue& animated = m_animated->animVal()->value();
+        SVGPreserveAspectRatioValue& animated = m_animated->animVal().value();
         m_function.animate(targetElement, progress, repeatCount, animated);
     }
 };
@@ -302,7 +302,7 @@ public:
 private:
     void animate(SVGElement& targetElement, float progress, unsigned repeatCount) final
     {
-        m_function.animate(targetElement, progress, repeatCount, m_animated->animVal()->value());
+        m_function.animate(targetElement, progress, repeatCount, m_animated->animVal().value());
     }
 };
 

--- a/Source/WebCore/svg/properties/SVGAnimatedPropertyImpl.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedPropertyImpl.h
@@ -82,18 +82,18 @@ public:
 
     SVGPathByteStream& currentPathByteStream()
     {
-        return isAnimating() ? animVal()->pathByteStream() : baseVal()->pathByteStream();
+        return isAnimating() ? animVal().pathByteStream() : baseVal()->pathByteStream();
     }
 
     Path currentPath()
     {
-        return isAnimating() ? animVal()->path() : baseVal()->path();
+        return isAnimating() ? animVal().path() : baseVal()->path();
     }
 
     size_t approximateMemoryCost() const
     {
         if (isAnimating())
-            return baseVal()->approximateMemoryCost() + animVal()->approximateMemoryCost();
+            return baseVal()->approximateMemoryCost() + animVal().approximateMemoryCost();
         return baseVal()->approximateMemoryCost();
     }
 };

--- a/Source/WebCore/svg/properties/SVGAnimatedPropertyList.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedPropertyList.h
@@ -52,10 +52,10 @@ public:
     Ref<ListType>& baseVal() { return m_baseVal; }
 
     // Used by the DOM.
-    const RefPtr<ListType>& animVal() const { return const_cast<SVGAnimatedPropertyList*>(this)->ensureAnimVal(); }
+    const ListType& animVal() const { return const_cast<SVGAnimatedPropertyList*>(this)->ensureAnimVal(); }
 
     // Called by SVGAnimatedPropertyAnimator to pass the animVal to the SVGAnimationFunction::progress.
-    RefPtr<ListType>& animVal() { return ensureAnimVal(); }
+    ListType& animVal() { return ensureAnimVal(); }
 
     // Used when committing a change from the SVGAnimatedProperty to the attribute.
     String baseValAsString() const override { return m_baseVal->valueAsString(); }
@@ -119,11 +119,11 @@ protected:
     {
     }
 
-    RefPtr<ListType>& ensureAnimVal()
+    ListType& ensureAnimVal()
     {
         if (!m_animVal)
             m_animVal = ListType::create(m_baseVal, SVGPropertyAccess::ReadOnly);
-        return m_animVal;
+        return *m_animVal;
     }
 
     // Called when m_baseVal changes or an item in m_baseVal changes.

--- a/Source/WebCore/svg/properties/SVGAnimatedPropertyPairAnimatorImpl.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedPropertyPairAnimatorImpl.h
@@ -90,7 +90,7 @@ private:
         }
 
         // auto, auto-start-reverse, or unknown.
-        m_animatedPropertyAnimator1->m_animated->animVal()->value().setValue(0);
+        m_animatedPropertyAnimator1->m_animated->animVal().value().setValue(0);
 
         if (m_animatedPropertyAnimator2->m_function.m_from == SVGMarkerOrientAuto || m_animatedPropertyAnimator2->m_function.m_from == SVGMarkerOrientAutoStartReverse)
             m_animatedPropertyAnimator2->m_animated->setAnimVal(m_animatedPropertyAnimator2->m_function.m_from);

--- a/Source/WebCore/svg/properties/SVGAnimatedValueProperty.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedValueProperty.h
@@ -68,10 +68,10 @@ public:
     }
 
     // Used by the DOM.
-    const RefPtr<PropertyType>& animVal() const { return const_cast<SVGAnimatedValueProperty*>(this)->ensureAnimVal(); }
+    const PropertyType& animVal() const { return const_cast<SVGAnimatedValueProperty*>(this)->ensureAnimVal(); }
 
     // Called by SVGAnimatedPropertyAnimator to pass the animVal to the SVGAnimationFunction::progress.
-    RefPtr<PropertyType>& animVal() { return ensureAnimVal(); }
+    PropertyType& animVal() { return ensureAnimVal(); }
 
     // Used when committing a change from the SVGAnimatedProperty to the attribute.
     String baseValAsString() const override { return m_baseVal->valueAsString(); }
@@ -144,11 +144,11 @@ protected:
     {
     }
 
-    RefPtr<PropertyType>& ensureAnimVal()
+    PropertyType& ensureAnimVal()
     {
         if (!m_animVal)
             m_animVal = PropertyType::create(this, SVGPropertyAccess::ReadOnly, m_baseVal->value());
-        return m_animVal;
+        return *m_animVal;
     }
 
     // Called when m_baseVal changes.

--- a/Source/WebCore/svg/properties/SVGAnimationAdditiveListFunction.h
+++ b/Source/WebCore/svg/properties/SVGAnimationAdditiveListFunction.h
@@ -44,21 +44,21 @@ public:
 protected:
     const Ref<ListType>& toAtEndOfDuration() const { return !m_toAtEndOfDuration->isEmpty() ? m_toAtEndOfDuration : m_to; }
 
-    bool adjustAnimatedList(AnimationMode animationMode, float percentage, RefPtr<ListType>& animated, bool resizeAnimatedIfNeeded = true)
+    bool adjustAnimatedList(AnimationMode animationMode, float percentage, ListType& animated, bool resizeAnimatedIfNeeded = true)
     {
         if (!m_to->numberOfItems())
             return false;
 
         if (m_from->numberOfItems() && m_from->size() != m_to->size()) {
             if (percentage >= 0.5)
-                *animated = m_to;
+                animated = m_to;
             else if (animationMode != AnimationMode::To)
-                *animated = m_from;
+                animated = m_from;
             return false;
         }
 
-        if (resizeAnimatedIfNeeded && animated->size() < m_to->size())
-            animated->resize(m_to->size());
+        if (resizeAnimatedIfNeeded && animated.size() < m_to->size())
+            animated.resize(m_to->size());
         return true;
     }
 

--- a/Source/WebCore/svg/properties/SVGAnimationAdditiveListFunctionImpl.h
+++ b/Source/WebCore/svg/properties/SVGAnimationAdditiveListFunctionImpl.h
@@ -57,16 +57,16 @@ public:
         m_toAtEndOfDuration->parse(toAtEndOfDuration);
     }
 
-    void animate(SVGElement& targetElement, float progress, unsigned repeatCount, RefPtr<SVGLengthList>& animated)
+    void animate(SVGElement& targetElement, float progress, unsigned repeatCount, SVGLengthList& animated)
     {
         if (!adjustAnimatedList(m_animationMode, progress, animated))
             return;
 
-        const Vector<Ref<SVGLength>>& fromItems = m_animationMode == AnimationMode::To ? animated->items() : m_from->items();
+        const Vector<Ref<SVGLength>>& fromItems = m_animationMode == AnimationMode::To ? animated.items() : m_from->items();
         const Vector<Ref<SVGLength>>& toItems = m_to->items();
         const Vector<Ref<SVGLength>>& toAtEndOfDurationItems = toAtEndOfDuration()->items();
-        Vector<Ref<SVGLength>>& animatedItems = animated->items();
-        SVGLengthMode lengthMode = animated->lengthMode();
+        Vector<Ref<SVGLength>>& animatedItems = animated.items();
+        SVGLengthMode lengthMode = animated.lengthMode();
 
         SVGLengthContext lengthContext(&targetElement);
         for (unsigned i = 0; i < toItems.size(); ++i) {
@@ -116,15 +116,15 @@ public:
         m_toAtEndOfDuration->parse(toAtEndOfDuration);
     }
 
-    void animate(SVGElement&, float progress, unsigned repeatCount, RefPtr<SVGNumberList>& animated)
+    void animate(SVGElement&, float progress, unsigned repeatCount, SVGNumberList& animated)
     {
         if (!adjustAnimatedList(m_animationMode, progress, animated))
             return;
 
-        auto& fromItems = m_animationMode == AnimationMode::To ? animated->items() : m_from->items();
+        auto& fromItems = m_animationMode == AnimationMode::To ? animated.items() : m_from->items();
         auto& toItems = m_to->items();
         auto& toAtEndOfDurationItems = toAtEndOfDuration()->items();
-        auto& animatedItems = animated->items();
+        auto& animatedItems = animated.items();
 
         for (unsigned i = 0; i < toItems.size(); ++i) {
             float from = i < fromItems.size() ? fromItems[i]->value() : 0;
@@ -166,15 +166,15 @@ public:
         m_toAtEndOfDuration->parse(toAtEndOfDuration);
     }
 
-    void animate(SVGElement&, float progress, unsigned repeatCount, RefPtr<SVGPointList>& animated)
+    void animate(SVGElement&, float progress, unsigned repeatCount, SVGPointList& animated)
     {
         if (!adjustAnimatedList(m_animationMode, progress, animated))
             return;
 
-        auto& fromItems = m_animationMode == AnimationMode::To ? animated->items() : m_from->items();
+        auto& fromItems = m_animationMode == AnimationMode::To ? animated.items() : m_from->items();
         auto& toItems = m_to->items();
         auto& toAtEndOfDurationItems = toAtEndOfDuration()->items();
-        auto& animatedItems = animated->items();
+        auto& animatedItems = animated.items();
 
         for (unsigned i = 0; i < toItems.size(); ++i) {
             FloatPoint from = i < fromItems.size() ? fromItems[i]->value() : FloatPoint();
@@ -219,7 +219,7 @@ public:
         m_toAtEndOfDuration->parse(toAtEndOfDuration);
     }
 
-    void animate(SVGElement&, float progress, unsigned repeatCount, RefPtr<SVGTransformList>& animated)
+    void animate(SVGElement&, float progress, unsigned repeatCount, SVGTransformList& animated)
     {
         // Pass false to 'resizeAnimatedIfNeeded', as the special post-multiplication behavior of <animateTransform> needs to be respected below.
         if (!adjustAnimatedList(m_animationMode, progress, animated, false))
@@ -232,7 +232,7 @@ public:
         const Vector<Ref<SVGTransform>>& fromItems = m_from->items();
         const Vector<Ref<SVGTransform>>& toItems = m_to->items();
         const Vector<Ref<SVGTransform>>& toAtEndOfDurationItems = toAtEndOfDuration()->items();
-        Vector<Ref<SVGTransform>>& animatedItems = animated->items();
+        Vector<Ref<SVGTransform>>& animatedItems = animated.items();
 
         // Never resize the animatedList to the m_to size, instead either clear the list
         // or append to it.

--- a/Source/WebCore/svg/properties/SVGValuePropertyListAnimator.h
+++ b/Source/WebCore/svg/properties/SVGValuePropertyListAnimator.h
@@ -59,7 +59,7 @@ protected:
     using Base::computeCSSPropertyValue;
     using Base::m_attributeName;
 
-    RefPtr<ListType> m_list;
+    Ref<ListType> m_list;
 };
 
 #define TZONE_TEMPLATE_PARAMS template<typename ListType, typename AnimationFunction>

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1369,10 +1369,9 @@ void Internals::setSpeculativeTilingDelayDisabledForTesting(bool disabled)
         frameView->setSpeculativeTilingDelayDisabledForTesting(disabled);
 }
 
-
-Node* Internals::treeScopeRootNode(Node& node)
+Node& Internals::treeScopeRootNode(Node& node)
 {
-    return &node.treeScope().rootNode();
+    return node.treeScope().rootNode();
 }
 
 Node* Internals::parentTreeScope(Node& node)
@@ -1587,9 +1586,9 @@ Ref<CSSComputedStyleDeclaration> Internals::computedStyleIncludingVisitedInfo(El
     return CSSComputedStyleDeclaration::create(element, CSSComputedStyleDeclaration::AllowVisited::Yes);
 }
 
-Node* Internals::ensureUserAgentShadowRoot(Element& host)
+Node& Internals::ensureUserAgentShadowRoot(Element& host)
 {
-    return &host.ensureUserAgentShadowRoot();
+    return host.ensureUserAgentShadowRoot();
 }
 
 Node* Internals::shadowRoot(Element& host)
@@ -7594,7 +7593,7 @@ bool Internals::destroySleepDisabler(unsigned identifier)
 
 #if ENABLE(WEBXR)
 
-ExceptionOr<RefPtr<WebXRTest>> Internals::xrTest()
+ExceptionOr<Ref<WebXRTest>> Internals::xrTest()
 {
     auto* document = contextDocument();
     if (!document || !document->window() || !document->settings().webXREnabled())
@@ -7607,7 +7606,7 @@ ExceptionOr<RefPtr<WebXRTest>> Internals::xrTest()
 
         m_xrTest = WebXRTest::create(NavigatorWebXR::xr(*navigator));
     }
-    return m_xrTest.get();
+    return Ref<WebXRTest> { *m_xrTest };
 }
 
 #endif

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -297,7 +297,7 @@ public:
 
     Ref<CSSComputedStyleDeclaration> computedStyleIncludingVisitedInfo(Element&) const;
 
-    Node* ensureUserAgentShadowRoot(Element& host);
+    Node& ensureUserAgentShadowRoot(Element& host);
     Node* shadowRoot(Element& host);
     ExceptionOr<String> shadowRootType(const Node&) const;
     const AtomString& userAgentPart(Element&);
@@ -347,7 +347,7 @@ public:
 
     double preferredRenderingUpdateInterval();
 
-    Node* treeScopeRootNode(Node&);
+    Node& treeScopeRootNode(Node&);
     Node* parentTreeScope(Node&);
 
     String visiblePlaceholder(Element&);
@@ -1526,7 +1526,7 @@ public:
     Vector<Ref<AbstractRange>> textExtractionHighlightRanges() const;
 
 #if ENABLE(WEBXR)
-    ExceptionOr<RefPtr<WebXRTest>> xrTest();
+    ExceptionOr<Ref<WebXRTest>> xrTest();
 #endif
 
 #if ENABLE(ENCRYPTED_MEDIA)

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -550,13 +550,13 @@ enum ContentsFormat {
     CSSStyleDeclaration computedStyleIncludingVisitedInfo(Element element);
 
     Node ensureUserAgentShadowRoot(Element host);
-    Node shadowRoot(Element host);
+    Node? shadowRoot(Element host);
 
     DOMString shadowRootType(Node root);
     DOMString userAgentPart(Element element);
     undefined setUserAgentPart(Element element, [AtomString] DOMString part);
     Node treeScopeRootNode(Node node);
-    Node parentTreeScope(Node node);
+    Node? parentTreeScope(Node node);
 
     // Spatial Navigation testing
     unsigned long lastSpatialNavigationCandidateCount();
@@ -612,7 +612,7 @@ enum ContentsFormat {
     DOMString markerDescriptionForNode(Node node, DOMString markerType, unsigned long index);
     DOMString dumpMarkerRects(DOMString markerType);
     undefined setMarkedTextMatchesAreHighlighted(boolean flag);
-    ImageData snapshotNode(Node node);
+    ImageData? snapshotNode(Node node);
 
     undefined invalidateFontCache();
 
@@ -654,7 +654,7 @@ enum ContentsFormat {
 
     undefined setCanShowPlaceholder(Element element, boolean canShowPlaceholder);
 
-    Element insertTextPlaceholder(long width, long height);
+    Element? insertTextPlaceholder(long width, long height);
     undefined removeTextPlaceholder(Element element);
 
     Range? rangeOfString(DOMString text, Range? referenceRange, sequence<DOMString> findOptions);
@@ -767,7 +767,7 @@ enum ContentsFormat {
 
     undefined setGridMaxTracksLimit(unsigned long maxTracksLimit);
 
-    readonly attribute InternalSettings settings;
+    readonly attribute InternalSettings? settings;
     readonly attribute unsigned long workerThreadCount;
 
     readonly attribute boolean areSVGAnimationsPaused;
@@ -1028,7 +1028,7 @@ enum ContentsFormat {
     [Conditional=VIDEO] undefined setPrimaryAudioTrackLanguageOverride(DOMString language);
     [Conditional=VIDEO] undefined setCaptionDisplayMode(DOMString mode);
     [Conditional=VIDEO] readonly attribute DOMString captionDisplayMode;
-    [Conditional=VIDEO] TextTrackCueGeneric createGenericCue(double startTime, double endTime, DOMString text);
+    [Conditional=VIDEO] TextTrackCueGeneric? createGenericCue(double startTime, double endTime, DOMString text);
     [Conditional=VIDEO] DOMString textTrackBCP47Language(TextTrack track);
 
     [Conditional=VIDEO] TimeRanges createTimeRanges(Float32Array startTimes, Float32Array
@@ -1038,7 +1038,7 @@ enum ContentsFormat {
     [Conditional=VIDEO] undefined showCaptionDisplaySettingsPreviewForMediaElement(HTMLMediaElement element);
     [Conditional=VIDEO] undefined hideCaptionDisplaySettingsPreviewForMediaElement(HTMLMediaElement element);
     [Conditional=VIDEO] undefined setMockCaptionDisplaySettingsClientCallback(MockCaptionDisplaySettingsClientCallback? callback);
-    [Conditional=VIDEO] MediaControlsHost controlsHostForMediaElement(HTMLMediaElement element);
+    [Conditional=VIDEO] MediaControlsHost? controlsHostForMediaElement(HTMLMediaElement element);
 
     boolean isSelectPopupVisible(HTMLSelectElement element);
 
@@ -1307,7 +1307,7 @@ enum ContentsFormat {
     [Conditional=VIDEO] boolean elementIsActiveNowPlayingSession(HTMLMediaElement element);
     undefined setNowPlayingUpdateInterval(double interval);
 
-    [Conditional=VIDEO] HTMLMediaElement bestMediaElementForRemoteControls(PlaybackControlsPurpose purpose);
+    [Conditional=VIDEO] HTMLMediaElement? bestMediaElementForRemoteControls(PlaybackControlsPurpose purpose);
     [Conditional=VIDEO] MediaSessionState mediaSessionState(HTMLMediaElement element);
 
     [Conditional=VIDEO] MediaUsageState mediaUsageState(HTMLMediaElement element);
@@ -1315,8 +1315,8 @@ enum ContentsFormat {
     [Conditional=VIDEO] readonly attribute unsigned long mediaElementCount;
     [Conditional=VIDEO] undefined setMediaElementVolumeLocked(HTMLMediaElement element, boolean volumeLocked);
 
-    [Conditional=SPEECH_SYNTHESIS] SpeechSynthesisUtterance speechSynthesisUtteranceForCue(VTTCue cue);
-    [Conditional=SPEECH_SYNTHESIS] VTTCue mediaElementCurrentlySpokenCue(HTMLMediaElement media);
+    [Conditional=SPEECH_SYNTHESIS] SpeechSynthesisUtterance? speechSynthesisUtteranceForCue(VTTCue cue);
+    [Conditional=SPEECH_SYNTHESIS] VTTCue? mediaElementCurrentlySpokenCue(HTMLMediaElement media);
 
     DOMString ongoingLoadsDescriptions();
     undefined setCaptureExtraNetworkLoadMetricsEnabled(boolean value);
@@ -1444,7 +1444,7 @@ enum ContentsFormat {
 
     undefined retainTextIteratorForDocumentContent();
 
-    PushSubscription createPushSubscription(USVString endpoint, EpochTimeStamp? expirationTime, ArrayBuffer serverVAPIDPublicKey, ArrayBuffer clientECDHPublicKey, ArrayBuffer auth);
+    PushSubscription? createPushSubscription(USVString endpoint, EpochTimeStamp? expirationTime, ArrayBuffer serverVAPIDPublicKey, ArrayBuffer clientECDHPublicKey, ArrayBuffer auth);
 
     [Conditional=ARKIT_INLINE_PREVIEW_MAC] Promise<sequence<DOMString>> modelInlinePreviewUUIDs();
     [Conditional=ARKIT_INLINE_PREVIEW_MAC] DOMString modelInlinePreviewUUIDForModelElement(HTMLModelElement modelElement);

--- a/Source/WebCore/testing/ServiceWorkerInternals.idl
+++ b/Source/WebCore/testing/ServiceWorkerInternals.idl
@@ -45,8 +45,8 @@
     readonly attribute long processIdentifier;
 
     Promise<boolean> lastNavigationWasAppInitiated();
-    
-    PushSubscription createPushSubscription(USVString endpoint, EpochTimeStamp? expirationTime, ArrayBuffer serverVAPIDPublicKey, ArrayBuffer clientECDHPublicKey, ArrayBuffer auth);
+
+    PushSubscription? createPushSubscription(USVString endpoint, EpochTimeStamp? expirationTime, ArrayBuffer serverVAPIDPublicKey, ArrayBuffer clientECDHPublicKey, ArrayBuffer auth);
 
     boolean fetchEventIsSameSite(FetchEvent event);
 

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchEvent.idl
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchEvent.idl
@@ -23,10 +23,12 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://wicg.github.io/background-fetch/#backgroundfetchevent
 [
     EnabledBySetting=ServiceWorkersEnabled&BackgroundFetchAPIEnabled,
     Exposed=ServiceWorker
 ] interface BackgroundFetchEvent : ExtendableEvent {
   constructor([AtomString] DOMString type, BackgroundFetchEventInit init);
-  readonly attribute BackgroundFetchRegistration registration;
+  // FIXME: `registration` should not be nullable.
+  readonly attribute BackgroundFetchRegistration? registration;
 };

--- a/Source/WebCore/xml/XPathResult.idl
+++ b/Source/WebCore/xml/XPathResult.idl
@@ -17,6 +17,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
+// https://dom.spec.whatwg.org/#xpathresult
 [
     ExportToWrappedFunction,
     JSCustomMarkFunction,
@@ -37,11 +38,10 @@
     readonly attribute unrestricted double numberValue;
     readonly attribute DOMString stringValue;
     readonly attribute boolean booleanValue;
-    readonly attribute Node singleNodeValue;
-
+    readonly attribute Node? singleNodeValue;
     readonly attribute boolean invalidIteratorState;
     readonly attribute unsigned long snapshotLength;
 
-    Node iterateNext();
-    Node snapshotItem(unsigned long index);
+    Node? iterateNext();
+    Node? snapshotItem(unsigned long index);
 };

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitFrame.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitFrame.cpp
@@ -109,7 +109,7 @@ Vector<GRefPtr<JSCValue>> webkitFrameGetJSCValuesForElementsInWorld(WebKitFrame*
         JSValueRef jsValue = nullptr;
         {
             JSC::JSLockHolder lock(globalObject);
-            jsValue = toRef(globalObject, toJS(globalObject, globalObject, element.ptr()));
+            jsValue = toRef(globalObject, toJS(globalObject, globalObject, element));
         }
         return jsValue ? jscContextGetOrCreateValue(jsContext.get(), jsValue) : nullptr;
     });

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebHitTestResult.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebHitTestResult.cpp
@@ -428,7 +428,7 @@ JSCValue* webkit_web_hit_test_result_get_js_node(WebKitWebHitTestResult* webHitT
     JSValueRef jsValue = nullptr;
     {
         JSC::JSLockHolder lock(globalObject);
-        jsValue = toRef(globalObject, toJS(globalObject, globalObject, webHitTestResult->priv->node.get()));
+        jsValue = toRef(globalObject, toJS(globalObject, globalObject, *webHitTestResult->priv->node));
     }
 
     return jsValue ? jscContextGetOrCreateValue(jsContext.get(), jsValue).leakRef() : nullptr;

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -1130,7 +1130,8 @@ JSValueRef WebFrame::jsWrapperForWorld(InjectedBundleNodeHandle* nodeHandle, Inj
     auto* globalObject = localFrame->checkedScript()->globalObject(world->protectedCoreWorld());
 
     JSLockHolder lock(globalObject);
-    return toRef(globalObject, toJS(globalObject, globalObject, RefPtr { nodeHandle->coreNode() }.get()));
+    RefPtr coreNode = nodeHandle->coreNode();
+    return toRef(globalObject, coreNode ? toJS(globalObject, globalObject, coreNode.releaseNonNull()) : JSC::jsNull());
 }
 
 JSValueRef WebFrame::jsWrapperForWorld(InjectedBundleRangeHandle* rangeHandle, InjectedBundleScriptWorld* world)

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLTableElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLTableElement.mm
@@ -36,6 +36,7 @@
 #import <WebCore/HTMLNames.h>
 #import <WebCore/HTMLTableCaptionElement.h>
 #import <WebCore/HTMLTableElement.h>
+#import <WebCore/HTMLTableRowElement.h>
 #import <WebCore/HTMLTableSectionElement.h>
 #import <WebCore/JSExecState.h>
 #import <WebCore/ThreadCheck.h>

--- a/Source/WebKitLegacy/mac/DOM/DOMInternal.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMInternal.mm
@@ -122,7 +122,7 @@ void removeDOMWrapper(DOMObjectInternal* impl)
     auto* globalObject = frame->script().globalObject(WebCore::mainThreadNormalWorldSingleton());
 
     // Get (or create) a cached JS object for the DOM node.
-    JSC::JSObject *scriptImp = asObject(WebCore::toJS(globalObject, globalObject, nodeImpl));
+    JSC::JSObject *scriptImp = asObject(WebCore::toJS(globalObject, globalObject, *nodeImpl));
 
     JSC::Bindings::RootObject* rootObject = frame->script().bindingRootObject();
 

--- a/Source/WebKitLegacy/mac/DOM/DOMNode.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMNode.mm
@@ -116,7 +116,7 @@ DOMNode *kit(Node* value)
 - (DOMNodeList *)childNodes
 {
     JSMainThreadNullState state;
-    return kit(unwrap(*self).childNodes().get());
+    return kit(unwrap(*self).childNodes().ptr());
 }
 
 - (DOMNode *)firstChild

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -2345,7 +2345,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     auto* lexicalGlobalObject = globalObject;
 
     JSC::JSLockHolder lock(lexicalGlobalObject);
-    return toRef(lexicalGlobalObject, toJS(lexicalGlobalObject, globalObject, core(node)));
+    RefPtr codeNode = core(node);
+    return toRef(lexicalGlobalObject, codeNode ? toJS(lexicalGlobalObject, globalObject, codeNode.releaseNonNull()) : JSC::jsNull());
 }
 
 - (NSDictionary *)elementAtPoint:(NSPoint)point


### PR DESCRIPTION
#### f96aecc3dd48fe35941d4aa2c3226424745418b8
<pre>
Make toJS() interface conversions require correct nullness and subtyping
<a href="https://bugs.webkit.org/show_bug.cgi?id=305413">https://bugs.webkit.org/show_bug.cgi?id=305413</a>

Reviewed by Chris Dumez and Anne van Kesteren.

Makes it so calling toJS() for an interface requires passing in a
reference or Ref value by removing toJS() overloads that take pointers
or RefPtr.

The fallout of making that change, and the subsequent changes to
the IDL type definitions for isNullValue/extractValueFromNullable
and JSConversion&lt;IDLInterface&lt;T&gt;&gt; is that idl files now need to
accurately annotate types nullability. This does not cause any
user observable changes, it only makes explicit what was previously
implicit.

In addition to needing to pass in the right nullability, conversion
now enforces that the type being converted is the correct type or a
one derived from it.

* Source/WebCore/Modules/WebGPU/NavigatorGPU.idl:
* Source/WebCore/Modules/async-clipboard/NavigatorClipboard.cpp:
* Source/WebCore/Modules/async-clipboard/NavigatorClipboard.h:
* Source/WebCore/Modules/audiosession/NavigatorAudioSession.cpp:
* Source/WebCore/Modules/audiosession/NavigatorAudioSession.h:
* Source/WebCore/Modules/cache/WindowOrWorkerGlobalScope+Caches.idl:
* Source/WebCore/Modules/contact-picker/NavigatorContacts.cpp:
* Source/WebCore/Modules/contact-picker/NavigatorContacts.h:
* Source/WebCore/Modules/credentialmanagement/Navigator+Credentials.idl:
* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.idl:
* Source/WebCore/Modules/geolocation/Navigator+Geolocation.idl:
* Source/WebCore/Modules/indexeddb/IDBCursor.idl:
* Source/WebCore/Modules/indexeddb/IDBRequest.idl:
* Source/WebCore/Modules/indexeddb/IDBTransaction.cpp:
* Source/WebCore/Modules/indexeddb/IDBTransaction.h:
* Source/WebCore/Modules/indexeddb/WindowOrWorkerGlobalScope+IndexedDatabase.idl:
* Source/WebCore/Modules/mediacontrols/DOMWindow+MediaControls.idl:
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.idl:
* Source/WebCore/Modules/mediacontrols/MediaControlsUtils.idl:
* Source/WebCore/Modules/mediasource/BufferedChangeEvent.idl:
* Source/WebCore/Modules/mediasource/SourceBufferList.idl:
* Source/WebCore/Modules/mediastream/MediaStream.idl:
* Source/WebCore/Modules/mediastream/MediaStreamTrack.idl:
* Source/WebCore/Modules/mediastream/MediaStreamTrackEvent.idl:
* Source/WebCore/Modules/mediastream/Navigator+MediaDevices.idl:
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp:
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.h:
* Source/WebCore/Modules/mediastream/RTCTrackEvent.idl:
* Source/WebCore/Modules/notifications/NotificationEvent.idl:
* Source/WebCore/Modules/speech/DOMWindow+SpeechSynthesis.idl:
* Source/WebCore/Modules/speech/SpeechRecognitionEvent.idl:
* Source/WebCore/Modules/speech/SpeechRecognitionResult.idl:
* Source/WebCore/Modules/speech/SpeechRecognitionResultList.idl:
* Source/WebCore/Modules/speech/SpeechSynthesisEvent.idl:
* Source/WebCore/Modules/streams/ReadableStreamReadRequest.cpp:
* Source/WebCore/Modules/webaudio/AudioContext.cpp:
* Source/WebCore/Modules/webaudio/AudioProcessingEvent.idl:
* Source/WebCore/Modules/webauthn/PublicKeyCredential.h:
* Source/WebCore/Modules/webtransport/WebTransport.cpp:
* Source/WebCore/Modules/webtransport/WebTransportDatagramDuplexStream.cpp:
* Source/WebCore/Modules/webtransport/WebTransportDatagramDuplexStream.h:
* Source/WebCore/Modules/webtransport/WebTransportDatagramsWritable.cpp:
* Source/WebCore/Modules/webtransport/WebTransportDatagramsWritable.h:
* Source/WebCore/Modules/webxr/WebXRHand.idl:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/animation/ViewTimeline.idl:
* Source/WebCore/bindings/IDLTypes.h:
* Source/WebCore/bindings/js/JSCustomElementInterface.cpp:
* Source/WebCore/bindings/js/JSDOMConvertInterface.h:
* Source/WebCore/bindings/js/JSDOMConvertNullable.h:
* Source/WebCore/bindings/js/JSDOMConvertPromise.h:
* Source/WebCore/bindings/js/JSDOMConvertUnion.h:
* Source/WebCore/bindings/js/JSDOMConvertWebGL.cpp:
* Source/WebCore/bindings/js/JSDOMIterator.h:
* Source/WebCore/bindings/js/JSDOMWindowBase.cpp:
* Source/WebCore/bindings/js/JSDOMWindowCustom.cpp:
* Source/WebCore/bindings/js/JSDOMWindowProperties.cpp:
* Source/WebCore/bindings/js/JSEventListener.cpp:
* Source/WebCore/bindings/js/JSIDBRequestCustom.cpp:
* Source/WebCore/bindings/js/JSXMLHttpRequestCustom.cpp:
* Source/WebCore/bindings/js/ScriptController.cpp:
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
* Source/WebCore/css/CSSComputedStyleDeclaration.cpp:
* Source/WebCore/css/CSSComputedStyleDeclaration.h:
* Source/WebCore/css/CSSMediaRule.cpp:
* Source/WebCore/css/CSSMediaRule.h:
* Source/WebCore/css/CSSRuleList.idl:
* Source/WebCore/css/CSSStyleDeclaration.h:
* Source/WebCore/css/CSSStyleDeclaration.idl:
* Source/WebCore/css/CSSStyleProperties.h:
* Source/WebCore/css/CSSStyleSheet.idl:
* Source/WebCore/css/DeprecatedCSSOMRect.h:
* Source/WebCore/css/DeprecatedCSSOMValueList.idl:
* Source/WebCore/css/PropertySetCSSDescriptors.h:
* Source/WebCore/css/StyleSheet.idl:
* Source/WebCore/css/typedom/StylePropertyMapReadOnly.idl:
* Source/WebCore/css/typedom/color/CSSOMColor.cpp:
* Source/WebCore/css/typedom/color/CSSOMColor.h:
* Source/WebCore/css/typedom/color/CSSOMColor.idl:
* Source/WebCore/css/typedom/color/CSSOMColorValue.idl:
* Source/WebCore/css/typedom/transform/CSSMatrixComponent.cpp:
* Source/WebCore/css/typedom/transform/CSSMatrixComponent.h:
* Source/WebCore/dom/Attr.idl:
* Source/WebCore/dom/CaretPosition.idl:
* Source/WebCore/dom/DOMRectList.idl:
* Source/WebCore/dom/DataTransferItem.idl:
* Source/WebCore/dom/DataTransferItemList.idl:
* Source/WebCore/dom/Document+Fullscreen.idl:
* Source/WebCore/dom/Document+HTML.idl:
* Source/WebCore/dom/Document+ViewTransition.idl:
* Source/WebCore/dom/Document.idl:
* Source/WebCore/dom/Element.cpp:
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/ElementInternals.cpp:
* Source/WebCore/dom/ElementInternals.h:
* Source/WebCore/dom/ElementInternals.idl:
* Source/WebCore/dom/Event.idl:
* Source/WebCore/dom/MutationObserver.cpp:
* Source/WebCore/dom/MutationRecord.cpp:
* Source/WebCore/dom/MutationRecord.h:
* Source/WebCore/dom/Node.cpp:
* Source/WebCore/dom/Node.h:
* Source/WebCore/dom/NodeIterator.idl:
* Source/WebCore/dom/Range.idl:
* Source/WebCore/dom/ShadowRoot.idl:
* Source/WebCore/dom/WindowOrWorkerGlobalScope+TrustedTypes.idl:
* Source/WebCore/fileapi/FileList.idl:
* Source/WebCore/html/FTPDirectoryDocument.cpp:
* Source/WebCore/html/FormListedElement.h:
* Source/WebCore/html/HTMLButtonElement.idl:
* Source/WebCore/html/HTMLFieldSetElement.idl:
* Source/WebCore/html/HTMLFrameElement.idl:
* Source/WebCore/html/HTMLInputElement.idl:
* Source/WebCore/html/HTMLLabelElement.idl:
* Source/WebCore/html/HTMLLegendElement.idl:
* Source/WebCore/html/HTMLLinkElement.idl:
* Source/WebCore/html/HTMLMediaElement.cpp:
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/HTMLMediaElement.idl:
* Source/WebCore/html/HTMLMeterElement.idl:
* Source/WebCore/html/HTMLObjectElement.idl:
* Source/WebCore/html/HTMLOptionElement.idl:
* Source/WebCore/html/HTMLOutputElement.idl:
* Source/WebCore/html/HTMLProgressElement.idl:
* Source/WebCore/html/HTMLSelectElement.idl:
* Source/WebCore/html/HTMLTableElement.cpp:
* Source/WebCore/html/HTMLTableElement.h:
* Source/WebCore/html/HTMLTextAreaElement.idl:
* Source/WebCore/html/OffscreenCanvas.idl:
* Source/WebCore/html/ValidityState.h:
* Source/WebCore/html/canvas/GPUCanvasContext.h:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.h:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm:
* Source/WebCore/html/canvas/OESVertexArrayObject.idl:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.idl:
* Source/WebCore/html/track/AudioTrackList.idl:
* Source/WebCore/html/track/TextTrackCue.idl:
* Source/WebCore/html/track/TextTrackCueList.idl:
* Source/WebCore/html/track/TextTrackList.idl:
* Source/WebCore/html/track/VTTCue.idl:
* Source/WebCore/html/track/VideoTrackList.idl:
* Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp:
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
* Source/WebCore/page/DOMWindow+CSSOMView.idl:
* Source/WebCore/page/DOMWindow.idl:
* Source/WebCore/page/IntersectionObserverEntry.idl:
* Source/WebCore/page/NavigateEvent.idl:
* Source/WebCore/page/NavigationCurrentEntryChangeEvent.idl:
* Source/WebCore/page/NavigationTransition.cpp:
* Source/WebCore/page/NavigationTransition.h:
* Source/WebCore/page/Performance.cpp:
* Source/WebCore/page/Performance.h:
* Source/WebCore/page/PerformanceUserTiming.cpp:
* Source/WebCore/page/ResizeObserverEntry.h:
* Source/WebCore/page/WebKitNamespace.idl:
* Source/WebCore/page/WindowLocalStorage.idl:
* Source/WebCore/page/WindowSessionStorage.idl:
* Source/WebCore/plugins/DOMMimeType.idl:
* Source/WebCore/svg/SVGGraphicsElement.idl:
* Source/WebCore/svg/SVGPathElement.h:
* Source/WebCore/svg/SVGPathElement.idl:
* Source/WebCore/svg/SVGPolyElement.h:
* Source/WebCore/svg/SVGTransformList.idl:
* Source/WebCore/svg/SVGViewSpec.idl:
* Source/WebCore/svg/properties/SVGAnimatedPrimitiveProperty.h:
* Source/WebCore/svg/properties/SVGAnimatedPropertyAnimatorImpl.h:
* Source/WebCore/svg/properties/SVGAnimatedPropertyImpl.h:
* Source/WebCore/svg/properties/SVGAnimatedPropertyList.h:
* Source/WebCore/svg/properties/SVGAnimatedPropertyPairAnimatorImpl.h:
* Source/WebCore/svg/properties/SVGAnimatedValueProperty.h:
* Source/WebCore/svg/properties/SVGAnimationAdditiveListFunction.h:
* Source/WebCore/svg/properties/SVGAnimationAdditiveListFunctionImpl.h:
* Source/WebCore/svg/properties/SVGValuePropertyListAnimator.h:
* Source/WebCore/testing/Internals.cpp:
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebCore/testing/ServiceWorkerInternals.idl:
* Source/WebCore/workers/service/background-fetch/BackgroundFetchEvent.idl:
* Source/WebCore/xml/XPathResult.idl:
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
* Source/WebKitLegacy/mac/DOM/DOMHTMLTableElement.mm:
* Source/WebKitLegacy/mac/DOM/DOMInternal.mm:
* Source/WebKitLegacy/mac/DOM/DOMNode.mm:
* Source/WebKitLegacy/mac/WebView/WebFrame.mm:
* Source/WebCore/bindings/scripts/test/*: (test result changes elided for brevity)

Canonical link: <a href="https://commits.webkit.org/305676@main">https://commits.webkit.org/305676@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/51155e936c96c08842168abb4e1f33b548eeffef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139043 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11411 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/530 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147168 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140916 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12119 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11566 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106430 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141990 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9153 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124551 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87304 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8707 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6489 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7463 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118155 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/450 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149948 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11095 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/456 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114820 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11113 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9397 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115139 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29270 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9026 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120901 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65998 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11142 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/430 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10878 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74792 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11081 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10929 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->