### PR TITLE
[threaded-animations] allow the `filter` property to be accelerated with `drop-shadow()` operations containing colors

### DIFF
--- a/LayoutTests/webanimations/threaded-animations/threaded-animation-disabled-for-drop-shadow-with-current-color-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/threaded-animation-disabled-for-drop-shadow-with-current-color-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Animations cannot be threaded with a drop-shadow() filter using currentcolor.
+

--- a/LayoutTests/webanimations/threaded-animations/threaded-animation-disabled-for-drop-shadow-with-current-color.html
+++ b/LayoutTests/webanimations/threaded-animations/threaded-animation-disabled-for-drop-shadow-with-current-color.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ThreadedTimeBasedAnimationsEnabled=true ] -->
+<body>
+<style>
+
+#target {
+    width: 100px;
+    height: 100px;
+    background-color: black;
+    filter: drop-shadow(rgba(255, 255, 255, 0) 0px 0px 0px);
+}
+
+</style>
+
+<script src="threaded-animations-utils.js"></script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../imported/w3c/web-platform-tests/web-animations/testcommon.js"></script>
+
+<script>
+
+promise_test(async t => { 
+    const target = createDiv(t);
+    target.id = "target";
+
+    const animation = target.animate({ filter: "drop-shadow(currentcolor 0px 0px 7px)" }, 1000);
+    
+    await animationAcceleration(animation);
+
+    assert_equals(window.internals?.acceleratedAnimationsForElement(target).length, 0);
+}, "Animations cannot be threaded with a drop-shadow() filter using currentcolor.");
+
+</script>
+</body>

--- a/LayoutTests/webanimations/threaded-animations/threaded-animation-for-drop-shadow-with-color-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/threaded-animation-for-drop-shadow-with-color-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Animations can be threaded with a drop-shadow() filter using a color.
+

--- a/LayoutTests/webanimations/threaded-animations/threaded-animation-for-drop-shadow-with-color.html
+++ b/LayoutTests/webanimations/threaded-animations/threaded-animation-for-drop-shadow-with-color.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ThreadedTimeBasedAnimationsEnabled=true ] -->
+<body>
+<style>
+
+#target {
+    width: 100px;
+    height: 100px;
+    background-color: black;
+    filter: drop-shadow(rgba(255, 255, 255, 0) 0px 0px 0px);
+}
+
+</style>
+
+<script src="threaded-animations-utils.js"></script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../imported/w3c/web-platform-tests/web-animations/testcommon.js"></script>
+
+<script>
+
+promise_test(async t => { 
+    const target = createDiv(t);
+    target.id = "target";
+
+    const animation = target.animate({ filter: "drop-shadow(rgb(235, 235, 235) 0px 0px 7px)" }, 1000);
+    
+    await animationAcceleration(animation);
+
+    assert_equals(window.internals?.acceleratedAnimationsForElement(target).length, 1);
+}, "Animations can be threaded with a drop-shadow() filter using a color.");
+
+</script>
+</body>

--- a/Source/WebCore/platform/animation/AcceleratedEffect.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.cpp
@@ -514,6 +514,10 @@ void AcceleratedEffect::validateFilters(const AcceleratedEffectValues& baseValue
         // PlatformCAFilters::setFiltersOnLayer().
         ASSERT(longestFilterList);
         for (auto& operation : *longestFilterList) {
+            // If we encounter a DropShadowFilterOperationWithStyleColor it means that it failed to be
+            // converted to a DropShadowFilterOperation during AcceleratedEffectValues creation due to
+            // the use of a complex color that could not be resolved outside of the style system within
+            // the remote layer tree.
             if (operation->type() == FilterOperation::Type::DropShadowWithStyleColor)
                 return false;
             if (operation->type() == FilterOperation::Type::DropShadow && operation != longestFilterList->last())

--- a/Source/WebCore/platform/animation/AcceleratedEffectValues.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffectValues.cpp
@@ -133,8 +133,8 @@ AcceleratedEffectValues::AcceleratedEffectValues(const RenderStyle& style, const
         }
     }
 
-    filter = Style::toPlatform(style.filter());
-    backdropFilter = Style::toPlatform(style.backdropFilter());
+    filter = Style::toPlatform(style.filter(), style, Style::Filter::PlatformConversionAllowsCurrentColor::No);
+    backdropFilter = Style::toPlatform(style.backdropFilter(), style, Style::Filter::PlatformConversionAllowsCurrentColor::No);
 }
 
 TransformationMatrix AcceleratedEffectValues::computedTransformationMatrix(const FloatRect& boundingBox) const

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -838,24 +838,14 @@ void RenderLayerBacking::updateChildrenTransformAndAnchorPoint(const LayoutRect&
     removeChildrenTransformFromLayers(layerForPerspective);
 }
 
-static FilterOperations resolveFilters(const Style::Filter& filter, const RenderStyle& style)
-{
-    return FilterOperations { WTF::map(filter, [&](const auto& value) -> Ref<FilterOperation> {
-        Ref operation = value.value;
-        if (auto dropShadow = dynamicDowncast<Style::DropShadowFilterOperationWithStyleColor>(operation))
-            return dropShadow->createEquivalentWithResolvedColor(style);
-        return operation;
-    }) };
-}
-
 void RenderLayerBacking::updateFilters(const RenderStyle& style)
 {
-    m_canCompositeFilters = m_graphicsLayer->setFilters(resolveFilters(style.filter(), style));
+    m_canCompositeFilters = m_graphicsLayer->setFilters(Style::toPlatform(style.filter(), style));
 }
 
 void RenderLayerBacking::updateBackdropFilters(const RenderStyle& style)
 {
-    m_canCompositeBackdropFilters = m_graphicsLayer->setBackdropFilters(resolveFilters(style.backdropFilter(), style));
+    m_canCompositeBackdropFilters = m_graphicsLayer->setBackdropFilters(Style::toPlatform(style.backdropFilter(), style));
 }
 
 void RenderLayerBacking::updateBackdropFiltersGeometry()
