### PR TITLE
Remove potentially unused function

### DIFF
--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1279,16 +1279,6 @@ void WebChromeClient::triggerRenderingUpdate()
         drawingArea->triggerRenderingUpdate();
 }
 
-bool WebChromeClient::scheduleRenderingUpdate()
-{
-    RefPtr page = m_page.get();
-    if (!page)
-        return false;
-    if (RefPtr drawingArea = page->drawingArea())
-        return drawingArea->scheduleRenderingUpdate();
-    return false;
-}
-
 void WebChromeClient::renderingUpdateFramesPerSecondChanged()
 {
     RefPtr page = m_page.get();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -245,7 +245,6 @@ private:
     void setNeedsOneShotDrawingSynchronization() final;
     bool shouldTriggerRenderingUpdate(unsigned rescheduledRenderingUpdateCount) const final;
     void triggerRenderingUpdate() final;
-    bool scheduleRenderingUpdate() final;
     void renderingUpdateFramesPerSecondChanged() final;
     unsigned remoteImagesCountForTesting() const final;
     void registerBlobPathForTesting(const String& path, CompletionHandler<void()>&&) final;


### PR DESCRIPTION
#### 4a42629faf3c0f5cb78080e9eac4a860dbc7e3d0
<pre>
Remove potentially unused function
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a42629faf3c0f5cb78080e9eac4a860dbc7e3d0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138741 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11107 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/223 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/146934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/91716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11811 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11262 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/146934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/91716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141688 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8905 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/124333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/146934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/8487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/6237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7155 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117909 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149615 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10789 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/186 "Found 60 new test failures: accessibility/mac/basic-embed-pdf-accessibility.html accessibility/mac/scrolling-in-pdf-crash.html accessibility/mac/selection-boundary-userinfo.html accessibility/mac/selection-change-userinfo.html animations/3d/change-transform-in-end-event.html animations/3d/replace-filling-transform.html animations/3d/state-at-end-event-transform.html animations/added-while-suspended.html animations/animation-add-events-in-handler.html animations/animation-direction-normal.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114547 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10807 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9124 "Found 60 new test failures: accessibility/ARIA-reflection.html accessibility/accessibility-crash-focused-element-change.html accessibility/accessibility-crash-setattribute.html accessibility/combobox/aria-combobox-control-owns-elements.html accessibility/combobox/aria-combobox-hierarchy.html accessibility/combobox/aria-combobox-no-owns.html accessibility/combobox/mac/aria-combobox-activedescendant.html accessibility/combobox/mac/combobox-activedescendant-notifications.html accessibility/combobox/mac/combobox-inherited-role.html accessibility/custom-elements/autocomplete.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114888 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8752 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120641 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/65684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10837 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/184 "Found 60 new test failures: accessibility/mac/basic-embed-pdf-accessibility.html accessibility/mac/scrolling-in-pdf-crash.html accessibility/mac/selection-boundary-userinfo.html animations/3d/change-transform-in-end-event.html animations/3d/replace-filling-transform.html animations/3d/state-at-end-event-transform.html animations/added-while-suspended.html animations/animation-add-events-in-handler.html animations/animation-direction-normal.html animations/animation-direction-reverse-fill-mode-hardware.html ... (failure)") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/10572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74478 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10775 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10626 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->