### PR TITLE
offlineasm incorrectly lowers references to global labels

### DIFF
--- a/Source/JavaScriptCore/offlineasm/asm.rb
+++ b/Source/JavaScriptCore/offlineasm/asm.rb
@@ -258,14 +258,10 @@ class Assembler
         @outp.puts(formatDump("  OFFLINE_ASM_LOCAL_LABEL(#{labelName})", lastComment))
     end
 
-    def self.externLabelReference(labelName)
-        "\" LOCAL_REFERENCE(#{labelName}) \""
+    def self.externOrGlobalLabelReference(labelName)
+        "\" LABEL_REFERENCE(#{labelName}) \""
     end
 
-    def self.labelReference(labelName)
-        "\" LOCAL_LABEL_STRING(#{labelName}) \""
-    end
-    
     def self.localLabelReference(labelName)
         "\" LOCAL_LABEL_STRING(#{labelName}) \""
     end

--- a/Source/JavaScriptCore/offlineasm/backends.rb
+++ b/Source/JavaScriptCore/offlineasm/backends.rb
@@ -151,10 +151,13 @@ end
 
 class LabelReference
     def asmLabel
-        if extern?
-            Assembler.externLabelReference(name[1..-1])
+        # For historical reasons a LabelReference may reference a label which is neither
+        # extern nor global, in which case it should act as a LocalLabelReference.
+        # See https://bugs.webkit.org/show_bug.cgi?id=131205.
+        if extern? || label.global?
+            Assembler.externOrGlobalLabelReference(name[1..-1])
         else
-            Assembler.labelReference(name[1..-1])
+            Assembler.localLabelReference(name[1..-1])
         end
     end
 

--- a/Source/WTF/wtf/InlineASM.h
+++ b/Source/WTF/wtf/InlineASM.h
@@ -52,10 +52,13 @@
 #endif
 
 #if HAVE(INTERNAL_VISIBILITY)
-#define LOCAL_REFERENCE(name) SYMBOL_STRING(name)
+#define LABEL_REFERENCE(name) SYMBOL_STRING(name)
 #else
-#define LOCAL_REFERENCE(name) GLOBAL_REFERENCE(name)
+#define LABEL_REFERENCE(name) GLOBAL_REFERENCE(name)
 #endif
+
+// Deprecated: misleading name. Will be removed once the dependency in WebKitAdditions is gone.
+#define LOCAL_REFERENCE(name) LABEL_REFERENCE(name)
 
 #if OS(DARWIN)
     // Mach-O platform


### PR DESCRIPTION
#### 018769c9e26017cfc29741ccb9ff252f5451c4e2
<pre>
offlineasm incorrectly lowers references to global labels
<a href="https://bugs.webkit.org/show_bug.cgi?id=305489">https://bugs.webkit.org/show_bug.cgi?id=305489</a>
<a href="https://rdar.apple.com/168153042">rdar://168153042</a>

Reviewed by Yusuke Suzuki.

Feeding this snippet into offlineasm:

global _foo
_foo:
    leap _foo, r0
    ret

produces the following in LLIntAssembly.h:

&quot;.loc 5 1541\n&quot;   OFFLINE_ASM_GLOBAL_LABEL(foo)
&quot;.loc 5 1543\n&quot;   &quot;movq &quot; LOCAL_LABEL_STRING(foo) &quot;@GOTPCREL(%rip), %rax \n&quot;
&quot;.loc 5 1544\n&quot;   &quot;ret \n&quot;

The label is incorrectly referenced using LOCAL_LABEL_STRING, as if it were declared using
OFFLINE_ASM_LOCAL_LABEL(). On x86, LOCAL_LABEL_STRING(foo) is rendered as &quot;Lfoo&quot; and
compilation fails because &quot;Lfoo&quot; is undefined.

The incorrect reference is emitted because LabelReference.asmLabel (in backend.rb) calls
Assembler.labelReference. That appears reasonable and parallels LocalLabelReference
calling Assembler.localLabelReference. However, the implementations of .labelReference and
.localLabelReference are identical and both produce LOCAL_LABEL_STRING.

Git archaeology shows that originally Assembler.labelReference and .localLabelReference
emitted different code. That changed with <a href="https://bugs.webkit.org/show_bug.cgi?id=131205">https://bugs.webkit.org/show_bug.cgi?id=131205</a>,
as part of a sweeping change to make opcode labels local. After the change, the asmLabel
of a LabelReference is the local string, unless the label is &apos;extern&apos;. A label is extern
if it&apos;s referenced but never defined in the assembly source, for example &apos;_g_config&apos;, so
instructions like &apos;leap _g_config, ws0&apos; are translated correctly.

This breaks when a label is defined as a global, in which case its &apos;extern&apos; attribute is
set to false, but using LOCAL_LABEL_STRING to reference it is incorrect.

The picture is further obscured by the naming of the methods and macros involved.
.labelReference suggests it&apos;s different, but is actually identical to
.localLabelReference, and .externLabelReference (by definition never local) expands into
the macro LOCAL_REFERENCE (!), which then usually expands into GLOBAL_REFERENCE.

The patch changes LabelReference.asmLabel to respect the &apos;global&apos; attribute, removes
Assembler.labelReference, and renames other methods and macros involved to better reflect
what&apos;s going on.

Testing: offlineasm has no dedicated test suite, but the upcoming JSPI PR
<a href="https://github.com/WebKit/WebKit/pull/54712">https://github.com/WebKit/WebKit/pull/54712</a> has code that relies on the corrected
behavior.

Canonical link: <a href="https://commits.webkit.org/305717@main">https://commits.webkit.org/305717@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54c66f9791399a7d0b79bc26fb99cfbdc38b420d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139159 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11532 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/656 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147286 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2649ff67-c680-45fd-99bb-ee25d54d9c31) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12239 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11683 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106529 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/19021103-957f-413e-847b-2e5756102923) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142106 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9254 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124644 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87396 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5a8d07cb-af4d-4579-bb7c-4561cfe5cd4e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8800 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6572 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7578 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/131132 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118253 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/546 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150065 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11217 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/556 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114917 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11230 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9488 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115230 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29291 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9181 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120994 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66119 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11260 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/521 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/170430 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10995 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74917 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44374 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11198 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11047 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->