### PR TITLE
[JSC] Optimize `[...set]`

### DIFF
--- a/JSTests/microbenchmarks/spread-set.js
+++ b/JSTests/microbenchmarks/spread-set.js
@@ -1,0 +1,10 @@
+function test(set) {
+    return [...set];
+}
+noInline(test);
+
+const set = new Set([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+for (let i = 0; i < 1e6; i++) {
+    test(set);
+}

--- a/JSTests/stress/spread-set-dfg-ftl.js
+++ b/JSTests/stress/spread-set-dfg-ftl.js
@@ -1,0 +1,124 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("Bad value: " + actual + " expected: " + expected);
+}
+
+function shouldBeArray(actual, expected) {
+    shouldBe(actual.length, expected.length);
+    for (let i = 0; i < expected.length; ++i)
+        shouldBe(actual[i], expected[i]);
+}
+
+{
+    function test(set) {
+        return [...set];
+    }
+    noInline(test);
+
+    const set = new Set([1, 2, 3, 4, 5]);
+
+    for (let i = 0; i < 1e5; ++i) {
+        const result = test(set);
+        shouldBe(result.length, 5);
+        if (i % 1e4 === 0) {
+            shouldBeArray(result, [1, 2, 3, 4, 5]);
+        }
+    }
+}
+
+{
+    function spreadSet(set) {
+        return [...set];
+    }
+    function test(set) {
+        const arr = spreadSet(set);
+        return arr.reduce((a, b) => a + b, 0);
+    }
+    noInline(test);
+    const set = new Set([1, 2, 3, 4, 5]);
+    for (let i = 0; i < 1e5; ++i) {
+        const result = test(set);
+        shouldBe(result, 15);
+    }
+}
+
+{
+    function test(set, n) {
+        let sum = 0;
+        for (let i = 0; i < n; ++i) {
+            const arr = [...set];
+            sum += arr[i % arr.length];
+        }
+        return sum;
+    }
+    noInline(test);
+    const set = new Set([1, 2, 3]);
+    for (let i = 0; i < 1e3; ++i) {
+        const result = test(set, 99); // 99 iterations: 33*1 + 33*2 + 33*3 = 198
+        shouldBe(result, 198);
+    }
+}
+
+{
+    function test(set) {
+        return [...set];
+    }
+    noInline(test);
+    const set = new Set([1]);
+    for (let i = 0; i < 1e4; ++i) {
+        const result = test(set);
+        shouldBe(result.length, set.size);
+        if (i % 100 === 0) {
+            set.add(i);
+        }
+        if (i % 500 === 0 && set.size > 10) {
+            const firstValue = set.values().next().value;
+            set.delete(firstValue);
+        }
+    }
+}
+
+{
+    function innerSpread(set) {
+        return [...set];
+    }
+    function outerSpread(set) {
+        const arr = innerSpread(set);
+        return [...new Set(arr.map(x => x * 2))];
+    }
+    noInline(outerSpread);
+    const set = new Set([1, 2, 3]);
+    for (let i = 0; i < 1e4; ++i) {
+        const result = outerSpread(set);
+        shouldBeArray(result, [2, 4, 6]);
+    }
+}
+
+{
+    function test(iterable) {
+        try {
+            return [...iterable];
+        } catch (e) {
+            return [];
+        }
+    }
+    noInline(test);
+    const set = new Set([1, 2, 3]);
+    for (let i = 0; i < 1e5; ++i) {
+        const result = test(set);
+        shouldBeArray(result, [1, 2, 3]);
+    }
+}
+
+{
+    function test(arr) {
+        const set = new Set(arr);
+        return [...set];
+    }
+    noInline(test);
+    const arr = [1, 2, 3, 2, 1]; // Has duplicates
+    for (let i = 0; i < 1e4; ++i) {
+        const result = test(arr);
+        shouldBeArray(result, [1, 2, 3]);
+    }
+}

--- a/JSTests/stress/spread-set-having-a-bad-time.js
+++ b/JSTests/stress/spread-set-having-a-bad-time.js
@@ -1,0 +1,112 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("Bad value: " + actual + " expected: " + expected);
+}
+
+function shouldBeArray(actual, expected) {
+    shouldBe(actual.length, expected.length);
+    for (let i = 0; i < expected.length; ++i)
+        shouldBe(actual[i], expected[i]);
+}
+{
+    function test(set) {
+        return [...set];
+    }
+    noInline(test);
+
+    const set = new Set([1, 2, 3]);
+    for (let i = 0; i < 1e4; ++i) {
+        const result = test(set);
+        shouldBeArray(result, [1, 2, 3]);
+    }
+    Array.prototype[10] = "bad";
+    try {
+        for (let i = 0; i < 1e3; ++i) {
+            const result = test(set);
+            shouldBe(result.length, 3);
+            shouldBe(result[0], 1);
+            shouldBe(result[1], 2);
+            shouldBe(result[2], 3);
+        }
+    } finally {
+        delete Array.prototype[10];
+    }
+}
+
+{
+    function test(set) {
+        return [...set];
+    }
+    noInline(test);
+    const set = new Set([1, 2, 3]);
+    for (let i = 0; i < 1e4; ++i) {
+        const result = test(set);
+        shouldBeArray(result, [1, 2, 3]);
+    }
+    Object.prototype[5] = "fromObject";
+    try {
+        for (let i = 0; i < 1e3; ++i) {
+            const result = test(set);
+            shouldBe(result.length, 3);
+            shouldBeArray(result, [1, 2, 3]);
+        }
+    } finally {
+        delete Object.prototype[5];
+    }
+}
+
+{
+    function test(set) {
+        const arr = [...set];
+        return arr;
+    }
+    noInline(test);
+    const set = new Set([1, 2, 3]);
+    for (let i = 0; i < 1e4; ++i) {
+        const result = test(set);
+        shouldBe(Object.getPrototypeOf(result), Array.prototype);
+        shouldBe(result.constructor, Array);
+        shouldBe(Array.isArray(result), true);
+    }
+}
+
+{
+    function test(set) {
+        return [...set];
+    }
+    noInline(test);
+    const set = new Set([0, 1, 2, 100, 1000]);
+    for (let i = 0; i < 1e4; ++i) {
+        const result = test(set);
+        shouldBe(result.length, 5);
+        shouldBeArray(result, [0, 1, 2, 100, 1000]);
+    }
+}
+
+{
+    function test(set) {
+        return [...set];
+    }
+    noInline(test);
+    const set = new Set([0, -0, 1]); // -0 should be treated same as 0
+    for (let i = 0; i < 1e4; ++i) {
+        const result = test(set);
+        shouldBe(result.length, 2);
+        shouldBe(result[0], 0);
+        shouldBe(result[1], 1);
+    }
+}
+
+{
+    function test(set) {
+        return [...set];
+    }
+    noInline(test);
+    const set = new Set([NaN, NaN, 1]); // NaN should be treated as same value
+    for (let i = 0; i < 1e4; ++i) {
+        const result = test(set);
+        shouldBe(result.length, 2);
+        shouldBe(Number.isNaN(result[0]), true);
+        shouldBe(result[1], 1);
+    }
+}

