### PR TITLE
Allow using new network loader for WebKit generally (non-Safari)

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/NetworkSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/NetworkSPI.h
@@ -104,6 +104,9 @@ void nw_parameters_set_traffic_class(nw_parameters_t, uint32_t traffic_class);
 OS_OBJECT_RETURNS_RETAINED nw_interface_t nw_path_copy_interface(nw_path_t);
 
 bool nw_settings_get_unified_http_enabled(void);
+#if HAVE(NWSETTINGS_UNIFIED_HTTP_WEBKIT)
+bool nw_settings_get_unified_http_enabled_webkit(void);
+#endif
 
 void nw_parameters_set_server_mode(nw_parameters_t, bool);
 OS_OBJECT_RETURNS_RETAINED nw_parameters_t nw_parameters_create_webtransport_http(nw_parameters_configure_protocol_block_t, nw_parameters_configure_protocol_block_t, nw_parameters_configure_protocol_block_t, nw_parameters_configure_protocol_block_t);

--- a/Source/WebKit/Configurations/AllowedSPI-legacy.toml
+++ b/Source/WebKit/Configurations/AllowedSPI-legacy.toml
@@ -1035,6 +1035,14 @@ requires = [
     "USE_APPLE_INTERNAL_SDK"
 ]
 
+[[legacy]]
+symbols = [
+    "nw_settings_get_unified_http_enabled_webkit",
+]
+requires = [
+    "HAVE_NWSETTINGS_UNIFIED_HTTP_WEBKIT"
+]
+
 # The public iOS build uses CGGeometry methods instead of internal only
 # NSGeometry methods. Clean up in rdar://6669434.
 [[legacy]]

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSoftLink.h
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSoftLink.h
@@ -25,12 +25,16 @@
 
 #pragma once
 
-#if HAVE(WEB_TRANSPORT)
+#if HAVE(WEB_TRANSPORT) || HAVE(NWSETTINGS_UNIFIED_HTTP_WEBKIT)
 
 #import <pal/spi/cocoa/NetworkSPI.h>
 #import <wtf/SoftLinking.h>
 
 SOFT_LINK_FRAMEWORK_FOR_HEADER(WebKit, Network)
+
+#endif // HAVE(WEB_TRANSPORT) || HAVE(NWSETTINGS_UNIFIED_HTTP_WEBKIT)
+
+#if HAVE(WEB_TRANSPORT)
 
 // FIXME: Replace this soft linking with a HAVE macro once rdar://158191390 is available on all tested OS builds.
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(WebKit, Network, nw_webtransport_options_set_allow_joining_before_ready, void, (nw_protocol_options_t options, bool allow), (options, allow))
@@ -66,3 +70,10 @@ SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(WebKit, Network, nw_connection_abort_read
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(WebKit, Network, nw_connection_abort_writes, void, (nw_connection_t connection, uint64_t error_code), (connection, error_code))
 
 #endif // HAVE(WEB_TRANSPORT)
+
+#if HAVE(NWSETTINGS_UNIFIED_HTTP_WEBKIT)
+
+SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(WebKit, Network, nw_settings_get_unified_http_enabled_webkit, bool, (), ())
+
+#endif
+

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSoftLink.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSoftLink.mm
@@ -25,12 +25,16 @@
 
 #import "config.h"
 
-#if HAVE(WEB_TRANSPORT)
+#if HAVE(WEB_TRANSPORT) || HAVE(NWSETTINGS_UNIFIED_HTTP_WEBKIT)
 
 #import <pal/spi/cocoa/NetworkSPI.h>
 #import <wtf/SoftLinking.h>
 
 SOFT_LINK_FRAMEWORK_FOR_SOURCE(WebKit, Network)
+
+#endif // HAVE(WEB_TRANSPORT) || HAVE(NWSETTINGS_UNIFIED_HTTP_WEBKIT)
+
+#if HAVE(WEB_TRANSPORT)
 
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE(WebKit, Network, nw_webtransport_options_set_allow_joining_before_ready, void, (nw_protocol_options_t options, bool allow), (options, allow))
 
@@ -55,3 +59,9 @@ SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE(WebKit, Network, nw_connection_abort_read
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE(WebKit, Network, nw_connection_abort_writes, void, (nw_connection_t connection, uint64_t error_code), (connection, error_code))
 
 #endif // HAVE(WEB_TRANSPORT)
+
+#if HAVE(NWSETTINGS_UNIFIED_HTTP_WEBKIT)
+
+SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE(WebKit, Network, nw_settings_get_unified_http_enabled_webkit, bool, (), ())
+
+#endif

--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
@@ -55,6 +55,7 @@
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 #import <wtf/text/MakeString.h>
 #import <wtf/text/cf/StringConcatenateCF.h>
+#import <NetworkProcess/cocoa/NetworkSoftLink.h>
 
 #if ENABLE(GPU_PROCESS)
 #import "GPUProcessProxy.h"
@@ -255,8 +256,13 @@ std::optional<bool> WebsiteDataStore::useNetworkLoader()
 #if HAVE(NWSETTINGS_UNIFIED_HTTP) && defined(NW_SETTINGS_HAS_UNIFIED_HTTP)
     if (isRunningTest(applicationBundleIdentifier()))
         return true;
-    if (nw_settings_get_unified_http_enabled())
-        return isSafari;
+    if (nw_settings_get_unified_http_enabled() && isSafari)
+        return true;
+#endif // HAVE(NWSETTINGS_UNIFIED_HTTP) && defined(NW_SETTINGS_HAS_UNIFIED_HTTP)
+
+#if HAVE(NWSETTINGS_UNIFIED_HTTP_WEBKIT)
+    if (canLoad_Network_nw_settings_get_unified_http_enabled_webkit())
+        return softLink_Network_nw_settings_get_unified_http_enabled_webkit();
 #endif
     return std::nullopt;
 


### PR DESCRIPTION
#### c391d1cfa50f5ac881e67407593f2ce464874686
<pre>
Allow using new network loader for WebKit generally (non-Safari)
<a href="https://rdar.apple.com/166146977">rdar://166146977</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=303843">https://bugs.webkit.org/show_bug.cgi?id=303843</a>

Reviewed by Alex Christensen.

* Source/WebCore/PAL/pal/spi/cocoa/NetworkSPI.h:
* Source/WebKit/Configurations/AllowedSPI-legacy.toml:
* Source/WebKit/NetworkProcess/cocoa/NetworkSoftLink.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkSoftLink.mm:
* Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm:
(WebKit::WebsiteDataStore::useNetworkLoader):

Canonical link: <a href="https://commits.webkit.org/305601@main">https://commits.webkit.org/305601@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db1b26c41459cb175c081f7b662fd71dd5af52a7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138886 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11253 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/373 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147005 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91913 "Build is in progress. Recent messages:") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140759 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11958 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11409 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/106302 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/91913 "Build is in progress. Recent messages:") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141833 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9028 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/124434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87172 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/8604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/6351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7306 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/118036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/311 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149791 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10935 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/318 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/114693 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10956 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9249 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115008 "Passed tests") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/8913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120764 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/65840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21398 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10984 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/305 "Passed tests") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/10720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/74634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/10924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10771 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->