### PR TITLE
[JSC][WASM][Debugger] Add build scripts, continue-interrupt test, and fix timing issues

### DIFF
--- a/JSTests/wasm/debugger/resources/c-wasm/add/main.js
+++ b/JSTests/wasm/debugger/resources/c-wasm/add/main.js
@@ -1,3 +1,5 @@
+// WASM Generation:
+//     emcc -g -O0 -s STANDALONE_WASM=1 -s EXPORTED_FUNCTIONS='["_main","_add"]' add.c -o add.wasm
 var wasm_code = read('add.wasm', 'binary');
 var wasm_module = new WebAssembly.Module(wasm_code);
 var imports = {

--- a/JSTests/wasm/debugger/resources/swift-wasm/test/build.sh
+++ b/JSTests/wasm/debugger/resources/swift-wasm/test/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# This script is used to compile Swift WASM.
+# Note that the corresponding tests needs to be updated due to updated WASM binary.
+set -e
+
+cd "$(dirname "$0")"
+
+# Build Swift WASM with Swiftly https://www.swift.org/documentation/articles/wasm-getting-started.html
+echo "Building Swift WebAssembly..."
+/Users/yijiahuang/.swiftly/bin/swift build --swift-sdk swift-6.2.3-RELEASE_wasm
+
+# Move compiled WASM beside main.js
+echo "Moving test.wasm..."
+mv .build/wasm32-unknown-wasip1/debug/test.wasm ./test.wasm
+
+# Clean up build artifacts
+echo "Cleaning up..."
+rm -rf .build
+
+echo "Done!"

--- a/JSTests/wasm/debugger/tests/tests.py
+++ b/JSTests/wasm/debugger/tests/tests.py
@@ -21,7 +21,7 @@ class CWasmTestCase(BaseTestCase):
                 self.quitTest()
 
         except Exception as e:
-            raise Exception(f"Breakpoint test failed: {e}")
+            raise Exception(f"Test failed: {e}")
 
     def continueInterruptTest(self):
         cycles = 10
@@ -277,7 +277,7 @@ class SwiftWasmTestCase(BaseTestCase):
                 self.stepTest()
 
         except Exception as e:
-            raise Exception(f"Breakpoint test failed: {e}")
+            raise Exception(f"Test failed: {e}")
 
     def continueInterruptTest(self):
         cycles = 10
@@ -509,7 +509,7 @@ class NopDropSelectEndTestCase(BaseTestCase):
                 self.stepTest()
 
         except Exception as e:
-            raise Exception(f"Breakpoint test failed: {e}")
+            raise Exception(f"Test failed: {e}")
 
     def stepTest(self):
         self.send_lldb_command_or_raise("b 0x4000000000000021")
@@ -554,7 +554,7 @@ class CallTestCase(BaseTestCase):
                 self.stepTest()
 
         except Exception as e:
-            raise Exception(f"Breakpoint test failed: {e}")
+            raise Exception(f"Test failed: {e}")
 
     def stepTest(self):
         self.send_lldb_command_or_raise("b 0x4000000000000036")
@@ -593,7 +593,7 @@ class CallIndirectTestCase(BaseTestCase):
                 self.stepTest()
 
         except Exception as e:
-            raise Exception(f"Breakpoint test failed: {e}")
+            raise Exception(f"Test failed: {e}")
 
     def stepTest(self):
         self.send_lldb_command_or_raise("b 0x4000000000000046")
@@ -634,7 +634,7 @@ class CallRefTestCase(BaseTestCase):
                 self.stepTest()
 
         except Exception as e:
-            raise Exception(f"Breakpoint test failed: {e}")
+            raise Exception(f"Test failed: {e}")
 
     def stepTest(self):
         self.send_lldb_command_or_raise("b 0x4000000000000043")
@@ -675,7 +675,7 @@ class ReturnCallTestCase(BaseTestCase):
                 self.stepTest()
 
         except Exception as e:
-            raise Exception(f"Tail call test failed: {e}")
+            raise Exception(f"Test failed: {e}")
 
     def stepTest(self):
         self.send_lldb_command_or_raise("b 0x4000000000000035")
@@ -717,7 +717,7 @@ class ReturnCallIndirectTestCase(BaseTestCase):
                 self.stepTest()
 
         except Exception as e:
-            raise Exception(f"Tail call indirect test failed: {e}")
+            raise Exception(f"Test failed: {e}")
 
     def stepTest(self):
         self.send_lldb_command_or_raise("b 0x4000000000000045")
@@ -761,7 +761,7 @@ class ReturnCallRefTestCase(BaseTestCase):
                 self.stepTest()
 
         except Exception as e:
-            raise Exception(f"Tail call ref test failed: {e}")
+            raise Exception(f"Test failed: {e}")
 
     def stepTest(self):
         for _ in range(10):
@@ -805,7 +805,7 @@ class ThrowCatchTestCase(BaseTestCase):
                 self.stepTest()
 
         except Exception as e:
-            raise Exception(f"Tail call ref test failed: {e}")
+            raise Exception(f"Test failed: {e}")
 
     def stepTest(self):
         self.send_lldb_command_or_raise("b 0x4000000000000071")
@@ -870,7 +870,7 @@ class ThrowCatchAllTestCase(BaseTestCase):
             self.stepTest()
 
         except Exception as e:
-            raise Exception(f"Throw catch_all test failed: {e}")
+            raise Exception(f"Test failed: {e}")
 
     def stepTest(self):
         self.send_lldb_command_or_raise("b 0x400000000000006e")
@@ -935,7 +935,7 @@ class DelegateTestCase(BaseTestCase):
             self.stepTest()
 
         except Exception as e:
-            raise Exception(f"Delegate test failed: {e}")
+            raise Exception(f"Test failed: {e}")
 
     def stepTest(self):
         self.send_lldb_command_or_raise("b 0x40000000000000c6")
@@ -1363,7 +1363,7 @@ class TryTableTestCase(BaseTestCase):
             self.stepTest()
 
         except Exception as e:
-            raise Exception(f"Try table test failed: {e}")
+            raise Exception(f"Test failed: {e}")
 
     def stepTest(self):
         self.send_lldb_command_or_raise("b 0x40000000000000aa")
@@ -1443,10 +1443,20 @@ class SystemCallTestCase(BaseTestCase):
 
         try:
             for _ in range(1):
+                self.continueInterruptTest()
                 self.stepTest()
 
         except Exception as e:
-            raise Exception(f"Try table test failed: {e}")
+            raise Exception(f"Test failed: {e}")
+
+    def continueInterruptTest(self):
+        cycles = 5
+        for cycle in range(1, cycles + 1):
+            try:
+                self.send_lldb_command_or_raise("c")
+                self.send_lldb_command_or_raise("process interrupt")
+            except Exception as e:
+                raise Exception(f"Cycle {cycle} failed: {e}")
 
     def stepTest(self):
         self.send_lldb_command_or_raise("si", patterns=[])
@@ -1476,7 +1486,7 @@ class MultiVMSameModuleSameFunctionTestCase(BaseTestCase):
                 self.stepTest()
 
         except Exception as e:
-            raise Exception(f"Try table test failed: {e}")
+            raise Exception(f"Test failed: {e}")
 
     def stepTest(self):
         # FIXME: Add tests when thread select is full supported
@@ -1498,7 +1508,7 @@ class MultiVMSameModuleDifferentFunctionsTestCase(BaseTestCase):
                 self.stepTest()
 
         except Exception as e:
-            raise Exception(f"Try table test failed: {e}")
+            raise Exception(f"Test failed: {e}")
 
     def stepTest(self):
         # FIXME: Add tests when thread select is full supported


### PR DESCRIPTION
#### 07a59b7cf94ca5af07e8406cd57c0b945ec87460
<pre>
[JSC][WASM][Debugger] Add build scripts, continue-interrupt test, and fix timing issues
<a href="https://rdar.apple.com/168190038">rdar://168190038</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=305528">https://bugs.webkit.org/show_bug.cgi?id=305528</a>

Reviewed by Yusuke Suzuki.

Add build infrastructure and continue/interrupt stress testing for timing issues,
plus standardize error messages across test cases.

* JSTests/wasm/debugger/resources/c-wasm/add/main.js:
Added comment documenting emcc command to build WASM test
* JSTests/wasm/debugger/resources/swift-wasm/test/build.sh: Added.
New build script to compile Swift WASM tests with Swiftly toolchain
* JSTests/wasm/debugger/tests/tests.py:
(SystemCallTestCase.continueInterruptTest): Added 5-cycle continue/interrupt test
(SystemCallTestCase.test_system_call): Call continueInterruptTest before stepTest
(SystemCallTestCase.stepTest): Uses patterns=[] for step commands at system call boundary
(Multiple test cases): Standardized error messages to generic &quot;Test failed&quot;

Canonical link: <a href="https://commits.webkit.org/305782@main">https://commits.webkit.org/305782@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b821b2b5938a2c6da217a680e305e672ef567218

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139401 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11777 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/903 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/147528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/12484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11927 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/147528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/161badb0-10bb-404b-ad80-e3379929549f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142348 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/12484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/124863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/147528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7a872b5c-d97f-4556-8bf3-c07fecd00ae9) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/12484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/6786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7825 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/131374 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/12484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/150311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/196 "Built successfully and passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/11461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/150311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/11474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/9771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/150311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/121270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/66465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21503 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11504 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/170672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/11239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/170672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/11441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/11291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->