### PR TITLE
Ignore delayed hasStorageForCurrentSite callbacks for Enhanced Security

### DIFF
--- a/Source/WebKit/UIProcess/API/APINavigation.cpp
+++ b/Source/WebKit/UIProcess/API/APINavigation.cpp
@@ -210,9 +210,8 @@ WTF::String Navigation::loggingString() const
 #endif
 
 
-void Navigation::setHasStorageForCurrentSite(const WTF::URL& url, bool hasStorageForCurrentSite)
+void Navigation::setHasStorageForCurrentSite(bool hasStorageForCurrentSite)
 {
-    ASSERT_UNUSED(url, url == m_currentRequest.url());
     m_hasStorageForCurrentSite = hasStorageForCurrentSite;
 }
 

--- a/Source/WebKit/UIProcess/API/APINavigation.h
+++ b/Source/WebKit/UIProcess/API/APINavigation.h
@@ -199,7 +199,7 @@ public:
 
     void setPendingSharedProcess(WebKit::FrameProcess&);
 
-    void setHasStorageForCurrentSite(const WTF::URL&, bool);
+    void setHasStorageForCurrentSite(bool);
     bool hasStorageForCurrentSite() const { return m_hasStorageForCurrentSite; }
 
 private:

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -16717,8 +16717,10 @@ void WebPageProxy::waitForInitialLinkDecorationFilteringData(WebFramePolicyListe
 void WebPageProxy::beginSiteHasStorageCheck(const URL& url, API::Navigation& navigation, WebFramePolicyListenerProxy& listener)
 {
     protectedWebsiteDataStore()->hasLocalStorageOrCookies(url, [navigation = Ref { navigation }, url, listener = Ref { listener }] (bool hasStorage) mutable {
-        navigation->setHasStorageForCurrentSite(url, hasStorage);
-        listener->didReceiveSiteHasStorageResults();
+        if (url == navigation->currentRequest().url()) {
+            navigation->setHasStorageForCurrentSite(hasStorage);
+            listener->didReceiveSiteHasStorageResults();
+        }
     });
 }
 


### PR DESCRIPTION
#### d47ac2b838c137ce990e1bb3f31a546bd8e49478
<pre>
Ignore delayed hasStorageForCurrentSite callbacks for Enhanced Security
<a href="https://bugs.webkit.org/show_bug.cgi?id=305319">https://bugs.webkit.org/show_bug.cgi?id=305319</a>
<a href="https://rdar.apple.com/167979248">rdar://167979248</a>

Reviewed by Per Arne Vollan.

The following test fails when the Enhanced Security heuristics flag
is enabled by default:

  * WKBackForwardList.BackForwardNavigationSkipsItemsWithoutUserGestureFragment

This appears to relate to our local storage / cookie check callback,
which occurs in the background for a navigation when the heuristics flag
is enabled. This checks if the site being navigated to has cookies or
local storage set.

If the callback is delayed, it looks like we can hit our assertion that
the URL being checked does not match the current navigation URL. Instead,
we should ignore the callback in this case as it is now irrelevant.

No new test as this fixes occasional failures in existing test behaviour.

* Source/WebKit/UIProcess/API/APINavigation.cpp:
(API::Navigation::setHasStorageForCurrentSite):

Canonical link: <a href="https://commits.webkit.org/305905@main">https://commits.webkit.org/305905@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d45dc4f36fc089734e427265bd60cd13fad0823

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139717 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12093 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1221 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147855 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92785 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8541a628-e23d-4391-b745-ce7c2305eec3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12802 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12244 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106986 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92785 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4f001500-f949-4238-8fa6-8f39033c7f69) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142664 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9850 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125128 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87855 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/da8f94ba-15b6-4d4f-8784-75fbf44017b0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9511 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7028 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8144 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118734 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150637 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11778 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1180 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115390 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11792 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10086 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115704 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29398 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10463 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121607 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66783 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11822 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1090 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11562 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75500 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11758 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11609 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->