### PR TITLE
Digital Credentials: DigitalCredentialRequest was renamed DigitalCredentialGetRequest

### DIFF
--- a/LayoutTests/http/tests/digital-credentials/digital-credential-console-messages.https-expected.txt
+++ b/LayoutTests/http/tests/digital-credentials/digital-credential-console-messages.https-expected.txt
@@ -1,7 +1,7 @@
-CONSOLE MESSAGE: Ignoring DigitalCredentialRequest with unsupported protocol: "unknown-protocol-1"
-CONSOLE MESSAGE: Ignoring DigitalCredentialRequest with unsupported protocol: "unknown-protocol-2"
-CONSOLE MESSAGE: Ignoring DigitalCredentialRequest with unsupported protocol: "unknown-before"
-CONSOLE MESSAGE: Ignoring DigitalCredentialRequest with unsupported protocol: "unknown-after"
+CONSOLE MESSAGE: Ignoring DigitalCredentialGetRequest with unsupported protocol: "unknown-protocol-1"
+CONSOLE MESSAGE: Ignoring DigitalCredentialGetRequest with unsupported protocol: "unknown-protocol-2"
+CONSOLE MESSAGE: Ignoring DigitalCredentialGetRequest with unsupported protocol: "unknown-before"
+CONSOLE MESSAGE: Ignoring DigitalCredentialGetRequest with unsupported protocol: "unknown-after"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -451,7 +451,7 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/highlight/HighlightRegistry.idl
 
     Modules/identity/DigitalCredential.idl
-    Modules/identity/DigitalCredentialRequest.idl
+    Modules/identity/DigitalCredentialGetRequest.idl
     Modules/identity/DigitalCredentialRequestOptions.idl
     Modules/identity/IdentityCredentialProtocol.idl
 

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -517,7 +517,7 @@ $(PROJECT_DIR)/Modules/geolocation/PositionOptions.idl
 $(PROJECT_DIR)/Modules/highlight/Highlight.idl
 $(PROJECT_DIR)/Modules/highlight/HighlightRegistry.idl
 $(PROJECT_DIR)/Modules/identity/DigitalCredential.idl
-$(PROJECT_DIR)/Modules/identity/DigitalCredentialRequest.idl
+$(PROJECT_DIR)/Modules/identity/DigitalCredentialGetRequest.idl
 $(PROJECT_DIR)/Modules/identity/DigitalCredentialRequestOptions.idl
 $(PROJECT_DIR)/Modules/identity/IdentityCredentialProtocol.idl
 $(PROJECT_DIR)/Modules/identity/protocols/ISO18013/MobileDocumentRequest.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -907,8 +907,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDeviceOrientationOrMotionPermissi
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDeviceOrientationOrMotionPermissionState.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDigitalCredential.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDigitalCredential.h
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDigitalCredentialRequest.cpp
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDigitalCredentialRequest.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDigitalCredentialGetRequest.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDigitalCredentialGetRequest.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDigitalCredentialRequestOptions.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDigitalCredentialRequestOptions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDistanceModelType.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -378,7 +378,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/highlight/HighlightRegistry.idl \
     $(WebCore)/Modules/highlight/Highlight.idl \
     $(WebCore)/Modules/identity/DigitalCredential.idl \
-    $(WebCore)/Modules/identity/DigitalCredentialRequest.idl \
+    $(WebCore)/Modules/identity/DigitalCredentialGetRequest.idl \
     $(WebCore)/Modules/identity/DigitalCredentialRequestOptions.idl \
     $(WebCore)/Modules/identity/IdentityCredentialProtocol.idl \
     $(WebCore)/Modules/identity/protocols/ISO18013/MobileDocumentRequest.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -493,7 +493,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/identity/CredentialRequestCoordinator.h
     Modules/identity/CredentialRequestCoordinatorClient.h
     Modules/identity/DigitalCredential.h
-    Modules/identity/DigitalCredentialRequest.h
+    Modules/identity/DigitalCredentialGetRequest.h
     Modules/identity/DigitalCredentialRequestOptions.h
     Modules/identity/DigitalCredentialsRequestData.h
     Modules/identity/DigitalCredentialsResponseData.h

--- a/Source/WebCore/Modules/identity/DigitalCredential.cpp
+++ b/Source/WebCore/Modules/identity/DigitalCredential.cpp
@@ -71,7 +71,7 @@ static std::optional<IdentityCredentialProtocol> convertProtocolString(const Str
     return std::nullopt;
 }
 
