### PR TITLE
High INP (Interaction to Next Paint) for interactions with no immediate screen updates

### DIFF
--- a/LayoutTests/performance-api/event-timing-entry-schedules-update-rendering-expected.txt
+++ b/LayoutTests/performance-api/event-timing-entry-schedules-update-rendering-expected.txt
@@ -1,0 +1,29 @@
+Test if a rendering update is scheduled after an event timing entry is queued.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS timeToDispatch[0] is <= 100
+PASS timeToDispatch[1] is <= 100
+PASS timeToDispatch[2] is <= 100
+PASS timeToDispatch[3] is <= 100
+PASS timeToDispatch[4] is <= 100
+PASS timeToDispatch[5] is <= 100
+PASS timeToDispatch[6] is <= 100
+PASS timeToDispatch[7] is <= 100
+PASS timeToDispatch[8] is <= 100
+PASS timeToDispatch[9] is <= 100
+PASS timeToDispatch[10] is <= 100
+PASS timeToDispatch[11] is <= 100
+PASS timeToDispatch[12] is <= 100
+PASS timeToDispatch[13] is <= 100
+PASS timeToDispatch[14] is <= 100
+PASS timeToDispatch[15] is <= 100
+PASS timeToDispatch[16] is <= 100
+PASS timeToDispatch[17] is <= 100
+PASS timeToDispatch[18] is <= 100
+PASS timeToDispatch[19] is <= 100
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Click me!

--- a/LayoutTests/performance-api/event-timing-entry-schedules-update-rendering.html
+++ b/LayoutTests/performance-api/event-timing-entry-schedules-update-rendering.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="../resources/js-test.js"></script>
+</head>
+
+<body>
+
+<h1 id="h1">Click me!</h1>
+
+<script>
+
+description("Test if a rendering update is scheduled after an event timing entry is queued.")
+window.jsTestIsAsync = true;
+
+function busyWait(delay) {
+    const startTime = performance.now();
+    while (performance.now() < startTime + delay);
+}
+
+const timeToDispatch = [];
+
+async function test()
+{
+    // This test tries to detect https://bugs.webkit.org/show_bug.cgi?id=305251 by
+    // triggering an event and then measuring if an update the rendering step happened
+    // or is scheduled to happen. This is non-deterministic because an update may be
+    // scheduled for other reasons, so we try to avoid spurious passes with several
+    // iterations.
+
+    window.internals.startTrackingRenderingUpdates();
+    await new Promise( r => requestAnimationFrame(r) );
+    let renderingCountAtEventHandling;
+    h1.addEventListener('click', e => {
+        busyWait(30);
+        renderingCountAtEventHandling = window.internals.renderingUpdateCount();
+    });
+
+    let resolve;
+    new PerformanceObserver( evs => {
+        evs.getEntriesByName('click').forEach( e => resolve() );
+    }).observe({type: 'event', durationThreshold: 16});
+
+    for (let i=0; i<20; i++) {
+        let promise;
+        ( {promise, resolve} = Promise.withResolvers() );
+
+        await eventSender.asyncMouseMoveTo(h1.offsetLeft + 5, h1.offsetTop + 5);
+        await eventSender.asyncMouseDown();
+        await eventSender.asyncMouseUp();
+
+        let updateHappened = window.internals.renderingUpdateCount() > renderingCountAtEventHandling;
+        let timeToNextRenderingUpdate = window.internals.timeToNextRenderingUpdate();
+        if (updateHappened)
+            timeToDispatch.push(0);
+        else if (!timeToNextRenderingUpdate)
+            timeToDispatch.push(Infinity);
+        else
+            timeToDispatch.push(timeToNextRenderingUpdate);
+
+        await promise;
+    }
+
+    // We can only check results after all measurements are taken because
+    // shouldBe*() can effect how rendering is scheduled.
+    for (let i=0; i<timeToDispatch.length; i++) {
+        // An update must be scheduled in 100ms because this is the
+        // default cutoff for event timing entries:
+        shouldBeLessThanOrEqual(`timeToDispatch[${i}]`, "100");
+    }
+
+    finishJSTest();
+}
+
+test();
+
+</script>
+
+</body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -357,6 +357,7 @@ http/tests/security/contentSecurityPolicy/object-redirect-blocked3.html
 imported/w3c/web-platform-tests/pointerlock [ Skip ]
 
 # webkit.org/b/285901 EventSender.mouse[Up|Down|MoveTo] do not work on iOS
+performance-api/event-timing-entry-schedules-update-rendering.html [ Skip ]
 pointer-lock/bug90391-move-then-window-open-crash.html [ Skip ]
 pointer-lock/mouse-event-delivery.html [ Skip ]
 pointer-lock/pointermove-movement-delta.html [ Skip ]

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -410,6 +410,7 @@ private:
     EventTimingInteractionID& ensureUserInteractionValue();
     EventTimingInteractionID generateInteractionID();
     EventTimingInteractionID generateInteractionIDWithoutIncreasingInteractionCount();
