### PR TITLE
[WIP] Skip pure pseudo-element rules in some cases in collectMatchingRulesForListSlow()

### DIFF
--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -587,6 +587,20 @@ void ElementRuleCollector::collectMatchingRulesForListSlow(const RuleSet::RuleDa
         if (!ruleData.canMatchPseudoElement() && m_pseudoElementRequest)
             continue;
 
+        // Skip pure pseudo-element rules (like ::marker, ::backdrop) when not matching pseudo-elements.
+        // We still need to track the pseudo-element's existence for the element, but we can skip the
+        // expensive matching logic since they won't match the element itself anyway.
+        if (ruleData.subjectIsPurePseudoElement() && !m_pseudoElementRequest) {
+            auto& selector = ruleData.selector();
+            if (selector.match() == CSSSelector::Match::PseudoElement) {
+                if (auto pseudoElementType = CSSSelector::stylePseudoElementTypeFor(selector.pseudoElement())) {
+                    if (allPublicPseudoElementTypes.contains(*pseudoElementType))
+                        m_matchedPseudoElements.add(*pseudoElementType);
+                }
+            }
+            continue;
+        }
+
         if (m_selectorMatchingState && m_selectorMatchingState->selectorFilter.fastRejectSelector(ruleData.descendantSelectorIdentifierHashes()))
             continue;
 

--- a/Source/WebCore/style/RuleData.cpp
+++ b/Source/WebCore/style/RuleData.cpp
@@ -113,11 +113,71 @@ static inline PropertyAllowlist determinePropertyAllowlist(const CSSSelector& se
     return PropertyAllowlist::None;
 }
 
+// Returns true if the subject compound consists only of pseudo-elements
+// with no element-matching constraints (tag, class, id, attribute).
+// Example: "::marker" returns true, "div::before" returns false.
+static inline bool computeSubjectIsPurePseudoElement(const CSSSelector& selector)
+{
+    // Must start with a pseudo-element.
+    if (selector.match() != CSSSelector::Match::PseudoElement)
+        return false;
+
+    // UserAgentPart pseudo-elements (like ::-webkit-slider-thumb), ::part(), ::slotted(),
+    // and ::cue() match actual elements, not virtual pseudo-elements. They need to go through
+    // normal matching.
+    // ::before and ::after also need normal matching because their existence tracking via
+    // hasPseudoStyle() is critical for correct dynamic style updates (e.g., when stylesheets
+    // are enabled/disabled). The skip path can cause timing issues where pseudo-element types
+    // are added after setHasPseudoStyles() has already been called.
+    auto pseudoElement = selector.pseudoElement();
+    if (pseudoElement == CSSSelector::PseudoElement::UserAgentPart
+        || pseudoElement == CSSSelector::PseudoElement::UserAgentPartLegacyAlias
+        || pseudoElement == CSSSelector::PseudoElement::WebKitUnknown
+        || pseudoElement == CSSSelector::PseudoElement::Part
+        || pseudoElement == CSSSelector::PseudoElement::Slotted
+        || pseudoElement == CSSSelector::PseudoElement::Before
+        || pseudoElement == CSSSelector::PseudoElement::After
+#if ENABLE(VIDEO)
+        || pseudoElement == CSSSelector::PseudoElement::Cue
+#endif
+        ) {
+        return false;
+    }
+
+    // Walk the subject compound checking for element-matching selectors.
+    for (auto* currentSelector = &selector; currentSelector; currentSelector = currentSelector->precedingInComplexSelector()) {
+        switch (currentSelector->match()) {
+        case CSSSelector::Match::Tag:
+            // Universal (*) is OK, specific tag is not.
+            if (currentSelector->tagQName().localName() != starAtom())
+                return false;
+            break;
+        case CSSSelector::Match::Id:
+        case CSSSelector::Match::Class:
+            return false;
+        default:
+            break;
+        }
+
+        // Continue past pseudo-elements.
+        if (currentSelector->match() == CSSSelector::Match::PseudoElement)
+            continue;
+
+        // If there's a combinator, we've exited the subject compound and there are more
+        // selectors that need to be matched (ancestors, siblings, etc.). We can't skip matching.
+        if (currentSelector->relation() != CSSSelector::Relation::Subselector)
+            return false;
+    }
+
+    return true;
+}
+
 RuleData::RuleData(const StyleRule& styleRule, unsigned selectorIndex, unsigned selectorListIndex, unsigned position, IsStartingStyle isStartingStyle)
     : m_styleRuleWithSelectorIndex(&styleRule, static_cast<uint16_t>(selectorIndex))
     , m_selectorListIndex(selectorListIndex)
     , m_matchBasedOnRuleHash(enumToUnderlyingType(computeMatchBasedOnRuleHash(selector())))
     , m_canMatchPseudoElement(complexSelectorCanMatchPseudoElement(selector()))
+    , m_subjectIsPurePseudoElement(computeSubjectIsPurePseudoElement(selector()))
     , m_propertyAllowlist(enumToUnderlyingType(determinePropertyAllowlist(selector())))
     , m_isStartingStyle(enumToUnderlyingType(isStartingStyle))
     , m_isEnabled(true)

--- a/Source/WebCore/style/RuleData.h
+++ b/Source/WebCore/style/RuleData.h
@@ -62,6 +62,7 @@ public:
     unsigned selectorListIndex() const { return m_selectorListIndex; }
 
     bool canMatchPseudoElement() const { return m_canMatchPseudoElement; }
+    bool subjectIsPurePseudoElement() const { return m_subjectIsPurePseudoElement; }
     MatchBasedOnRuleHash matchBasedOnRuleHash() const { return static_cast<MatchBasedOnRuleHash>(m_matchBasedOnRuleHash); }
     unsigned linkMatchType() const { return m_linkMatchType; }
     void setLinkMatchType(unsigned value) { m_linkMatchType = value; }
@@ -80,6 +81,7 @@ private:
     unsigned m_selectorListIndex : 16;
     unsigned m_matchBasedOnRuleHash : 3;
     unsigned m_canMatchPseudoElement : 1;
+    unsigned m_subjectIsPurePseudoElement : 1;
     unsigned m_linkMatchType : 2; //  SelectorChecker::LinkMatchMask
     unsigned m_propertyAllowlist : 2;
     unsigned m_isStartingStyle : 1;


### PR DESCRIPTION
#### 2228530b5b9c73894fd746dfca4c810d23806ee9
<pre>
[WIP] Skip pure pseudo-element rules in some cases in collectMatchingRulesForListSlow()
<a href="https://bugs.webkit.org/show_bug.cgi?id=305465">https://bugs.webkit.org/show_bug.cgi?id=305465</a>

Reviewed by NOBODY (OOPS!).

Skip pure pseudo-element rules in ElementRuleCollector::collectMatchingRulesForListSlow()
when we are not matching pseudo elements.

* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::collectMatchingRulesForListSlow):
* Source/WebCore/style/RuleData.cpp:
(WebCore::Style::computeSubjectIsPurePseudoElement):
(WebCore::Style::RuleData::RuleData):
* Source/WebCore/style/RuleData.h:
(WebCore::Style::RuleData::subjectIsPurePseudoElement const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2228530b5b9c73894fd746dfca4c810d23806ee9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138996 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11363 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/483 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147115 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92023 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/435b8249-22a2-49ca-b625-2c57dc663d6a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140869 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12071 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11519 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77545 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9b40db8e-240e-46c9-8d58-62188bf86b42) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141943 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9116 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124509 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87261 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/df622a2a-9750-45d9-97e5-26cb2c319bf4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8677 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6436 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7416 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118117 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/407 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149901 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11048 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/413 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114779 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11066 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9340 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115098 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8984 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120858 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65950 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11094 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/390 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10831 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74744 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11034 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10882 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->