### PR TITLE
Facebook video call web page is promoted to now playing info application

### DIFF
--- a/LayoutTests/fast/mediastream/now-playing-and-mediastream-2-expected.txt
+++ b/LayoutTests/fast/mediastream/now-playing-and-mediastream-2-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS HTMLMediaElement will not become the now playing info source if active media element is using media stream and mediaSession API is not used
+

--- a/LayoutTests/fast/mediastream/now-playing-and-mediastream-2.html
+++ b/LayoutTests/fast/mediastream/now-playing-and-mediastream-2.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="../../resources/testharness.js"></script>
+        <script src="../../resources/testharnessreport.js"></script>
+    </head>
+    <body>
+        <video id=video1 autoplay playsinline></video>
+        <video id=video2 autoplay playsinline></video>
+        <script>
+function waitFor(delay)
+{
+    return new Promise(resolve => setTimeout(resolve, delay));
+}
+
+async function waitForCriteria(test, criteria)
+{
+    let counter = 0;
+    while (!criteria() && ++counter < 100)
+        await waitFor(50);
+}
+
+promise_test(async test => {
+    if (!window.internals)
+        return;
+
+    assert_false(!!internals.nowPlayingState.uniqueIdentifier, "test0");
+
+    video1.srcObject = await navigator.mediaDevices.getUserMedia({ audio:true, video:true });
+    test.add_cleanup(() => video1.srcObject.getTracks().forEach(track => track.stop()));
+    await video1.play();
+
+    await waitFor(500);
+    assert_false(!!internals.nowPlayingState.uniqueIdentifier, "test1");
+
+    video2.src = "../canvas/webgl/resources/red-green.mp4";
+    await video2.play();
+    video2.pause();
+
+    await waitFor(500);
+    assert_false(!!internals.nowPlayingState.uniqueIdentifier, "test2");
+
+    navigator.mediaSession.metadata = new MediaMetadata({ title: "test" });
+    await waitForCriteria(test, () => !!internals.nowPlayingState.uniqueIdentifier);
+    assert_true(!!internals.nowPlayingState.uniqueIdentifier, "test3");
+
+    navigator.mediaSession.metadata = null;
+    await waitForCriteria(test, () => !internals.nowPlayingState.uniqueIdentifier);
+    assert_false(!!internals.nowPlayingState.uniqueIdentifier, "test4");
+
+    navigator.mediaSession.setActionHandler("pause", () => { });
+    await waitForCriteria(test, () => !!internals.nowPlayingState.uniqueIdentifier);
+    assert_true(!!internals.nowPlayingState.uniqueIdentifier, "test5");
+
+    navigator.mediaSession.setActionHandler("pause", null);
+    await waitForCriteria(test, () => !internals.nowPlayingState.uniqueIdentifier);
+    assert_false(!!internals.nowPlayingState.uniqueIdentifier, "test6");
+}, "HTMLMediaElement will not become the now playing info source if active media element is using media stream and mediaSession API is not used");
+
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
#### 54b3bb5bb0669034734b7bf49a584693165945b7
<pre>
Facebook video call web page is promoted to now playing info application
<a href="https://rdar.apple.com/168095616">rdar://168095616</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=305469">https://bugs.webkit.org/show_bug.cgi?id=305469</a>

Reviewed by Eric Carlson.

Facebook video call web page is using media elements to play some sounds (change of devices, user entering the call...).
But most video elements are playing MediaStream objects, including the active media element.

We decide to not promote a web page in case its active media element is using a srcObject and MediaSession callbacks are not registered.

Manually tested on Facebook video call web page and with added test.

Canonical link: <a href="https://commits.webkit.org/305865@main">https://commits.webkit.org/305865@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b48224b8754a93f78752abfb6f427fbadccd4d3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138812 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11178 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/300 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146930 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91787 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1407686b-dbed-4796-8235-084c7a1e5088) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140685 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11882 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11333 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106246 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77509 "2 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bbe1d48c-46f4-4ff8-b584-67ceac6e1e52) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141759 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8970 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124390 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87115 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1e961db4-fec5-433b-b549-1531f51ffad3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8551 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6298 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7229 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117980 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/251 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149714 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10860 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/256 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114632 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10883 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9189 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114948 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29374 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8828 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120705 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65757 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10908 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/251 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10646 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74562 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10849 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10697 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->