--- a/JSTests/stress/spread-set-osr-exit.js
+++ b/JSTests/stress/spread-set-osr-exit.js
@@ -1,0 +1,125 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("Bad value: " + actual + " expected: " + expected);
+}
+
+function shouldBeArray(actual, expected) {
+    shouldBe(actual.length, expected.length);
+    for (let i = 0; i < expected.length; ++i)
+        shouldBe(actual[i], expected[i]);
+}
+
+{
+    function test(iterable) {
+        return [...iterable];
+    }
+    noInline(test);
+    const set = new Set([1, 2, 3]);
+    for (let i = 0; i < 1e4; ++i) {
+        const result = test(set);
+        shouldBeArray(result, [1, 2, 3]);
+    }
+    const arr = [4, 5, 6];
+    for (let i = 0; i < 100; ++i) {
+        const result = test(arr);
+        shouldBeArray(result, [4, 5, 6]);
+    }
+    for (let i = 0; i < 100; ++i) {
+        const result = test(set);
+        shouldBeArray(result, [1, 2, 3]);
+    }
+}
+
+{
+    function test(iterable) {
+        return [...iterable];
+    }
+    noInline(test);
+    const set = new Set([1, 2, 3]);
+    for (let i = 0; i < 1e4; ++i) {
+        const result = test(set);
+        shouldBeArray(result, [1, 2, 3]);
+    }
+    const map = new Map([[1, "a"], [2, "b"]]);
+    for (let i = 0; i < 100; ++i) {
+        const result = test(map);
+        shouldBe(result.length, 2);
+        shouldBeArray(result[0], [1, "a"]);
+        shouldBeArray(result[1], [2, "b"]);
+    }
+}
+
+{
+    function test(set) {
+        return [...set];
+    }
+    noInline(test);
+    const smallSet = new Set([1, 2, 3]);
+    const largeSet = new Set();
+    for (let i = 0; i < 1000; ++i)
+        largeSet.add(i);
+    for (let i = 0; i < 1e4; ++i) {
+        if (i % 2 === 0) {
+            const result = test(smallSet);
+            shouldBe(result.length, 3);
+        } else {
+            const result = test(largeSet);
+            shouldBe(result.length, 1000);
+        }
+    }
+}
+
+{
+    function test(iterable) {
+        try {
+            return [...iterable];
+        } catch (e) {
+            return null;
+        }
+    }
+    noInline(test);
+    const set = new Set([1, 2, 3]);
+    for (let i = 0; i < 1e4; ++i) {
+        const result = test(set);
+        shouldBeArray(result, [1, 2, 3]);
+    }
+    shouldBe(test(null), null);
+    shouldBe(test(undefined), null);
+    const result = test(set);
+    shouldBeArray(result, [1, 2, 3]);
+}
+
+{
+    function test(s1, s2) {
+        return [...s1, ...s2];
+    }
+    noInline(test);
+    const set1 = new Set([1, 2, 3]);
+    const set2 = new Set([4, 5, 6]);
+    for (let i = 0; i < 1e4; ++i) {
+        const result = test(set1, set2);
+        shouldBeArray(result, [1, 2, 3, 4, 5, 6]);
+    }
+}
+
+{
+    function* gen() {
+        yield 7;
+        yield 8;
+        yield 9;
+    }
+    function test(iterable) {
+        return [...iterable];
+    }
+    noInline(test);
+    const set = new Set([1, 2, 3]);
+    for (let i = 0; i < 1e4; ++i) {
+        if (i % 100 === 0) {
+            const result = test(gen());
+            shouldBeArray(result, [7, 8, 9]);
+        } else {
+            const result = test(set);
+            shouldBeArray(result, [1, 2, 3]);
+        }
+    }
+}