-static ExceptionOr<std::optional<UnvalidatedDigitalCredentialRequest>> jsToCredentialRequest(const Document& document, const DigitalCredentialRequest& request)
+static ExceptionOr<std::optional<UnvalidatedDigitalCredentialRequest>> jsToCredentialRequest(const Document& document, const DigitalCredentialGetRequest& request)
 {
     auto scope = DECLARE_THROW_SCOPE(document.globalObject()->vm());
     auto* globalObject = document.globalObject();
@@ -98,7 +98,7 @@ static ExceptionOr<std::optional<UnvalidatedDigitalCredentialRequest>> jsToCrede
     }
 }
 
-ExceptionOr<Vector<UnvalidatedDigitalCredentialRequest>> DigitalCredential::convertObjectsToDigitalPresentationRequests(const Document& document, const Vector<DigitalCredentialRequest>& requests)
+ExceptionOr<Vector<UnvalidatedDigitalCredentialRequest>> DigitalCredential::convertObjectsToDigitalPresentationRequests(const Document& document, const Vector<DigitalCredentialGetRequest>& requests)
 {
     Vector<UnvalidatedDigitalCredentialRequest> results;
     for (auto& request : requests) {
@@ -112,13 +112,13 @@ ExceptionOr<Vector<UnvalidatedDigitalCredentialRequest>> DigitalCredential::conv
         }
 
         if (RefPtr context = document.scriptExecutionContext()) {
-            String warning = makeString("Ignoring DigitalCredentialRequest with unsupported protocol: \""_s, request.protocol, "\""_s);
+            String warning = makeString("Ignoring DigitalCredentialGetRequest with unsupported protocol: \""_s, request.protocol, "\""_s);
             context->addConsoleMessage(MessageSource::Other, MessageLevel::Warning, warning);
         }
     }
 
     if (results.isEmpty())
-        return Exception { ExceptionCode::TypeError, "At least one supported DigitalCredentialRequest must present"_s };
+        return Exception { ExceptionCode::TypeError, "At least one supported DigitalCredentialGetRequest must present"_s };
 
     return results;
 }

