### PR TITLE
[GTK][WPE][Coordinated Graphics] wheel event async scrolling doesn't start while the main thread is blocked

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinator.cpp
@@ -52,7 +52,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollingCoordinator);
 
-#if PLATFORM(IOS_FAMILY) || !ENABLE(ASYNC_SCROLLING)
+#if PLATFORM(IOS_FAMILY) || !ENABLE(ASYNC_SCROLLING) || USE(COORDINATED_GRAPHICS)
 Ref<ScrollingCoordinator> ScrollingCoordinator::create(Page* page)
 {
     return adoptRef(*new ScrollingCoordinator(page));

--- a/Source/WebCore/page/scrolling/ThreadedScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingTree.h
@@ -114,8 +114,8 @@ private:
     void scheduleDelayedRenderingUpdateDetectionTimer(Seconds) WTF_REQUIRES_LOCK(m_treeLock);
     void delayedRenderingUpdateDetectionTimerFired();
 
-    void hasNodeWithAnimatedScrollChanged(bool) final;
-    
+    void hasNodeWithAnimatedScrollChanged(bool) override;
+
     bool isScrollingSynchronizedWithMainThread() final WTF_REQUIRES_LOCK(m_treeLock);
 
     void receivedWheelEventWithPhases(PlatformWheelEventPhase, PlatformWheelEventPhase) final;

--- a/Source/WebCore/page/scrolling/coordinated/ScrollingTreeCoordinated.cpp
+++ b/Source/WebCore/page/scrolling/coordinated/ScrollingTreeCoordinated.cpp
@@ -162,6 +162,21 @@ RefPtr<ScrollingTreeNode> ScrollingTreeCoordinated::scrollingNodeForPoint(FloatP
     return rootScrollingNode;
 }
 
+#if HAVE(DISPLAY_LINK)
+void ScrollingTreeCoordinated::hasNodeWithAnimatedScrollChanged(bool hasNodeWithAnimatedScroll)
+{
+    ASSERT(ScrollingThread::isCurrentThread());
+
+    if (hasNodeWithAnimatedScroll)
+        didScheduleRenderingUpdate();
+
+    RefPtr scrollingCoordinator = m_scrollingCoordinator;
+    if (!scrollingCoordinator)
+        return;
+    scrollingCoordinator->hasNodeWithAnimatedScrollChanged(hasNodeWithAnimatedScroll);
+}
+#endif
+
 } // namespace WebCore
 
 #endif // ENABLE(ASYNC_SCROLLING) && USE(COORDINATED_GRAPHICS)

--- a/Source/WebCore/page/scrolling/coordinated/ScrollingTreeCoordinated.h
+++ b/Source/WebCore/page/scrolling/coordinated/ScrollingTreeCoordinated.h
@@ -49,6 +49,11 @@ private:
     void applyLayerPositionsInternal() final;
     void didCompleteRenderingUpdate() final;
 
+#if HAVE(DISPLAY_LINK)
+    // ScrollingTree
+    void hasNodeWithAnimatedScrollChanged(bool /* hasNodeWithAnimatedScroll */) final;
+#endif
+
     RefPtr<ScrollingTreeNode> scrollingNodeForPoint(FloatPoint) final;
 };
 

--- a/Source/WebCore/platform/TextureMapper.cmake
+++ b/Source/WebCore/platform/TextureMapper.cmake
@@ -54,7 +54,6 @@ if (USE_COORDINATED_GRAPHICS)
         "${WEBCORE_DIR}/platform/graphics/texmap/coordinated"
     )
     list(APPEND WebCore_SOURCES
-        page/scrolling/coordinated/ScrollingCoordinatorCoordinated.cpp
         page/scrolling/coordinated/ScrollingStateNodeCoordinated.cpp
         page/scrolling/coordinated/ScrollingTreeCoordinated.cpp
         page/scrolling/coordinated/ScrollingTreeFixedNodeCoordinated.cpp
@@ -84,6 +83,8 @@ if (USE_COORDINATED_GRAPHICS)
         platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp
     )
     list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
+        page/scrolling/coordinated/ScrollingTreeCoordinated.h
+
         platform/graphics/texmap/coordinated/CoordinatedAnimatedBackingStoreClient.h
         platform/graphics/texmap/coordinated/CoordinatedBackingStore.h
         platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h

--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -360,6 +360,7 @@ WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp @no-unify
 WebProcess/WebPage/CoordinatedGraphics/CoordinatedSceneState.cpp
 WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
 WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+WebProcess/WebPage/CoordinatedGraphics/ScrollingCoordinatorCoordinated.cpp
 WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
 
 WebProcess/WebPage/glib/WebPageGLib.cpp

