### PR TITLE
PlatformSpeechSynthesizer::initializeVoiceList() should not block

### DIFF
--- a/LayoutTests/fast/speechsynthesis/speech-synthesis-empty-initial-voice-list-expected.txt
+++ b/LayoutTests/fast/speechsynthesis/speech-synthesis-empty-initial-voice-list-expected.txt
@@ -1,0 +1,11 @@
+This tests that the voice list can initially be empty and populated after voiceschanged event.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS initialVoices.length is 0
+PASS voices.length > 0 is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/speechsynthesis/speech-synthesis-empty-initial-voice-list.html
+++ b/LayoutTests/fast/speechsynthesis/speech-synthesis-empty-initial-voice-list.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<script>
+    description("This tests that the voice list can initially be empty and populated after voiceschanged event.");
+
+    window.jsTestIsAsync = true;
+    if (window.testRunner)
+        testRunner.waitUntilDone();
+
+    if (window.internals) {
+        internals.enableMockSpeechSynthesizer();
+        internals.setInitialVoiceListToEmpty();
+
+        initialVoices = speechSynthesis.getVoices();
+        shouldBe("initialVoices.length", "0");
+
+        speechSynthesis.onvoiceschanged = () => {
+            voices = speechSynthesis.getVoices();
+            shouldBeTrue("voices.length > 0");
+            finishJSTest();
+        };
+
+        setTimeout(() => {
+            internals.simulateSpeechSynthesizerVoiceListChange();
+        }, 0);
+    } else {
+        debug("Test requires window.internals to run.");
+        finishJSTest();
+    }
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/speechsynthesis/voices-non-mock.html
+++ b/LayoutTests/fast/speechsynthesis/voices-non-mock.html
@@ -8,24 +8,43 @@
 <script>
     description("This tests that we can get synthesizer voices.");
 
+    window.jsTestIsAsync = true;
+    if (window.testRunner)
+        testRunner.waitUntilDone();
+
     var speech = window.speechSynthesis;
-    var list = speech.getVoices();
+    var timeoutID;
 
