### PR TITLE
RenderSearchField should not implement PopupMenuClient.

### DIFF
--- a/Source/WebCore/html/SearchInputType.h
+++ b/Source/WebCore/html/SearchInputType.h
@@ -32,6 +32,8 @@
 #pragma once
 
 #include "BaseTextInputType.h"
+#include "PopupMenuClient.h"
+#include "SearchPopupMenu.h"
 #include "Timer.h"
 #include <wtf/TZoneMalloc.h>
 
@@ -39,7 +41,7 @@ namespace WebCore {
 
 class SearchFieldResultsButtonElement;
 
-class SearchInputType final : public BaseTextInputType {
+class SearchInputType final : public BaseTextInputType, public PopupMenuClient {
     WTF_MAKE_TZONE_ALLOCATED(SearchInputType);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SearchInputType);
 public:
@@ -47,6 +49,43 @@ public:
     {
         return adoptRef(*new SearchInputType(element));
     }
+
+    // CheckedPtr interface - resolve multiple inheritance ambiguity
+    uint32_t checkedPtrCount() const final { return BaseTextInputType::checkedPtrCount(); }
+    uint32_t checkedPtrCountWithoutThreadCheck() const final { return BaseTextInputType::checkedPtrCountWithoutThreadCheck(); }
+    void incrementCheckedPtrCount() const final { BaseTextInputType::incrementCheckedPtrCount(); }
+    void decrementCheckedPtrCount() const final { BaseTextInputType::decrementCheckedPtrCount(); }
+    void setDidBeginCheckedPtrDeletion() final { CanMakeCheckedPtr::setDidBeginCheckedPtrDeletion(); }
+
+    // PopupMenuClient methods
+    void valueChanged(unsigned listIndex, bool fireEvents = true) override;
+    void selectionChanged(unsigned, bool) override { }
+    void selectionCleared() override { }
+    String itemText(unsigned listIndex) const override;
+    String itemLabel(unsigned listIndex) const override;
+    String itemIcon(unsigned listIndex) const override;
+    String itemToolTip(unsigned) const override { return String(); }
+    String itemAccessibilityText(unsigned) const override { return String(); }
+    bool itemIsEnabled(unsigned listIndex) const override;
+    PopupMenuStyle itemStyle(unsigned listIndex) const override;
+    PopupMenuStyle menuStyle() const override;
+    int clientInsetLeft() const override;
+    int clientInsetRight() const override;
+    LayoutUnit clientPaddingLeft() const override;
+    LayoutUnit clientPaddingRight() const override;
+    int listSize() const override;
+    int popupSelectedIndex() const override;
+    void popupDidHide() override;
+    bool itemIsSeparator(unsigned listIndex) const override;
+    bool itemIsLabel(unsigned listIndex) const override;
+    bool itemIsSelected(unsigned listIndex) const override;
+    bool shouldPopOver() const override { return false; }
+    void setTextFromItem(unsigned listIndex) override;
+    FontSelector* fontSelector() const override;
+    HostWindow* hostWindow() const override;
+    Ref<Scrollbar> createScrollbar(ScrollableArea&, ScrollbarOrientation, ScrollbarWidth) override;
+
+    Vector<RecentSearch>& recentSearches() { return m_recentSearches; }
 
 private:
     explicit SearchInputType(HTMLInputElement&);
@@ -68,6 +107,8 @@ private:
 
     RefPtr<SearchFieldResultsButtonElement> m_resultsButton;
     RefPtr<HTMLElement> m_cancelButton;
+
+    Vector<RecentSearch> m_recentSearches;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderSearchField.h
+++ b/Source/WebCore/rendering/RenderSearchField.h
@@ -22,7 +22,6 @@
 
 #pragma once
 
-#include "PopupMenuClient.h"
 #include "RenderTextControlSingleLine.h"
 #include "SearchPopupMenu.h"
 
@@ -30,7 +29,7 @@ namespace WebCore {
 
 class HTMLInputElement;
 
-class RenderSearchField final : public RenderTextControlSingleLine, private PopupMenuClient {
+class RenderSearchField final : public RenderTextControlSingleLine {
     WTF_MAKE_TZONE_ALLOCATED(RenderSearchField);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderSearchField);
 public:
@@ -39,19 +38,19 @@ public:
 
     void updateCancelButtonVisibility() const;
 
-    void addSearchResult();
-
     bool popupIsVisible() const { return m_searchPopupIsVisible; }
     void showPopup();
     void hidePopup();
+    void popupDidHide();
     WEBCORE_EXPORT std::span<const RecentSearch> recentSearches();
 
-    // CheckedPtr interface.
-    uint32_t checkedPtrCount() const final { return RenderTextControlSingleLine::checkedPtrCount(); }
-    uint32_t checkedPtrCountWithoutThreadCheck() const final { return RenderTextControlSingleLine::checkedPtrCountWithoutThreadCheck(); }
-    void incrementCheckedPtrCount() const final { RenderTextControlSingleLine::incrementCheckedPtrCount(); }
-    void decrementCheckedPtrCount() const final { RenderTextControlSingleLine::decrementCheckedPtrCount(); }
-    void setDidBeginCheckedPtrDeletion() final { CanMakeCheckedPtr::setDidBeginCheckedPtrDeletion(); }
+    void updatePopup(const AtomString& name, const Vector<WebCore::RecentSearch>& searchItems);
+    int clientInsetRight() const;
+    int clientInsetLeft() const;
+    LayoutUnit clientPaddingRight() const;
+    LayoutUnit clientPaddingLeft() const;
+    FontSelector* fontSelector() const;
+    HostWindow* hostWindow() const;
 
 private:
     void willBeDestroyed() override;
@@ -60,33 +59,6 @@ private:
     Visibility visibilityForCancelButton() const;
     const AtomString& autosaveName() const;
 
-    // PopupMenuClient methods
-    void valueChanged(unsigned listIndex, bool fireEvents = true) override;
-    void selectionChanged(unsigned, bool) override { }
-    void selectionCleared() override { }
-    String itemText(unsigned listIndex) const override;
-    String itemLabel(unsigned listIndex) const override;
-    String itemIcon(unsigned listIndex) const override;
-    String itemToolTip(unsigned) const override { return String(); }
-    String itemAccessibilityText(unsigned) const override { return String(); }
-    bool itemIsEnabled(unsigned listIndex) const override;
-    PopupMenuStyle itemStyle(unsigned listIndex) const override;
-    PopupMenuStyle menuStyle() const override;
-    int clientInsetLeft() const override;
-    int clientInsetRight() const override;
-    LayoutUnit clientPaddingLeft() const override;
-    LayoutUnit clientPaddingRight() const override;
-    int listSize() const override;
-    int popupSelectedIndex() const override;
-    void popupDidHide() override;
-    bool itemIsSeparator(unsigned listIndex) const override;
-    bool itemIsLabel(unsigned listIndex) const override;
-    bool itemIsSelected(unsigned listIndex) const override;
-    bool shouldPopOver() const override { return false; }
-    void setTextFromItem(unsigned listIndex) override;
-    FontSelector* fontSelector() const override;
-    HostWindow* hostWindow() const override;
-    Ref<Scrollbar> createScrollbar(ScrollableArea&, ScrollbarOrientation, ScrollbarWidth) override;
     RefPtr<SearchPopupMenu> protectedSearchPopup() const { return m_searchPopup; };
 
     HTMLElement* resultsButtonElement() const;
@@ -94,7 +66,6 @@ private:
 
     bool m_searchPopupIsVisible;
     RefPtr<SearchPopupMenu> m_searchPopup;
-    Vector<RecentSearch> m_recentSearches;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 757d6002fa59286da6e8ef246cc52fadd648dccf
<pre>
RenderSearchField should not implement PopupMenuClient.
<a href="https://bugs.webkit.org/show_bug.cgi?id=305530">https://bugs.webkit.org/show_bug.cgi?id=305530</a>
<a href="https://rdar.apple.com/168190761">rdar://168190761</a>

Reviewed by Wenson Hsieh.

Continuing the work started in 305556@main
to move PopupMenuClient for stability because
renderers cannot be ref counted, and thus will
crash if they&apos;ve already been destroyed.

* Source/WebCore/html/SearchInputType.cpp:
(WebCore::SearchInputType::valueChanged):
(WebCore::SearchInputType::itemText const):
(WebCore::SearchInputType::itemLabel const):
(WebCore::SearchInputType::itemIcon const):
(WebCore::SearchInputType::itemIsEnabled const):
(WebCore::SearchInputType::itemStyle const):
(WebCore::SearchInputType::menuStyle const):
(WebCore::SearchInputType::clientInsetLeft const):
(WebCore::SearchInputType::clientInsetRight const):
(WebCore::SearchInputType::clientPaddingLeft const):
(WebCore::SearchInputType::clientPaddingRight const):
(WebCore::SearchInputType::listSize const):
(WebCore::SearchInputType::popupSelectedIndex const):
(WebCore::SearchInputType::popupDidHide):
(WebCore::SearchInputType::itemIsSeparator const):
(WebCore::SearchInputType::itemIsLabel const):
(WebCore::SearchInputType::itemIsSelected const):
(WebCore::SearchInputType::setTextFromItem):
(WebCore::SearchInputType::fontSelector const):
(WebCore::SearchInputType::hostWindow const):
(WebCore::SearchInputType::createScrollbar):
(WebCore::SearchInputType::addSearchResult):
* Source/WebCore/html/SearchInputType.h:
* Source/WebCore/rendering/RenderSearchField.cpp:
(WebCore::RenderSearchField::showPopup):
(WebCore::RenderSearchField::recentSearches):
(WebCore::RenderSearchField::createPopup):
(WebCore::RenderSearchField::addSearchResult): Deleted.
(WebCore::RenderSearchField::valueChanged): Deleted.
(WebCore::RenderSearchField::itemText const): Deleted.
(WebCore::RenderSearchField::itemLabel const): Deleted.
(WebCore::RenderSearchField::itemIcon const): Deleted.
(WebCore::RenderSearchField::itemIsEnabled const): Deleted.
(WebCore::RenderSearchField::itemStyle const): Deleted.
(WebCore::RenderSearchField::menuStyle const): Deleted.
(WebCore::RenderSearchField::listSize const): Deleted.
(WebCore::RenderSearchField::popupSelectedIndex const): Deleted.
(WebCore::RenderSearchField::itemIsSeparator const): Deleted.
(WebCore::RenderSearchField::itemIsLabel const): Deleted.
(WebCore::RenderSearchField::itemIsSelected const): Deleted.
(WebCore::RenderSearchField::setTextFromItem): Deleted.
(WebCore::RenderSearchField::createScrollbar): Deleted.
* Source/WebCore/rendering/RenderSearchField.h:

Canonical link: <a href="https://commits.webkit.org/305728@main">https://commits.webkit.org/305728@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ee714752bbb425b939be317d228ac11f56e7a63

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139223 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11599 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/725 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147350 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b16206b2-cb59-451e-8be7-63ef7fae366f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141096 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12306 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11749 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106584 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fb4e929e-cd31-48a8-a879-8ac27956e52a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142170 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9313 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124702 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87444 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/19274f5f-b2c2-4541-838b-398b48da2e2e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8864 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6632 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7647 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118319 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/598 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150132 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11283 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/616 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114975 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11296 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9550 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115280 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29297 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9339 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121045 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66201 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11326 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/577 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11060 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74992 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11263 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11113 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->