### PR TITLE
Mutation with ruby containing block-in-inline hits nullptr

### DIFF
--- a/LayoutTests/fast/ruby/ruby-block-in-inline-crash-expected.txt
+++ b/LayoutTests/fast/ruby/ruby-block-in-inline-crash-expected.txt
@@ -1,0 +1,2 @@
+This test passes if it doesn't crash.
+

--- a/LayoutTests/fast/ruby/ruby-block-in-inline-crash.html
+++ b/LayoutTests/fast/ruby/ruby-block-in-inline-crash.html
@@ -1,0 +1,20 @@
+<style>
+:last-child { display: grid; }
+</style>
+<script>
+window.testRunner?.dumpAsText();
+
+let n0 = document.documentElement;
+let n1 = document.createElement('ruby');
+n0.appendChild(n1);
+let n3 = document.createElement('rtc');
+n1.append(n3);
+let n8 = document.createElement('ruby');
+n1.append(n8);
+let n14 = document.createElement('span');
+n3.after(n14);
+let n16 = document.createElement('rt');
+n1.append(n16);
+n0.offsetLeft;
+n14.after("This test passes if it doesn't crash.");
+</script>

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderRuby.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderRuby.cpp
@@ -83,8 +83,11 @@ RenderElement& RenderTreeBuilder::Ruby::findOrCreateParentForStyleBasedRubyChild
                 ASSERT(first->style().display() == DisplayType::Ruby);
                 break;
             }
-            if (first->style().display() == DisplayType::Ruby)
+            if (first->style().display() == DisplayType::Ruby) {
+                if (beforeChild && !beforeChild->isDescendantOf(first.get()))
+                    beforeChild = nullptr;
                 return downcast<RenderElement>(*first);
+            }
         }
     }
 


### PR DESCRIPTION
#### 638eb211482df718b006d050483e3df63ef3da53
<pre>
Mutation with ruby containing block-in-inline hits nullptr
<a href="https://bugs.webkit.org/show_bug.cgi?id=305462">https://bugs.webkit.org/show_bug.cgi?id=305462</a>
<a href="https://rdar.apple.com/167840436">rdar://167840436</a>

Reviewed by Alan Baradlay.

One path of Ruby::findOrCreateParentForStyleBasedRubyChild fails to update beforeChild for the new parent and it
ends up outside the parent subtree. This breaks assumptions elsewhere and causes a nullptr crash.

Test: fast/ruby/ruby-block-in-inline-crash.html
* LayoutTests/fast/ruby/ruby-block-in-inline-crash-expected.txt: Added.
* LayoutTests/fast/ruby/ruby-block-in-inline-crash.html: Added.
* Source/WebCore/rendering/updating/RenderTreeBuilderRuby.cpp:
(WebCore::RenderTreeBuilder::Ruby::findOrCreateParentForStyleBasedRubyChild):

Fix by clearing beforeChild when needed.

Canonical link: <a href="https://commits.webkit.org/305571@main">https://commits.webkit.org/305571@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ebdc8dc20761cf39d6b4a3e24a6f99604d1b2be

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138795 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11161 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/277 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146912 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/91770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3711a4e4-4acc-4ebb-a1c5-edea2ded04d0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140668 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11865 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11316 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106208 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/91770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6b869c54-08c3-4f6c-8910-01a6be889896) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141742 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8950 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/124378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87078 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ba28e08c-7789-4280-ab2f-ee6e1fde9729) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8529 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6276 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7210 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117954 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/235 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149670 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10843 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/235 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114593 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10861 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9165 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114934 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29214 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8809 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120690 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65738 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10891 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/232 "Passed tests") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/10629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74532 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10830 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10680 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->