### PR TITLE
Apply pixel snapping consistently for all border-width value types

### DIFF
--- a/LayoutTests/fast/backgrounds/size/contain-and-cover-zoomed-expected.txt
+++ b/LayoutTests/fast/backgrounds/size/contain-and-cover-zoomed-expected.txt
@@ -1,13 +1,13 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x260
-  RenderBlock {HTML} at (0,0) size 800x261
+layer at (0,0) size 800x257
+  RenderBlock {HTML} at (0,0) size 800x258
     RenderBody {BODY} at (0,0) size 800x0
-      RenderBlock (floating) {DIV} at (1,1) size 230x85 [bgcolor=#ADD8E6] [border: (1.73px solid #000000)]
-      RenderBlock (floating) {DIV} at (232,1) size 230x85 [bgcolor=#ADD8E6] [border: (1.73px solid #000000)]
-      RenderBlock (floating) {DIV} at (464,1) size 230x85 [bgcolor=#ADD8E6] [border: (1.73px solid #000000)]
-      RenderBlock (floating) {DIV} at (1,87) size 230x86 [bgcolor=#ADD8E6] [border: (1.73px solid #000000)]
-      RenderBlock (floating) {DIV} at (232,87) size 115x173 [bgcolor=#ADD8E6] [border: (1.73px solid #000000)]
-      RenderBlock (floating) {DIV} at (348,87) size 114x173 [bgcolor=#ADD8E6] [border: (1.73px solid #000000)]
-      RenderBlock (floating) {DIV} at (464,87) size 114x173 [bgcolor=#ADD8E6] [border: (1.73px solid #000000)]
-      RenderBlock (floating) {DIV} at (579,87) size 115x173 [bgcolor=#ADD8E6] [border: (1.73px solid #000000)]
+      RenderBlock (floating) {DIV} at (1,1) size 228x84 [bgcolor=#ADD8E6] [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (231,1) size 228x84 [bgcolor=#ADD8E6] [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (461,1) size 228x84 [bgcolor=#ADD8E6] [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (1,86) size 228x84 [bgcolor=#ADD8E6] [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (231,86) size 113x171 [bgcolor=#ADD8E6] [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (345,86) size 113x171 [bgcolor=#ADD8E6] [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (459,86) size 113x171 [bgcolor=#ADD8E6] [border: (1px solid #000000)]
+      RenderBlock (floating) {DIV} at (573,86) size 113x171 [bgcolor=#ADD8E6] [border: (1px solid #000000)]

--- a/LayoutTests/platform/ios/fast/reflections/reflection-with-zoom-expected.txt
+++ b/LayoutTests/platform/ios/fast/reflections/reflection-with-zoom-expected.txt
@@ -1,0 +1,8 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (6,6) size 788x588
+      RenderText {#text} at (0,0) size 0x0
+layer at (6,6) size 252x223
+  RenderImage {IMG} at (0,0) size 253x223 [border: (0.50px solid #000000)]

--- a/LayoutTests/platform/mac/fast/backgrounds/background-position-parsing-expected.txt
+++ b/LayoutTests/platform/mac/fast/backgrounds/background-position-parsing-expected.txt
@@ -1,158 +1,158 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x387
-  RenderBlock {HTML} at (0,0) size 800x387
+layer at (0,0) size 800x381
+  RenderBlock {HTML} at (0,0) size 800x381
     RenderBody {BODY} at (8,16) size 784x18
       RenderBlock {P} at (0,0) size 784x18
         RenderText {#text} at (0,0) size 509x18
           text run at (0,0) width 509: "In all the following boxes, the fuchsia diamond should be surrounded by a ring."
-      RenderBlock (floating) {DIV} at (1,35) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (1,35) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (83,35) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (82,35) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (164,35) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (162,35) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (246,35) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (243,35) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (328,35) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (324,35) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (409,35) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (404,35) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (491,35) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (485,35) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (572,35) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (565,35) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (654,35) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (646,35) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (1,91) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (1,90) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (83,91) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (82,90) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (164,91) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (162,90) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (246,91) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (243,90) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (328,91) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (324,90) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (409,91) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (404,90) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (491,91) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (485,90) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (572,91) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (565,90) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (654,91) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (646,90) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (1,147) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (1,145) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (83,147) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (82,145) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (164,147) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (162,145) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (246,147) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (243,145) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (328,147) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (324,145) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (409,147) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (404,145) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (491,147) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (485,145) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (572,147) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (565,145) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (654,147) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (646,145) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (1,203) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (1,200) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (83,203) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (82,200) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (164,203) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (162,200) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (246,203) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (243,200) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (328,203) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (324,200) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (409,203) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (404,200) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (491,203) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (485,200) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (572,203) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (565,200) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (654,203) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (646,200) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (1,259) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (1,255) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (83,259) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (82,255) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (164,259) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (162,255) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (246,259) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (243,255) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (328,259) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (324,255) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (409,259) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (404,255) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (491,259) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (485,255) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (572,259) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (565,255) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (654,259) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (646,255) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (1,315) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (1,310) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (83,315) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (82,310) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (164,315) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (162,310) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (246,315) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (243,310) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (328,315) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (324,310) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34

--- a/LayoutTests/platform/wpe-wk2/fast/backgrounds/background-position-parsing-expected.txt
+++ b/LayoutTests/platform/wpe-wk2/fast/backgrounds/background-position-parsing-expected.txt
@@ -1,158 +1,158 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x387
-  RenderBlock {HTML} at (0,0) size 800x387
+layer at (0,0) size 800x381
+  RenderBlock {HTML} at (0,0) size 800x381
     RenderBody {BODY} at (8,16) size 784x18
       RenderBlock {P} at (0,0) size 784x18
         RenderText {#text} at (0,0) size 500x17
           text run at (0,0) width 500: "In all the following boxes, the fuchsia diamond should be surrounded by a ring."
-      RenderBlock (floating) {DIV} at (1,35) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (1,35) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (83,35) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (82,35) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (164,35) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (162,35) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (246,35) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (243,35) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (328,35) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (324,35) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (409,35) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (404,35) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (491,35) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (485,35) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (572,35) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (565,35) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (654,35) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (646,35) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (1,91) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (1,90) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (83,91) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (82,90) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (164,91) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (162,90) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (246,91) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (243,90) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (328,91) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (324,90) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (409,91) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (404,90) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (491,91) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (485,90) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (572,91) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (565,90) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (654,91) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (646,90) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (1,147) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (1,145) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (83,147) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (82,145) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (164,147) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (162,145) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (246,147) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (243,145) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (328,147) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (324,145) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (409,147) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (404,145) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (491,147) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (485,145) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (572,147) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (565,145) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (654,147) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (646,145) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (1,203) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (1,200) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (83,203) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (82,200) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (164,203) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (162,200) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (246,203) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (243,200) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (328,203) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (324,200) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (409,203) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (404,200) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (491,203) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (485,200) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (572,203) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (565,200) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (654,203) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (646,200) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (1,259) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (1,255) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (83,259) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (82,255) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (164,259) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (162,255) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (246,259) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (243,255) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (328,259) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (324,255) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (409,259) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (404,255) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (491,259) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (485,255) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (572,259) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (565,255) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (654,259) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (646,255) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (1,315) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (1,310) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (83,315) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (82,310) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (164,315) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (162,310) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (246,315) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (243,310) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (328,315) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (324,310) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34

--- a/LayoutTests/platform/wpe/fast/backgrounds/background-position-parsing-expected.txt
+++ b/LayoutTests/platform/wpe/fast/backgrounds/background-position-parsing-expected.txt
@@ -1,158 +1,158 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x387
-  RenderBlock {HTML} at (0,0) size 800x387
+layer at (0,0) size 800x381
+  RenderBlock {HTML} at (0,0) size 800x381
     RenderBody {BODY} at (8,16) size 784x18
       RenderBlock {P} at (0,0) size 784x18
         RenderText {#text} at (0,0) size 500x17
           text run at (0,0) width 500: "In all the following boxes, the fuchsia diamond should be surrounded by a ring."
-      RenderBlock (floating) {DIV} at (1,35) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (1,35) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (83,35) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (82,35) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (164,35) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (162,35) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (246,35) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (243,35) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (328,35) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (324,35) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (409,35) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (404,35) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (491,35) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (485,35) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (572,35) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (565,35) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (654,35) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (646,35) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (1,91) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (1,90) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (83,91) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (82,90) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (164,91) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (162,90) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (246,91) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (243,90) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (328,91) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (324,90) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (409,91) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (404,90) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (491,91) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (485,90) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (572,91) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (565,90) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (654,91) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (646,90) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (1,147) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (1,145) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (83,147) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (82,145) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (164,147) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (162,145) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (246,147) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (243,145) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (328,147) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (324,145) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (409,147) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (404,145) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (491,147) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (485,145) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (572,147) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (565,145) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (654,147) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (646,145) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (1,203) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (1,200) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (83,203) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (82,200) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (164,203) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (162,200) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (246,203) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (243,200) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (328,203) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (324,200) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (409,203) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (404,200) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (491,203) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (485,200) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (572,203) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (565,200) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (654,203) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (646,200) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (1,259) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (1,255) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (83,259) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (82,255) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (164,259) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (162,255) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (246,259) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (243,255) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (328,259) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (324,255) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (409,259) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (404,255) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (491,259) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (485,255) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (572,259) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (565,255) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (654,259) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (646,255) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (1,315) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (1,310) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (83,315) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (82,310) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (164,315) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (162,310) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (246,315) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (243,310) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34
-      RenderBlock (floating) {DIV} at (328,315) size 79x54 [border: (1.50px solid #000000)]
-        RenderBlock {DIV} at (1,1) size 76x51 [bgcolor=#FFFFCC]
+      RenderBlock (floating) {DIV} at (324,310) size 78x53 [border: (1px solid #000000)]
+        RenderBlock {DIV} at (1,1) size 75x50 [bgcolor=#FFFFCC]
           RenderBlock {DIV} at (8,8) size 59x34

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -589,32 +589,32 @@ inline void BuilderCustom::applyValueFontFamily(BuilderState& builderState, CSSV
 
 inline void BuilderCustom::applyInitialBorderTopWidth(BuilderState& builderState)
 {
-    builderState.style().setBorderTopWidth(Style::LineWidth { Style::ComputedStyle::initialBorderTopWidth().value.unresolvedValue() * builderState.style().usedZoom() });
+    builderState.style().setBorderTopWidth(Style::LineWidth::snapLengthAsBorderWidth(3.0f * builderState.style().usedZoom(), builderState.document().deviceScaleFactor()));
 }
 
 inline void BuilderCustom::applyInitialBorderRightWidth(BuilderState& builderState)
 {
-    builderState.style().setBorderRightWidth(Style::LineWidth { Style::ComputedStyle::initialBorderRightWidth().value.unresolvedValue() * builderState.style().usedZoom() });
+    builderState.style().setBorderRightWidth(Style::LineWidth::snapLengthAsBorderWidth(3.0f * builderState.style().usedZoom(), builderState.document().deviceScaleFactor()));
 }
 
 inline void BuilderCustom::applyInitialBorderBottomWidth(BuilderState& builderState)
 {
-    builderState.style().setBorderBottomWidth(Style::LineWidth { Style::ComputedStyle::initialBorderBottomWidth().value.unresolvedValue() * builderState.style().usedZoom() });
+    builderState.style().setBorderBottomWidth(Style::LineWidth::snapLengthAsBorderWidth(3.0f * builderState.style().usedZoom(), builderState.document().deviceScaleFactor()));
 }
 
 inline void BuilderCustom::applyInitialBorderLeftWidth(BuilderState& builderState)
 {
-    builderState.style().setBorderLeftWidth(Style::LineWidth { Style::ComputedStyle::initialBorderLeftWidth().value.unresolvedValue() * builderState.style().usedZoom() });
+    builderState.style().setBorderLeftWidth(Style::LineWidth::snapLengthAsBorderWidth(3.0f * builderState.style().usedZoom(), builderState.document().deviceScaleFactor()));
 }
 
 inline void BuilderCustom::applyInitialOutlineWidth(BuilderState& builderState)
 {
-    builderState.style().setOutlineWidth(Style::LineWidth { Style::ComputedStyle::initialOutlineWidth().value.unresolvedValue() * builderState.style().usedZoom() });
+    builderState.style().setOutlineWidth(Style::LineWidth::snapLengthAsBorderWidth(3.0f * builderState.style().usedZoom(), builderState.document().deviceScaleFactor()));
 }
 
 inline void BuilderCustom::applyInitialColumnRuleWidth(BuilderState& builderState)
 {
-    builderState.style().setColumnRuleWidth(Style::LineWidth { Style::ComputedStyle::initialColumnRuleWidth().value.unresolvedValue() * builderState.style().usedZoom() });
+    builderState.style().setColumnRuleWidth(Style::LineWidth::snapLengthAsBorderWidth(3.0f * builderState.style().usedZoom(), builderState.document().deviceScaleFactor()));
 }
 
 inline void BuilderCustom::applyInitialFontSize(BuilderState& builderState)

--- a/Source/WebCore/style/values/backgrounds/StyleLineWidth.h
+++ b/Source/WebCore/style/values/backgrounds/StyleLineWidth.h
@@ -46,6 +46,9 @@ struct LineWidth {
     constexpr LineWidth(Length length) : value { length } { }
     constexpr LineWidth(CSS::ValueLiteral<CSS::LengthUnit::Px> literal) : value { literal } { }
 
+    static Length snapLengthAsBorderWidth(float, float deviceScaleFactor);
+    static Length snapLengthAsBorderWidth(Length, float deviceScaleFactor);
+
     constexpr bool isZero() const { return value.isZero(); }
     constexpr bool isPositive() const { return value.isPositive(); }
 


### PR DESCRIPTION
#### dbd24cefb1e0a62f74961f20be9ef4398e3294f2
<pre>
Apply pixel snapping consistently for all border-width value types
<a href="https://bugs.webkit.org/show_bug.cgi?id=305439">https://bugs.webkit.org/show_bug.cgi?id=305439</a>

Reviewed by Alan Baradlay.

Consistently apply the same pixel snapping for line width.

Updated results show borders now pixel snap initial values
after zoom is applied, just like all other values.

* LayoutTests/fast/backgrounds/size/contain-and-cover-zoomed-expected.txt:
* LayoutTests/platform/ios/fast/reflections/reflection-with-zoom-expected.txt: Added.
* LayoutTests/platform/mac/fast/backgrounds/background-position-parsing-expected.txt:
* LayoutTests/platform/wpe-wk2/fast/backgrounds/background-position-parsing-expected.txt:
* LayoutTests/platform/wpe/fast/backgrounds/background-position-parsing-expected.txt:
* Source/WebCore/style/StyleBuilderCustom.h:
* Source/WebCore/style/values/backgrounds/StyleLineWidth.cpp:
* Source/WebCore/style/values/backgrounds/StyleLineWidth.h:

Canonical link: <a href="https://commits.webkit.org/305658@main">https://commits.webkit.org/305658@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f24af694721e204c2e0c5a6d6a3b9da589dba0a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138939 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11432 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/426 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147058 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/91966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140812 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12012 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11462 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106347 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/91966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141886 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9066 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124468 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87218 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8639 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6391 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7359 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118074 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/357 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149844 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10989 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/363 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114739 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11009 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9294 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115055 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29258 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8941 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120809 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65893 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11037 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/347 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10774 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74687 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10977 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10825 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->