### PR TITLE
Reduce unsafeness in PlatformMediaSessionInterface and MediaSessionCoordinator

### DIFF
--- a/Source/WebCore/Modules/mediasession/MediaSessionCoordinator.h
+++ b/Source/WebCore/Modules/mediasession/MediaSessionCoordinator.h
@@ -60,7 +60,7 @@ public:
     ExceptionOr<void> leave();
     void close();
 
-    String identifier() const { return m_privateCoordinator ? m_privateCoordinator->identifier() : String(); }
+    String identifier() const { return m_privateCoordinator ? protectedPrivateCoordinator()->identifier() : String(); }
     MediaSessionCoordinatorState state() const { return m_state; }
 
     void seekTo(double, DOMPromiseDeferred<void>&&);
@@ -111,6 +111,8 @@ private:
     static WTFLogChannel& logChannel();
     static ASCIILiteral logClassName() { return "MediaSessionCoordinator"_s; }
     bool shouldFireEvents() const;
+
+    RefPtr<MediaSessionCoordinatorPrivate> protectedPrivateCoordinator() const { return m_privateCoordinator; }
 
     WeakPtr<MediaSession> m_session;
     RefPtr<MediaSessionCoordinatorPrivate> m_privateCoordinator;

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -372,7 +372,6 @@ platform/ScrollView.cpp
 platform/ScrollingEffectsController.cpp
 platform/Widget.cpp
 platform/audio/PlatformMediaSession.cpp
-platform/audio/PlatformMediaSessionInterface.h
 [ Mac ] platform/cocoa/DragImageCocoa.mm
 platform/cocoa/LowPowerModeNotifier.mm
 platform/cocoa/VideoPresentationModelVideoElement.mm

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -8,7 +8,6 @@ Modules/identity/CredentialRequestCoordinator.cpp
 Modules/mediasession/MediaMetadata.cpp
 Modules/mediasession/MediaSession.cpp
 [ Mac ] Modules/mediasession/MediaSessionCoordinator.cpp
-[ Mac ] Modules/mediasession/MediaSessionCoordinator.h
 Modules/mediastream/MediaStreamTrack.cpp
 Modules/mediastream/MediaStreamTrackProcessor.cpp
 Modules/mediastream/RTCDTMFSender.cpp