--- a/JSTests/stress/spread-set.js
+++ b/JSTests/stress/spread-set.js
@@ -1,0 +1,323 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("Bad value: " + actual + " expected: " + expected);
+}
+
+function shouldBeArray(actual, expected) {
+    shouldBe(actual.length, expected.length);
+    for (let i = 0; i < expected.length; ++i)
+        shouldBe(actual[i], expected[i]);
+}
+
+// Basic case: spread Set with integers
+{
+    function test(s) {
+        return [...s];
+    }
+    noInline(test);
+
+    const set = new Set([1, 2, 3]);
+    for (let i = 0; i < 1e4; ++i) {
+        const result = test(set);
+        shouldBeArray(result, [1, 2, 3]);
+    }
+}
+
+// Empty Set
+{
+    function test(s) {
+        return [...s];
+    }
+    noInline(test);
+
+    const set = new Set();
+    for (let i = 0; i < 1e4; ++i) {
+        const result = test(set);
+        shouldBeArray(result, []);
+    }
+}
+
+// Set with deleted elements
+{
+    function test(s) {
+        return [...s];
+    }
+    noInline(test);
+
+    const set = new Set([1, 2, 3, 4, 5]);
+    set.delete(2);
+    set.delete(4);
+    for (let i = 0; i < 1e4; ++i) {
+        const result = test(set);
+        shouldBeArray(result, [1, 3, 5]);
+    }
+}
+
+// Large Set
+{
+    function test(s) {
+        return [...s];
+    }
+    noInline(test);
+
+    const arr = [];
+    for (let i = 0; i < 1000; ++i)
+        arr.push(i);
+    const set = new Set(arr);
+
+    for (let i = 0; i < 1e3; ++i) {
+        const result = test(set);
+        shouldBe(result.length, 1000);
+        for (let j = 0; j < 1000; ++j)
+            shouldBe(result[j], j);
+    }
+}
+
+// Various types: double
+{
+    function test(s) {
+        return [...s];
+    }
+    noInline(test);
+
+    const set = new Set([1.5, 2.5, 3.5]);
+    for (let i = 0; i < 1e4; ++i) {
+        const result = test(set);
+        shouldBeArray(result, [1.5, 2.5, 3.5]);
+    }
+}
+
+// Various types: object
+{
+    function test(s) {
+        return [...s];
+    }
+    noInline(test);
+
+    const obj1 = {};
+    const obj2 = {};
+    const obj3 = {};
+    const set = new Set([obj1, obj2, obj3]);
+    for (let i = 0; i < 1e4; ++i) {
+        const result = test(set);
+        shouldBe(result.length, 3);
+        shouldBe(result[0], obj1);
+        shouldBe(result[1], obj2);
+        shouldBe(result[2], obj3);
+    }
+}
+
+// Various types: string
+{
+    function test(s) {
+        return [...s];
+    }
+    noInline(test);
+
+    const set = new Set(["a", "b", "c"]);
+    for (let i = 0; i < 1e4; ++i) {
+        const result = test(set);
+        shouldBeArray(result, ["a", "b", "c"]);
+    }
+}
+
+// Various types: symbol
+{
+    function test(s) {
+        return [...s];
+    }
+    noInline(test);
+
+    const sym1 = Symbol("a");
+    const sym2 = Symbol("b");
+    const sym3 = Symbol("c");
+    const set = new Set([sym1, sym2, sym3]);
+    for (let i = 0; i < 1e4; ++i) {
+        const result = test(set);
+        shouldBe(result.length, 3);
+        shouldBe(result[0], sym1);
+        shouldBe(result[1], sym2);
+        shouldBe(result[2], sym3);
+    }
+}
+
+// Various types: BigInt
+{
+    function test(s) {
+        return [...s];
+    }
+    noInline(test);
+
+    const set = new Set([1n, 2n, 3n]);
+    for (let i = 0; i < 1e4; ++i) {
+        const result = test(set);
+        shouldBeArray(result, [1n, 2n, 3n]);
+    }
+}
+
+// Insertion order preserved
+{
+    function test(s) {
+        return [...s];
+    }
+    noInline(test);
+
+    const set = new Set();
+    set.add(3);
+    set.add(1);
+    set.add(4);
+    set.add(1); // Duplicate, should not change order
+    set.add(5);
+    set.add(9);
+    for (let i = 0; i < 1e4; ++i) {
+        const result = test(set);
+        shouldBeArray(result, [3, 1, 4, 5, 9]);
+    }
+}
+
+// Fallback when Symbol.iterator is modified
+{
+    function test(s) {
+        return [...s];
+    }
+    noInline(test);
+
+    const set = new Set([1, 2, 3]);
+
+    // First, run normally to warm up
+    for (let i = 0; i < 1e3; ++i) {
+        const result = test(set);
+        shouldBeArray(result, [1, 2, 3]);
+    }
+
+    // Modify Symbol.iterator
+    const originalIterator = Set.prototype[Symbol.iterator];
+    Set.prototype[Symbol.iterator] = function* () {
+        yield 100;
+        yield 200;
+    };
+
+    try {
+        const result = test(set);
+        shouldBeArray(result, [100, 200]);
+    } finally {
+        Set.prototype[Symbol.iterator] = originalIterator;
+    }
+
+    // Ensure it falls back correctly
+    const result2 = test(set);
+    shouldBeArray(result2, [1, 2, 3]);
+}
+
+// Fallback when SetIteratorPrototype.next is modified
+{
+    function test(s) {
+        return [...s];
+    }
+    noInline(test);
+
+    const set = new Set([1, 2, 3]);
+
+    // First, run normally to warm up
+    for (let i = 0; i < 1e3; ++i) {
+        const result = test(set);
+        shouldBeArray(result, [1, 2, 3]);
+    }
+
+    // Get SetIteratorPrototype and modify next
+    const setIteratorPrototype = Object.getPrototypeOf(set[Symbol.iterator]());
+    const originalNext = setIteratorPrototype.next;
+    setIteratorPrototype.next = function() {
+        const result = originalNext.call(this);
+        if (!result.done)
+            result.value = result.value * 10;
+        return result;
+    };
+
+    try {
+        const result = test(set);
+        shouldBeArray(result, [10, 20, 30]);
+    } finally {
+        setIteratorPrototype.next = originalNext;
+    }
+
+    // Ensure it falls back correctly
+    const result2 = test(set);
+    shouldBeArray(result2, [1, 2, 3]);
+}
+
+// Set subclass
+{
+    class MySet extends Set {
+        constructor(iterable) {
+            super(iterable);
+        }
+    }
+
+    function test(s) {
+        return [...s];
+    }
+    noInline(test);
+
+    const set = new MySet([1, 2, 3]);
+    for (let i = 0; i < 1e4; ++i) {
+        const result = test(set);
+        shouldBeArray(result, [1, 2, 3]);
+    }
+}
+
+// Mixed types in one Set
+{
+    function test(s) {
+        return [...s];
+    }
+    noInline(test);
+
+    const obj = {};
+    const sym = Symbol();
+    const set = new Set([1, "two", 3.0, null, undefined, obj, sym, 100n]);
+    for (let i = 0; i < 1e4; ++i) {
+        const result = test(set);
+        shouldBe(result.length, 8);
+        shouldBe(result[0], 1);
+        shouldBe(result[1], "two");
+        shouldBe(result[2], 3.0);
+        shouldBe(result[3], null);
+        shouldBe(result[4], undefined);
+        shouldBe(result[5], obj);
+        shouldBe(result[6], sym);
+        shouldBe(result[7], 100n);
+    }
+}
+
+// Spread in array literal context
+{
+    function test(s) {
+        return [0, ...s, 4];
+    }
+    noInline(test);
+
+    const set = new Set([1, 2, 3]);
+    for (let i = 0; i < 1e4; ++i) {
+        const result = test(set);
+        shouldBeArray(result, [0, 1, 2, 3, 4]);
+    }
+}
+
+// Spread in function call context
+{
+    function sum(...args) {
+        return args.reduce((a, b) => a + b, 0);
+    }
+
+    function test(s) {
+        return sum(...s);
+    }
+    noInline(test);
+
+    const set = new Set([1, 2, 3, 4, 5]);
+    for (let i = 0; i < 1e4; ++i) {
+        const result = test(set);
+        shouldBe(result, 15);
+    }
+}