--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -330,6 +330,7 @@ WebProcess/WebPage/CoordinatedGraphics/CoordinatedSceneState.cpp
 WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
 WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
 WebProcess/WebPage/CoordinatedGraphics/NonCompositedFrameRenderer.cpp
+WebProcess/WebPage/CoordinatedGraphics/ScrollingCoordinatorCoordinated.cpp
 WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
 
 WebProcess/WebPage/glib/WebPageGLib.cpp

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -9694,6 +9694,17 @@ void WebPageProxy::setHasActiveAnimatedScrolls(bool isRunning)
 #endif
 }
 
+#if USE(COORDINATED_GRAPHICS) && HAVE(DISPLAY_LINK)
+void WebPageProxy::setHasActiveAnimatedScrollsForAsyncScrolling(DisplayLinkObserverID observerID, bool isRunning)
+{
+    if (isRunning)
+        protect(legacyMainFrameProcess())->startDisplayLink(observerID, m_displayID.value_or(0), FullSpeedFramesPerSecond);
+    else
+        protect(legacyMainFrameProcess())->stopDisplayLink(observerID, m_displayID.value_or(0));
+    setHasActiveAnimatedScrolls(isRunning);
+}
+#endif
+
 #if ENABLE(MODEL_PROCESS)
 void WebPageProxy::setHasModelElement(bool hasModelElement)
 {

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -43,6 +43,10 @@
 #include <wtf/UniqueRef.h>
 #include <wtf/WeakHashSet.h>
 
+#if USE(COORDINATED_GRAPHICS) && HAVE(DISPLAY_LINK)
+#include "DisplayLinkObserverID.h"
+#endif
+
 namespace API {
 class Attachment;
 class ContentWorld;
@@ -1054,6 +1058,9 @@ public:
     void setNeedsScrollGeometryUpdates(bool);
 
     void setHasActiveAnimatedScrolls(bool isRunning);
+#if USE(COORDINATED_GRAPHICS) && HAVE(DISPLAY_LINK)
+    void setHasActiveAnimatedScrollsForAsyncScrolling(DisplayLinkObserverID, bool isRunning);
+#endif
 
 #if ENABLE(MODEL_PROCESS)
     bool hasModelElement() const { return m_hasModelElement; }

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -68,6 +68,9 @@ messages -> WebPageProxy {
     RunBeforeUnloadConfirmPanel(WebCore::FrameIdentifier frameID, struct WebKit::FrameInfoData frameInfo, String message) -> (bool shouldClose) Synchronous
     PageDidScroll(WebCore::IntPoint scrollPosition)
     SetHasActiveAnimatedScrolls(bool hasActiveAnimatedScrolls)
+#if USE(COORDINATED_GRAPHICS) && HAVE(DISPLAY_LINK)
+    SetHasActiveAnimatedScrollsForAsyncScrolling(WebKit::DisplayLinkObserverID observerID, bool hasActiveAnimatedScrolls)
+#endif
 #if ENABLE(MODEL_PROCESS)
     SetHasModelElement(bool hasModelElement)
 #endif

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -172,6 +172,10 @@
 #include "TiledCoreAnimationScrollingCoordinator.h"
 #endif
 
+#if USE(COORDINATED_GRAPHICS)
+#include "ScrollingCoordinatorCoordinated.h"
+#endif
+
 #if PLATFORM(COCOA)
 #include "WebIconUtilities.h"
 #endif
@@ -1335,6 +1339,8 @@ RefPtr<WebCore::ScrollingCoordinator> WebChromeClient::createScrollingCoordinato
     }
 #elif PLATFORM(COCOA)
     return RemoteScrollingCoordinator::create(page.get());
+#elif USE(COORDINATED_GRAPHICS)
+    return ScrollingCoordinatorCoordinated::create(page.get());
 #else
     return nullptr;
 #endif

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ScrollingCoordinatorCoordinated.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ScrollingCoordinatorCoordinated.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018, 2024 Igalia S.L.
+ * Copyright (C) 2018, 2024, 2026 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,19 +28,37 @@
 #pragma once
 
 #if ENABLE(ASYNC_SCROLLING) && USE(COORDINATED_GRAPHICS)
-#include "ThreadedScrollingCoordinator.h"
+#include <WebCore/ThreadedScrollingCoordinator.h>
 
-namespace WebCore {
+#if HAVE(DISPLAY_LINK)
+#include "DisplayLinkObserverID.h"
+#endif
 
-class ScrollingCoordinatorCoordinated final : public ThreadedScrollingCoordinator {
+namespace WebKit {
+
+class WebPage;
+
+class ScrollingCoordinatorCoordinated final : public WebCore::ThreadedScrollingCoordinator {
 public:
-    explicit ScrollingCoordinatorCoordinated(Page*);
-    virtual ~ScrollingCoordinatorCoordinated();
+    static Ref<ScrollingCoordinatorCoordinated> create(WebPage* page)
+    {
+        return adoptRef(*new ScrollingCoordinatorCoordinated(page));
+    }
 
 private:
+    explicit ScrollingCoordinatorCoordinated(WebPage*);
+    ~ScrollingCoordinatorCoordinated() final;
+
     void didCompletePlatformRenderingUpdate() final;
+    void pageDestroyed() final;
+#if HAVE(DISPLAY_LINK)
+    void hasNodeWithAnimatedScrollChanged(bool) final;
+
+    uint64_t m_destinationID { 0 };
+    DisplayLinkObserverID m_observerID;
+#endif
 };
 
-} // namespace WebCore
+} // namespace WebKit
 
 #endif // ENABLE(ASYNC_SCROLLING) && USE(COORDINATED_GRAPHICS)


### PR DESCRIPTION
#### 2f1345fa776aa3938daeea03bb4c214e56513ad3
<pre>
[GTK][WPE][Coordinated Graphics] wheel event async scrolling doesn&apos;t start while the main thread is blocked
<a href="https://bugs.webkit.org/show_bug.cgi?id=305451">https://bugs.webkit.org/show_bug.cgi?id=305451</a>

Reviewed by Carlos Garcia Campos.

The async scrolling animation is using DisplayRefreshMonitor class.
WebDisplayRefreshMonitor class is the implementation of it for WebKit. It sends
messages to UI process to monitor the display refresh. However,
WebDisplayRefreshMonitor is the main thread specific class. Thus, while the
main thread is blocked, it can&apos;t send a message.

Moved ScrollingCoordinatorCoordinated from WebCore to WebKit. Changed it to
send a message to UI process to start monitoring the display refresh. Added a
new Messages::WebPageProxy::SetHasActiveAnimatedScrollsForAsyncScrolling.

The main thread is still painting the scrollbar layers. The scrollbars aren&apos;t
updated while the main thread is blocked. This is another problem tracked by
bug#305561.

* Source/WebCore/page/scrolling/ScrollingCoordinator.cpp:
* Source/WebCore/page/scrolling/ThreadedScrollingTree.h:
* Source/WebCore/page/scrolling/coordinated/ScrollingTreeCoordinated.cpp:
(WebCore::ScrollingTreeCoordinated::hasNodeWithAnimatedScrollChanged):
* Source/WebCore/page/scrolling/coordinated/ScrollingTreeCoordinated.h:
* Source/WebCore/platform/TextureMapper.cmake:
* Source/WebKit/SourcesGTK.txt:
* Source/WebKit/SourcesWPE.txt:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::setHasActiveAnimatedScrollsForAsyncScrolling):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::createScrollingCoordinator const):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ScrollingCoordinatorCoordinated.cpp: Renamed from Source/WebCore/page/scrolling/coordinated/ScrollingCoordinatorCoordinated.cpp.
(WebKit::ScrollingCoordinatorCoordinated::ScrollingCoordinatorCoordinated):
(WebKit::ScrollingCoordinatorCoordinated::~ScrollingCoordinatorCoordinated):
(WebKit::ScrollingCoordinatorCoordinated::pageDestroyed):
(WebKit::ScrollingCoordinatorCoordinated::hasNodeWithAnimatedScrollChanged):
(WebKit::ScrollingCoordinatorCoordinated::didCompletePlatformRenderingUpdate):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ScrollingCoordinatorCoordinated.h: Renamed from Source/WebCore/page/scrolling/coordinated/ScrollingCoordinatorCoordinated.h.

Canonical link: <a href="https://commits.webkit.org/306396@main">https://commits.webkit.org/306396@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4dc73758a9bae6891fc32bb6b7913ad22ab3d425

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141255 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13639 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2953 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149829 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143128 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14350 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13792 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108520 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144206 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11067 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/126418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89425 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10642 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8251 "Passed tests") | [⏳ 🛠 wpe-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119903 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2394 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152223 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13325 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/2838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116618 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13341 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11633 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116958 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13006 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123070 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68499 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21791 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13368 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13107 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77074 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13306 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13151 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->