### PR TITLE
[JSC] Fix JIT-less Wasm-to-JS i31ref, anyref, eqref marshalling of i31 values

### DIFF
--- a/JSTests/wasm/gc/wasm-js-marshal-i31-return.js
+++ b/JSTests/wasm/gc/wasm-js-marshal-i31-return.js
@@ -1,0 +1,115 @@
+import * as assert from "../assert.js";
+import { instantiate } from "./wast-wrapper.js";
+
+function testI31refImport(value) {
+  let jsFunc = () => value;
+
+  let m = instantiate(`
+    (module
+      (import "env" "getNumber" (func $getNumber (result i31ref)))
+      (func (export "test") (result i32)
+        (call $getNumber)
+        (i31.get_s))
+    )
+  `, { env: { getNumber: jsFunc } });
+
+  let result = m.exports.test();
+  assert.eq(result, value);
+}
+
+function testEqrefImport(value) {
+  let jsFunc = () => value;
+
+  let m = instantiate(`
+    (module
+      (import "env" "getNumber" (func $getNumber (result eqref)))
+      (func (export "test") (result i32)
+        (call $getNumber)
+        (ref.cast (ref i31))
+        (i31.get_s))
+    )
+  `, { env: { getNumber: jsFunc } });
+
+  let result = m.exports.test();
+  assert.eq(result, value);
+}
+
+function testAnyrefImport(value) {
+  let jsFunc = () => value;
+
+  let m = instantiate(`
+    (module
+      (import "env" "getNumber" (func $getNumber (result anyref)))
+      (func (export "test") (result i32)
+        (call $getNumber)
+        (ref.cast (ref i31))
+        (i31.get_s))
+    )
+  `, { env: { getNumber: jsFunc } });
+
+  let result = m.exports.test();
+  assert.eq(result, value);
+}
+
+testI31refImport(42);
+testI31refImport(42.0);
+testI31refImport(-3251.0);
+// Max i31ref value: 2^30 - 1 = 1073741823
+testI31refImport(1073741823);
+testI31refImport(1073741823.0);
+// Min i31ref value: -2^30 = -1073741824
+testI31refImport(-1073741824);
+testI31refImport(-1073741824.0);
+
+assert.throws(() => testI31refImport(42.5),
+    TypeError,
+    "Argument value did not match the reference type");
+assert.throws(() => testI31refImport(1073741824),
+    TypeError,
+    "Argument value did not match the reference type");
+assert.throws(() => testI31refImport(-1073741825),
+    TypeError,
+    "Argument value did not match the reference type");
+
+
+testEqrefImport(42);
+testEqrefImport(42.0);
+testEqrefImport(-3251.0);
+// Max i31ref value: 2^30 - 1 = 1073741823
+testEqrefImport(1073741823);
+testEqrefImport(1073741823.0);
+// Min i31ref value: -2^30 = -1073741824
+testEqrefImport(-1073741824);
+testEqrefImport(-1073741824.0);
+
+assert.throws(() => testEqrefImport(42.5),
+    TypeError,
+    "Argument value did not match the reference type");
+assert.throws(() => testEqrefImport(1073741824),
+    TypeError,
+    "Argument value did not match the reference type");
+assert.throws(() => testEqrefImport(-1073741825),
+    TypeError,
+    "Argument value did not match the reference type");
+
+
+testAnyrefImport(42);
+testAnyrefImport(42.0);
+testAnyrefImport(-3251.0);
+// Max i31ref value: 2^30 - 1 = 1073741823
+testAnyrefImport(1073741823);
+testAnyrefImport(1073741823.0);
+// Min i31ref value: -2^30 = -1073741824
+testAnyrefImport(-1073741824);
+testAnyrefImport(-1073741824.0);
+
+assert.throws(() => testAnyrefImport(42.5),
+    WebAssembly.RuntimeError,
+    "ref.cast failed to cast reference to target heap type");
+assert.throws(() => testAnyrefImport(1073741824),
+    WebAssembly.RuntimeError,
+    "ref.cast failed to cast reference to target heap type");
+assert.throws(() => testAnyrefImport(-1073741825),
+    WebAssembly.RuntimeError,
+    "ref.cast failed to cast reference to target heap type");
+

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -580,6 +580,7 @@ JSC_DEFINE_JIT_OPERATION(operationWasmToJSExitMarshalReturnValues, void, (void* 
                             OPERATION_RETURN(scope);
                         }
                     }
+                    // Validation only: value not modified so write back not needed.
                 } else {
                     // operationConvertToAnyref
                     JSValue value = JSValue::decode(std::bit_cast<EncodedJSValue>(returned));
@@ -588,8 +589,8 @@ JSC_DEFINE_JIT_OPERATION(operationWasmToJSExitMarshalReturnValues, void, (void* 
                         throwTypeError(globalObject, scope, "Argument value did not match the reference type"_s);
                         OPERATION_RETURN(scope);
                     }
+                    *access.operator()<uint64_t>(registerSpace, 0) = std::bit_cast<uint64_t>(value);
                 }
-                // do nothing, the register is already there
             } else
                 RELEASE_ASSERT_NOT_REACHED();
         }


### PR DESCRIPTION
#### 8579516f4b614767454617d0a4fcd6f3261b04f4
<pre>
[JSC] Fix JIT-less Wasm-to-JS i31ref, anyref, eqref marshalling of i31 values
<a href="https://bugs.webkit.org/show_bug.cgi?id=305485">https://bugs.webkit.org/show_bug.cgi?id=305485</a>
<a href="https://rdar.apple.com/164144482">rdar://164144482</a>

Reviewed by Justin Michaud.

When a JS function is imported to wasm and returns an i31ref or
anyref/eqref with an i31 value, the JIT-less marshalling code was
converting legal i31 number JSValues to Int32 format for validation, but
not actually returning that reformatted value back. So if the
value was in double format, the i31 value would be incorrect.
Fix this by writing back the converted value.

Test: JSTests/wasm/gc/wasm-js-marshal-i31-return.js
Canonical link: <a href="https://commits.webkit.org/305595@main">https://commits.webkit.org/305595@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9327a47d7ef5e7b5ffd24eddd1a0f864be34b164

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138841 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11208 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/328 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146960 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/91818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/942bd607-2c32-4a7c-b17f-d05d7feedd28) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11912 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11364 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106269 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/91818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a13e1b3e-d617-4b73-b47c-5b9f96247fb9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141788 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8995 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/124410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87138 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b2fc10b4-1194-44ef-b739-0ddc15a768e9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8575 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/6322 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7258 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/130813 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118004 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/278 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149746 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/137443 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10889 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/286 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114658 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10910 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9215 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114974 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8860 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120732 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65795 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21394 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10937 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/276 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/170114 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/10675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/74589 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44329 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10878 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10726 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->