### PR TITLE
[JSC] Add constant materialization JIT code for x64

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
+++ b/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
@@ -866,13 +866,13 @@ MoveZeroToFloat D:F:32
 64: Move64ToDouble U:G:64, D:F:64
     Tmp, Tmp
     x86: Addr, Tmp as loadDouble
-    arm64: FPImm64, Tmp
+    FPImm64, Tmp
     Index, Tmp as loadDouble
 
 32: Move64ToDouble U:G:32, U:G:32, D:F:64
     Tmp, Tmp, Tmp
 
-arm64: Move128ToVector U:G:128, D:F:128
+64: Move128ToVector U:G:128, D:F:128
     FPImm128, Tmp
 
 32: Move32ToDoubleHi U:G:32, UD:F:64
@@ -881,7 +881,7 @@ arm64: Move128ToVector U:G:128, D:F:128
 Move32ToFloat U:G:32, D:F:32
     Tmp, Tmp
     x86: Addr, Tmp as loadFloat
-    arm64: FPImm32, Tmp
+    64: FPImm32, Tmp
     Index, Tmp as loadFloat
 
 64: MoveDoubleTo64 U:F:64, D:G:64

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -3816,21 +3816,7 @@ void BBQJIT::notifyFunctionUsesSIMD()
 
 void BBQJIT::materializeVectorConstant(v128_t value, Location result)
 {
-    if (isARM64()) {
-        m_jit.move128ToVector(value, result.asFPR());
-        return;
-    }
-
-    if (!value.u64x2[0] && !value.u64x2[1])
-        m_jit.moveZeroToVector(result.asFPR());
-    else if (value.u64x2[0] == 0xffffffffffffffffull && value.u64x2[1] == 0xffffffffffffffffull)
-#if CPU(X86_64)
-        m_jit.compareIntegerVector(RelationalCondition::Equal, SIMDInfo { SIMDLane::i32x4, SIMDSignMode::Unsigned }, result.asFPR(), result.asFPR(), result.asFPR(), wasmScratchFPR);
-#else
-        m_jit.compareIntegerVector(RelationalCondition::Equal, SIMDInfo { SIMDLane::i32x4, SIMDSignMode::Unsigned }, result.asFPR(), result.asFPR(), result.asFPR());
-#endif
-    else
-        m_jit.move128ToVector(value, result.asFPR());
+    m_jit.move128ToVector(value, result.asFPR());
 }
 
 [[nodiscard]] ExpressionType BBQJIT::addConstant(v128_t value)


### PR DESCRIPTION
#### aa596dded063f62c79361988e85d561c4292842c
<pre>
[JSC] Add constant materialization JIT code for x64
<a href="https://bugs.webkit.org/show_bug.cgi?id=305532">https://bugs.webkit.org/show_bug.cgi?id=305532</a>
<a href="https://rdar.apple.com/168193277">rdar://168193277</a>

Reviewed by Sosuke Suzuki.

This patch adds more wide variety of constants for
move128ToVector / move64ToDouble / move32ToFloat in x64. This is a
preparation for SIMD optimization in x64 in YarrJIT where it needs these
constant materializations for masks.

Test: Source/JavaScriptCore/assembler/testmasm.cpp

* Source/JavaScriptCore/assembler/AssemblerCommon.h:
(JSC::X86ContiguousBitPattern32::create):
(JSC::X86ContiguousBitPattern32::isValid const):
(JSC::X86ContiguousBitPattern32::leftShift const):
(JSC::X86ContiguousBitPattern32::rightShift const):
(JSC::X86ContiguousBitPattern32::X86ContiguousBitPattern32):
(JSC::X86ContiguousBitPattern64::create):
(JSC::X86ContiguousBitPattern64::isValid const):
(JSC::X86ContiguousBitPattern64::leftShift const):
(JSC::X86ContiguousBitPattern64::rightShift const):
(JSC::X86ContiguousBitPattern64::X86ContiguousBitPattern64):
* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::moveAllOnesToVector):
(JSC::MacroAssemblerX86_64::move32ToFloat):
(JSC::MacroAssemblerX86_64::move64ToDouble):
(JSC::MacroAssemblerX86_64::move128ToVector):
* Source/JavaScriptCore/assembler/X86Assembler.h:
(JSC::X86Assembler::punpcklbw_rr):
(JSC::X86Assembler::punpcklwd_rr):
(JSC::X86Assembler::pcmpeqd_rr):
(JSC::X86Assembler::pcmpeqq_rr):
(JSC::X86Assembler::movlhps_rr):
(JSC::X86Assembler::vbroadcastss_rr):
(JSC::X86Assembler::vpbroadcastb_rr):
(JSC::X86Assembler::vpbroadcastw_rr):
(JSC::X86Assembler::vpbroadcastd_rr):
(JSC::X86Assembler::vpbroadcastq_rr):
* Source/JavaScriptCore/assembler/testmasm.cpp:
(JSC::testMove128ToVectorMovi):
(JSC::testMove32ToFloatComprehensive):
(JSC::testMove64ToDoubleComprehensive):
(JSC::testMove128ToVectorComprehensive):
(JSC::testFMovHalfPrecisionEncoding):
(JSC::testMove32ToFloatX64):
(JSC::testMove64ToDoubleX64):
* Source/JavaScriptCore/b3/air/AirArg.h:
(JSC::B3::Air::Arg::isValidFPImm32Form):
(JSC::B3::Air::Arg::isValidFPImm64Form):
(JSC::B3::Air::Arg::isValidFPImm128Form):
* Source/JavaScriptCore/b3/air/AirOpcode.opcodes:
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::materializeVectorConstant):

Canonical link: <a href="https://commits.webkit.org/306399@main">https://commits.webkit.org/306399@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/018249ccbff68eb06ea2c2a9b26ab1e218c0fd18

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141098 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13482 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2773 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149646 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94195 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c5ffcd73-0a03-462a-89bd-8f4874215502) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14192 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13634 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108385 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78504 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cf01a2fc-b7b3-42b2-845b-472d3c46bc51) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144049 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10959 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126271 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89292 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f68c0a54-be81-458e-b202-082720e8c0f6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10542 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8131 "Passed tests") | [⏳ 🛠 wpe-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/133078 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119799 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2262 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152063 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/1899 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13168 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2608 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116497 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13184 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11507 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116840 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12898 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122945 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68341 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21794 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13211 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/172391 "Hash 018249cc for PR 56610 does not build (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12950 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76916 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/172391 "Hash 018249cc for PR 56610 does not build (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13149 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12994 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->