### PR TITLE
Test enabling EnhancedSecurityHeuristics flag by default.

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2761,17 +2761,20 @@ EncryptedMediaAPIEnabled:
 
 EnhancedSecurityHeuristicsEnabled:
   type: bool
-  status: testable
+  status: stable
   category: security
   defaultsOverridable: true
   humanReadableName: "Enable EnhancedSecurity Heuristics"
   humanReadableDescription: "Triggers EnhancedSecurity when insecure HTTP loads occur"
   defaultValue:
     WebKitLegacy:
+      "PLATFORM(COCOA)": true
       default: false
     WebKit:
+      "PLATFORM(COCOA)": true
       default: false
     WebCore:
+      "PLATFORM(COCOA)": true
       default: false
 
 EnterKeyHintEnabled:


### PR DESCRIPTION
#### f2251787c8f98cb2dd69624546dbd78b47f1a181
<pre>
Test enabling EnhancedSecurityHeuristics flag by default.

Reviewed by NOBODY (OOPS!).

Enables the EnhancedSecurityHeuristics flag by default, testing for
results across EWS.

No new tests (OOPS!).

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2251787c8f98cb2dd69624546dbd78b47f1a181

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138718 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11084 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/200 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146832 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91693 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bc1c62d2-3bd8-4506-a9f8-4f288f0f7dd4) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11788 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11239 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106147 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77454 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b29da637-b969-4386-a082-9a10b692373f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141665 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8896 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124322 "Found 18 new API test failures: TestWebKitAPI.WKNavigation.HTTPSFirstWithHTTPRedirect, TestWebKitAPI.WKHTTPCookieStore.ObserveCookiesReceivedFromHTTP, TestWebKitAPI.HistoryDelegate.PersistentDataStoreSendsHistoryEvents, TestWebKitAPI.WKWebExtensionAPIDeclarativeNetRequest.RedirectRule, TestWebKitAPI.WebKit.RedirectToPlaintextHTTPSUpgrade, TestWebKitAPI.SOAuthorizationPopUp.InterceptionSucceedWithCookie, TestWebKitAPI.SOAuthorizationPopUp.InterceptionSucceedTwice, TestWebKitAPI.SiteIsolation.MainFrameRedirectBetweenExistingProcesses, TestWebKitAPI.WKNavigation.PreferredHTTPSPolicyAutomaticHTTPFallbackWithHTTPRedirect, TestWebKitAPI.SOAuthorizationPopUp.InterceptionSucceedNewWindowNavigation ... (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87017 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/36b1f1d7-5010-4829-acee-1f886b29b88a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8479 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6224 "Found 21 new API test failures: TestWebKitAPI.WKNavigation.HTTPSFirstWithHTTPRedirect, TestWebKitAPI.WKBackForwardList.BackForwardNavigationSkipsItemsWithoutUserGestureFragment, TestWebKitAPI.WKHTTPCookieStore.ObserveCookiesReceivedFromHTTP, TestWebKitAPI.HistoryDelegate.PersistentDataStoreSendsHistoryEvents, TestWebKitAPI.WKWebExtensionAPIDeclarativeNetRequest.RedirectRule, TestWebKitAPI.WebKit.RedirectToPlaintextHTTPSUpgrade, TestWebKitAPI.SOAuthorizationPopUp.InterceptionSucceedWithCookie, TestWebKitAPI.SOAuthorizationPopUp.InterceptionSucceedTwice, TestWebKitAPI.PermissionsAPI.GeolocationPermissionGrantedFromPromptAndGeolocationRequestedSinceLoad, TestWebKitAPI.SiteIsolation.MainFrameRedirectBetweenExistingProcesses ... (failure)") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7130 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/130689 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117900 "Found 18 new API test failures: TestWebKitAPI.WKNavigation.HTTPSFirstWithHTTPRedirect, TestWebKitAPI.WKHTTPCookieStore.ObserveCookiesReceivedFromHTTP, TestWebKitAPI.HistoryDelegate.PersistentDataStoreSendsHistoryEvents, TestWebKitAPI.WKWebExtensionAPIDeclarativeNetRequest.RedirectRule, TestWebKitAPI.SOAuthorizationPopUp.InterceptionSucceedTwice, TestWebKitAPI.SOAuthorizationPopUp.InterceptionSucceedWithCookie, TestWebKitAPI.WebKit.RedirectToPlaintextHTTPSUpgrade, TestWebKitAPI.SiteIsolation.MainFrameRedirectBetweenExistingProcesses, TestWebKitAPI.WKNavigation.PreferredHTTPSPolicyAutomaticHTTPFallbackWithHTTPRedirect, TestWebKitAPI.SOAuthorizationPopUp.InterceptionSucceedSuppressActiveSession ... (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/169 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149588 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/137319 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10766 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/170 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114630 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10784 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9107 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114870 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8732 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120625 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/65661 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10814 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/169 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/169991 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10549 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74455 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44309 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10752 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10603 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->