@@ -4459,10 +4449,10 @@ bool RenderLayerBacking::startAnimation(double timeOffset, const GraphicsLayerAn
             opacityVector.insert(makeUnique<GraphicsLayerFloatAnimationValue>(offset, keyframeStyle->opacity().value.value, tf));
 
         if (currentKeyframe.animatesProperty(CSSPropertyFilter))
-            filterVector.insert(makeUnique<GraphicsLayerFilterAnimationValue>(offset, Style::toPlatform(keyframeStyle->filter()), tf));
+            filterVector.insert(makeUnique<GraphicsLayerFilterAnimationValue>(offset, Style::toPlatform(keyframeStyle->filter(), renderer().style()), tf));
 
         if (currentKeyframe.animatesProperty(CSSPropertyWebkitBackdropFilter) || currentKeyframe.animatesProperty(CSSPropertyBackdropFilter))
-            backdropFilterVector.insert(makeUnique<GraphicsLayerFilterAnimationValue>(offset, Style::toPlatform(keyframeStyle->backdropFilter()), tf));
+            backdropFilterVector.insert(makeUnique<GraphicsLayerFilterAnimationValue>(offset, Style::toPlatform(keyframeStyle->backdropFilter(), renderer().style()), tf));
     }
 
     bool didAnimate = false;

--- a/Source/WebCore/style/values/filter-effects/StyleFilter.h
+++ b/Source/WebCore/style/values/filter-effects/StyleFilter.h
@@ -80,6 +80,8 @@ struct Filter : ListOrNone<FilterValueList> {
     bool isReferenceFilter() const;
 
     IntOutsets outsets() const;
+
+    enum class PlatformConversionAllowsCurrentColor : bool { No, Yes };
 };
 
 template<FilterOperation::Type type> bool Filter::hasFilterOfType() const
@@ -112,7 +114,7 @@ template<> struct Blending<Filter> {
 // MARK: - Platform
 
 template<> struct ToPlatform<FilterValue> { auto operator()(const FilterValue&) -> Ref<FilterOperation>; };
-template<> struct ToPlatform<Filter> { auto operator()(const Filter&) -> FilterOperations; };
+template<> struct ToPlatform<Filter> { auto operator()(const Filter&, const RenderStyle&, Filter::PlatformConversionAllowsCurrentColor allowCurrentColor = Filter::PlatformConversionAllowsCurrentColor::Yes) -> FilterOperations; };
 
 // MARK: - Logging
 


### PR DESCRIPTION
#### 3ed74b8fd5e6bd0a68c5059236607cf4d12ec202
<pre>
[threaded-animations] allow the `filter` property to be accelerated with `drop-shadow()` operations containing colors
<a href="https://bugs.webkit.org/show_bug.cgi?id=305481">https://bugs.webkit.org/show_bug.cgi?id=305481</a>
<a href="https://rdar.apple.com/168144301">rdar://168144301</a>

Reviewed by Sam Weinig.

In 305530@main we made it so that `drop-shadow()` operations in `filter` properties using a color would not
be accelerated with threaded animations enabled. This was due to `DropShadowFilterOperationWithStyleColor`
not having encoding support.

However, provided the color provided is not `currentcolor`, we can resolve this filter operation type to a
`DropShadowFilterOperation` which we know how to encode. In fact, this is already what `RenderLayerBacking`
does in its `updateFilters()` and `updateBackdropFilters()` methods.

We now extract the code from `RenderLayerBacking` and move it to `Style::Filter` such that the `toPlatform()`
function takes a `RenderStyle` to convert to a `DropShadowFilterOperation` instead of a
`DropShadowFilterOperationWithStyleColor`, as well as a flag that indicates whether `currentcolor` is allowed.
We now make use of this new `toPlatform()` method when constructing `AcceleratedEffectValues`.

This now means that we should only find `DropShadowFilterOperationWithStyleColor` filter operations in
`AcceleratedEffectValues` if it uses `currentcolor`, in which case the code added in 305530@main will
correctly disallow threaded animation support.

Finally, we needed to restore the blending support for `DropShadowFilterOperation` which had been removed
in 293027@main, but with new checks that it should only be used from within the UI process.

The two new tests check that we correctly allow threaded animation generation depending on whether `currentcolor`
is used.

Tests: webanimations/threaded-animations/threaded-animation-disabled-for-drop-shadow-with-current-color.html
       webanimations/threaded-animations/threaded-animation-for-drop-shadow-with-color.html

Canonical link: <a href="https://commits.webkit.org/305629@main">https://commits.webkit.org/305629@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d669f0edf1b308bd7d163483f9be2d19ff65a6f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/139066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11243 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/363 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146995 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/91903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1b3b807d-9e33-44f6-8398-faaa2e1c57f3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140749 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11948 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11399 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106298 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/91903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b184a1f1-79e0-4645-87c9-a46071d71c1a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141823 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9021 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124432 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87168 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7350f8e4-144f-4c87-ab69-22a3adb7a905) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8598 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6347 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7296 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118029 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/307 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149781 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10925 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/314 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114687 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10946 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9244 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115002 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8899 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120760 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65830 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21415 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10974 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/301 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10710 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74624 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10914 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10761 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->