### PR TITLE
AX: Voice Control: "Select WebKit" on webkit.org causes the web process to hang.

### DIFF
--- a/LayoutTests/accessibility-isolated-tree/TestExpectations
+++ b/LayoutTests/accessibility-isolated-tree/TestExpectations
@@ -45,6 +45,8 @@ accessibility/text-marker/text-marker-bidi-element-hebrew.html [ Failure ]
 # Fails because we don't emit a tab between table cells.
 accessibility/mac/attributed-string-for-table.html [ Failure ]
 
+accessibility/mac/search-text-with-image-hang.html [ Failure ]
+
 # Failures introduced by ENABLE(AX_THREAD_TEXT_APIS).
 accessibility/content-editable-as-textarea.html [ Failure ]
 accessibility/mac/attributed-string-for-text-marker-range-using-webarea.html [ Failure ]

--- a/LayoutTests/accessibility/mac/search-text-with-image-hang-expected.txt
+++ b/LayoutTests/accessibility/mac/search-text-with-image-hang-expected.txt
@@ -1,0 +1,8 @@
+This test ensures we don't hang when using the text-search API.
+
+PASS: webArea.stringForTextMarkerRange(markerRange[0]) === 'WebKit'
+PASS: Did not hang.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+WebKit WebKit

--- a/LayoutTests/accessibility/mac/search-text-with-image-hang.html
+++ b/LayoutTests/accessibility/mac/search-text-with-image-hang.html
@@ -1,0 +1,35 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<style>
+#logo {
+    display: inline-block;
+    background: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiIgdmlld0JveD0iMCAwIDE2IDE2Ij4KPHJlY3Qgd2lkdGg9IjE2IiBoZWlnaHQ9IjE2IiByeD0iMyIgZmlsbD0iIzAwN2FmZiIvPgo8L3N2Zz4=") no-repeat center / contain;
+    -webkit-user-select: none;
+    user-select: none
+}
+</style>
+</head>
+<body>
+
+<div id="logo">WebKit</div>
+WebKit
+ 
+<script>
+var output = "This test ensures we don't hang when using the text-search API.\n\n";
+
+if (window.accessibilityController) {
+    var webArea = accessibilityController.rootElement.childAtIndex(0);
+
+    var markerRange = webArea.searchTextWithCriteria("WebKit", "AXSearchTextStartFromBegin", "AXSearchTextDirectionAll");
+    output += expect("webArea.stringForTextMarkerRange(markerRange[0])", "'WebKit'");
+    output += "PASS: Did not hang.";
+
+    debug(output);
+}
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -215,6 +215,51 @@ struct AccessibilitySearchTextCriteria {
         : start(AccessibilitySearchTextStartFrom::Selection)
         , direction(AccessibilitySearchTextDirection::Forward)
     { }
+
+    String debugDescription() const
+    {
+        String startFrom;
+        switch (start) {
+        case AccessibilitySearchTextStartFrom::Begin:
+            startFrom = "begin"_s;
+            break;
+        case AccessibilitySearchTextStartFrom::Selection:
+            startFrom = "selection"_s;
+            break;
+        case AccessibilitySearchTextStartFrom::End:
+            startFrom = "end"_s;
+            break;
+        }
+
+        String directionString;
+        switch (direction) {
+        case AccessibilitySearchTextDirection::Forward:
+            directionString = "forward"_s;
+            break;
+        case AccessibilitySearchTextDirection::Backward:
+            directionString = "backward"_s;
+            break;
+        case AccessibilitySearchTextDirection::Closest:
+            directionString = "closest"_s;
+            break;
+        case AccessibilitySearchTextDirection::All:
+            directionString = "all"_s;
+            break;
+        }
+
+        StringBuilder allSearchStrings;
+        for (unsigned i = 0; i < searchStrings.size(); i++) {
+            allSearchStrings.append(searchStrings[i]);
+            if (i != searchStrings.size() - 1)
+                allSearchStrings.append(", "_s);
+        }
+
+        return makeString(
+            "starting from "_s, startFrom, ", "_s,
+            "with direction "_s, directionString, ", "_s,
+            "seeking strings: {"_s, allSearchStrings.toString(), "}"_s
+        );
+    }
 };
 
 struct AccessibilityText {


### PR DESCRIPTION
#### 486ac0f1922b10f270d0845ee244a86fb1d4ca9e
<pre>
AX: Voice Control: &quot;Select WebKit&quot; on webkit.org causes the web process to hang.
<a href="https://bugs.webkit.org/show_bug.cgi?id=305383">https://bugs.webkit.org/show_bug.cgi?id=305383</a>
<a href="https://rdar.apple.com/168061323">rdar://168061323</a>

Reviewed by Joshua Hoffman.

Prior to this commit, it was possible that AccessibilityObject::findTextRanges could loop infinitely when
rangeOfStringClosestToRangeInDirection returned the same range it was given.

This commit makes that function more resilient such that if we get back the same range, we slide the range forwards or
backwards and try again to make progress.

Test: accessibility/mac/search-text-with-image-hang.html

* LayoutTests/accessibility-isolated-tree/TestExpectations:
New test fails due to some pre-existing bug in how we handle AccessibilityUIElement::searchTextWithCriteria off the main-thread.
* LayoutTests/accessibility/mac/search-text-with-image-hang-expected.txt: Added.
* LayoutTests/accessibility/mac/search-text-with-image-hang.html: Added.
* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::AccessibilitySearchTextCriteria::debugDescription const):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::rangeOfStringClosestToRangeInDirection const):
(WebCore::AccessibilityObject::findTextRange const):
(WebCore::AccessibilityObject::findTextRanges const):

Canonical link: <a href="https://commits.webkit.org/305668@main">https://commits.webkit.org/305668@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/804c637b53223809e3336b1ca8b12cfd80fca6f5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138951 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11318 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/438 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147070 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/91978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/25cf71f5-8ea3-4238-9de2-0e261af8c4ed) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140824 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12150 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11474 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106352 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/91978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2876da23-6355-4ce1-8ee6-02416d9c7faa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141898 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9174 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124478 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87223 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9109f163-8d99-4561-8862-10f7db0dd644) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8730 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6398 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7371 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118179 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/369 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149856 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11001 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/375 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114746 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11021 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9301 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115062 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29264 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8950 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120821 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65905 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11049 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/359 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10786 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74699 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10989 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10837 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->