### PR TITLE
[WTF] Add test cases for `isPowerOfTwo`

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp
@@ -676,6 +676,21 @@ TEST(WTF, isIntegral)
     EXPECT_FALSE(WTF::isIntegral(std::numeric_limits<float>::quiet_NaN()));
 }
 
+TEST(WTF, isPowerOfTwo)
+{
+    for (size_t i = 0; i < 10000; ++i) {
+        if (i && !((i & (i - 1))))
+            EXPECT_TRUE(WTF::isPowerOfTwo(i));
+        else
+            EXPECT_FALSE(WTF::isPowerOfTwo(i));
+    }
+
+    // Even though std::numeric_limits<int64_t>::min() is a negative value,
+    // isPowerOfTwo expects true
+    constexpr size_t INT64_MIN_VALUE = static_cast<size_t>(std::numeric_limits<int64_t>::min());
+    EXPECT_TRUE(WTF::isPowerOfTwo<size_t>(INT64_MIN_VALUE));
+}
+
 TEST(WTF, negate)
 {
     auto expected_int8_t = WTF::negate<int8_t>(0);


### PR DESCRIPTION
#### d8deaa006843e82c66320f6e71f5c86f13b6f355
<pre>
[WTF] Add test cases for `isPowerOfTwo`
<a href="https://bugs.webkit.org/show_bug.cgi?id=305467">https://bugs.webkit.org/show_bug.cgi?id=305467</a>

Reviewed by NOBODY (OOPS!).

This patch adds test cases for `isPowerOfTwo`,
including `std::numeric_limits&lt;int64_t&gt;::min()`,
which is negative but expected to return true.

* Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp:
(TestWebKitAPI::TEST(WTF, isPowerOfTwo)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8deaa006843e82c66320f6e71f5c86f13b6f355

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138813 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11179 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/295 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146931 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91788 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140686 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11883 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11334 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106247 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77510 "6 flakes 2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141760 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8971 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124389 "Found 1 new API test failure: TestWebKitAPI.ContextMenuTests.ContextMenuElementInfoContainsQRCodePayloadString (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87116 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8552 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6336 "1 api test failed or timed out") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7230 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117981 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/250 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149715 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10861 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/255 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114633 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10879 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9191 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114949 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8823 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120704 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/65758 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10909 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/250 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10647 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10850 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10698 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->