### PR TITLE
[32-bit] Armv7 tail call shuffler should not run out of registers when loading cells.

### DIFF
--- a/JSTests/stress/tail-call-register-pressure.js
+++ b/JSTests/stress/tail-call-register-pressure.js
@@ -1,0 +1,137 @@
+"use strict";
+
+function getModuleExports() {
+    return () => {}
+};
+
+function ownKeys(ee, te) {
+    var re = Object.keys(ee);
+    if (Object.getOwnPropertySymbols) {
+        var ne = Object.getOwnPropertySymbols(ee);
+        te && (ne = ne.filter((function(te) {
+            return Object.getOwnPropertyDescriptor(ee, te).enumerable
+        }))),
+        re.push.apply(re, ne)
+    }
+    return re
+}
+
+function _objectSpread(ee) {
+    for (var te = 1; te < arguments.length; te++) {
+        var re = null != arguments[te] ? arguments[te] : {};
+        te % 2 ? ownKeys(Object(re), !0).forEach((function(te) {
+            getModuleExports()(ee, te, re[te])
+        })) : Object.getOwnPropertyDescriptors ? Object.defineProperties(ee, Object.getOwnPropertyDescriptors(re)) : ownKeys(Object(re)).forEach((function(te) {
+            Object.defineProperty(ee, te, Object.getOwnPropertyDescriptor(re, te))
+        }))
+    }
+    return ee
+}
+
+var ae = {
+    cleanAndTrimSelfLink: function() {
+    }
+};
+
+var browseItems = function(ee, te, re) {
+    function parseBrowseItem(ee, te, re, ne, ie) {
+        var ce, le, de, he;
+        if (ee.hasEmbedded("linearInfo")) {
+            var fe = ee.getEmbedded("linearInfo"),
+                pe = Object(ae.cleanSelfLink)(fe.getFirstAction("channel").getRawActionUrl());
+            if (!ne[pe] && !ie) return;
+        }
+
+        var ge = function parseBrowseItemUrl(ee, te) {
+            var re = ee.getProp("entityId"),
+                ne = ee.getProp("entityType"),
+                ie = ee.getProp("seriesProgramId"),
+                oe = ee.getProp("_type");
+            return "entity/".concat(re)
+        }(ee, he),
+            me = ee.getProps();
+        if (("NETWORK" !== te || ee.hasEmbedded("contentProvider")) && ("3X4_PROGRAM_LINEAR" !== te || ee.hasEmbedded("linearInfo"))) {
+            var ve = ee.hasAction("programImageLink") ? ee.getFirstAction("programImageLink") : re.programImageLink,
+                Se = ee.hasAction("programFallbackImageLink"),
+                _t = Se ? ee.getFirstAction("programFallbackImageLink") : re.programFallbackImageLink;
+
+            var Et, kt, Tt, Pt = _t.setParams(de).getActionUrl();
+            return Et = Se ? Pt : ve.setParams(de).getActionUrl(), me.contentRating && me.contentRatingScheme && (kt = {
+                scheme: me.contentRatingScheme,
+                name: me.contentRating
+            }), (null === (ce = me.ordering) || void 0 === ce ? void 0 : ce.criticScore) && (null === (le = me.ordering) || void 0 === le ? void 0 : le.fanScore) && (Tt = {
+                rt: {
+                    criticScore: Math.floor(me.ordering.criticScore),
+                    criticCertified: Math.floor(me.ordering.criticScore) >= 75,
+                    criticRotten: Math.floor(me.ordering.criticScore) < 60,
+                    fanScore: Math.floor(me.ordering.fanScore),
+                    fanRotten: Math.floor(me.ordering.fanScore) < 60
+                }
+            }), _objectSpread({
+                _type: me._type
+            }, me.adBrand && {
+                adBrand: me.adBrand
+            }, {}, me.entityId && {
+                entityId: me.entityId
+            }, {}, me.entityType && {
+                entityType: me.entityType
+            }, {}, me.episodeNumber && {
+                episodeNumber: me.episodeNumber
+            }, {}, he && {
+                linearInfo: he
+            }, {}, me.numberOfEpisodes && {
+                numberOfEpisodes: me.numberOfEpisodes
+            }, {}, me.programType && {
+                programType: me.programType
+            }, {}, kt && {
+                rating: kt
+            }, {}, Tt && {
+                reviews: Tt
+            }, {}, me.hasDVS && {
+                dvs: me.hasDVS
+            }, {}, me.isHD && {
+                hd: me.isHD
+            }, {}, me.closedCaption && {
+                cc: me.closedCaption
+            }, {}, me.isSAP && {
+                sap: me.isSAP
+            }, {}, me.releaseYear && {
+                releaseYear: me.releaseYear
+            }, {}, me.seasonNumber && {
+                seasonNumber: me.seasonNumber
+            }, {}, me.seriesTitle && {
+                seriesTitle: me.seriesTitle
+            }, {}, {
+                tileRenderStyle: me.tileRenderStyle || te,
+                title: me.title,
+                subtitle: me.subtitle,
+                image: Et,
+                fallbackImage: Pt,
+                url: ge
+            })
+        }
+    }
+
+    return parseBrowseItem(ee, te, re,{},{})
+}
+
+const runTest = function() {
+    for (var i = 1; i < 100; ++i) {
+        browseItems(
+            {
+                hasAction: () => {},
+                hasEmbedded: (i) => { return i === "contentProvider"; },
+                getProp: () => { return undefined },
+                getProps: () => { return {} },
+                getFirstAction: () => { return { getRawActionUrl: () => "url" } },
+            },
+            {},
+            {
+                programImageLink: { setParams: () => { return { getActionUrl: () => "programImageLink" }; } },
+                programFallbackImageLink: { setParams: () => { return { getActionUrl: () => "programFallbackImageLinkrl" }; } },
+            }
+        )
+    }
+}
+
+runTest()

