### PR TITLE
Fixed unretained local variable warnings in WebCore/{ bridge, editing, loader, page }

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -8,19 +8,15 @@ accessibility/cocoa/AccessibilityObjectCocoa.mm
 [ Mac ] accessibility/mac/AccessibilityObjectMac.mm
 accessibility/mac/WebAccessibilityObjectWrapperBase.mm
 bindings/js/ScriptControllerMac.mm
-bridge/objc/WebScriptObject.mm
 bridge/objc/objc_class.mm
 bridge/objc/objc_instance.mm
 bridge/objc/objc_runtime.mm
 bridge/objc/objc_utility.mm
 crypto/cocoa/SerializedCryptoKeyWrapMac.mm
-[ Mac ] editing/cocoa/AlternativeTextUIController.mm
-editing/cocoa/DataDetection.mm
 editing/cocoa/EditingHTMLConverter.mm
 editing/cocoa/NodeHTMLConverter.mm
 loader/archive/cf/LegacyWebArchive.cpp
 [ iOS ] page/ios/EventHandlerIOS.mm
-page/mac/ChromeMac.mm
 [ Mac ] page/mac/EventHandlerMac.mm
 [ Mac ] page/scrolling/mac/ScrollingStateScrollingNodeMac.mm
 [ Mac ] page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm

--- a/Source/WebCore/bridge/objc/WebScriptObject.mm
+++ b/Source/WebCore/bridge/objc/WebScriptObject.mm
@@ -85,8 +85,8 @@ NSObject *getJSWrapper(JSObject* impl)
     ASSERT(isMainThread());
     Locker locker { wrapperCacheLock };
 
-    NSObject* wrapper = wrapperCache().get(impl);
-    return wrapper ? retainPtr(wrapper).autorelease() : nil;
+    RetainPtr<id> wrapper = wrapperCache().get(impl);
+    return wrapper.autorelease();
 }
 
 void addJSWrapper(NSObject *wrapper, JSObject* impl)
