### PR TITLE
Digital Credentials: WebKitSwift.h should have no platform conditions

### DIFF
--- a/Source/WebKit/WebKitSwift/IdentityDocumentServices/WKISO18013Request.h
+++ b/Source/WebKit/WebKitSwift/IdentityDocumentServices/WKISO18013Request.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if ENABLE(WEB_AUTHN)
+
 @interface WKISO18013Request : NSObject
 
 @property (nonatomic, copy) NSString *encryptionInfo;
@@ -35,3 +37,5 @@
 - (instancetype)init NS_UNAVAILABLE;
 
 @end
+
+#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentController.h
+++ b/Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentController.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if ENABLE(WEB_AUTHN)
+
 #import "WKIdentityDocumentPresentmentDelegate.h"
 #import "WKIdentityDocumentPresentmentRequest.h"
 #import "WKIdentityDocumentPresentmentResponse.h"
@@ -44,3 +46,5 @@ NS_SWIFT_UI_ACTOR
 @end
 
 NS_ASSUME_NONNULL_END
+
+#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentDelegate.h
+++ b/Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentDelegate.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if ENABLE(WEB_AUTHN)
+
 #import <wtf/Compiler.h>
 #import "WKIdentityDocumentPresentmentRawRequest.h"
 
@@ -47,3 +49,5 @@ NS_SWIFT_UI_ACTOR
 @end
 
 NS_ASSUME_NONNULL_END
+
+#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentError.h
+++ b/Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentError.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if ENABLE(WEB_AUTHN)
+
 #import <Foundation/Foundation.h>
 #import <WebKit/WKFoundation.h>
 
@@ -41,3 +43,5 @@ NS_ERROR_ENUM(WKIdentityDocumentPresentmentErrorDomain, WKIdentityDocumentPresen
 };
 
 NS_ASSUME_NONNULL_END
+
+#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentError.mm
+++ b/Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentError.mm
@@ -26,4 +26,8 @@
 #import "config.h"
 #import "WKIdentityDocumentPresentmentError.h"
 
+#if ENABLE(WEB_AUTHN)
+
 NSErrorDomain const WKIdentityDocumentPresentmentErrorDomain = @"WebKit.IdentityDocumentPresentmentError";
+
+#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentMobileDocumentRequest.h
+++ b/Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentMobileDocumentRequest.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if ENABLE(WEB_AUTHN)
+
 #import <Foundation/Foundation.h>
 #import <Security/Security.h>
 
@@ -82,3 +84,5 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+
+#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentRawRequest.h
+++ b/Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentRawRequest.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if ENABLE(WEB_AUTHN)
+
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -41,3 +43,5 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+
+#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentRequest.h
+++ b/Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentRequest.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if ENABLE(WEB_AUTHN)
+
 #import "WKIdentityDocumentPresentmentMobileDocumentRequest.h"
 #import <Foundation/Foundation.h>
 
@@ -42,3 +44,5 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+
+#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentResponse.h
+++ b/Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentResponse.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if ENABLE(WEB_AUTHN)
+
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -42,3 +44,5 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+
+#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentRawRequestValidator.h
+++ b/Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentRawRequestValidator.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if ENABLE(WEB_AUTHN)
+
 #import "WKISO18013Request.h"
 #import "WKIdentityDocumentPresentmentRequest.h"
 #import "WKIdentityDocumentPresentmentResponse.h"
@@ -38,3 +40,5 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+
+#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebKit/WebKitSwift/WebKitSwift.h
+++ b/Source/WebKit/WebKitSwift/WebKitSwift.h
@@ -26,6 +26,14 @@
 #import "CredentialUpdaterShim.h"
 
 #import "WKGroupSession.h"
+#import "WKIdentityDocumentPresentmentController.h"
+#import "WKIdentityDocumentPresentmentDelegate.h"
+#import "WKIdentityDocumentPresentmentError.h"
+#import "WKIdentityDocumentPresentmentMobileDocumentRequest.h"
+#import "WKIdentityDocumentPresentmentRawRequest.h"
+#import "WKIdentityDocumentPresentmentRequest.h"
+#import "WKIdentityDocumentPresentmentResponse.h"
+#import "WKIdentityDocumentRawRequestValidator.h"
 #import "WKIntelligenceReplacementTextEffectCoordinator.h"
 #import "WKIntelligenceSmartReplyTextEffectCoordinator.h"
 #import "WKIntelligenceTextEffectCoordinator.h"
@@ -36,14 +44,3 @@
 #import "WKSLinearMediaTypes.h"
 #import "WKStageMode.h"
 #import "WKTextAnimationManagerIOS.h"
