### PR TITLE
Experiment with removing seemingly duplicative border width clamping code

### DIFF
--- a/Source/WebCore/style/values/backgrounds/StyleLineWidth.cpp
+++ b/Source/WebCore/style/values/backgrounds/StyleLineWidth.cpp
@@ -91,15 +91,6 @@ auto CSSValueConversion<LineWidth>::operator()(BuilderState& state, const CSSVal
     if (primitiveValue->isValueID())
         return handleKeywordValue(state, primitiveValue->valueID());
 
-    // Any original result that was >= 1 should not be allowed to fall below 1. This keeps border lines from vanishing.
-
-    auto result = primitiveValue->resolveAsLength<float>(state.cssToLengthConversionData());
-    if (state.style().usedZoom() < 1.0f && result < 1.0f) {
-        auto originalLength = primitiveValue->resolveAsLength<float>(state.cssToLengthConversionData().copyWithAdjustedZoom(1.0));
-        if (originalLength >= 1.0f)
-            return LineWidth::Length { 1.0f };
-    }
-
     return snapLengthAsBorderWidth(result, state.document().deviceScaleFactor());
 }
 


### PR DESCRIPTION
#### 6d4371e7515e76faad6874895d6e42cf4fd37a33
<pre>
Experiment with removing seemingly duplicative border width clamping code
<a href="https://bugs.webkit.org/show_bug.cgi?id=305437">https://bugs.webkit.org/show_bug.cgi?id=305437</a>

Reviewed by NOBODY (OOPS!).

Remove unnecessary clamping code. Pixel snapping code takes care of it better.

* Source/WebCore/style/values/backgrounds/StyleLineWidth.cpp:
(WebCore::Style::CSSValueConversion&lt;LineWidth&gt;::operator):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d4371e7515e76faad6874895d6e42cf4fd37a33

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138748 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11114 "Hash 6d4371e7 for PR 56533 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/230 "Hash 6d4371e7 for PR 56533 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146864 "Hash 6d4371e7 for PR 56533 does not build (failure)") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/91723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140621 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11818 "Hash 6d4371e7 for PR 56533 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11269 "Hash 6d4371e7 for PR 56533 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/146864 "Hash 6d4371e7 for PR 56533 does not build (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/91723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141695 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/11818 "Hash 6d4371e7 for PR 56533 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/230 "Hash 6d4371e7 for PR 56533 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/146864 "Hash 6d4371e7 for PR 56533 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/11818 "Hash 6d4371e7 for PR 56533 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/168/builds/230 "Hash 6d4371e7 for PR 56533 does not build (failure)") | [❌ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7162 "Hash 6d4371e7 for PR 56533 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/11818 "Hash 6d4371e7 for PR 56533 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/230 "Hash 6d4371e7 for PR 56533 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149622 "Hash 6d4371e7 for PR 56533 does not build (failure)") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10796 "Hash 6d4371e7 for PR 56533 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/230 "Hash 6d4371e7 for PR 56533 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/149622 "Hash 6d4371e7 for PR 56533 does not build (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10814 "Hash 6d4371e7 for PR 56533 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/11269 "Hash 6d4371e7 for PR 56533 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/149622 "Hash 6d4371e7 for PR 56533 does not build (failure)") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/230 "Hash 6d4371e7 for PR 56533 does not build (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/65691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10844 "Hash 6d4371e7 for PR 56533 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/230 "Hash 6d4371e7 for PR 56533 does not build (failure)") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/10579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/74485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10783 "Hash 6d4371e7 for PR 56533 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10633 "Hash 6d4371e7 for PR 56533 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->