### PR TITLE
Add fragment length check to SecurityOrigin::canDisplay().

### DIFF
--- a/LayoutTests/fast/url/fragment-large-expected.txt
+++ b/LayoutTests/fast/url/fragment-large-expected.txt
@@ -1,0 +1,6 @@
+PASS 2MB fragment
+PASS Blocked 2MB+1 fragment
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/url/fragment-large.html
+++ b/LayoutTests/fast/url/fragment-large.html
@@ -1,0 +1,55 @@
+<!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script>
+jsTestIsAsync = true;
+const dataUrl = "data:text/plain,hello";
+
+let shouldPass = true;
+
+async function testURL(url) {
+    return new Promise((resolve, reject) => {
+        const xhr = new XMLHttpRequest();
+        xhr.onload = () => resolve(true);
+        xhr.onerror = () => resolve(false);
+        xhr.open("GET", url);
+        xhr.send();
+    });
+}
+
+function expectedSuccess(result, message) {
+    if (result) {
+        testPassed(message);
+    } else {
+        testFailed(message);
+    }
+}
+
+function expectedFail(result, message) {
+    if (result) {
+        testFailed(message);
+    } else {
+        testPassed(message);
+    }
+}
+
+async function runTest() {
+    try {
+        const result1 = await testURL(dataUrl + "#" + "a".repeat(2 * 1024 * 1024));
+        expectedSuccess(result1, "2MB fragment");
+
+        const result2 = await testURL(dataUrl + "#" + "a".repeat(2 * 1024 * 1024 + 1));
+        expectedFail(result2, "Blocked 2MB+1 fragment");
+    } catch (e) {
+        testFailed(`Unknown exception: ${e}`);
+    }
+    finishJSTest();
+}
+
+runTest();
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/loader/ThreadableLoader.cpp
+++ b/Source/WebCore/loader/ThreadableLoader.cpp
@@ -164,7 +164,7 @@ void ThreadableLoader::logError(ScriptExecutionContext& context, const ResourceE
         messageStart = "Cannot load "_s;
 
     String messageEnd = error.isAccessControl() ? " due to access control checks."_s : "."_s;
-    context.addConsoleMessage(MessageSource::JS, MessageLevel::Error, makeString(messageStart, error.failingURL().string(), messageEnd));
+    context.addConsoleMessage(MessageSource::JS, MessageLevel::Error, makeString(messageStart, error.failingURL().stringCenterEllipsizedToLength(), messageEnd));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/SecurityOrigin.cpp
+++ b/Source/WebCore/page/SecurityOrigin.cpp
@@ -52,6 +52,7 @@
 namespace WebCore {
 
 constexpr unsigned maximumURLSize = 0x04000000;
+constexpr unsigned maximumFragmentIdentifierSize = 2u * 1024u * 1024u;
 
 bool SecurityOrigin::shouldIgnoreHost(const URL& url)
 {
@@ -365,12 +366,16 @@ static bool isFeedWithNestedProtocolInHTTPFamily(const URL& url)
 bool SecurityOrigin::canDisplay(const URL& url, const OriginAccessPatterns& patterns) const
 {
     ASSERT(!isInNetworkProcess());
+
+    if (url.string().length() > maximumURLSize)
+        return false;
+
+    if (url.fragmentIdentifier().length() > maximumFragmentIdentifierSize)
+        return false;
+
     if (m_universalAccess)
         return true;
 
-    if (url.pathEnd() > maximumURLSize)
-        return false;
-    
 #if !PLATFORM(IOS_FAMILY) && !ENABLE(BUBBLEWRAP_SANDBOX)
     if (m_data.protocol() == "file"_s && url.protocolIsFile() && !FileSystem::filesHaveSameVolume(m_filePath, url.fileSystemPath()))
         return false;


### PR DESCRIPTION
#### c8e9806e77faccba904006f7d3e302d8aed16a58
<pre>
Add fragment length check to SecurityOrigin::canDisplay().
<a href="https://bugs.webkit.org/show_bug.cgi?id=305505">https://bugs.webkit.org/show_bug.cgi?id=305505</a>
<a href="https://rdar.apple.com/165801515">rdar://165801515</a>

Reviewed by Alex Christensen and Brent Fulgham.

Add a length check for URL fragment identifiers to SecurityOrigin::canDisplay().
Currently the threshold is 2MB. Also update the existing length check to use
the entire URL length when checking against `maximumURLSize`, which is semantically
more correct than using pathEnd().

The fragment length check is performed before the universalAccess check to apply
in all contexts including layout tests.

Additionally, update ThreadableLoader::logError to use stringCenterEllipsizedToLength()
when displaying URLs in error messages to avoid console spam from extremely long URLs.

Tests: fast/url/fragment-large.html

* LayoutTests/fast/url/fragment-large-expected.txt: Added.
* LayoutTests/fast/url/fragment-large.html: Added.
* Source/WebCore/loader/ThreadableLoader.cpp:
(WebCore::ThreadableLoader::logError):
* Source/WebCore/page/SecurityOrigin.cpp:
(WebCore::SecurityOrigin::canDisplay const):

Canonical link: <a href="https://commits.webkit.org/305780@main">https://commits.webkit.org/305780@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af2ea9b2450324d1af0ae748c6b372b1280e4787

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139291 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11667 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/793 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147418 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92358 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e6764222-5abb-4004-851a-7f7a2b5053b3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141164 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12374 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11817 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106641 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77627 "2 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/39fe2afe-1d8f-4dc5-aa8f-faf1029b4ec2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142238 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9371 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124760 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87501 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a55d1876-f2a9-4921-a4ba-d7a588ce06a7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8915 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6686 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7715 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118374 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/660 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150200 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11351 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/678 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115034 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11364 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9607 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115341 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/29406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9465 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121107 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66328 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11394 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/630 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11128 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75060 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11331 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11181 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->