### PR TITLE
Fixed unretained local variable warnings in WebKitLegacy (part 2)

### DIFF
--- a/Source/WebKitLegacy/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebKitLegacy/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -1,5 +1,3 @@
-WebCoreSupport/SocketStreamHandleImplCFNet.cpp
-cf/WebCoreSupport/WebInspectorClientCF.cpp
 [ iOS ] ios/WebCoreSupport/WebChromeClientIOS.mm
 [ iOS ] ios/WebCoreSupport/WebFixedPositionContent.mm
 [ iOS ] ios/WebCoreSupport/WebFrameIOS.mm
@@ -8,85 +6,11 @@ cf/WebCoreSupport/WebInspectorClientCF.cpp
 [ iOS ] ios/WebView/WebPDFViewIOS.mm
 [ iOS ] ios/WebView/WebPDFViewPlaceholder.mm
 [ iOS ] ios/WebView/WebPlainWhiteView.mm
-mac/DOM/DOM.mm
-mac/DOM/DOMAbstractView.mm
-mac/DOM/DOMBlob.mm
-mac/DOM/DOMCSSRule.mm
-mac/DOM/DOMCSSRuleList.mm
-mac/DOM/DOMCSSStyleDeclaration.mm
-mac/DOM/DOMCSSValue.mm
-mac/DOM/DOMCounter.mm
-mac/DOM/DOMEvent.mm
-mac/DOM/DOMFileList.mm
-mac/DOM/DOMHTMLCollection.mm
-mac/DOM/DOMHTMLOptionsCollection.mm
-mac/DOM/DOMImplementation.mm
-mac/DOM/DOMInternal.mm
-mac/DOM/DOMMediaError.mm
-mac/DOM/DOMMediaList.mm
-mac/DOM/DOMNamedNodeMap.mm
-mac/DOM/DOMNode.mm
-mac/DOM/DOMNodeIterator.mm
-mac/DOM/DOMNodeList.mm
-mac/DOM/DOMRGBColor.mm
-mac/DOM/DOMRange.mm
-mac/DOM/DOMRect.mm
-mac/DOM/DOMStyleSheet.mm
-mac/DOM/DOMStyleSheetList.mm
-mac/DOM/DOMTimeRanges.mm
-mac/DOM/DOMTokenList.mm
-mac/DOM/DOMTreeWalker.mm
-mac/DOM/DOMXPath.mm
-mac/DOM/DOMXPathExpression.mm
-mac/DOM/DOMXPathResult.mm
-mac/DOM/ObjCEventListener.mm
-[ Mac ] mac/DefaultDelegates/WebDefaultContextMenuDelegate.mm
-mac/History/WebHistory.mm
-mac/History/WebHistoryItem.mm
-[ Mac ] mac/Misc/WebDownload.mm
-[ Mac ] mac/Misc/WebKitNSStringExtras.mm
-mac/Misc/WebLocalizableStrings.mm
-mac/Misc/WebNSFileManagerExtras.mm
-[ Mac ] mac/Misc/WebNSPasteboardExtras.mm
-mac/Misc/WebNSURLExtras.mm
 [ Mac ] mac/Misc/WebNSViewExtras.m
-[ Mac ] mac/Misc/WebSharingServicePickerController.mm
 [ Mac ] mac/Panels/WebAuthenticationPanel.m
 [ Mac ] mac/Panels/WebPanelAuthenticationHandler.m
-mac/Plugins/WebBasePluginPackage.mm
-[ Mac ] mac/Plugins/WebPluginController.mm
-mac/Plugins/WebPluginDatabase.mm
 [ iOS ] mac/Storage/WebDatabaseManager.mm
 [ iOS ] mac/Storage/WebDatabaseManagerClient.mm
-mac/Storage/WebStorageManager.mm
-[ Mac ] mac/WebCoreSupport/PopupMenuMac.mm
-mac/WebCoreSupport/WebChromeClient.mm
-[ Mac ] mac/WebCoreSupport/WebContextMenuClient.mm
-[ Mac ] mac/WebCoreSupport/WebDragClient.mm
-mac/WebCoreSupport/WebEditorClient.mm
-mac/WebCoreSupport/WebFrameLoaderClient.mm
-mac/WebCoreSupport/WebFrameNetworkingContext.mm
-[ Mac ] mac/WebCoreSupport/WebInspectorClient.mm
 [ iOS ] mac/WebCoreSupport/WebProgressTrackerClient.mm
-mac/WebCoreSupport/WebVisitedLinkStore.mm
-[ Mac ] mac/WebInspector/WebNodeHighlight.mm
 [ iOS ] mac/WebInspector/WebNodeHighlighter.mm
-mac/WebView/WebArchive.mm
-mac/WebView/WebDataSource.mm
-mac/WebView/WebDelegateImplementationCaching.mm
-[ Mac ] mac/WebView/WebDynamicScrollBarsView.mm
-mac/WebView/WebFrame.mm
-mac/WebView/WebFrameView.mm
 mac/WebView/WebHTMLView.mm
-[ Mac ] mac/WebView/WebImmediateActionController.mm
-mac/WebView/WebJSPDFDoc.mm
-[ Mac ] mac/WebView/WebPDFRepresentation.mm
-[ Mac ] mac/WebView/WebPDFView.mm
-mac/WebView/WebPreferences.mm
-mac/WebView/WebResource.mm
-mac/WebView/WebScriptDebugDelegate.mm
-mac/WebView/WebScriptDebugger.mm
-mac/WebView/WebScriptWorld.mm
-[ Mac ] mac/WebView/WebTextCompletionController.mm
-mac/WebView/WebView.mm
-mac/WebView/WebViewRenderingUpdateScheduler.mm

