### PR TITLE
[JSC][WASM][Debugger] Re-enable previously disabled WASM debugger tests and remove LLDB workarounds

### DIFF
--- a/JSTests/wasm/debugger/lib/core/base.py
+++ b/JSTests/wasm/debugger/lib/core/base.py
@@ -359,11 +359,6 @@ class BaseTestCase:
             self.lldb_process = subprocess.Popen(
                 [
                     lldb_path,
-                    # FIXME: Should remove these two once Swift LLDB step over issue is fixed
-                    "-o",
-                    "settings set stop-line-count-before 0",  # FIXME: Disable showing lines before
-                    "-o",
-                    "settings set stop-line-count-after 0",  # FIXME: Disable showing lines after
                     "-o",
                     connect_cmd,
                 ],
@@ -494,7 +489,7 @@ class BaseTestCase:
             return result
 
     def send_lldb_command_or_raise(
-        self, command: str, patterns=None, mode=PatternMatchMode.ALL, timeout=30.0
+        self, command: str, patterns=None, mode=PatternMatchMode.ALL, timeout=60.0
     ):
         """Send LLDB command with patterns and raise exception on failure"""
         result = self.send_lldb_command_with_patterns(command, patterns, mode, timeout)

--- a/JSTests/wasm/debugger/tests/tests.py
+++ b/JSTests/wasm/debugger/tests/tests.py
@@ -866,13 +866,11 @@ class ThrowCatchAllTestCase(BaseTestCase):
     def execute(self):
         self.setup_debugging_session_or_raise("resources/wasm/throw-catch-all.js")
 
-        # FIXME: LLDB crashes on this test.
-        # try:
-        #     for _ in range(1):
-        #         self.stepTest()
+        try:
+            self.stepTest()
 
-        # except Exception as e:
-        #     raise Exception(f"Throw catch_all test failed: {e}")
+        except Exception as e:
+            raise Exception(f"Throw catch_all test failed: {e}")
 
     def stepTest(self):
         self.send_lldb_command_or_raise("b 0x400000000000006e")
@@ -933,13 +931,11 @@ class DelegateTestCase(BaseTestCase):
     def execute(self):
         self.setup_debugging_session_or_raise("resources/wasm/delegate.js")
 
-        # FIXME: LLDB crashes on this test.
-        # try:
-        #     for _ in range(1):
-        #         self.stepTest()
+        try:
+            self.stepTest()
 
-        # except Exception as e:
-        #     raise Exception(f"Delegate test failed: {e}")
+        except Exception as e:
+            raise Exception(f"Delegate test failed: {e}")
 
     def stepTest(self):
         self.send_lldb_command_or_raise("b 0x40000000000000c6")
@@ -1046,13 +1042,11 @@ class RethrowTestCase(BaseTestCase):
     def execute(self):
         self.setup_debugging_session_or_raise("resources/wasm/rethrow.js")
 
-        # FIXME: LLDB crashes on this test.
-        # try:
-        #     for _ in range(1):
-        #         self.stepTest()
+        try:
+            self.stepTest()
 
-        # except Exception as e:
-        #     raise Exception(f"Rethrow test failed: {e}")
+        except Exception as e:
+            raise Exception(f"Rethrow test failed: {e}")
 
     def stepTest(self):
         self.send_lldb_command_or_raise("b 0x40000000000000b8")
@@ -1365,13 +1359,11 @@ class TryTableTestCase(BaseTestCase):
     def execute(self):
         self.setup_debugging_session_or_raise("resources/wasm/try-table.js")
 
-        # FIXME: LLDB crashes on this test.
-        # try:
-        #     for _ in range(1):
-        #         self.stepTest()
+        try:
+            self.stepTest()
 
-        # except Exception as e:
-        #     raise Exception(f"Try table test failed: {e}")
+        except Exception as e:
+            raise Exception(f"Try table test failed: {e}")
 
     def stepTest(self):
         self.send_lldb_command_or_raise("b 0x40000000000000aa")


### PR DESCRIPTION
#### a0b9671d5371b96119693289ba8df43e77c5a48a
<pre>
[JSC][WASM][Debugger] Re-enable previously disabled WASM debugger tests and remove LLDB workarounds
<a href="https://bugs.webkit.org/show_bug.cgi?id=305495">https://bugs.webkit.org/show_bug.cgi?id=305495</a>
<a href="https://rdar.apple.com/168161278">rdar://168161278</a>

Reviewed by Justin Michaud.

Following up on the LLDB path fix in [1], the WASM debugger
tests now work correctly with the standard Xcode LLDB.

Re-enable three test cases that were previously commented out due to
LLDB crashes:
- ThrowCatchAllTestCase
- DelegateTestCase
- TryTableTestCase
- RethrowTestCase

Remove LLDB display workarounds (stop-line-count-before/after settings)
that are no longer needed. Increase command timeout from 30s to 60s for
better reliability.

No test needed since this is a config change.

[1] <a href="https://commits.webkit.org/305587@main">https://commits.webkit.org/305587@main</a>

Canonical link: <a href="https://commits.webkit.org/305600@main">https://commits.webkit.org/305600@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c9c650affe0249fe81c0aef2e11579a9047026a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138885 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11252 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/372 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147004 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/91912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9209b15a-2785-4313-8320-8e27679364f9) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11957 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11408 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/106303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/91912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7ffdb915-254d-431e-833f-c465a16e58b5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141832 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9026 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/124438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/87173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fb61ef43-f11b-4bf9-8ae9-50847aa90447) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/8602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/6352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7305 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/130857 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/118034 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149790 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/137487 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10934 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/114692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10955 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/9250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/115007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8906 "Passed tests") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/120769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/65839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21397 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/10983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/170158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/10719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/170158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/10923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10770 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->