### PR TITLE
Move class `FloatRoundedRect::Radii` into new class `CornerRadii`

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2553,6 +2553,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/ContentTypeUtilities.h
     platform/graphics/ContentsFormat.h
     platform/graphics/CopyImageOptions.h
+    platform/graphics/CornerRadii.h
     platform/graphics/Damage.h
     platform/graphics/DashArray.h
     platform/graphics/DecodingOptions.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2486,6 +2486,7 @@ platform/graphics/ColorUtilities.cpp
 platform/graphics/ComplexTextController.cpp
 platform/graphics/ContentTypeUtilities.cpp
 platform/graphics/ContentsFormat.cpp
+platform/graphics/CornerRadii.cpp
 platform/graphics/CrossfadeGeneratedImage.cpp
 platform/graphics/DestinationColorSpace.cpp
 platform/graphics/DisplayRefreshMonitor.cpp

--- a/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -1131,7 +1131,7 @@ void InspectorOverlay::drawRulers(GraphicsContext& context, const InspectorOverl
         }
         context.translate(translate);
 
-        context.fillRoundedRect(FloatRoundedRect(viewportTextRect, FloatRoundedRect::Radii(radius)), rulerBackgroundColor);
+        context.fillRoundedRect(FloatRoundedRect(viewportTextRect, CornerRadii(radius)), rulerBackgroundColor);
 
         context.setFillColor(Color::black);
         context.drawText(font, viewportTextRun, { margin +  padding, margin + padding + fontHeight - font.metricsOfPrimaryFont().intDescent() });

--- a/Source/WebCore/inspector/InspectorOverlayLabel.cpp
+++ b/Source/WebCore/inspector/InspectorOverlayLabel.cpp
@@ -350,7 +350,7 @@ Path InspectorOverlayLabel::draw(GraphicsContext& context, float maximumLineWidt
                 textPosition.y() + yOffset - lineHeight + lineDescent,
                 computedContentRun.computedWidth + (labelContentDecorationBorderedLeadingAndTrailingPadding * 2),
                 lineHeight,
-            }, FloatRoundedRect::Radii(2));
+            }, CornerRadii(2));
 
             Path backgroundPath;
             backgroundPath.addRoundedRect(backgroundRect);