-    var foundDefaultVoice = false;
-    var foundEnglishVoice = false;
-    var voiceCount = list.length;
+    function runTest() {
+        clearTimeout(timeoutID);
+        var list = speech.getVoices();
 
-    for (let k = 0; k < list.length; k++) {
-        let voice = list[k];
-        if (voice.lang == "en-US")
-            foundEnglishVoice = true;
-        if (voice.default)
-            foundDefaultVoice = true;
+        foundDefaultVoice = false;
+        foundEnglishVoice = false;
+        voiceCount = list.length;
+
+        for (let k = 0; k < list.length; k++) {
+            let voice = list[k];
+            if (voice.lang == "en-US")
+                foundEnglishVoice = true;
+            if (voice.default)
+                foundDefaultVoice = true;
+        }
+
+        shouldBeTrue(`voiceCount >= ${window.internals.minimumExpectedVoiceCount}`);
+        shouldBeTrue("foundEnglishVoice");
+        shouldBeTrue("foundDefaultVoice");
+
+        finishJSTest();
     }
 
-    shouldBeTrue(`voiceCount >= ${window.internals.minimumExpectedVoiceCount}`);
-    shouldBeTrue("foundEnglishVoice");
-    shouldBeTrue("foundDefaultVoice");
+    speech.onvoiceschanged = runTest;
+
+    var list = speech.getVoices();
+    if (list.length > 0)
+        runTest();
+    else
+        timeoutID = setTimeout(runTest, 1000);
 
 </script>
 

--- a/Source/WebCore/Configurations/AllowedSPI-legacy.toml
+++ b/Source/WebCore/Configurations/AllowedSPI-legacy.toml
@@ -115,6 +115,13 @@ selectors = [
 requires = ["USE_APPLE_INTERNAL_SDK"]
 
 [[legacy]]
+# These are needed to only show built-in voices to reduce fingerprinting surface area.
+selectors = [
+    { name = "speechVoicesIncludingSuperCompact", class = "?" },
+    { name = "speechVoicesIncludingSuperCompactWithCompletionHandler:", class = "?" },
+]
+
+[[legacy]]
 classes = [
     "AVAssetCollection",
     "AVContentKeyReportGroup",
@@ -411,7 +418,6 @@ selectors = [
     { name = "sharedTextEffectsWindowForWindowScene:", class = "?" },
     { name = "signature", class = "RSABSSATokenReady" },
     { name = "sizeValue", class = "?" },
-    { name = "speechVoicesIncludingSuperCompact", class = "?" },
     { name = "startRoutingVideoToPictureInPicturePlayerLayerView", class = "?" },
     { name = "startingColumn", class = "?" },
     { name = "startingRow", class = "?" },

--- a/Source/WebCore/PAL/pal/spi/cocoa/AXSpeechManagerSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/AXSpeechManagerSPI.h
@@ -41,9 +41,12 @@ DECLARE_SYSTEM_HEADER
 
 #include <AVFoundation/AVFoundation.h>
 
+typedef void (^AVSpeechSynthesisVoiceCallbackBlock)(NSArray<AVSpeechSynthesisVoice *> *);
+
 @interface AVSpeechSynthesisVoice (PrivateAttributes)
 @property (nonatomic, readonly) BOOL isSystemVoice;
 + (nonnull NSArray<AVSpeechSynthesisVoice *> *)speechVoicesIncludingSuperCompact;
++ (void)speechVoicesIncludingSuperCompactWithCompletionHandler:(nonnull AVSpeechSynthesisVoiceCallbackBlock)completion;
 @end
 
 #endif // USE(APPLE_INTERNAL_SDK)

--- a/Source/WebCore/platform/cocoa/PlatformSpeechSynthesizerCocoa.mm
+++ b/Source/WebCore/platform/cocoa/PlatformSpeechSynthesizerCocoa.mm
@@ -38,9 +38,16 @@
 
 #import <pal/spi/cocoa/AXSpeechManagerSPI.h>
 #import <wtf/BlockObjCExceptions.h>
+#import <wtf/MainThread.h>
 #import <wtf/RetainPtr.h>
 
 #import <pal/cocoa/AVFoundationSoftLink.h>
+
+typedef void (^AVSpeechSynthesisVoiceCallbackBlock)(NSArray<AVSpeechSynthesisVoice *> *);
+
+@interface AVSpeechSynthesisVoice (AsyncAddition)
++ (void)speechVoicesIncludingSuperCompactWithCompletionHandler:(nonnull AVSpeechSynthesisVoiceCallbackBlock)completion;
+@end
 
 static float getAVSpeechUtteranceDefaultSpeechRate()
 {
@@ -293,13 +300,31 @@ void PlatformSpeechSynthesizer::initializeVoiceList()
         return;
 
     BEGIN_BLOCK_OBJC_EXCEPTIONS
-    // SpeechSynthesis replaces on-device compact with higher quality compact voices. These
-    // are not available to WebKit so we're losing these default voices for WebSpeech.
-    // Only show built-in voices when requesting through WebKit to reduce fingerprinting surface area.
-    for (AVSpeechSynthesisVoice *voice in [PAL::getAVSpeechSynthesisVoiceClassSingleton() speechVoicesIncludingSuperCompact]) {
-        if (voice.isSystemVoice)
-            m_voiceList.append(PlatformSpeechSynthesisVoice::create(voice.identifier, voice.name, voice.language, true, true));
+
+    Class avSpeechSynthesisVoiceClass = PAL::getAVSpeechSynthesisVoiceClassSingleton();
+    auto appendVoices = [protectedThis = Ref { *this }](NSArray<AVSpeechSynthesisVoice *> *voices) {
+        for (AVSpeechSynthesisVoice *voice in voices) {
+            if (voice.isSystemVoice)
+                protectedThis->m_voiceList.append(PlatformSpeechSynthesisVoice::create(voice.identifier, voice.name, voice.language, /* localService */ true, /* isDefault */ true));
+        }
+    };
+
+    // Support older OS versions that don't have the asynchronous version yet.
+    // Remove this once 26.3 is the minimum OS version supported by Safari.
+    if (![avSpeechSynthesisVoiceClass respondsToSelector:@selector(speechVoicesIncludingSuperCompactWithCompletionHandler:)]) {
+        appendVoices([avSpeechSynthesisVoiceClass speechVoicesIncludingSuperCompact]);
+        return;
     }
+
+    [avSpeechSynthesisVoiceClass speechVoicesIncludingSuperCompactWithCompletionHandler:^(NSArray<AVSpeechSynthesisVoice *> *voices) {
+        callOnMainThread([this, protectedThis = Ref { *this }, voices = RetainPtr { voices }, appendVoices]() {
+            BEGIN_BLOCK_OBJC_EXCEPTIONS
+            appendVoices(voices.get());
+            m_speechSynthesizerClient.voicesDidChange();
+            END_BLOCK_OBJC_EXCEPTIONS
+        });
+    }];
+
     END_BLOCK_OBJC_EXCEPTIONS
 }
 

--- a/Source/WebCore/platform/mock/PlatformSpeechSynthesizerMock.cpp
+++ b/Source/WebCore/platform/mock/PlatformSpeechSynthesizerMock.cpp
@@ -55,6 +55,8 @@ void PlatformSpeechSynthesizerMock::speakingFinished()
 
 void PlatformSpeechSynthesizerMock::initializeVoiceList()
 {
+    if (m_initialVoiceListShouldBeEmpty)
+        return;
     m_voiceList.append(PlatformSpeechSynthesisVoice::create("mock.voice.bruce"_s, "bruce"_s, "en-US"_s, true, true));
     m_voiceList.append(PlatformSpeechSynthesisVoice::create("mock.voice.clark"_s, "clark"_s, "en-US"_s, true, false));
     m_voiceList.append(PlatformSpeechSynthesisVoice::create("mock.voice.logan"_s, "logan"_s, "fr-CA"_s, true, true));

--- a/Source/WebCore/platform/mock/PlatformSpeechSynthesizerMock.h
+++ b/Source/WebCore/platform/mock/PlatformSpeechSynthesizerMock.h
@@ -44,16 +44,18 @@ public:
     virtual void cancel();
 
     void setUtteranceDuration(Seconds duration) { m_utteranceDuration = duration; }
+    void setInitialVoiceListToEmpty(bool empty) { m_initialVoiceListShouldBeEmpty = empty; }
+    virtual void initializeVoiceList();
 
 private:
     explicit PlatformSpeechSynthesizerMock(PlatformSpeechSynthesizerClient&);
 
-    virtual void initializeVoiceList();
     void speakingFinished();
 
     Timer m_speakingFinishedTimer;
     RefPtr<PlatformSpeechSynthesisUtterance> m_utterance;
     Seconds m_utteranceDuration { 100_ms };
+    bool m_initialVoiceListShouldBeEmpty { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1801,6 +1801,8 @@ ExceptionOr<void> Internals::setFormControlStateOfPreviousHistoryItem(const Vect
 void Internals::simulateSpeechSynthesizerVoiceListChange()
 {
     if (m_platformSpeechSynthesizer) {
+        m_platformSpeechSynthesizer->setInitialVoiceListToEmpty(false);
+        m_platformSpeechSynthesizer->initializeVoiceList();
         m_platformSpeechSynthesizer->client().voicesDidChange();
         return;
     }
@@ -1834,6 +1836,12 @@ void Internals::enableMockSpeechSynthesizerForMediaElement(HTMLMediaElement& ele
 
     m_platformSpeechSynthesizer = mock.copyRef();
     synthesis.setPlatformSynthesizer(WTF::move(mock));
+}
+
+void Internals::setInitialVoiceListToEmpty()
+{
+    if (m_platformSpeechSynthesizer)
+        m_platformSpeechSynthesizer->setInitialVoiceListToEmpty(true);
 }
 
 ExceptionOr<void> Internals::setSpeechUtteranceDuration(double duration)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -775,6 +775,7 @@ public:
     void simulateSpeechSynthesizerVoiceListChange();
     void enableMockSpeechSynthesizer();
     void enableMockSpeechSynthesizerForMediaElement(HTMLMediaElement&);
+    void setInitialVoiceListToEmpty();
     ExceptionOr<void> setSpeechUtteranceDuration(double);
     unsigned minimumExpectedVoiceCount();
 #endif

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1017,6 +1017,7 @@ enum ContentsFormat {
     [Conditional=SPEECH_SYNTHESIS] undefined enableMockSpeechSynthesizer();
     [Conditional=SPEECH_SYNTHESIS] undefined simulateSpeechSynthesizerVoiceListChange();
     [Conditional=SPEECH_SYNTHESIS] undefined enableMockSpeechSynthesizerForMediaElement(HTMLMediaElement element);
+    [Conditional=SPEECH_SYNTHESIS] undefined setInitialVoiceListToEmpty();
     [Conditional=SPEECH_SYNTHESIS] undefined setSpeechUtteranceDuration(double duration);
     [Conditional=SPEECH_SYNTHESIS] readonly attribute unsigned long minimumExpectedVoiceCount;
 


### PR DESCRIPTION
#### 0845cdb9f9cd7466099cd80f2e610950e2f7f832
<pre>
PlatformSpeechSynthesizer::initializeVoiceList() should not block
<a href="https://bugs.webkit.org/show_bug.cgi?id=304944">https://bugs.webkit.org/show_bug.cgi?id=304944</a>
<a href="https://rdar.apple.com/164447645">rdar://164447645</a>

Reviewed by Tyler Wilcock.

Uses a new asynchronous variant of the internal method to fetch the voice list.
Originally merged as 305553@main, but reverted because it did not build on older SDKs.
Updated to forward-declare the new method; it already did a respondsToSelector check.

Test: fast/speechsynthesis/speech-synthesis-empty-initial-voice-list.html

* LayoutTests/fast/speechsynthesis/speech-synthesis-empty-initial-voice-list-expected.txt: Added.
* LayoutTests/fast/speechsynthesis/speech-synthesis-empty-initial-voice-list.html: Added.
* LayoutTests/fast/speechsynthesis/voices-non-mock.html:
* Source/WebCore/Configurations/AllowedSPI-legacy.toml:
* Source/WebCore/PAL/pal/spi/cocoa/AXSpeechManagerSPI.h:
* Source/WebCore/platform/cocoa/PlatformSpeechSynthesizerCocoa.mm:
(WebCore::PlatformSpeechSynthesizer::initializeVoiceList):
* Source/WebCore/platform/mock/PlatformSpeechSynthesizerMock.cpp:
(WebCore::PlatformSpeechSynthesizerMock::initializeVoiceList):
* Source/WebCore/platform/mock/PlatformSpeechSynthesizerMock.h:
(WebCore::PlatformSpeechSynthesizerMock::setInitialVoiceListToEmpty):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::simulateSpeechSynthesizerVoiceListChange):
(WebCore::Internals::setInitialVoiceListToEmpty):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Canonical link: <a href="https://commits.webkit.org/305673@main">https://commits.webkit.org/305673@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/32668d093cf81dbd57b3865b35e9055119d8193d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139071 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11444 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/567 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147197 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140943 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12149 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11595 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106455 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142018 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9172 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124575 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87323 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8728 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6505 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7490 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118177 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/472 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149977 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11127 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/483 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114848 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11142 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9413 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115159 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29268 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9047 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120922 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66031 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11171 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/454 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10907 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74829 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11110 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10959 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->