### PR TITLE
Web Inspector: Copy function on right-click on a function name

### DIFF
--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -481,6 +481,7 @@ localizedStrings["Copy Table"] = "Copy Table";
 localizedStrings["Copy as cURL"] = "Copy as cURL";
 /* Copy the URL, method, headers, etc. of the given network request in the format of a JS fetch expression. */
 localizedStrings["Copy as fetch"] = "Copy as fetch";
+localizedStrings["Copy Function"] = "Copy Function";
 localizedStrings["Core Features"] = "Core Features";
 localizedStrings["Could not capture screenshot"] = "Could not capture screenshot";
 localizedStrings["Could not fetch properties. Object may no longer exist."] = "Could not fetch properties. Object may no longer exist.";

--- a/Source/WebInspectorUI/UserInterface/Views/SourceCodeTextEditor.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SourceCodeTextEditor.js
@@ -69,6 +69,9 @@ WI.SourceCodeTextEditor = class SourceCodeTextEditor extends WI.TextEditor
 
         this.element.classList.add("source-code");
 
+        this._boundHandleTextAreaContextMenu = this._handleTextAreaContextMenu.bind(this);
+        this._codeMirror.getScrollerElement().addEventListener("contextmenu", this._boundHandleTextAreaContextMenu);
+
         if (this._supportsDebugging) {
             WI.JavaScriptBreakpoint.addEventListener(WI.Breakpoint.Event.DisabledStateDidChange, this._breakpointStatusDidChange, this);
             WI.JavaScriptBreakpoint.addEventListener(WI.Breakpoint.Event.AutoContinueDidChange, this._breakpointStatusDidChange, this);
@@ -203,6 +206,8 @@ WI.SourceCodeTextEditor = class SourceCodeTextEditor extends WI.TextEditor
             WI.notifications.removeEventListener(WI.Notification.GlobalModifierKeysDidChange, this._updateTokenTrackingControllerState, this);
         else
             this._sourceCode.removeEventListener(WI.SourceCode.Event.SourceMapAdded, this._sourceCodeSourceMapAdded, this);
+
+        this._codeMirror.getScrollerElement().removeEventListener("contextmenu", this._boundHandleTextAreaContextMenu);
 
         WI.consoleManager.removeEventListener(WI.ConsoleManager.Event.Cleared, this._logCleared, this);
     }
@@ -1689,6 +1694,85 @@ WI.SourceCodeTextEditor = class SourceCodeTextEditor extends WI.TextEditor
                 this._addThreadIndicatorForTarget(target);
         }
     }