--- a/Source/WebCore/Modules/identity/DigitalCredential.h
+++ b/Source/WebCore/Modules/identity/DigitalCredential.h
@@ -41,7 +41,7 @@ namespace WebCore {
 class Document;
 enum class IdentityCredentialProtocol : uint8_t;
 struct CredentialRequestOptions;
-struct DigitalCredentialRequest;
+struct DigitalCredentialGetRequest;
 struct DigitalCredentialRequestOptions;
 template<typename IDLType> class DOMPromiseDeferred;
 template<typename> class ExceptionOr;
@@ -75,7 +75,7 @@ private:
     DigitalCredential(JSC::Strong<JSC::JSObject>&&, IdentityCredentialProtocol);
 
     static ExceptionOr<Vector<ValidatedDigitalCredentialRequest>> validateRequests(const Document&, Vector<UnvalidatedDigitalCredentialRequest>&&);
-    static ExceptionOr<Vector<UnvalidatedDigitalCredentialRequest>> convertObjectsToDigitalPresentationRequests(const Document&, const Vector<DigitalCredentialRequest>&);
+    static ExceptionOr<Vector<UnvalidatedDigitalCredentialRequest>> convertObjectsToDigitalPresentationRequests(const Document&, const Vector<DigitalCredentialGetRequest>&);
     static bool parseResponseData(RefPtr<Document>, const String&, JSC::JSObject*&);
 
     Type credentialType() const final { return Type::DigitalCredential; }

--- a/Source/WebCore/Modules/identity/DigitalCredentialGetRequest.h
+++ b/Source/WebCore/Modules/identity/DigitalCredentialGetRequest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,7 +23,19 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-dictionary DigitalCredentialRequest {
-    required DOMString protocol;
-    required object data;
+#pragma once
+
+#include <JavaScriptCore/Strong.h>
+#include <wtf/text/WTFString.h>
+namespace JSC {
+class JSObject;
+}
+
+namespace WebCore {
+
+struct DigitalCredentialGetRequest {
+    String protocol;
+    JSC::Strong<JSC::JSObject> data;
 };
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/identity/DigitalCredentialGetRequest.idl
+++ b/Source/WebCore/Modules/identity/DigitalCredentialGetRequest.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,19 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
-#include <JavaScriptCore/Strong.h>
-#include <wtf/text/WTFString.h>
-namespace JSC {
-class JSObject;
-}
-
-namespace WebCore {
-
-struct DigitalCredentialRequest {
-    String protocol;
-    JSC::Strong<JSC::JSObject> data;
+dictionary DigitalCredentialGetRequest {
+    required DOMString protocol;
+    required object data;
 };
-
-} // namespace WebCore

--- a/Source/WebCore/Modules/identity/DigitalCredentialRequestOptions.h
+++ b/Source/WebCore/Modules/identity/DigitalCredentialRequestOptions.h
@@ -25,13 +25,13 @@
 
 #pragma once
 
-#include <WebCore/DigitalCredentialRequest.h>
+#include <WebCore/DigitalCredentialGetRequest.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
 
 struct DigitalCredentialRequestOptions {
-    Vector<DigitalCredentialRequest> requests;
+    Vector<DigitalCredentialGetRequest> requests;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/identity/DigitalCredentialRequestOptions.idl
+++ b/Source/WebCore/Modules/identity/DigitalCredentialRequestOptions.idl
@@ -24,5 +24,5 @@
  */
 
 dictionary DigitalCredentialRequestOptions {
-    required sequence<DigitalCredentialRequest> requests;
+    required sequence<DigitalCredentialGetRequest> requests;
 };

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -4040,7 +4040,7 @@ JSDeviceMotionEvent.cpp
 JSDeviceOrientationEvent.cpp
 JSDeviceOrientationOrMotionPermissionState.cpp
 JSDigitalCredential.cpp
-JSDigitalCredentialRequest.cpp
+JSDigitalCredentialGetRequest.cpp
 JSDigitalCredentialRequestOptions.cpp
 JSDistanceModelType.cpp
 JSDocument.cpp

--- a/Source/WebKit/UIProcess/DigitalCredentials/WKDigitalCredentialsPicker.mm
+++ b/Source/WebKit/UIProcess/DigitalCredentials/WKDigitalCredentialsPicker.mm
@@ -41,7 +41,7 @@
 #import <Foundation/Foundation.h>
 #import <JavaScriptCore/ConsoleTypes.h>
 #import <Security/SecTrust.h>
-#import <WebCore/DigitalCredentialRequest.h>
+#import <WebCore/DigitalCredentialGetRequest.h>
 #import <WebCore/DigitalCredentialsProtocols.h>
 #import <WebCore/DigitalCredentialsRequestData.h>
 #import <WebCore/DigitalCredentialsResponseData.h>

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -223,7 +223,7 @@
 #include <WebCore/DeprecatedGlobalSettings.h>
 #include <WebCore/DiagnosticLoggingClient.h>
 #include <WebCore/DiagnosticLoggingKeys.h>
-#include <WebCore/DigitalCredentialRequest.h>
+#include <WebCore/DigitalCredentialGetRequest.h>
 #include <WebCore/DigitalCredentialRequestOptions.h>
 #include <WebCore/DigitalCredentialsProtocols.h>
 #include <WebCore/DigitalCredentialsRequestData.h>


### PR DESCRIPTION
#### dd91c6549835134e91cbf822fd1f412033005029
<pre>
Digital Credentials: DigitalCredentialRequest was renamed DigitalCredentialGetRequest
<a href="https://bugs.webkit.org/show_bug.cgi?id=304311">https://bugs.webkit.org/show_bug.cgi?id=304311</a>
<a href="https://rdar.apple.com/167115220">rdar://167115220</a>

Reviewed by Anne van Kesteren.

Renamed DigitalCredentialRequest to DigitalCredentialGetRequest, as per spec change:
<a href="https://github.com/w3c-fedid/digital-credentials/pull/204">https://github.com/w3c-fedid/digital-credentials/pull/204</a>

* LayoutTests/http/tests/digital-credentials/digital-credential-console-messages.https-expected.txt:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/identity/DigitalCredential.cpp:
(WebCore::jsToCredentialRequest):
(WebCore::DigitalCredential::convertObjectsToDigitalPresentationRequests):
* Source/WebCore/Modules/identity/DigitalCredential.h:
* Source/WebCore/Modules/identity/DigitalCredentialGetRequest.h: Renamed from Source/WebCore/Modules/identity/DigitalCredentialRequest.h.
* Source/WebCore/Modules/identity/DigitalCredentialGetRequest.idl: Renamed from Source/WebCore/Modules/identity/DigitalCredentialRequest.idl.
* Source/WebCore/Modules/identity/DigitalCredentialRequestOptions.h:
* Source/WebCore/Modules/identity/DigitalCredentialRequestOptions.idl:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebKit/UIProcess/DigitalCredentials/WKDigitalCredentialsPicker.mm:
* Source/WebKit/UIProcess/WebPageProxy.cpp:

Canonical link: <a href="https://commits.webkit.org/305608@main">https://commits.webkit.org/305608@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/652aa5cd588942b61e083fa9913a63ccdd58eb60

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138767 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11133 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/249 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146883 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91742 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/16d42664-f1aa-463c-ac81-c2c07c382224) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140640 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11837 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11288 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106185 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77484 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/109ce782-b525-43de-a87e-e37349cbf7e4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141714 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8928 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124355 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87056 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a9682c3c-a466-4229-86a7-1b292f831440) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8508 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6257 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7181 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117932 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/213 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149641 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10815 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/214 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114570 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10833 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9145 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114911 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29235 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8788 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120668 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65710 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10863 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/211 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10598 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74504 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10802 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10652 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->