### PR TITLE
[JSC] Implement MakeFullYear abstract operation

### DIFF
--- a/JSTests/stress/date-make-full-year.js
+++ b/JSTests/stress/date-make-full-year.js
@@ -1,0 +1,35 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`Expected ${expected}, but got ${actual}`);
+}
+
+shouldBe(new Date(0, 0).getFullYear(), 1900);
+shouldBe(new Date(1, 0).getFullYear(), 1901);
+shouldBe(new Date(50, 0).getFullYear(), 1950);
+shouldBe(new Date(98, 0).getFullYear(), 1998);
+shouldBe(new Date(99, 0).getFullYear(), 1999);
+
+shouldBe(new Date(100, 0).getFullYear(), 100);
+shouldBe(new Date(1900, 0).getFullYear(), 1900);
+shouldBe(new Date(2024, 0).getFullYear(), 2024);
+shouldBe(new Date(9999, 0).getFullYear(), 9999);
+
+shouldBe(new Date(-1, 0).getFullYear(), -1);
+shouldBe(new Date(-100, 0).getFullYear(), -100);
+
+// Fractional years truncate
+shouldBe(new Date(0.9, 0).getFullYear(), 1900);
+shouldBe(new Date(50.1, 0).getFullYear(), 1950);
+shouldBe(new Date(50.9, 0).getFullYear(), 1950);
+shouldBe(new Date(99.9, 0).getFullYear(), 1999);
+shouldBe(new Date(100.1, 0).getFullYear(), 100);
+shouldBe(new Date(100.9, 0).getFullYear(), 100);
+
+shouldBe(new Date(Date.UTC(0, 0)).getUTCFullYear(), 1900);
+shouldBe(new Date(Date.UTC(50, 0)).getUTCFullYear(), 1950);
+shouldBe(new Date(Date.UTC(99, 0)).getUTCFullYear(), 1999);
+shouldBe(new Date(Date.UTC(100, 0)).getUTCFullYear(), 100);
+shouldBe(new Date(Date.UTC(2024, 0)).getUTCFullYear(), 2024);
+
+// NaN
+shouldBe(isNaN(new Date(NaN, 0).getTime()), true);

--- a/Source/JavaScriptCore/runtime/DateConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/DateConstructor.cpp
@@ -90,8 +90,7 @@ static double millisecondsFromComponents(JSGlobalObject* globalObject, const Arg
     if (hasNonFinite)
         return PNaN;
 
-    if (0 <= doubleArguments[0] && doubleArguments[0] <= 99)
-        doubleArguments[0] += 1900;
+    doubleArguments[0] = makeFullYear(doubleArguments[0]);
 
     double time = makeDate(makeDay(doubleArguments[0], doubleArguments[1], doubleArguments[2]), makeTime(doubleArguments[3], doubleArguments[4], doubleArguments[5], doubleArguments[6]));
     return timeClip(vm.dateCache.localTimeToMS(time, timeType));

--- a/Source/JavaScriptCore/runtime/DateConstructor.h
+++ b/Source/JavaScriptCore/runtime/DateConstructor.h
@@ -85,4 +85,15 @@ constexpr static inline double makeTime(double hour, double min, double sec, dou
 #endif
     return (((hour * msPerHour) + min * msPerMinute) + sec * msPerSecond) + ms;
 }
+
+// https://tc39.es/ecma262/#sec-makefullyear
+constexpr static inline double makeFullYear(double year)
+{
+    if (std::isnan(year))
+        return PNaN;
+    double truncated = std::trunc(year);
+    if (0 <= truncated && truncated <= 99)
+        return 1900 + truncated;
+    return truncated;
+}
 } // namespace JSC


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=301271

Reviewed by NOBODY (OOPS!).

Extract existing year logic (in DateConstructor.cpp) into a named function for the spec operation.

Test: JSTests/stress/date-make-full-year.js

* JSTests/stress/date-make-full-year.js: Added. (shouldBe):
* Source/JavaScriptCore/runtime/DateConstructor.cpp: (JSC::millisecondsFromComponents):
* Source/JavaScriptCore/runtime/DateConstructor.h: (JSC::makeFullYear):<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d9620e7edbe99207e03c8977df1137f242bfd34

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138864 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11231 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/351 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146983 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/91891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11936 "Hash 2d9620e7 for PR 56578 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11387 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106287 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/91891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141811 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/11936 "Hash 2d9620e7 for PR 56578 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124424 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87157 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/11936 "Hash 2d9620e7 for PR 56578 does not build (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6339 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7284 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/130836 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/11936 "Hash 2d9620e7 for PR 56578 does not build (failure)") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149769 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/137466 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10913 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/304 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114684 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10934 "Hash 2d9620e7 for PR 56578 does not build (failure)") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9235 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114992 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120750 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/65818 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10962 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/293 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/170137 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10698 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74612 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44334 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10902 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10749 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->