+  
+    _handleTextAreaContextMenu(event)
+    {
+        let coords = this._codeMirror.coordsChar({left: event.pageX, top: event.pageY});
+        let token = this._codeMirror.getTokenAt(coords);
+
+        // Only proceed if we have a script and clicked on a token
+        if (!this._getAssociatedScript() || !token?.type)
+            return;
+
+        // Check if token is an identifier (variable or function name)
+        if (!(token.type.includes("variable") || token.type.includes("def")))
+            return;
+
+        if (!this._isFunctionDeclarationToken(coords, token))
+            return;
+
+        // Show custom menu - prevent OS default menu
+        event.preventDefault();
+
+        let contextMenu = WI.ContextMenu.createFromEvent(event);
+
+        contextMenu.appendItem(WI.UIString("Copy Function"), () => {
+            this._copyFunctionAtPosition(new WI.SourceCodePosition(coords.line, coords.ch));
+        });
+
+        contextMenu.appendSeparator();
+        contextMenu.appendItem(WI.UIString("Copy"), () => document.execCommand('copy'));
+    }
+
+    _isFunctionDeclarationToken(coords, token)
+    {
+        let lineText = this._codeMirror.getLine(coords.line);
+
+        // Check for traditional function declaration: "function identifier"
+        let textBeforeToken = lineText.substring(0, token.start);
+        if (WI.SourceCodeTextEditor.FunctionKeywordRegex.test(textBeforeToken))
+            return true;
+
+        // Check for arrow function: "const/let identifier = () =>" or "identifier = () =>"
+        let textAfterToken = lineText.substring(token.end);
+        if (WI.SourceCodeTextEditor.ArrowFunctionRegex.test(textAfterToken))
+            return true;
+
+        return false;
+    }
+
+    _copyFunctionAtPosition(position)
+    {
+        let script = this._getAssociatedScript();
+        if (!script)
+            return;
+
+        script.requestScriptSyntaxTree((syntaxTree) => {
+            if (!syntaxTree)
+                return;
+
+            // Find the function node where we clicked on its name
+            let functionNode = syntaxTree.containersOfPosition(position).find((node) => {
+                if (!node.id)
+                    return false;
+
+                // Check if this node is a function (declaration, expression, or arrow function)
+                if (!WI.SourceCodeTextEditor.FunctionNodeTypes.has(node.type))
+                    return false;
+
+                // Verify that we clicked specifically on the function's name
+                let {startPosition: nameStart, endPosition: nameEnd} = node.id;
+                return position.lineNumber === nameStart.lineNumber &&
+                       position.columnNumber >= nameStart.columnNumber &&
+                       position.columnNumber <= nameEnd.columnNumber;
+            });
+
+            if (functionNode) {
+                let functionText = this.getTextInRange(functionNode.startPosition, functionNode.endPosition);
+                InspectorFrontendHost.copyText(functionText);
+            }
+        });
+    }
 
     _debuggerDidPause(event)
     {
@@ -2403,6 +2487,14 @@ WI.SourceCodeTextEditor.DurationToMouseOutOfHoveredTokenToRelease = 1000;
 WI.SourceCodeTextEditor.DurationToUpdateTypeTokensAfterScrolling = 100;
 WI.SourceCodeTextEditor.WidgetContainsMultipleIssuesSymbol = Symbol("source-code-widget-contains-multiple-issues");
 WI.SourceCodeTextEditor.WidgetContainsMultipleThreadsSymbol = Symbol("source-code-widget-contains-multiple-threads");
+
+WI.SourceCodeTextEditor.FunctionKeywordRegex = /\bfunction\s*$/;
+WI.SourceCodeTextEditor.ArrowFunctionRegex = /^\s*=\s*(?:async\s+)?\([^)]*\)\s*=>/;
+WI.SourceCodeTextEditor.FunctionNodeTypes = new Set([
+    WI.ScriptSyntaxTree.NodeType.FunctionDeclaration,
+    WI.ScriptSyntaxTree.NodeType.FunctionExpression,
+    WI.ScriptSyntaxTree.NodeType.ArrowFunctionExpression
+]);
 
 WI.SourceCodeTextEditor.Event = {
     ContentWillPopulate: "source-code-text-editor-content-will-populate",


### PR DESCRIPTION
#### 5c086b53dc2c7df7dafc59a9021e219429bae6ea
<pre>
Web Inspector: Copy function on right-click on a function name
<a href="https://bugs.webkit.org/show_bug.cgi?id=293673">https://bugs.webkit.org/show_bug.cgi?id=293673</a>
<a href="https://rdar.apple.com/152558956">rdar://152558956</a>

Reviewed by NOBODY (OOPS!).

Added a context menu handler that detects function declarations and
provides a &quot;Copy Function&quot; option that uses the syntax tree to
copy the entire function to clipboard.
Supports traditional functions and arrow functions with parentheses.

No new tests.

* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:
* Source/WebInspectorUI/UserInterface/Views/SourceCodeTextEditor.js:
(WI.SourceCodeTextEditor):
(WI.SourceCodeTextEditor.prototype.close):
(WI.SourceCodeTextEditor.prototype._handleTextAreaContextMenu):
(WI.SourceCodeTextEditor.prototype._isFunctionDeclarationToken):
(WI.SourceCodeTextEditor.prototype._copyFunctionAtPosition):
(WI.SourceCodeTextEditor.ArrowFunctionRegex.s.s.async s):

:# Combined changes:
 * Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c086b53dc2c7df7dafc59a9021e219429bae6ea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140934 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13318 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2573 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149372 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94022 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14028 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13470 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108151 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78439 "1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143885 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10828 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126159 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89051 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/140279 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10425 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8008 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9368 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119676 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2149 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151898 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13004 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2414 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116370 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/140357 "Build is in progress. Recent messages:") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13019 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11361 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116709 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12784 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122832 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/68165 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13047 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2243 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12786 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76748 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12985 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12830 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->