### PR TITLE
Support cursor property on ::marker

### DIFF
--- a/LayoutTests/fast/events/mouse-cursor-pseudo-elements-expected.txt
+++ b/LayoutTests/fast/events/mouse-cursor-pseudo-elements-expected.txt
@@ -13,6 +13,11 @@ TEST CASE: ::before & ::after
 Cursor info for ::before: type=WestResize hotSpot=0,0
 Cursor info for ::after: type=EastResize hotSpot=0,0
 
+TEST CASE: ::marker && ::before & ::after
+Cursor info for ::marker: type=Wait hotSpot=0,0
+Cursor info for ::before: type=WestResize hotSpot=0,0
+Cursor info for ::after: type=EastResize hotSpot=0,0
+
 TEST CASE: ::backdrop
 Cursor info for ::backdrop: type=Help hotSpot=0,0
 

--- a/LayoutTests/fast/events/mouse-cursor-pseudo-elements.html
+++ b/LayoutTests/fast/events/mouse-cursor-pseudo-elements.html
@@ -83,8 +83,7 @@
     <div class="before">::before</div>
     <div class="after">::after</div>
     <div class="before after">::before & ::after</div>
-    <!-- Uncomment when ::marker is fixed. -->
-    <!-- <li class="before after">::marker && ::before & ::after</li> -->
+    <li class="before after">::marker && ::before & ::after</li>
     <dialog>::backdrop</dialog>
     <div class="view-transition">View transition pseudo-elements</div>
 </div>

--- a/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/Source/WebCore/rendering/RenderListMarker.cpp
@@ -458,6 +458,11 @@ const RenderListItem* RenderListMarker::listItem() const
     return m_listItem.get();
 }
 
+Node* RenderListMarker::nodeForHitTest() const
+{
+    return m_listItem ? m_listItem->element() : nullptr;
+}
+
 FloatRect RenderListMarker::relativeMarkerRect()
 {
     if (isImage())

--- a/Source/WebCore/rendering/RenderListMarker.h
+++ b/Source/WebCore/rendering/RenderListMarker.h
@@ -86,6 +86,7 @@ private:
     bool canBeSelectionLeaf() const final { return true; }
     void styleWillChange(Style::Difference, const RenderStyle& newStyle) final;
     void styleDidChange(Style::Difference, const RenderStyle* oldStyle) final;
+    Node* nodeForHitTest() const final;
     void computeIntrinsicLogicalWidths(LayoutUnit&, LayoutUnit&) const override { ASSERT_NOT_REACHED(); }
     std::pair<float, float> layoutBoundForTextContent(String) const;
 


### PR DESCRIPTION
#### c058bd451cc81f005bbea759085761b21c8eb1e3
<pre>
Support cursor property on ::marker
<a href="https://bugs.webkit.org/show_bug.cgi?id=305478">https://bugs.webkit.org/show_bug.cgi?id=305478</a>
<a href="https://rdar.apple.com/168142945">rdar://168142945</a>

Reviewed by Alan Baradlay.

Now that selection behavior for pseudo-elements was fixed in 304719@main, we can re-attempt this change that complements 298777@main.

Test: LayoutTests/fast/events/mouse-cursor-pseudo-elements.html

* LayoutTests/fast/events/mouse-cursor-pseudo-elements-expected.txt:
* LayoutTests/fast/events/mouse-cursor-pseudo-elements.html:
* Source/WebCore/rendering/RenderListMarker.cpp:
(WebCore::RenderListMarker::nodeForHitTest const):
* Source/WebCore/rendering/RenderListMarker.h:

Canonical link: <a href="https://commits.webkit.org/305580@main">https://commits.webkit.org/305580@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6afa43987087a947e9f1bd64cd75b1e012780ee2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138827 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11193 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/314 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146946 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91802 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e7d5e7e0-4c39-4278-a7e8-fc5dbd9e9f09) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140700 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11898 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11349 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106259 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/77520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8adc336f-f2c8-44ff-8ffd-c7f6e317ebe7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141774 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8983 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/124399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87128 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9a8e0e2a-765a-4c70-9f75-b1b3fb1dc9c2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8563 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6310 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7244 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/117992 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/262 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149731 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10875 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/268 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114646 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10896 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9202 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114963 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29223 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8844 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120716 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65777 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10923 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/262 "Passed tests") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/10661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/74575 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10864 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10712 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->