### PR TITLE
Crash in Node::invalidateNodeListAndCollectionCachesInAncestors via ContainerNode::removeAllChildrenWithScriptAssertion

### DIFF
--- a/LayoutTests/fast/dom/insert-new-child-to-remove-during-mutation-events-crash-expected.txt
+++ b/LayoutTests/fast/dom/insert-new-child-to-remove-during-mutation-events-crash-expected.txt
@@ -1,0 +1,4 @@
+CONSOLE MESSAGE: HierarchyRequestError: The operation would yield an incorrect node tree.
+This tests inserting a new node to be removed during mutation events of textContent setter. WebKit should not hit a crash.
+
+PASS

--- a/LayoutTests/fast/dom/insert-new-child-to-remove-during-mutation-events-crash.html
+++ b/LayoutTests/fast/dom/insert-new-child-to-remove-during-mutation-events-crash.html
@@ -1,0 +1,18 @@
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+function main() {
+    const select = document.querySelector('select');
+    const option = document.querySelector('option');
+    const container = document.querySelector('span');
+    document.addEventListener('DOMNodeRemoved', () => {
+        document.addEventListener("DOMSubtreeModified", () => select.options.length = 1, {once: true});
+        option.prepend(container);
+        select.add(option, 0);
+    }, {once: true});
+    select.textContent = '';
+    document.body.innerHTML = '<p>This tests inserting a new node to be removed during mutation events of textContent setter. WebKit should not hit a crash.</p>PASS';
+}
+</script>
+<body onload="main()"><span><form><select> </select></form></span><option></option></body>

--- a/LayoutTests/fast/dom/insert-new-child-to-remove-during-unload-crash-expected.txt
+++ b/LayoutTests/fast/dom/insert-new-child-to-remove-during-unload-crash-expected.txt
@@ -1,0 +1,4 @@
+CONSOLE MESSAGE: HierarchyRequestError: The operation would yield an incorrect node tree.
+This tests inserting a new node to be removed during unload of an iframe. WebKit should not hit a crash.
+
+PASS

--- a/LayoutTests/fast/dom/insert-new-child-to-remove-during-unload-crash.html
+++ b/LayoutTests/fast/dom/insert-new-child-to-remove-during-unload-crash.html
@@ -1,0 +1,28 @@
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+function main() {
+    const div = document.querySelector('div');
+    const select = document.querySelector('select');
+    const outerOption = document.getElementById('outerOption');
+    const innerOption = document.getElementById('innerOption');
+    const container = document.querySelector('span');
+    (() => {
+        let iframe2 = document.createElement('iframe');
+        container.appendChild(iframe2);
+        iframe2.contentWindow.addEventListener('unload', () => {
+            select.options.length = 2;
+        });
+        let iframe1 = document.createElement('iframe');
+        innerOption.appendChild(iframe1);
+        iframe1.contentWindow.addEventListener('unload', () => {
+            outerOption.prepend(container);
+            select.add(outerOption, 1);
+        });
+    })();
+    select.textContent = '';
+    document.body.innerHTML = '<p>This tests inserting a new node to be removed during unload of an iframe. WebKit should not hit a crash.</p>PASS';
+}
+</script>
+<body onload="main()"><span><form><select><option id="innerOption"></option></select></form></span><option id="outerOption"></option></body>


### PR DESCRIPTION
#### a9934374583dc0b3b9c4d5334a602637509119dd
<pre>
Crash in Node::invalidateNodeListAndCollectionCachesInAncestors via ContainerNode::removeAllChildrenWithScriptAssertion
<a href="https://bugs.webkit.org/show_bug.cgi?id=305494">https://bugs.webkit.org/show_bug.cgi?id=305494</a>

Reviewed by Geoffrey Garen and Wenson Hsieh.

The crash was caused by ContainerNode::removeAllChildrenWithScriptAssertion sometimes deleting a child node before
node lists of the parent node are invalidated. When node lists&apos; iterator type uses a CheckedPtr internally, this
can lead to a crash during the invalidation (because invalidation will try to clear that outliving CheckedPtr).

Fixed the bug by re-collecting child nodes of the parent node in ContainerNode::removeAllChildrenWithScriptAssertion
if the DOM tree version has changed between when we collected child nodes and when mutation events and unload event
handlers are dispatched.

Tests: fast/dom/insert-new-child-to-remove-during-mutation-events-crash.html
       fast/dom/insert-new-child-to-remove-during-unload-crash.html

* LayoutTests/fast/dom/insert-new-child-to-remove-during-mutation-events-crash-expected.txt: Added.
* LayoutTests/fast/dom/insert-new-child-to-remove-during-mutation-events-crash.html: Added.
* LayoutTests/fast/dom/insert-new-child-to-remove-during-unload-crash-expected.txt: Added.
* LayoutTests/fast/dom/insert-new-child-to-remove-during-unload-crash.html: Added.
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::removeAllChildrenWithScriptAssertion):

Canonical link: <a href="https://commits.webkit.org/305651@main">https://commits.webkit.org/305651@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ff90eb6db9a68acb9cd25bb084c1f3b83dc6db9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138889 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11256 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/376 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147008 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/91916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140762 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11961 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11412 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106306 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/91916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/71d44859-5132-4a29-a688-d1bac3fce407) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141836 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9030 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124437 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87176 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8605 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6353 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7309 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118037 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/315 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149794 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10938 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/322 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114695 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10959 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9252 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115010 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8909 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120768 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65843 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21428 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10987 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/309 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10723 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74637 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10927 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10774 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->