--- a/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImplCFNet.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImplCFNet.cpp
@@ -228,10 +228,10 @@ void SocketStreamHandleImpl::chooseProxyFromArray(CFArrayRef proxyArray)
 
     // PAC is always the first entry, if present.
     if (proxyArrayCount) {
-        if (auto proxyInfo = dynamic_cf_cast<CFDictionaryRef>(CFArrayGetValueAtIndex(proxyArray, 0))) {
-            if (auto proxyType = dynamic_cf_cast<CFStringRef>(CFDictionaryGetValue(proxyInfo, kCFProxyTypeKey)); proxyType && CFEqual(proxyType, kCFProxyTypeAutoConfigurationURL)) {
-                if (auto pacFileURL = dynamic_cf_cast<CFURLRef>(CFDictionaryGetValue(proxyInfo, kCFProxyAutoConfigurationURLKey))) {
-                    executePACFileURL(static_cast<CFURLRef>(pacFileURL));
+        if (RetainPtr proxyInfo = dynamic_cf_cast<CFDictionaryRef>(CFArrayGetValueAtIndex(proxyArray, 0))) {
+            if (RetainPtr proxyType = dynamic_cf_cast<CFStringRef>(CFDictionaryGetValue(proxyInfo.get(), kCFProxyTypeKey)); proxyType && CFEqual(proxyType.get(), kCFProxyTypeAutoConfigurationURL)) {
+                if (RetainPtr pacFileURL = dynamic_cf_cast<CFURLRef>(CFDictionaryGetValue(proxyInfo.get(), kCFProxyAutoConfigurationURLKey))) {
+                    executePACFileURL(static_cast<CFURLRef>(pacFileURL.get()));
                     return;
                 }
             }
@@ -240,16 +240,16 @@ void SocketStreamHandleImpl::chooseProxyFromArray(CFArrayRef proxyArray)
 
     CFDictionaryRef chosenProxy = nullptr;
     for (CFIndex i = 0; i < proxyArrayCount; ++i) {
-        if (auto proxyInfo = dynamic_cf_cast<CFDictionaryRef>(CFArrayGetValueAtIndex(proxyArray, i))) {
-            if (auto proxyType = dynamic_cf_cast<CFStringRef>(CFDictionaryGetValue(proxyInfo, kCFProxyTypeKey))) {
-                if (CFEqual(proxyType, kCFProxyTypeSOCKS)) {
+        if (RetainPtr proxyInfo = dynamic_cf_cast<CFDictionaryRef>(CFArrayGetValueAtIndex(proxyArray, i))) {
+            if (RetainPtr proxyType = dynamic_cf_cast<CFStringRef>(CFDictionaryGetValue(proxyInfo.get(), kCFProxyTypeKey))) {
+                if (CFEqual(proxyType.get(), kCFProxyTypeSOCKS)) {
                     m_connectionType = SOCKSProxy;
-                    chosenProxy = proxyInfo;
+                    chosenProxy = proxyInfo.get();
                     break;
                 }
-                if (CFEqual(proxyType, kCFProxyTypeHTTPS)) {
+                if (CFEqual(proxyType.get(), kCFProxyTypeHTTPS)) {
                     m_connectionType = CONNECTProxy;
-                    chosenProxy = proxyInfo;
+                    chosenProxy = proxyInfo.get();
                     // Keep looking for proxies, as a SOCKS one is preferable.
                 }
             }
@@ -260,12 +260,12 @@ void SocketStreamHandleImpl::chooseProxyFromArray(CFArrayRef proxyArray)
         ASSERT(m_connectionType != Unknown);
         ASSERT(m_connectionType != Direct);
 
-        auto proxyHost = dynamic_cf_cast<CFStringRef>(CFDictionaryGetValue(chosenProxy, kCFProxyHostNameKey));
-        auto proxyPort = dynamic_cf_cast<CFNumberRef>(CFDictionaryGetValue(chosenProxy, kCFProxyPortNumberKey));
+        RetainPtr proxyHost = dynamic_cf_cast<CFStringRef>(CFDictionaryGetValue(chosenProxy, kCFProxyHostNameKey));
+        RetainPtr proxyPort = dynamic_cf_cast<CFNumberRef>(CFDictionaryGetValue(chosenProxy, kCFProxyPortNumberKey));
 
         if (proxyHost && proxyPort) {
-            m_proxyHost = proxyHost;
-            m_proxyPort = proxyPort;
+            m_proxyHost = proxyHost.get();
+            m_proxyPort = proxyPort.get();
             return;
         }
     }

--- a/Source/WebKitLegacy/cf/WebCoreSupport/WebInspectorClientCF.cpp
+++ b/Source/WebKitLegacy/cf/WebCoreSupport/WebInspectorClientCF.cpp
@@ -44,8 +44,8 @@ static RetainPtr<CFStringRef> createKeyForPreferences(const String& key)
 static String loadSetting(const String& key)
 {
     auto value = adoptCF(CFPreferencesCopyAppValue(createKeyForPreferences(key).get(), kCFPreferencesCurrentApplication));
-    if (auto string = dynamic_cf_cast<CFStringRef>(value.get()))
-        return string;
+    if (RetainPtr string = dynamic_cf_cast<CFStringRef>(value.get()))
+        return string.get();
     if (value == kCFBooleanTrue)
         return "true"_s;
     if (value == kCFBooleanFalse)

--- a/Source/WebKitLegacy/mac/DOM/DOM.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOM.mm
@@ -179,10 +179,10 @@ static Class elementClass(const QualifiedName& tag, Class defaultClass)
 {
     if (!elementClassMap)
         createElementClassMap();
-    Class objcClass = lookupElementClass(tag);
+    RetainPtr<Class> objcClass = lookupElementClass(tag);
     if (!objcClass)
         objcClass = defaultClass;
-    return objcClass;
+    return objcClass.autorelease();
 }
 
 #if PLATFORM(IOS_FAMILY)
@@ -780,10 +780,10 @@ DOMNodeFilter *kit(WebCore::NodeFilter* impl)
 {
     if (!impl)
         return nil;
-    
-    if (DOMNodeFilter *wrapper = getDOMWrapper(impl))
-        return retainPtr(wrapper).autorelease();
-    
+
+    if (RetainPtr wrapper = getDOMWrapper(impl))
+        return wrapper.autorelease();
+
     auto wrapper = adoptNS([[DOMNodeFilter alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(impl);
     impl->ref();

--- a/Source/WebKitLegacy/mac/DOM/DOMAbstractView.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMAbstractView.mm
@@ -86,8 +86,8 @@ DOMAbstractView *kit(WebCore::LocalDOMWindow* value)
     auto* frame = value->frame();
     if (!frame)
         return nil;
-    if (DOMAbstractView *wrapper = getDOMWrapper(frame))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(frame))
+        return wrapper.autorelease();
     auto wrapper = adoptNS([[DOMAbstractView alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(frame);
     addDOMWrapper(wrapper.get(), frame);

--- a/Source/WebKitLegacy/mac/DOM/DOMBlob.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMBlob.mm
@@ -69,8 +69,8 @@ DOMBlob *kit(WebCore::Blob* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMBlob *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     auto wrapper = adoptNS([[DOMBlob alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(value);
     value->ref();

--- a/Source/WebKitLegacy/mac/DOM/DOMCSSRule.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMCSSRule.mm
@@ -90,8 +90,8 @@ DOMCSSRule *kit(WebCore::CSSRule* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMCSSRule *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     RetainPtr<DOMCSSRule> wrapper = adoptNS([[kitClass(value) alloc] _init]);
     if (!wrapper)
         return nil;

--- a/Source/WebKitLegacy/mac/DOM/DOMCSSRuleList.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMCSSRuleList.mm
@@ -71,8 +71,8 @@ DOMCSSRuleList *kit(WebCore::CSSRuleList* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMCSSRuleList *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     auto wrapper = adoptNS([[DOMCSSRuleList alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(value);
     value->ref();

--- a/Source/WebKitLegacy/mac/DOM/DOMCSSStyleDeclaration.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMCSSStyleDeclaration.mm
@@ -148,8 +148,8 @@ DOMCSSStyleDeclaration *kit(WebCore::CSSStyleDeclaration* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMCSSStyleDeclaration *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     auto wrapper = adoptNS([[DOMCSSStyleDeclaration alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(value);
     value->ref();

--- a/Source/WebKitLegacy/mac/DOM/DOMCSSValue.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMCSSValue.mm
@@ -75,8 +75,8 @@ DOMCSSValue *kit(WebCore::DeprecatedCSSOMValue* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMCSSValue *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     RetainPtr<DOMCSSValue> wrapper = adoptNS([[kitClass(value) alloc] _init]);
     if (!wrapper)
         return nil;

--- a/Source/WebKitLegacy/mac/DOM/DOMCounter.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMCounter.mm
@@ -75,8 +75,8 @@ DOMCounter *kit(WebCore::DeprecatedCSSOMCounter* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMCounter *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     auto wrapper = adoptNS([[DOMCounter alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(value);
     value->ref();

--- a/Source/WebKitLegacy/mac/DOM/DOMEvent.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMEvent.mm
@@ -187,8 +187,8 @@ DOMEvent *kit(WebCore::Event* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMEvent *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     RetainPtr<DOMEvent> wrapper = adoptNS([[kitClass(value) alloc] _init]);
     if (!wrapper)
         return nil;

--- a/Source/WebKitLegacy/mac/DOM/DOMFileList.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMFileList.mm
@@ -75,8 +75,8 @@ DOMFileList *kit(WebCore::FileList* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMFileList *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     auto wrapper = adoptNS([[DOMFileList alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(value);
     value->ref();

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLCollection.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLCollection.mm
@@ -87,8 +87,8 @@ DOMHTMLCollection *kit(WebCore::HTMLCollection* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMHTMLCollection *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     RetainPtr<DOMHTMLCollection> wrapper = adoptNS([[kitClass(value) alloc] _init]);
     if (!wrapper)
         return nil;

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLOptionsCollection.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLOptionsCollection.mm
@@ -111,8 +111,8 @@ DOMHTMLOptionsCollection *kit(WebCore::HTMLOptionsCollection* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMHTMLOptionsCollection *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     auto wrapper = adoptNS([[DOMHTMLOptionsCollection alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(value);
     value->ref();

--- a/Source/WebKitLegacy/mac/DOM/DOMImplementation.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMImplementation.mm
@@ -117,8 +117,8 @@ DOMImplementation *kit(WebCore::DOMImplementation* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMImplementation *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     auto wrapper = adoptNS([[DOMImplementation alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(value);
     value->ref();

--- a/Source/WebKitLegacy/mac/DOM/DOMInternal.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMInternal.mm
@@ -36,6 +36,7 @@
 #import <wtf/HashMap.h>
 #import <wtf/Lock.h>
 #import <wtf/NeverDestroyed.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 #if PLATFORM(IOS_FAMILY)
 #define NEEDS_WRAPPER_CACHE_LOCK 1
@@ -110,8 +111,8 @@ void removeDOMWrapper(DOMObjectInternal* impl)
     }
     
     // Extract the WebCore::Node from the ObjectiveC wrapper.
-    DOMNode *n = (DOMNode *)self;
-    WebCore::Node *nodeImpl = core(n);
+    RetainPtr n = dynamic_objc_cast<DOMNode>(self);
+    WebCore::Node *nodeImpl = core(n.get());
 
     // Dig up Interpreter and ExecState.
     auto* frame = nodeImpl->document().frame();

--- a/Source/WebKitLegacy/mac/DOM/DOMMediaError.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMMediaError.mm
@@ -68,8 +68,8 @@ DOMMediaError *kit(WebCore::MediaError* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMMediaError *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     auto wrapper = adoptNS([[DOMMediaError alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(value);
     value->ref();

--- a/Source/WebKitLegacy/mac/DOM/DOMMediaList.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMMediaList.mm
@@ -95,8 +95,8 @@ DOMMediaList *kit(WebCore::MediaList* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMMediaList *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     auto wrapper = adoptNS([[DOMMediaList alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(value);
     value->ref();

--- a/Source/WebKitLegacy/mac/DOM/DOMNamedNodeMap.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMNamedNodeMap.mm
@@ -124,8 +124,8 @@ DOMNamedNodeMap *kit(WebCore::NamedNodeMap* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMNamedNodeMap *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     auto wrapper = adoptNS([[DOMNamedNodeMap alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(value);
     value->ref();

--- a/Source/WebKitLegacy/mac/DOM/DOMNode.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMNode.mm
@@ -61,8 +61,8 @@ DOMNode *kit(Node* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMNode *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     RetainPtr<DOMNode> wrapper = adoptNS([[kitClass(value) alloc] _init]);
     if (!wrapper)
         return nil;

--- a/Source/WebKitLegacy/mac/DOM/DOMNodeIterator.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMNodeIterator.mm
@@ -126,8 +126,8 @@ DOMNodeIterator *kit(WebCore::NodeIterator* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMNodeIterator *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     auto wrapper = adoptNS([[DOMNodeIterator alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(value);
     value->ref();

--- a/Source/WebKitLegacy/mac/DOM/DOMNodeList.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMNodeList.mm
@@ -69,8 +69,8 @@ DOMNodeList *kit(WebCore::NodeList* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMNodeList *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     auto wrapper = adoptNS([[DOMNodeList alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(value);
     value->ref();

--- a/Source/WebKitLegacy/mac/DOM/DOMRGBColor.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMRGBColor.mm
@@ -103,8 +103,8 @@ DOMRGBColor *kit(WebCore::DeprecatedCSSOMRGBColor* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMRGBColor *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     auto wrapper = adoptNS([[DOMRGBColor alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(value);
     value->ref();

--- a/Source/WebKitLegacy/mac/DOM/DOMRange.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMRange.mm
@@ -304,8 +304,8 @@ DOMRange *kit(WebCore::Range* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMRange *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     auto wrapper = adoptNS([[DOMRange alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(value);
     value->ref();

--- a/Source/WebKitLegacy/mac/DOM/DOMRect.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMRect.mm
@@ -82,8 +82,8 @@ DOMRect *kit(WebCore::DeprecatedCSSOMRect* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMRect *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     auto wrapper = adoptNS([[DOMRect alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(value);
     value->ref();

--- a/Source/WebKitLegacy/mac/DOM/DOMStyleSheet.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMStyleSheet.mm
@@ -110,8 +110,8 @@ DOMStyleSheet *kit(WebCore::StyleSheet* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMStyleSheet *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     RetainPtr<DOMStyleSheet> wrapper = adoptNS([[kitClass(value) alloc] _init]);
     if (!wrapper)
         return nil;

--- a/Source/WebKitLegacy/mac/DOM/DOMStyleSheetList.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMStyleSheetList.mm
@@ -72,8 +72,8 @@ DOMStyleSheetList *kit(WebCore::StyleSheetList* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMStyleSheetList *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     auto wrapper = adoptNS([[DOMStyleSheetList alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(value);
     value->ref();

--- a/Source/WebKitLegacy/mac/DOM/DOMTimeRanges.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMTimeRanges.mm
@@ -79,8 +79,8 @@ DOMTimeRanges *kit(WebCore::TimeRanges* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMTimeRanges *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     auto wrapper = adoptNS([[DOMTimeRanges alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(value);
     value->ref();

--- a/Source/WebKitLegacy/mac/DOM/DOMTokenList.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMTokenList.mm
@@ -94,8 +94,8 @@ DOMTokenList *kit(WebCore::DOMTokenList* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMTokenList *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     auto wrapper = adoptNS([[DOMTokenList alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(value);
     value->ref();

--- a/Source/WebKitLegacy/mac/DOM/DOMTreeWalker.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMTreeWalker.mm
@@ -175,8 +175,8 @@ DOMTreeWalker *kit(WebCore::TreeWalker* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMTreeWalker *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     auto wrapper = adoptNS([[DOMTreeWalker alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(value);
     value->ref();

--- a/Source/WebKitLegacy/mac/DOM/DOMXPath.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMXPath.mm
@@ -62,8 +62,8 @@ DOMNativeXPathNSResolver *kit(WebCore::XPathNSResolver* impl)
     if (!impl)
         return nil;
     
-    if (DOMNativeXPathNSResolver *wrapper = getDOMWrapper(impl))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(impl))
+        return wrapper.autorelease();
     
     auto wrapper = adoptNS([[DOMNativeXPathNSResolver alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(impl);

--- a/Source/WebKitLegacy/mac/DOM/DOMXPathExpression.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMXPathExpression.mm
@@ -77,8 +77,8 @@ DOMXPathExpression *kit(WebCore::XPathExpression* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMXPathExpression *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     auto wrapper = adoptNS([[DOMXPathExpression alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(value);
     value->ref();

--- a/Source/WebKitLegacy/mac/DOM/DOMXPathResult.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMXPathResult.mm
@@ -117,8 +117,8 @@ DOMXPathResult *kit(WebCore::XPathResult* value)
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
         return nil;
-    if (DOMXPathResult *wrapper = getDOMWrapper(value))
-        return retainPtr(wrapper).autorelease();
+    if (RetainPtr wrapper = getDOMWrapper(value))
+        return wrapper.autorelease();
     auto wrapper = adoptNS([[DOMXPathResult alloc] _init]);
     wrapper->_internal = reinterpret_cast<DOMObjectInternal*>(value);
     value->ref();

--- a/Source/WebKitLegacy/mac/DOM/ObjCEventListener.mm
+++ b/Source/WebKitLegacy/mac/DOM/ObjCEventListener.mm
@@ -78,8 +78,8 @@ ObjCEventListener::~ObjCEventListener()
 
 void ObjCEventListener::handleEvent(ScriptExecutionContext&, Event& event)
 {
-    ObjCListener listener = m_listener.get();
-    [listener handleEvent:kit(&event)];
+    RetainPtr listener = m_listener.get();
+    [listener.get() handleEvent:kit(&event)];
 }
 
 bool ObjCEventListener::operator==(const EventListener& listener) const

--- a/Source/WebKitLegacy/mac/DefaultDelegates/WebDefaultContextMenuDelegate.mm
+++ b/Source/WebKitLegacy/mac/DefaultDelegates/WebDefaultContextMenuDelegate.mm
@@ -62,9 +62,9 @@
     [menuItem setTarget:target]; // can be nil
     [menuItem setRepresentedObject:representedObject];
     
-    NSString *title = nil;
+    RetainPtr<NSString> title;
     SEL action = NULL;
-    
+
     switch(tag) {
         case WebMenuItemTagCopy:
             title = UI_STRING_INTERNAL("Copy", "Copy context menu item");
@@ -106,7 +106,7 @@
     }
 
     if (title)
-        [menuItem setTitle:title];
+        [menuItem setTitle:title.get()];
 
     [menuItem setAction:action];
     

--- a/Source/WebKitLegacy/mac/History/WebHistory.mm
+++ b/Source/WebKitLegacy/mac/History/WebHistory.mm
@@ -228,11 +228,11 @@ static inline WebHistoryDateKey dateKey(NSTimeInterval date)
         return NO;
 
     DateToEntriesMap::iterator it = _entriesByDate->find(dateKey);
-    NSMutableArray *entriesForDate = it->value.get();
-    [entriesForDate removeObjectIdenticalTo:entry];
-    
+    RetainPtr<NSMutableArray> entriesForDate = it->value.get();
+    [entriesForDate.get() removeObjectIdenticalTo:entry];
+
     // remove this date entirely if there are no other entries on it
-    if ([entriesForDate count] == 0) {
+    if ([entriesForDate.get() count] == 0) {
         _entriesByDate->remove(it);
         // Clear _orderedLastVisitedDays so it will be regenerated when next requested.
         _orderedLastVisitedDays = nil;

--- a/Source/WebKitLegacy/mac/Misc/WebDownload.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebDownload.mm
@@ -132,9 +132,9 @@ using namespace WebCore;
 #if !PLATFORM(IOS_FAMILY)
     // Try previously stored credential first.
     if (![challenge previousFailureCount]) {
-        NSURLCredential *credential = NetworkStorageSessionMap::defaultStorageSession().credentialStorage().get(emptyString(), ProtectionSpace([challenge protectionSpace])).nsCredential();
+        RetainPtr credential = NetworkStorageSessionMap::defaultStorageSession().credentialStorage().get(emptyString(), ProtectionSpace([challenge protectionSpace])).nsCredential();
         if (credential) {
-            [[challenge sender] useCredential:credential forAuthenticationChallenge:challenge];
+            [[challenge sender] useCredential:credential.get() forAuthenticationChallenge:challenge];
             return;
         }
     }

--- a/Source/WebKitLegacy/mac/Misc/WebKitNSStringExtras.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebKitNSStringExtras.mm
@@ -77,19 +77,19 @@ static bool canUseFastRenderer(std::span<const UniChar> buffer)
         point.y = CGCeiling(point.y);
 
         NSGraphicsContext *nsContext = [NSGraphicsContext currentContext];
-        CGContextRef cgContext = [nsContext CGContext];
-        GraphicsContextCG graphicsContext { cgContext };
+        RetainPtr cgContext = [nsContext CGContext];
+        GraphicsContextCG graphicsContext { cgContext.get() };
 
         // WebCore requires a flipped graphics context.
         bool flipped = [nsContext isFlipped];
         if (!flipped)
-            CGContextScaleCTM(cgContext, 1, -1);
+            CGContextScaleCTM(cgContext.get(), 1, -1);
 
         graphicsContext.setFillColor(colorFromCocoaColor(textColor));
         webCoreFont.drawText(graphicsContext, run, FloatPoint(point.x, flipped ? point.y : -point.y));
 
         if (!flipped)
-            CGContextScaleCTM(cgContext, 1, -1);
+            CGContextScaleCTM(cgContext.get(), 1, -1);
     } else {
         // The given point is on the baseline.
         if ([[NSView focusView] isFlipped])

--- a/Source/WebKitLegacy/mac/Misc/WebLocalizableStrings.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebLocalizableStrings.mm
@@ -37,22 +37,22 @@ WebLocalizableStringsBundle WebKitLocalizableStringsBundle = { "com.apple.WebKit
 
 NSString *WebLocalizedString(WebLocalizableStringsBundle *stringsBundle, const char *key)
 {
-    NSBundle *bundle;
+    RetainPtr<NSBundle> bundle;
     if (stringsBundle == NULL) {
         static NeverDestroyed<RetainPtr<NSBundle>> mainBundle = [NSBundle mainBundle];
         ASSERT(mainBundle.get());
         bundle = mainBundle.get().get();
     } else {
         bundle = stringsBundle->bundle;
-        if (bundle == nil) {
+        if (!bundle) {
             bundle = [NSBundle bundleWithIdentifier:[NSString stringWithUTF8String:stringsBundle->identifier]];
             ASSERT(bundle);
-            stringsBundle->bundle = bundle;
+            stringsBundle->bundle = bundle.get();
         }
     }
     NSString *notFound = @"localized string not found";
     auto keyString = adoptCF(CFStringCreateWithCStringNoCopy(NULL, key, kCFStringEncodingUTF8, kCFAllocatorNull));
-    NSString *result = [bundle localizedStringForKey:(__bridge NSString *)keyString.get() value:notFound table:nil];
+    NSString *result = [bundle.get() localizedStringForKey:(__bridge NSString *)keyString.get() value:notFound table:nil];
     ASSERT_WITH_MESSAGE(result != notFound, "could not find localizable string %s in bundle", key);
     return result;
 }

--- a/Source/WebKitLegacy/mac/Misc/WebNSPasteboardExtras.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebNSPasteboardExtras.mm
@@ -199,18 +199,18 @@ static NSArray *writableTypesForImageWithArchive()
     // This image data is either the only subresource of an archive (HTML image case)
     // or the main resource (standalone image case).
     NSArray *subresources = [archive subresources];
-    WebResource *resource = [archive mainResource];
+    RetainPtr resource = [archive mainResource];
     if (containsImage && [subresources count] > 0) {
         WebResource *subresource = [subresources objectAtIndex:0];
         NSString *subresourceMIMEType = [subresource MIMEType];
         if (MIMETypeRegistry::isSupportedImageMIMEType(subresourceMIMEType) || MIMETypeRegistry::isPDFMIMEType(subresourceMIMEType))
             resource = subresource;
     }
-    ASSERT(resource != nil);
-    
-    ASSERT(!containsImage || MIMETypeRegistry::isSupportedImageMIMEType([resource MIMEType]) || MIMETypeRegistry::isPDFMIMEType([resource MIMEType]));
-    if (!containsImage || MIMETypeRegistry::isSupportedImageMIMEType([resource MIMEType]) || MIMETypeRegistry::isPDFMIMEType([resource MIMEType]))
-        [self _web_writeFileWrapperAsRTFDAttachment:[resource _fileWrapperRepresentation]];
+    ASSERT(resource);
+
+    ASSERT(!containsImage || MIMETypeRegistry::isSupportedImageMIMEType([resource.get() MIMEType]) || MIMETypeRegistry::isPDFMIMEType([resource.get() MIMEType]));
+    if (!containsImage || MIMETypeRegistry::isSupportedImageMIMEType([resource.get() MIMEType]) || MIMETypeRegistry::isPDFMIMEType([resource.get() MIMEType]))
+        [self _web_writeFileWrapperAsRTFDAttachment:[resource.get() _fileWrapperRepresentation]];
     
 }
 

--- a/Source/WebKitLegacy/mac/Misc/WebNSURLExtras.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebNSURLExtras.mm
@@ -138,13 +138,13 @@
 
 -(NSData *)_web_hostData
 {
-    NSData *result = WTF::dataForURLComponentType(self, kCFURLComponentHost);
+    RetainPtr result = WTF::dataForURLComponentType(self, kCFURLComponentHost);
 
     // Take off localhost for file.
     if ([result _web_isCaseInsensitiveEqualToCString:"localhost"] && [[self _web_schemeData] _web_isCaseInsensitiveEqualToCString:"file"])
         return nil;
 
-    return result;
+    return result.autorelease();
 }
 
 - (NSString *)_web_hostString

--- a/Source/WebKitLegacy/mac/Misc/WebSharingServicePickerController.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebSharingServicePickerController.mm
@@ -193,12 +193,12 @@ RetainPtr<NSImage> WebSharingServicePickerClient::imageForCurrentSharingServiceP
     if ([item isKindOfClass:[NSImage class]])
         [self didShareImageData:[item TIFFRepresentation] confirmDataIsValidTIFFData:NO];
     else if ([item isKindOfClass:[NSItemProvider class]]) {
-        NSItemProvider *itemProvider = (NSItemProvider *)item;
-        NSString *itemUTI = itemProvider.registeredTypeIdentifiers.firstObject;
+        RetainPtr itemProvider = (NSItemProvider *)item;
+        NSString *itemUTI = itemProvider.get().registeredTypeIdentifiers.firstObject;
 
         // FIXME: <rdar://165255055> Migrate from deprecated NSItemProvider APIs
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        [itemProvider loadItemForTypeIdentifier:itemUTI options:nil completionHandler:^(id receivedData, NSError *dataError) {
+        [itemProvider.get() loadItemForTypeIdentifier:itemUTI options:nil completionHandler:^(id receivedData, NSError *dataError) {
             if (!receivedData) {
                 LOG_ERROR("Did not receive data from NSItemProvider");
                 return;

--- a/Source/WebKitLegacy/mac/Plugins/WebBasePluginPackage.mm
+++ b/Source/WebKitLegacy/mac/Plugins/WebBasePluginPackage.mm
@@ -110,11 +110,11 @@ static constexpr auto QuickTimeCocoaPluginIdentifier = "com.apple.quicktime.webp
 
 - (id)_objectForInfoDictionaryKey:(NSString *)key
 {
-    CFDictionaryRef bundleInfoDictionary = CFBundleGetInfoDictionary(cfBundle.get());
+    RetainPtr bundleInfoDictionary = CFBundleGetInfoDictionary(cfBundle.get());
     if (!bundleInfoDictionary)
         return nil;
 
-    return (__bridge id)CFDictionaryGetValue(bundleInfoDictionary, (__bridge CFStringRef)key);
+    return (__bridge id)CFDictionaryGetValue(bundleInfoDictionary.get(), (__bridge CFStringRef)key);
 }
 
 - (BOOL)getPluginInfoFromPLists
@@ -155,17 +155,17 @@ static constexpr auto QuickTimeCocoaPluginIdentifier = "com.apple.quicktime.webp
         pluginInfo.mimes.append(mimeClassInfo);
     }
 
-    NSString *filename = [path.createNSString() lastPathComponent];
-    pluginInfo.file = filename;
+    RetainPtr filename = [path.createNSString() lastPathComponent];
+    pluginInfo.file = filename.get();
 
     NSString *theName = [self _objectForInfoDictionaryKey:WebPluginNameKey];
     if (!theName)
-        theName = filename;
+        theName = filename.get();
     pluginInfo.name = theName;
 
     NSString *description = [self _objectForInfoDictionaryKey:WebPluginDescriptionKey];
     if (!description)
-        description = filename;
+        description = filename.get();
     pluginInfo.desc = description;
 
     pluginInfo.isApplicationPlugin = false;
@@ -366,11 +366,11 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (String)bundleVersion
 {
-    auto infoDictionary = CFBundleGetInfoDictionary(cfBundle.get());
+    RetainPtr infoDictionary = CFBundleGetInfoDictionary(cfBundle.get());
     if (!infoDictionary)
         return String();
 
-    return dynamic_cf_cast<CFStringRef>(CFDictionaryGetValue(infoDictionary, kCFBundleVersionKey));
+    return dynamic_cf_cast<CFStringRef>(CFDictionaryGetValue(infoDictionary.get(), kCFBundleVersionKey));
 }
 
 @end

--- a/Source/WebKitLegacy/mac/Plugins/WebPluginController.mm
+++ b/Source/WebKitLegacy/mac/Plugins/WebPluginController.mm
@@ -60,6 +60,7 @@
 #import <WebCore/UserGestureIndicator.h>
 #import <WebCore/WebCoreURLResponse.h>
 #import <objc/runtime.h>
+#import <wtf/RetainPtr.h>
 #import <wtf/text/WTFString.h>
 
 #if PLATFORM(IOS_FAMILY)
@@ -616,12 +617,12 @@ static void installFlip4MacPlugInWorkaroundIfNecessary()
 {
     static bool hasInstalledFlip4MacPlugInWorkaround;
     if (!hasInstalledFlip4MacPlugInWorkaround) {
-        Class TSUpdateCheck = objc_lookUpClass("TSUpdateCheck");
+        RetainPtr<Class> TSUpdateCheck = objc_lookUpClass("TSUpdateCheck");
         if (!TSUpdateCheck)
             return;
 
 IGNORE_WARNINGS_BEGIN("undeclared-selector")
-        Method methodToPatch = class_getInstanceMethod(TSUpdateCheck, @selector(alertDidEnd:returnCode:contextInfo:));
+        Method methodToPatch = class_getInstanceMethod(TSUpdateCheck.get(), @selector(alertDidEnd:returnCode:contextInfo:));
 IGNORE_WARNINGS_END
         if (!methodToPatch)
             return;

--- a/Source/WebKitLegacy/mac/Plugins/WebPluginDatabase.mm
+++ b/Source/WebKitLegacy/mac/Plugins/WebPluginDatabase.mm
@@ -163,8 +163,8 @@ struct PluginPackageCandidates {
             candidates.update(plugin);
     }
     
-    WebBasePluginPackage *plugin = candidates.bestCandidate();
-    
+    RetainPtr plugin = candidates.bestCandidate();
+
     if (!plugin) {
         // If no plug-in was found from the extension, attempt to map from the extension to a MIME type
         // and find the a plug-in from the MIME type. This is done in case the plug-in has not fully specified
@@ -173,7 +173,7 @@ struct PluginPackageCandidates {
         if ([MIMEType length] > 0)
             plugin = [self pluginForMIMEType:MIMEType];
     }
-    return plugin;
+    return plugin.autorelease();
 }
 
 - (NSArray *)plugins

--- a/Source/WebKitLegacy/mac/Storage/WebStorageManager.mm
+++ b/Source/WebKitLegacy/mac/Storage/WebStorageManager.mm
@@ -100,8 +100,8 @@ NSString * const WebStorageDidModifyOriginNotification = @"WebStorageDidModifyOr
         NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
         RetainPtr<NSString> localStoragePath = [defaults objectForKey:WebStorageDirectoryDefaultsKey];
         if (!localStoragePath || ![localStoragePath isKindOfClass:[NSString class]]) {
-            NSArray *paths = NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES);
-            NSString *libraryDirectory = [paths objectAtIndex:0];
+            RetainPtr paths = NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES);
+            NSString *libraryDirectory = [paths.get() objectAtIndex:0];
             localStoragePath = [libraryDirectory stringByAppendingPathComponent:@"WebKit/LocalStorage"];
         }
         return [localStoragePath stringByStandardizingPath];

--- a/Source/WebKitLegacy/mac/WebCoreSupport/PopupMenuMac.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/PopupMenuMac.mm
@@ -143,11 +143,11 @@ void PopupMenuMac::show(const IntRect& r, LocalFrameView& frameView, int selecte
     if (selectedIndex == -1 && numItems == 2 && !checkedClient()->shouldPopOver() && ![[m_popup itemAtIndex:1] isEnabled])
         selectedIndex = 0;
 
-    NSView* view = frameView.documentView();
+    RetainPtr view = frameView.documentView();
 
     TextDirection textDirection = checkedClient()->menuStyle().textDirection();
 
-    [m_popup attachPopUpWithFrame:r inView:view];
+    [m_popup attachPopUpWithFrame:r inView:view.get()];
     [m_popup selectItemAtIndex:selectedIndex];
     [m_popup setUserInterfaceLayoutDirection:textDirection == TextDirection::LTR ? NSUserInterfaceLayoutDirectionLeftToRight : NSUserInterfaceLayoutDirectionRightToLeft];
 
@@ -155,7 +155,7 @@ void PopupMenuMac::show(const IntRect& r, LocalFrameView& frameView, int selecte
     [menu setUserInterfaceLayoutDirection:textDirection == TextDirection::LTR ? NSUserInterfaceLayoutDirectionLeftToRight : NSUserInterfaceLayoutDirectionRightToLeft];
 
     NSPoint location;
-    CTFontRef font = checkedClient()->menuStyle().font().primaryFont()->ctFont();
+    RetainPtr font = checkedClient()->menuStyle().font().primaryFont()->ctFont();
 
     // These values were borrowed from AppKit to match their placement of the menu.
     const int popOverHorizontalAdjust = -13;
@@ -167,8 +167,8 @@ void PopupMenuMac::show(const IntRect& r, LocalFrameView& frameView, int selecte
             titleFrame = r;
         float vertOffset = roundf((NSMaxY(r) - NSMaxY(titleFrame)) + NSHeight(titleFrame));
         // Adjust for fonts other than the system font.
-        auto defaultFont = adoptCF(CTFontCreateUIFontForLanguage(kCTFontUIFontSystem, CTFontGetSize(font), nil));
-        vertOffset += CTFontGetDescent(font) - CTFontGetDescent(defaultFont.get());
+        auto defaultFont = adoptCF(CTFontCreateUIFontForLanguage(kCTFontUIFontSystem, CTFontGetSize(font.get()), nil));
+        vertOffset += CTFontGetDescent(font.get()) - CTFontGetDescent(defaultFont.get());
         vertOffset = fminf(NSHeight(r), vertOffset);
         if (textDirection == TextDirection::LTR)
             location = NSMakePoint(NSMinX(r) + popOverHorizontalAdjust, NSMaxY(r) - vertOffset);
@@ -189,8 +189,8 @@ void PopupMenuMac::show(const IntRect& r, LocalFrameView& frameView, int selecte
 
     RetainPtr<NSView> dummyView = adoptNS([[NSView alloc] initWithFrame:r]);
     [dummyView.get() setUserInterfaceLayoutDirection:textDirection == TextDirection::LTR ? NSUserInterfaceLayoutDirectionLeftToRight : NSUserInterfaceLayoutDirectionRightToLeft];
-    [view addSubview:dummyView.get()];
-    location = [dummyView convertPoint:location fromView:view];
+    [view.get() addSubview:dummyView.get()];
+    location = [dummyView convertPoint:location fromView:view.get()];
     
     if (Page* page = frame->page()) {
         RetainPtr webView = kit(page);
@@ -215,7 +215,7 @@ void PopupMenuMac::show(const IntRect& r, LocalFrameView& frameView, int selecte
         break;
     }
 
-    PAL::popUpMenu(menu, location, roundf(NSWidth(r)), dummyView.get(), selectedIndex, (__bridge NSFont *)font, controlSize, !checkedClient()->menuStyle().hasDefaultAppearance());
+    PAL::popUpMenu(menu, location, roundf(NSWidth(r)), dummyView.get(), selectedIndex, (__bridge NSFont *)font.get(), controlSize, !checkedClient()->menuStyle().hasDefaultAppearance());
 
     [m_popup dismissPopUp];
     [dummyView removeFromSuperview];

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.mm
@@ -275,17 +275,17 @@ void WebContextMenuClient::showContextMenu()
     if (!frameView)
         return;
 
-    NSView* view = frameView->documentView();
+    RetainPtr view = frameView->documentView();
     IntPoint point = frameView->contentsToWindow(page->contextMenuController().hitTestResult().roundedPointInInnerNodeFrame());
-    NSEvent* event = [NSEvent mouseEventWithType:NSEventTypeRightMouseDown location:point modifierFlags:0 timestamp:0 windowNumber:[[view window] windowNumber] context:0 eventNumber:0 clickCount:1 pressure:1];
+    NSEvent* event = [NSEvent mouseEventWithType:NSEventTypeRightMouseDown location:point modifierFlags:0 timestamp:0 windowNumber:[[view.get() window] windowNumber] context:0 eventNumber:0 clickCount:1 pressure:1];
 
     // Show the contextual menu for this event.
     bool isServicesMenu;
-    if (NSMenu *menu = contextMenuForEvent(event, view, isServicesMenu)) {
+    if (RetainPtr menu = contextMenuForEvent(event, view.get(), isServicesMenu)) {
         if (isServicesMenu)
-            [menu popUpMenuPositioningItem:nil atLocation:[view convertPoint:point toView:nil] inView:view];
+            [menu.get() popUpMenuPositioningItem:nil atLocation:[view.get() convertPoint:point toView:nil] inView:view.get()];
         else
-            [NSMenu popUpContextMenu:menu withEvent:event forView:view];
+            [NSMenu popUpContextMenu:menu.get() withEvent:event forView:view.get()];
     }
 }
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebDragClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebDragClient.mm
@@ -154,31 +154,31 @@ void WebDragClient::startDrag(DragItem dragItem, DataTransfer& dataTransfer, Fra
     if (![htmlView.get() isKindOfClass:[WebHTMLView class]])
         return;
     
-    NSEvent *event = (dragItem.sourceAction && *dragItem.sourceAction == DragSourceAction::Link) ? localFrame->eventHandler().currentNSEvent() : [htmlView.get() _mouseDownEvent];
-    WebHTMLView* topHTMLView = getTopHTMLView(localFrame);
+    RetainPtr event = (dragItem.sourceAction && *dragItem.sourceAction == DragSourceAction::Link) ? localFrame->eventHandler().currentNSEvent() : [htmlView.get() _mouseDownEvent];
+    RetainPtr topHTMLView = getTopHTMLView(localFrame);
     RetainPtr<WebHTMLView> topViewProtector = topHTMLView;
     
-    [topHTMLView _stopAutoscrollTimer];
-    NSPasteboard *pasteboard = [NSPasteboard pasteboardWithName:dataTransfer.pasteboard().name().createNSString().get()];
+    [topHTMLView.get() _stopAutoscrollTimer];
+    RetainPtr pasteboard = [NSPasteboard pasteboardWithName:dataTransfer.pasteboard().name().createNSString().get()];
 
-    NSImage *dragNSImage = dragImage.get().unsafeGet();
-    WebHTMLView *sourceHTMLView = htmlView.get();
+    RetainPtr dragNSImage = dragImage.get().unsafeGet();
+    RetainPtr sourceHTMLView = htmlView.get();
 
-    IntSize size([dragNSImage size]);
+    IntSize size([dragNSImage.get() size]);
     size.scale(1 / localFrame->page()->deviceScaleFactor());
-    [dragNSImage setSize:size];
+    [dragNSImage.get() setSize:size];
 
     id delegate = [m_webView UIDelegate];
     SEL selector = @selector(webView:dragImage:at:offset:event:pasteboard:source:slideBack:forView:);
     if ([delegate respondsToSelector:selector]) {
         @try {
-            [delegate webView:m_webView dragImage:dragNSImage at:dragLocationInContentCoordinates offset:NSZeroSize event:event pasteboard:pasteboard source:sourceHTMLView slideBack:YES forView:topHTMLView];
+            [delegate webView:m_webView dragImage:dragNSImage.get() at:dragLocationInContentCoordinates offset:NSZeroSize event:event.get() pasteboard:pasteboard.get() source:sourceHTMLView.get() slideBack:YES forView:topHTMLView.get()];
         } @catch (id exception) {
             ReportDiscardedDelegateException(selector, exception);
         }
     } else
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        [topHTMLView dragImage:dragNSImage at:dragLocationInContentCoordinates offset:NSZeroSize event:event pasteboard:pasteboard source:sourceHTMLView slideBack:YES];
+        [topHTMLView.get() dragImage:dragNSImage.get() at:dragLocationInContentCoordinates offset:NSZeroSize event:event.get() pasteboard:pasteboard.get() source:sourceHTMLView.get() slideBack:YES];
 ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
@@ -202,8 +202,8 @@ void WebDragClient::beginDrag(DragItem dragItem, LocalFrame& frame, const IntPoi
     [draggingItem setDraggingFrame:draggingFrame contents:dragItem.image.get().get()];
 
     // FIXME: We should be able to make a fake event with the mosue dragged coordinates.
-    NSEvent *event = frame.eventHandler().currentNSEvent();
-    [topWebHTMLView.get() beginDraggingSessionWithItems:@[ draggingItem.get() ] event:event source:topWebHTMLView.get()];
+    RetainPtr event = frame.eventHandler().currentNSEvent();
+    [topWebHTMLView.get() beginDraggingSessionWithItems:@[ draggingItem.get() ] event:event.get() source:topWebHTMLView.get()];
 }
 
 void WebDragClient::declareAndWriteDragImage(const String& pasteboardName, Element& element, const URL& url, const String& title, WebCore::LocalFrame* frame)

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm
@@ -480,8 +480,8 @@ void _WebCreateFragment(Document& document, NSAttributedString *string, Fragment
 void WebEditorClient::setInsertionPasteboard(const String& pasteboardName)
 {
 #if !PLATFORM(IOS_FAMILY)
-    NSPasteboard *pasteboard = pasteboardName.isEmpty() ? nil : [NSPasteboard pasteboardWithName:pasteboardName.createNSString().get()];
-    [m_webView _setInsertionPasteboard:pasteboard];
+    RetainPtr<NSPasteboard> pasteboard = pasteboardName.isEmpty() ? nil : [NSPasteboard pasteboardWithName:pasteboardName.createNSString().get()];
+    [m_webView _setInsertionPasteboard:pasteboard.get()];
 #endif
 }
 
@@ -733,27 +733,27 @@ static DOMElement *dynamicDowncastToKit(Element& element)
 
 void WebEditorClient::textFieldDidBeginEditing(Element& element)
 {
-    auto *inputElement = dynamicDowncastToKit<HTMLInputElement>(element);
+    RetainPtr inputElement = dynamicDowncastToKit<HTMLInputElement>(element);
     if (!inputElement)
         return;
 
-    FormDelegateLog(inputElement);
-    CallFormDelegate(m_webView, @selector(textFieldDidBeginEditing:inFrame:), inputElement, kit(element.document().frame()));
+    FormDelegateLog(inputElement.get());
+    CallFormDelegate(m_webView, @selector(textFieldDidBeginEditing:inFrame:), inputElement.get(), kit(element.document().frame()));
 }
 
 void WebEditorClient::textFieldDidEndEditing(Element& element)
 {
-    auto *inputElement = dynamicDowncastToKit<HTMLInputElement>(element);
+    RetainPtr inputElement = dynamicDowncastToKit<HTMLInputElement>(element);
     if (!inputElement)
         return;
 
-    FormDelegateLog(inputElement);
-    CallFormDelegate(m_webView, @selector(textFieldDidEndEditing:inFrame:), inputElement, kit(element.document().frame()));
+    FormDelegateLog(inputElement.get());
+    CallFormDelegate(m_webView, @selector(textFieldDidEndEditing:inFrame:), inputElement.get(), kit(element.document().frame()));
 }
 
 void WebEditorClient::textDidChangeInTextField(Element& element)
 {
-    auto *inputElement = dynamicDowncastToKit<HTMLInputElement>(element);
+    RetainPtr inputElement = dynamicDowncastToKit<HTMLInputElement>(element);
     if (!inputElement)
         return;
 
@@ -762,8 +762,8 @@ void WebEditorClient::textDidChangeInTextField(Element& element)
         return;
 #endif
 
-    FormDelegateLog(inputElement);
-    CallFormDelegate(m_webView, @selector(textDidChangeInTextField:inFrame:), inputElement, kit(element.document().frame()));
+    FormDelegateLog(inputElement.get());
+    CallFormDelegate(m_webView, @selector(textDidChangeInTextField:inFrame:), inputElement.get(), kit(element.document().frame()));
 }
 
 static SEL selectorForKeyEvent(KeyboardEvent* event)
@@ -793,35 +793,35 @@ IGNORE_WARNINGS_END
 
 bool WebEditorClient::doTextFieldCommandFromEvent(Element& element, KeyboardEvent* event)
 {
-    auto *inputElement = dynamicDowncastToKit<HTMLInputElement>(element);
+    RetainPtr inputElement = dynamicDowncastToKit<HTMLInputElement>(element);
     if (!inputElement)
         return NO;
 
-    FormDelegateLog(inputElement);
+    FormDelegateLog(inputElement.get());
     if (SEL commandSelector = selectorForKeyEvent(event))
-        return CallFormDelegateReturningBoolean(NO, m_webView, @selector(textField:doCommandBySelector:inFrame:), inputElement, commandSelector, kit(element.document().frame()));
+        return CallFormDelegateReturningBoolean(NO, m_webView, @selector(textField:doCommandBySelector:inFrame:), inputElement.get(), commandSelector, kit(element.document().frame()));
     return NO;
 }
 
 void WebEditorClient::textWillBeDeletedInTextField(Element& element)
 {
-    auto *inputElement = dynamicDowncastToKit<HTMLInputElement>(element);
+    RetainPtr inputElement = dynamicDowncastToKit<HTMLInputElement>(element);
     if (!inputElement)
         return;
 
-    FormDelegateLog(inputElement);
+    FormDelegateLog(inputElement.get());
     // We're using the deleteBackward selector for all deletion operations since the autofill code treats all deletions the same way.
-    CallFormDelegateReturningBoolean(NO, m_webView, @selector(textField:doCommandBySelector:inFrame:), inputElement, @selector(deleteBackward:), kit(element.document().frame()));
+    CallFormDelegateReturningBoolean(NO, m_webView, @selector(textField:doCommandBySelector:inFrame:), inputElement.get(), @selector(deleteBackward:), kit(element.document().frame()));
 }
 
 void WebEditorClient::textDidChangeInTextArea(Element& element)
 {
-    auto *textAreaElement = dynamicDowncastToKit<HTMLTextAreaElement>(element);
+    RetainPtr textAreaElement = dynamicDowncastToKit<HTMLTextAreaElement>(element);
     if (!textAreaElement)
         return;
 
-    FormDelegateLog(textAreaElement);
-    CallFormDelegate(m_webView, @selector(textDidChangeInTextArea:inFrame:), textAreaElement, kit(element.document().frame()));
+    FormDelegateLog(textAreaElement.get());
+    CallFormDelegate(m_webView, @selector(textDidChangeInTextArea:inFrame:), textAreaElement.get(), kit(element.document().frame()));
 }
 
 #if PLATFORM(IOS_FAMILY)
@@ -1095,9 +1095,9 @@ void WebEditorClient::getGuessesForWord(const String& word, const String& contex
         [checker checkString:nsContext.get() range:NSMakeRange(0, context.length()) types:NSTextCheckingTypeOrthography options:options inSpellDocumentWithTag:spellCheckerDocumentTag() orthography:&orthography wordCount:0];
         language = [checker languageForWordRange:NSMakeRange(0, context.length()) inString:nsContext.get() orthography:orthography];
     }
-    NSArray *stringsArray = [checker guessesForWordRange:NSMakeRange(0, word.length()) inString:word.createNSString().get() language:language.get() inSpellDocumentWithTag:spellCheckerDocumentTag()];
-    if (stringsArray.count)
-        guesses = makeVector<String>(stringsArray);
+    RetainPtr stringsArray = [checker guessesForWordRange:NSMakeRange(0, word.length()) inString:word.createNSString().get() language:language.get() inSpellDocumentWithTag:spellCheckerDocumentTag()];
+    if (stringsArray.get().count)
+        guesses = makeVector<String>(stringsArray.get());
 }
 
 #endif // !PLATFORM(IOS_FAMILY)

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameNetworkingContext.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameNetworkingContext.mm
@@ -77,11 +77,11 @@ RetainPtr<CFDataRef> WebFrameNetworkingContext::sourceApplicationAuditData() con
     if (!frame() || !frame()->page())
         return nullptr;
     
-    WebView *webview = kit(frame()->page());
+    RetainPtr webview = kit(frame()->page());
     if (!webview)
         return nullptr;
 
-    return (__bridge CFDataRef)webview._sourceApplicationAuditData;
+    return (__bridge CFDataRef)webview.get()._sourceApplicationAuditData;
 }
 
 String WebFrameNetworkingContext::sourceApplicationIdentifier() const

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.mm
@@ -162,16 +162,16 @@ void WebInspectorClient::hideHighlight()
 
 void WebInspectorClient::didSetSearchingForNode(bool enabled)
 {
-    WebInspector *inspector = [m_inspectedWebView.get() inspector];
+    RetainPtr inspector = [m_inspectedWebView.get() inspector];
 
     ASSERT(isMainThread());
 
     if (enabled) {
         [[m_inspectedWebView.get() window] makeKeyAndOrderFront:nil];
         [[m_inspectedWebView.get() window] makeFirstResponder:m_inspectedWebView.get().get()];
-        [[NSNotificationCenter defaultCenter] postNotificationName:WebInspectorDidStartSearchingForNode object:inspector];
+        [[NSNotificationCenter defaultCenter] postNotificationName:WebInspectorDidStartSearchingForNode object:inspector.get()];
     } else
-        [[NSNotificationCenter defaultCenter] postNotificationName:WebInspectorDidStopSearchingForNode object:inspector];
+        [[NSNotificationCenter defaultCenter] postNotificationName:WebInspectorDidStopSearchingForNode object:inspector.get()];
 }
 
 void WebInspectorClient::releaseFrontend()
@@ -211,12 +211,12 @@ void WebInspectorFrontendClient::frontendLoaded()
 
     InspectorFrontendClientLocal::frontendLoaded();
 
-    WebFrame *frame = [m_inspectedWebView.get() mainFrame];
+    RetainPtr frame = [m_inspectedWebView.get() mainFrame];
 
     WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(m_inspectedWebView.get().get());
     if (implementations->didClearInspectorWindowObjectForFrameFunc)
         CallFrameLoadDelegate(implementations->didClearInspectorWindowObjectForFrameFunc, m_inspectedWebView.get().get(),
-                              @selector(webView:didClearInspectorWindowObject:forFrame:), [frame windowObject], frame);
+                              @selector(webView:didClearInspectorWindowObject:forFrame:), [frame.get() windowObject], frame.get());
 
     bool attached = [m_frontendWindowController.get() attached];
     setAttachedWindow(attached ? DockSide::Bottom : DockSide::Undocked);
@@ -259,9 +259,9 @@ void WebInspectorFrontendClient::closeWindow()
 
 void WebInspectorFrontendClient::reopen()
 {
-    WebInspector* inspector = [m_inspectedWebView.get() inspector];
-    [inspector close:nil];
-    [inspector show:nil];
+    RetainPtr inspector = [m_inspectedWebView.get() inspector];
+    [inspector.get() close:nil];
+    [inspector.get() show:nil];
 }
 
 void WebInspectorFrontendClient::resetState()
@@ -381,8 +381,8 @@ void WebInspectorFrontendClient::logDiagnosticEvent(const String& eventName, con
 
 void WebInspectorFrontendClient::updateWindowTitle() const
 {
-    NSString *title = [NSString stringWithFormat:UI_STRING_INTERNAL("Web Inspector — %@", "Web Inspector window title"), m_inspectedURL.createNSString().get()];
-    [[m_frontendWindowController.get() window] setTitle:title];
+    RetainPtr title = [NSString stringWithFormat:UI_STRING_INTERNAL("Web Inspector — %@", "Web Inspector window title"), m_inspectedURL.createNSString().get()];
+    [[m_frontendWindowController.get() window] setTitle:title.get()];
 }
 
 bool WebInspectorFrontendClient::canSave(InspectorFrontendClient::SaveMode saveMode)
@@ -461,9 +461,9 @@ void WebInspectorFrontendClient::save(Vector<InspectorFrontendClient::SaveData>&
     };
 
     NSWindow *frontendWindow = [[m_frontendWindowController frontendWebView] window];
-    NSWindow *window = frontendWindow ? frontendWindow : [NSApp keyWindow];
+    RetainPtr window = frontendWindow ? frontendWindow : [NSApp keyWindow];
     if (window)
-        [panel beginSheetModalForWindow:window completionHandler:completionHandler];
+        [panel beginSheetModalForWindow:window.get() completionHandler:completionHandler];
     else
         completionHandler([panel runModal]);
 }

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebVisitedLinkStore.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebVisitedLinkStore.mm
@@ -128,14 +128,14 @@ void WebVisitedLinkStore::populateVisitedLinksIfNeeded(Page& page)
 
     m_visitedLinksPopulated = true;
 
-    WebView *webView = kit(&page);
+    RetainPtr webView = kit(&page);
     ASSERT(webView);
 
-    if (webView.historyDelegate) {
-        WebHistoryDelegateImplementationCache* implementations = WebViewGetHistoryDelegateImplementations(webView);
+    if (webView.get().historyDelegate) {
+        WebHistoryDelegateImplementationCache* implementations = WebViewGetHistoryDelegateImplementations(webView.get());
 
         if (implementations->populateVisitedLinksFunc)
-            CallHistoryDelegate(implementations->populateVisitedLinksFunc, webView, @selector(populateVisitedLinksForWebView:));
+            CallHistoryDelegate(implementations->populateVisitedLinksFunc, webView.get(), @selector(populateVisitedLinksForWebView:));
 
         return;
     }

--- a/Source/WebKitLegacy/mac/WebInspector/WebNodeHighlight.mm
+++ b/Source/WebKitLegacy/mac/WebInspector/WebNodeHighlight.mm
@@ -146,9 +146,9 @@ using namespace WebCore;
     // the entire superview hierarchy to handle scrolling, bars coming and going, etc. 
     // (without making concrete assumptions about the view hierarchy).
     NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
-    for (NSView *v = _targetView; v; v = [v superview]) {
-        [notificationCenter addObserver:self selector:@selector(_repositionHighlightWindow) name:NSViewFrameDidChangeNotification object:v];
-        [notificationCenter addObserver:self selector:@selector(_repositionHighlightWindow) name:NSViewBoundsDidChangeNotification object:v];
+    for (RetainPtr view = _targetView; view; view = [view.get() superview]) {
+        [notificationCenter addObserver:self selector:@selector(_repositionHighlightWindow) name:NSViewFrameDidChangeNotification object:view.get()];
+        [notificationCenter addObserver:self selector:@selector(_repositionHighlightWindow) name:NSViewBoundsDidChangeNotification object:view.get()];
     }
 #else
     ASSERT(_highlightLayer);

--- a/Source/WebKitLegacy/mac/WebView/WebArchive.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebArchive.mm
@@ -209,11 +209,11 @@ static BOOL isArrayOfClass(id object, Class elementClass)
 }
 
 - (instancetype)initWithCoder:(NSCoder *)decoder
-{    
-    WebResource *mainResource = nil;
-    NSArray *subresources = nil;
-    NSArray *subframeArchives = nil;
-    
+{
+    RetainPtr<WebResource> mainResource;
+    RetainPtr<NSArray> subresources;
+    RetainPtr<NSArray> subframeArchives;
+
     @try {
         id object = [decoder decodeObjectForKey:WebMainResourceKey];
         if ([object isKindOfClass:[WebResource class]])
@@ -229,7 +229,7 @@ static BOOL isArrayOfClass(id object, Class elementClass)
         return nil;
     }
 
-    return [self initWithMainResource:mainResource subresources:subresources subframeArchives:subframeArchives];
+    return [self initWithMainResource:mainResource.get() subresources:subresources.get() subframeArchives:subframeArchives.get()];
 }
 
 - (void)encodeWithCoder:(NSCoder *)encoder

--- a/Source/WebKitLegacy/mac/WebView/WebDataSource.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebDataSource.mm
@@ -380,8 +380,8 @@ void addTypesFromClass(NSMutableDictionary *allTypes, Class objCClass, NSArray *
         [self _setRepresentation:(id <WebDocumentRepresentation>)newRep.get()];
     }
 
-    id<WebDocumentRepresentation> representation = toPrivate(_private)->representation.get();
-    [representation setDataSource:self];
+    RetainPtr<id<WebDocumentRepresentation>> representation = toPrivate(_private)->representation.get();
+    [representation.get() setDataSource:self];
 #if PLATFORM(IOS_FAMILY)
     toPrivate(_private)->loader->setResponseMIMEType([self _responseMIMEType]);
 #endif

--- a/Source/WebKitLegacy/mac/WebView/WebDelegateImplementationCaching.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebDelegateImplementationCaching.mm
@@ -1373,11 +1373,11 @@ id CallHistoryDelegate(IMP implementation, WebView *self, SEL selector, id objec
 id CallFormDelegate(WebView *self, SEL selector, id object1, id object2)
 {
 #if !PLATFORM(IOS_FAMILY)
-    id delegate = self->_private->formDelegate;
-    if (!delegate || ![delegate respondsToSelector:selector])
+    RetainPtr<id> delegate = self->_private->formDelegate;
+    if (!delegate || ![delegate.get() respondsToSelector:selector])
         return nil;
     @try {
-        return wtfObjCMsgSend<id>(delegate, selector, object1, object2);
+        return wtfObjCMsgSend<id>(delegate.get(), selector, object1, object2);
     } @catch(id exception) {
         ReportDiscardedDelegateException(selector, exception);
     }
@@ -1409,11 +1409,11 @@ id CallFormDelegate(WebView *self, SEL selector, id object1, id object2)
 id CallFormDelegate(WebView *self, SEL selector, id object1, id object2, id object3)
 {
 #if !PLATFORM(IOS_FAMILY)
-    id delegate = self->_private->formDelegate;
-    if (!delegate || ![delegate respondsToSelector:selector])
+    RetainPtr<id> delegate = self->_private->formDelegate;
+    if (!delegate || ![delegate.get() respondsToSelector:selector])
         return nil;
     @try {
-        return wtfObjCMsgSend<id>(delegate, selector, object1, object2, object3);
+        return wtfObjCMsgSend<id>(delegate.get(), selector, object1, object2, object3);
     } @catch(id exception) {
         ReportDiscardedDelegateException(selector, exception);
     }
@@ -1446,11 +1446,11 @@ id CallFormDelegate(WebView *self, SEL selector, id object1, id object2, id obje
 id CallFormDelegate(WebView *self, SEL selector, id object1, id object2, id object3, id object4, id object5)
 {
 #if !PLATFORM(IOS_FAMILY)
-    id delegate = self->_private->formDelegate;
-    if (!delegate || ![delegate respondsToSelector:selector])
+    RetainPtr<id> delegate = self->_private->formDelegate;
+    if (!delegate || ![delegate.get() respondsToSelector:selector])
         return nil;
     @try {
-        return wtfObjCMsgSend<id>(delegate, selector, object1, object2, object3, object4, object5);
+        return wtfObjCMsgSend<id>(delegate.get(), selector, object1, object2, object3, object4, object5);
     } @catch(id exception) {
         ReportDiscardedDelegateException(selector, exception);
     }
@@ -1485,11 +1485,11 @@ id CallFormDelegate(WebView *self, SEL selector, id object1, id object2, id obje
 BOOL CallFormDelegateReturningBoolean(BOOL result, WebView *self, SEL selector, id object1, SEL selectorArg, id object2)
 {
 #if !PLATFORM(IOS_FAMILY)
-    id delegate = self->_private->formDelegate;
-    if (!delegate || ![delegate respondsToSelector:selector])
+    RetainPtr<id> delegate = self->_private->formDelegate;
+    if (!delegate || ![delegate.get() respondsToSelector:selector])
         return result;
     @try {
-        return wtfObjCMsgSend<BOOL>(delegate, selector, object1, selectorArg, object2);
+        return wtfObjCMsgSend<BOOL>(delegate.get(), selector, object1, selectorArg, object2);
     } @catch(id exception) {
         ReportDiscardedDelegateException(selector, exception);
     }

--- a/Source/WebKitLegacy/mac/WebView/WebDynamicScrollBarsView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebDynamicScrollBarsView.mm
@@ -283,8 +283,8 @@ static const unsigned cMaxUpdateScrollbarsPass = 2;
     // (This will be the common case, e.g., when the page changes due to window resizing for example).
     // This layout will not re-enter updateScrollers and does not count towards our max layout pass total.
     if (!_private->suppressLayout && !_private->suppressScrollers && [documentView isKindOfClass:[WebHTMLView class]]) {
-        WebHTMLView* htmlView = (WebHTMLView*)documentView;
-        if ([htmlView _needsLayout]) {
+        RetainPtr htmlView = (WebHTMLView*)documentView;
+        if ([htmlView.get() _needsLayout]) {
             _private->inUpdateScrollers = YES;
             [(id <WebDocumentView>)documentView layout];
             _private->inUpdateScrollers = NO;
@@ -367,8 +367,8 @@ static const unsigned cMaxUpdateScrollbarsPass = 2;
     _private->verticalScrollingAllowedButScrollerHidden = newHasVerticalScroller && _private->alwaysHideVerticalScroller;
 
     if ([documentView isKindOfClass:[WebHTMLView class]]) {
-        WebHTMLView* htmlView = (WebHTMLView*)documentView;
-        WebCore::ScrollbarWidth scrollbarWidthStyle = [htmlView _scrollbarWidthStyle];
+        RetainPtr htmlView = (WebHTMLView*)documentView;
+        WebCore::ScrollbarWidth scrollbarWidthStyle = [htmlView.get() _scrollbarWidthStyle];
         if (scrollbarWidthStyle == WebCore::ScrollbarWidth::None) {
             _private->horizontalScrollingAllowedButScrollerHidden = true;
             _private->verticalScrollingAllowedButScrollerHidden = true;

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -335,7 +335,7 @@ WebView *getWebView(WebFrame *webFrame)
 
     coreFrame.get().init();
 
-    [webView _setZoomMultiplier:[webView _realZoomMultiplier] isTextOnly:[webView _realZoomMultiplierIsTextOnly]];
+    [webView.get() _setZoomMultiplier:[webView.get() _realZoomMultiplier] isTextOnly:[webView.get() _realZoomMultiplierIsTextOnly]];
 
     if (RefPtr controller = [webView.get() inspectorController]) {
         frame->_private->webPageInspectorController = controller.get();
@@ -359,10 +359,10 @@ WebView *getWebView(WebFrame *webFrame)
     localMainFrame->tree().setSpecifiedName(name);
     localMainFrame->init();
 
-    [webView _setZoomMultiplier:[webView _realZoomMultiplier] isTextOnly:[webView _realZoomMultiplierIsTextOnly]];
+    [webView.get() _setZoomMultiplier:[webView.get() _realZoomMultiplier] isTextOnly:[webView.get() _realZoomMultiplierIsTextOnly]];
 
     frame->_private->webPageInspectorController = [webView.get() inspectorController];
-    [webView inspectorController]->frameCreated(*localMainFrame);
+    [webView.get() inspectorController]->frameCreated(*localMainFrame);
 }
 
 + (Ref<WebCore::LocalFrame>)_createSubframeWithOwnerElement:(WebCore::HTMLFrameOwnerElement&)ownerElement page:(WebCore::Page&)page frameName:(const AtomString&)name frameView:(WebFrameView *)frameView
@@ -461,11 +461,11 @@ static NSURL *createUniqueWebDataURL();
 - (void)_updateBackgroundAndUpdatesWhileOffscreen
 {
     RetainPtr webView = getWebView(self);
-    BOOL drawsBackground = [webView drawsBackground];
+    BOOL drawsBackground = [webView.get() drawsBackground];
 #if !PLATFORM(IOS_FAMILY)
-    NSColor *backgroundColor = [webView backgroundColor];
+    NSColor *backgroundColor = [webView.get() backgroundColor];
 #else
-    CGColorRef backgroundColor = [webView backgroundColor];
+    CGColorRef backgroundColor = [webView.get() backgroundColor];
 #endif
 
     auto coreFrame = _private->coreFrame;
@@ -477,9 +477,9 @@ static NSURL *createUniqueWebDataURL();
         // in progress; WebFrameLoaderClient keeps it set to NO during the load process.
         RetainPtr webFrame = kit(frame);
         if (!drawsBackground)
-            [[[webFrame frameView] _scrollView] setDrawsBackground:NO];
+            [[[webFrame.get() frameView] _scrollView] setDrawsBackground:NO];
 #if !PLATFORM(IOS_FAMILY)
-        [[[webFrame frameView] _scrollView] setBackgroundColor:backgroundColor];
+        [[[webFrame.get() frameView] _scrollView] setBackgroundColor:backgroundColor];
 #endif
 
         if (auto* view = frame->view()) {
@@ -490,7 +490,7 @@ static NSURL *createUniqueWebDataURL();
             WebCore::Color color(WebCore::roundAndClampToSRGBALossy(backgroundColor));
 #endif
             view->setBaseBackgroundColor(color);
-            view->setShouldUpdateWhileOffscreen([webView shouldUpdateWhileOffscreen]);
+            view->setShouldUpdateWhileOffscreen([webView.get() shouldUpdateWhileOffscreen]);
         }
     }
 }
@@ -581,7 +581,7 @@ static NSURL *createUniqueWebDataURL();
         if (!frame)
             continue;
         RetainPtr webFrame = kit(frame);
-        if ([webFrame _hasSelection])
+        if ([webFrame.get() _hasSelection])
             return webFrame.autorelease();
     }
     return nil;
@@ -930,9 +930,9 @@ static NSURL *createUniqueWebDataURL();
 
 - (void)_replaceSelectionWithNode:(DOMNode *)node selectReplacement:(BOOL)selectReplacement smartReplace:(BOOL)smartReplace matchStyle:(BOOL)matchStyle
 {
-    DOMDocumentFragment *fragment = kit(_private->coreFrame->document()->createDocumentFragment().ptr());
-    [fragment appendChild:node];
-    [self _replaceSelectionWithFragment:fragment selectReplacement:selectReplacement smartReplace:smartReplace matchStyle:matchStyle];
+    RetainPtr fragment = kit(_private->coreFrame->document()->createDocumentFragment().ptr());
+    [fragment.get() appendChild:node];
+    [self _replaceSelectionWithFragment:fragment.get() selectReplacement:selectReplacement smartReplace:smartReplace matchStyle:matchStyle];
 }
 
 - (void)_insertParagraphSeparatorInQuotedContent
@@ -1994,8 +1994,8 @@ static WebFrameLoadType toWebFrameLoadType(WebCore::FrameLoadType frameLoadType)
 - (void)_replaceSelectionWithText:(NSString *)text selectReplacement:(BOOL)selectReplacement smartReplace:(BOOL)smartReplace
 {
     auto range = _private->coreFrame->selection().selection().toNormalizedRange();
-    DOMDocumentFragment* fragment = range ? kit(createFragmentFromText(*range, text).ptr()) : nil;
-    [self _replaceSelectionWithFragment:fragment selectReplacement:selectReplacement smartReplace:smartReplace matchStyle:YES];
+    RetainPtr<DOMDocumentFragment> fragment = range ? kit(createFragmentFromText(*range, text).ptr()) : nil;
+    [self _replaceSelectionWithFragment:fragment.get() selectReplacement:selectReplacement smartReplace:smartReplace matchStyle:YES];
 }
 
 - (void)_replaceSelectionWithMarkupString:(NSString *)markupString baseURLString:(NSString *)baseURLString selectReplacement:(BOOL)selectReplacement smartReplace:(BOOL)smartReplace

--- a/Source/WebKitLegacy/mac/WebView/WebFrameView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrameView.mm
@@ -1143,18 +1143,18 @@ enum {
     unsigned i;
     for (i=0; i < [frameChildren count]; i++) {
         WebFrameView *childFrameView = [[frameChildren objectAtIndex:i] frameView];
-        WebFrameView *scrollableFrameView = [childFrameView _isScrollable] ? childFrameView : [childFrameView _largestScrollableChild];
+        RetainPtr scrollableFrameView = [childFrameView _isScrollable] ? childFrameView : [childFrameView _largestScrollableChild];
         if (!scrollableFrameView)
             continue;
-        
+
         // Some ads lurk in child frames of zero width and height, see radar 4406994. These don't count as scrollable.
         // Maybe someday we'll discover that this minimum area check should be larger, but this covers the known cases.
-        float area = [scrollableFrameView _area];
+        float area = [scrollableFrameView.get() _area];
         if (area < 1.0)
             continue;
-        
+
         if (!largest || (area > [largest _area])) {
-            largest = scrollableFrameView;
+            largest = scrollableFrameView.get();
         }
     }
     
@@ -1181,18 +1181,18 @@ enum {
     unsigned i;
     for (i=0; i < [frameChildren count]; i++) {
         WebFrameView *childFrameView = [[frameChildren objectAtIndex:i] frameView];
-        WebFrameView *scrollableFrameView = [childFrameView _hasScrollBars] ? childFrameView : [childFrameView _largestChildWithScrollBars];
+        RetainPtr scrollableFrameView = [childFrameView _hasScrollBars] ? childFrameView : [childFrameView _largestChildWithScrollBars];
         if (!scrollableFrameView)
             continue;
-        
+
         // Some ads lurk in child frames of zero width and height, see radar 4406994. These don't count as scrollable.
         // Maybe someday we'll discover that this minimum area check should be larger, but this covers the known cases.
-        float area = [scrollableFrameView _area];
+        float area = [scrollableFrameView.get() _area];
         if (area < 1.0)
             continue;
-        
+
         if (!largest || (area > [largest _area])) {
-            largest = scrollableFrameView;
+            largest = scrollableFrameView.get();
         }
     }
     

--- a/Source/WebKitLegacy/mac/WebView/WebImmediateActionController.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebImmediateActionController.mm
@@ -92,8 +92,8 @@
 
     id animationController = [_immediateActionRecognizer animationController];
     if (PAL::isQuickLookUIFrameworkAvailable() && [animationController isKindOfClass:PAL::getQLPreviewMenuItemClassSingleton()]) {
-        QLPreviewMenuItem *menuItem = (QLPreviewMenuItem *)animationController;
-        menuItem.delegate = nil;
+        RetainPtr menuItem = (QLPreviewMenuItem *)animationController;
+        menuItem.get().delegate = nil;
     }
 
     _immediateActionRecognizer = nil;
@@ -498,11 +498,11 @@ static WebCore::IntRect elementBoundingBoxInWindowCoordinatesFromNode(WebCore::N
 
     [_currentActionContext setHighlightFrame:[_webView.window convertRectToScreen:elementBoundingBoxInWindowCoordinatesFromNode(_hitTestResult.URLElement())]];
 
-    NSArray *menuItems = [[PAL::getDDActionsManagerClassSingleton() sharedManager] menuItemsForTargetURL:_hitTestResult.absoluteLinkURL().string().createNSString().get() actionContext:_currentActionContext.get()];
-    if (menuItems.count != 1)
+    RetainPtr menuItems = [[PAL::getDDActionsManagerClassSingleton() sharedManager] menuItemsForTargetURL:_hitTestResult.absoluteLinkURL().string().createNSString().get() actionContext:_currentActionContext.get()];
+    if ([menuItems.get() count] != 1)
         return nil;
-    
-    return menuItems.lastObject;
+
+    return menuItems.get().lastObject;
 }
 
 #pragma mark Text action

--- a/Source/WebKitLegacy/mac/WebView/WebJSPDFDoc.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebJSPDFDoc.mm
@@ -31,6 +31,7 @@
 #import "WebUIDelegate.h"
 #import "WebView.h"
 #import <JavaScriptCore/JSObjectRef.h>
+#import <wtf/RetainPtr.h>
 
 static void jsPDFDocInitialize(JSContextRef ctx, JSObjectRef object)
 {
@@ -49,10 +50,10 @@ static JSValueRef jsPDFDocPrint(JSContextRef ctx, JSObjectRef function, JSObject
     if (!JSValueIsObjectOfClass(ctx, thisObject, jsPDFDocClass()))
         return JSValueMakeUndefined(ctx);
 
-    WebDataSource *dataSource = (__bridge WebDataSource *)JSObjectGetPrivate(thisObject);
+    RetainPtr dataSource = (__bridge WebDataSource *)JSObjectGetPrivate(thisObject);
 
-    WebView *webView = [[dataSource webFrame] webView];
-    CallUIDelegate(webView, @selector(webView:printFrameView:), [[dataSource webFrame] frameView]);
+    WebView *webView = [[dataSource.get() webFrame] webView];
+    CallUIDelegate(webView, @selector(webView:printFrameView:), [[dataSource.get() webFrame] frameView]);
 
     return JSValueMakeUndefined(ctx);
 }

--- a/Source/WebKitLegacy/mac/WebView/WebPDFRepresentation.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPDFRepresentation.mm
@@ -77,13 +77,13 @@
     auto document = adoptNS([[[[self class] PDFDocumentClass] alloc] initWithData:[dataSource data]]);
     [view setPDFDocument:document.get()];
 
-    NSArray *scripts = allScriptsInPDFDocument(document.get());
-    if (![scripts count])
+    RetainPtr scripts = allScriptsInPDFDocument(document.get());
+    if (![scripts.get() count])
         return;
 
     JSGlobalContextRef ctx = JSGlobalContextCreate(0);
     JSObjectRef jsPDFDoc = makeJSPDFDoc(ctx, dataSource);
-    for (NSString *script in scripts)
+    for (NSString *script in scripts.get())
         JSEvaluateScript(ctx, OpaqueJSString::tryCreate(script).get(), jsPDFDoc, nullptr, 0, nullptr);
     JSGlobalContextRelease(ctx);
 }

--- a/Source/WebKitLegacy/mac/WebView/WebPDFView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPDFView.mm
@@ -281,14 +281,14 @@ static BOOL _PDFSelectionsAreEqual(PDFSelection *selectionA, PDFSelection *selec
             newFirstResponder = PDFDocumentView;
     }
 
-    if (!newFirstResponder.get())
+    if (!newFirstResponder)
         return NO;
 
     if (![window makeFirstResponder:newFirstResponder.get()])
         return NO;
-    
+
     [[dataSource webFrame] _clearSelectionInOtherFrames];
-    
+
     return YES;
 }
 
@@ -389,7 +389,7 @@ static BOOL _PDFSelectionsAreEqual(PDFSelection *selectionA, PDFSelection *selec
     NSImage *appIcon = nil;
 
     _applicationInfoForMIMEType([dataSource _responseMIMEType], appName, &appIcon);
-    if (!appName.get())
+    if (!appName)
         appName = UI_STRING_INTERNAL("Finder", "Default application name for Open With context menu");
 
     // To match the PDFKit style, we'll add Open with Preview even when there's no document yet to view, and
@@ -400,9 +400,9 @@ static BOOL _PDFSelectionsAreEqual(PDFSelection *selectionA, PDFSelection *selec
     if (appIcon)
         [item setImage:appIcon];
     [items insertObject:item.get() atIndex:0];
-    
+
     [items insertObject:[NSMenuItem separatorItem] atIndex:1];
-    
+
     // pass the items off to the WebKit context menu mechanism
     WebView *webView = [[dataSource webFrame] webView];
     ASSERT(webView);
@@ -661,7 +661,7 @@ static BOOL _PDFSelectionsAreEqual(PDFSelection *selectionA, PDFSelection *selec
     }
 
     [self _setTextMatches:matches.get()];
-    
+
     return [matches count];
 }
 
@@ -910,21 +910,21 @@ static BOOL _PDFSelectionsAreEqual(PDFSelection *selectionA, PDFSelection *selec
 
 - (void)writeSelectionWithPasteboardTypes:(NSArray *)types toPasteboard:(NSPasteboard *)pasteboard
 {
-    NSAttributedString *attributedString = [self selectedAttributedString];
-    
-    if ([types containsObject:WebCore::legacyRTFDPasteboardTypeSingleton()]) {
-        NSData *RTFDData = [attributedString RTFDFromRange:NSMakeRange(0, [attributedString length]) documentAttributes:@{ }];
-        [pasteboard setData:RTFDData forType:WebCore::legacyRTFDPasteboardTypeSingleton()];
-    }        
-    
-    if ([types containsObject:WebCore::legacyRTFPasteboardTypeSingleton()]) {
-        if ([attributedString containsAttachments])
-            attributedString = WebCore::attributedStringByStrippingAttachmentCharacters(attributedString);
+    RetainPtr attributedString = [self selectedAttributedString];
 
-        NSData *RTFData = [attributedString RTFFromRange:NSMakeRange(0, [attributedString length]) documentAttributes:@{ }];
+    if ([types containsObject:WebCore::legacyRTFDPasteboardTypeSingleton()]) {
+        NSData *RTFDData = [attributedString.get() RTFDFromRange:NSMakeRange(0, [attributedString.get() length]) documentAttributes:@{ }];
+        [pasteboard setData:RTFDData forType:WebCore::legacyRTFDPasteboardTypeSingleton()];
+    }
+
+    if ([types containsObject:WebCore::legacyRTFPasteboardTypeSingleton()]) {
+        if ([attributedString.get() containsAttachments])
+            attributedString = WebCore::attributedStringByStrippingAttachmentCharacters(attributedString.get());
+
+        NSData *RTFData = [attributedString.get() RTFDFromRange:NSMakeRange(0, [attributedString.get() length]) documentAttributes:@{ }];
         [pasteboard setData:RTFData forType:WebCore::legacyRTFPasteboardTypeSingleton()];
     }
-    
+
     if ([types containsObject:WebCore::legacyStringPasteboardTypeSingleton()])
         [pasteboard setString:[self selectedString] forType:WebCore::legacyStringPasteboardTypeSingleton()];
 }

--- a/Source/WebKitLegacy/mac/WebView/WebPreferences.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferences.mm
@@ -387,7 +387,7 @@ public:
 {
     WebCore::initializeMainThreadIfNeeded();
 
-    NSDictionary *dict = [NSDictionary dictionaryWithObjectsAndKeys:
+    RetainPtr dict = [NSDictionary dictionaryWithObjectsAndKeys:
         INITIALIZE_DEFAULT_PREFERENCES_DICTIONARY_FROM_GENERATED_PREFERENCES
 
         @NO, WebKitUserStyleSheetEnabledPreferenceKey,
@@ -428,7 +428,7 @@ public:
     // This value shouldn't ever change, which is assumed in the initialization of WebKitPDFDisplayModePreferenceKey above
     ASSERT(kPDFDisplaySinglePageContinuous == 1);
 #endif
-    [[NSUserDefaults standardUserDefaults] registerDefaults:dict];
+    [[NSUserDefaults standardUserDefaults] registerDefaults:dict.get()];
 }
 
 - (void)dealloc
@@ -492,13 +492,13 @@ public:
     if (![value isKindOfClass:[NSArray class]])
         return nil;
 
-    NSArray *array = (NSArray *)value;
-    for (id object in array) {
+    RetainPtr array = (NSArray *)value;
+    for (id object in array.get()) {
         if (![object isKindOfClass:[NSString class]])
             return nil;
     }
 
-    return (NSArray<NSString *> *)array;
+    return (NSArray<NSString *> *)array.autorelease();
 }
 
 - (void)_setStringArrayValueForKey:(NSArray<NSString *> *)value forKey:(NSString *)key

--- a/Source/WebKitLegacy/mac/WebView/WebResource.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebResource.mm
@@ -119,11 +119,13 @@ static NSString * const WebResourceResponseKey =          @"WebResourceResponse"
     if (!self)
         return nil;
 
-    NSData *data = nil;
-    NSURL *url = nil;
-    NSString *mimeType = nil, *textEncoding = nil, *frameName = nil;
-    NSURLResponse *response = nil;
-    
+    RetainPtr<NSData> data;
+    RetainPtr<NSURL> url;
+    RetainPtr<NSString> mimeType;
+    RetainPtr<NSString> textEncoding;
+    RetainPtr<NSString> frameName;
+    RetainPtr<NSURLResponse> response;
+
     @try {
         id object = [decoder decodeObjectForKey:WebResourceDataKey];
         if ([object isKindOfClass:[NSData class]])
@@ -148,7 +150,7 @@ static NSString * const WebResourceResponseKey =          @"WebResourceResponse"
         return nil;
     }
 
-    auto coreResource = ArchiveResource::create(SharedBuffer::create(data), url, mimeType, textEncoding, frameName, response);
+    auto coreResource = ArchiveResource::create(SharedBuffer::create(data.get()), url.get(), mimeType.get(), textEncoding.get(), frameName.get(), response.get());
     if (!coreResource) {
         [self release];
         return nil;

--- a/Source/WebKitLegacy/mac/WebView/WebScriptDebugDelegate.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebScriptDebugDelegate.mm
@@ -96,15 +96,15 @@ NSString * const WebScriptErrorLineNumberKey = @"WebScriptErrorLineNumber";
     if (!value)
         return nil;
 
-    WebScriptObject *globalObject = _private->globalObject;
-    if (value == [globalObject _imp])
-        return globalObject;
+    RetainPtr globalObject = _private->globalObject;
+    if (value == [globalObject.get() _imp])
+        return globalObject.autorelease();
 
-    JSC::Bindings::RootObject* root1 = [globalObject _originRootObject];
+    JSC::Bindings::RootObject* root1 = [globalObject.get() _originRootObject];
     if (!root1)
         return nil;
 
-    JSC::Bindings::RootObject* root2 = [globalObject _rootObject];
+    JSC::Bindings::RootObject* root2 = [globalObject.get() _rootObject];
     if (!root2)
         return nil;
 

--- a/Source/WebKitLegacy/mac/WebView/WebScriptWorld.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebScriptWorld.mm
@@ -86,8 +86,8 @@ static WorldMap& allWorlds()
 
 + (WebScriptWorld *)standardWorld
 {
-    static WebScriptWorld *world = [[WebScriptWorld alloc] initWithWorld:WebCore::mainThreadNormalWorldSingleton()];
-    return world;
+    static NeverDestroyed<RetainPtr<WebScriptWorld>> world = adoptNS([[WebScriptWorld alloc] initWithWorld:WebCore::mainThreadNormalWorldSingleton()]);
+    return world->get();
 }
 
 + (WebScriptWorld *)world

--- a/Source/WebKitLegacy/mac/WebView/WebTextCompletionController.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebTextCompletionController.mm
@@ -170,11 +170,11 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
         // Get preceeding word stem
         WebFrame *frame = [_htmlView _frame];
-        DOMRange *selection = kit(core(frame)->selection().selection().toNormalizedRange());
+        RetainPtr selection = kit(core(frame)->selection().selection().toNormalizedRange());
         DOMRange *wholeWord = [frame _rangeByAlteringCurrentSelection:FrameSelection::Alteration::Extend
             direction:SelectionDirection::Backward granularity:TextGranularity::WordGranularity];
         DOMRange *prefix = [wholeWord cloneRange];
-        [prefix setEnd:[selection startContainer] offset:[selection startOffset]];
+        [prefix setEnd:[selection.get() startContainer] offset:[selection.get() startOffset]];
 
         // Reject some NOP cases
         if ([prefix collapsed]) {
@@ -200,7 +200,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
             [self _insertMatch:[_completions objectAtIndex:0]];
         } else {
             ASSERT(!_originalString);       // this should only be set IFF we have a popup window
-            _originalString = [[frame _stringForRange:selection] retain];
+            _originalString = [[frame _stringForRange:selection.get()] retain];
             [self _buildUI];
             NSRect wordRect = [frame _caretRectAtPosition:Position(core([wholeWord startContainer]), [wholeWord startOffset], Position::PositionIsOffsetInAnchor) affinity:NSSelectionAffinityDownstream];
             // +1 to be under the word, not the caret

--- a/Source/WebKitLegacy/mac/WebView/WebViewRenderingUpdateScheduler.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebViewRenderingUpdateScheduler.mm
@@ -101,13 +101,13 @@ void WebViewRenderingUpdateScheduler::registerCACommitHandlers()
     if (m_haveRegisteredCommitHandlers)
         return;
 
-    WebView* webView = m_webView;
+    RetainPtr webView = m_webView;
     [CATransaction addCommitHandler:^{
-        [webView _willStartRenderingUpdateDisplay];
+        [webView.get() _willStartRenderingUpdateDisplay];
     } forPhase:kCATransactionPhasePreLayout];
 
     [CATransaction addCommitHandler:^{
-        [webView _didCompleteRenderingUpdateDisplay];
+        [webView.get() _didCompleteRenderingUpdateDisplay];
     } forPhase:kCATransactionPhasePostCommit];
     
     m_haveRegisteredCommitHandlers = true;


### PR DESCRIPTION
#### 058698aeb50e0a143937d9a8c19454f52af052fa
<pre>
Fixed unretained local variable warnings in WebKitLegacy (part 2)
<a href="https://bugs.webkit.org/show_bug.cgi?id=305475">https://bugs.webkit.org/show_bug.cgi?id=305475</a>
<a href="https://rdar.apple.com/168141283">rdar://168141283</a>

Reviewed by Ryosuke Niwa and David Kilzer.

Mechanical fixes dictated by the SaferCPP bot.

Canonical link: <a href="https://commits.webkit.org/305754@main">https://commits.webkit.org/305754@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/205c9fa21c0fb6746c61632fe90a35f0cc0f9d04

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139299 "16 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11675 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/801 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147426 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12382 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11825 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106645 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6376c7d9-806c-456f-ac1a-2f901ae72dfa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142246 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9377 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124766 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87505 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f8fc1fbd-187b-4255-9206-830ebca15a38) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8921 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6692 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7723 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118380 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/666 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150208 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11359 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/684 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115039 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11372 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9613 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115346 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9472 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121113 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/66333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21487 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11402 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/636 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11136 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75068 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11339 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11189 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->