### PR TITLE
Crash under WTF::Persistence::Decoder::operator>>

### DIFF
--- a/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.h
@@ -49,6 +49,15 @@ public:
 private:
     CacheStorageDiskStore(const String& cacheName, const String& path, Ref<WorkQueue>&&);
 
+    struct SafeFileData {
+        Variant<std::monostate, FileSystem::MappedFileData, Vector<uint8_t>> data;
+
+        std::span<const uint8_t> span() const;
+        RefPtr<WebCore::SharedBuffer> convertToSharedBuffer() &&;
+        explicit operator bool() const;
+        static SafeFileData read(const String& filePath);
+    };
+
     // CacheStorageStore
     void readAllRecordInfos(ReadAllRecordInfosCallback&&) final;
     void readRecords(const Vector<CacheStorageRecordInformation>&, ReadRecordsCallback&&) final;
@@ -62,7 +71,7 @@ private:
     String recordBlobFilePath(const String&) const;
     String blobsDirectoryPath() const;
     String blobFilePath(const String&) const;
-    std::optional<CacheStorageRecord> readRecordFromFileData(std::span<const uint8_t>, FileSystem::MappedFileData&&);
+    std::optional<CacheStorageRecord> readRecordFromFileData(std::span<const uint8_t>, SafeFileData&&);
     void readAllRecordInfosInternal(ReadAllRecordInfosCallback&&);
     void readRecordsInternal(const Vector<CacheStorageRecordInformation>&, ReadRecordsCallback&&);
 


### PR DESCRIPTION
#### d939960fe8b12868072f09000c2a8ae6c8f8cd9d
<pre>
Crash under WTF::Persistence::Decoder::operator&gt;&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=305539">https://bugs.webkit.org/show_bug.cgi?id=305539</a>
<a href="https://rdar.apple.com/155698666">rdar://155698666</a>

Reviewed by Sihui Liu.

We sometimes crash in memcpySpan() in WTF::Persistence::Decoder::operator&gt;&gt;
when decoding data that was just mmap&apos;d from disk. The crash log seems to
indicate the crash is due to apfs rejecting the read due to file protection.

To try and prevent this issue, I am updating CacheStorageDiskStore to rely
on `FileSystem::isSafeToUseMemoryMapForPath()` to determine if it is safe
to mmap or not. If not, we fall back to calling `FileSystem::readEntireFile()`.

* Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp:
(WebKit::CacheStorageDiskStore::SafeFileData::span const):
(WebKit::CacheStorageDiskStore::SafeFileData::convertToSharedBuffer):
(WebKit::CacheStorageDiskStore::SafeFileData::operator bool const):
(WebKit::CacheStorageDiskStore::SafeFileData::read):
(WebKit::CacheStorageDiskStore::readRecordFromFileData):
(WebKit::CacheStorageDiskStore::readAllRecordInfosInternal):
(WebKit::CacheStorageDiskStore::readRecordsInternal):
* Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.h:

Canonical link: <a href="https://commits.webkit.org/305698@main">https://commits.webkit.org/305698@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67079c0441db76baf215493b6c17841ce45c214a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139126 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11499 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/623 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147253 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f5e676bb-f25c-411a-b004-ed8a62ed1b90) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12206 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11650 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106502 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/33f63018-2138-4c16-9d0f-0adbde78642a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142073 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9219 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124618 "Found 1 new API test failure: TestWebKitAPI.WKDownload.DownloadRequestFailure (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87369 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4acc63c4-3771-4e9c-8241-e3ee97d89c83) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8768 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6545 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7545 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118220 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150032 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11184 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/528 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114890 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11197 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9460 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115202 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29283 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9119 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120967 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66086 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11226 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/495 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10962 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74884 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11165 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11014 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->