--- a/Source/JavaScriptCore/bytecode/SpeculatedType.h
+++ b/Source/JavaScriptCore/bytecode/SpeculatedType.h
@@ -246,6 +246,11 @@ inline bool isProxyObjectSpeculation(SpeculatedType value)
     return value == SpecProxyObject;
 }
 
+inline bool isSetObjectSpeculation(SpeculatedType value)
+{
+    return value == SpecSetObject;
+}
+
 inline bool isGlobalProxySpeculation(SpeculatedType value)
 {
     return value == SpecGlobalProxy;

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -3669,9 +3669,13 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         case PhantomCreateRest:
             break;
         default:
-            if (!m_graph.canDoFastSpread(node, forNode(node->child1())))
-                clobberWorld();
-            else
+            if (!m_graph.canDoFastSpread(node, forNode(node->child1()))) {
+                // SetObjectUse has no side effects since we iterate directly over internal storage.
+                if (node->child1().useKind() == SetObjectUse)
+                    didFoldClobberWorld();
+                else
+                    clobberWorld();
+            } else
                 didFoldClobberWorld();
             break;
         }

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -1964,6 +1964,10 @@ private:
                 && m_graph.isWatchingArrayIteratorProtocolWatchpoint(node->child1().node())
                 && m_graph.isWatchingHavingABadTimeWatchpoint(node->child1().node()))
                 fixEdge<ArrayUse>(node->child1());
