### PR TITLE
Fixed unretained local variable warnings in Tools/DumpRenderTree and Tools/**

### DIFF
--- a/Tools/DumpRenderTree/mac/AccessibilityUIElementMac.mm
+++ b/Tools/DumpRenderTree/mac/AccessibilityUIElementMac.mm
@@ -185,8 +185,8 @@ static NSString* attributesOfElement(id accessibilityObject)
         BEGIN_AX_OBJC_EXCEPTIONS
         if ([attribute isEqualToString:@"AXVisibleCharacterRange"]) {
             id value = [accessibilityObject accessibilityAttributeValue:NSAccessibilityRoleAttribute];
-            NSString *role = [value isKindOfClass:[NSString class]] ? (NSString *)value : nil;
-            if (role == nil || [role isEqualToString:@"AXList"] || [role isEqualToString:@"AXLink"] || [role isEqualToString:@"AXGroup"] || [role isEqualToString:@"AXRow"] || [role isEqualToString:@"AXColumn"] || [role isEqualToString:@"AXTable"] || [role isEqualToString:@"AXWebArea"]) {
+            RetainPtr<NSString> role = [value isKindOfClass:[NSString class]] ? (NSString *)value : nil;
+            if (role.get() == nil || [role isEqualToString:@"AXList"] || [role isEqualToString:@"AXLink"] || [role isEqualToString:@"AXGroup"] || [role isEqualToString:@"AXRow"] || [role isEqualToString:@"AXColumn"] || [role isEqualToString:@"AXTable"] || [role isEqualToString:@"AXWebArea"]) {
                 // For some roles, behavior with ITM on and ITM off differ for this API in ways
                 // that are not clearly meaningful to any actual user-facing behavior. Skip dumping this
                 // attribute for all of the "dump every attribute for every element" tests.
@@ -196,14 +196,14 @@ static NSString* attributesOfElement(id accessibilityObject)
         }
 
         id valueObject = [accessibilityObject accessibilityAttributeValue:attribute];
-        NSString* value = descriptionOfValue(valueObject, accessibilityObject);
+        RetainPtr value = descriptionOfValue(valueObject, accessibilityObject);
 
         if (!value
             && ([attribute isEqualToString:NSAccessibilityTextInputMarkedRangeAttribute]
                 || [attribute isEqualToString:NSAccessibilityTextInputMarkedTextMarkerRangeAttribute]))
             continue;
 
-        [attributesString appendFormat:@"%@: %@\n", attribute, value];
+        [attributesString appendFormat:@"%@: %@\n", attribute, value.get()];
         END_AX_OBJC_EXCEPTIONS
     }
 
@@ -229,8 +229,8 @@ static JSRetainPtr<JSStringRef> descriptionOfElements(Vector<AccessibilityUIElem
     NSMutableString* allElementString = [NSMutableString string];
     size_t size = elementVector.size();
     for (size_t i = 0; i < size; ++i) {
-        NSString* attributes = attributesOfElement(elementVector[i].platformUIElement());
-        [allElementString appendFormat:@"%@\n------------\n", attributes];
+        RetainPtr attributes = attributesOfElement(elementVector[i].platformUIElement());
+        [allElementString appendFormat:@"%@\n------------\n", attributes.get()];
     }
 
     return [allElementString createJSStringRef];
@@ -675,8 +675,8 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::parameterizedAttributeNames()
 JSRetainPtr<JSStringRef> AccessibilityUIElement::role()
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    NSString *role = descriptionOfValue([m_element accessibilityAttributeValue:NSAccessibilityRoleAttribute], m_element.get());
-    return concatenateAttributeAndValue(@"AXRole", role);
+    RetainPtr role = descriptionOfValue([m_element accessibilityAttributeValue:NSAccessibilityRoleAttribute], m_element.get());
+    return concatenateAttributeAndValue(@"AXRole", role.get());
     END_AX_OBJC_EXCEPTIONS
 
     return nullptr;
@@ -685,8 +685,8 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::role()
 JSRetainPtr<JSStringRef> AccessibilityUIElement::subrole()
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    NSString* role = descriptionOfValue([m_element accessibilityAttributeValue:NSAccessibilitySubroleAttribute], m_element.get());
-    return concatenateAttributeAndValue(@"AXSubrole", role);
+    RetainPtr role = descriptionOfValue([m_element accessibilityAttributeValue:NSAccessibilitySubroleAttribute], m_element.get());
+    return concatenateAttributeAndValue(@"AXSubrole", role.get());
     END_AX_OBJC_EXCEPTIONS
 
     return nullptr;
@@ -695,8 +695,8 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::subrole()
 JSRetainPtr<JSStringRef> AccessibilityUIElement::roleDescription()
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    NSString* role = descriptionOfValue([m_element accessibilityAttributeValue:NSAccessibilityRoleDescriptionAttribute], m_element.get());
-    return concatenateAttributeAndValue(@"AXRoleDescription", role);
+    RetainPtr role = descriptionOfValue([m_element accessibilityAttributeValue:NSAccessibilityRoleDescriptionAttribute], m_element.get());
+    return concatenateAttributeAndValue(@"AXRoleDescription", role.get());
     END_AX_OBJC_EXCEPTIONS
 
     return nullptr;
@@ -705,7 +705,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::roleDescription()
 JSRetainPtr<JSStringRef> AccessibilityUIElement::computedRoleString()
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    NSString *computedRoleString = descriptionOfValue([m_element accessibilityAttributeValue:@"AXARIARole"], m_element.get());
+    RetainPtr computedRoleString = descriptionOfValue([m_element accessibilityAttributeValue:@"AXARIARole"], m_element.get());
     return [computedRoleString createJSStringRef];
     END_AX_OBJC_EXCEPTIONS
 
@@ -715,8 +715,8 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::computedRoleString()
 JSRetainPtr<JSStringRef> AccessibilityUIElement::title()
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    NSString* title = descriptionOfValue([m_element accessibilityAttributeValue:NSAccessibilityTitleAttribute], m_element.get());
-    return concatenateAttributeAndValue(@"AXTitle", title);
+    RetainPtr title = descriptionOfValue([m_element accessibilityAttributeValue:NSAccessibilityTitleAttribute], m_element.get());
+    return concatenateAttributeAndValue(@"AXTitle", title.get());
     END_AX_OBJC_EXCEPTIONS
 
     return nullptr;
@@ -725,8 +725,8 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::title()
 JSRetainPtr<JSStringRef> AccessibilityUIElement::description()
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    id description = descriptionOfValue([m_element accessibilityAttributeValue:NSAccessibilityDescriptionAttribute], m_element.get());
-    return concatenateAttributeAndValue(@"AXDescription", description);
+    RetainPtr description = descriptionOfValue([m_element accessibilityAttributeValue:NSAccessibilityDescriptionAttribute], m_element.get());
+    return concatenateAttributeAndValue(@"AXDescription", description.get());
     END_AX_OBJC_EXCEPTIONS
 
     return nullptr;
@@ -750,8 +750,8 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::liveRegionStatus() const
 JSRetainPtr<JSStringRef> AccessibilityUIElement::orientation() const
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    id description = descriptionOfValue([m_element accessibilityAttributeValue:NSAccessibilityOrientationAttribute], m_element.get());
-    return concatenateAttributeAndValue(@"AXOrientation", description);
+    RetainPtr description = descriptionOfValue([m_element accessibilityAttributeValue:NSAccessibilityOrientationAttribute], m_element.get());
+    return concatenateAttributeAndValue(@"AXOrientation", description.get());
     END_AX_OBJC_EXCEPTIONS
 
     return nullptr;
@@ -760,9 +760,9 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::orientation() const
 JSRetainPtr<JSStringRef> AccessibilityUIElement::stringValue()
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    id description = descriptionOfValue([m_element accessibilityAttributeValue:NSAccessibilityValueAttribute], m_element.get());
+    RetainPtr description = descriptionOfValue([m_element accessibilityAttributeValue:NSAccessibilityValueAttribute], m_element.get());
     if (description)
-        return concatenateAttributeAndValue(@"AXValue", description);
+        return concatenateAttributeAndValue(@"AXValue", description.get());
     END_AX_OBJC_EXCEPTIONS
 
     return nullptr;
@@ -771,8 +771,8 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::stringValue()
 JSRetainPtr<JSStringRef> AccessibilityUIElement::language()
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    id description = descriptionOfValue([m_element accessibilityAttributeValue:@"AXLanguage"], m_element.get());
-    return concatenateAttributeAndValue(@"AXLanguage", description);
+    RetainPtr description = descriptionOfValue([m_element accessibilityAttributeValue:@"AXLanguage"], m_element.get());
+    return concatenateAttributeAndValue(@"AXLanguage", description.get());
     END_AX_OBJC_EXCEPTIONS
 
     return nullptr;
@@ -781,8 +781,8 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::language()
 JSRetainPtr<JSStringRef> AccessibilityUIElement::helpText() const
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    id description = descriptionOfValue([m_element accessibilityAttributeValue:NSAccessibilityHelpAttribute], m_element.get());
-    return concatenateAttributeAndValue(@"AXHelp", description);
+    RetainPtr description = descriptionOfValue([m_element accessibilityAttributeValue:NSAccessibilityHelpAttribute], m_element.get());
+    return concatenateAttributeAndValue(@"AXHelp", description.get());
     END_AX_OBJC_EXCEPTIONS
 
     return nullptr;
@@ -1039,8 +1039,8 @@ bool AccessibilityUIElement::isGrabbed() const
 JSRetainPtr<JSStringRef> AccessibilityUIElement::embeddedImageDescription() const
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    NSString *value = descriptionOfValue([m_element accessibilityAttributeValue:@"AXEmbeddedImageDescription"], m_element.get());
-    return concatenateAttributeAndValue(@"AXEmbeddedImageDescription", value);
+    RetainPtr value = descriptionOfValue([m_element accessibilityAttributeValue:@"AXEmbeddedImageDescription"], m_element.get());
+    return concatenateAttributeAndValue(@"AXEmbeddedImageDescription", value.get());
     END_AX_OBJC_EXCEPTIONS
 }
 
@@ -1169,8 +1169,8 @@ bool AccessibilityUIElement::attributedStringRangeIsMisspelled(unsigned location
 unsigned AccessibilityUIElement::uiElementCountForSearchPredicate(JSContextRef context, AccessibilityUIElement *startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly)
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    NSDictionary *parameterizedAttribute = searchPredicateParameterizedAttributeForSearchCriteria(context, startElement, isDirectionNext, UINT_MAX, searchKey, searchText, visibleOnly, immediateDescendantsOnly);
-    id value = [m_element accessibilityAttributeValue:@"AXUIElementsForSearchPredicate" forParameter:parameterizedAttribute];
+    RetainPtr parameterizedAttribute = searchPredicateParameterizedAttributeForSearchCriteria(context, startElement, isDirectionNext, UINT_MAX, searchKey, searchText, visibleOnly, immediateDescendantsOnly);
+    id value = [m_element accessibilityAttributeValue:@"AXUIElementsForSearchPredicate" forParameter:parameterizedAttribute.get()];
     if ([value isKindOfClass:[NSArray class]])
         return [value count];
     END_AX_OBJC_EXCEPTIONS
@@ -1181,8 +1181,8 @@ unsigned AccessibilityUIElement::uiElementCountForSearchPredicate(JSContextRef c
 AccessibilityUIElement AccessibilityUIElement::uiElementForSearchPredicate(JSContextRef context, AccessibilityUIElement *startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly)
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    NSDictionary *parameter = searchPredicateParameterizedAttributeForSearchCriteria(context, startElement, isDirectionNext, 1, searchKey, searchText, visibleOnly, immediateDescendantsOnly);
-    id value = [m_element accessibilityAttributeValue:@"AXUIElementsForSearchPredicate" forParameter:parameter];
+    RetainPtr parameter = searchPredicateParameterizedAttributeForSearchCriteria(context, startElement, isDirectionNext, 1, searchKey, searchText, visibleOnly, immediateDescendantsOnly);
+    id value = [m_element accessibilityAttributeValue:@"AXUIElementsForSearchPredicate" forParameter:parameter.get()];
     if (![value isKindOfClass:[NSArray class]] || ![value count])
         return nullptr;
 
@@ -1200,8 +1200,8 @@ AccessibilityUIElement AccessibilityUIElement::uiElementForSearchPredicate(JSCon
 JSRetainPtr<JSStringRef> AccessibilityUIElement::selectTextWithCriteria(JSContextRef context, JSStringRef ambiguityResolution, JSValueRef searchStrings, JSStringRef replacementString, JSStringRef activity)
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    NSDictionary *parameterizedAttribute = selectTextParameterizedAttributeForCriteria(context, ambiguityResolution, searchStrings, replacementString, activity);
-    id result = [m_element accessibilityAttributeValue:@"AXSelectTextWithCriteria" forParameter:parameterizedAttribute];
+    RetainPtr parameterizedAttribute = selectTextParameterizedAttributeForCriteria(context, ambiguityResolution, searchStrings, replacementString, activity);
+    id result = [m_element accessibilityAttributeValue:@"AXSelectTextWithCriteria" forParameter:parameterizedAttribute.get()];
     if ([result isKindOfClass:[NSString class]])
         return [result createJSStringRef];
     END_AX_OBJC_EXCEPTIONS
@@ -1213,8 +1213,8 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::selectTextWithCriteria(JSContex
 JSValueRef AccessibilityUIElement::searchTextWithCriteria(JSContextRef context, JSValueRef searchStrings, JSStringRef startFrom, JSStringRef direction)
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    NSDictionary *parameterizedAttribute = searchTextParameterizedAttributeForCriteria(context, searchStrings, startFrom, direction);
-    id result = [m_element accessibilityAttributeValue:@"AXSearchTextWithCriteria" forParameter:parameterizedAttribute];
+    RetainPtr parameterizedAttribute = searchTextParameterizedAttributeForCriteria(context, searchStrings, startFrom, direction);
+    id result = [m_element accessibilityAttributeValue:@"AXSearchTextWithCriteria" forParameter:parameterizedAttribute.get()];
     if ([result isKindOfClass:[NSArray class]])
         return convertVectorToObjectArray(context, makeVector<AccessibilityTextMarkerRange>(result));
     END_AX_OBJC_EXCEPTIONS
@@ -1933,7 +1933,7 @@ static void appendColorDescription(RetainPtr<NSMutableString> string, NSString* 
 static JSRetainPtr<JSStringRef> createJSStringRef(id string)
 {
     auto mutableString = adoptNS([[NSMutableString alloc] init]);
-    id attributeEnumerationBlock = ^(NSDictionary<NSString *, id> *attributes, NSRange range, BOOL *stop) {
+    RetainPtr<id> attributeEnumerationBlock = ^(NSDictionary<NSString *, id> *attributes, NSRange range, BOOL *stop) {
         [mutableString appendFormat:@"Attributes in range %@:\n", NSStringFromRange(range)];
         BOOL misspelled = [[attributes objectForKey:NSAccessibilityMisspelledTextAttribute] boolValue];
         if (misspelled)
@@ -1975,7 +1975,7 @@ static JSRetainPtr<JSStringRef> createJSStringRef(id string)
         if ([attributes objectForKey:NSAccessibilityTableAttribute])
             [mutableString appendFormat:@"%@: {present}\n", NSAccessibilityTableAttribute];
     };
-    [string enumerateAttributesInRange:NSMakeRange(0, [string length]) options:(NSAttributedStringEnumerationOptions)0 usingBlock:attributeEnumerationBlock];
+    [string enumerateAttributesInRange:NSMakeRange(0, [string length]) options:(NSAttributedStringEnumerationOptions)0 usingBlock:attributeEnumerationBlock.get()];
     [mutableString appendString:[string string]];
     return [mutableString createJSStringRef];
 }
@@ -1988,12 +1988,12 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::attributedStringForTextMarkerRa
 
 JSRetainPtr<JSStringRef> AccessibilityUIElement::attributedStringForTextMarkerRangeWithOptions(AccessibilityTextMarkerRange* markerRange, bool includeSpellCheck)
 {
-    id parameter = nil;
+    RetainPtr<id> parameter;
     if (includeSpellCheck)
         parameter = @{ @"AXSpellCheck": includeSpellCheck ? @YES : @NO, @"AXTextMarkerRange": markerRange->platformTextMarkerRange() };
     else
         parameter = markerRange->platformTextMarkerRange();
-    id string = [m_element accessibilityAttributeValue:@"AXAttributedStringForTextMarkerRangeWithOptions" forParameter:parameter];
+    id string = [m_element accessibilityAttributeValue:@"AXAttributedStringForTextMarkerRangeWithOptions" forParameter:parameter.get()];
     return createJSStringRef(string);
 }
 

--- a/Tools/DumpRenderTree/mac/EventSendingController.mm
+++ b/Tools/DumpRenderTree/mac/EventSendingController.mm
@@ -151,7 +151,7 @@ static NSDraggingSession *drt_WebHTMLView_beginDraggingSessionWithItemsEventSour
 {
     ASSERT(!draggingInfo);
 
-    WebFrameView *webFrameView = ^ {
+    RetainPtr webFrameView = ^ {
         for (NSView *superview = self.superview; superview; superview = superview.superview) {
             if ([superview isKindOfClass:WebFrameView.class])
                 return (WebFrameView *)superview;
@@ -161,7 +161,7 @@ static NSDraggingSession *drt_WebHTMLView_beginDraggingSessionWithItemsEventSour
         return (WebFrameView *)nil;
     }();
 
-    WebView *webView = webFrameView.webFrame.webView;
+    WebView *webView = webFrameView.get().webFrame.webView;
 
     NSPasteboard *pasteboard = [NSPasteboard pasteboardWithName:NSDragPboard];
     for (NSDraggingItem *item in items)
@@ -725,9 +725,9 @@ static NSInteger swizzledEventButtonNumber()
                                                       location:lastMousePosition]);
 #endif
 
-    NSView *targetView = [[mainFrame webView] hitTest:[event locationInWindow]];
+    RetainPtr targetView = [[mainFrame webView] hitTest:[event locationInWindow]];
     // FIXME: Silly hack to teach DRT to respect capturing mouse events outside the WebView.
-    // The right solution is just to use NSApplication's built-in event sending methods, 
+    // The right solution is just to use NSApplication's built-in event sending methods,
     // instead of rolling our own algorithm for selecting an event target.
     targetView = targetView ? targetView : [[mainFrame frameView] documentView];
     assert(targetView);
@@ -736,7 +736,7 @@ static NSInteger swizzledEventButtonNumber()
 #endif
     {
 #if !PLATFORM(IOS_FAMILY)
-        auto eventPressedMouseButtonsSwizzler = eventPressedMouseButtonsSwizzlerForViewAndEvent(targetView, event.get());
+        auto eventPressedMouseButtonsSwizzler = eventPressedMouseButtonsSwizzlerForViewAndEvent(targetView.get(), event.get());
         auto eventButtonNumberSwizzler = makeUnique<InstanceMethodSwizzler>([NSEvent class], @selector(buttonNumber), reinterpret_cast<IMP>(swizzledEventButtonNumber));
 #endif
         [targetView mouseUp:event.get()];

--- a/Tools/TestRunnerShared/EventSerialization/mac/EventSerializerMac.mm
+++ b/Tools/TestRunnerShared/EventSerialization/mac/EventSerializerMac.mm
@@ -196,7 +196,7 @@ bool eventIsOfGestureTypes(CGEventRef event, IOHIDEventType first, Types ... res
 
 + (NSDictionary *)dictionaryForEvent:(CGEventRef)rawEvent relativeToTime:(CGEventTimestamp)referenceTimestamp
 {
-    auto plainEvent = adoptCF(CGEventCreate(NULL));
+    const RetainPtr plainEvent = adoptCF(CGEventCreate(NULL));
     CGEventRef rawPlainEvent = plainEvent.get();
 
     auto dict = adoptNS([[NSMutableDictionary alloc] init]);
@@ -227,7 +227,7 @@ bool eventIsOfGestureTypes(CGEventRef event, IOHIDEventType first, Types ... res
 
 + (RetainPtr<CGEventRef>)createEventForDictionary:(NSDictionary *)dict inWindow:(NSWindow *)window relativeToTime:(MonotonicTime)referenceTimestamp
 {
-    auto event = adoptCF(CGEventCreate(NULL));
+    const RetainPtr event = adoptCF(CGEventCreate(NULL));
     CGEventRef rawEvent = event.get();
 
     FOR_EACH_CGEVENT_INTEGER_FIELD(STORE_INTEGER_FIELD_TO_EVENT);

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
@@ -794,9 +794,9 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::allAttributes()
             continue;
 
         if ([attribute isEqualToString:@"AXVisibleCharacterRange"]) {
-            id value = attributeValue(NSAccessibilityRoleAttribute).unsafeGet();
-            NSString *role = [value isKindOfClass:[NSString class]] ? (NSString *)value : nil;
-            if (role == nil || [role isEqualToString:@"AXList"] || [role isEqualToString:@"AXLink"] || [role isEqualToString:@"AXGroup"] || [role isEqualToString:@"AXRow"] || [role isEqualToString:@"AXColumn"] || [role isEqualToString:@"AXTable"] || [role isEqualToString:@"AXWebArea"]) {
+            RetainPtr value = attributeValue(NSAccessibilityRoleAttribute);
+            RetainPtr<NSString> role = [value isKindOfClass:[NSString class]] ? (NSString *)value.get() : nil;
+            if (role.get() == nil || [role isEqualToString:@"AXList"] || [role isEqualToString:@"AXLink"] || [role isEqualToString:@"AXGroup"] || [role isEqualToString:@"AXRow"] || [role isEqualToString:@"AXColumn"] || [role isEqualToString:@"AXTable"] || [role isEqualToString:@"AXWebArea"]) {
                 // For some roles, behavior with ITM on and ITM off differ for this API in ways
                 // that are not clearly meaningful to any actual user-facing behavior. Skip dumping this
                 // attribute for all of the "dump every attribute for every element" tests.


### PR DESCRIPTION
#### 3d99a6b32a4aeb57956ec8d02890f1f4cd95313a
<pre>
Fixed unretained local variable warnings in Tools/DumpRenderTree and Tools/**
<a href="https://bugs.webkit.org/show_bug.cgi?id=305417">https://bugs.webkit.org/show_bug.cgi?id=305417</a>
<a href="https://rdar.apple.com/168090269">rdar://168090269</a>

Reviewed by Ryosuke Niwa.

Mechanical changes dictated by the SaferCPP bot.

Canonical link: <a href="https://commits.webkit.org/305547@main">https://commits.webkit.org/305547@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f22b2763d48d8ab53456910bcfb6edffcf71cd7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138705 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11071 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/187 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146819 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/91680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/72035c61-6961-4d03-a937-2947f9d4433b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140578 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11775 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11226 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106138 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/91680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141652 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8871 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/124312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87008 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9a8373f2-704b-4681-86a1-dbcf7ac55dd5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8459 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/6218 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7117 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117880 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/153 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149575 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10753 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/154 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114523 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10771 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9098 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114862 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8712 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120610 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/65648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21378 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10801 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/154 "Passed tests") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/10536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10739 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10590 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->