### PR TITLE
ThrowScopes should not be able to clear termination exceptions

### DIFF
--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -895,7 +895,7 @@ static void sanitizeRemoteFunctionException(VM& vm, JSRemoteFunction* remoteFunc
 
     JSGlobalObject* globalObject = remoteFunction->globalObject();
     JSValue exceptionValue = exception->value();
-    scope.clearException();
+    TRY_CLEAR_EXCEPTION(scope, void());
 
     // Avoid user-observable ToString()
     String exceptionString;

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -2468,13 +2468,12 @@ LLINT_SLOW_PATH_DECL(slow_path_retrieve_and_clear_exception_if_catchable)
     RELEASE_ASSERT(!!throwScope.exception());
 
     Exception* exception = throwScope.exception();
-    if (vm.isTerminationException(exception))
-        LLINT_RETURN_TWO(pc, nullptr);
-
     // We want to clear the exception here rather than in the catch prologue
     // JIT code because clearing it also entails clearing a bit in an Atomic
     // bit field in VMTraps.
-    throwScope.clearException();
+    if (!throwScope.tryClearException())
+        LLINT_RETURN_TWO(pc, nullptr);
+
     LLINT_RETURN_TWO(pc, exception);
 }
 

--- a/Source/JavaScriptCore/runtime/FunctionConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/FunctionConstructor.cpp
@@ -200,7 +200,7 @@ JSObject* constructFunction(JSGlobalObject* globalObject, const ArgList& args, c
 
     if (!globalObject->evalEnabled()) [[unlikely]] {
         if (globalObject->trustedTypesEnforcement() != TrustedTypesEnforcement::EnforcedWithEvalEnabled) {
-            scope.clearException();
+            TRY_CLEAR_EXCEPTION(scope, nullptr);
             globalObject->globalObjectMethodTable()->reportViolationForUnsafeEval(globalObject, !code.isNull() ? WTF::move(code) : nullString());
             throwException(globalObject, scope, createEvalError(globalObject, globalObject->evalDisabledErrorMessage()));
             return nullptr;

--- a/Source/JavaScriptCore/runtime/JSInternalPromiseConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSInternalPromiseConstructor.cpp
@@ -90,7 +90,7 @@ JSC_DEFINE_HOST_FUNCTION(internalPromiseConstructorFuncInternalAll, (JSGlobalObj
     auto callReject = [&]() -> void {
         Exception* exception = scope.exception();
         ASSERT(exception);
-        scope.clearException();
+        TRY_CLEAR_EXCEPTION(scope, void());
         scope.release();
         promise->reject(vm, globalObject, exception);
     };

--- a/Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp
@@ -164,11 +164,8 @@ JSC_DEFINE_HOST_FUNCTION(iteratorProtoFuncForEach, (JSGlobalObject* globalObject
 
     JSValue callbackArg = callFrame->argument(0);
     if (!callbackArg.isCallable()) {
-        {
-            auto catchScope = DECLARE_CATCH_SCOPE(vm);
-            iteratorClose(globalObject, thisValue);
-            catchScope.clearException();
-        }
+        iteratorClose(globalObject, thisValue);
+        TRY_CLEAR_EXCEPTION(scope, { });
         return throwVMTypeError(globalObject, scope, "Iterator.prototype.forEach requires the callback argument to be callable."_s);
     }
 

--- a/Source/JavaScriptCore/runtime/JSPromise.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromise.cpp
@@ -239,11 +239,7 @@ JSPromise* JSPromise::rejectWithCaughtException(JSGlobalObject* globalObject, Th
     VM& vm = globalObject->vm();
     Exception* exception = scope.exception();
     ASSERT(exception);
-    if (vm.isTerminationException(exception)) [[unlikely]] {
-        scope.release();
-        return this;
-    }
-    scope.clearException();
+    TRY_CLEAR_EXCEPTION(scope, nullptr);
     scope.release();
     reject(vm, globalObject, exception->value());
     return this;

--- a/Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp
@@ -169,7 +169,7 @@ static JSObject* promiseRaceSlow(JSGlobalObject* globalObject, CallFrame* callFr
     auto callRejectWithScopeException = [&]() -> void {
         Exception* exception = scope.exception();
         ASSERT(exception);
-        scope.clearException();
+        TRY_CLEAR_EXCEPTION(scope, void());
         callReject(exception->value());
     };
 
@@ -252,7 +252,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncRace, (JSGlobalObject* globalObje
     auto callReject = [&]() -> void {
         Exception* exception = scope.exception();
         ASSERT(exception);
-        scope.clearException();
+        TRY_CLEAR_EXCEPTION(scope, void());
         scope.release();
         promise->reject(vm, globalObject, exception);
     };
@@ -318,7 +318,7 @@ static JSObject* promiseAllSlow(JSGlobalObject* globalObject, CallFrame* callFra
     auto callRejectWithScopeException = [&]() -> void {
         Exception* exception = scope.exception();
         ASSERT(exception);
-        scope.clearException();
+        TRY_CLEAR_EXCEPTION(scope, void());
         callReject(exception->value());
     };
 
@@ -451,7 +451,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncAll, (JSGlobalObject* globalObjec
     auto callReject = [&]() -> void {
         Exception* exception = scope.exception();
         ASSERT(exception);
-        scope.clearException();
+        TRY_CLEAR_EXCEPTION(scope, void());
         scope.release();
         promise->reject(vm, globalObject, exception);
     };
@@ -639,7 +639,7 @@ static JSObject* promiseAllSettledSlow(JSGlobalObject* globalObject, CallFrame* 
     auto callRejectWithScopeException = [&]() -> void {
         Exception* exception = scope.exception();
         ASSERT(exception);
-        scope.clearException();
+        TRY_CLEAR_EXCEPTION(scope, void());
         callReject(exception->value());
     };
 
@@ -777,7 +777,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncAllSettled, (JSGlobalObject* glob
     auto callReject = [&]() -> void {
         Exception* exception = scope.exception();
         ASSERT(exception);
-        scope.clearException();
+        TRY_CLEAR_EXCEPTION(scope, void());
         scope.release();
         promise->reject(vm, globalObject, exception);
     };
@@ -1122,7 +1122,7 @@ static JSObject* promiseAnySlow(JSGlobalObject* globalObject, CallFrame* callFra
     auto callRejectWithScopeException = [&]() -> void {
         Exception* exception = scope.exception();
         ASSERT(exception);
-        scope.clearException();
+        TRY_CLEAR_EXCEPTION(scope, void());
         callReject(exception->value());
     };
 
@@ -1250,7 +1250,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncAny, (JSGlobalObject* globalObjec
     auto callReject = [&]() -> void {
         Exception* exception = scope.exception();
         ASSERT(exception);
-        scope.clearException();
+        TRY_CLEAR_EXCEPTION(scope, void());
         scope.release();
         promise->reject(vm, globalObject, exception);
     };

--- a/Source/JavaScriptCore/runtime/JSRemoteFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSRemoteFunction.cpp
@@ -250,9 +250,8 @@ void JSRemoteFunction::finishCreation(JSGlobalObject* globalObject, VM& vm)
     auto scope = DECLARE_THROW_SCOPE(vm);
     copyNameAndLength(globalObject);
 
-    auto* exception = scope.exception();
-    if (exception && !vm.isTerminationException(exception)) [[unlikely]] {
-        scope.clearException();
+    if (scope.exception()) {
+        TRY_CLEAR_EXCEPTION(scope, void());
         throwTypeError(globalObject, scope, "wrapping returned function throws an error"_s);
     }
 }

--- a/Source/JavaScriptCore/runtime/ShadowRealmPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ShadowRealmPrototype.cpp
@@ -110,7 +110,7 @@ JSC_DEFINE_HOST_FUNCTION(evalInRealm, (JSGlobalObject* globalObject, CallFrame* 
         JSValue error = executableError.get();
         ErrorInstance* errorInstance = jsDynamicCast<ErrorInstance*>(error);
         if (errorInstance != nullptr && errorInstance->errorType() == ErrorType::SyntaxError) {
-            scope.clearException();
+            TRY_CLEAR_EXCEPTION(scope, { });
             const String syntaxErrorMessage = errorInstance->sanitizedMessageString(globalObject);
             RETURN_IF_EXCEPTION(scope, { });
             return throwVMError(globalObject, scope, createSyntaxError(globalObject, syntaxErrorMessage));
@@ -125,7 +125,7 @@ JSC_DEFINE_HOST_FUNCTION(evalInRealm, (JSGlobalObject* globalObject, CallFrame* 
     if (scope.exception()) [[unlikely]] {
         NakedPtr<Exception> exception = scope.exception();
         JSValue error = exception->value();
-        scope.clearException();
+        TRY_CLEAR_EXCEPTION(scope, { });
         auto typeError = createTypeErrorCopy(globalObject, error);
         RETURN_IF_EXCEPTION(scope, { });
         return throwVMError(globalObject, scope, typeError);

--- a/Source/JavaScriptCore/runtime/TemporalInstant.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalInstant.cpp
@@ -124,7 +124,7 @@ TemporalInstant* TemporalInstant::tryCreateIfValid(JSGlobalObject* globalObject,
     if (bigIntTooLong || !exactTime.isValid()) {
         String argAsString = bigint->toString(globalObject, 10);
         if (scope.exception()) {
-            scope.clearException();
+            TRY_CLEAR_EXCEPTION(scope, nullptr);
             argAsString = "The given number of"_s;
         }
 

--- a/Source/JavaScriptCore/runtime/ThrowScope.h
+++ b/Source/JavaScriptCore/runtime/ThrowScope.h
@@ -52,8 +52,6 @@ public:
 
     void release() { m_isReleased = true; }
 
-    void clearException() { m_vm.clearException(); }
-
 private:
     void simulateThrow();
 
@@ -77,8 +75,6 @@ public:
     ALWAYS_INLINE Exception* throwException(JSGlobalObject* globalObject, JSValue value) { return m_vm.throwException(globalObject, value); }
 
     ALWAYS_INLINE void release() { }
-
-    ALWAYS_INLINE void clearException() { m_vm.clearException(); }
 };
 
 #define DECLARE_THROW_SCOPE(vm__) \

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -3301,8 +3301,7 @@ JSC_DEFINE_HOST_FUNCTION(functionCreateWasmStreamingCompilerForCompile, (JSGloba
     args.append(compiler);
     ASSERT(!args.hasOverflowed());
     call(globalObject, callback, jsUndefined(), args, "You shouldn't see this..."_s);
-    if (scope.exception()) [[unlikely]]
-        scope.clearException();
+    TRY_CLEAR_EXCEPTION(scope, { });
     compiler->streamingCompiler().finalize(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
     return JSValue::encode(compiler->promise());
@@ -3332,8 +3331,7 @@ JSC_DEFINE_HOST_FUNCTION(functionCreateWasmStreamingCompilerForInstantiate, (JSG
     args.append(compiler);
     ASSERT(!args.hasOverflowed());
     call(globalObject, callback, jsUndefined(), args, "You shouldn't see this..."_s);
-    if (scope.exception()) [[unlikely]]
-        scope.clearException();
+    TRY_CLEAR_EXCEPTION(scope, { });
     compiler->streamingCompiler().finalize(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
     return JSValue::encode(compiler->promise());

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
@@ -371,7 +371,7 @@ WASM_IPINT_EXTERN_CPP_DECL(retrieve_and_clear_exception, CallFrame* callFrame, I
     // We want to clear the exception here rather than in the catch prologue
     // JIT code because clearing it also entails clearing a bit in an Atomic
     // bit field in VMTraps.
-    throwScope.clearException();
+    (void)throwScope.tryClearException();
 
     WASM_RETURN_TWO(nullptr, nullptr);
 }
@@ -394,7 +394,7 @@ WASM_IPINT_EXTERN_CPP_DECL(retrieve_clear_and_push_exception, CallFrame* callFra
     // We want to clear the exception here rather than in the catch prologue
     // JIT code because clearing it also entails clearing a bit in an Atomic
     // bit field in VMTraps.
-    throwScope.clearException();
+    (void)throwScope.tryClearException();
 
     WASM_RETURN_TWO(nullptr, nullptr);
 }
@@ -422,7 +422,7 @@ WASM_IPINT_EXTERN_CPP_DECL(retrieve_clear_and_push_exception_and_arguments, Call
     // We want to clear the exception here rather than in the catch prologue
     // JIT code because clearing it also entails clearing a bit in an Atomic
     // bit field in VMTraps.
-    throwScope.clearException();
+    (void)throwScope.tryClearException();
 
     WASM_RETURN_TWO(nullptr, nullptr);
 }

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -1719,7 +1719,9 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmRetrieveAndClearExceptionIfCatcha
     // We want to clear the exception here rather than in the catch prologue
     // JIT code because clearing it also entails clearing a bit in an Atomic
     // bit field in VMTraps.
-    throwScope.clearException();
+    bool didClear = throwScope.tryClearException();
+    // If we had a pending termination exception it should have propagated past any wasm catch handlers.
+    ASSERT_UNUSED(didClear, didClear);
 
     return { JSValue::encode(thrownValue), jumpTarget };
 }
@@ -1741,7 +1743,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmRetrieveAndClearExceptionIfCatcha
     // We want to clear the exception here rather than in the catch prologue
     // JIT code because clearing it also entails clearing a bit in an Atomic
     // bit field in VMTraps.
-    throwScope.clearException();
+    (void)throwScope.tryClearException();
 
     return jumpTarget;
 }

--- a/Source/WebCore/Modules/applepay/paymentrequest/ApplePayPaymentHandler.cpp
+++ b/Source/WebCore/Modules/applepay/paymentrequest/ApplePayPaymentHandler.cpp
@@ -448,12 +448,10 @@ Vector<Ref<ApplePayError>> ApplePayPaymentHandler::computeErrors(String&& error,
 
     computePayerErrors(WTF::move(payerErrors), errors);
 
-    auto scope = DECLARE_CATCH_SCOPE(protectedScriptExecutionContext()->protectedVM().get());
+    auto scope = DECLARE_THROW_SCOPE(protectedScriptExecutionContext()->protectedVM().get());
     auto exception = computePaymentMethodErrors(paymentMethodErrors, errors);
-    if (exception.hasException()) {
-        ASSERT(scope.exception());
-        scope.clearException();
-    }
+    if (exception.hasException())
+        TRY_CLEAR_EXCEPTION(scope, errors);
 
     return errors;
 }
@@ -462,12 +460,10 @@ Vector<Ref<ApplePayError>> ApplePayPaymentHandler::computeErrors(JSC::JSObject* 
 {
     Vector<Ref<ApplePayError>> errors;
 
-    auto scope = DECLARE_CATCH_SCOPE(protectedScriptExecutionContext()->protectedVM().get());
+    auto scope = DECLARE_THROW_SCOPE(protectedScriptExecutionContext()->protectedVM().get());
     auto exception = computePaymentMethodErrors(paymentMethodErrors, errors);
-    if (exception.hasException()) {
-        ASSERT(scope.exception());
-        scope.clearException();
-    }
+    if (exception.hasException())
+        TRY_CLEAR_EXCEPTION(scope, errors);
 
     return errors;
 }

--- a/Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp
+++ b/Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp
@@ -231,7 +231,7 @@ ExceptionOr<JSC::JSObject*> CredentialRequestCoordinator::parseDigitalCredential
     }
 
     JSC::VM& vm = globalObject->vm();
-    auto scope = DECLARE_CATCH_SCOPE(vm);
+    auto scope = DECLARE_THROW_SCOPE(vm);
     JSC::JSLockHolder lock(globalObject);
     auto parsedJSON = JSC::JSONParse(globalObject, responseDataJSON);
     if (!parsedJSON) {
@@ -241,7 +241,9 @@ ExceptionOr<JSC::JSObject*> CredentialRequestCoordinator::parseDigitalCredential
 
     if (scope.exception()) [[unlikely]] {
         LOG(DigitalCredentials, "Failed to parse response JSON data");
-        scope.clearException();
+        bool cleared = scope.tryClearException();
+        // We're on the main thread so we can't get a termination exception.
+        ASSERT_UNUSED(cleared, cleared);
         return Exception { ExceptionCode::SyntaxError, "Failed to parse response JSON data."_s };
     }
 

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
@@ -1027,7 +1027,7 @@ static inline ExceptionOr<PeerConnectionBackend::CertificateInformation> certifi
 
     auto parametersConversionResult = convertDictionary<RTCPeerConnection::CertificateParameters>(lexicalGlobalObject, value.get());
     if (parametersConversionResult.hasException(scope)) [[unlikely]] {
-        scope.clearException();
+        TRY_CLEAR_EXCEPTION(scope, Exception(ExceptionCode::TypeError, "Termination"_s));
         return Exception { ExceptionCode::TypeError, "Unable to read certificate parameters"_s };
     }
     auto parameters = parametersConversionResult.releaseReturnValue();

--- a/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.cpp
@@ -111,11 +111,11 @@ void ReadableStreamDefaultReader::read(JSDOMGlobalObject& globalObject, Ref<Read
                 return;
 
             Ref vm = globalObject->vm();
-            auto scope = DECLARE_CATCH_SCOPE(vm);
+            auto scope = DECLARE_THROW_SCOPE(vm);
             auto resultOrException = convertDictionary<ReadableStreamReadResult>(*globalObject, promiseResult);
             ASSERT(!resultOrException.hasException(scope));
             if (resultOrException.hasException(scope)) {
-                scope.clearException();
+                TRY_CLEAR_EXCEPTION(scope, void());
                 return;
             }
             auto result = resultOrException.releaseReturnValue();

--- a/Source/WebCore/Modules/streams/ReadableStreamToSharedBufferSink.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStreamToSharedBufferSink.cpp
@@ -67,10 +67,10 @@ private:
             return;
 
         Ref vm = globalObject->vm();
-        auto scope = DECLARE_CATCH_SCOPE(vm);
+        auto scope = DECLARE_THROW_SCOPE(vm);
         auto chunkOrException = convert<IDLUint8Array>(*globalObject, value);
         if (chunkOrException.hasException(scope)) [[unlikely]] {
-            scope.clearException();
+            TRY_CLEAR_EXCEPTION(scope, void());
             sink->error(Exception { ExceptionCode::TypeError, "Unable to convert chunk to Uin8Array"_s });
             return;
         }

--- a/Source/WebCore/Modules/streams/StreamTeeUtilities.cpp
+++ b/Source/WebCore/Modules/streams/StreamTeeUtilities.cpp
@@ -396,10 +396,10 @@ private:
         m_state->setReadAgainForBranch1(false);
         m_state->setReadAgainForBranch2(false);
 
-        auto scope = DECLARE_CATCH_SCOPE(globalObject->vm());
+        auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
         auto chunkResult = convert<IDLArrayBufferView>(*globalObject, value);
         if (chunkResult.hasException(scope)) [[unlikely]] {
-            scope.clearException();
+            TRY_CLEAR_EXCEPTION(scope, void());
             return;
         }
 
@@ -505,10 +505,10 @@ private:
         RefPtr branch1 = m_state->branch1();
         RefPtr branch2 = m_state->branch2();
 
-        auto scope = DECLARE_CATCH_SCOPE(globalObject->vm());
+        auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
         auto chunkResult = convert<IDLArrayBufferView>(*globalObject, value);
         if (chunkResult.hasException(scope)) [[unlikely]] {
-            scope.clearException();
+            TRY_CLEAR_EXCEPTION(scope, void());
             return;
         }
 
@@ -571,10 +571,10 @@ private:
             return;
 
         if (!value.isUndefined()) {
-            auto scope = DECLARE_CATCH_SCOPE(globalObject->vm());
+            auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
             auto chunkResult = convert<IDLArrayBufferView>(*globalObject, value);
             if (chunkResult.hasException(scope)) [[unlikely]] {
-                scope.clearException();
+                TRY_CLEAR_EXCEPTION(scope, void());
                 return;
             }
 

--- a/Source/WebCore/bindings/js/InternalReadableStream.cpp
+++ b/Source/WebCore/bindings/js/InternalReadableStream.cpp
@@ -83,7 +83,7 @@ bool InternalReadableStream::isLocked() const
     if (!globalObject)
         return false;
 
-    auto scope = DECLARE_CATCH_SCOPE(globalObject->vm());
+    auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
 
     auto* clientData = downcast<JSVMClientData>(globalObject->vm().clientData);
     auto& privateName = clientData->builtinFunctions().readableStreamInternalsBuiltins().isReadableStreamLockedPrivateName();
@@ -93,8 +93,7 @@ bool InternalReadableStream::isLocked() const
     ASSERT(!arguments.hasOverflowed());
 
     auto result = invokeReadableStreamFunction(*globalObject, privateName, arguments);
-    if (scope.exception())
-        scope.clearException();
+    TRY_CLEAR_EXCEPTION(scope, false);
 
     return result.hasException() ? false : result.returnValue().isTrue();
 }
@@ -105,7 +104,7 @@ bool InternalReadableStream::isDisturbed() const
     if (!globalObject)
         return false;
 
-    auto scope = DECLARE_CATCH_SCOPE(globalObject->vm());
+    auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
 
     auto* clientData = downcast<JSVMClientData>(globalObject->vm().clientData);
     auto& privateName = clientData->builtinFunctions().readableStreamInternalsBuiltins().isReadableStreamDisturbedPrivateName();
@@ -115,8 +114,7 @@ bool InternalReadableStream::isDisturbed() const
     ASSERT(!arguments.hasOverflowed());
 
     auto result = invokeReadableStreamFunction(*globalObject, privateName, arguments);
-    if (scope.exception())
-        scope.clearException();
+    TRY_CLEAR_EXCEPTION(scope, false);
 
     return result.hasException() ? false : result.returnValue().isTrue();
 }
@@ -168,11 +166,10 @@ void InternalReadableStream::cancel(Exception&& exception)
     if (!globalObject)
         return;
 
-    auto scope = DECLARE_CATCH_SCOPE(globalObject->vm());
+    auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
     JSC::JSLockHolder lock(globalObject->vm());
     cancel(*globalObject, toJSNewlyCreated(globalObject, JSC::jsCast<JSDOMGlobalObject*>(globalObject), DOMException::create(WTF::move(exception))));
-    if (scope.exception()) [[unlikely]]
-        scope.clearException();
+    TRY_CLEAR_EXCEPTION(scope, void());
 }
 
 void InternalReadableStream::lock()
@@ -181,7 +178,7 @@ void InternalReadableStream::lock()
     if (!globalObject)
         return;
 
-    auto scope = DECLARE_CATCH_SCOPE(globalObject->vm());
+    auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
 
     auto* clientData = downcast<JSVMClientData>(globalObject->vm().clientData);
     auto& privateName = clientData->builtinFunctions().readableStreamInternalsBuiltins().acquireReadableStreamDefaultReaderPrivateName();
@@ -191,8 +188,7 @@ void InternalReadableStream::lock()
     ASSERT(!arguments.hasOverflowed());
 
     invokeReadableStreamFunction(*globalObject, privateName, arguments);
-    if (scope.exception()) [[unlikely]]
-        scope.clearException();
+    TRY_CLEAR_EXCEPTION(scope, void());
 }
 
 ExceptionOr<std::pair<Ref<InternalReadableStream>, Ref<InternalReadableStream>>> InternalReadableStream::tee(bool shouldClone)

--- a/Source/WebCore/bindings/js/InternalWritableStream.cpp
+++ b/Source/WebCore/bindings/js/InternalWritableStream.cpp
@@ -113,7 +113,7 @@ bool InternalWritableStream::locked() const
     if (!globalObject)
         return false;
 
-    auto scope = DECLARE_CATCH_SCOPE(globalObject->vm());
+    auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
 
     auto* clientData = downcast<JSVMClientData>(globalObject->vm().clientData);
     auto& privateName = clientData->builtinFunctions().writableStreamInternalsBuiltins().isWritableStreamLockedPrivateName();
@@ -123,8 +123,7 @@ bool InternalWritableStream::locked() const
     ASSERT(!arguments.hasOverflowed());
 
     auto result = invokeWritableStreamFunction(*globalObject, privateName, arguments);
-    if (scope.exception())
-        scope.clearException();
+    TRY_CLEAR_EXCEPTION(scope, false);
 
     return result.hasException() ? false : result.returnValue().isTrue();
 }
@@ -135,7 +134,7 @@ void InternalWritableStream::lock()
     if (!globalObject)
         return;
 
-    auto scope = DECLARE_CATCH_SCOPE(globalObject->vm());
+    auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
 
     auto* clientData = downcast<JSVMClientData>(globalObject->vm().clientData);
     auto& privateName = clientData->builtinFunctions().writableStreamInternalsBuiltins().acquireWritableStreamDefaultWriterPrivateName();
@@ -145,8 +144,7 @@ void InternalWritableStream::lock()
     ASSERT(!arguments.hasOverflowed());
 
     invokeWritableStreamFunction(*globalObject, privateName, arguments);
-    if (scope.exception()) [[unlikely]]
-        scope.clearException();
+    TRY_CLEAR_EXCEPTION(scope, void());
 }
 
 JSC::JSValue InternalWritableStream::abortForBindings(JSC::JSGlobalObject& globalObject, JSC::JSValue reason)
@@ -205,7 +203,7 @@ void InternalWritableStream::closeIfPossible()
     if (!globalObject)
         return;
 
-    auto scope = DECLARE_CATCH_SCOPE(globalObject->vm());
+    auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
 
     auto* clientData = downcast<JSVMClientData>(globalObject->vm().clientData);
     auto& privateName = clientData->builtinFunctions().writableStreamInternalsBuiltins().writableStreamCloseIfPossiblePrivateName();
@@ -215,8 +213,7 @@ void InternalWritableStream::closeIfPossible()
     ASSERT(!arguments.hasOverflowed());
 
     invokeWritableStreamFunction(*globalObject, privateName, arguments);
-    if (scope.exception()) [[unlikely]]
-        scope.clearException();
+    TRY_CLEAR_EXCEPTION(scope, void());
 }
 
 void InternalWritableStream::errorIfPossible(Exception&& exception)
@@ -227,7 +224,7 @@ void InternalWritableStream::errorIfPossible(Exception&& exception)
 
     Ref vm = globalObject->vm();
     JSC::JSLockHolder lock(vm);
-    auto scope = DECLARE_CATCH_SCOPE(vm);
+    auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* clientData = downcast<JSVMClientData>(vm->clientData);
     auto& privateName = clientData->builtinFunctions().writableStreamInternalsBuiltins().writableStreamErrorIfPossiblePrivateName();
@@ -240,8 +237,7 @@ void InternalWritableStream::errorIfPossible(Exception&& exception)
     ASSERT(!arguments.hasOverflowed());
 
     invokeWritableStreamFunction(*globalObject, privateName, arguments);
-    if (scope.exception()) [[unlikely]]
-        scope.clearException();
+    TRY_CLEAR_EXCEPTION(scope, void());
 }
 
 JSC::JSValue InternalWritableStream::errorIfPossible(JSC::JSGlobalObject& globalObject, JSC::JSValue reason)

--- a/Source/WebCore/bindings/js/JSCallbackData.cpp
+++ b/Source/WebCore/bindings/js/JSCallbackData.cpp
@@ -50,7 +50,7 @@ JSValue JSCallbackData::invokeCallback(JSDOMGlobalObject& globalObject, JSObject
     JSGlobalObject* lexicalGlobalObject = &globalObject;
     VM& vm = lexicalGlobalObject->vm();
 
-    auto scope = DECLARE_CATCH_SCOPE(vm);
+    auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue function;
     CallData callData;
@@ -69,7 +69,7 @@ JSValue JSCallbackData::invokeCallback(JSDOMGlobalObject& globalObject, JSObject
         function = callback->get(lexicalGlobalObject, functionName);
         if (scope.exception()) [[unlikely]] {
             returnedException = scope.exception();
-            scope.clearException();
+            TRY_CLEAR_EXCEPTION(scope, JSValue());
             return JSValue();
         }
 

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
@@ -431,7 +431,7 @@ bool JSDOMGlobalObject::canCompileStrings(JSGlobalObject* globalObject, Compilat
         // https://w3c.github.io/webappsec-csp/#can-compile-strings
         // Step 2.7. If the algorithm throws an error, throw an EvalError.
         // This clears the existing exceptions and returns false, where the caller throws an EvalError.
-        throwScope.clearException();
+        TRY_CLEAR_EXCEPTION(throwScope, false);
         return false;
     }
 

--- a/Source/WebCore/bindings/js/ScriptController.cpp
+++ b/Source/WebCore/bindings/js/ScriptController.cpp
@@ -870,7 +870,7 @@ void ScriptController::executeJavaScriptURL(const URL& url, const NavigationActi
 
     auto preNavigationCheckHolder = requireTrustedTypesForPreNavigationCheckPasses(*scriptExecutionContext, url.string());
     if (preNavigationCheckHolder.hasException()) {
-        throwScope.clearException();
+        TRY_CLEAR_EXCEPTION(throwScope, void());
         return;
     }
 

--- a/Source/WebCore/dom/TrustedType.cpp
+++ b/Source/WebCore/dom/TrustedType.cpp
@@ -295,7 +295,7 @@ ExceptionOr<String> requireTrustedTypesForPreNavigationCheckPasses(ScriptExecuti
 
     auto convertedScriptSource = processValueWithDefaultPolicy(scriptExecutionContext, expectedType, scriptSource, sink);
     if (std::holds_alternative<Exception>(convertedScriptSource))
-        throwScope.clearException();
+        TRY_CLEAR_EXCEPTION(throwScope, WTF::move(std::get<Exception>(convertedScriptSource)));
     else if (!std::holds_alternative<std::monostate>(convertedScriptSource)) {
         auto stringifiedConvertedScriptSource = WTF::visit(TrustedTypeVisitor { }, convertedScriptSource);
 


### PR DESCRIPTION
#### 67abaaa35c4d826409cb716d68bc3e05995e8888
<pre>
ThrowScopes should not be able to clear termination exceptions
<a href="https://bugs.webkit.org/show_bug.cgi?id=305496">https://bugs.webkit.org/show_bug.cgi?id=305496</a>
<a href="https://rdar.apple.com/168161400">rdar://168161400</a>

Reviewed by Yusuke Suzuki.

Right now when folks call clearException on a ThrowScope they often end
up unintentionally clearing termination exceptions. This is a bit of a
footgun.

With this change it&apos;s now only possible to tryClearException, which
fails when there&apos;s a termination exception pending. Long term, the goal
is to have all &quot;interior&quot; code use ThrowScopes as they have to support
propagating termination exceptions. I fixed a few places in this patch
such as IteratorOperations and will fix the remaining ones when renaming
CatchScope in a follow up change.

No new tests, no behavior change.

Canonical link: <a href="https://commits.webkit.org/305675@main">https://commits.webkit.org/305675@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0b7ca43cfa6a3b3afa0839120ad8e489b76156e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139072 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11445 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/568 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147198 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0a6fb306-e2a1-4de2-960e-0781ae7833f4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140944 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12151 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11596 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106457 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e11e5abe-9192-4689-ad18-7f030070508b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142019 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9179 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124578 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87325 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c6c0f8c7-1e52-49cc-9771-3285158aa8c4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8735 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6506 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7491 "Built successfully") | | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/131045 "Found unexpected failure with change (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118184 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/475 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149978 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/137673 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11128 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/486 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114855 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11143 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9414 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115166 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9057 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120925 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66032 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21440 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11172 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/457 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/170343 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10908 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74830 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/44359 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11111 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10960 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->