+            else if (node->child1()->shouldSpeculateSetObject()
+                && m_graph.isWatchingSetIteratorProtocolWatchpoint(node->child1().node())
+                && m_graph.isWatchingHavingABadTimeWatchpoint(node->child1().node()))
+                fixEdge<SetObjectUse>(node->child1());
             else
                 fixEdge<CellUse>(node->child1());
             break;

--- a/Source/JavaScriptCore/dfg/DFGGraph.h
+++ b/Source/JavaScriptCore/dfg/DFGGraph.h
@@ -902,6 +902,13 @@ public:
         return isWatchingGlobalObjectWatchpoint(globalObject, set, LinkerIR::Type::ArrayIteratorProtocolWatchpointSet);
     }
 
+    bool isWatchingSetIteratorProtocolWatchpoint(Node* node)
+    {
+        JSGlobalObject* globalObject = globalObjectFor(node->origin.semantic);
+        InlineWatchpointSet& set = globalObject->setIteratorProtocolWatchpointSet();
+        return isWatchingGlobalObjectWatchpoint(globalObject, set, LinkerIR::Type::SetIteratorProtocolWatchpointSet);
+    }
+
     bool isWatchingNumberToStringWatchpoint(Node* node)
     {
         JSGlobalObject* globalObject = globalObjectFor(node->origin.semantic);

--- a/Source/JavaScriptCore/dfg/DFGJITCode.cpp
+++ b/Source/JavaScriptCore/dfg/DFGJITCode.cpp
@@ -48,6 +48,7 @@ JITData::JITData(unsigned stubInfoSize, unsigned poolSize, const JITCode& jitCod
         case LinkerIR::Type::MasqueradesAsUndefinedWatchpointSet:
         case LinkerIR::Type::ArrayBufferDetachWatchpointSet:
         case LinkerIR::Type::ArrayIteratorProtocolWatchpointSet:
+        case LinkerIR::Type::SetIteratorProtocolWatchpointSet:
         case LinkerIR::Type::NumberToStringWatchpointSet:
         case LinkerIR::Type::StructureCacheClearedWatchpointSet:
         case LinkerIR::Type::StringToStringWatchpointSet:
@@ -145,6 +146,11 @@ bool JITData::tryInitialize(VM& vm, CodeBlock* codeBlock, const JITCode& jitCode
         case LinkerIR::Type::ArrayIteratorProtocolWatchpointSet: {
             auto& watchpoint = m_watchpoints[indexOfWatchpoints++];
             success &= attemptToWatch(codeBlock, m_globalObject->arrayIteratorProtocolWatchpointSet(), watchpoint);
+            break;
+        }
+        case LinkerIR::Type::SetIteratorProtocolWatchpointSet: {
+            auto& watchpoint = m_watchpoints[indexOfWatchpoints++];
+            success &= attemptToWatch(codeBlock, m_globalObject->setIteratorProtocolWatchpointSet(), watchpoint);
             break;
         }
         case LinkerIR::Type::NumberToStringWatchpointSet: {

--- a/Source/JavaScriptCore/dfg/DFGJITCode.h
+++ b/Source/JavaScriptCore/dfg/DFGJITCode.h
@@ -95,6 +95,7 @@ public:
         MasqueradesAsUndefinedWatchpointSet,
         ArrayBufferDetachWatchpointSet,
         ArrayIteratorProtocolWatchpointSet,
+        SetIteratorProtocolWatchpointSet,
         NumberToStringWatchpointSet,
         StructureCacheClearedWatchpointSet,
         StringToStringWatchpointSet,

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -3247,6 +3247,11 @@ public:
         return isProxyObjectSpeculation(prediction());
     }
 
+    bool shouldSpeculateSetObject()
+    {
+        return isSetObjectSpeculation(prediction());
+    }
+
     bool shouldSpeculateGlobalProxy()
     {
         return isGlobalProxySpeculation(prediction());

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -4612,6 +4612,19 @@ JSC_DEFINE_JIT_OPERATION(operationSpreadGeneric, JSCell*, (JSGlobalObject* globa
     OPERATION_RETURN(scope, JSCellButterfly::createFromArray(globalObject, vm, array));
 }
 
+JSC_DEFINE_JIT_OPERATION(operationSpreadSet, JSCell*, (JSGlobalObject* globalObject, JSCell* cell))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    ASSERT(jsDynamicCast<JSSet*>(cell));
+    JSSet* set = jsCast<JSSet*>(cell);
+
+    OPERATION_RETURN(scope, JSCellButterfly::createFromSet(globalObject, set));
+}
+
 JSC_DEFINE_JIT_OPERATION(operationSpreadFastArray, JSCell*, (JSGlobalObject* globalObject, JSCell* cell))
 {
     VM& vm = globalObject->vm();

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -397,6 +397,7 @@ JSC_DECLARE_JIT_OPERATION(operationArrayIndexOfValueInt32, UCPUStrictInt32, (JSG
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationArrayIndexOfNonStringIdentityValueContiguous, UCPUStrictInt32, (Butterfly*, EncodedJSValue, int32_t));
 
 JSC_DECLARE_JIT_OPERATION(operationSpreadFastArray, JSCell*, (JSGlobalObject*, JSCell*));
+JSC_DECLARE_JIT_OPERATION(operationSpreadSet, JSCell*, (JSGlobalObject*, JSCell*));
 JSC_DECLARE_JIT_OPERATION(operationSpreadGeneric, JSCell*, (JSGlobalObject*, JSCell*));
 JSC_DECLARE_JIT_OPERATION(operationNewArrayWithSpreadSlow, JSCell*, (JSGlobalObject*, void*, uint32_t));
 JSC_DECLARE_JIT_OPERATION(operationCreateImmutableButterfly, JSCell*, (JSGlobalObject*, unsigned length));

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -8963,6 +8963,8 @@ void SpeculativeJIT::compileSpread(Node* node)
 
     if (node->child1().useKind() == ArrayUse)
         speculateArray(node->child1(), argument);
+    else if (node->child1().useKind() == SetObjectUse)
+        speculateSetObject(node->child1(), argument);
 
     if (m_graph.canDoFastSpread(node, m_state.forNode(node->child1()))) {
 #if USE(JSVALUE64)
@@ -9054,6 +9056,13 @@ void SpeculativeJIT::compileSpread(Node* node)
         callOperation(operationSpreadFastArray, resultGPR, LinkableConstant::globalObject(*this, node), argument);
         cellResult(resultGPR, node);
 #endif // USE(JSVALUE64)
+    } else if (node->child1().useKind() == SetObjectUse) {
+        flushRegisters();
+
+        GPRFlushedCallResult result(this);
+        GPRReg resultGPR = result.gpr();
+        callOperation(operationSpreadSet, resultGPR, LinkableConstant::globalObject(*this, node), argument);
+        cellResult(resultGPR, node);
     } else {
         flushRegisters();
 

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -10178,6 +10178,8 @@ IGNORE_CLANG_WARNINGS_END
 
         if (m_node->child1().useKind() == ArrayUse)
             speculateArray(m_node->child1());
+        else if (m_node->child1().useKind() == SetObjectUse)
+            speculateSetObject(m_node->child1());
 
         if (m_graph.canDoFastSpread(m_node, m_state.forNode(m_node->child1()))) {
             LBasicBlock copyOnWriteContiguousCheck = m_out.newBlock();
@@ -10270,7 +10272,9 @@ IGNORE_CLANG_WARNINGS_END
             m_out.appendTo(continuation, lastNext);
             result = m_out.phi(pointerType(), sharedResult, fastResult, slowResult);
             mutatorFence();
-        } else
+        } else if (m_node->child1().useKind() == SetObjectUse)
+            result = vmCall(pointerType(), operationSpreadSet, weakPointer(globalObject), argument);
+        else
             result = vmCall(pointerType(), operationSpreadGeneric, weakPointer(globalObject), argument);
 
         setJSValue(result);

--- a/Source/JavaScriptCore/runtime/CommonSlowPathsInlines.h
+++ b/Source/JavaScriptCore/runtime/CommonSlowPathsInlines.h
@@ -29,6 +29,7 @@
 #include "ClonedArguments.h"
 #include "CommonSlowPaths.h"
 #include "DirectArguments.h"
+#include "JSSetInlines.h"
 #include "ScopedArguments.h"
 
 namespace JSC {
@@ -192,6 +193,12 @@ ALWAYS_INLINE JSCellButterfly* trySpreadFast(JSGlobalObject* globalObject, JSCel
         auto* arguments = jsCast<ScopedArguments*>(iterable);
         if (arguments->isIteratorProtocolFastAndNonObservable()) [[likely]]
             return JSCellButterfly::createFromScopedArguments(globalObject, arguments);
+        return nullptr;
+    }
+    case JSSetType: {
+        auto* set = jsCast<JSSet*>(iterable);
+        if (set->isIteratorProtocolFastAndNonObservable()) [[likely]]
+            return JSCellButterfly::createFromSet(globalObject, set);
         return nullptr;
     }
     default:

--- a/Source/JavaScriptCore/runtime/JSCellButterfly.h
+++ b/Source/JavaScriptCore/runtime/JSCellButterfly.h
@@ -40,6 +40,7 @@ namespace JSC {
 
 class ClonedArguments;
 class DirectArguments;
+class JSSet;
 class ScopedArguments;
 
 // This is essentially a normal butterfly but it can also be handled as a cell since it has a cell header.
@@ -147,6 +148,7 @@ public:
     static JSCellButterfly* createFromClonedArguments(JSGlobalObject*, ClonedArguments*);
     static JSCellButterfly* createFromDirectArguments(JSGlobalObject*, DirectArguments*);
     static JSCellButterfly* createFromScopedArguments(JSGlobalObject*, ScopedArguments*);
+    static JSCellButterfly* createFromSet(JSGlobalObject*, JSSet*);
     static JSCellButterfly* createFromString(JSGlobalObject*, JSString*);
     static JSCellButterfly* tryCreateFromArgList(VM&, ArgList);
 


### PR DESCRIPTION
#### 38411ab91e0177e045e7ec63d9d978d5c689aa2d
<pre>
[JSC] Optimize `[...set]`
<a href="https://bugs.webkit.org/show_bug.cgi?id=305446">https://bugs.webkit.org/show_bug.cgi?id=305446</a>

Reviewed by Yusuke Suzuki.

This patch optimizes the spread syntax ([...set]) for Set objects by bypassing
the generic iterator protocol. Instead of calling Symbol.iterator and creating
{value, done} objects for each element, we directly iterate over the Set&apos;s
internal hash table storage.

                        TipOfTree                  Patched

spread-set           59.8129+-2.6835     ^     22.9277+-0.0935        ^ definitely 2.6088x faster

* JSTests/microbenchmarks/spread-set.js: Added.
(const.set new):
* JSTests/stress/spread-set-dfg-ftl.js: Added.
(shouldBe):
(shouldBeArray):
(shouldBe.set shouldBe):
(shouldBe.const.set new):
(set let):
(test):
* JSTests/stress/spread-set-having-a-bad-time.js: Added.
(shouldBe):
(shouldBeArray):
* JSTests/stress/spread-set-osr-exit.js: Added.
(shouldBe):
(shouldBeArray):
(shouldBe.test):
(test):
(test.set return):
(set shouldBeArray):
(gen):
* JSTests/stress/spread-set.js: Added.
(shouldBe):
(shouldBeArray):
(shouldBe.test):
(test):
(Set.prototype.Symbol.iterator):
(setIteratorPrototype.next):
(MySet):
(sum):
* Source/JavaScriptCore/bytecode/SpeculatedType.h:
(JSC::isSetObjectSpeculation):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGGraph.h:
* Source/JavaScriptCore/dfg/DFGJITCode.cpp:
(JSC::DFG::JITData::JITData):
(JSC::DFG::JITData::tryInitialize):
* Source/JavaScriptCore/dfg/DFGJITCode.h:
* Source/JavaScriptCore/dfg/DFGNode.h:
(JSC::DFG::Node::shouldSpeculateSetObject):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileSpread):
* Source/JavaScriptCore/runtime/CommonSlowPathsInlines.h:
(JSC::CommonSlowPaths::trySpreadFast):
* Source/JavaScriptCore/runtime/JSCellButterfly.cpp:
(JSC::JSCellButterfly::createFromSet):
* Source/JavaScriptCore/runtime/JSCellButterfly.h:

Canonical link: <a href="https://commits.webkit.org/305845@main">https://commits.webkit.org/305845@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb2a7a22e4d8d65b74f47d1f0dcbfcf2c70e1d88

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138770 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11136 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/252 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146886 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91745 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11840 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11291 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106187 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77483 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141717 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8932 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124370 "Passed tests") | [⏳ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/API-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8511 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6943 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7184 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/130741 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117936 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/217 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149644 "Built successfully") | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10818 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1046 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114574 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10836 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9148 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114915 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29361 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8795 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120672 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65713 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10866 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/215 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/170043 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10604 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74507 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44320 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10805 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10655 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->