### PR TITLE
[threaded-animations] filters are animated in reverse

### DIFF
--- a/LayoutTests/webanimations/threaded-animations/filter-animation-blending-expected.html
+++ b/LayoutTests/webanimations/threaded-animations/filter-animation-blending-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<style>
+
+div {
+    width: 100px;
+    height: 100px;
+    background-color: blue;
+    filter: grayscale(100%);
+}
+
+</style>
+<div></div>

--- a/LayoutTests/webanimations/threaded-animations/filter-animation-blending.html
+++ b/LayoutTests/webanimations/threaded-animations/filter-animation-blending.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ThreadedTimeBasedAnimationsEnabled=true ] -->
+<style>
+
+@keyframes anim {
+	0% { filter: grayscale(100%) }
+	50% { filter: grayscale(100%) }
+	100% { filter: grayscale(0%) }
+}
+
+div {
+    width: 100px;
+    height: 100px;
+    background-color: blue;
+	animation: anim 1000s;
+}
+
+</style>
+<div></div>
+<script src="threaded-animations-utils.js"></script>
+<script>
+
+(async function () {
+    window.testRunner?.waitUntilDone();
+    await threadedAnimationsCommit();
+    window.testRunner?.notifyDone();
+})();
+
+</script>

--- a/Source/WebCore/platform/animation/AcceleratedEffect.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.cpp
@@ -358,10 +358,10 @@ static void blend(AcceleratedEffectProperty property, AcceleratedEffectValues& o
         output.offsetRotate = blend(from.offsetRotate, to.offsetRotate, blendingContext);
         break;
     case AcceleratedEffectProperty::Filter:
-        output.filter = to.filter.blend(from.filter, blendingContext);
+        output.filter = from.filter.blend(to.filter, blendingContext);
         break;
     case AcceleratedEffectProperty::BackdropFilter:
-        output.backdropFilter = to.backdropFilter.blend(from.backdropFilter, blendingContext);
+        output.backdropFilter = from.backdropFilter.blend(to.backdropFilter, blendingContext);
         break;
     case AcceleratedEffectProperty::Invalid:
         ASSERT_NOT_REACHED();


### PR DESCRIPTION
#### d28f6dfad9a53d8da171aa464a706e84a164cf37
<pre>
[threaded-animations] filters are animated in reverse
<a href="https://bugs.webkit.org/show_bug.cgi?id=305486">https://bugs.webkit.org/show_bug.cgi?id=305486</a>
<a href="https://rdar.apple.com/168149976">rdar://168149976</a>

Reviewed by Anne van Kesteren.

Switch the `FilterOperations` callee and argument when blending filters so that they are
animated in the correct direction.

Test: webanimations/threaded-animations/filter-animation-blending.html
Canonical link: <a href="https://commits.webkit.org/305596@main">https://commits.webkit.org/305596@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e98b84fab8052975c1be3268b199fe4a8faf439

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138842 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11209 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/329 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146961 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/91820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8aa7e6b7-e13d-4841-8c76-c2994301aa7d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140715 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11913 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11365 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106270 "Found 1 new test failure: platform/glib/non-compositing/simple-dom.html (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/91820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/655f2ac2-1a29-430c-a60f-093a0bc4e197) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141789 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8999 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/124411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87139 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f08b218c-928e-4bbc-86c6-a706146f4bcf) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8578 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/6324 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7259 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118007 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/279 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149747 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10890 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/287 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114659 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10911 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9217 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114975 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8864 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120733 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65796 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21395 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10938 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/277 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10676 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/74590 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10879 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10727 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->