-
-#if HAVE(DIGITAL_CREDENTIALS_UI)
-#import "WKIdentityDocumentPresentmentController.h"
-#import "WKIdentityDocumentPresentmentDelegate.h"
-#import "WKIdentityDocumentPresentmentError.h"
-#import "WKIdentityDocumentPresentmentMobileDocumentRequest.h"
-#import "WKIdentityDocumentPresentmentRawRequest.h"
-#import "WKIdentityDocumentPresentmentRequest.h"
-#import "WKIdentityDocumentPresentmentResponse.h"
-#import "WKIdentityDocumentRawRequestValidator.h"
-#endif

--- a/Source/WebKit/WebProcess/cocoa/IdentityDocumentServices/DigitalCredentialsRequestValidatorBridge.h
+++ b/Source/WebKit/WebProcess/cocoa/IdentityDocumentServices/DigitalCredentialsRequestValidatorBridge.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if ENABLE(WEB_AUTHN)
+
 #include <WebCore/MobileDocumentRequest.h>
 #include <WebCore/ValidatedMobileDocumentRequest.h>
 #include <wtf/Vector.h>
@@ -42,3 +44,5 @@ Vector<WebCore::ValidatedMobileDocumentRequest> validateRequests(const WebCore::
 
 } // namespace DigitalCredentials
 } // namespace WebKit
+
+#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebKit/WebProcess/cocoa/IdentityDocumentServices/DigitalCredentialsRequestValidatorBridge.mm
+++ b/Source/WebKit/WebProcess/cocoa/IdentityDocumentServices/DigitalCredentialsRequestValidatorBridge.mm
@@ -27,6 +27,8 @@
 #import "config.h"
 #import "DigitalCredentialsRequestValidatorBridge.h"
 
+#if ENABLE(WEB_AUTHN)
+
 #import "Logging.h"
 #import "WKIdentityDocumentRawRequestValidator.h"
 #import <Foundation/Foundation.h>
@@ -174,12 +176,11 @@ Vector<WebCore::ValidatedMobileDocumentRequest> DigitalCredentials::validateRequ
             if ([debugDescription length])
                 errorMessage = makeString(errorMessage, " ("_s, String(debugDescription.get()), ")"_s);
 
-            const_cast<Document&>(document).addConsoleMessage(makeUnique<Inspector::ConsoleMessage>(
+            const_cast<Document &>(document).addConsoleMessage(makeUnique<Inspector::ConsoleMessage>(
                 MessageSource::JS,
                 MessageType::Log,
                 MessageLevel::Warning,
-                errorMessage
-            ));
+                errorMessage));
 
             LOG(DigitalCredentials, "Validation failed for request: %@", error);
         }
@@ -188,4 +189,6 @@ Vector<WebCore::ValidatedMobileDocumentRequest> DigitalCredentials::validateRequ
     return validatedRequests;
 }
 
-}
+} // namespace WebKit
+
+#endif // ENABLE(WEB_AUTHN)


### PR DESCRIPTION
#### 0a312b3e109787f064cb7fef7333418f8da05123
<pre>
Digital Credentials: WebKitSwift.h should have no platform conditions
<a href="https://bugs.webkit.org/show_bug.cgi?id=305515">https://bugs.webkit.org/show_bug.cgi?id=305515</a>
<a href="https://rdar.apple.com/168175632">rdar://168175632</a>

Reviewed by Pascoe.

Removed platform conditions around WebKitSwift.h, and put the guard in
the relevant files instead.

Refactor, relies on existing tests.

* Source/WebKit/WebKitSwift/IdentityDocumentServices/WKISO18013Request.h:
* Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentController.h:
* Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentDelegate.h:
* Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentError.h:
* Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentError.mm:
* Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentMobileDocumentRequest.h:
* Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentRawRequest.h:
* Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentRequest.h:
* Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentResponse.h:
* Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentRawRequestValidator.h:
* Source/WebKit/WebKitSwift/WebKitSwift.h:
* Source/WebKit/WebProcess/cocoa/IdentityDocumentServices/DigitalCredentialsRequestValidatorBridge.h:
* Source/WebKit/WebProcess/cocoa/IdentityDocumentServices/DigitalCredentialsRequestValidatorBridge.mm:
(WebKit::DigitalCredentials::validateRequests):

Canonical link: <a href="https://commits.webkit.org/305667@main">https://commits.webkit.org/305667@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c3362ae4dc09c9644cb88ea8a97e2159c089515d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138999 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11366 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/486 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147118 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/198f6e0a-ead1-40ae-953f-f004ee0829ed) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12074 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11522 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106391 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/42518daf-abd4-4f3a-b3fd-366d9cd51880) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141946 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9110 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124514 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87265 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/34ab616d-c596-4915-8539-6608e6d069bb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8672 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6438 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7419 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118111 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149904 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11051 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/418 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114781 "Failed to checkout and rebase branch from PR 56592") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11069 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9342 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115100 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29263 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8989 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120863 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65953 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11097 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/395 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10834 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74747 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11037 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10885 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->