@@ -177,10 +177,10 @@ void disconnectWindowWrapper(WebScriptObject *windowWrapper)
     auto& wrapped = *toJS(jsObject);
 
     if (WebCore::createDOMWrapperFunction) {
-        if (auto wrapper = WebCore::createDOMWrapperFunction(wrapped)) {
-            if (![wrapper _hasImp]) // new wrapper, not from cache
-                [wrapper _setImp:&wrapped originRootObject:originRootObject rootObject:rootObject];
-            return wrapper;
+        if (RetainPtr wrapper = WebCore::createDOMWrapperFunction(wrapped)) {
+            if (![wrapper.get() _hasImp]) // new wrapper, not from cache
+                [wrapper.get() _setImp:&wrapped originRootObject:originRootObject rootObject:rootObject];
+            return wrapper.autorelease();
         }
     }
 

--- a/Source/WebCore/editing/cocoa/AlternativeTextUIController.mm
+++ b/Source/WebCore/editing/cocoa/AlternativeTextUIController.mm
@@ -73,13 +73,13 @@ void AlternativeTextUIController::showAlternatives(NSView *view, const FloatRect
 
     m_view = view;
 
-    PlatformTextAlternatives *alternatives = m_contextController.alternativesForContext(context);
+    RetainPtr alternatives = m_contextController.alternativesForContext(context);
     if (!alternatives)
         return;
 
-    [[NSSpellChecker sharedSpellChecker] showCorrectionIndicatorOfType:NSCorrectionIndicatorTypeGuesses primaryString:retainPtr(alternatives.primaryString).get() alternativeStrings:retainPtr(alternatives.alternativeStrings).get() forStringInRect:boundingBoxOfPrimaryString view:m_view.get() completionHandler:^(NSString *acceptedString) {
+    [[NSSpellChecker sharedSpellChecker] showCorrectionIndicatorOfType:NSCorrectionIndicatorTypeGuesses primaryString:retainPtr(alternatives.get().primaryString).get() alternativeStrings:retainPtr(alternatives.get().alternativeStrings).get() forStringInRect:boundingBoxOfPrimaryString view:m_view.get() completionHandler:^(NSString *acceptedString) {
         if (acceptedString) {
-            handleAcceptedAlternative(acceptedString, context, alternatives);
+            handleAcceptedAlternative(acceptedString, context, alternatives.get());
             acceptanceHandler(acceptedString);
         }
     }];

--- a/Source/WebCore/editing/cocoa/DataDetection.mm
+++ b/Source/WebCore/editing/cocoa/DataDetection.mm
@@ -100,12 +100,12 @@ static std::optional<DetectedItem> detectItem(const VisiblePosition& position, c
     RetainPtr results = adoptCF(DDScannerCopyResultsWithOptions(scanner.get(), DDScannerCopyResultsOptionsNoOverlap));
 
     // Find the DDResultRef that intersects the hitTestResult's VisiblePosition.
-    DDResultRef mainResult = nullptr;
+    RetainPtr<DDResultRef> mainResult;
     std::optional<SimpleRange> mainResultRange;
     CFIndex resultCount = CFArrayGetCount(results.get());
     for (CFIndex i = 0; i < resultCount; i++) {
-        auto result = checked_cf_cast<DDResultRef>(CFArrayGetValueAtIndex(results.get(), i));
-        CFRange resultRangeInContext = DDResultGetRange(result);
+        RetainPtr result = checked_cf_cast<DDResultRef>(CFArrayGetValueAtIndex(results.get(), i));
+        CFRange resultRangeInContext = DDResultGetRange(result.get());
         if (hitLocation >= resultRangeInContext.location && (hitLocation - resultRangeInContext.location) < resultRangeInContext.length) {
             mainResult = result;
             mainResultRange = resolveCharacterRange(contextRange, resultRangeInContext);
@@ -122,8 +122,8 @@ static std::optional<DetectedItem> detectItem(const VisiblePosition& position, c
 
     RetainPtr actionContext = adoptNS([PAL::allocWKDDActionContextInstance() init]);
 
-    [actionContext setAllResults:@[ (__bridge id)mainResult ]];
-    [actionContext setMainResult:mainResult];
+    [actionContext setAllResults:@[ (__bridge id)mainResult.get() ]];
+    [actionContext setMainResult:mainResult.get()];
 
     return { {
         WTF::move(actionContext),

--- a/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
+++ b/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
@@ -250,61 +250,61 @@ RefPtr<ArchiveResource> LegacyWebArchive::createResource(CFDictionaryRef diction
     if (!dictionary)
         return nullptr;
 
-    auto resourceData = static_cast<CFDataRef>(CFDictionaryGetValue(dictionary, LegacyWebArchiveResourceDataKey));
-    if (resourceData && CFGetTypeID(resourceData) != CFDataGetTypeID()) {
+    RetainPtr resourceData = static_cast<CFDataRef>(CFDictionaryGetValue(dictionary, LegacyWebArchiveResourceDataKey));
+    if (resourceData && CFGetTypeID(resourceData.get()) != CFDataGetTypeID()) {
         LOG(Archives, "LegacyWebArchive - Resource data is not of type CFData, cannot create invalid resource");
         return nullptr;
     }
 
-    auto frameName = static_cast<CFStringRef>(CFDictionaryGetValue(dictionary, LegacyWebArchiveResourceFrameNameKey));
-    if (frameName && CFGetTypeID(frameName) != CFStringGetTypeID()) {
+    RetainPtr frameName = static_cast<CFStringRef>(CFDictionaryGetValue(dictionary, LegacyWebArchiveResourceFrameNameKey));
+    if (frameName && CFGetTypeID(frameName.get()) != CFStringGetTypeID()) {
         LOG(Archives, "LegacyWebArchive - Frame name is not of type CFString, cannot create invalid resource");
         return nullptr;
     }
 
-    auto mimeType = static_cast<CFStringRef>(CFDictionaryGetValue(dictionary, LegacyWebArchiveResourceMIMETypeKey));
-    if (mimeType && CFGetTypeID(mimeType) != CFStringGetTypeID()) {
+    RetainPtr mimeType = static_cast<CFStringRef>(CFDictionaryGetValue(dictionary, LegacyWebArchiveResourceMIMETypeKey));
+    if (mimeType && CFGetTypeID(mimeType.get()) != CFStringGetTypeID()) {
         LOG(Archives, "LegacyWebArchive - MIME type is not of type CFString, cannot create invalid resource");
         return nullptr;
     }
 
-    auto url = static_cast<CFStringRef>(CFDictionaryGetValue(dictionary, LegacyWebArchiveResourceURLKey));
-    if (url && CFGetTypeID(url) != CFStringGetTypeID()) {
+    RetainPtr url = static_cast<CFStringRef>(CFDictionaryGetValue(dictionary, LegacyWebArchiveResourceURLKey));
+    if (url && CFGetTypeID(url.get()) != CFStringGetTypeID()) {
         LOG(Archives, "LegacyWebArchive - URL is not of type CFString, cannot create invalid resource");
         return nullptr;
     }
 
-    auto textEncoding = static_cast<CFStringRef>(CFDictionaryGetValue(dictionary, LegacyWebArchiveResourceTextEncodingNameKey));
-    if (textEncoding && CFGetTypeID(textEncoding) != CFStringGetTypeID()) {
+    RetainPtr textEncoding = static_cast<CFStringRef>(CFDictionaryGetValue(dictionary, LegacyWebArchiveResourceTextEncodingNameKey));
+    if (textEncoding && CFGetTypeID(textEncoding.get()) != CFStringGetTypeID()) {
         LOG(Archives, "LegacyWebArchive - Text encoding is not of type CFString, cannot create invalid resource");
         return nullptr;
     }
 
     ResourceResponse response;
 
-    if (auto resourceResponseData = static_cast<CFDataRef>(CFDictionaryGetValue(dictionary, LegacyWebArchiveResourceResponseKey))) {
-        if (CFGetTypeID(resourceResponseData) != CFDataGetTypeID()) {
+    if (RetainPtr resourceResponseData = static_cast<CFDataRef>(CFDictionaryGetValue(dictionary, LegacyWebArchiveResourceResponseKey))) {
+        if (CFGetTypeID(resourceResponseData.get()) != CFDataGetTypeID()) {
             LOG(Archives, "LegacyWebArchive - Resource response data is not of type CFData, cannot create invalid resource");
             return nullptr;
         }
 
-        auto resourceResponseVersion = static_cast<CFStringRef>(CFDictionaryGetValue(dictionary, LegacyWebArchiveResourceResponseVersionKey));
-        if (resourceResponseVersion && CFGetTypeID(resourceResponseVersion) != CFStringGetTypeID()) {
+        RetainPtr resourceResponseVersion = static_cast<CFStringRef>(CFDictionaryGetValue(dictionary, LegacyWebArchiveResourceResponseVersionKey));
+        if (resourceResponseVersion && CFGetTypeID(resourceResponseVersion.get()) != CFStringGetTypeID()) {
             LOG(Archives, "LegacyWebArchive - Resource response version is not of type CFString, cannot create invalid resource");
             return nullptr;
         }
 
-        response = createResourceResponseFromPropertyListData(resourceResponseData, resourceResponseVersion);
+        response = createResourceResponseFromPropertyListData(resourceResponseData.get(), resourceResponseVersion.get());
     }
 
     auto filePathValue = CFDictionaryGetValue(dictionary, LegacyWebArchiveResourceFilePathKey);
-    auto filePath = dynamic_cf_cast<CFStringRef>(filePathValue);
+    RetainPtr filePath = dynamic_cf_cast<CFStringRef>(filePathValue);
     if (filePathValue && !filePath) {
         LOG(Archives, "LegacyWebArchive - File path is not of type CFString, cannot create invalid resource");
         return nullptr;
     }
 
-    return ArchiveResource::create(SharedBuffer::create(resourceData), URL { url }, mimeType, textEncoding, frameName, response, filePath);
+    return ArchiveResource::create(SharedBuffer::create(resourceData.get()), URL { url.get() }, mimeType.get(), textEncoding.get(), frameName.get(), response, filePath.get());
 }
 
 LegacyWebArchive::LegacyWebArchive(std::optional<FrameIdentifier> frameIdentifier, Vector<FrameIdentifier>&& subframeIdentifiers)
@@ -381,17 +381,17 @@ RefPtr<LegacyWebArchive> LegacyWebArchive::create(CFDictionaryRef dictionary)
         return nullptr;
     }
 
-    CFDictionaryRef mainResourceDict = static_cast<CFDictionaryRef>(CFDictionaryGetValue(dictionary, LegacyWebArchiveMainResourceKey));
+    RetainPtr mainResourceDict = static_cast<CFDictionaryRef>(CFDictionaryGetValue(dictionary, LegacyWebArchiveMainResourceKey));
     if (!mainResourceDict) {
         LOG(Archives, "LegacyWebArchive - No main resource in archive, aborting invalid WebArchive");
         return nullptr;
     }
-    if (CFGetTypeID(mainResourceDict) != CFDictionaryGetTypeID()) {
+    if (CFGetTypeID(mainResourceDict.get()) != CFDictionaryGetTypeID()) {
         LOG(Archives, "LegacyWebArchive - Main resource is not the expected CFDictionary, aborting invalid WebArchive");
         return nullptr;
     }
 
-    RefPtr mainResource = createResource(mainResourceDict);
+    RefPtr mainResource = createResource(mainResourceDict.get());
     if (!mainResource) {
         LOG(Archives, "LegacyWebArchive - Failed to parse main resource from CFDictionary or main resource does not exist, aborting invalid WebArchive");
         return nullptr;

--- a/Source/WebCore/page/mac/ChromeMac.mm
+++ b/Source/WebCore/page/mac/ChromeMac.mm
@@ -41,8 +41,8 @@ void Chrome::focusNSView(NSView* view)
         return;
     }
     
-    NSResponder *firstResponder = client().firstResponder();
-    if (firstResponder == view)
+    RetainPtr firstResponder = client().firstResponder();
+    if (firstResponder.get() == view)
         return;
 
     if (![view window] || ![view superview] || ![view acceptsFirstResponder])
@@ -55,7 +55,7 @@ void Chrome::focusNSView(NSView* view)
     // first responder. This confuses AppKit so we must restore
     // the old first responder.
     if (![view superview])
-        client().makeFirstResponder(firstResponder);
+        client().makeFirstResponder(firstResponder.get());
 
     END_BLOCK_OBJC_EXCEPTIONS
 }

--- a/Source/WebCore/page/mac/EventHandlerMac.mm
+++ b/Source/WebCore/page/mac/EventHandlerMac.mm
@@ -256,9 +256,9 @@ bool EventHandler::passMouseDownEventToWidget(Widget* pWidget)
 
     BEGIN_BLOCK_OBJC_EXCEPTIONS
 
-    NSView *nodeView = widget->platformWidget();
-    ASSERT([nodeView superview]);
-    NSView *view = [nodeView hitTest:[[nodeView superview] convertPoint:[currentNSEvent() locationInWindow] fromView:nil]];
+    RetainPtr nodeView = widget->platformWidget();
+    ASSERT([nodeView.get() superview]);
+    NSView *view = [nodeView.get() hitTest:[[nodeView.get() superview] convertPoint:[currentNSEvent() locationInWindow] fromView:nil]];
     if (!view) {
         // We probably hit the border of a RenderWidget
         return true;
@@ -344,8 +344,8 @@ RetainPtr<NSView> EventHandler::mouseDownViewIfStillGood()
         return nil;
     }
     auto* topFrameView = m_frame->view();
-    NSView *topView = topFrameView ? topFrameView->platformWidget() : nil;
-    if (!topView || !findViewInSubviews(topView, mouseDownView.get())) {
+    RetainPtr<NSView> topView = topFrameView ? topFrameView->platformWidget() : nil;
+    if (!topView || !findViewInSubviews(topView.get(), mouseDownView.get())) {
         m_mouseDownView = nil;
         return nil;
     }
@@ -486,7 +486,7 @@ bool EventHandler::passWheelEventToWidget(const PlatformWheelEvent& wheelEvent, 
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS
 
-    NSView* nodeView = widget.platformWidget();
+    RetainPtr nodeView = widget.platformWidget();
     if (!nodeView) {
         // WebKit2 code path.
         RefPtr frameView = dynamicDowncast<LocalFrameView>(widget);
@@ -500,8 +500,8 @@ bool EventHandler::passWheelEventToWidget(const PlatformWheelEvent& wheelEvent, 
         return false;
 
     ASSERT(nodeView);
-    ASSERT([nodeView superview]);
-    NSView *view = [nodeView hitTest:[[nodeView superview] convertPoint:[currentNSEvent() locationInWindow] fromView:nil]];
+    ASSERT([nodeView.get() superview]);
+    NSView *view = [nodeView.get() hitTest:[[nodeView.get() superview] convertPoint:[currentNSEvent() locationInWindow] fromView:nil]];
     if (!view) {
         // We probably hit the border of a RenderWidget
         return false;
@@ -739,10 +739,10 @@ HandleUserInputEventResult EventHandler::passMouseReleaseEventToSubframe(MouseEv
 
 PlatformMouseEvent EventHandler::currentPlatformMouseEvent() const
 {
-    NSView *windowView = nil;
+    RetainPtr<NSView> windowView;
     if (RefPtr page = m_frame->page())
         windowView = page->chrome().platformPageClient();
-    return PlatformEventFactory::createPlatformMouseEvent(currentNSEvent(), correspondingPressureEvent(), windowView);
+    return PlatformEventFactory::createPlatformMouseEvent(currentNSEvent(), correspondingPressureEvent(), windowView.get());
 }
 
 bool EventHandler::eventActivatedView(const PlatformMouseEvent& event) const


### PR DESCRIPTION
#### bde65dfa93415746d7d6848f9b9ebd486a79cdfe
<pre>
Fixed unretained local variable warnings in WebCore/{ bridge, editing, loader, page }
<a href="https://bugs.webkit.org/show_bug.cgi?id=305510">https://bugs.webkit.org/show_bug.cgi?id=305510</a>
<a href="https://rdar.apple.com/168172951">rdar://168172951</a>

Reviewed by Ryosuke Niwa and David Kilzer.

Mechanical fixes dictated by the SaferCPP bot.

Canonical link: <a href="https://commits.webkit.org/305755@main">https://commits.webkit.org/305755@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b1c4c82c7eaf6052fcb98145c1ce08ea46fa901

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139302 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11678 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/804 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147429 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3d4fcce4-9bef-4904-ae4c-2d64a93220a7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141175 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12385 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11828 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106646 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/681048ec-4da3-48cf-b4e4-75ac20e0e348) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142249 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9378 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/124769 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87506 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e1ed4df5-e806-4d9c-9460-853ee57e155e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8922 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6695 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7726 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118381 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/669 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150211 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11362 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/687 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115040 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11375 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9616 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115347 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9470 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121116 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/66336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21488 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11405 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11139 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75071 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11342 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11192 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->