### PR TITLE
Fix a race condition with the setting of VM::m_hasTerminationRequest.

### DIFF
--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -987,9 +987,15 @@ bool VM::hasExceptionsAfterHandlingTraps()
     return exception();
 }
 
+void VM::setHasTerminationRequest()
+{
+    m_hasTerminationRequest = true;
+    requestEntryScopeService(ConcurrentEntryScopeService::ResetTerminationRequest);
+}
+
 void VM::setException(Exception* exception)
 {
-    ASSERT(!exception || !isTerminationException(exception) || hasTerminationRequest());
+    ASSERT(!isTerminationException(exception) || hasTerminationRequest());
     m_exception = exception;
     m_lastException = exception;
     if (exception)

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -295,19 +295,12 @@ public:
     Type& ensureSideData(void* key, const Functor&);
 
     bool hasTerminationRequest() const { return m_hasTerminationRequest; }
-    // While setHasTerminationRequest() needs to be CONCURRENT_SAFE (called for stopping worker
-    // threads), clearHasTerminationRequest() should only be called by the owner mutator thread
-    // after servicing the requests. Hence, it should not be concurrent.
     void clearHasTerminationRequest()
     {
         m_hasTerminationRequest = false;
         clearEntryScopeService(ConcurrentEntryScopeService::ResetTerminationRequest);
     }
-    CONCURRENT_SAFE void setHasTerminationRequest()
-    {
-        m_hasTerminationRequest = true;
-        requestEntryScopeService(ConcurrentEntryScopeService::ResetTerminationRequest);
-    }
+    void setHasTerminationRequest();
 
     bool executionForbidden() const { return m_executionForbidden; }
     void setExecutionForbidden() { m_executionForbidden = true; }
@@ -1100,11 +1093,7 @@ public:
 
     CONCURRENT_SAFE void notifyNeedDebuggerBreak() { traps().fireTrap(VMTraps::NeedDebuggerBreak); }
     CONCURRENT_SAFE void notifyNeedShellTimeoutCheck() { traps().fireTrap(VMTraps::NeedShellTimeoutCheck); }
-    CONCURRENT_SAFE void notifyNeedTermination()
-    {
-        setHasTerminationRequest();
-        traps().fireTrap(VMTraps::NeedTermination);
-    }
+    CONCURRENT_SAFE void notifyNeedTermination() { traps().fireTrap(VMTraps::NeedTermination); }
     CONCURRENT_SAFE void notifyNeedWatchdogCheck() { traps().fireTrap(VMTraps::NeedWatchdogCheck); }
 
     CONCURRENT_SAFE void requestStop()

--- a/Source/JavaScriptCore/runtime/VMTraps.cpp
+++ b/Source/JavaScriptCore/runtime/VMTraps.cpp
@@ -491,11 +491,10 @@ bool VMTraps::handleTraps(VMTraps::BitField mask)
             ASSERT(vm.watchdog());
             if (!vm.watchdog()->isActive() || !vm.watchdog()->shouldTerminate(vm.entryScope->globalObject())) [[likely]]
                 continue;
-            vm.setHasTerminationRequest();
             [[fallthrough]];
 
         case NeedTermination:
-            ASSERT(vm.hasTerminationRequest());
+            vm.setHasTerminationRequest();
             scope.release();
             if (!isDeferringTermination())
                 vm.throwTerminationException();


### PR DESCRIPTION
#### 23922a766f070f42e408f607b37e0a47612b00e2
<pre>
Fix a race condition with the setting of VM::m_hasTerminationRequest.
<a href="https://bugs.webkit.org/show_bug.cgi?id=305440">https://bugs.webkit.org/show_bug.cgi?id=305440</a>
<a href="https://rdar.apple.com/168110635">rdar://168110635</a>

Reviewed by Yusuke Suzuki.

VM::notifyNeedTermination() was calling setHasTerminationRequest() followed by setting the
VMTraps::NeedTermination trap bit.  The code expects m_hasTerminationRequest to be set while
a NeedTermination trap is being processed.  VM::notifyNeedTermination() can be called from
the main thread.

However, on the worker thread, VM::executeEntryScopeServicesOnExit() will clearHasTerminationRequest()
if the trap bit is not already set.  If VM::notifyNeedTermination() is called between these 2
 operations, we will effectively clear the m_hasTerminationRequest while the NeedTermination
trap bit is set.  This breaks the invariant that expects m_hasTerminationRequest to still be set.

In fact, there really wasn&apos;t a need to setHasTerminationRequest() from VM::notifyNeedTermination().
We can just set it inside VMTraps::handleTraps() when we know that we need to process a termination.
VMTraps::handleTraps() is only called from the mutator thread, which is the worker thread in this
case.  This will completely remove the race.

Also removed the `!exception` condition from the ASSERT in VM::setException().  We should never
be calling VM::setException() with a nullptr.  This is stale code from back when we didn&apos;t have
a distinct VM::clearException() function.

No new test because This issue can only manifest if a termination request happen to land in time
between 2 statements being executed in the worker thread.  It is exceedingly difficult to reproduce
this race condition in order to write a test.

* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::setHasTerminationRequest):
(JSC::VM::setException):
* Source/JavaScriptCore/runtime/VM.h:
(JSC::VM::hasTerminationRequest const):
(JSC::VM::notifyNeedTermination):
(JSC::VM::setHasTerminationRequest): Deleted.
* Source/JavaScriptCore/runtime/VMTraps.cpp:
(JSC::VMTraps::handleTraps):

Canonical link: <a href="https://commits.webkit.org/305643@main">https://commits.webkit.org/305643@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71ffa490494dab5d8f390ecd5128af0bef1b3d21

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138756 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11122 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/238 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146872 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91731 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/195abcb4-ed39-413d-8fe1-6446d42d645b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11826 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11277 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106175 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77473 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/243815a8-b19f-4673-82fd-8e0b6fcef43c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141703 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8916 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124443 "Found 1 new API test failure: TestWebKitAPI.ContextMenuTests.ContextMenuElementInfoContainsQRCodePayloadString (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87046 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/054f340a-8c8c-40f7-9dc8-df2b8e79a9c0) 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6311 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7170 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/130727 "Built successfully and passed tests") | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/199 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149630 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/137358 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10804 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/201 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114560 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10822 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9136 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114901 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8776 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120655 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65699 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21422 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10852 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/198 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/170029 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10587 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74493 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44316 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10791 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10641 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->