### PR TITLE
Test enabling EnhancedSecurityHeuristics flag by default.

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2761,17 +2761,20 @@ EncryptedMediaAPIEnabled:
 
 EnhancedSecurityHeuristicsEnabled:
   type: bool
-  status: testable
+  status: stable
   category: security
   defaultsOverridable: true
   humanReadableName: "Enable EnhancedSecurity Heuristics"
   humanReadableDescription: "Triggers EnhancedSecurity when insecure HTTP loads occur"
   defaultValue:
     WebKitLegacy:
+      "PLATFORM(COCOA)": true
       default: false
     WebKit:
+      "PLATFORM(COCOA)": true
       default: false
     WebCore:
+      "PLATFORM(COCOA)": true
       default: false
 
 EnterKeyHintEnabled:

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -181,12 +181,12 @@ DocumentLoader* DocumentLoader::fromScriptExecutionContextIdentifier(ScriptExecu
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(DocumentLoader);
 
-DocumentLoader::DocumentLoader(ResourceRequest&& request, SubstituteData&& substituteData)
+DocumentLoader::DocumentLoader(ResourceRequest&& request, SubstituteData&& substituteData, std::optional<ResourceRequest>&& originalRequest)
     : FrameDestructionObserver(nullptr)
     , m_cachedResourceLoader(CachedResourceLoader::create(this))
-    , m_originalRequest(request)
+    , m_originalRequest(originalRequest.has_value() ? originalRequest.value() : request)
     , m_substituteData(WTF::move(substituteData))
-    , m_originalRequestCopy(request)
+    , m_originalRequestCopy(originalRequest.has_value() ? *std::exchange(originalRequest, std::nullopt) : request)
     , m_request(WTF::move(request))
     , m_substituteResourceDeliveryTimer(*this, &DocumentLoader::substituteResourceDeliveryTimerFired)
     , m_originalSubstituteDataWasValid(substituteData.isValid())

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -519,6 +519,9 @@ public:
     bool isContinuingLoadAfterProvisionalLoadStarted() const { return m_isContinuingLoadAfterProvisionalLoadStarted; }
     void setIsContinuingLoadAfterProvisionalLoadStarted(bool isContinuingLoadAfterProvisionalLoadStarted) { m_isContinuingLoadAfterProvisionalLoadStarted = isContinuingLoadAfterProvisionalLoadStarted; }
 
+    bool isContinuingLoadAfterNavigationPolicyDecision() const { return m_isContinuingLoadAfterNavigationPolicyDecision; }
+    void setIsContinuingLoadAfterNavigationPolicyDecision(bool isContinuingLoadAfterNavigationPolicyDecision) { m_isContinuingLoadAfterNavigationPolicyDecision = isContinuingLoadAfterNavigationPolicyDecision; }
+
     bool isRequestFromClientOrUserInput() const { return m_isRequestFromClientOrUserInput; }
     void setIsRequestFromClientOrUserInput(bool isRequestFromClientOrUserInput) { m_isRequestFromClientOrUserInput = isRequestFromClientOrUserInput; }
 
@@ -797,6 +800,7 @@ private:
     bool m_isClientRedirect { false };
     bool m_isLoadingMultipartContent { false };
     bool m_isContinuingLoadAfterProvisionalLoadStarted { false };
+    bool m_isContinuingLoadAfterNavigationPolicyDecision { false };
     bool m_isInFinishedLoadingOfEmptyDocument { false };
     bool m_isInitialAboutBlank { false };
 

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -187,9 +187,9 @@ class DocumentLoader
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(DocumentLoader, DocumentLoader);
     friend class ContentFilter;
 public:
-    static Ref<DocumentLoader> create(ResourceRequest&& request, SubstituteData&& data)
+    static Ref<DocumentLoader> create(ResourceRequest&& request, SubstituteData&& data, std::optional<ResourceRequest>&& originalRequest = std::nullopt)
     {
-        return adoptRef(*new DocumentLoader(WTF::move(request), WTF::move(data)));
+        return adoptRef(*new DocumentLoader(WTF::move(request), WTF::move(data), WTF::move(originalRequest)));
     }
 
     USING_CAN_MAKE_WEAKPTR(CachedRawResourceClient);
@@ -548,7 +548,7 @@ public:
     void setCrossSiteRequester(NavigationRequester&& crossSiteRequester) { m_crossSiteRequester = WTF::move(crossSiteRequester); }
 
 protected:
-    WEBCORE_EXPORT DocumentLoader(ResourceRequest&&, SubstituteData&&);
+    WEBCORE_EXPORT DocumentLoader(ResourceRequest&&, SubstituteData&&, std::optional<ResourceRequest>&&);
 
     WEBCORE_EXPORT virtual void attachToFrame();
 

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -697,9 +697,9 @@ void EmptyFrameLoaderClient::dispatchWillSubmitForm(FormState&, URL&&, String&&,
     completionHandler();
 }
 
-Ref<DocumentLoader> EmptyFrameLoaderClient::createDocumentLoader(ResourceRequest&& request, SubstituteData&& substituteData)
+Ref<DocumentLoader> EmptyFrameLoaderClient::createDocumentLoader(ResourceRequest&& request, SubstituteData&& substituteData, std::optional<ResourceRequest>&& originalRequest)
 {
-    return DocumentLoader::create(WTF::move(request), WTF::move(substituteData));
+    return DocumentLoader::create(WTF::move(request), WTF::move(substituteData), WTF::move(originalRequest));
 }
 
 RefPtr<LocalFrame> EmptyFrameLoaderClient::createFrame(const AtomString&, HTMLFrameOwnerElement&)

--- a/Source/WebCore/loader/EmptyFrameLoaderClient.h
+++ b/Source/WebCore/loader/EmptyFrameLoaderClient.h
@@ -37,7 +37,7 @@ public:
     { }
 
 private:
-    Ref<DocumentLoader> createDocumentLoader(ResourceRequest&&, SubstituteData&&) override;
+    Ref<DocumentLoader> createDocumentLoader(ResourceRequest&&, SubstituteData&&, std::optional<ResourceRequest>&& = std::nullopt) override;
 
     bool hasWebView() const final;
 

--- a/Source/WebCore/loader/FrameLoadRequest.h
+++ b/Source/WebCore/loader/FrameLoadRequest.h
@@ -75,6 +75,9 @@ public:
     bool isContentRuleListRedirect() const { return m_isContentRuleListRedirect; }
     void setIsContentRuleListRedirect(bool isContentRuleListRedirect) { m_isContentRuleListRedirect = isContentRuleListRedirect; }
 
+    bool isCrossOriginContentRuleListRedirect() const { return m_isCrossOriginContentRuleListRedirect; }
+    void setIsCrossOriginContentRuleListRedirect(bool isCrossOriginContentRuleListRedirect) { m_isCrossOriginContentRuleListRedirect = isCrossOriginContentRuleListRedirect; }
+
     bool isFromNavigationAPI() const { return m_isFromNavigationAPI; }
     void setIsFromNavigationAPI(bool isFromNavigationAPI) { m_isFromNavigationAPI = isFromNavigationAPI; }
 
@@ -102,6 +105,7 @@ private:
     bool m_isInitialFrameSrcLoad { false };
     bool m_isContentRuleListRedirect { false };
     bool m_isFromNavigationAPI { false };
+    bool m_isCrossOriginContentRuleListRedirect { false };
 };
 
 class FrameLoadRequest : public FrameLoadRequestBase {

--- a/Source/WebCore/loader/FrameLoadRequest.h
+++ b/Source/WebCore/loader/FrameLoadRequest.h
@@ -127,6 +127,10 @@ public:
     const ResourceRequest& resourceRequest() const { return m_resourceRequest; }
     ResourceRequest takeResourceRequest() { return std::exchange(m_resourceRequest, { }); }
 
+    void setOriginalResourceRequest(ResourceRequest originalResourceRequest) { m_originalResourceRequest = originalResourceRequest; }
+    bool hasOriginalResourceRequest() { return !!m_originalResourceRequest; }
+    std::optional<ResourceRequest> takeOriginalResourceRequest() { return std::exchange(m_originalResourceRequest, { }); }
+
     const AtomString& frameName() const { return m_frameName; }
     void setFrameName(const AtomString& frameName) { m_frameName = frameName; }
 
@@ -177,6 +181,7 @@ private:
     AtomString m_frameName;
     SubstituteData m_substituteData;
     String m_clientRedirectSourceForHistory;
+    std::optional<ResourceRequest> m_originalResourceRequest;
 
     bool m_shouldCheckNewWindowPolicy { false };
     ShouldTreatAsContinuingLoad m_shouldTreatAsContinuingLoad { ShouldTreatAsContinuingLoad::No };

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1751,7 +1751,7 @@ void FrameLoader::load(FrameLoadRequest&& request, std::optional<NavigationReque
     if (!request.hasSubstituteData())
         request.setSubstituteData(defaultSubstituteDataForURL(request.resourceRequest().url()));
 
-    Ref loader = m_client->createDocumentLoader(request.takeResourceRequest(), request.takeSubstituteData());
+    Ref loader = m_client->createDocumentLoader(request.takeResourceRequest(), request.takeSubstituteData(), request.takeOriginalResourceRequest());
     loader->setIsContentRuleListRedirect(request.isContentRuleListRedirect());
     loader->setIsRequestFromClientOrUserInput(request.isRequestFromClientOrUserInput());
     loader->setIsContinuingLoadAfterProvisionalLoadStarted(request.shouldTreatAsContinuingLoad() == ShouldTreatAsContinuingLoad::YesAfterProvisionalLoadStarted);

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1755,6 +1755,7 @@ void FrameLoader::load(FrameLoadRequest&& request, std::optional<NavigationReque
     loader->setIsContentRuleListRedirect(request.isContentRuleListRedirect());
     loader->setIsRequestFromClientOrUserInput(request.isRequestFromClientOrUserInput());
     loader->setIsContinuingLoadAfterProvisionalLoadStarted(request.shouldTreatAsContinuingLoad() == ShouldTreatAsContinuingLoad::YesAfterProvisionalLoadStarted);
+    loader->setIsContinuingLoadAfterNavigationPolicyDecision(request.shouldTreatAsContinuingLoad() == ShouldTreatAsContinuingLoad::YesAfterNavigationPolicyDecision);
     if (crossSiteRequester)
         loader->setCrossSiteRequester(WTF::move(*crossSiteRequester));
 

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1774,6 +1774,7 @@ void FrameLoader::load(FrameLoadRequest&& request, std::optional<NavigationReque
     }
 
     SetForScope continuingLoadGuard(m_currentLoadContinuingState, request.shouldTreatAsContinuingLoad() != ShouldTreatAsContinuingLoad::No ? LoadContinuingState::ContinuingWithRequest : LoadContinuingState::NotContinuing);
+    SetForScope crossOriginContentRuleListCancellationGuard(m_needsCancellationForContentRuleListCrossOriginRedirect, request.isCrossOriginContentRuleListRedirect());
     load(loader.get(), request.protectedRequesterSecurityOrigin().ptr());
 }
 
@@ -2941,6 +2942,12 @@ void FrameLoader::checkLoadCompleteForThisFrame(LoadWillContinueInAnotherProcess
 
             if (loadWillContinueInAnotherProcess == LoadWillContinueInAnotherProcess::No) {
                 auto willInternallyHandleFailure = (error.errorRecoveryMethod() == ResourceError::ErrorRecoveryMethod::NoRecovery || (error.errorRecoveryMethod() == ResourceError::ErrorRecoveryMethod::HTTPFallback && (!isHTTPSFirstApplicable || isHTTPFallbackInProgress()))) ? WillInternallyHandleFailure::No : WillInternallyHandleFailure::Yes;
+
+                if (error.isCancellation() && m_needsCancellationForContentRuleListCrossOriginRedirect) {
+                    willInternallyHandleFailure = WillInternallyHandleFailure::Yes;
+                    m_needsCancellationForContentRuleListCrossOriginRedirect = false;
+                }
+
                 dispatchDidFailProvisionalLoad(*provisionalDocumentLoader, error, willInternallyHandleFailure);
             }
 

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -562,6 +562,8 @@ private:
     const Ref<DocumentPrefetcher> m_documentPrefetcher;
 
     Function<bool()> m_pendingDispatchNavigateEvent;
+
+    bool m_needsCancellationForContentRuleListCrossOriginRedirect { false };
 };
 
 // This function is called by createWindow() in JSDOMWindowBase.cpp, for example, for

--- a/Source/WebCore/loader/LocalFrameLoaderClient.h
+++ b/Source/WebCore/loader/LocalFrameLoaderClient.h
@@ -36,6 +36,7 @@
 #include <WebCore/LoaderMalloc.h>
 #include <WebCore/RegistrableDomain.h>
 #include <WebCore/ResourceLoaderIdentifier.h>
+#include <WebCore/ResourceRequest.h>
 #include <wtf/Expected.h>
 #include <wtf/Forward.h>
 #include <wtf/Platform.h>
@@ -246,7 +247,7 @@ public:
     virtual void didFinishLoad() = 0;
     virtual void prepareForDataSourceReplacement() = 0;
 
-    virtual Ref<DocumentLoader> createDocumentLoader(ResourceRequest&&, SubstituteData&&) = 0;
+    virtual Ref<DocumentLoader> createDocumentLoader(ResourceRequest&&, SubstituteData&&, std::optional<ResourceRequest>&& = std::nullopt) = 0;
     virtual void updateCachedDocumentLoader(DocumentLoader&) = 0;
     virtual void setTitle(const StringWithDirection&, const URL&) = 0;
 

--- a/Source/WebCore/loader/SubresourceLoader.cpp
+++ b/Source/WebCore/loader/SubresourceLoader.cpp
@@ -298,7 +298,7 @@ void SubresourceLoader::willSendRequestInternal(ResourceRequest&& newRequest, co
         Ref cachedResourceLoader = documentLoader->cachedResourceLoader();
         m_site = CachedResourceLoader::computeFetchMetadataSiteAfterRedirection(newRequest, m_resource->type(), options().mode, originalOrigin.get(), m_site, frame && frame->isMainFrame() && documentLoader->isRequestFromClientOrUserInput());
 
-        if (!cachedResourceLoader->updateRequestAfterRedirection(resource->type(), newRequest, options(), m_site, originalRequest().url())) {
+        if (!cachedResourceLoader->updateRequestAfterRedirection(resource->type(), newRequest, options(), m_site, originalRequest().url(), redirectResponse.url())) {
             SUBRESOURCELOADER_RELEASE_LOG(SUBRESOURCELOADER_WILLSENDREQUESTINTERNAL_RESOURCE_LOAD_CANCELLED_CANNOT_REQUEST_AFTER_REDIRECTION);
             cancel(ResourceError { String(), 0, request().url(), "Redirect was not allowed"_s, ResourceError::Type::AccessControl });
             return completionHandler(WTF::move(newRequest));

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -1166,6 +1166,7 @@ ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::requ
             if (type == CachedResource::Type::MainResource && RegistrableDomain { resourceRequest.url() } != originalDomain) {
                 FrameLoadRequest frameLoadRequest(frame, ResourceRequest(URL { resourceRequest.url() }));
                 frameLoadRequest.setIsContentRuleListRedirect(true);
+                frameLoadRequest.setIsCrossOriginContentRuleListRedirect(true);
                 frame->loader().load(WTF::move(frameLoadRequest));
                 return makeUnexpected(ResourceError { errorDomainWebKitInternal, 0, url, "Loading in a new process"_s, ResourceError::Type::Cancellation });
             }

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -771,7 +771,7 @@ static bool shouldPerformHTTPSUpgrade(const URL& originalURL, const URL& newURL,
         && !frame.loader().isHTTPFallbackInProgress();
 }
 
-bool CachedResourceLoader::updateRequestAfterRedirection(CachedResource::Type type, ResourceRequest& request, const ResourceLoaderOptions& options, FetchMetadataSite site, const URL& preRedirectURL)
+bool CachedResourceLoader::updateRequestAfterRedirection(CachedResource::Type type, ResourceRequest& request, const ResourceLoaderOptions& options, FetchMetadataSite site, const URL& preRedirectURL, const URL& lastRedirectURL)
 {
     ASSERT(m_documentLoader);
     if (!m_documentLoader)
@@ -786,7 +786,7 @@ bool CachedResourceLoader::updateRequestAfterRedirection(CachedResource::Type ty
     if (frame) {
         RefPtr page = frame->page();
         bool isHTTPSByDefaultEnabled = page ? page->settings().httpsByDefault() : false;
-        if (shouldPerformHTTPSUpgrade(preRedirectURL, request.url(), *frame, type, isHTTPSByDefaultEnabled, m_documentLoader->advancedPrivacyProtections(), m_documentLoader->httpsByDefaultMode())) {
+        if (shouldPerformHTTPSUpgrade(lastRedirectURL, request.url(), *frame, type, isHTTPSByDefaultEnabled, m_documentLoader->advancedPrivacyProtections(), m_documentLoader->httpsByDefaultMode())) {
             auto portsForUpgradingInsecureScheme = page ? std::optional { page->portsForUpgradingInsecureSchemeForTesting() } : std::nullopt;
             auto upgradePort = (portsForUpgradingInsecureScheme && request.url().port() == portsForUpgradingInsecureScheme->first) ? std::optional { portsForUpgradingInsecureScheme->second } : std::nullopt;
             request.upgradeInsecureRequestIfNeeded(ShouldUpgradeLocalhostAndIPAddress::No, upgradePort);

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -1144,7 +1144,8 @@ ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::requ
         RefPtr userContentProvider = frame->userContentProvider();
         if (request.options().shouldEnableContentExtensionsCheck == ShouldEnableContentExtensionsCheck::Yes && userContentProvider) {
             RegistrableDomain originalDomain { resourceRequest.url() };
-            auto results = userContentProvider->processContentRuleListsForLoad(page, resourceRequest.url(), ContentExtensions::toResourceType(type, request.resourceRequest().requester(), frame->isMainFrame()), *documentLoader);
+            auto redirectFromURL = (documentLoader->isContinuingLoadAfterNavigationPolicyDecision() && documentLoader->originalRequest().url() != resourceRequest.url()) ? documentLoader->originalRequest().url() : URL { };
+            auto results = userContentProvider->processContentRuleListsForLoad(page, resourceRequest.url(), ContentExtensions::toResourceType(type, request.resourceRequest().requester(), frame->isMainFrame()), *documentLoader, redirectFromURL);
             madeHTTPS = results.summary.madeHTTPS;
             request.applyResults(WTF::move(results), page.ptr());
             if (results.shouldBlock()) {

--- a/Source/WebCore/loader/cache/CachedResourceLoader.h
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.h
@@ -166,7 +166,7 @@ public:
     void warnUnusedPreloads();
     void stopUnusedPreloadsTimer();
 
-    bool updateRequestAfterRedirection(CachedResource::Type, ResourceRequest&, const ResourceLoaderOptions&, FetchMetadataSite, const URL& preRedirectURL);
+    bool updateRequestAfterRedirection(CachedResource::Type, ResourceRequest&, const ResourceLoaderOptions&, FetchMetadataSite, const URL& preRedirectURL, const URL& lastRedirectURL);
     bool allowedByContentSecurityPolicy(CachedResource::Type, const URL&, const ResourceLoaderOptions&, ContentSecurityPolicy::RedirectResponseReceived, const URL& preRedirectURL = URL(), bool shouldReportViolationAsConsoleMessage = true) const;
 
     static const ResourceLoaderOptions& defaultCachedResourceOptions();

--- a/Source/WebCore/platform/network/FormData.h
+++ b/Source/WebCore/platform/network/FormData.h
@@ -19,7 +19,6 @@
 
 #pragma once
 
-#include <WebCore/BlobData.h>
 #include <optional>
 #include <wtf/ArgumentCoder.h>
 #include <wtf/Forward.h>

--- a/Source/WebCore/platform/network/ResourceRequestBase.h
+++ b/Source/WebCore/platform/network/ResourceRequestBase.h
@@ -30,6 +30,7 @@
 #include <WebCore/FormData.h>
 #include <WebCore/FrameLoaderTypes.h>
 #include <WebCore/HTTPHeaderMap.h>
+#include <WebCore/IPAddressSpace.h>
 #include <WebCore/IntRect.h>
 #include <WebCore/ResourceLoadPriority.h>
 #include <optional>
@@ -40,8 +41,6 @@
 #include <wtf/WallTime.h>
 
 namespace WebCore {
-
-enum class IPAddressSpace : bool;
 
 enum class ResourceRequestCachePolicy : uint8_t {
     UseProtocolCachePolicy, // normal load, equivalent to fetch "default" cache mode.

--- a/Source/WebCore/platform/network/cocoa/CookieStorageObserver.h
+++ b/Source/WebCore/platform/network/cocoa/CookieStorageObserver.h
@@ -55,6 +55,8 @@ public:
 
     void cookiesDidChange();
 
+    void registerInternalsForNotifications(bool isReregistering);
+
 private:
     RetainPtr<NSHTTPCookieStorage> m_cookieStorage;
     bool m_hasRegisteredInternalsForNotifications { false };

--- a/Source/WebCore/platform/network/cocoa/CookieStorageObserver.mm
+++ b/Source/WebCore/platform/network/cocoa/CookieStorageObserver.mm
@@ -110,15 +110,26 @@ void CookieStorageObserver::startObserving(WTF::Function<void()>&& callback)
     m_observerAdapter = adoptNS([[WebCookieObserverAdapter alloc] initWithObserver:*this]);
 
     if (!m_hasRegisteredInternalsForNotifications) {
-        if (m_cookieStorage.get() != [NSHTTPCookieStorage sharedHTTPCookieStorage]) {
-            RetainPtr internalObject = (static_cast<WebNSHTTPCookieStorageDummyForInternalAccess *>(m_cookieStorage.get()))->_internal;
-            [internalObject registerForPostingNotificationsWithContext:m_cookieStorage.get()];
-        }
-
+        registerInternalsForNotifications(false);
         m_hasRegisteredInternalsForNotifications = true;
     }
 
     [[NSNotificationCenter defaultCenter] addObserver:m_observerAdapter.get() selector:@selector(cookiesChangedNotificationHandler:) name:NSHTTPCookieManagerCookiesChangedNotification object:m_cookieStorage.get()];
+}
+
+void CookieStorageObserver::registerInternalsForNotifications(bool isReregistering)
+{
+    // This will not be required once rdar://56248709 is fixed.
+    ASSERT(isMainThread());
+    ASSERT(hasProcessPrivilege(ProcessPrivilege::CanAccessRawCookies));
+
+    if (isReregistering && !m_hasRegisteredInternalsForNotifications)
+        return;
+
+    if (m_cookieStorage.get() != [NSHTTPCookieStorage sharedHTTPCookieStorage]) {
+        RetainPtr internalObject = (static_cast<WebNSHTTPCookieStorageDummyForInternalAccess *>(m_cookieStorage.get()))->_internal;
+        [internalObject registerForPostingNotificationsWithContext:m_cookieStorage.get()];
+    }
 }
 
 void CookieStorageObserver::stopObserving()

--- a/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
@@ -134,15 +134,21 @@ Vector<Cookie> NetworkStorageSession::getCookies(const URL& url)
 void NetworkStorageSession::hasCookies(const RegistrableDomain& domain, CompletionHandler<void(bool)>&& completionHandler) const
 {
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanAccessRawCookies));
+
+    bool hasCookieForDomain = false;
     
     for (NSHTTPCookie *nsCookie in [nsCookieStorage() cookies]) {
         if (RegistrableDomain::uncheckedCreateFromHost(nsCookie.domain) == domain) {
-            completionHandler(true);
-            return;
+            hasCookieForDomain = true;
+            break;
         }
     }
 
-    completionHandler(false);
+    // Workaround until rdar://56248709 is fixed.
+    if (m_cookieStorageObserver && cookieStorage().get())
+        checkedCookieStorageObserver()->registerInternalsForNotifications(true);
+
+    completionHandler(hasCookieForDomain);
 }
 
 void NetworkStorageSession::setAllCookiesToSameSiteStrict(const RegistrableDomain& domain, CompletionHandler<void()>&& completionHandler)

--- a/Source/WebCore/platform/network/curl/CurlFormDataStream.cpp
+++ b/Source/WebCore/platform/network/curl/CurlFormDataStream.cpp
@@ -36,6 +36,7 @@
 
 #include "BlobRegistry.h"
 #include "Logging.h"
+#include <wtf/FileSystem.h>
 #include <wtf/MainThread.h>
 
 namespace WebCore {

--- a/Source/WebKit/Shared/LoadParameters.h
+++ b/Source/WebKit/Shared/LoadParameters.h
@@ -96,6 +96,7 @@ struct LoadParameters {
     std::optional<OptionSet<WebCore::AdvancedPrivacyProtections>> advancedPrivacyProtections;
     uint64_t requiredCookiesVersion { 0 };
     std::optional<WebCore::NavigationRequester> requester;
+    std::optional<WebCore::ResourceRequest> originalRequest;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/LoadParameters.serialization.in
+++ b/Source/WebKit/Shared/LoadParameters.serialization.in
@@ -63,4 +63,5 @@ enum class WebCore::NavigationUpgradeToHTTPSBehavior : bool;
     std::optional<OptionSet<WebCore::AdvancedPrivacyProtections>> advancedPrivacyProtections;
     uint64_t requiredCookiesVersion;
     std::optional<WebCore::NavigationRequester> requester;
+    std::optional<WebCore::ResourceRequest> originalRequest;
 };

--- a/Source/WebKit/UIProcess/API/APINavigation.cpp
+++ b/Source/WebKit/UIProcess/API/APINavigation.cpp
@@ -212,7 +212,9 @@ WTF::String Navigation::loggingString() const
 
 void Navigation::setHasStorageForCurrentSite(const WTF::URL& url, bool hasStorageForCurrentSite)
 {
-    ASSERT_UNUSED(url, url == m_currentRequest.url());
+    if (url != m_currentRequest.url())
+        return;
+
     m_hasStorageForCurrentSite = hasStorageForCurrentSite;
 }
 

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
@@ -51,7 +51,7 @@ void BrowsingContextGroup::sharedProcessForSite(WebsiteDataStore& websiteDataSto
 {
     if (!preferences.siteIsolationEnabled() || !preferences.siteIsolationSharedProcessEnabled())
         return completionHandler(nullptr);
-    if (site.isEmpty() || m_processMap.contains(site))
+    if (site.isEmpty() || m_processMap.contains(std::make_pair(site, enhancedSecurity)))
         return completionHandler(nullptr);
     if (!m_sharedProcessSites.contains(site)) {
         if (isMainFrame == IsMainFrame::Yes)
@@ -99,7 +99,7 @@ Ref<FrameProcess> BrowsingContextGroup::ensureProcessForSite(const Site& site, c
             ASSERT(&m_sharedProcess->process() == &process);
             return *m_sharedProcess;
         }
-        if (RefPtr existingProcess = processForSite(site)) {
+        if (RefPtr existingProcess = processForSite(site, process.enhancedSecurity())) {
             if (existingProcess->process().coreProcessIdentifier() == process.coreProcessIdentifier())
                 return existingProcess.releaseNonNull();
         }
@@ -108,11 +108,11 @@ Ref<FrameProcess> BrowsingContextGroup::ensureProcessForSite(const Site& site, c
     return FrameProcess::create(process, *this, site, mainFrameSite, preferences, loadedWebArchive, browsingContextGroupUpdate);
 }
 
-RefPtr<FrameProcess> BrowsingContextGroup::processForSite(const Site& site)
+RefPtr<FrameProcess> BrowsingContextGroup::processForSite(const Site& site, EnhancedSecurity enhancedSecurity)
 {
     if (m_sharedProcessSites.contains(site))
         return m_sharedProcess.get();
-    RefPtr process = m_processMap.get(site);
+    RefPtr process = m_processMap.get(std::make_pair(site, enhancedSecurity));
     if (!process)
         return nullptr;
     if (process->process().state() == WebProcessProxy::State::Terminated)
@@ -166,6 +166,11 @@ void BrowsingContextGroup::addFrameProcessAndInjectPageContextIf(FrameProcess& p
     if (!addFrameProcessWithoutInjectingPageContext(process))
         return;
     auto& site = *process.site();
+    auto key = std::make_pair(site, processProxy->enhancedSecurity());
+    if (m_processMap.get(key) == &process)
+        return;
+    ASSERT(!m_processMap.get(key) || m_processMap.get(key)->process().state() == WebProcessProxy::State::Terminated);
+    m_processMap.set(key, process);
     for (Ref page : m_pages) {
         if (site == Site(URL(page->currentURL())))
             continue;
@@ -191,8 +196,9 @@ void BrowsingContextGroup::removeFrameProcess(FrameProcess& process)
         m_sharedProcessSites.clear();
     } else {
         auto& site = *process.site();
-        ASSERT(site.isEmpty() || m_processMap.get(site) == &process || process.process().state() == WebProcessProxy::State::Terminated);
-        m_processMap.remove(site);
+        auto key = std::make_pair(site, process.process().enhancedSecurity());
+        ASSERT(site.isEmpty() || m_processMap.get(key) == &process || process.process().state() == WebProcessProxy::State::Terminated);
+        m_processMap.remove(key);
     }
     m_remotePages.removeIf([&] (auto& pair) {
         auto& set = pair.value;
@@ -214,7 +220,7 @@ void BrowsingContextGroup::addPage(WebPageProxy& page)
         return HashSet<Ref<RemotePageProxy>> { };
     }).iterator->value;
     m_processMap.removeIf([&] (auto& pair) {
-        auto& site = pair.key;
+        auto& site = pair.key.first;
         auto& process = pair.value;
         if (!process) {
             ASSERT_NOT_REACHED_WITH_MESSAGE("FrameProcess should remove itself in the destructor so we should never find a null WeakPtr");

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
@@ -176,10 +176,11 @@ void BrowsingContextGroup::addFrameProcessAndInjectPageContextIf(FrameProcess& p
 bool BrowsingContextGroup::addFrameProcessWithoutInjectingPageContext(FrameProcess& process)
 {
     auto& site = *process.site();
-    if (m_processMap.get(site) == &process)
+    auto key = std::make_pair(site, process.process().enhancedSecurity());
+    if (m_processMap.get(key) == &process)
         return false;
-    ASSERT(!m_processMap.get(site) || m_processMap.get(site)->process().state() == WebProcessProxy::State::Terminated);
-    m_processMap.set(site, process);
+    ASSERT(!m_processMap.get(key) || m_processMap.get(key)->process().state() == WebProcessProxy::State::Terminated);
+    m_processMap.set(key, process);
     return true;
 }
 

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.h
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.h
@@ -63,7 +63,7 @@ public:
 
     void sharedProcessForSite(WebsiteDataStore&, API::WebsitePolicies*, const WebPreferences&, const WebCore::Site&, const WebCore::Site& mainFrameSite, WebProcessProxy::LockdownMode, EnhancedSecurity, API::PageConfiguration&, IsMainFrame, CompletionHandler<void(FrameProcess*)>&&);
     Ref<FrameProcess> ensureProcessForSite(const WebCore::Site&, const WebCore::Site& mainFrameSite, WebProcessProxy&, const WebPreferences&, LoadedWebArchive = LoadedWebArchive::No, BrowsingContextGroupUpdate = BrowsingContextGroupUpdate::AddProcessAndInjectBrowsingContext);
-    RefPtr<FrameProcess> processForSite(const WebCore::Site&);
+    RefPtr<FrameProcess> processForSite(const WebCore::Site&, EnhancedSecurity);
     void addFrameProcess(FrameProcess&);
     void addFrameProcessAndInjectPageContextIf(FrameProcess&, Function<bool(WebPageProxy&)>);
     bool addFrameProcessWithoutInjectingPageContext(FrameProcess&);
@@ -91,7 +91,7 @@ private:
     HashSet<WebCore::Site> m_sharedProcessSites;
     WeakHashSet<WebPageProxy> m_pagesInSharedProcess;
 
-    HashMap<WebCore::Site, WeakPtr<FrameProcess>> m_processMap;
+    HashMap<std::pair<WebCore::Site, EnhancedSecurity>, WeakPtr<FrameProcess>> m_processMap;
     WeakListHashSet<WebPageProxy> m_pages;
     WeakHashMap<WebPageProxy, HashSet<Ref<RemotePageProxy>>> m_remotePages;
 };

--- a/Source/WebKit/UIProcess/EnhancedSecurityTracking.cpp
+++ b/Source/WebKit/UIProcess/EnhancedSecurityTracking.cpp
@@ -190,6 +190,8 @@ void EnhancedSecurityTracking::handleBackForwardNavigation(const API::Navigation
 void EnhancedSecurityTracking::trackNavigation(const API::Navigation& navigation)
 {
     auto lastNavigationAction = navigation.lastNavigationAction();
+    if (lastNavigationAction->hasOpener)
+        return;
 
     bool isBackForward = lastNavigationAction && lastNavigationAction->navigationType == NavigationType::BackForward;
     bool isReload = lastNavigationAction && lastNavigationAction->navigationType == NavigationType::Reload;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2231,6 +2231,8 @@ void WebPageProxy::loadRequestWithNavigationShared(Ref<WebProcessProxy>&& proces
     loadParameters.originatingFrame = navigation.lastNavigationAction() ? std::optional(navigation.lastNavigationAction()->originatingFrameInfoData) : std::nullopt;
     if (auto& action = navigation.lastNavigationAction())
         loadParameters.requester = action->requester;
+    if (shouldTreatAsContinuingLoad == ShouldTreatAsContinuingLoad::YesAfterNavigationPolicyDecision)
+        loadParameters.originalRequest = navigation.originalRequest();
 
 #if ENABLE(CONTENT_EXTENSIONS)
     if (protectedPreferences()->iFrameResourceMonitoringEnabled())

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1394,7 +1394,7 @@ void WebPageProxy::launchProcess(const Site& site, ProcessLaunchReason reason)
     Ref processPool = m_configuration->processPool();
     RefPtr relatedPage = m_configuration->relatedPage();
 
-    if (RefPtr frameProcess = protectedBrowsingContextGroup()->processForSite(site)) {
+    if (RefPtr frameProcess = protectedBrowsingContextGroup()->processForSite(site, currentEnhancedSecurityState())) {
         ASSERT(protectedPreferences()->siteIsolationEnabled());
         m_legacyMainFrameProcess = frameProcess->process();
     } else if (relatedPage && !relatedPage->isClosed() && reason == ProcessLaunchReason::InitialProcess && hasSameGPUAndNetworkProcessPreferencesAs(*relatedPage)) {
@@ -16632,9 +16632,9 @@ void WebPageProxy::generateTestReport(const String& message, const String& group
     send(Messages::WebPage::GenerateTestReport(message, group));
 }
 
-WebProcessProxy* WebPageProxy::processForSite(const Site& site)
+WebProcessProxy* WebPageProxy::processForSite(const Site& site, EnhancedSecurity enhancedSecurity)
 {
-    if (RefPtr process = protectedBrowsingContextGroup()->processForSite(site))
+    if (RefPtr process = protectedBrowsingContextGroup()->processForSite(site, enhancedSecurity))
         return &process->process();
 
     return nullptr;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2547,7 +2547,7 @@ public:
     WKQuickLookPreviewController *quickLookPreviewController() const { return m_quickLookPreviewController.get(); }
 #endif
 
-    WebProcessProxy* processForSite(const WebCore::Site&);
+    WebProcessProxy* processForSite(const WebCore::Site&, EnhancedSecurity);
 
     void observeAndCreateRemoteSubframesInOtherProcesses(WebFrameProxy&, const String& frameName);
     void broadcastDocumentSyncData(IPC::Connection&, const WebCore::DocumentSyncSerializationData&);

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -2164,7 +2164,7 @@ void WebProcessPool::processForNavigation(WebPageProxy& page, WebFrameProxy& fra
                 return completionHandler(mainFrameProcess.copyRef(), nullptr, "Found process for the same site as main frame"_s);
         }
         RefPtr<WebProcessProxy> process;
-        if (RefPtr frameProcess = browsingContextGroup.processForSite(site))
+        if (RefPtr frameProcess = browsingContextGroup.processForSite(site, enhancedSecurity))
             process = &frameProcess->process();
         if (process && process->websiteDataStore() == dataStore.ptr() && process->websiteDataStore() == &page.websiteDataStore() && !process->isInProcessCache() && process->lockdownMode() == lockdownMode && enhancedSecurityStatesAreConsistent(process->enhancedSecurity(), enhancedSecurity)) {
             dataStore->protectedNetworkProcess()->addAllowedFirstPartyForCookies(*process, mainFrameSite.domain(), LoadedWebArchive::No, [completionHandler = WTF::move(completionHandler), process] () mutable {

--- a/Source/WebKit/WebProcess/Storage/RemoteWorkerFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/Storage/RemoteWorkerFrameLoaderClient.cpp
@@ -39,9 +39,9 @@ RemoteWorkerFrameLoaderClient::RemoteWorkerFrameLoaderClient(WebCore::FrameLoade
     RELEASE_LOG(Worker, "RemoteWorkerFrameLoaderClient::RemoteWorkerFrameLoaderClient webPageProxyID %" PRIu64 ", pageID %" PRIu64, webPageProxyID.toUInt64(), pageID.toUInt64());
 }
 
-Ref<WebCore::DocumentLoader> RemoteWorkerFrameLoaderClient::createDocumentLoader(WebCore::ResourceRequest&& request, WebCore::SubstituteData&& substituteData)
+Ref<WebCore::DocumentLoader> RemoteWorkerFrameLoaderClient::createDocumentLoader(WebCore::ResourceRequest&& request, WebCore::SubstituteData&& substituteData, std::optional<WebCore::ResourceRequest>&& originalRequest)
 {
-    return WebCore::DocumentLoader::create(WTF::move(request), WTF::move(substituteData));
+    return WebCore::DocumentLoader::create(WTF::move(request), WTF::move(substituteData), WTF::move(originalRequest));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Storage/RemoteWorkerFrameLoaderClient.h
+++ b/Source/WebKit/WebProcess/Storage/RemoteWorkerFrameLoaderClient.h
@@ -48,7 +48,7 @@ public:
     std::optional<WebCore::ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier() const { return m_serviceWorkerPageIdentifier; }
 
 private:
-    Ref<WebCore::DocumentLoader> createDocumentLoader(WebCore::ResourceRequest&&, WebCore::SubstituteData&&) final;
+    Ref<WebCore::DocumentLoader> createDocumentLoader(WebCore::ResourceRequest&&, WebCore::SubstituteData&&, std::optional<WebCore::ResourceRequest>&& = std::nullopt) final;
 
     bool shouldUseCredentialStorage(WebCore::DocumentLoader*, WebCore::ResourceLoaderIdentifier) final { return true; }
     bool isRemoteWorkerFrameLoaderClient() const final { return true; }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -1480,9 +1480,9 @@ void WebLocalFrameLoaderClient::prepareForDataSourceReplacement()
     notImplemented();
 }
 
-Ref<DocumentLoader> WebLocalFrameLoaderClient::createDocumentLoader(ResourceRequest&& request, SubstituteData&& substituteData)
+Ref<DocumentLoader> WebLocalFrameLoaderClient::createDocumentLoader(ResourceRequest&& request, SubstituteData&& substituteData, std::optional<ResourceRequest>&& originalRequest)
 {
-    return m_frame->protectedPage()->createDocumentLoader(protectedLocalFrame(), WTF::move(request), WTF::move(substituteData));
+    return m_frame->protectedPage()->createDocumentLoader(protectedLocalFrame(), WTF::move(request), WTF::move(substituteData), WTF::move(originalRequest));
 }
 
 void WebLocalFrameLoaderClient::updateCachedDocumentLoader(WebCore::DocumentLoader& loader)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
@@ -190,8 +190,8 @@ private:
     void provisionalLoadStarted() final;
     void didFinishLoad() final;
     void prepareForDataSourceReplacement() final;
-    
-    Ref<WebCore::DocumentLoader> createDocumentLoader(WebCore::ResourceRequest&&, WebCore::SubstituteData&&) final;
+
+    Ref<WebCore::DocumentLoader> createDocumentLoader(WebCore::ResourceRequest&&, WebCore::SubstituteData&&, std::optional<WebCore::ResourceRequest>&& = std::nullopt) final;
     void updateCachedDocumentLoader(WebCore::DocumentLoader&) final;
 
     void setTitle(const WebCore::StringWithDirection&, const URL&) final;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2211,6 +2211,8 @@ void WebPage::loadRequest(LoadParameters&& loadParameters)
         frameLoadRequest.setIsRequestFromClientOrUserInput();
     if (loadParameters.advancedPrivacyProtections)
         frameLoadRequest.setAdvancedPrivacyProtections(*loadParameters.advancedPrivacyProtections);
+    if (loadParameters.originalRequest)
+        frameLoadRequest.setOriginalResourceRequest(*loadParameters.originalRequest);
 
     if (loadParameters.effectiveSandboxFlags)
         localFrame->updateSandboxFlags(loadParameters.effectiveSandboxFlags, Frame::NotifyUIProcess::No);
@@ -8000,9 +8002,9 @@ void WebPage::setScrollbarOverlayStyle(std::optional<WebCore::ScrollbarOverlaySt
         localMainFrame->protectedView()->recalculateScrollbarOverlayStyle();
 }
 
-Ref<DocumentLoader> WebPage::createDocumentLoader(LocalFrame& frame, ResourceRequest&& request, SubstituteData&& substituteData)
+Ref<DocumentLoader> WebPage::createDocumentLoader(LocalFrame& frame, ResourceRequest&& request, SubstituteData&& substituteData, std::optional<ResourceRequest>&& originalRequest)
 {
-    auto documentLoader = DocumentLoader::create(WTF::move(request), WTF::move(substituteData));
+    auto documentLoader = DocumentLoader::create(WTF::move(request), WTF::move(substituteData), WTF::move(originalRequest));
 
     documentLoader->setLastNavigationWasAppInitiated(m_lastNavigationWasAppInitiated);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -56,6 +56,7 @@
 #include <WebCore/PointerID.h>
 #include <WebCore/RectEdges.h>
 #include <WebCore/RegistrableDomain.h>
+#include <WebCore/ResourceRequest.h>
 #include <WebCore/SecurityPolicyViolationEvent.h>
 #include <WebCore/ShareData.h>
 #include <WebCore/ShareableBitmap.h>
@@ -212,7 +213,6 @@ class RegistrableDomain;
 class RemoteFrameGeometryTransformer;
 class RenderImage;
 class Report;
-class ResourceRequest;
 class ResourceResponse;
 class ScrollingCoordinator;
 class SelectionData;
@@ -1576,7 +1576,7 @@ public:
     std::optional<WebCore::ScrollbarOverlayStyle> scrollbarOverlayStyle() { return m_scrollbarOverlayStyle; }
     void setScrollbarOverlayStyle(std::optional<WebCore::ScrollbarOverlayStyle> scrollbarStyle);
 
-    Ref<WebCore::DocumentLoader> createDocumentLoader(WebCore::LocalFrame&, WebCore::ResourceRequest&&, WebCore::SubstituteData&&);
+    Ref<WebCore::DocumentLoader> createDocumentLoader(WebCore::LocalFrame&, WebCore::ResourceRequest&&, WebCore::SubstituteData&&, std::optional<WebCore::ResourceRequest>&& = std::nullopt);
     void updateCachedDocumentLoader(WebCore::DocumentLoader&, WebCore::LocalFrame&);
 
     void getBytecodeProfile(CompletionHandler<void(const String&)>&&);

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.h
@@ -190,7 +190,7 @@ private:
     void provisionalLoadStarted() final;
     void didFinishLoad() final;
     void prepareForDataSourceReplacement() final;
-    Ref<WebCore::DocumentLoader> createDocumentLoader(WebCore::ResourceRequest&&, WebCore::SubstituteData&&) final;
+    Ref<WebCore::DocumentLoader> createDocumentLoader(WebCore::ResourceRequest&&, WebCore::SubstituteData&&, std::optional<WebCore::ResourceRequest>&& = std::nullopt) final;
     void updateCachedDocumentLoader(WebCore::DocumentLoader&) final { }
 
     void setTitle(const WebCore::StringWithDirection&, const URL&) final;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
@@ -1269,9 +1269,9 @@ void WebFrameLoaderClient::prepareForDataSourceReplacement()
 #endif
 }
 
-Ref<WebCore::DocumentLoader> WebFrameLoaderClient::createDocumentLoader(WebCore::ResourceRequest&& request, WebCore::SubstituteData&& substituteData)
+Ref<WebCore::DocumentLoader> WebFrameLoaderClient::createDocumentLoader(WebCore::ResourceRequest&& request, WebCore::SubstituteData&& substituteData, std::optional<WebCore::ResourceRequest>&& originalRequest)
 {
-    auto loader = WebDocumentLoaderMac::create(WTF::move(request), WTF::move(substituteData));
+    auto loader = WebDocumentLoaderMac::create(WTF::move(request), WTF::move(substituteData), WTF::move(originalRequest));
 
     auto dataSource = adoptNS([[WebDataSource alloc] _initWithDocumentLoader:loader.copyRef()]);
     loader->setDataSource(dataSource.get(), getWebView(m_webFrame.get()));

--- a/Source/WebKitLegacy/mac/WebView/WebDocumentLoaderMac.h
+++ b/Source/WebKitLegacy/mac/WebView/WebDocumentLoaderMac.h
@@ -40,9 +40,9 @@ class ResourceRequest;
 
 class WebDocumentLoaderMac : public WebCore::DocumentLoader {
 public:
-    static Ref<WebDocumentLoaderMac> create(WebCore::ResourceRequest&& request, WebCore::SubstituteData&& data)
+    static Ref<WebDocumentLoaderMac> create(WebCore::ResourceRequest&& request, WebCore::SubstituteData&& data, std::optional<WebCore::ResourceRequest>&& originalRequest = std::nullopt)
     {
-        return adoptRef(*new WebDocumentLoaderMac(WTF::move(request), WTF::move(data)));
+        return adoptRef(*new WebDocumentLoaderMac(WTF::move(request), WTF::move(data), WTF::move(originalRequest)));
     }
 
     void setDataSource(WebDataSource *, WebView*);
@@ -53,7 +53,7 @@ public:
     void decreaseLoadCount(WebCore::ResourceLoaderIdentifier);
 
 private:
-    WebDocumentLoaderMac(WebCore::ResourceRequest&&, WebCore::SubstituteData&&);
+    WebDocumentLoaderMac(WebCore::ResourceRequest&&, WebCore::SubstituteData&&, std::optional<WebCore::ResourceRequest>&&);
 
     virtual void attachToFrame();
     virtual void detachFromFrame(WebCore::LoadWillContinueInAnotherProcess);

--- a/Source/WebKitLegacy/mac/WebView/WebDocumentLoaderMac.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebDocumentLoaderMac.mm
@@ -34,8 +34,8 @@
 
 using namespace WebCore;
 
-WebDocumentLoaderMac::WebDocumentLoaderMac(ResourceRequest&& request, SubstituteData&& substituteData)
-    : DocumentLoader(WTF::move(request), WTF::move(substituteData))
+WebDocumentLoaderMac::WebDocumentLoaderMac(ResourceRequest&& request, SubstituteData&& substituteData, std::optional<ResourceRequest>&& originalRequest)
+    : DocumentLoader(WTF::move(request), WTF::move(substituteData), WTF::move(originalRequest))
     , m_dataSource(nil)
     , m_isDataSourceRetained(false)
 {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm
@@ -395,6 +395,82 @@ static void runHttpsToSameSiteHttpExplicitRedirect(bool useSiteIsolation)
 }
 TEST_WITH_AND_WITHOUT_SITE_ISOLATION(HttpsToSameSiteHttpExplicitRedirect)
 
+static void runHttpsOnlyExplicitlyBypassedWithHttpRedirect(bool useSiteIsolation)
+{
+    HTTPServer plaintextServer({
+        { "http://site.example/secure"_s, { { }, "hi: not secure"_s } },
+        { "http://site2.example/secure2"_s, { { }, "hi: not secure"_s } },
+        { "http://site2.example/secure3"_s, { { }, "hi: not secure"_s } },
+    }, HTTPServer::Protocol::Http);
+
+    HTTPServer secureServer({
+        { "/secure"_s, { 302, {{ "Location"_s, "http://site.example/secure"_s }}, "redirecting..."_s } },
+        { "/secure2"_s, { 302, {{ "Location"_s, "http://site2.example/secure3"_s }}, "redirecting..."_s } },
+        { "/secure3"_s, { 302, {{ "Location"_s, "http://site2.example/secure2"_s }}, "redirecting..."_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto webView = enhancedSecurityTestConfiguration(&plaintextServer, &secureServer, useSiteIsolation);
+
+    __block int errorCode { 0 };
+    __block bool finishedSuccessfully { false };
+    __block int loadCount { 0 };
+
+    RetainPtr<TestNavigationDelegate> delegate = adoptNS([webView navigationDelegate]);
+    delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^completionHandler)(WKNavigationActionPolicy)) {
+        ++loadCount;
+        completionHandler(WKNavigationActionPolicyAllow);
+    };
+
+    delegate.get().didFinishNavigation = ^(WKWebView *, WKNavigation *) {
+        finishedSuccessfully = true;
+    };
+
+    delegate.get().didFailProvisionalNavigation = ^(WKWebView *, WKNavigation *, NSError *error) {
+        EXPECT_NULL(error);
+        if (error)
+            errorCode = error.code;
+    };
+
+    [webView configuration].defaultWebpagePreferences._networkConnectionIntegrityPolicy = _WKWebsiteNetworkConnectionIntegrityPolicyHTTPSOnly | _WKWebsiteNetworkConnectionIntegrityPolicyHTTPSOnlyExplicitlyBypassedForDomain;
+
+    errorCode = 0;
+    finishedSuccessfully = false;
+    loadCount = 0;
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://site.example/secure"]]];
+    TestWebKitAPI::Util::run(&finishedSuccessfully);
+
+    EXPECT_EQ(errorCode, 0);
+    EXPECT_TRUE(finishedSuccessfully);
+    EXPECT_EQ(loadCount, 2);
+    EXPECT_WK_STREQ(@"http://site.example/secure", [webView URL].absoluteString);
+
+    errorCode = 0;
+    finishedSuccessfully = false;
+    loadCount = 0;
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://site.example/secure2"]]];
+    TestWebKitAPI::Util::run(&finishedSuccessfully);
+
+    EXPECT_EQ(errorCode, 0);
+    EXPECT_TRUE(finishedSuccessfully);
+    EXPECT_EQ(loadCount, 3);
+    EXPECT_WK_STREQ(@"http://site2.example/secure2", [webView URL].absoluteString);
+
+    // Now use a different domain to the above to ensure a process swap happens,
+    // this ensures testing of an edge case in the HTTPS upgrade / same-site HTTP logic.
+    errorCode = 0;
+    finishedSuccessfully = false;
+    loadCount = 0;
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://different.example/secure2"]]];
+    TestWebKitAPI::Util::run(&finishedSuccessfully);
+
+    EXPECT_EQ(errorCode, 0);
+    EXPECT_TRUE(finishedSuccessfully);
+    EXPECT_EQ(loadCount, 3);
+    EXPECT_WK_STREQ(@"http://site2.example/secure2", [webView URL].absoluteString);
+}
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(HttpsOnlyExplicitlyBypassedWithHttpRedirect)
+
 // MARK: - Window Tests
 
 static void runHttpOpeningHttpsWindow(bool useSiteIsolation)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm
@@ -378,6 +378,23 @@ static void runCrossSiteHttpToHttpsRedirect(bool useSiteIsolation)
 }
 TEST_WITH_AND_WITHOUT_SITE_ISOLATION(CrossSiteHttpToHttpsRedirect)
 
+static void runHttpsToSameSiteHttpExplicitRedirect(bool useSiteIsolation)
+{
+    HTTPServer plaintextServer({
+        { "http://download/redirectTarget"_s, { "<script>alert('insecure-site')</script>"_s } },
+    });
+
+    HTTPServer secureServer({
+        { "/originalRequest"_s, { 302, { { "Location"_s, "http://download/redirectTarget"_s } }, emptyString() } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto webView = enhancedSecurityTestConfiguration(&plaintextServer, &secureServer, useSiteIsolation);
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"https://download/originalRequest", {
+        { "insecure-site"_s, ExpectedEnhancedSecurity::Enabled }
+    });
+}
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(HttpsToSameSiteHttpExplicitRedirect)
+
 // MARK: - Window Tests
 
 static void runHttpOpeningHttpsWindow(bool useSiteIsolation)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm
@@ -108,6 +108,23 @@ using namespace TestWebKitAPI;
 
 @end
 
+static uint64_t observerCallbacks;
+static RetainPtr<WKHTTPCookieStore> globalCookieStore;
+
+@interface EnhancedSecurityCookieObserver : NSObject<WKHTTPCookieStoreObserver>
+- (void)cookiesDidChangeInCookieStore:(WKHTTPCookieStore *)cookieStore;
+@end
+
+@implementation EnhancedSecurityCookieObserver
+
+- (void)cookiesDidChangeInCookieStore:(WKHTTPCookieStore *)cookieStore
+{
+    ASSERT_EQ(cookieStore, globalCookieStore.get());
+    ++observerCallbacks;
+}
+
+@end
+
 static void testAlertWithEnhancedSecurity(RetainPtr<TestUIDelegate> uiDelegate, String message, BOOL enhancedSecurityEnabled)
 {
     NSArray *result = [uiDelegate waitForAlertWithEnhancedSecurity];
@@ -1092,5 +1109,26 @@ static void runHttpThenNavigateToHttpsSiteWithCookiesViaAPIAndSeenOutsideEnhance
 }
 
 TEST_WITH_AND_WITHOUT_SITE_ISOLATION(HttpThenNavigateToHttpsSiteWithCookiesViaAPIAndSeenOutsideEnhancedSecurity)
+
+TEST(EnhancedSecurityPolicies, NonPersistentDataStoreCookieNotification)
+{
+    HTTPServer plaintextServer({
+        { "http://insecure.example.internal/"_s, {{{ "Set-Cookie"_s, "testkey=testvalue"_s }}, "<script>alert('insecure-site')</script>"_s }}
+    });
+
+    auto webView = enhancedSecurityTestConfiguration(&plaintextServer, nullptr, /* useSiteIsolation */ false, /* useNonPersistentStore */ true);
+
+    auto observer = adoptNS([EnhancedSecurityCookieObserver new]);
+    globalCookieStore = webView.get().configuration.websiteDataStore.httpCookieStore;
+    [globalCookieStore addObserver:observer.get()];
+
+    observerCallbacks = 0;
+
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"http://insecure.example.internal/", {
+        { "insecure-site"_s, ExpectedEnhancedSecurity::Enabled }
+    });
+
+    EXPECT_EQ(observerCallbacks, 1u);
+}
 
 #endif

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm
@@ -365,6 +365,25 @@ static void runHttpOpeningHttpsTargetSelf(bool useSiteIsolation)
 }
 TEST_WITH_AND_WITHOUT_SITE_ISOLATION(HttpOpeningHttpsTargetSelf)
 
+static void runHttpsOpeningHttp(bool useSiteIsolation)
+{
+    HTTPServer plaintextServer({
+        { "http://insecure.example.internal/"_s, { "<script>alert('opened-window'); alert(!!window.opener)</script>"_s } }
+    });
+
+    HTTPServer secureServer({
+        { "/"_s, { "<script>window.onload = function() { window.open('http://insecure.example.internal/'); }</script>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto webView = enhancedSecurityTestConfiguration(&plaintextServer, &secureServer, useSiteIsolation);
+
+    loadRequestAndCheckEnhancedSecurityAlerts(webView, @"https://secure.different.internal/", {
+        { "opened-window"_s, ExpectedEnhancedSecurity::Disabled },
+        { "false"_s, ExpectedEnhancedSecurity::Disabled }
+    });
+}
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(HttpsOpeningHttp)
+
 static void runHttpOpeningHttpsNoOpener(bool useSiteIsolation)
 {
     HTTPServer plaintextServer({

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm
@@ -559,9 +559,7 @@ static void runMultiHopThenBack(bool useSiteIsolation)
         { "tainted-https-site"_s, ExpectedEnhancedSecurity::Enabled }
     });
 }
-
-// FIXME: rdar://164474301 (Fix SiteIsolation compatibility with EnhancedSecurity feature)
-TEST_WITHOUT_SITE_ISOLATION(MultiHopThenBack)
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(MultiHopThenBack)
 
 static void runMultiHopThenBackJavascript(bool useSiteIsolation)
 {
@@ -590,9 +588,7 @@ static void runMultiHopThenBackJavascript(bool useSiteIsolation)
         { "tainted-https-site"_s, ExpectedEnhancedSecurity::Enabled }
     });
 }
-
-// FIXME: rdar://164474301 (Fix SiteIsolation compatibility with EnhancedSecurity feature)
-TEST_WITHOUT_SITE_ISOLATION(MultiHopThenBackJavascript)
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(MultiHopThenBackJavascript)
 
 static void runMultiHopThenBackToSecure(bool useSiteIsolation)
 {
@@ -851,8 +847,7 @@ static void runHttpRedirectsHttpsWithExplicitNavigationToMeaningfulSite(bool use
         { "location-redirected-site"_s, ExpectedEnhancedSecurity::Disabled }
     });
 }
-// FIXME: rdar://164474301 (Fix SiteIsolation compatibility with EnhancedSecurity feature)
-TEST_WITHOUT_SITE_ISOLATION(HttpRedirectsHttpsWithExplicitNavigationToMeaningfulSite)
+TEST_WITH_AND_WITHOUT_SITE_ISOLATION(HttpRedirectsHttpsWithExplicitNavigationToMeaningfulSite)
 
 static void runWindowOpenThenNavigateToMeaningfulSite(bool useSiteIsolation)
 {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm
@@ -28,6 +28,7 @@
 #import "HTTPServer.h"
 #import "PlatformUtilities.h"
 #import "Test.h"
+#import "TestCocoa.h"
 #import "TestNavigationDelegate.h"
 #import "TestUIDelegate.h"
 #import "TestWKWebView.h"
@@ -37,6 +38,7 @@
 #import <WebKit/WKFoundation.h>
 #import <WebKit/WKFrameInfoPrivate.h>
 #import <WebKit/WKHTTPCookieStorePrivate.h>
+#import <WebKit/WKHistoryDelegatePrivate.h>
 #import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKProcessPoolPrivate.h>
 #import <WebKit/WKWebViewConfigurationPrivate.h>
@@ -52,6 +54,7 @@
 #import <wtf/Assertions.h>
 #import <wtf/Function.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/text/MakeString.h>
 
 using namespace TestWebKitAPI;
 
@@ -121,6 +124,35 @@ static RetainPtr<WKHTTPCookieStore> globalCookieStore;
 {
     ASSERT_EQ(cookieStore, globalCookieStore.get());
     ++observerCallbacks;
+}
+
+@end
+
+@interface EnhancedSecurityHistoryDelegate : NSObject <WKHistoryDelegatePrivate> {
+    @public
+    RetainPtr<WKNavigationData> lastNavigationData;
+    RetainPtr<NSString> lastUpdatedTitle;
+    RetainPtr<NSURL> lastRedirectSource;
+    RetainPtr<NSURL> lastRedirectDestination;
+}
+@end
+
+@implementation EnhancedSecurityHistoryDelegate
+
+- (void)_webView:(WKWebView *)webView didNavigateWithNavigationData:(WKNavigationData *)navigationData
+{
+    lastNavigationData = navigationData;
+}
+
+- (void)_webView:(WKWebView *)webView didUpdateHistoryTitle:(NSString *)title forURL:(NSURL *)URL
+{
+    lastUpdatedTitle = title;
+}
+
+- (void)_webView:(WKWebView *)webView didPerformServerRedirectFromURL:(NSURL *)sourceURL toURL:(NSURL *)destinationURL
+{
+    lastRedirectSource = sourceURL;
+    lastRedirectDestination = destinationURL;
 }
 
 @end
@@ -1129,6 +1161,54 @@ TEST(EnhancedSecurityPolicies, NonPersistentDataStoreCookieNotification)
     });
 
     EXPECT_EQ(observerCallbacks, 1u);
+}
+
+TEST(EnhancedSecurityPolicies, HistoryEventsUseCorrectOriginalRequest)
+{
+    TestWebKitAPI::HTTPServer plaintextServer({
+        { "http://example.internal/"_s, { "<head><title>Page Title</title></head><body><script>alert('first-page')</script></body>"_s } },
+        { "http://example.internal/server_redirect_source"_s, { 301, { { "Location"_s, "server_redirect_destination"_s } } } },
+        { "http://example.internal/server_redirect_destination"_s, { "<head><title>Target Page</title></head><body><script>alert('target-page')</script></body>"_s } },
+    });
+
+    auto webView = enhancedSecurityTestConfiguration(&plaintextServer, nullptr, /* useSiteIsolation */ false, /* useNonPersistentStore */ false);
+
+    RetainPtr historyDelegate = adoptNS([[EnhancedSecurityHistoryDelegate alloc] init]);
+    [webView _setHistoryDelegate:historyDelegate.get()];
+
+    auto mainURL = "http://example.internal/"_s;
+    RetainPtr url = adoptNS([[NSURL alloc] initWithString:mainURL.createNSString().get()]);
+    RetainPtr request = adoptNS([[NSURLRequest alloc] initWithURL:url.get()]);
+
+    runActionAndCheckEnhancedSecurityAlerts(webView, [webView, request] {
+        [webView loadRequest:request.get()];
+    }, { { "first-page"_s, ExpectedEnhancedSecurity::Enabled } });
+
+    TestWebKitAPI::Util::waitFor([&] {
+        return historyDelegate->lastNavigationData && historyDelegate->lastUpdatedTitle;
+    });
+
+    EXPECT_NS_EQUAL([historyDelegate->lastNavigationData originalRequest], request.get());
+    EXPECT_NS_EQUAL([historyDelegate->lastNavigationData originalRequest].URL, url.get());
+    EXPECT_NS_EQUAL(historyDelegate->lastUpdatedTitle.get(), @"Page Title");
+
+    auto sourceURL = "http://example.internal/server_redirect_source"_s;
+    auto destinationURL = "http://example.internal/server_redirect_destination"_s;
+    url = adoptNS([[NSURL alloc] initWithString:sourceURL.createNSString().get()]);
+    request = adoptNS([[NSURLRequest alloc] initWithURL:url.get()]);
+
+    runActionAndCheckEnhancedSecurityAlerts(webView, [webView, request] {
+        [webView loadRequest:request.get()];
+    }, { { "target-page"_s, ExpectedEnhancedSecurity::Enabled } });
+
+    TestWebKitAPI::Util::spinRunLoop();
+
+    TestWebKitAPI::Util::waitFor([&] {
+        return historyDelegate->lastRedirectSource && historyDelegate->lastRedirectDestination;
+    });
+
+    EXPECT_WK_STREQ([historyDelegate->lastRedirectSource absoluteString], sourceURL);
+    EXPECT_WK_STREQ([historyDelegate->lastRedirectDestination absoluteString], destinationURL);
 }
 
 #endif

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm
@@ -2636,13 +2636,14 @@ TEST(WKNavigation, HTTPSFirstWithHTTPRedirect)
     didFailNavigation = false;
     loadCount = 0;
 
-    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://site.example/secure2"]]];
+    // Encourage a process swap to ensure consistency of the test with and without Enhanced Security enabled
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://different.example/secure2"]]];
     TestWebKitAPI::Util::run(&finishedSuccessfully);
 
     EXPECT_EQ(errorCode, 0);
     EXPECT_FALSE(didFailNavigation);
-    EXPECT_EQ(loadCount, 23);
-    EXPECT_WK_STREQ(@"http://site2.example/secure3", [webView URL].absoluteString);
+    EXPECT_EQ(loadCount, 22);
+    EXPECT_WK_STREQ(@"http://site2.example/secure2", [webView URL].absoluteString);
 }
 
 TEST(WKNavigation, DISABLED_PreferredHTTPSPolicyAutomaticHTTPFallbackRedirectNo3SecondTimeout)
@@ -3698,13 +3699,14 @@ TEST(WKNavigation, PreferredHTTPSPolicyAutomaticHTTPFallbackWithHTTPRedirect)
     didFailNavigation = false;
     loadCount = 0;
 
-    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://site.example/secure2"]]];
+    // Encourage a process swap to ensure consistency of the test with and without Enhanced Security enabled
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://different.example/secure2"]]];
     TestWebKitAPI::Util::run(&finishedSuccessfully);
 
     EXPECT_EQ(errorCode, 0);
     EXPECT_FALSE(didFailNavigation);
-    EXPECT_EQ(loadCount, 23);
-    EXPECT_WK_STREQ(@"http://site2.example/secure3", [webView URL].absoluteString);
+    EXPECT_EQ(loadCount, 22);
+    EXPECT_WK_STREQ(@"http://site2.example/secure2", [webView URL].absoluteString);
 }
 
 TEST(WKNavigation, PreferredHTTPSPolicyNoFallbackRedirectNoHTTPDowngradeRedirect)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
@@ -3982,7 +3982,7 @@ TEST(SiteIsolation, MainFrameRedirectBetweenExistingProcesses)
     EXPECT_EQ([[webView objectByEvaluatingJavaScript:@"window.length"] intValue], 1);
     auto pidBefore = [webView _webProcessIdentifier];
 
-    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"http://webkit.org/webkit_redirect"]]];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://webkit.org/webkit_redirect"]]];
     [navigationDelegate waitForDidFinishNavigation];
     EXPECT_EQ([[webView objectByEvaluatingJavaScript:@"window.length"] intValue], 0);
     EXPECT_EQ([webView _webProcessIdentifier], pidBefore);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm
@@ -30,6 +30,8 @@
 #import "HTTPServer.h"
 #import "TestNavigationDelegate.h"
 #import "WebExtensionUtilities.h"
+#import <WebKit/WKPreferencesPrivate.h>
+#import <WebKit/_WKFeature.h>
 #import <WebKit/_WKWebExtensionDeclarativeNetRequestRule.h>
 #import <WebKit/_WKWebExtensionDeclarativeNetRequestTranslator.h>
 
@@ -776,7 +778,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, RemoveDynamicRules)
     Util::loadAndRunExtension(declarativeNetRequestManifest, @{ @"background.js": backgroundScript  });
 }
 
-TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRule)
+static void runRedirectRule(bool useEnhancedSecurity)
 {
     auto *pageScript = Util::constructScript(@[
         @"<script>",
@@ -840,7 +842,18 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRule)
         @"rules.json": rules
     };
 
-    auto manager = Util::loadExtension(manifest, resources);
+    auto extensionConfiguration = WKWebExtensionControllerConfiguration.nonPersistentConfiguration;
+
+    if (useEnhancedSecurity) {
+        auto preferences = [extensionConfiguration.webViewConfiguration preferences];
+        for (_WKFeature *feature in [WKPreferences _features]) {
+            if ([feature.key isEqualToString:@"EnhancedSecurityHeuristicsEnabled"])
+                [preferences _setEnabled:YES forFeature:feature];
+        }
+    }
+
+    auto manager = Util::loadExtension(manifest, resources, extensionConfiguration, /* usesEnhancedSecurity */ useEnhancedSecurity);
+
     auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
     navigationDelegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *navigationAction, void (^decisionHandler)(WKNavigationActionPolicy)) {
         decisionHandler(WKNavigationActionPolicyAllow);
@@ -858,6 +871,16 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRule)
     [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
+}
+
+TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRule)
+{
+    runRedirectRule(/* useEnhancedSecurity */ false);
+}
+
+TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRuleWithEnhancedSecurity)
+{
+    runRedirectRule(/* useEnhancedSecurity */ true);
 }
 
 TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRuleWithoutHostAccessPermission)

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
@@ -42,6 +42,7 @@
 
 - (instancetype)initForExtension:(WKWebExtension *)extension;
 - (instancetype)initForExtension:(WKWebExtension *)extension extensionControllerConfiguration:(WKWebExtensionControllerConfiguration *)configuration;
+- (instancetype)initForExtension:(WKWebExtension *)extension extensionControllerConfiguration:(WKWebExtensionControllerConfiguration *)configuration usesEnhancedSecurity:(BOOL)usesEnhancedSecurity;
 
 @property (nonatomic, strong) WKWebExtension *extension;
 @property (nonatomic, strong) WKWebExtensionContext *context;
@@ -110,7 +111,8 @@
 
 @interface TestWebExtensionWindow : NSObject <WKWebExtensionWindow>
 
-- (instancetype)initWithExtensionController:(WKWebExtensionController *)extensionController usesPrivateBrowsing:(BOOL)usesPrivateBrowsing NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithExtensionController:(WKWebExtensionController *)extensionController usesPrivateBrowsing:(BOOL)usesPrivateBrowsing;
+- (instancetype)initWithExtensionController:(WKWebExtensionController *)extensionController usesPrivateBrowsing:(BOOL)usesPrivateBrowsing usesEnhancedSecurity:(BOOL)usesEnhancedSecurity NS_DESIGNATED_INITIALIZER;
 
 @property (nonatomic, copy) NSArray<TestWebExtensionTab *> *tabs;
 @property (nonatomic, strong) TestWebExtensionTab *activeTab;
@@ -133,6 +135,7 @@
 @property (nonatomic) CGRect screenFrame;
 
 @property (nonatomic, readonly, getter=isUsingPrivateBrowsing) BOOL usingPrivateBrowsing;
+@property (nonatomic, readonly, getter=isUsingEnhancedSecurity) BOOL usingEnhancedSecurity;
 
 @property (nonatomic, copy) void (^didFocus)(void);
 @property (nonatomic, copy) void (^didClose)(void);
@@ -163,8 +166,8 @@ void performWithAppearance(Appearance, void (^block)(void));
 
 #endif
 
-RetainPtr<TestWebExtensionManager> parseExtension(NSDictionary *manifest, NSDictionary *resources, WKWebExtensionControllerConfiguration * = nil);
-RetainPtr<TestWebExtensionManager> loadExtension(NSDictionary *manifest, NSDictionary *resources, WKWebExtensionControllerConfiguration * = nil);
+RetainPtr<TestWebExtensionManager> parseExtension(NSDictionary *manifest, NSDictionary *resources, WKWebExtensionControllerConfiguration * = nil, BOOL usesEnhancedSecurity = NO);
+RetainPtr<TestWebExtensionManager> loadExtension(NSDictionary *manifest, NSDictionary *resources, WKWebExtensionControllerConfiguration * = nil, BOOL usesEnhancedSecurity = NO);
 void loadAndRunExtension(NSDictionary *manifest, NSDictionary *resources, WKWebExtensionControllerConfiguration * = nil);
 
 } // namespace TestWebKitAPI::Util


### PR DESCRIPTION
#### 0b65af3cbc223819f451d7a659a8edb593c386c0
<pre>
Test enabling EnhancedSecurityHeuristics flag by default.

Reviewed by NOBODY (OOPS!).

Enables the EnhancedSecurityHeuristics flag by default, testing for
results across EWS.

No new tests (OOPS!).

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
</pre>
----------------------------------------------------------------------
#### 0793c39a3cd697bc860faa801af4e1ed1828a1b7
<pre>
Fix DeclarativeNetRequest cross-site redirect issue with Enhanced Security
<a href="https://bugs.webkit.org/show_bug.cgi?id=305405">https://bugs.webkit.org/show_bug.cgi?id=305405</a>
<a href="https://rdar.apple.com/168079499">rdar://168079499</a>

Reviewed by NOBODY (OOPS!).

When enabling the EnhancedSecurityHeuristics flag, the following test began
to fail:

* WKWebExtensionAPIDeclarativeNetRequest.RedirectRule

This test performs a cross-site redirect from localhost -&gt; 127.0.0.1 via
a web extension using the DeclarativeNetRequest API, which is handled
within the WebContent proecss. When such a redirect occurs, the WebContent
process opts to perform a new load and cancel the existing load.

When Enhanced Security is enabled, this cross-site redirect occurs in the
newly selected Enhanced Security process, which is only alive due to this
provisional load. When the current provisional load is cleared, to perform
the new navigation policy check, the UI process decides that our WebContent
process can be torn down now.

This change handles this case by marking the new FrameLoadRequest as being
related to such a ContentRuleList cross-site redirect. Then, when we clear
the current provisional load and send the DidFailProvisionalLoad message
to the UI process, we can check if this is a Cancellation error, and that
it was due to such a cross-site redirect, and if so, indicate to the UI
process that we will be handling this load failure internally. This is a
similar mechanism to how HTTPS upgrade fallbacks are handled.

Testing this is quite difficult - the only case I&apos;ve managed to reliably
produce this is by using the extension API and having Enhanced Security
enabled. Rather than duplicating this into EnhancedSecurityPolicies, I&apos;ve
added some plumbing that allows us to enable the EnhancedSecurityHeuristics
flag in the TestWebExtensionManager related code, and we now test this
RedirectRule test both with and without EnhancedSecurityHeuristics.

Tests: Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm
       Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
       Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm

* Source/WebCore/loader/FrameLoadRequest.h:
(WebCore::FrameLoadRequestBase::isCrossOriginContentRuleListRedirect const):
(WebCore::FrameLoadRequestBase::setIsCrossOriginContentRuleListRedirect):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::load):
(WebCore::FrameLoader::checkLoadCompleteForThisFrame):
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::requestResource):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm:
(TestWebKitAPI::runRedirectRule):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRule)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRuleWithEnhancedSecurity)):
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h:
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm:
(-[TestWebExtensionManager initForExtension:extensionControllerConfiguration:]):
(-[TestWebExtensionManager initForExtension:extensionControllerConfiguration:usesEnhancedSecurity:]):
(-[TestWebExtensionTab initWithWindow:extensionController:]):
(-[TestWebExtensionWindow initWithExtensionController:usesPrivateBrowsing:]):
(-[TestWebExtensionWindow initWithExtensionController:usesPrivateBrowsing:usesEnhancedSecurity:]):
(TestWebKitAPI::Util::parseExtension):
(TestWebKitAPI::Util::loadExtension):
</pre>
----------------------------------------------------------------------
#### bb99280f3c9640691030f08176941304281b5b67
<pre>
Fix HTTPSOnly behaviour when PSON occurs
<a href="https://bugs.webkit.org/show_bug.cgi?id=305385">https://bugs.webkit.org/show_bug.cgi?id=305385</a>
<a href="https://rdar.apple.com/168062302">rdar://168062302</a>

Reviewed by NOBODY (OOPS!).

The WKNavigation.HTTPSOnlyWithHTTPRedirect failed when enabling
the EnhancedSecurityHeuristics flag by default.

Investigating this uncovered a slight issue in the HTTPS upgrade /
same-site HTTP upgrade prevention logic which can also occur outside of
the EnhancedSecurityHeuristics being enabled.

The attached change to the HTTPSOnlyWithHTTPRedirect test shows this,
which ensures we do a process swap for the initial load, rather than on
the first redirect.  Without this, we do a proces swap on the redirect,
and the original request site that is used in upgradeRequestAfterRedirection
is the newly redirected site - at which point we decide not to attempt
a HTTPS upgrade because this is a same site HTTPS -&gt; HTTP redirect.

The issue appears to be that on a PSON, the original URL used in
updateRequestAfterRedirection always remains as the initial load site,
which prevents our HTTPS -&gt; HTTP same-site logic from stopping the HTTPS
upgrade, which results in a continuous loop of this request until it
caps out at the max redirects count.

This fix adds another parameter to updateRequestAfterRedirection which
tracks the last redirect URL and uses this when determining if a HTTPS
upgrade should occur. The original preRedirectURL is still required as
this is later used for reporting CSP violations.

The HTTPSOnlyWithHTTPRedirect test is modified to now test this PSON
case, as well as standardise behaviour between EnhancedSecurityHeuristics
flag being enabled or disabled.

Another test is added to EnhancedSecurityPolicies, which ensures this
HTTPSOnly behaviour is always tested with Enhanced Security:

* HttpsOnlyExplicitlyBypassedWithHttpRedirect

Tests: Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm
       Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm

* Source/WebCore/loader/SubresourceLoader.cpp:
(WebCore::SubresourceLoader::willSendRequestInternal):
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::updateRequestAfterRedirection):
* Source/WebCore/loader/cache/CachedResourceLoader.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm:
(runHttpsOnlyExplicitlyBypassedWithHttpRedirect):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm:
(TEST(WKNavigation, HTTPSOnlyWithHTTPRedirect)):
</pre>
----------------------------------------------------------------------
#### 235bad81f375dc2dfc4259c40705968d8320ac81
<pre>
Fix ContentRuleList HTTPS upgrade behaviour with Enhanced Security
<a href="https://bugs.webkit.org/show_bug.cgi?id=305379">https://bugs.webkit.org/show_bug.cgi?id=305379</a>
<a href="https://rdar.apple.com/168058731">rdar://168058731</a>

Reviewed by NOBODY (OOPS!).

When the Enhanced Security heuristics flag is enabled by default, a test
failure occurred in:

  * WebKit.RedirectToPlaintextHTTPSUpgrade

This test ensures that a HTTPS site performing a same-site redirect to
plaintext HTTP does not get upgraded by the ContentRuleList rules, as this
is an explicit HTTP redirect.

When the Enhanced Security heuristics flag is enabled, the redirect to the
HTTP site causes us to process swap and load this in an Enhanced Security
process. In doing so, we change the load code path taken and lost information
that this explicit redirect had occurred.

To address this, this change explicitly checks for us having continued the
load due to a navigation policy change, and uses the original request URL,
if different, when processing the ContentRuleList for this load.

We also now have an explicit test that checks this case.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm

* Source/WebCore/loader/DocumentLoader.h:
(WebCore::DocumentLoader::isContinuingLoadAfterNavigationPolicyDecision const):
(WebCore::DocumentLoader::setIsContinuingLoadAfterNavigationPolicyDecision):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::load):
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::requestResource):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm:
(runHttpsToSameSiteHttpExplicitRedirect):
</pre>
----------------------------------------------------------------------
#### dc4ffe077473836d25b5ed0e0efa1101450cfadf
<pre>
Fix History events original request tracking in Enhanced Security
<a href="https://bugs.webkit.org/show_bug.cgi?id=305376">https://bugs.webkit.org/show_bug.cgi?id=305376</a>
<a href="https://rdar.apple.com/168056407">rdar://168056407</a>

Reviewed by NOBODY (OOPS!).

Addresses the following test failures when Enhanced Security Heuristics
are enabled:

    * HistoryDelegate.PersistentDataStoreSendsHistoryEvents
    * HistoryDelegate.NonpersistentDataStoreSendsHistoryEventsWhenAllowingPrivacySensitiveOperations

The issue here relates to having begun to load a request in the regular
WebContent process, before navigation policy decisions decide to switch
to an Enhanced Security process.

When this occurs, we do a new loadRequest call on the ProvisionalPageProxy
via continueNavigationInNewProcess. This, however, uses the ResourceRequest
from the Navigation object that was passed to decidePolicyForNavigationAction,
which has already been mutated by the original WebContent process. When
this is then passed to the new Enhanced Security process, this is treated
as the original ResourceRequest and used for reporting history events,
leading to the failing test.

Instead, we now pass through the original ResourceRequest if we are doing
a continuing load from such a policy decision, and use this as the original
request when creating the DocumentLoader in the new Enhanced Security
process.

Some minor header refactoring was also required as ResourceRequest.h now
becomes a necessary include in LocalFrameLoaderClient.h, which triggered
some build issues on Linux and Windows platforms. Removing BlobData.h
was feasible and prevented many other header includes that caused the
build issue.

Added a new test (HistoryEventsUseCorrectOriginalRequest) that ensures
this behaviour is tested without the flag needing to be enabled by default.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm

* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::DocumentLoader):
* Source/WebCore/loader/DocumentLoader.h:
(WebCore::DocumentLoader::create):
* Source/WebCore/loader/EmptyClients.cpp:
(WebCore::EmptyFrameLoaderClient::createDocumentLoader):
* Source/WebCore/loader/EmptyFrameLoaderClient.h:
* Source/WebCore/loader/FrameLoadRequest.h:
(WebCore::FrameLoadRequest::setOriginalResourceRequest):
(WebCore::FrameLoadRequest::hasOriginalResourceRequest):
(WebCore::FrameLoadRequest::takeOriginalResourceRequest):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::load):
* Source/WebCore/loader/LocalFrameLoaderClient.h:
* Source/WebCore/platform/network/FormData.h:
* Source/WebCore/platform/network/ResourceRequestBase.h:
* Source/WebCore/platform/network/curl/CurlFormDataStream.cpp:
* Source/WebKit/Shared/LoadParameters.h:
* Source/WebKit/Shared/LoadParameters.serialization.in:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::loadRequestWithNavigationShared):
* Source/WebKit/WebProcess/Storage/RemoteWorkerFrameLoaderClient.cpp:
(WebKit::RemoteWorkerFrameLoaderClient::createDocumentLoader):
* Source/WebKit/WebProcess/Storage/RemoteWorkerFrameLoaderClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::createDocumentLoader):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::loadRequest):
(WebKit::WebPage::createDocumentLoader):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm:
(WebFrameLoaderClient::createDocumentLoader):
* Source/WebKitLegacy/mac/WebView/WebDocumentLoaderMac.h:
(WebDocumentLoaderMac::create):
* Source/WebKitLegacy/mac/WebView/WebDocumentLoaderMac.mm:
(WebDocumentLoaderMac::WebDocumentLoaderMac):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm:
(-[EnhancedSecurityHistoryDelegate _webView:didNavigateWithNavigationData:]):
(-[EnhancedSecurityHistoryDelegate _webView:didUpdateHistoryTitle:forURL:]):
(-[EnhancedSecurityHistoryDelegate _webView:didPerformServerRedirectFromURL:toURL:]):
(TEST(EnhancedSecurityPolicies, HistoryEventsUseCorrectOriginalRequest)):
</pre>
----------------------------------------------------------------------
#### b9dd8520f6029446de08e397c0887b42b613f79d
<pre>
Workaround Cookie observer issues with Enhanced Security heuristics
<a href="https://bugs.webkit.org/show_bug.cgi?id=305331">https://bugs.webkit.org/show_bug.cgi?id=305331</a>
<a href="https://rdar.apple.com/167988684">rdar://167988684</a>

Reviewed by NOBODY (OOPS!).

A bug exists in CFNetwork which can cause our notification registration
for cookie changes to be unregistered. This occurs when a
NSHTTPCookieStorage object is destroyed, particularly when a
non-persistent website data store is used.

When the Enhanced Security heuristics flag is enabled, we perform a
hasCookies call to check for cookies more regularly, which surfaces this
bug more frequently. This change applies a temporary workaround that
re-registers for cookie notifications, if required, after a call to
hasCookies.

A new test is also added that ensures this behaviour is tested for.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm

* Source/WebCore/platform/network/cocoa/CookieStorageObserver.h:
* Source/WebCore/platform/network/cocoa/CookieStorageObserver.mm:
(WebCore::CookieStorageObserver::startObserving):
(WebCore::CookieStorageObserver::registerInternalsForNotifications):
* Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm:
(WebCore::NetworkStorageSession::hasCookies const):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm:
(-[EnhancedSecurityCookieObserver cookiesDidChangeInCookieStore:]):
(TEST(EnhancedSecurityPolicies, NonPersistentDataStoreCookieNotification)):
</pre>
----------------------------------------------------------------------
#### f5d7b3bbe54d32adbdbca4fcfedcfa07a0bf440a
<pre>
Fix Site Isolation compatibility with Enhanced Security
<a href="https://bugs.webkit.org/show_bug.cgi?id=305328">https://bugs.webkit.org/show_bug.cgi?id=305328</a>
<a href="https://rdar.apple.com/164474301">rdar://164474301</a>

Reviewed by NOBODY (OOPS!).

With the introduction of Enhanced Security, it is now possible for a
BrowsingContextGroup to contain multiple processes for a given site if their
Enhanced Security requirement differs. This triggered an assertion when site
isolation was enabled as it expects the process map in a BrowsingContextGroup
to only contain a single process for any given site.

Instead, we now need to track the required Enhanced Security state of the
process when inspecting / modifying the process map.

This also adjusts the MainFrameRedirectBetweenExistingProcesses test to
use HTTPS instead of HTTP, as using HTTP affects the test behaviour when
the Enhanced Security heuristics flag is enabled as it performs more
process swapping.

This change allows re-enabling various tests in EnhancedSecurityPolicies
with site isolation enabled, which previously would fail.

The MainFrameRedirectBetweenExistingProcesses test in SiteIsolation was
also adjusted to not rely on a HTTP load, as otherwise the Enhanced
Security swap due to HTTP complicates test behaviour.

Tests: Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm
       Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm

* Source/WebKit/UIProcess/BrowsingContextGroup.cpp:
(WebKit::BrowsingContextGroup::sharedProcessForSite):
(WebKit::BrowsingContextGroup::ensureProcessForSite):
(WebKit::BrowsingContextGroup::processForSite):
(WebKit::BrowsingContextGroup::addFrameProcessAndInjectPageContextIf):
(WebKit::BrowsingContextGroup::removeFrameProcess):
(WebKit::BrowsingContextGroup::addPage):
* Source/WebKit/UIProcess/BrowsingContextGroup.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::launchProcess):
(WebKit::WebPageProxy::processForSite):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::processForNavigation):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, MainFrameRedirectBetweenExistingProcesses)):
</pre>
----------------------------------------------------------------------
#### 2f47c41b50601b5f9cec0ccca46db1fbba5620dc
<pre>
Fix WKNavigation tests when Enhanced Security is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=305325">https://bugs.webkit.org/show_bug.cgi?id=305325</a>
<a href="https://rdar.apple.com/167982762">rdar://167982762</a>

Reviewed by NOBODY (OOPS!).

When the EnhancedSecurityHeuristics flag is enabled, the following two
tests in WKNavigation fail:

  * HTTPSFirstWithHTTPRedirect
  * PreferredHTTSPolicyAutomaticHTTPFallbackWithHTTPRedirect

These have specific results which expect a particular load count and final
URL. However, these have an underlying reliance on the initial load
re-using a WebContent process, then a PSON occurring when we get the
cross-site redirect. This is because we previously have loaded the same
site as the initial request.

Removing the initial load to site.example showcases this by hitting the
same assertion failure. With Enhanced Security heuristics enabled, we&apos;ll
perform a process swap earlier and so hit this same failure case.

To make test behaviour consistent, with or without the Enhanced Security
heuristics flag, this test fix simply ensures the second browse is to a
different site than the initial browse, standardising the process
swapping behaviour.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm:
(TEST(WKNavigation, HTTPSFirstWithHTTPRedirect)):
(TEST(WKNavigation, PreferredHTTPSPolicyAutomaticHTTPFallbackWithHTTPRedirect)):
</pre>
----------------------------------------------------------------------
#### 1159c1c95ebf5d3f1e9a9462e7b72806d204890a
<pre>
Ignore delayed hasStorageForCurrentSite callbacks for Enhanced Security
<a href="https://bugs.webkit.org/show_bug.cgi?id=305319">https://bugs.webkit.org/show_bug.cgi?id=305319</a>
<a href="https://rdar.apple.com/167979248">rdar://167979248</a>

Reviewed by NOBODY (OOPS!).

The following test fails when the Enhanced Security heuristics flag
is enabled by default:

  * WKBackForwardList.BackForwardNavigationSkipsItemsWithoutUserGestureFragment

This appears to relate to our local storage / cookie check callback,
which occurs in the background for a navigation when the heuristics flag
is enabled. This checks if the site being navigated to has cookies or
local storage set.

If the callback is delayed, it looks like we can hit our assertion that
the URL being checked does not match the current navigation URL. Instead,
we should ignore the callback in this case as it is now irrelevant.

No new test as this fixes occassional failures in existing test behaviour.

* Source/WebKit/UIProcess/API/APINavigation.cpp:
(API::Navigation::setHasStorageForCurrentSite):
</pre>
----------------------------------------------------------------------
#### df86629cff345f5c75ee3b8ca44f8b1499ae8450
<pre>
Fix opener relationship behaviour with Enhanced Security
<a href="https://bugs.webkit.org/show_bug.cgi?id=305317">https://bugs.webkit.org/show_bug.cgi?id=305317</a>
<a href="https://rdar.apple.com/167971340">rdar://167971340</a>

Reviewed by NOBODY (OOPS!).

We cannot make an EnhancedSecurity state change when we have an opener
relationship, as we do not have the ability to maintain the opener
relationship across process boundaries until site isolation is present.

Therefore, we should not change EnhancedSecurity state when a navigation
requires an opener relationship, as otherwise a process swap will have to
occur to accommodate the change in state.

This change applies this behaviour, which fixes the following tests when
the Enhanced Security heuristics flag is enabled by default:

  * AdvancedPrivacyProtections.DoNotHideReferrerInPopupWindow
  * SOAuthorizationPopUp.InterceptionSucceedCloseByItself
  * SOAuthorizationPopUp.InterceptionSucceedCloseByParent
  * SOAuthorizationPopUp.InterceptionSucceedCloseByWebKit
  * SOAuthorizationPopUp.InterceptionSucceedNewWindowNavigation
  * SOAuthorizationPopUp.InterceptionSucceedSuppressActiveSession
  * SOAuthorizationPopUp.InterceptionSucceedTwice
  * SOAuthorizationPopUp.InterceptionSucceedWithCookie
  * SOAuthorizationPopUp.SOAuthorizationLoadPolicyAllowAsync
  * WKWebExtensionAPIDevTools.PortMessagePassingFromPanelToBackground

An additional test is also added that ensures correct behaviour with and
without site isolation:

  * EnhancedSecurityPolicies.HttpsOpeningHttp

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm
* Source/WebKit/UIProcess/EnhancedSecurityTracking.cpp:
(WebKit::EnhancedSecurityTracking::trackNavigation):
* Source/WebKit/UIProcess/EnhancedSecurityTracking.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm:
(runHttpsOpeningHttp):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b65af3cbc223819f451d7a659a8edb593c386c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138794 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11160 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/276 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146911 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91769 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e4dbea44-98c6-403c-9a5c-fa5ccba0d493) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140667 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11864 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11315 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106207 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77503 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141741 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8949 "Found 55 new test failures: http/tests/site-isolation/basic-iframe-render-output.html http/tests/site-isolation/basic-iframe.html http/tests/site-isolation/basic-transparent-iframe.html http/tests/site-isolation/cross-site-window-open-uses-different-process.html http/tests/site-isolation/document-access.html http/tests/site-isolation/domwindow-length-with-remote-frames.html http/tests/site-isolation/double-iframe.html http/tests/site-isolation/draw-after-cross-origin-navigation.html http/tests/site-isolation/focus-click-navigation-activeElement.html http/tests/site-isolation/frame-index.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124377 "Found 149 new API test failures: TestWebKitAPI.SiteIsolation.FindStringMatchCount, TestWebKitAPI.SiteIsolation.CanGoBackAfterNavigatingFrameCrossOrigin, TestWebKitAPI.SiteIsolation.ProtocolProcessSeparation, TestWebKitAPI.SiteIsolation.PasteGIF, TestWebKitAPI.SiteIsolation.CrossOriginOpenerPolicyMainFrame, TestWebKitAPI.SiteIsolation.CancelNavigationResponseCleansUpProvisionalFrame, TestWebKitAPI.SiteIsolation.IframeWithPrompt, TestWebKitAPI.SiteIsolation.DragSourceEndedAtCoordinateTransformation, TestWebKitAPI.SiteIsolation.SandboxFlags, TestWebKitAPI.SiteIsolation.NavigateIframeSameOriginBackForward ... (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87077 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c104fb62-b9a6-4e25-a9e1-f559735ca3f1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8528 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6293 "Found 145 new API test failures: TestWebKitAPI.SiteIsolation.FindStringMatchCount, TestWebKitAPI.SiteIsolation.CanGoBackAfterNavigatingFrameCrossOrigin, TestWebKitAPI.SiteIsolation.ProtocolProcessSeparation, TestWebKitAPI.SiteIsolation.PasteGIF, TestWebKitAPI.SiteIsolation.CrossOriginOpenerPolicyMainFrame, TestWebKitAPI.SiteIsolation.CancelNavigationResponseCleansUpProvisionalFrame, TestWebKitAPI.SiteIsolation.IframeWithPrompt, TestWebKitAPI.SiteIsolation.DragSourceEndedAtCoordinateTransformation, TestWebKitAPI.SiteIsolation.SandboxFlags, TestWebKitAPI.SiteIsolation.NavigateIframeSameOriginBackForward ... (failure)") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7209 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/130765 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117972 "Found 138 new API test failures: TestWebKitAPI.SiteIsolation.FindStringMatchCount, TestWebKitAPI.SiteIsolation.CanGoBackAfterNavigatingFrameCrossOrigin, TestWebKitAPI.SiteIsolation.FindStringInFrameAndReplaceIOS, TestWebKitAPI.SiteIsolation.ProtocolProcessSeparation, TestWebKitAPI.iOSMouseSupport.FractionalCoordinatesInScaledIFrameCrossOrigin, TestWebKitAPI.SiteIsolation.CrossOriginOpenerPolicyMainFrame, TestWebKitAPI.SiteIsolation.CancelNavigationResponseCleansUpProvisionalFrame, TestWebKitAPI.SiteIsolation.FindStringNestedFramesOrderIOS, TestWebKitAPI.SiteIsolation.IframeWithPrompt, TestWebKitAPI.SiteIsolation.SandboxFlags ... (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/234 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149669 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/137396 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10842 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/234 "Found 60 new test failures: compositing/shared-backing/backing-sharing-compositing-change.html fast/forms/datalist/data-list-search-input-with-appearance-none.html fast/media/mq-invalid-media-feature-03.html http/tests/contentextensions/cross-origin-content-rules.html http/tests/performance/performance-resource-timing-cross-origin-media.html http/tests/privateClickMeasurement/multiple-app-bundle-ids.html http/tests/resourceLoadStatistics/log-cross-site-load-with-link-decoration.html http/tests/site-isolation/accessibility/hit-test-resolving-remote-frame.html http/tests/site-isolation/accessibility/hit-test-returns-remote-frame.html http/tests/site-isolation/accessibility/remote-element-returned.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114594 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10860 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9166 "Found 60 new test failures: http/tests/contentextensions/cross-origin-content-rules.html http/tests/security/referrer-policy-header-empty.html http/tests/site-isolation/accessibility/hit-test-resolving-remote-frame.html http/tests/site-isolation/accessibility/hit-test-returns-remote-frame.html http/tests/site-isolation/accessibility/remote-element-returned.html http/tests/site-isolation/basic-iframe-render-output.html http/tests/site-isolation/basic-iframe.html http/tests/site-isolation/basic-transparent-iframe.html http/tests/site-isolation/compositing/iframes/iframe-content-flipping.html http/tests/site-isolation/compositing/iframes/iframe-scrolling-change.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114935 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8810 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120689 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/65737 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10890 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/231 "Found 60 new test failures: fast/box-decoration-break/box-decoration-break-rendering.html fast/forms/datalist/data-list-search-input-with-appearance-none.html http/tests/contentextensions/cross-origin-content-rules.html http/tests/inspector/network/intercept-request-subresource-with-response-error-status-code.html http/tests/site-isolation/accessibility/hit-test-resolving-remote-frame.html http/tests/site-isolation/accessibility/hit-test-returns-remote-frame.html http/tests/site-isolation/accessibility/remote-element-returned.html http/tests/site-isolation/basic-iframe-render-output.html http/tests/site-isolation/basic-iframe.html http/tests/site-isolation/basic-transparent-iframe.html ... (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/170067 "Built successfully") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10888 "Failed to checkout and rebase branch from PR 56550") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74531 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44322 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10829 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10679 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->