--- a/Source/WebCore/page/DebugPageOverlays.cpp
+++ b/Source/WebCore/page/DebugPageOverlays.cpp
@@ -449,7 +449,7 @@ static void drawCheckbox(const String& text, GraphicsContext& context, const Fon
     context.drawText(font, textRun, box.location() + FloatSize { checkboxRect.width() + textHorizontalPadding, lineHeight });
 
     Path checkboxPath;
-    checkboxPath.addRoundedRect(FloatRoundedRect { checkboxRect, FloatRoundedRect::Radii { 3 } });
+    checkboxPath.addRoundedRect(FloatRoundedRect { checkboxRect, CornerRadii { 3 } });
 
     if (state) {
         context.setFillColor(Color::darkGray);
@@ -500,7 +500,7 @@ void InteractionRegionOverlay::drawSettings(GraphicsContext& context)
     {
         GraphicsContextStateSaver stateSaver(context);
         context.setDropShadow({ { }, 5, Color(Color::black).colorWithAlpha(0.5), ShadowRadiusMode::Default });
-        context.fillRoundedRect(FloatRoundedRect { rect, FloatRoundedRect::Radii { 6 } }, Color(Color::white).colorWithAlpha(0.85));
+        context.fillRoundedRect(FloatRoundedRect { rect, CornerRadii { 6 } }, Color(Color::white).colorWithAlpha(0.85));
     }
 
     FontCascadeDescription fontDescription;

--- a/Source/WebCore/platform/DictationCaretAnimator.cpp
+++ b/Source/WebCore/platform/DictationCaretAnimator.cpp
@@ -284,7 +284,7 @@ void DictationCaretAnimator::fillCaretTail(const FloatRect& rect, GraphicsContex
 FloatRoundedRect DictationCaretAnimator::expandedCaretRect(const FloatRect& rect, bool fillTail) const
 {
     if (m_initialScale <= 0.f && fillTail)
-        return FloatRoundedRect { rect, FloatRoundedRect::Radii { 1.f } };
+        return FloatRoundedRect { rect, CornerRadii { 1.f } };
 
     auto extraScaleFactor = 1.f;
     auto pulseExpansion = 1.f;
@@ -301,7 +301,7 @@ FloatRoundedRect DictationCaretAnimator::expandedCaretRect(const FloatRect& rect
     float verticalPulseExpansion = pulseExpansion * (1.f + 3.f * (extraScaleFactor - 1.f)) - 1.f;
     FloatRect expandedRect = rect;
     expandedRect.expand(FloatBoxExtent { verticalPulseExpansion, horizontalPulseExpansion, verticalPulseExpansion, horizontalPulseExpansion });
-    return FloatRoundedRect { expandedRect, FloatRoundedRect::Radii(1.f + std::max(0.f, .5f * horizontalPulseExpansion), 1.f + std::max(0.f, .5f * horizontalPulseExpansion)) };
+    return FloatRoundedRect { expandedRect, CornerRadii(1.f + std::max(0.f, .5f * horizontalPulseExpansion), 1.f + std::max(0.f, .5f * horizontalPulseExpansion)) };
 }
 
 void DictationCaretAnimator::paint(GraphicsContext& context, const FloatRect& rect, const Color& caretColor, const LayoutPoint& paintOffset) const

--- a/Source/WebCore/platform/OpacityCaretAnimator.cpp
+++ b/Source/WebCore/platform/OpacityCaretAnimator.cpp
@@ -121,7 +121,7 @@ void OpacityCaretAnimator::paint(GraphicsContext& context, const FloatRect& rect
     if (caretColor != Color::transparentBlack)
         caretColorWithOpacity = caretColor.colorWithAlpha(caretPresentationProperties.opacity);
 
-    context.fillRoundedRect(FloatRoundedRect { rect, FloatRoundedRect::Radii { 1.0 } }, caretColorWithOpacity);
+    context.fillRoundedRect(FloatRoundedRect { rect, CornerRadii { 1.0 } }, caretColorWithOpacity);
 }
 
 LayoutRect OpacityCaretAnimator::caretRepaintRectForLocalRect(LayoutRect repaintRect) const

--- a/Source/WebCore/platform/cocoa/DragImageCocoa.mm
+++ b/Source/WebCore/platform/cocoa/DragImageCocoa.mm
@@ -299,7 +299,7 @@ DragImageData createDragImageForLink(Element& element, URL& url, const String& t
 
     GraphicsContextCG context([NSGraphicsContext currentContext].CGContext);
 
-    context.fillRoundedRect(FloatRoundedRect(layout.boundingRect, FloatRoundedRect::Radii(linkImageCornerRadius)), colorFromCocoaColor([NSColor controlBackgroundColor]));
+    context.fillRoundedRect(FloatRoundedRect(layout.boundingRect, CornerRadii(linkImageCornerRadius)), colorFromCocoaColor([NSColor controlBackgroundColor]));
 
     for (const auto& label : layout.labels) {
         GraphicsContextStateSaver saver(context);

--- a/Source/WebCore/platform/graphics/CornerRadii.cpp
+++ b/Source/WebCore/platform/graphics/CornerRadii.cpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2013 Adobe Systems Incorporated. All rights reserved.
+ * Copyright (C) 2024-2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials
+ *    provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CornerRadii.h"
+
+#include <wtf/TZoneMallocInlines.h>
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CornerRadii);
+
+bool CornerRadii::hasEvenCorners() const
+{
+    return areEssentiallyEqual(m_topLeft, m_topRight)
+        && areEssentiallyEqual(m_topLeft, m_bottomLeft)
+        && areEssentiallyEqual(m_topLeft, m_bottomRight);
+}
+
+bool CornerRadii::isUniformCornerRadius() const
+{
+    return WTF::areEssentiallyEqual(m_topLeft.width(), m_topLeft.height()) && hasEvenCorners();
+}
+
+void CornerRadii::scale(float factor)
+{
+    scale(factor, factor);
+}
+
+void CornerRadii::scale(float horizontalFactor, float verticalFactor)
+{
+    if (horizontalFactor == 1 && verticalFactor == 1)
+        return;
+
+    // If either radius on a corner becomes zero, reset both radii on that corner.
+    m_topLeft.scale(horizontalFactor, verticalFactor);
+    if (!m_topLeft.width() || !m_topLeft.height())
+        m_topLeft = FloatSize();
+    m_topRight.scale(horizontalFactor, verticalFactor);
+    if (!m_topRight.width() || !m_topRight.height())
+        m_topRight = FloatSize();
+    m_bottomLeft.scale(horizontalFactor, verticalFactor);
+    if (!m_bottomLeft.width() || !m_bottomLeft.height())
+        m_bottomLeft = FloatSize();
+    m_bottomRight.scale(horizontalFactor, verticalFactor);
+    if (!m_bottomRight.width() || !m_bottomRight.height())
+        m_bottomRight = FloatSize();
+}
+
+void CornerRadii::expand(float topWidth, float bottomWidth, float leftWidth, float rightWidth)
+{
+    if (m_topLeft.width() > 0 && m_topLeft.height() > 0) {
+        m_topLeft.setWidth(std::max<float>(0, m_topLeft.width() + leftWidth));
+        m_topLeft.setHeight(std::max<float>(0, m_topLeft.height() + topWidth));
+    }
+    if (m_topRight.width() > 0 && m_topRight.height() > 0) {
+        m_topRight.setWidth(std::max<float>(0, m_topRight.width() + rightWidth));
+        m_topRight.setHeight(std::max<float>(0, m_topRight.height() + topWidth));
+    }
+    if (m_bottomLeft.width() > 0 && m_bottomLeft.height() > 0) {
+        m_bottomLeft.setWidth(std::max<float>(0, m_bottomLeft.width() + leftWidth));
+        m_bottomLeft.setHeight(std::max<float>(0, m_bottomLeft.height() + bottomWidth));
+    }
+    if (m_bottomRight.width() > 0 && m_bottomRight.height() > 0) {
+        m_bottomRight.setWidth(std::max<float>(0, m_bottomRight.width() + rightWidth));
+        m_bottomRight.setHeight(std::max<float>(0, m_bottomRight.height() + bottomWidth));
+    }
+}
+
+void CornerRadii::expandEvenIfZero(float size)
+{
+    auto expand = [&](auto& corner) {
+        corner.setWidth(std::max(0.f, corner.width() + size));
+        corner.setHeight(std::max(0.f, corner.height() + size));
+    };
+
+    expand(m_topLeft);
+    expand(m_topRight);
+    expand(m_bottomLeft);
+    expand(m_bottomRight);
+}
+
+TextStream& operator<<(TextStream& ts, const CornerRadii& cornerRadii)
+{
+    ts.dumpProperty("top-left"_s, cornerRadii.topLeft());
+    ts.dumpProperty("top-right"_s, cornerRadii.topRight());
+    ts.dumpProperty("bottom-left"_s, cornerRadii.bottomLeft());
+    ts.dumpProperty("bottom-right"_s, cornerRadii.bottomRight());
+    return ts;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/CornerRadii.h
+++ b/Source/WebCore/platform/graphics/CornerRadii.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2013 Adobe Systems Incorporated. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials
+ *    provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/FloatSize.h>
+#include <WebCore/LayoutRoundedRect.h>
+#include <wtf/TZoneMalloc.h>
+
+namespace WebCore {
+
+class CornerRadii {
+    WTF_MAKE_TZONE_ALLOCATED(CornerRadii);
+public:
+    CornerRadii() = default;
+    CornerRadii(const FloatSize& topLeft, const FloatSize& topRight, const FloatSize& bottomLeft, const FloatSize& bottomRight)
+        : m_topLeft(topLeft)
+        , m_topRight(topRight)
+        , m_bottomLeft(bottomLeft)
+        , m_bottomRight(bottomRight)
+    {
+    }
+
+    CornerRadii(const LayoutRoundedRect::Radii& intRadii)
+        : m_topLeft(intRadii.topLeft())
+        , m_topRight(intRadii.topRight())
+        , m_bottomLeft(intRadii.bottomLeft())
+        , m_bottomRight(intRadii.bottomRight())
+    {
+    }
+
+    explicit CornerRadii(float uniformRadius)
+        : m_topLeft(uniformRadius, uniformRadius)
+        , m_topRight(uniformRadius, uniformRadius)
+        , m_bottomLeft(uniformRadius, uniformRadius)
+        , m_bottomRight(uniformRadius, uniformRadius)
+    {
+    }
+
+    explicit CornerRadii(float uniformRadiusWidth, float uniformRadiusHeight)
+        : m_topLeft(uniformRadiusWidth, uniformRadiusHeight)
+        , m_topRight(uniformRadiusWidth, uniformRadiusHeight)
+        , m_bottomLeft(uniformRadiusWidth, uniformRadiusHeight)
+        , m_bottomRight(uniformRadiusWidth, uniformRadiusHeight)
+    {
+    }
+
+    void setTopLeft(const FloatSize& size) { m_topLeft = size; }
+    void setTopRight(const FloatSize& size) { m_topRight = size; }
+    void setBottomLeft(const FloatSize& size) { m_bottomLeft = size; }
+    void setBottomRight(const FloatSize& size) { m_bottomRight = size; }
+    const FloatSize& topLeft() const { return m_topLeft; }
+    const FloatSize& topRight() const { return m_topRight; }
+    const FloatSize& bottomLeft() const { return m_bottomLeft; }
+    const FloatSize& bottomRight() const { return m_bottomRight; }
+
+    bool isZero() const { return m_topLeft.isZero() && m_topRight.isZero() && m_bottomLeft.isZero() && m_bottomRight.isZero(); }
+    bool hasEvenCorners() const;
+    bool isUniformCornerRadius() const; // Including no radius.
+
+    void scale(float factor);
+    void scale(float horizontalFactor, float verticalFactor);
+    void expandEvenIfZero(float size);
+    void expand(float topWidth, float bottomWidth, float leftWidth, float rightWidth);
+    void expand(float size) { expand(size, size, size, size); }
+    void shrink(float topWidth, float bottomWidth, float leftWidth, float rightWidth) { expand(-topWidth, -bottomWidth, -leftWidth, -rightWidth); }
+    void shrink(float size) { shrink(size, size, size, size); }
+
+    friend bool operator==(const CornerRadii&, const CornerRadii&) = default;
+
+private:
+    FloatSize m_topLeft;
+    FloatSize m_topRight;
+    FloatSize m_bottomLeft;
+    FloatSize m_bottomRight;
+};
+
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const CornerRadii&);
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/FloatRoundedRect.h
+++ b/Source/WebCore/platform/graphics/FloatRoundedRect.h
@@ -30,6 +30,7 @@
 #ifndef FloatRoundedRect_h
 #define FloatRoundedRect_h
 
+#include <WebCore/CornerRadii.h>
 #include <WebCore/FloatRect.h>
 #include <WebCore/FloatSize.h>
 #include <WebCore/LayoutRoundedRect.h>
@@ -47,85 +48,19 @@ class Path;
 class FloatRoundedRect {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(FloatRoundedRect, WEBCORE_EXPORT);
 public:
-    class Radii {
-        WTF_MAKE_TZONE_ALLOCATED(Radii);
-    public:
-        Radii() = default;
-        Radii(const FloatSize& topLeft, const FloatSize& topRight, const FloatSize& bottomLeft, const FloatSize& bottomRight)
-            : m_topLeft(topLeft)
-            , m_topRight(topRight)
-            , m_bottomLeft(bottomLeft)
-            , m_bottomRight(bottomRight)
-        {
-        }
-
-        Radii(const LayoutRoundedRect::Radii& intRadii)
-            : m_topLeft(intRadii.topLeft())
-            , m_topRight(intRadii.topRight())
-            , m_bottomLeft(intRadii.bottomLeft())
-            , m_bottomRight(intRadii.bottomRight())
-        {
-        }
-
-        explicit Radii(float uniformRadius)
-            : m_topLeft(uniformRadius, uniformRadius)
-            , m_topRight(uniformRadius, uniformRadius)
-            , m_bottomLeft(uniformRadius, uniformRadius)
-            , m_bottomRight(uniformRadius, uniformRadius)
-        {
-        }
-
-        explicit Radii(float uniformRadiusWidth, float uniformRadiusHeight)
-            : m_topLeft(uniformRadiusWidth, uniformRadiusHeight)
-            , m_topRight(uniformRadiusWidth, uniformRadiusHeight)
-            , m_bottomLeft(uniformRadiusWidth, uniformRadiusHeight)
-            , m_bottomRight(uniformRadiusWidth, uniformRadiusHeight)
-        {
-        }
-
-        void setTopLeft(const FloatSize& size) { m_topLeft = size; }
-        void setTopRight(const FloatSize& size) { m_topRight = size; }
-        void setBottomLeft(const FloatSize& size) { m_bottomLeft = size; }
-        void setBottomRight(const FloatSize& size) { m_bottomRight = size; }
-        const FloatSize& topLeft() const { return m_topLeft; }
-        const FloatSize& topRight() const { return m_topRight; }
-        const FloatSize& bottomLeft() const { return m_bottomLeft; }
-        const FloatSize& bottomRight() const { return m_bottomRight; }
-
-        bool isZero() const;
-        bool hasEvenCorners() const;
-        bool isUniformCornerRadius() const; // Including no radius.
-
-        void scale(float factor);
-        void scale(float horizontalFactor, float verticalFactor);
-        void expandEvenIfZero(float size);
-        void expand(float topWidth, float bottomWidth, float leftWidth, float rightWidth);
-        void expand(float size) { expand(size, size, size, size); }
-        void shrink(float topWidth, float bottomWidth, float leftWidth, float rightWidth) { expand(-topWidth, -bottomWidth, -leftWidth, -rightWidth); }
-        void shrink(float size) { shrink(size, size, size, size); }
-
-        friend bool operator==(const Radii&, const Radii&) = default;
-
-    private:
-        FloatSize m_topLeft;
-        FloatSize m_topRight;
-        FloatSize m_bottomLeft;
-        FloatSize m_bottomRight;
-    };
-
-    WEBCORE_EXPORT explicit FloatRoundedRect(const FloatRect& = FloatRect(), const Radii& = Radii());
+    WEBCORE_EXPORT explicit FloatRoundedRect(const FloatRect& = FloatRect(), const CornerRadii& = CornerRadii());
     WEBCORE_EXPORT FloatRoundedRect(const FloatRect&, const FloatSize& topLeft, const FloatSize& topRight, const FloatSize& bottomLeft, const FloatSize& bottomRight);
     explicit FloatRoundedRect(const LayoutRoundedRect&);
     FloatRoundedRect(float x, float y, float width, float height);
 
     const FloatRect& rect() const { return m_rect; }
-    const Radii& radii() const { return m_radii; }
+    const CornerRadii& radii() const { return m_radii; }
     bool isRounded() const { return !m_radii.isZero(); }
     bool isEmpty() const { return m_rect.isEmpty(); }
 
     void setRect(const FloatRect& rect) { m_rect = rect; }
     void setLocation(FloatPoint location) { m_rect.setLocation(location); }
-    void setRadii(const Radii& radii) { m_radii = radii; }
+    void setRadii(const CornerRadii& radii) { m_radii = radii; }
 
     void move(const FloatSize& size) { m_rect.move(size); }
     void inflate(float size) { m_rect.inflate(size);  }
@@ -167,10 +102,10 @@ public:
 
 private:
     FloatRect m_rect;
-    Radii m_radii;
+    CornerRadii m_radii;
 };
 
-inline float calcBorderRadiiConstraintScaleFor(const FloatRect& rect, const FloatRoundedRect::Radii& radii)
+inline float calcBorderRadiiConstraintScaleFor(const FloatRect& rect, const CornerRadii& radii)
 {
     // Constrain corner radii using CSS3 rules:
     // http://www.w3.org/TR/css3-background/#the-border-radius

--- a/Source/WebCore/platform/graphics/LayoutRoundedRect.cpp
+++ b/Source/WebCore/platform/graphics/LayoutRoundedRect.cpp
@@ -292,7 +292,7 @@ FloatRoundedRect LayoutRoundedRect::pixelSnappedRoundedRectForPainting(float dev
         return FloatRoundedRect(pixelSnappedRect, radii());
 
     // Snapping usually does not alter size, but when it does, we need to make sure that the final rect is still renderable by distributing the size delta proportionally.
-    FloatRoundedRect::Radii adjustedRadii = radii();
+    CornerRadii adjustedRadii = radii();
     adjustedRadii.scale(pixelSnappedRect.width() / originalRect.width().toFloat(), pixelSnappedRect.height() / originalRect.height().toFloat());
     FloatRoundedRect snappedRoundedRect = FloatRoundedRect(pixelSnappedRect, adjustedRadii);
     if (!snappedRoundedRect.isRenderable()) {

--- a/Source/WebCore/platform/graphics/NativeImageSource.cpp
+++ b/Source/WebCore/platform/graphics/NativeImageSource.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 #include "NativeImageSource.h"
+#include <wtf/text/TextStream.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/graphics/PathUtilities.cpp
+++ b/Source/WebCore/platform/graphics/PathUtilities.cpp
@@ -106,7 +106,7 @@ Path PathUtilities::pathWithShrinkWrappedRects(const Vector<FloatRect>& rects, f
     return unionPath;
 }
 
-Path PathUtilities::pathWithShrinkWrappedRects(const Vector<FloatRect>& rects, const FloatRoundedRect::Radii& radii)
+Path PathUtilities::pathWithShrinkWrappedRects(const Vector<FloatRect>& rects, const CornerRadii& radii)
 {
     if (radii.isUniformCornerRadius())
         return pathWithShrinkWrappedRects(rects, radii.topLeft().width());

--- a/Source/WebCore/platform/graphics/PathUtilities.h
+++ b/Source/WebCore/platform/graphics/PathUtilities.h
@@ -35,7 +35,7 @@ class Path;
 class PathUtilities {
 public:
     WEBCORE_EXPORT static Path pathWithShrinkWrappedRects(const Vector<FloatRect>& rects, float radius);
-    WEBCORE_EXPORT static Path pathWithShrinkWrappedRects(const Vector<FloatRect>&, const FloatRoundedRect::Radii&);
+    WEBCORE_EXPORT static Path pathWithShrinkWrappedRects(const Vector<FloatRect>&, const CornerRadii&);
     WEBCORE_EXPORT static Vector<Path> pathsWithShrinkWrappedRects(const Vector<FloatRect>& rects, float radius);
 };
 

--- a/Source/WebCore/platform/graphics/ShadowBlur.cpp
+++ b/Source/WebCore/platform/graphics/ShadowBlur.cpp
@@ -94,7 +94,7 @@ public:
         return m_imageBuffer;
     }
 
-    bool setCachedShadowValues(const FloatSize& radius, const Color& color, const FloatRect& shadowRect, const FloatRoundedRect::Radii& radii, const FloatSize& layerSize) WTF_REQUIRES_LOCK(lock())
+    bool setCachedShadowValues(const FloatSize& radius, const Color& color, const FloatRect& shadowRect, const CornerRadii& radii, const FloatSize& layerSize) WTF_REQUIRES_LOCK(lock())
     {
         ASSERT(lock().isHeld());
         if (!m_lastWasInset && m_lastRadius == radius && m_lastColor == color && m_lastShadowRect == shadowRect &&  m_lastRadii == radii && m_lastLayerSize == layerSize)
@@ -110,7 +110,7 @@ public:
         return true;
     }
 
-    bool setCachedInsetShadowValues(const FloatSize& radius, const Color& color, const FloatRect& bounds, const FloatRect& shadowRect, const FloatRoundedRect::Radii& radii) WTF_REQUIRES_LOCK(lock())
+    bool setCachedInsetShadowValues(const FloatSize& radius, const Color& color, const FloatRect& bounds, const FloatRect& shadowRect, const CornerRadii& radii) WTF_REQUIRES_LOCK(lock())
     {
         ASSERT(lock().isHeld());
         if (m_lastWasInset && m_lastRadius == radius && m_lastColor == color && m_lastInsetBounds == bounds && shadowRect == m_lastShadowRect && radii == m_lastRadii)
@@ -161,7 +161,7 @@ private:
 
     FloatRect m_lastInsetBounds;
     FloatRect m_lastShadowRect;
-    FloatRoundedRect::Radii m_lastRadii;
+    CornerRadii m_lastRadii;
     Color m_lastColor;
     FloatSize m_lastRadius;
     bool m_lastWasInset { false };
@@ -484,7 +484,7 @@ void ShadowBlur::drawShadowBuffer(GraphicsContext& graphicsContext, ImageBuffer&
     graphicsContext.fillRect(FloatRect(layerOrigin, layerSize));
 }
 
-static void computeSliceSizesFromRadii(const IntSize& twiceRadius, const FloatRoundedRect::Radii& radii, int& leftSlice, int& rightSlice, int& topSlice, int& bottomSlice)
+static void computeSliceSizesFromRadii(const IntSize& twiceRadius, const CornerRadii& radii, int& leftSlice, int& rightSlice, int& topSlice, int& bottomSlice)
 {
     leftSlice = twiceRadius.width() + std::max(radii.topLeft().width(), radii.bottomLeft().width());
     rightSlice = twiceRadius.width() + std::max(radii.topRight().width(), radii.bottomRight().width());
@@ -493,7 +493,7 @@ static void computeSliceSizesFromRadii(const IntSize& twiceRadius, const FloatRo
     bottomSlice = twiceRadius.height() + std::max(radii.bottomLeft().height(), radii.bottomRight().height());
 }
 
-IntSize ShadowBlur::templateSize(const IntSize& radiusPadding, const FloatRoundedRect::Radii& radii) const
+IntSize ShadowBlur::templateSize(const IntSize& radiusPadding, const CornerRadii& radii) const
 {
     const int templateSideLength = 1;
 
@@ -817,7 +817,7 @@ void ShadowBlur::drawInsetShadowWithTilingWithLayerImageBuffer(ImageBuffer& laye
     drawLayerPieces(layerImage, destHoleBounds, holeRect.radii(), edgeSize, templateSize, drawImage);
 }
 
-void ShadowBlur::drawLayerPieces(ImageBuffer& layerImage, const FloatRect& shadowBounds, const FloatRoundedRect::Radii& radii, const IntSize& bufferPadding, const IntSize& templateSize, const DrawImageCallback& drawImage)
+void ShadowBlur::drawLayerPieces(ImageBuffer& layerImage, const FloatRect& shadowBounds, const CornerRadii& radii, const IntSize& bufferPadding, const IntSize& templateSize, const DrawImageCallback& drawImage)
 {
     const IntSize twiceRadius = IntSize(bufferPadding.width() * 2, bufferPadding.height() * 2);
 
@@ -876,7 +876,7 @@ void ShadowBlur::drawLayerPieces(ImageBuffer& layerImage, const FloatRect& shado
     drawImage(layerImage, destRect, tileRect);
 }
 
-void ShadowBlur::drawLayerPiecesAndFillCenter(ImageBuffer& layerImage, const FloatRect& shadowBounds, const FloatRoundedRect::Radii& radii, const IntSize& bufferPadding, const IntSize& templateSize, const DrawImageCallback& drawImage, const FillRectCallback& fillRect)
+void ShadowBlur::drawLayerPiecesAndFillCenter(ImageBuffer& layerImage, const FloatRect& shadowBounds, const CornerRadii& radii, const IntSize& bufferPadding, const IntSize& templateSize, const DrawImageCallback& drawImage, const FillRectCallback& fillRect)
 {
     const IntSize twiceRadius = IntSize(bufferPadding.width() * 2, bufferPadding.height() * 2);
 

--- a/Source/WebCore/platform/graphics/ShadowBlur.h
+++ b/Source/WebCore/platform/graphics/ShadowBlur.h
@@ -101,7 +101,7 @@ private:
     };
 
     std::optional<ShadowBlur::LayerImageProperties> calculateLayerBoundingRect(const AffineTransform&, const FloatRect& layerArea, const IntRect& clipRect);
-    IntSize templateSize(const IntSize& blurredEdgeSize, const FloatRoundedRect::Radii&) const;
+    IntSize templateSize(const IntSize& blurredEdgeSize, const CornerRadii&) const;
 
     void blurShadowBuffer(ImageBuffer& layerImage, const IntSize& templateSize);
     void blurAndColorShadowBuffer(ImageBuffer& layerImage, const IntSize& templateSize);
@@ -114,8 +114,8 @@ private:
     void drawRectShadowWithTiling(const AffineTransform&, const FloatRoundedRect& shadowedRect, const IntSize& shadowTemplateSize, const IntSize& blurredEdgeSize, const DrawImageCallback&, const FillRectCallback&, const LayerImageProperties&);
     void drawRectShadowWithTilingWithLayerImageBuffer(ImageBuffer& layerImage, const AffineTransform&, const FloatRoundedRect& shadowedRect, const IntSize& templateSize, const IntSize& edgeSize, const DrawImageCallback&, const FillRectCallback&, const FloatRect& templateShadow, bool redrawNeeded = true);
 
-    void drawLayerPiecesAndFillCenter(ImageBuffer& layerImage, const FloatRect& shadowBounds, const FloatRoundedRect::Radii&, const IntSize& roundedRadius, const IntSize& templateSize, const DrawImageCallback&, const FillRectCallback&);
-    void drawLayerPieces(ImageBuffer& layerImage, const FloatRect& shadowBounds, const FloatRoundedRect::Radii&, const IntSize& roundedRadius, const IntSize& templateSize, const DrawImageCallback&);
+    void drawLayerPiecesAndFillCenter(ImageBuffer& layerImage, const FloatRect& shadowBounds, const CornerRadii&, const IntSize& roundedRadius, const IntSize& templateSize, const DrawImageCallback&, const FillRectCallback&);
+    void drawLayerPieces(ImageBuffer& layerImage, const FloatRect& shadowBounds, const CornerRadii&, const IntSize& roundedRadius, const IntSize& templateSize, const DrawImageCallback&);
 
     IntSize blurredEdgeSize() const;
 

--- a/Source/WebCore/platform/graphics/adwaita/SliderTrackAdwaita.cpp
+++ b/Source/WebCore/platform/graphics/adwaita/SliderTrackAdwaita.cpp
@@ -76,7 +76,7 @@ void SliderTrackAdwaita::draw(GraphicsContext& graphicsContext, const FloatRound
     path.clear();
 
     FloatRect rangeRect = fieldRect;
-    FloatRoundedRect::Radii corners;
+    CornerRadii corners;
     if (isHorizontal) {
         float offset = rangeRect.width() * sliderTrackPart->thumbPosition();
         if (style.states.contains(ControlStyle::State::InlineFlippedWritingMode)) {

--- a/Source/WebCore/platform/graphics/avfoundation/FormatDescriptionUtilities.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/FormatDescriptionUtilities.cpp
@@ -31,6 +31,7 @@
 #include "FourCC.h"
 #include "HEVCUtilities.h"
 #include "ImmersiveVideoMetadata.h"
+#include "Logging.h"
 #include "PlatformVideoColorSpace.h"
 #include "SharedBuffer.h"
 #include <wtf/cf/TypeCastsCF.h>

--- a/Source/WebCore/platform/graphics/cairo/PathCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/PathCairo.cpp
@@ -324,7 +324,7 @@ void PathCairo::add(PathRoundedRect roundedRect)
 void PathCairo::add(PathContinuousRoundedRect continuousRoundedRect)
 {
     // Continuous rounded rects are unavailable. Paint a normal rounded rect instead.
-    add(PathRoundedRect { FloatRoundedRect { continuousRoundedRect.rect, FloatRoundedRect::Radii { continuousRoundedRect.cornerWidth, continuousRoundedRect.cornerHeight } }, PathRoundedRect::Strategy::PreferNative });
+    add(PathRoundedRect { FloatRoundedRect { continuousRoundedRect.rect, CornerRadii { continuousRoundedRect.cornerWidth, continuousRoundedRect.cornerHeight } }, PathRoundedRect::Strategy::PreferNative });
 }
 
 void PathCairo::add(PathCloseSubpath)

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -919,7 +919,7 @@ void GraphicsContextCG::fillRoundedRectImpl(const FloatRoundedRect& rect, const 
     }
 
     const FloatRect& r = rect.rect();
-    const FloatRoundedRect::Radii& radii = rect.radii();
+    const CornerRadii& radii = rect.radii();
     bool equalWidths = (radii.topLeft().width() == radii.topRight().width() && radii.topRight().width() == radii.bottomLeft().width() && radii.bottomLeft().width() == radii.bottomRight().width());
     bool equalHeights = (radii.topLeft().height() == radii.bottomLeft().height() && radii.bottomLeft().height() == radii.topRight().height() && radii.topRight().height() == radii.bottomRight().height());
     bool hasCustomFill = fillGradient() || fillPattern();

--- a/Source/WebCore/platform/graphics/cg/PathCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/PathCG.cpp
@@ -245,7 +245,7 @@ static inline void addToCGPath(CGMutablePathRef path, const PathContinuousRounde
 #else
     // Continuous rounded rects are unavailable. Paint a normal rounded rect instead.
     // FIXME: Determine if PreferNative is the optimal strategy here.
-    addToCGPath(path, PathRoundedRect { FloatRoundedRect { continuousRoundedRect.rect, FloatRoundedRect::Radii { continuousRoundedRect.cornerWidth, continuousRoundedRect.cornerHeight } }, PathRoundedRect::Strategy::PreferNative });
+    addToCGPath(path, PathRoundedRect { FloatRoundedRect { continuousRoundedRect.rect, CornerRadii { continuousRoundedRect.cornerWidth, continuousRoundedRect.cornerHeight } }, PathRoundedRect::Strategy::PreferNative });
 #endif
 }
 

--- a/Source/WebCore/platform/graphics/mac/controls/ControlMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlMac.mm
@@ -417,7 +417,7 @@ void ControlMac::drawListButton(GraphicsContext& context, const FloatRect& rect,
     auto& comboBoxButtonContext = comboBoxButtonImageBuffer->context();
 
     comboBoxButtonContext.scale(desiredComboBoxButtonSize.width() / comboBoxButtonSize.width());
-    comboBoxButtonContext.clipRoundedRect(FloatRoundedRect(FloatRect(FloatPoint::zero(), comboBoxButtonSize), FloatRoundedRect::Radii(comboBoxButtonCornerRadii)));
+    comboBoxButtonContext.clipRoundedRect(FloatRoundedRect(FloatRect(FloatPoint::zero(), comboBoxButtonSize), CornerRadii(comboBoxButtonCornerRadii)));
     comboBoxButtonContext.translate(comboBoxButtonInset.scaled(-1));
     comboBoxButtonContext.drawConsumingImageBuffer(WTF::move(comboBoxImageBuffer), FloatPoint::zero(), ImagePaintingOptions { ImageOrientation::Orientation::OriginBottomRight });
 

--- a/Source/WebCore/platform/graphics/skia/PathSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/PathSkia.cpp
@@ -224,7 +224,7 @@ void PathSkia::add(PathContinuousRoundedRect continuousRoundedRect)
 {
     // Continuous rounded rects are unavailable. Paint a normal rounded rect instead.
     // FIXME: Determine if PreferNative is the optimal strategy here.
-    add(PathRoundedRect { FloatRoundedRect { continuousRoundedRect.rect, FloatRoundedRect::Radii { continuousRoundedRect.cornerWidth, continuousRoundedRect.cornerHeight } }, PathRoundedRect::Strategy::PreferNative });
+    add(PathRoundedRect { FloatRoundedRect { continuousRoundedRect.rect, CornerRadii { continuousRoundedRect.cornerWidth, continuousRoundedRect.cornerHeight } }, PathRoundedRect::Strategy::PreferNative });
 }
 
 void PathSkia::add(PathCloseSubpath)

--- a/Source/WebCore/platform/ios/DragImageIOS.mm
+++ b/Source/WebCore/platform/ios/DragImageIOS.mm
@@ -210,7 +210,7 @@ DragImageRef createDragImageForRange(LocalFrame& frame, const SimpleRange& range
 DragImageRef createDragImageForColor(const Color& color, const FloatRect& elementRect, float pageScaleFactor, Path& visiblePath)
 {
     FloatRect imageRect { 0, 0, elementRect.width() * pageScaleFactor, elementRect.height() * pageScaleFactor };
-    FloatRoundedRect swatch { imageRect, FloatRoundedRect::Radii(ColorSwatchCornerRadius * pageScaleFactor) };
+    FloatRoundedRect swatch { imageRect, CornerRadii(ColorSwatchCornerRadius * pageScaleFactor) };
 
     auto render = adoptNS([PAL::allocUIGraphicsImageRendererInstance() initWithSize:imageRect.size()]);
     UIImage *image = [render imageWithActions:^(UIGraphicsImageRendererContext *rendererContext) {

--- a/Source/WebCore/rendering/OutlinePainter.cpp
+++ b/Source/WebCore/rendering/OutlinePainter.cpp
@@ -535,7 +535,7 @@ static std::pair<FloatPoint, FloatPoint> controlPointsForBezierCurve(CornerType 
     return std::make_pair(cp1, cp2);
 }
 
-static FloatRoundedRect::Radii adjustedRadiiForHuggingCurve(const FloatRoundedRect::Radii& inputRadii, float outlineOffset)
+static CornerRadii adjustedRadiiForHuggingCurve(const CornerRadii& inputRadii, float outlineOffset)
 {
     // This adjusts the radius so that it follows the border curve even when offset is present.
     auto adjustedRadius = [outlineOffset](const FloatSize& radius) {
@@ -585,7 +585,7 @@ static std::optional<FloatRect> rectFromPolygon(const FloatPointGraph::Polygon& 
 Path OutlinePainter::pathWithShrinkWrappedRects(const Vector<FloatRect>& rects, const Style::BorderRadius& radii, float outlineOffset, WritingMode writingMode, float deviceScaleFactor)
 {
     auto roundedRect = [radii, outlineOffset, deviceScaleFactor](const FloatRect& rect) {
-        auto adjustedRadii = adjustedRadiiForHuggingCurve(Style::evaluate<FloatRoundedRect::Radii>(radii, rect.size(), Style::ZoomNeeded { }), outlineOffset);
+        auto adjustedRadii = adjustedRadiiForHuggingCurve(Style::evaluate<CornerRadii>(radii, rect.size(), Style::ZoomNeeded { }), outlineOffset);
         adjustedRadii.scale(calcBorderRadiiConstraintScaleFor(rect, adjustedRadii));
 
         LayoutRoundedRect roundedRect(
@@ -622,8 +622,8 @@ Path OutlinePainter::pathWithShrinkWrappedRects(const Vector<FloatRect>& rects, 
     auto firstLineRect = isLeftToRight ? rects.at(0) : rects.at(rects.size() - 1);
     auto lastLineRect = isLeftToRight ? rects.at(rects.size() - 1) : rects.at(0);
     // Adjust radius so that it matches the box border.
-    auto firstLineRadii = Style::evaluate<FloatRoundedRect::Radii>(radii, firstLineRect.size(), Style::ZoomNeeded { });
-    auto lastLineRadii = Style::evaluate<FloatRoundedRect::Radii>(radii, lastLineRect.size(), Style::ZoomNeeded { });
+    auto firstLineRadii = Style::evaluate<CornerRadii>(radii, firstLineRect.size(), Style::ZoomNeeded { });
+    auto lastLineRadii = Style::evaluate<CornerRadii>(radii, lastLineRect.size(), Style::ZoomNeeded { });
     firstLineRadii.scale(calcBorderRadiiConstraintScaleFor(firstLineRect, firstLineRadii));
     lastLineRadii.scale(calcBorderRadiiConstraintScaleFor(lastLineRect, lastLineRadii));
 

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -2222,7 +2222,7 @@ void RenderTheme::paintSystemPreviewBadge(Image& image, const PaintInfo& paintIn
         return;
 
     auto markerRect = FloatRect {rect.x() + rect.width() - 24, rect.y() + 8, 16, 16 };
-    auto roundedMarkerRect = FloatRoundedRect { markerRect, FloatRoundedRect::Radii { 8 } };
+    auto roundedMarkerRect = FloatRoundedRect { markerRect, CornerRadii { 8 } };
     context.fillRoundedRect(roundedMarkerRect, Color::red);
 }
 #endif

--- a/Source/WebCore/rendering/TextBoxPainter.cpp
+++ b/Source/WebCore/rendering/TextBoxPainter.cpp
@@ -621,7 +621,7 @@ void TextBoxPainter::paintBackgroundFillForRange(unsigned startOffset, unsigned 
     if (backgroundStyle == BackgroundStyle::Rounded) {
         backgroundRect.expand(-1, -1);
         backgroundRect.move(0.5, 0.5);
-        context.fillRoundedRect(FloatRoundedRect { backgroundRect, FloatRoundedRect::Radii { 2 } }, color);
+        context.fillRoundedRect(FloatRoundedRect { backgroundRect, CornerRadii { 2 } }, color);
         return;
     }
 
@@ -933,9 +933,9 @@ void TextBoxPainter::paintForegroundDecorations(TextDecorationPainter& decoratio
         m_paintInfo.context().concatCTM(rotation(m_paintRect, RotationDirection::Counterclockwise));
 }
 
-static FloatRoundedRect::Radii radiiForUnderline(const CompositionUnderline& underline, unsigned markedTextStartOffset, unsigned markedTextEndOffset)
+static CornerRadii radiiForUnderline(const CompositionUnderline& underline, unsigned markedTextStartOffset, unsigned markedTextEndOffset)
 {
-    auto radii = FloatRoundedRect::Radii { 0 };
+    auto radii = CornerRadii { 0 };
 
 #if HAVE(REDESIGNED_TEXT_CURSOR)
     if (!redesignedTextCursorEnabled())
@@ -965,7 +965,7 @@ enum class TrimSide : bool {
     Right,
 };
 
-static FloatRoundedRect::Radii trimRadii(const FloatRoundedRect::Radii& radii, TrimSide trimSide)
+static CornerRadii trimRadii(const CornerRadii& radii, TrimSide trimSide)
 {
     switch (trimSide) {
     case TrimSide::Left:
@@ -1007,7 +1007,7 @@ static OptionSet<TextBoxFragmentLocationWithinLayoutBox> textBoxFragmentLocation
 }
 #endif
 
-void TextBoxPainter::fillCompositionUnderline(float start, float width, const CompositionUnderline& underline, const FloatRoundedRect::Radii& radii, bool hasLiveConversion) const
+void TextBoxPainter::fillCompositionUnderline(float start, float width, const CompositionUnderline& underline, const CornerRadii& radii, bool hasLiveConversion) const
 {
 #if HAVE(REDESIGNED_TEXT_CURSOR)
     if (!redesignedTextCursorEnabled())
@@ -1159,7 +1159,7 @@ float TextBoxPainter::textPosition()
     return m_logicalRect.x() - makeIterator()->lineBox()->contentLogicalLeft();
 }
 
-void TextBoxPainter::paintCompositionUnderline(const CompositionUnderline& underline, const FloatRoundedRect::Radii& radii, bool hasLiveConversion)
+void TextBoxPainter::paintCompositionUnderline(const CompositionUnderline& underline, const CornerRadii& radii, bool hasLiveConversion)
 {
     float start = 0; // start of line to draw, relative to tx
     float width = m_logicalRect.width(); // how much line to draw

--- a/Source/WebCore/rendering/TextBoxPainter.h
+++ b/Source/WebCore/rendering/TextBoxPainter.h
@@ -74,8 +74,8 @@ protected:
     TextDecorationPainter createDecorationPainter(const StyledMarkedText&, const FloatRect&);
     void paintBackgroundDecorations(TextDecorationPainter&, const StyledMarkedText&, const FloatRect&);
     void paintForegroundDecorations(TextDecorationPainter&, const StyledMarkedText&, const FloatRect&);
-    void paintCompositionUnderline(const CompositionUnderline&, const FloatRoundedRect::Radii&, bool hasLiveConversion);
-    void fillCompositionUnderline(float start, float width, const CompositionUnderline&, const FloatRoundedRect::Radii&, bool hasLiveConversion) const;
+    void paintCompositionUnderline(const CompositionUnderline&, const CornerRadii&, bool hasLiveConversion);
+    void fillCompositionUnderline(float start, float width, const CompositionUnderline&, const CornerRadii&, bool hasLiveConversion) const;
     void paintPlatformDocumentMarker(const MarkedText&);
     LayoutRect selectionRectForRange(unsigned startOffset, unsigned endOffset) const;
 

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -1165,7 +1165,7 @@ static RoundedShape roundedShape(const FloatRect& rect, const float cornerRadius
         return { { }, rect, cornerRadius, CornerType::Noncontinuous };
 
     Path path;
-    path.addRoundedRect(FloatRoundedRect { rect, FloatRoundedRect::Radii { cornerRadius, cornerRadius } });
+    path.addRoundedRect(FloatRoundedRect { rect, CornerRadii { cornerRadius, cornerRadius } });
     return { WTF::move(path), rect, cornerRadius, CornerType::Noncontinuous };
 }
 
@@ -1635,7 +1635,7 @@ bool RenderThemeCocoa::paintColorWellForVectorBasedControls(const RenderElement&
     const auto isEnabled = states.contains(ControlStyle::State::Enabled);
 
     const auto radius = std::min(rect.width(), rect.height()) / 2.f;
-    const FloatRoundedRect boundingRoundedRect(rect, FloatRoundedRect::Radii(radius));
+    const FloatRoundedRect boundingRoundedRect(rect, CornerRadii(radius));
 
     auto backgroundColor = systemColor(CSSValueAppleSystemQuinaryLabel, box.styleColorOptions());
 
@@ -1693,7 +1693,7 @@ bool RenderThemeCocoa::paintColorWellSwatchForVectorBasedControls(const RenderEl
     }
 
     const auto radius = std::min(rect.width(), rect.height()) / 2.f;
-    const FloatRoundedRect boundingRoundedRect(rect, FloatRoundedRect::Radii(radius));
+    const FloatRoundedRect boundingRoundedRect(rect, CornerRadii(radius));
 
     Path path;
     path.addRoundedRect(boundingRoundedRect);
@@ -2107,7 +2107,7 @@ bool RenderThemeCocoa::paintInnerSpinButtonForVectorBasedControls(const RenderEl
 
     const auto centerDividerRect = FloatRect { paintRect.center().x() - centerDividerWidth / 2.f, paintRect.center().y() - centerDividerHeight / 2.f, centerDividerWidth, centerDividerHeight };
 
-    FloatRoundedRect roundedDividerRect(centerDividerRect, FloatRoundedRect::Radii(centerDividerRect.height() / 2.f));
+    FloatRoundedRect roundedDividerRect(centerDividerRect, CornerRadii(centerDividerRect.height() / 2.f));
 
 #if PLATFORM(MAC)
     if (userPrefersContrast)
@@ -2900,7 +2900,7 @@ bool RenderThemeCocoa::paintMeterForVectorBasedControls(const RenderElement& ren
     GraphicsContextStateSaver stateSaver(context);
 
     float cornerRadius = std::min(rect.width(), rect.height()) / 2.0f;
-    FloatRoundedRect roundedFillRect(rect, FloatRoundedRect::Radii(cornerRadius));
+    FloatRoundedRect roundedFillRect(rect, CornerRadii(cornerRadius));
 
     auto styleColorOptions = renderer.styleColorOptions();
     auto isHorizontalWritingMode = renderer.writingMode().isHorizontal();
@@ -3136,7 +3136,7 @@ bool RenderThemeCocoa::paintProgressBarForVectorBasedControls(const RenderElemen
     constexpr auto reducedMotionProgressAnimationMinOpacity = 0.3f;
     constexpr auto reducedMotionProgressAnimationMaxOpacity = 0.6f;
 
-    FloatRoundedRect::Radii barCornerRadii(
+    CornerRadii barCornerRadii(
         isHorizontalWritingMode ? barCornerRadiusInlineSize : barCornerRadiusBlockSize,
         isHorizontalWritingMode ? barCornerRadiusBlockSize : barCornerRadiusInlineSize
     );
@@ -3386,7 +3386,7 @@ bool RenderThemeCocoa::paintSliderTrackForVectorBasedControls(const RenderElemen
 
     auto cornerRadius = std::min(trackClip.width(), trackClip.height()) / 2.f;
 
-    FloatRoundedRect::Radii cornerRadii(cornerRadius, cornerRadius);
+    CornerRadii cornerRadii(cornerRadius, cornerRadius);
     FloatRoundedRect innerBorder(trackClip, cornerRadii);
     FloatRoundedRect outerBorder(trackClip, cornerRadii);
 
@@ -3460,7 +3460,7 @@ bool RenderThemeCocoa::paintSliderTrackForVectorBasedControls(const RenderElemen
     }
 
     const auto fillCornerRadius = isThumbVisible ? 0.f : std::min(trackClip.width(), trackClip.height()) / 2.f;
-    const auto fillCornerRadii = FloatRoundedRect::Radii { fillCornerRadius, fillCornerRadius };
+    const auto fillCornerRadii = CornerRadii { fillCornerRadius, fillCornerRadius };
 
     FloatRoundedRect fillRect(trackClip, fillCornerRadii);
     context.fillRoundedRect(fillRect, fillColor);
@@ -3923,7 +3923,7 @@ bool RenderThemeCocoa::paintPlatformResizerForVectorBasedControls(const RenderLa
     paintRect.setLocation(resizerCornerRect.maxXMaxYCorner() - paintRect.size());
 
     const auto barThickness = length * 0.075f;
-    const auto barRadii = FloatRoundedRect::Radii { barThickness / 2.f, barThickness / 2.f };
+    const auto barRadii = CornerRadii { barThickness / 2.f, barThickness / 2.f };
 
     const auto wideBarWidth = length * 0.75f;
     const auto wideBarX = paintRect.x() + (paintRect.width() - wideBarWidth) / 2.f;

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.mm
@@ -700,7 +700,7 @@ bool RenderThemeIOS::paintSliderTrack(const RenderElement& box, const PaintInfo&
     auto cornerWidth = trackClip.width() < defaultTrackThickness ? trackClip.width() / 2.0f : defaultTrackRadius;
     auto cornerHeight = trackClip.height() < defaultTrackThickness ? trackClip.height() / 2.0f : defaultTrackRadius;
 
-    FloatRoundedRect::Radii cornerRadii(cornerWidth, cornerHeight);
+    CornerRadii cornerRadii(cornerWidth, cornerHeight);
     FloatRoundedRect innerBorder(trackClip, cornerRadii);
 
     FloatRoundedRect outerBorder(innerBorder);
@@ -782,7 +782,7 @@ bool RenderThemeIOS::paintProgressBar(const RenderElement& renderer, const Paint
     constexpr auto barCornerRadiusInlineSize = 2.5f;
     constexpr auto barCornerRadiusBlockSize = 1.5f;
 
-    FloatRoundedRect::Radii barCornerRadii(
+    CornerRadii barCornerRadii(
         isHorizontalWritingMode ? barCornerRadiusInlineSize : barCornerRadiusBlockSize,
         isHorizontalWritingMode ? barCornerRadiusBlockSize : barCornerRadiusInlineSize
     );
@@ -1538,7 +1538,7 @@ bool RenderThemeIOS::paintCheckbox(const RenderElement& box, const PaintInfo& pa
     constexpr auto checkboxHeight = 16.0f;
     constexpr auto checkboxCornerRadius = 5.0f;
 
-    FloatRoundedRect checkboxRect(rect, FloatRoundedRect::Radii(checkboxCornerRadius * rect.height() / checkboxHeight));
+    FloatRoundedRect checkboxRect(rect, CornerRadii(checkboxCornerRadius * rect.height() / checkboxHeight));
 
     auto controlStates = extractControlStyleStatesForRenderer(box);
     auto styleColorOptions = box.styleColorOptions();
@@ -1630,7 +1630,7 @@ bool RenderThemeIOS::paintRadio(const RenderElement& box, const PaintInfo& paint
 
     auto backgroundColor = checkboxRadioBackgroundColor(box.style(), controlStates, styleColorOptions);
 
-    FloatRoundedRect radioRect { rect, FloatRoundedRect::Radii(rect.width() / 2, rect.height() / 2) };
+    FloatRoundedRect radioRect { rect, CornerRadii(rect.width() / 2, rect.height() / 2) };
 
     if (controlStates.contains(ControlStyle::State::Checked)) {
         context.setFillColor(backgroundColor);
@@ -1695,7 +1695,7 @@ bool RenderThemeIOS::paintMeter(const RenderElement& renderer, const PaintInfo& 
     auto isHorizontalWritingMode = renderer.writingMode().isHorizontal();
 
     float cornerRadius = std::min(rect.width(), rect.height()) / 2.0f;
-    FloatRoundedRect roundedFillRect(rect, FloatRoundedRect::Radii(cornerRadius));
+    FloatRoundedRect roundedFillRect(rect, CornerRadii(cornerRadius));
     context.fillRoundedRect(roundedFillRect, systemColor(CSSValueWebkitControlBackground, styleColorOptions));
 
     roundedFillRect.inflateWithRadii(-nativeControlBorderInlineSize);
@@ -1805,7 +1805,7 @@ void RenderThemeIOS::paintSliderTicks(const RenderElement& box, const PaintInfo&
     constexpr int tickCornerRadius = 1;
 
     FloatRect tickRect;
-    FloatRoundedRect::Radii tickCornerRadii(tickCornerRadius);
+    CornerRadii tickCornerRadii(tickCornerRadius);
 
     bool isHorizontal = box.style().usedAppearance() == StyleAppearance::SliderHorizontal;
     if (isHorizontal) {

--- a/Source/WebCore/rendering/mac/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.mm
@@ -1850,7 +1850,7 @@ static void paintAttachmentIconBackground(const RenderAttachment& attachment, Gr
 
     Style::ColorResolver colorResolver { attachment.style() };
     auto backgroundColor = colorResolver.colorApplyingColorFilter(attachmentIconBackgroundColor);
-    context.fillRoundedRect(FloatRoundedRect(backgroundRect, FloatRoundedRect::Radii(attachmentIconBackgroundRadius)), backgroundColor);
+    context.fillRoundedRect(FloatRoundedRect(backgroundRect, CornerRadii(attachmentIconBackgroundRadius)), backgroundColor);
 
     if (paintBorder) {
         FloatRect borderRect = layout.iconBackgroundRect;
@@ -1939,7 +1939,7 @@ static void paintAttachmentProgress(const RenderAttachment& attachment, Graphics
     FloatRect backgroundRect = borderRect;
     backgroundRect.inflate(-attachmentProgressBarBorderWidth / 2);
 
-    FloatRoundedRect backgroundRoundedRect(backgroundRect, FloatRoundedRect::Radii(backgroundRect.height() / 2));
+    FloatRoundedRect backgroundRoundedRect(backgroundRect, CornerRadii(backgroundRect.height() / 2));
     context.fillRoundedRect(backgroundRoundedRect, attachmentProgressBarBackgroundColor);
 
     {

--- a/Source/WebCore/rendering/shapes/LayoutShape.cpp
+++ b/Source/WebCore/rendering/shapes/LayoutShape.cpp
@@ -140,7 +140,7 @@ Ref<const LayoutShape> LayoutShape::createShape(const Style::BasicShape& basicSh
             auto topRightRadius = physicalSizeToLogical(Style::evaluate<FloatSize>(horizontalWritingMode ? inset->radii.topRight() : isBlockLeftToRight ? inset->radii.bottomLeft() : inset->radii.bottomRight(), boxSize, Style::ZoomNeeded { }), writingMode);
             auto bottomLeftRadius = physicalSizeToLogical(Style::evaluate<FloatSize>(horizontalWritingMode ? inset->radii.bottomLeft() : isBlockLeftToRight ? inset->radii.topRight() : inset->radii.topLeft(), boxSize, Style::ZoomNeeded { }), writingMode);
             auto bottomRightRadius = physicalSizeToLogical(Style::evaluate<FloatSize>(horizontalWritingMode ? inset->radii.bottomRight() : isBlockLeftToRight ? inset->radii.bottomRight() : inset->radii.bottomLeft(), boxSize, Style::ZoomNeeded { }), writingMode);
-            auto cornerRadii = FloatRoundedRect::Radii(topLeftRadius, topRightRadius, bottomLeftRadius, bottomRightRadius);
+            auto cornerRadii = CornerRadii(topLeftRadius, topRightRadius, bottomLeftRadius, bottomRightRadius);
             if (shouldFlipStartAndEndPoints(writingMode))
                 cornerRadii = { cornerRadii.topRight(), cornerRadii.topLeft(), cornerRadii.bottomRight(), cornerRadii.bottomLeft() };
 

--- a/Source/WebCore/style/values/borders/StyleBorderRadius.cpp
+++ b/Source/WebCore/style/values/borders/StyleBorderRadius.cpp
@@ -85,7 +85,7 @@ auto CSSValueConversion<BorderRadiusValue>::operator()(BuilderState& state, cons
 
 // MARK: - Evaluation
 
-auto Evaluation<BorderRadius, FloatRoundedRect::Radii>::operator()(const BorderRadius& value, FloatSize referenceSize, ZoomNeeded token) -> FloatRoundedRect::Radii
+auto Evaluation<BorderRadius, CornerRadii>::operator()(const BorderRadius& value, FloatSize referenceSize, ZoomNeeded token) -> CornerRadii
 {
     return {
         evaluate<FloatSize>(value.topLeft(), referenceSize, token),

--- a/Source/WebCore/style/values/borders/StyleBorderRadius.h
+++ b/Source/WebCore/style/values/borders/StyleBorderRadius.h
@@ -79,8 +79,8 @@ template<> struct CSSValueConversion<BorderRadiusValue> { auto operator()(Builde
 
 // MARK: - Evaluation
 
-template<> struct Evaluation<BorderRadius, FloatRoundedRect::Radii> {
-    auto operator()(const BorderRadius&, FloatSize, ZoomNeeded) -> FloatRoundedRect::Radii;
+template<> struct Evaluation<BorderRadius, CornerRadii> {
+    auto operator()(const BorderRadius&, FloatSize, ZoomNeeded) -> CornerRadii;
 };
 template<> struct Evaluation<BorderRadius, LayoutRoundedRect::Radii> {
     auto operator()(const BorderRadius&, LayoutSize, ZoomNeeded) -> LayoutRoundedRect::Radii;

--- a/Source/WebCore/style/values/shapes/StyleInsetFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StyleInsetFunction.cpp
@@ -72,7 +72,7 @@ WebCore::Path PathComputation<Inset>::operator()(const Inset& value, const Float
         std::max<float>(boundingSize.height() - top - evaluate<float>(value.insets.bottom(), boundingSize.height(), Style::ZoomNeeded { }), 0)
     };
 
-    auto radii = evaluate<FloatRoundedRect::Radii>(value.radii, boundingSize, Style::ZoomNeeded { });
+    auto radii = evaluate<CornerRadii>(value.radii, boundingSize, Style::ZoomNeeded { });
     radii.scale(calcBorderRadiiConstraintScaleFor(rect, radii));
 
     return cachedRoundedInsetPath(FloatRoundedRect { rect, radii });

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -2606,7 +2606,7 @@ static inline WebCore::FloatSize tapHighlightBorderRadius(WebCore::FloatSize bor
         [_tapHighlightView setQuads:WTF::move(inflatedHighlightQuads) boundaryRect:_page->exposedContentRect()];
     }
 
-    [_tapHighlightView setCornerRadii:WebCore::FloatRoundedRect::Radii {
+    [_tapHighlightView setCornerRadii:WebCore::CornerRadii {
         tapHighlightBorderRadius(_tapHighlightInformation.topLeftRadius, selfScale),
         tapHighlightBorderRadius(_tapHighlightInformation.topRightRadius, selfScale),
         tapHighlightBorderRadius(_tapHighlightInformation.bottomLeftRadius, selfScale),

--- a/Source/WebKit/UIProcess/ios/WKTapHighlightView.h
+++ b/Source/WebKit/UIProcess/ios/WKTapHighlightView.h
@@ -36,7 +36,7 @@
 
 - (void)setColor:(UIColor *)color;
 - (void)setMinimumCornerRadius:(float)radius;
-- (void)setCornerRadii:(WebCore::FloatRoundedRect::Radii&&)radii;
+- (void)setCornerRadii:(WebCore::CornerRadii&&)radii;
 - (void)setFrames:(Vector<WebCore::FloatRect>&&)frames;
 - (void)setQuads:(Vector<WebCore::FloatQuad>&&)quads boundaryRect:(const WebCore::FloatRect&)rect;
 

--- a/Source/WebKit/UIProcess/ios/WKTapHighlightView.mm
+++ b/Source/WebKit/UIProcess/ios/WKTapHighlightView.mm
@@ -35,7 +35,7 @@
 @implementation WKTapHighlightView {
     RetainPtr<UIColor> _color;
     float _minimumCornerRadius;
-    WebCore::FloatRoundedRect::Radii _cornerRadii;
+    WebCore::CornerRadii _cornerRadii;
     Vector<WebCore::FloatRect> _innerFrames;
     Vector<WebCore::FloatQuad> _innerQuads;
 }
@@ -63,7 +63,7 @@
     _minimumCornerRadius = radius;
 }
 
-- (void)setCornerRadii:(WebCore::FloatRoundedRect::Radii&&)radii
+- (void)setCornerRadii:(WebCore::CornerRadii&&)radii
 {
     _cornerRadii = WTF::move(radii);
 }


### PR DESCRIPTION
#### fe600b1b5ea228e31405c356f669b86e69c675c1
<pre>
Move class `FloatRoundedRect::Radii` into new class `CornerRadii`
<a href="https://bugs.webkit.org/show_bug.cgi?id=305447">https://bugs.webkit.org/show_bug.cgi?id=305447</a>
<a href="https://rdar.apple.com/168117393">rdar://168117393</a>

Reviewed by Abrar Rahman Protyasha and Wenson Hsieh.

Move `FloatRoundedRect::Radii` into new class `CornerRadii` so that it can
be used without importing `FloatRoundedRect`, and so that serialization
will be simpler (which will be useful in a later patch).

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/inspector/InspectorOverlay.cpp:
(WebCore::InspectorOverlay::drawRulers):
* Source/WebCore/inspector/InspectorOverlayLabel.cpp:
(WebCore::InspectorOverlayLabel::draw):
* Source/WebCore/page/DebugPageOverlays.cpp:
(WebCore::drawCheckbox):
(WebCore::InteractionRegionOverlay::drawSettings):
* Source/WebCore/platform/DictationCaretAnimator.cpp:
(WebCore::DictationCaretAnimator::expandedCaretRect const):
* Source/WebCore/platform/OpacityCaretAnimator.cpp:
(WebCore::OpacityCaretAnimator::paint const):
* Source/WebCore/platform/cocoa/DragImageCocoa.mm:
(WebCore::createDragImageForLink):
* Source/WebCore/platform/graphics/CornerRadii.cpp: Added.
(WebCore::CornerRadii::isZero const):
(WebCore::CornerRadii::hasEvenCorners const):
(WebCore::CornerRadii::isUniformCornerRadius const):
(WebCore::CornerRadii::scale):
(WebCore::CornerRadii::expand):
(WebCore::CornerRadii::expandEvenIfZero):
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/CornerRadii.h: Added.
(WebCore::CornerRadii::CornerRadii):
(WebCore::CornerRadii::setTopLeft):
(WebCore::CornerRadii::setTopRight):
(WebCore::CornerRadii::setBottomLeft):
(WebCore::CornerRadii::setBottomRight):
(WebCore::CornerRadii::topLeft const):
(WebCore::CornerRadii::topRight const):
(WebCore::CornerRadii::bottomLeft const):
(WebCore::CornerRadii::bottomRight const):
(WebCore::CornerRadii::expand):
(WebCore::CornerRadii::shrink):
* Source/WebCore/platform/graphics/FloatRoundedRect.cpp:
(WebCore::FloatRoundedRect::FloatRoundedRect):
(WebCore::operator&lt;&lt;):
(WebCore::FloatRoundedRect::Radii::isZero const): Deleted.
(WebCore::FloatRoundedRect::Radii::hasEvenCorners const): Deleted.
(WebCore::FloatRoundedRect::Radii::isUniformCornerRadius const): Deleted.
(WebCore::FloatRoundedRect::Radii::scale): Deleted.
(WebCore::FloatRoundedRect::Radii::expand): Deleted.
(WebCore::FloatRoundedRect::Radii::expandEvenIfZero): Deleted.
* Source/WebCore/platform/graphics/FloatRoundedRect.h:
(WebCore::FloatRoundedRect::radii const):
(WebCore::FloatRoundedRect::setRadii):
(WebCore::calcBorderRadiiConstraintScaleFor):
(WebCore::FloatRoundedRect::Radii::Radii): Deleted.
(WebCore::FloatRoundedRect::Radii::setTopLeft): Deleted.
(WebCore::FloatRoundedRect::Radii::setTopRight): Deleted.
(WebCore::FloatRoundedRect::Radii::setBottomLeft): Deleted.
(WebCore::FloatRoundedRect::Radii::setBottomRight): Deleted.
(WebCore::FloatRoundedRect::Radii::topLeft const): Deleted.
(WebCore::FloatRoundedRect::Radii::topRight const): Deleted.
(WebCore::FloatRoundedRect::Radii::bottomLeft const): Deleted.
(WebCore::FloatRoundedRect::Radii::bottomRight const): Deleted.
(WebCore::FloatRoundedRect::Radii::expand): Deleted.
(WebCore::FloatRoundedRect::Radii::shrink): Deleted.
* Source/WebCore/platform/graphics/LayoutRoundedRect.cpp:
(WebCore::LayoutRoundedRect::pixelSnappedRoundedRectForPainting const):
* Source/WebCore/platform/graphics/NativeImageSource.cpp:
* Source/WebCore/platform/graphics/PathUtilities.cpp:
(WebCore::PathUtilities::pathWithShrinkWrappedRects):
* Source/WebCore/platform/graphics/PathUtilities.h:
* Source/WebCore/platform/graphics/ShadowBlur.cpp:
(WebCore::computeSliceSizesFromRadii):
(WebCore::ShadowBlur::templateSize const):
(WebCore::ShadowBlur::drawLayerPieces):
(WebCore::ShadowBlur::drawLayerPiecesAndFillCenter):
* Source/WebCore/platform/graphics/ShadowBlur.h:
* Source/WebCore/platform/graphics/adwaita/SliderTrackAdwaita.cpp:
(WebCore::SliderTrackAdwaita::draw):
* Source/WebCore/platform/graphics/avfoundation/FormatDescriptionUtilities.cpp:
* Source/WebCore/platform/graphics/cairo/PathCairo.cpp:
(WebCore::PathCairo::add):
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::fillRoundedRectImpl):
* Source/WebCore/platform/graphics/cg/PathCG.cpp:
(WebCore::addToCGPath):
* Source/WebCore/platform/graphics/mac/controls/ControlMac.mm:
(WebCore::ControlMac::drawListButton):
* Source/WebCore/platform/graphics/skia/PathSkia.cpp:
(WebCore::PathSkia::add):
* Source/WebCore/platform/ios/DragImageIOS.mm:
(WebCore::createDragImageForColor):
* Source/WebCore/rendering/OutlinePainter.cpp:
(WebCore::adjustedRadiiForHuggingCurve):
(WebCore::OutlinePainter::pathWithShrinkWrappedRects):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::paintSystemPreviewBadge):
* Source/WebCore/rendering/TextBoxPainter.cpp:
(WebCore::TextBoxPainter::paintBackgroundFillForRange):
(WebCore::radiiForUnderline):
(WebCore::trimRadii):
(WebCore::TextBoxPainter::fillCompositionUnderline const):
(WebCore::TextBoxPainter::paintCompositionUnderline):
* Source/WebCore/rendering/TextBoxPainter.h:
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::roundedShape):
(WebCore::RenderThemeCocoa::paintColorWellForVectorBasedControls):
(WebCore::RenderThemeCocoa::paintColorWellSwatchForVectorBasedControls):
(WebCore::RenderThemeCocoa::paintInnerSpinButtonForVectorBasedControls):
(WebCore::RenderThemeCocoa::paintMeterForVectorBasedControls):
(WebCore::RenderThemeCocoa::paintProgressBarForVectorBasedControls):
(WebCore::RenderThemeCocoa::paintSliderTrackForVectorBasedControls):
(WebCore::RenderThemeCocoa::paintPlatformResizerForVectorBasedControls):
* Source/WebCore/rendering/ios/RenderThemeIOS.mm:
(WebCore::RenderThemeIOS::paintSliderTrack):
(WebCore::RenderThemeIOS::paintProgressBar):
(WebCore::RenderThemeIOS::paintCheckbox):
(WebCore::RenderThemeIOS::paintRadio):
(WebCore::RenderThemeIOS::paintMeter):
(WebCore::RenderThemeIOS::paintSliderTicks):
* Source/WebCore/rendering/mac/RenderThemeMac.mm:
(WebCore::paintAttachmentIconBackground):
(WebCore::paintAttachmentProgress):
* Source/WebCore/rendering/shapes/LayoutShape.cpp:
(WebCore::LayoutShape::createShape):
* Source/WebCore/style/values/borders/StyleBorderRadius.cpp:
(WebCore::Style::CornerRadii&gt;::operator):
(WebCore::Style::FloatRoundedRect::Radii&gt;::operator): Deleted.
* Source/WebCore/style/values/borders/StyleBorderRadius.h:
* Source/WebCore/style/values/shapes/StyleInsetFunction.cpp:
(WebCore::Style::PathComputation&lt;Inset&gt;::operator):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _updateTapHighlight]):
* Source/WebKit/UIProcess/ios/WKTapHighlightView.h:
* Source/WebKit/UIProcess/ios/WKTapHighlightView.mm:
(-[WKTapHighlightView setCornerRadii:]):

Canonical link: <a href="https://commits.webkit.org/305588@main">https://commits.webkit.org/305588@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e16f11fa29909459c1ffb5d29951db2fbf92f250

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138783 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11149 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/265 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146900 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91758 "Hash e16f11fa for PR 56541 does not build (failure)") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ce5e92e8-0125-47b9-8b83-e6c06e58fffa) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140656 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11853 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11304 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106199 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/91758 "Hash e16f11fa for PR 56541 does not build (failure)") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ff66c611-e1d8-40a8-9468-1378356a881e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141730 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8939 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124362 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87069 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/991448b5-439e-4a72-b8e2-59f971f86241) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/138130 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8518 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6267 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7198 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117943 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/224 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149658 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10831 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/224 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114584 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10849 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9156 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114925 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8800 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120679 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65726 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21389 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10879 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/222 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10617 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74520 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10818 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10668 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->