### PR TITLE
Bring WebGPU Swift CommandEncoder in-line with previous implementation

### DIFF
--- a/Source/WebGPU/WebGPU/CommandEncoder.swift
+++ b/Source/WebGPU/WebGPU/CommandEncoder.swift
@@ -414,7 +414,7 @@ extension WebGPU.CommandEncoder {
                     destinationSlice: Int(mutableSlice),
                     destinationLevel: Int(mipLevel),
                     destinationOrigin: MTLOrigin(x: 0, y: 0, z: 0),
-                    options: options
+                    options: .stencilFromDepthStencil
                 )
         }
     }
@@ -1529,11 +1529,13 @@ extension WebGPU.CommandEncoder {
                     guard !didOverflow else {
                         return
                     }
-                    var yTimesDestinationBytesPerImage = y
-                    guard destinationBytesPerImage <= UInt32.max else {
+                    var yTimesDestinationBytesPerRow = y
+                    guard destinationBytesPerRow <= UInt32.max else {
                         return
                     }
-                    (yTimesDestinationBytesPerImage, didOverflow) = yTimesDestinationBytesPerImage.multipliedReportingOverflow(by: UInt32(destinationBytesPerImage))
+                    (yTimesDestinationBytesPerRow, didOverflow) = yTimesDestinationBytesPerRow.multipliedReportingOverflow(
+                        by: UInt32(destinationBytesPerRow)
+                    )
                     guard !didOverflow else {
                         return
                     }
@@ -1548,7 +1550,7 @@ extension WebGPU.CommandEncoder {
                     guard !didOverflow else {
                         return
                     }
-                    (tripleSum, didOverflow) = tripleSum.addingReportingOverflow(UInt64(yTimesDestinationBytesPerImage))
+                    (tripleSum, didOverflow) = tripleSum.addingReportingOverflow(UInt64(yTimesDestinationBytesPerRow))
                     guard !didOverflow else {
                         return
                     }
@@ -1631,7 +1633,11 @@ extension WebGPU.CommandEncoder {
                 guard !didOverflow else {
                     return
                 }
-                let sum = UInt(destinationOffset) + UInt(widthTimesBlockSize)
+                var sum = UInt(destinationOffset)
+                (sum, didOverflow) = sum.addingReportingOverflow(UInt(widthTimesBlockSize))
+                guard !didOverflow else {
+                    return
+                }
                 if sum > destinationBuffer.length {
                     continue
                 }
@@ -1828,21 +1834,24 @@ extension WebGPU.CommandEncoder {
                     return
                 }
                 var zTimesSourceBytesPerImage = z
-                guard let sourceBytesPerRowU32 = UInt32(exactly: sourceBytesPerRow) else {
+                guard let sourceBytesPerImageU32 = UInt32(exactly: sourceBytesPerImage) else {
                     return
                 }
-                (zTimesSourceBytesPerImage, didOverflow) = zTimesSourceBytesPerImage.multipliedReportingOverflow(by: sourceBytesPerRowU32)
+                (zTimesSourceBytesPerImage, didOverflow) = zTimesSourceBytesPerImage.multipliedReportingOverflow(by: sourceBytesPerImageU32)
                 guard !didOverflow else {
                     return
                 }
+                guard let sourceBytesPerRowU32 = UInt32(exactly: sourceBytesPerRow) else {
+                    return
+                }
                 for y in 0..<copySize.height {
-                    var yTimesSourceBytesPerImage = y
-                    (yTimesSourceBytesPerImage, didOverflow) = yTimesSourceBytesPerImage.multipliedReportingOverflow(by: sourceBytesPerRowU32)
+                    var yTimesSourceBytesPerRow = y
+                    (yTimesSourceBytesPerRow, didOverflow) = yTimesSourceBytesPerRow.multipliedReportingOverflow(by: sourceBytesPerRowU32)
                     guard !didOverflow else {
                         return
                     }
                     var tripleSum = UInt64(zTimesSourceBytesPerImage)
-                    (tripleSum, didOverflow) = tripleSum.addingReportingOverflow(UInt64(yTimesSourceBytesPerImage))
+                    (tripleSum, didOverflow) = tripleSum.addingReportingOverflow(UInt64(yTimesSourceBytesPerRow))
                     guard !didOverflow else {
                         return
                     }
@@ -1929,8 +1938,8 @@ extension WebGPU.CommandEncoder {
                 guard !didOverflow else {
                     return
                 }
-                guard sourceOffsetPlusSourceBytesPerRow <= sourceBuffer.length else {
-                    return
+                if sourceOffsetPlusSourceBytesPerRow > sourceBuffer.length {
+                    continue
                 }
 
                 // FIXME: Remove these unnecessary force unwraps.


### PR DESCRIPTION
#### 30f11cdf3fda4ed385b3f6e84e0eafcdb2370a6f
<pre>
Bring WebGPU Swift CommandEncoder in-line with previous implementation
<a href="https://bugs.webkit.org/show_bug.cgi?id=305480">https://bugs.webkit.org/show_bug.cgi?id=305480</a>
<a href="https://rdar.apple.com/168144897">rdar://168144897</a>

Reviewed by NOBODY (OOPS!).

This patch corrects some differences between the Swift and Objective-C CommandEncoder implementation in WebGPU

No new tests (OOPS!).

* Source/WebGPU/WebGPU/CommandEncoder.swift:
(WebGPU.copyTextureToBuffer(_:destination:copySize:)):
(WebGPU.copyBufferToTexture(_:destination:copySize:)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30f11cdf3fda4ed385b3f6e84e0eafcdb2370a6f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138830 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11196 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/317 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146949 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91805 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1c9a1ebd-9ac7-4294-b4d9-1d4f63bc4bb8) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11901 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11352 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106261 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77521 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/17e964c8-7ec4-4477-9bdb-f842e12b1e40) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141777 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8985 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124403 "1 api test failed or timed out") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87130 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/47767954-d0b5-4114-a64e-630cd3ad1a4d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8565 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6314 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7247 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117994 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149735 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10878 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/272 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114649 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10899 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9206 "1 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114965 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8850 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120720 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/65784 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10926 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/266 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10664 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74578 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10867 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10715 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->