--- a/Source/JavaScriptCore/jit/CallFrameShuffler32_64.cpp
+++ b/Source/JavaScriptCore/jit/CallFrameShuffler32_64.cpp
@@ -88,13 +88,13 @@ void CallFrameShuffler::emitLoad(CachedRecovery& location)
     bool tryFPR { true };
     JSValueRegs wantedJSValueRegs { location.wantedJSValueRegs() };
     if (wantedJSValueRegs) {
-        if (wantedJSValueRegs.payloadGPR() != InvalidGPRReg
-            && !m_registers[wantedJSValueRegs.payloadGPR()]
-            && !m_lockedRegisters.contains(wantedJSValueRegs.payloadGPR(), IgnoreVectors))
-            tryFPR = false;
-        if (wantedJSValueRegs.tagGPR() != InvalidGPRReg
-            && !m_registers[wantedJSValueRegs.tagGPR()]
-            && !m_lockedRegisters.contains(wantedJSValueRegs.tagGPR(), IgnoreVectors))
+        const auto isAvailable = [this](GPRReg reg) {
+            return reg != InvalidGPRReg
+                && !m_registers[reg]
+                && !m_lockedRegisters.contains(reg, IgnoreVectors);
+        };
+        if (isAvailable(wantedJSValueRegs.payloadGPR())
+            && isAvailable(wantedJSValueRegs.tagGPR()))
             tryFPR = false;
     }
 


### PR DESCRIPTION
#### 9cc23c0e75b77974539bcb414eacef33bf94ed02
<pre>
[32-bit] Armv7 tail call shuffler should not run out of registers when loading cells.
<a href="https://bugs.webkit.org/show_bug.cgi?id=305427">https://bugs.webkit.org/show_bug.cgi?id=305427</a>

Reviewed by Yusuke Suzuki.

Patch by @emutavchi downstream: <a href="https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1593.">https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1593.</a>

We find ourselves in a state where canLoad says yes, because our JSValue
can be loaded via FPR, but we choose to load it via GPR instead because
we do not have two gprs free. This inconsistency causes an assertion failure,
and incorrect tail call shuffling.

This can only happen if loadsIntoFPR is true, but loadsIntoGPR is false.

In addition, everything DisplacedInJSStack must either have loadsIntoFPR or
loadsIntoGPR, so no other corner cases need to be considered.

Canonical link: <a href="https://commits.webkit.org/305572@main">https://commits.webkit.org/305572@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b01eb98ae5f2870c153d0c251a004215335a0eb2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138733 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11099 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/215 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146848 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91708 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11803 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11254 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106157 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77458 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141680 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8899 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124327 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87028 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8482 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6230 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7147 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/130704 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117903 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/176 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149605 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/137334 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10781 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/177 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114542 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10799 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9115 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114883 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29215 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8736 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120632 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65676 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10829 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/176 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/170006 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10564 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74470 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44311 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10767 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10618 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->