### PR TITLE
AX: Add live region management capability to attribute names

### DIFF
--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -631,7 +631,10 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
         // This exists to tell assistive technologies that WebKit stitches adjacent text
         // elements together in the accessibility tree — thus, assistive technologies know
         // they don't need to.
-        @"AXPerformsOwnTextStitching"
+        @"AXPerformsOwnTextStitching",
+        // This indicates to assistive technologies whether WebKit will handle posting
+        // announcements for live region updates, or whether the AT is responsible.
+        @"AXPostsOwnLiveRegionAnnouncements"
     ];
     static NeverDestroyed spinButtonCommonAttributes = [] {
         auto tempArray = adoptNS([[NSMutableArray alloc] initWithArray:attributes.get().get()]);

--- a/Tools/DumpRenderTree/mac/AccessibilityUIElementMac.mm
+++ b/Tools/DumpRenderTree/mac/AccessibilityUIElementMac.mm
@@ -175,7 +175,7 @@ static NSString* attributesOfElement(id accessibilityObject)
         if ([attribute isEqualToString:@"_AXPrimaryScreenHeight"] || [attribute isEqualToString:@"AXRelativeFrame"])
             continue;
 
-        if ([attribute isEqualToString:@"AXPerformsOwnTextStitching"]) {
+        if ([attribute isEqualToString:@"AXPerformsOwnTextStitching"] || [attribute isEqualToString:@"AXPostsOwnLiveRegionAnnouncements"]) {
             // Exposing this in tests is not valuable, so remove it to decrease test maintenance burden.
             continue;
         }

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
@@ -145,6 +145,7 @@ RetainPtr<NSArray> supportedAttributes(id element)
         attributes = [[element accessibilityAttributeNames] mutableCopy];
         // Exposing this in tests is not valuable, so remove it to decrease test maintenance burden.
         [attributes removeObject:@"AXPerformsOwnTextStitching"];
+        [attributes removeObject:@"AXPostsOwnLiveRegionAnnouncements"];
     });
     END_AX_OBJC_EXCEPTIONS
 


### PR DESCRIPTION
#### 023c8bc1a7d8520bf8fa1dbd4d08deff86a9c12c
<pre>
AX: Add live region management capability to attribute names
<a href="https://bugs.webkit.org/show_bug.cgi?id=305423">https://bugs.webkit.org/show_bug.cgi?id=305423</a>
<a href="https://rdar.apple.com/167662223">rdar://167662223</a>

Reviewed by Tyler Wilcock.

Assistive technologies should know when a web engine handles posting its own live region
announcements, so that it doesn&apos;t have to do duplicate work to manage them within the AT.

Exposing this new attribute as part of accessibilityAttributeNames tells the AT what the
WebKit will do, so it can behave appropriately.

* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper accessibilityAttributeNames]):

Canonical link: <a href="https://commits.webkit.org/305579@main">https://commits.webkit.org/305579@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3fc97923b714027e35be024aff27510b160366b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138739 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11105 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/221 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146855 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91714 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140612 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11809 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11260 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106162 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77462 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5b66f538-da16-470a-be63-0807e039f5a6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141686 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8901 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/124401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87033 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/68200529-7430-4847-96ce-36407247ea65) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8484 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6235 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7153 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117905 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/181 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149613 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10787 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/182 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114549 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10805 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9121 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114890 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29221 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8748 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120637 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65682 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10835 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/180 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10570 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74476 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10773 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10624 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->