+    void queueEventTimingCandidateForDispatch(PerformanceEventTimingCandidate&);
 
     bool isSameSecurityOriginAsMainFrame() const;
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2141,6 +2141,15 @@ std::optional<MonotonicTime> Page::nextRenderingUpdateTimestamp() const
     return m_lastRenderingUpdateTimestamp + std::floor((now + interval - m_lastRenderingUpdateTimestamp) / interval) * interval;
 }
 
+std::optional<Seconds> Page::timeToNextRenderingUpdateForTesting() const
+{
+    auto nextUpdate = nextRenderingUpdateTimestamp();
+    if (!nextUpdate)
+        return std::nullopt;
+
+    return *nextUpdate - MonotonicTime::now();
+}
+
 void Page::didScheduleRenderingUpdate()
 {
 #if ENABLE(ASYNC_SCROLLING)

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1184,6 +1184,7 @@ public:
 
     MonotonicTime lastRenderingUpdateTimestamp() const { return m_lastRenderingUpdateTimestamp; }
     std::optional<MonotonicTime> nextRenderingUpdateTimestamp() const;
+    WEBCORE_EXPORT std::optional<Seconds> timeToNextRenderingUpdateForTesting() const;
 
     bool httpsUpgradeEnabled() const { return m_httpsUpgradeEnabled; }
 

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -4372,6 +4372,18 @@ ExceptionOr<unsigned> Internals::renderingUpdateCount()
     return document->page()->renderingUpdateCount();
 }
 
+ExceptionOr<std::optional<double>> Internals::timeToNextRenderingUpdate()
+{
+    Document* document = contextDocument();
+    if (!document || !document->page())
+        return Exception { ExceptionCode::InvalidAccessError };
+
+    if (auto timeToNextUpdate = document->page()->timeToNextRenderingUpdateForTesting())
+        return timeToNextUpdate->milliseconds();
+
+    return { std::nullopt };
+}
+
 ExceptionOr<void> Internals::setCompositingPolicyOverride(std::optional<CompositingPolicy> policyOverride)
 {
     Document* document = contextDocument();

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -736,6 +736,8 @@ public:
     ExceptionOr<void> startTrackingRenderingUpdates();
     ExceptionOr<unsigned> renderingUpdateCount();
 
+    ExceptionOr<std::optional<double>> timeToNextRenderingUpdate();
+
     enum CompositingPolicy { Normal, Conservative };
     ExceptionOr<void> setCompositingPolicyOverride(std::optional<CompositingPolicy>);
     ExceptionOr<std::optional<CompositingPolicy>> compositingPolicyOverride() const;

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -981,6 +981,8 @@ enum ContentsFormat {
     undefined startTrackingRenderingUpdates();
     unsigned long renderingUpdateCount();
 
+    double? timeToNextRenderingUpdate();
+
     attribute CompositingPolicy? compositingPolicyOverride;
 
     undefined updateLayoutAndStyleForAllFrames();


### PR DESCRIPTION
#### 8af8a7cdd78db735eaa75c88b9dd8b987512f697
<pre>
High INP (Interaction to Next Paint) for interactions with no immediate screen updates
<a href="https://bugs.webkit.org/show_bug.cgi?id=305251">https://bugs.webkit.org/show_bug.cgi?id=305251</a>
<a href="https://rdar.apple.com/168016487">rdar://168016487</a>

Reviewed by Ryan Reno

We now ensure &quot;update the rendering&quot; (Page::updateRendering()) is
scheduled to run whenever an event timing entry is queued to be
dispatched. This ensures the dispatch will happen in a timely manner.

Previously, static pages in which nothing forces an update to
rendering could take too long to dispatch the entries, producing
entries with unreasonably large durations. That could be interpreted
as the page being unresponsive in metrics such as INP.

In order to test this, we need to probe the scheduling state, so a new
testing API was added: window.internals.timeToNextRenderingUpdate().

Test added:
* LayoutTests/performance-api/event-timing-entry-schedules-update-rendering.html

Canonical link: <a href="https://commits.webkit.org/306142@main">https://commits.webkit.org/306142@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63197fada848aa42f615cbe9d4787657c8fdab25

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140400 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12782 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1913 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148723 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93487 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142273 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13494 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12936 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107635 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/78153 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143351 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10388 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125690 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88533 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10009 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7568 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8833 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119248 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1702 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151349 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12470 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1772 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115936 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12485 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10687 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116273 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29567 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/11433 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122179 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67488 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12512 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1629 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12252 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76212 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12450 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12296 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->