### PR TITLE
New-Test(302373@main): ASSERTION FAILED: !(blobSize % sizeof(T)) on TestWebKitAPI.IndexedDB.OpenDatabaseWithMismatchedMetadataVersionAndName

### DIFF
--- a/Source/WebCore/platform/sql/SQLiteExtras.h
+++ b/Source/WebCore/platform/sql/SQLiteExtras.h
@@ -76,9 +76,8 @@ inline std::span<const T> sqliteColumnBlob(sqlite3_stmt* statement, int index)
     if (!blob)
         return { };
     auto blobSize = sqlite3_column_bytes(statement, index); // NOLINT
-    if (blobSize < 0)
+    if (blobSize < 0 || (blobSize % sizeof(T)))
         return { };
-    ASSERT(!(blobSize % sizeof(T)));
     return unsafeMakeSpan(blob, blobSize / sizeof(T));
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBFileName.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBFileName.mm
@@ -318,12 +318,7 @@ TEST(IndexedDB, OpenDatabaseAfterDatabaseNameUpgrade)
     EXPECT_WK_STREQ(@"Success", string.get());
 }
 
-// FIXME: rdar://163819252 (New-Test(302373@main)[ Debug ]: TestWebKitAPI.IndexedDB.OpenDatabaseWithMismatchedMetadataVersionAndName is a constant failure (301776))
-#if !defined(NDEBUG)
-TEST(IndexedDB, DISABLED_OpenDatabaseWithMismatchedMetadataVersionAndName)
-#else
 TEST(IndexedDB, OpenDatabaseWithMismatchedMetadataVersionAndName)
-#endif
 {
     RetainPtr handler = adoptNS([[IndexedDBFileNameMessageHandler alloc] init]);
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);


### PR DESCRIPTION
#### 9035d2c04f376fd2238a730666d336d9099a0901
<pre>
New-Test(302373@main): ASSERTION FAILED: !(blobSize % sizeof(T)) on TestWebKitAPI.IndexedDB.OpenDatabaseWithMismatchedMetadataVersionAndName
<a href="https://bugs.webkit.org/show_bug.cgi?id=301776">https://bugs.webkit.org/show_bug.cgi?id=301776</a>
<a href="https://rdar.apple.com/163819252">rdar://163819252</a>

Reviewed by Sihui Liu.

The test case is covering a case where the user has an IDB database whose
IDB version is 2 but is still using the old encoding for Strings (due to
a bug we had in WebKit for a while). In this case, it tries to read the
database name string in the new format and gets &quot;garbage&quot; and then later
compared it with the expected name and if it doesn&apos;t match, there is logic
to handle the migration. The issue is that there is a debug assertion in
sqliteColumnBlob() which hits in debug when trying to read the database
name in the new format (which doesn&apos;t match the format on disk). Since
this is expected in this case, I am replacing the debug assertion with
an `if` check which returns an empty span in this case (which is strictly
better than returning &quot;garbage&quot;) and it will keep the database upgrade
logic working as intended.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBFileName.mm

* Source/WebCore/platform/sql/SQLiteExtras.h:
(WebCore::sqliteColumnBlob):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBFileName.mm:
(TEST(IndexedDB, OpenDatabaseWithMismatchedMetadataVersionAndName)):

Canonical link: <a href="https://commits.webkit.org/305603@main">https://commits.webkit.org/305603@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea63bdfbc897c6a4640769925f0242a8bb1b7266

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138799 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11165 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/281 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146916 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91774 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c8f6fb91-40df-40ef-af55-85f803a7b233) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140672 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11869 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11320 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106211 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77501 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3ab024d8-d73b-466a-9c44-661c6f91166a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141746 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8952 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124381 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87081 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/162616f2-8715-4562-a002-71ff3aeb03e1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8531 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6279 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7214 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117956 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/238 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149674 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10847 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/238 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114597 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10865 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9168 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114938 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29233 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8811 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120693 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65742 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10895 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/235 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10633 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74536 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10834 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10684 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->