--- a/Source/WebCore/page/PageOverlayController.cpp
+++ b/Source/WebCore/page/PageOverlayController.cpp
@@ -403,7 +403,7 @@ Vector<String> PageOverlayController::copyAccessibilityAttributesNames(bool para
         return { };
 
     for (auto it = m_pageOverlays.rbegin(), end = m_pageOverlays.rend(); it != end; ++it) {
-        Vector<String> names = Ref { *it }->copyAccessibilityAttributeNames(parameterizedNames);
+        auto names = Ref { *it }->copyAccessibilityAttributeNames(parameterizedNames);
         if (!names.isEmpty())
             return names;
     }

--- a/Source/WebCore/platform/audio/PlatformMediaSessionInterface.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionInterface.h
@@ -140,8 +140,8 @@ public:
     virtual void setActive(bool) = 0;
 
     using MediaType = PlatformMediaSessionMediaType;
-    virtual MediaType mediaType() const { return client().mediaType(); }
-    virtual MediaType presentationType() const { return client().presentationType(); }
+    virtual MediaType mediaType() const { return checkedClient()->mediaType(); }
+    virtual MediaType presentationType() const { return checkedClient()->presentationType(); }
 
     using State = PlatformMediaSessionState;
     virtual State state() const = 0;
@@ -171,20 +171,20 @@ public:
 
     using RemoteCommandArgument = PlatformMediaSessionRemoteCommandArgument;
     using RemoteControlCommandType = PlatformMediaSessionRemoteControlCommandType;
-    bool canReceiveRemoteControlCommands() const { return client().canReceiveRemoteControlCommands(); }
+    bool canReceiveRemoteControlCommands() const { return checkedClient()->canReceiveRemoteControlCommands(); }
     virtual void didReceiveRemoteControlCommand(RemoteControlCommandType, const RemoteCommandArgument&) = 0;
 
     using DisplayType = PlatformMediaSessionDisplayType;
-    virtual DisplayType displayType() const { return client().displayType(); }
+    virtual DisplayType displayType() const { return checkedClient()->displayType(); }
 
-    virtual bool supportsSeeking() const { return client().supportsSeeking(); }
-    virtual bool isSuspended() const { return client().isSuspended(); }
-    virtual bool isPlaying() const { return client().isPlaying(); }
-    virtual bool isAudible() const { return client().isAudible(); }
-    virtual bool isEnded() const { return client().isEnded(); }
-    virtual MediaTime duration() const { return client().mediaSessionDuration(); }
+    virtual bool supportsSeeking() const { return checkedClient()->supportsSeeking(); }
+    virtual bool isSuspended() const { return checkedClient()->isSuspended(); }
+    virtual bool isPlaying() const { return checkedClient()->isPlaying(); }
+    virtual bool isAudible() const { return checkedClient()->isAudible(); }
+    virtual bool isEnded() const { return checkedClient()->isEnded(); }
+    virtual MediaTime duration() const { return checkedClient()->mediaSessionDuration(); }
 
-    virtual bool shouldOverrideBackgroundLoadingRestriction() const { return client().shouldOverrideBackgroundLoadingRestriction(); }
+    virtual bool shouldOverrideBackgroundLoadingRestriction() const { return checkedClient()->shouldOverrideBackgroundLoadingRestriction(); }
 
     virtual bool isPlayingToWirelessPlaybackTarget() const { return false; }
     virtual void isPlayingToWirelessPlaybackTargetChanged(bool) = 0;
@@ -203,8 +203,8 @@ public:
 
     virtual bool blockedBySystemInterruption() const = 0;
     virtual bool activeAudioSessionRequired() const = 0;
-    virtual bool canProduceAudio() const { return client().canProduceAudio(); }
-    virtual bool hasMediaStreamSource() const { return client().hasMediaStreamSource(); }
+    virtual bool canProduceAudio() const { return checkedClient()->canProduceAudio(); }
+    virtual bool hasMediaStreamSource() const { return checkedClient()->hasMediaStreamSource(); }
     virtual void canProduceAudioChanged() = 0;
 
     virtual void resetPlaybackSessionState() { }
@@ -215,10 +215,10 @@ public:
     virtual bool preparingToPlay() const = 0;
 
     virtual bool canPlayConcurrently(const PlatformMediaSessionInterface&) const = 0;
-    virtual bool shouldOverridePauseDuringRouteChange() const { return client().shouldOverridePauseDuringRouteChange(); }
+    virtual bool shouldOverridePauseDuringRouteChange() const { return checkedClient()->shouldOverridePauseDuringRouteChange(); }
 
-    virtual std::optional<NowPlayingInfo> nowPlayingInfo() const { return client().nowPlayingInfo(); }
-    virtual bool isNowPlayingEligible() const { return client().isNowPlayingEligible(); }
+    virtual std::optional<NowPlayingInfo> nowPlayingInfo() const { return checkedClient()->nowPlayingInfo(); }
+    virtual bool isNowPlayingEligible() const { return checkedClient()->isNowPlayingEligible(); }
 
     using PlaybackControlsPurpose = PlatformMediaSessionPlaybackControlsPurpose;
     virtual WeakPtr<PlatformMediaSessionInterface> selectBestMediaSession(const Vector<WeakPtr<PlatformMediaSessionInterface>>&, PlaybackControlsPurpose) = 0;
@@ -239,8 +239,8 @@ public:
     virtual String description() const = 0;
 #endif
 
-    virtual std::optional<MediaSessionGroupIdentifier> mediaSessionGroupIdentifier() const { return client().mediaSessionGroupIdentifier(); }
-    virtual bool isPlayingOnSecondScreen() const { return client().isPlayingOnSecondScreen(); }
+    virtual std::optional<MediaSessionGroupIdentifier> mediaSessionGroupIdentifier() const { return checkedClient()->mediaSessionGroupIdentifier(); }
+    virtual bool isPlayingOnSecondScreen() const { return checkedClient()->isPlayingOnSecondScreen(); }
 
     virtual bool isRemoteSessionProxy() const;
 
@@ -263,7 +263,7 @@ protected:
     {
     }
 
-    RefPtr<MediaSessionManagerInterface> sessionManager() const { return m_client->sessionManager(); }
+    RefPtr<MediaSessionManagerInterface> sessionManager() const { return checkedClient()->sessionManager(); }
 
 private:
     CheckedRef<PlatformMediaSessionClient> m_client;


### PR DESCRIPTION
#### eebc3852d9a1a4e5beacdefa2147b389f563a943
<pre>
Reduce unsafeness in PlatformMediaSessionInterface and MediaSessionCoordinator
<a href="https://bugs.webkit.org/show_bug.cgi?id=305529">https://bugs.webkit.org/show_bug.cgi?id=305529</a>
<a href="https://rdar.apple.com/168190482">rdar://168190482</a>

Reviewed by Ryosuke Niwa.

Apply Safer CPP guidelines.

* Source/WebCore/Modules/mediasession/MediaSessionCoordinator.h:
(WebCore::MediaSessionCoordinator::identifier const):
(WebCore::MediaSessionCoordinator::protectedPrivateCoordinator const):
* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/page/PageOverlayController.cpp:
(WebCore::PageOverlayController::copyAccessibilityAttributesNames):
* Source/WebCore/platform/audio/PlatformMediaSessionInterface.h:

Canonical link: <a href="https://commits.webkit.org/305653@main">https://commits.webkit.org/305653@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea394096f6565a290ea457e005647ca4f258df6d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138953 "19 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11320 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/440 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147072 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/91980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fdb0903c-be8d-4efa-ba22-c6f9fc781e8b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140826 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12027 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11476 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106358 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/91980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d757b988-cd46-4528-9655-561cc2fc29a3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141900 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9070 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124476 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87230 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e23ba2f2-45cc-4996-a79d-4b856acd1d99) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8641 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6400 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7373 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118077 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/367 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149858 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11003 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/373 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114747 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11023 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9303 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115063 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8951 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120819 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65907 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21429 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11051 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/357 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10788 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74701 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10991 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10839 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->