### PR TITLE
[JSC][WASM][Debugger] Extract GDB packet parser to handle multi-packet recv() calls

### DIFF
--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -1466,6 +1466,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     wasm/debugger/WasmDebugServer.h
     wasm/debugger/WasmDebugServerUtilities.h
     wasm/debugger/WasmExecutionHandler.h
+    wasm/debugger/WasmGDBPacketParser.h
     wasm/debugger/WasmMemoryHandler.h
     wasm/debugger/WasmModuleDebugInfo.h
     wasm/debugger/WasmModuleManager.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -2261,6 +2261,7 @@
 		FEF9AD642D8B985E005821C5 /* SourceProfiler.h in Headers */ = {isa = PBXBuildFile; fileRef = FEF9AD612D8B9848005821C5 /* SourceProfiler.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FEFD6FC61D5E7992008F2F0B /* JSStringInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = FEFD6FC51D5E7970008F2F0B /* JSStringInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FEFF211D2E73558000533F23 /* VMThreadContext.h in Headers */ = {isa = PBXBuildFile; fileRef = FEFF211C2E73558000533F23 /* VMThreadContext.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FF06E8BF2F19BC33007B3403 /* GDBPacketParserTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FF06E8BE2F19BC33007B3403 /* GDBPacketParserTest.cpp */; };
 		FF0F56752E333E1D002A232A /* WasmModuleManager.h in Headers */ = {isa = PBXBuildFile; fileRef = FF0F56712E333E1D002A232A /* WasmModuleManager.h */; };
 		FF0F568D2E33437C002A232A /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 932F5BD90822A1C700736975 /* JavaScriptCore.framework */; };
 		FF0F569A2E3348CA002A232A /* testwasmdebugger.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FF0F56992E3348CA002A232A /* testwasmdebugger.cpp */; };
@@ -2279,6 +2280,7 @@
 		FFA2E02F2EA16F37006661A3 /* UnaryTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FFA2E0262EA16F37006661A3 /* UnaryTests.cpp */; };
 		FFB951142C043CA800349750 /* OrderedHashTableHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = FFB951132C043CA800349750 /* OrderedHashTableHelper.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FFB963922E38302B0069A70F /* WasmBreakpointManager.h in Headers */ = {isa = PBXBuildFile; fileRef = FFB9638F2E38302B0069A70F /* WasmBreakpointManager.h */; };
+		FFBF548A2F189712008F124F /* WasmGDBPacketParser.h in Headers */ = {isa = PBXBuildFile; fileRef = FFBF54872F189712008F124F /* WasmGDBPacketParser.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FFCC9A412BDD7C4700C75345 /* OrderedHashTable.h in Headers */ = {isa = PBXBuildFile; fileRef = FFCC9A402BDD7C4700C75345 /* OrderedHashTable.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FFD49E6E2E276CA10083E383 /* WasmDebugServer.h in Headers */ = {isa = PBXBuildFile; fileRef = FFD49E5A2E276CA10083E383 /* WasmDebugServer.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FFD49E6F2E276CA10083E383 /* WasmQueryHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = FFD49E602E276CA10083E383 /* WasmQueryHandler.h */; };
@@ -6320,6 +6322,8 @@
 		FEFD6FC51D5E7970008F2F0B /* JSStringInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSStringInlines.h; sourceTree = "<group>"; };
 		FEFF211C2E73558000533F23 /* VMThreadContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VMThreadContext.h; sourceTree = "<group>"; };
 		FF05D49B2E720AE7009501BD /* WasmModuleDebugInfo.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WasmModuleDebugInfo.cpp; sourceTree = "<group>"; };
+		FF06E8BD2F19BC33007B3403 /* GDBPacketParserTest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GDBPacketParserTest.h; sourceTree = "<group>"; };
+		FF06E8BE2F19BC33007B3403 /* GDBPacketParserTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = GDBPacketParserTest.cpp; sourceTree = "<group>"; };
 		FF0F56712E333E1D002A232A /* WasmModuleManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WasmModuleManager.h; sourceTree = "<group>"; };
 		FF0F56722E333E1D002A232A /* WasmModuleManager.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WasmModuleManager.cpp; sourceTree = "<group>"; };
 		FF0F56942E33437C002A232A /* testwasmdebugger */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = testwasmdebugger; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -6345,6 +6349,8 @@
 		FFB951132C043CA800349750 /* OrderedHashTableHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OrderedHashTableHelper.h; sourceTree = "<group>"; };
 		FFB9638F2E38302B0069A70F /* WasmBreakpointManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WasmBreakpointManager.h; sourceTree = "<group>"; };
 		FFB963902E38302B0069A70F /* WasmBreakpointManager.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WasmBreakpointManager.cpp; sourceTree = "<group>"; };
+		FFBF54872F189712008F124F /* WasmGDBPacketParser.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WasmGDBPacketParser.h; sourceTree = "<group>"; };
+		FFBF54882F189712008F124F /* WasmGDBPacketParser.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WasmGDBPacketParser.cpp; sourceTree = "<group>"; };
 		FFCC9A402BDD7C4700C75345 /* OrderedHashTable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OrderedHashTable.h; sourceTree = "<group>"; };
 		FFD49E5A2E276CA10083E383 /* WasmDebugServer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WasmDebugServer.h; sourceTree = "<group>"; };
 		FFD49E5B2E276CA10083E383 /* WasmDebugServer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WasmDebugServer.cpp; sourceTree = "<group>"; };
@@ -10568,6 +10574,8 @@
 				FFFAF8CD2EC9A7C000042238 /* ExecutionHandlerTestSupport.cpp */,
 				FFFAF8CC2EC9A7C000042238 /* ExecutionHandlerTestSupport.h */,
 				FF1344652EB3F2A600940C00 /* ExtGCTests.cpp */,
+				FF06E8BE2F19BC33007B3403 /* GDBPacketParserTest.cpp */,
+				FF06E8BD2F19BC33007B3403 /* GDBPacketParserTest.h */,
 				FFA2E0232EA16F37006661A3 /* MemoryTests.cpp */,
 				FFA2E0242EA16F37006661A3 /* SpecialTests.cpp */,
 				FFFAF8CA2EC97B2B00042238 /* TestScripts.cpp */,
@@ -10592,6 +10600,8 @@
 				FFD49E642E276CA10083E383 /* WasmDebugServerUtilities.h */,
 				FFD49E5D2E276CA10083E383 /* WasmExecutionHandler.cpp */,
 				FFD49E5C2E276CA10083E383 /* WasmExecutionHandler.h */,
+				FFBF54882F189712008F124F /* WasmGDBPacketParser.cpp */,
+				FFBF54872F189712008F124F /* WasmGDBPacketParser.h */,
 				FFD49E5F2E276CA10083E383 /* WasmMemoryHandler.cpp */,
 				FFD49E5E2E276CA10083E383 /* WasmMemoryHandler.h */,
 				FF05D49B2E720AE7009501BD /* WasmModuleDebugInfo.cpp */,
@@ -12385,6 +12395,7 @@
 				7BC547D31B6959A100959B58 /* WasmFormat.h in Headers */,
 				F323932D2A43748000421AD2 /* WasmFunctionIPIntMetadataGenerator.h in Headers */,
 				53F40E8B1D5901BB0099A1B6 /* WasmFunctionParser.h in Headers */,
+				FFBF548A2F189712008F124F /* WasmGDBPacketParser.h in Headers */,
 				E383500A2390D93B0036316D /* WasmGlobal.h in Headers */,
 				148521D826EAEBFE00CC1D1A /* WasmHandlerInfo.h in Headers */,
 				AD8FF3981EB5BDB20087FF82 /* WasmIndexOrName.h in Headers */,
@@ -13826,6 +13837,7 @@
 				FFE88B9E2EC96CA700C9F5E2 /* ExecutionHandlerTest.cpp in Sources */,
 				FFFAF8CE2EC9A7C000042238 /* ExecutionHandlerTestSupport.cpp in Sources */,
 				FF1344662EB3F2A600940C00 /* ExtGCTests.cpp in Sources */,
+				FF06E8BF2F19BC33007B3403 /* GDBPacketParserTest.cpp in Sources */,
 				FFA2E02E2EA16F37006661A3 /* MemoryTests.cpp in Sources */,
 				FFA2E02C2EA16F37006661A3 /* SpecialTests.cpp in Sources */,
 				FFFAF8CB2EC97B2B00042238 /* TestScripts.cpp in Sources */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -1254,6 +1254,7 @@ wasm/debugger/WasmBreakpointManager.cpp
 wasm/debugger/WasmDebugServer.cpp
 wasm/debugger/WasmDebugServerUtilities.cpp
 wasm/debugger/WasmExecutionHandler.cpp
+wasm/debugger/WasmGDBPacketParser.cpp
 wasm/debugger/WasmMemoryHandler.cpp
 wasm/debugger/WasmModuleManager.cpp
 wasm/debugger/WasmQueryHandler.cpp

--- a/Source/JavaScriptCore/shell/CMakeLists.txt
+++ b/Source/JavaScriptCore/shell/CMakeLists.txt
@@ -91,6 +91,7 @@ if (DEVELOPER_MODE)
         ../wasm/debugger/tests/ExecutionHandlerTest.cpp
         ../wasm/debugger/tests/ExecutionHandlerTestSupport.cpp
         ../wasm/debugger/tests/ExtGCTests.cpp
+        ../wasm/debugger/tests/GDBPacketParserTest.cpp
         ../wasm/debugger/tests/MemoryTests.cpp
         ../wasm/debugger/tests/SpecialTests.cpp
         ../wasm/debugger/tests/TestScripts.cpp

--- a/Source/JavaScriptCore/wasm/debugger/RWI_ARCHITECTURE.md
+++ b/Source/JavaScriptCore/wasm/debugger/RWI_ARCHITECTURE.md
@@ -86,7 +86,7 @@ WebKit's WebAssembly debugging uses a **singleton `WasmDebugServer`** that manag
 **WasmDebugServer** - Process-wide debugging coordinator
 - Singleton: `DebugServer::singleton()`
 - Dual-mode operation: Standalone (TCP) and RWI (IPC)
-- Thread-safe in RWI mode: WorkQueue is serial, guarantees no concurrent access to `handleRawPacket()`
+- Thread-safe in RWI mode: WorkQueue is serial, guarantees no concurrent access
 - Tracks all Wasm modules and instances across entire process
 
 > **Implementation Details**: See [README.md](./README.md) for debug server internals, protocol handlers, and virtual address encoding.

--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.h
@@ -35,6 +35,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include <JavaScriptCore/JSExportMacros.h>
 #include <JavaScriptCore/VM.h>
 #include <JavaScriptCore/WasmDebugServerUtilities.h>
+#include <JavaScriptCore/WasmGDBPacketParser.h>
 #include <JavaScriptCore/WasmVirtualAddress.h>
 
 #include <atomic>
@@ -119,7 +120,7 @@ public:
 
     JS_EXPORT_PRIVATE bool isConnected() const;
 
-    JS_EXPORT_PRIVATE void handleRawPacket(StringView rawPacket);
+    JS_EXPORT_PRIVATE void handlePacket(StringView packet);
 
     ExecutionHandler& execution() const
     {
@@ -146,7 +147,6 @@ private:
     void closeSocket(SocketType&);
 
     void handleClient();
-    void handlePacket(StringView packet);
     void handleThreadManagement(StringView packet);
 
     void sendAck();
@@ -181,6 +181,8 @@ private:
     std::unique_ptr<ExecutionHandler> m_executionHandler;
 
     std::unique_ptr<ModuleManager> m_moduleManager;
+
+    GDBPacketParser m_packetParser;
 
 #if ENABLE(REMOTE_INSPECTOR)
     Function<bool(const String&)> m_rwiResponseHandler;

--- a/Source/JavaScriptCore/wasm/debugger/WasmGDBPacketParser.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmGDBPacketParser.cpp
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WasmGDBPacketParser.h"
+
+#if ENABLE(WEBASSEMBLY)
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
+#include <wtf/ASCIICType.h>
+#include <wtf/DataLog.h>
+#include <wtf/PrintStream.h>
+
+namespace JSC {
+namespace Wasm {
+
+void GDBPacketParser::reset()
+{
+    m_bufferIndex = 0;
+    m_checksum = 0;
+    m_phase = ReceivePhase::Idle;
+    m_checksumBytesRead = 0;
+    m_errorReason = ErrorReason::None;
+}
+
+void GDBPacketParser::dumpBuffer(std::span<const uint8_t> buffer)
+{
+    for (auto byte : buffer) {
+        if (isASCIIPrintable(byte))
+            dataLog("'", static_cast<char>(byte), "' ");
+        else
+            dataLog("<", byte, "> ");
+    }
+}
+
+void GDBPacketParser::dump(PrintStream& out) const
+{
+    out.print(m_bufferIndex, " bytes buffered, phase=", m_phase);
+    if (m_bufferIndex > 0) {
+        out.print(", buffer: ");
+        dumpBuffer({ m_buffer.data(), m_bufferIndex });
+    }
+}
+
+StringView GDBPacketParser::getCompletedPacket() const
+{
+    // Return view of the null-terminated packet payload
+    auto buffer = byteCast<char>(m_buffer.data());
+    return StringView(buffer, strlen(buffer), true);
+}
+
+GDBPacketParser::ParseResult GDBPacketParser::processByte(uint8_t byte)
+{
+    // If parser is in error state, reject further processing until reset
+    if (m_errorReason != ErrorReason::None)
+        return ParseResult::Error;
+
+    switch (m_phase) {
+    case ReceivePhase::Idle:
+        m_bufferIndex = 0;
+        m_checksum = 0;
+        m_checksumBytesRead = 0;
+
+        // Check for interrupt character (Ctrl+C) - treat as complete single-byte packet
+        if (byte == 0x03) {
+            m_buffer[0] = 0x03;
+            m_buffer[1] = '\0';
+            m_bufferIndex = 1;
+            return ParseResult::CompletePacket;
+        }
+
+        // Check for packet start
+        if (byte == '$')
+            m_phase = ReceivePhase::Payload;
+
+        return ParseResult::Incomplete;
+
+    case ReceivePhase::Payload:
+        if (byte == '#') {
+            // End of payload, start reading checksum
+            m_phase = ReceivePhase::Checksum;
+
+            // Add '#' to buffer but don't include in checksum
+            if (!pushByte(byte))
+                return ParseResult::Error;
+        } else {
+            // Regular payload byte - add to buffer and checksum
+            if (!pushByte<IncludeInChecksum::Yes>(byte))
+                return ParseResult::Error;
+        }
+
+        return ParseResult::Incomplete;
+
+    case ReceivePhase::Checksum:
+        // Reading checksum bytes (2 hex digits)
+        if (!pushByte(byte))
+            return ParseResult::Error;
+
+        m_checksumBytesRead++;
+
+        if (m_checksumBytesRead == 2) {
+            ASSERT(m_bufferIndex >= 3); // At least '#' + 2 checksum bytes
+
+            uint8_t checksumHigh = m_buffer[m_bufferIndex - 2];
+            uint8_t checksumLow = m_buffer[m_bufferIndex - 1];
+            if (!isASCIIHexDigit(checksumHigh) || !isASCIIHexDigit(checksumLow)) {
+                m_errorReason = ErrorReason::InvalidHexInChecksum;
+                return ParseResult::Error;
+            }
+
+            uint8_t receivedChecksum = toASCIIHexValue(checksumHigh, checksumLow);
+            if (receivedChecksum != m_checksum) {
+                m_errorReason = ErrorReason::ChecksumMismatch;
+                return ParseResult::Error;
+            }
+
+            // Null-terminate the payload (replace '#' with '\0')
+            m_buffer[m_bufferIndex - 3] = '\0';
+            m_phase = ReceivePhase::Idle;
+            return ParseResult::CompletePacket;
+        }
+
+        return ParseResult::Incomplete;
+    }
+
+    RELEASE_ASSERT_NOT_REACHED();
+    return ParseResult::Incomplete;
+}
+
+} // namespace Wasm
+} // namespace JSC
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/debugger/WasmGDBPacketParser.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmGDBPacketParser.h
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Compiler.h>
+#include <wtf/Platform.h>
+
+#if ENABLE(WEBASSEMBLY)
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
+#include <array>
+#include <wtf/text/WTFString.h>
+
+namespace JSC {
+namespace Wasm {
+
+// FIXME: This parser has no WebAssembly-specific dependencies and could potentially be moved to WTF
+// if other subsystems need GDB protocol support. Note: This is a simplified implementation that
+// doesn't support escape sequences ('}' character) or run-length encoding ('*' character). This is
+// sufficient for typical LLDB/WASM debugger communication where all data is hex-encoded, but may
+// not handle all possible GDB protocol packets.
+
+// GDB Remote Serial Protocol packet parser
+// Implements byte-by-byte state machine parsing for packets of the form: $<data>#<checksum>
+// Also handles special interrupt character (0x03 / Ctrl+C)
+class JS_EXPORT_PRIVATE GDBPacketParser {
+public:
+    enum class ParseResult : uint8_t {
+        Incomplete, // Continue accumulating bytes
+        CompletePacket, // Full packet received and validated (includes interrupt 0x03)
+        Error, // Parse error - check getError() for details
+    };
+
+    enum class ErrorReason : uint8_t {
+        None,
+        BufferOverflow,
+        InvalidHexInChecksum,
+        ChecksumMismatch,
+    };
+
+    GDBPacketParser() = default;
+
+    ParseResult processByte(uint8_t byte);
+    StringView getCompletedPacket() const;
+
+    void reset();
+
+    bool isIdle() const { return m_phase == ReceivePhase::Idle; }
+    ErrorReason getError() const { return m_errorReason; }
+    void dump(PrintStream&) const;
+
+    static void dumpBuffer(std::span<const uint8_t> buffer);
+
+private:
+    enum class ReceivePhase : uint8_t {
+        Idle, // Waiting for '$' or interrupt (0x03)
+        Payload, // Reading packet content until '#'
+        Checksum, // Reading 2-byte checksum
+    };
+
+    enum class IncludeInChecksum : bool { No, Yes };
+
+    static constexpr size_t bufferSize = 4096;
+
+    template<IncludeInChecksum includeInChecksum = IncludeInChecksum::No>
+    bool pushByte(uint8_t byte)
+    {
+        if (m_bufferIndex >= bufferSize) {
+            m_errorReason = ErrorReason::BufferOverflow;
+            return false;
+        }
+        m_buffer[m_bufferIndex++] = byte;
+        if constexpr (includeInChecksum == IncludeInChecksum::Yes)
+            m_checksum += byte;
+        return true;
+    }
+
+    std::array<uint8_t, bufferSize> m_buffer;
+    size_t m_bufferIndex { 0 };
+    uint8_t m_checksum { 0 };
+    ReceivePhase m_phase { ReceivePhase::Idle };
+    uint8_t m_checksumBytesRead { 0 };
+    ErrorReason m_errorReason { ErrorReason::None };
+};
+
+} // namespace Wasm
+} // namespace JSC
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/debugger/tests/GDBPacketParserTest.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/tests/GDBPacketParserTest.cpp
@@ -1,0 +1,461 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "GDBPacketParserTest.h"
+
+#if ENABLE(WEBASSEMBLY)
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
+#include "TestUtilities.h"
+#include "WasmGDBPacketParser.h"
+#include <wtf/DataLog.h>
+#include <wtf/text/WTFString.h>
+
+using namespace JSC;
+using namespace JSC::Wasm;
+
+static void testGDBPacketParserBasic()
+{
+    dataLogLn("=== Testing GDB Packet Parser - Basic Packets ===");
+
+    GDBPacketParser parser;
+
+    // Test simple step command: $s#73
+    const uint8_t stepPacket[] = { '$', 's', '#', '7', '3' };
+    GDBPacketParser::ParseResult result = GDBPacketParser::ParseResult::Incomplete;
+
+    for (size_t i = 0; i < sizeof(stepPacket); i++) {
+        result = parser.processByte(stepPacket[i]);
+        if (i < sizeof(stepPacket) - 1)
+            TEST_ASSERT(result == GDBPacketParser::ParseResult::Incomplete, "Should be incomplete until last byte");
+    }
+
+    TEST_ASSERT(result == GDBPacketParser::ParseResult::CompletePacket, "Should be complete after last byte");
+    StringView packet = parser.getCompletedPacket();
+    TEST_ASSERT(packet == "s"_s, "Packet payload should be 's'");
+
+    dataLogLn("GDB Packet Parser basic tests completed");
+}
+
+static void testGDBPacketParserMultiPacket()
+{
+    dataLogLn("=== Testing GDB Packet Parser - Multiple Packets in One recv() ===");
+
+    GDBPacketParser parser;
+
+    // Simulate recv() returning "$s#73\x03" (step packet + interrupt)
+    const uint8_t multiPacket[] = {
+        '$', 's', '#', '7', '3', // Step command
+        0x03 // Interrupt
+    };
+
+    int packetsReceived = 0;
+    for (size_t i = 0; i < sizeof(multiPacket); i++) {
+        auto result = parser.processByte(multiPacket[i]);
+        if (result == GDBPacketParser::ParseResult::CompletePacket) {
+            packetsReceived++;
+            StringView packet = parser.getCompletedPacket();
+            if (packetsReceived == 1)
+                TEST_ASSERT(packet == "s"_s, "First packet should be 's'");
+            else if (packetsReceived == 2)
+                TEST_ASSERT(packet.length() == 1 && packet[0] == 0x03, "Second packet should be interrupt");
+        }
+    }
+
+    TEST_ASSERT(packetsReceived == 2, "Should receive exactly 2 packets");
+
+    dataLogLn("GDB Packet Parser multi-packet tests completed");
+}
+
+static void testGDBPacketParserPartialPacket()
+{
+    dataLogLn("=== Testing GDB Packet Parser - Partial Packets Across recv() Calls ===");
+
+    GDBPacketParser parser;
+
+    // Simulate first recv() gets: $c#
+    const uint8_t part1[] = { '$', 'c', '#' };
+    for (size_t i = 0; i < sizeof(part1); i++) {
+        auto result = parser.processByte(part1[i]);
+        TEST_ASSERT(result == GDBPacketParser::ParseResult::Incomplete, "Should be incomplete without checksum");
+    }
+
+    TEST_ASSERT(!parser.isIdle(), "Parser should not be idle while accumulating");
+
+    // Simulate second recv() gets: 63
+    const uint8_t part2[] = { '6', '3' };
+    GDBPacketParser::ParseResult result = GDBPacketParser::ParseResult::Incomplete;
+    for (size_t i = 0; i < sizeof(part2); i++)
+        result = parser.processByte(part2[i]);
+
+    TEST_ASSERT(result == GDBPacketParser::ParseResult::CompletePacket, "Should complete after checksum");
+    StringView packet = parser.getCompletedPacket();
+    TEST_ASSERT(packet == "c"_s, "Packet payload should be 'c'");
+    TEST_ASSERT(parser.isIdle(), "Parser should be idle after complete packet");
+
+    dataLogLn("GDB Packet Parser partial packet tests completed");
+}
+
+static void testGDBPacketParserChecksumValidation()
+{
+    dataLogLn("=== Testing GDB Packet Parser - Checksum Validation ===");
+
+    GDBPacketParser parser;
+
+    // Test valid checksum: $s#73 (checksum of 's' = 0x73)
+    const uint8_t validPacket[] = { '$', 's', '#', '7', '3' };
+    GDBPacketParser::ParseResult result = GDBPacketParser::ParseResult::Incomplete;
+    for (size_t i = 0; i < sizeof(validPacket); i++)
+        result = parser.processByte(validPacket[i]);
+
+    TEST_ASSERT(result == GDBPacketParser::ParseResult::CompletePacket, "Valid checksum should succeed");
+    TEST_ASSERT(parser.getCompletedPacket() == "s"_s, "Should return packet on valid checksum");
+
+    // Test invalid checksum: $s#FF (wrong checksum)
+    parser.reset();
+    const uint8_t invalidPacket[] = { '$', 's', '#', 'F', 'F' };
+    result = GDBPacketParser::ParseResult::Incomplete;
+    for (size_t i = 0; i < sizeof(invalidPacket); i++)
+        result = parser.processByte(invalidPacket[i]);
+
+    TEST_ASSERT(result == GDBPacketParser::ParseResult::Error, "Invalid checksum should be rejected");
+    TEST_ASSERT(parser.getError() == GDBPacketParser::ErrorReason::ChecksumMismatch, "Should report checksum mismatch error");
+    TEST_ASSERT(!parser.isIdle(), "Parser should not be idle after error (caller must reset)");
+
+    dataLogLn("GDB Packet Parser checksum validation tests completed");
+}
+
+static void testGDBPacketParserInterrupt()
+{
+    dataLogLn("=== Testing GDB Packet Parser - Interrupt Character ===");
+
+    GDBPacketParser parser;
+
+    // Test interrupt character (0x03 / Ctrl+C) as single-byte packet
+    auto result = parser.processByte(0x03);
+
+    TEST_ASSERT(result == GDBPacketParser::ParseResult::CompletePacket, "Interrupt should be complete immediately");
+    StringView packet = parser.getCompletedPacket();
+    TEST_ASSERT(packet.length() == 1, "Interrupt packet should be 1 byte");
+    TEST_ASSERT(packet[0] == 0x03, "Interrupt packet should contain 0x03");
+    TEST_ASSERT(parser.isIdle(), "Parser should be idle after interrupt");
+
+    dataLogLn("GDB Packet Parser interrupt tests completed");
+}
+
+static void testGDBPacketParserReset()
+{
+    dataLogLn("=== Testing GDB Packet Parser - Reset Functionality ===");
+
+    GDBPacketParser parser;
+
+    // Start parsing a packet
+    parser.processByte('$');
+    parser.processByte('s');
+    TEST_ASSERT(!parser.isIdle(), "Parser should not be idle during parsing");
+
+    // Reset
+    parser.reset();
+    TEST_ASSERT(parser.isIdle(), "Parser should be idle after reset");
+
+    // Verify parser works after reset
+    const uint8_t packet[] = { '$', 'c', '#', '6', '3' };
+    GDBPacketParser::ParseResult result = GDBPacketParser::ParseResult::Incomplete;
+    for (size_t i = 0; i < sizeof(packet); i++)
+        result = parser.processByte(packet[i]);
+
+    TEST_ASSERT(result == GDBPacketParser::ParseResult::CompletePacket, "Parser should work after reset");
+    TEST_ASSERT(parser.getCompletedPacket() == "c"_s, "Should parse correctly after reset");
+
+    dataLogLn("GDB Packet Parser reset tests completed");
+}
+
+static void testGDBPacketParserBufferOverflow()
+{
+    dataLogLn("=== Testing GDB Packet Parser - Buffer Overflow ===");
+
+    GDBPacketParser parser;
+
+    // Test payload exceeding bufferSize (4096 bytes)
+    // Build a packet with 4100 byte payload
+    parser.processByte('$');
+
+    // Add 4100 'A' characters - should trigger overflow
+    GDBPacketParser::ParseResult result = GDBPacketParser::ParseResult::Incomplete;
+    for (size_t i = 0; i < 4100; i++) {
+        result = parser.processByte('A');
+        if (result == GDBPacketParser::ParseResult::Error)
+            break;
+    }
+
+    // Parser should have returned error due to overflow
+    TEST_ASSERT(result == GDBPacketParser::ParseResult::Error, "Should return error on buffer overflow");
+    TEST_ASSERT(parser.getError() == GDBPacketParser::ErrorReason::BufferOverflow, "Should report buffer overflow error");
+    TEST_ASSERT(!parser.isIdle(), "Parser should not be idle after error (caller must reset)");
+
+    // Manually reset parser before recovery test
+    parser.reset();
+
+    // Verify parser still works after reset
+    const uint8_t recoveryPacket[] = { '$', 's', '#', '7', '3' };
+    result = GDBPacketParser::ParseResult::Incomplete;
+    for (size_t i = 0; i < sizeof(recoveryPacket); i++)
+        result = parser.processByte(recoveryPacket[i]);
+
+    TEST_ASSERT(result == GDBPacketParser::ParseResult::CompletePacket, "Parser should recover after overflow");
+    TEST_ASSERT(parser.getCompletedPacket() == "s"_s, "Parser should work correctly after recovery");
+
+    dataLogLn("GDB Packet Parser buffer overflow tests completed");
+}
+
+static void testGDBPacketParserMalformedPackets()
+{
+    dataLogLn("=== Testing GDB Packet Parser - Malformed Packets ===");
+
+    GDBPacketParser parser;
+
+    // Test 1: $ without closing #
+    parser.processByte('$');
+    parser.processByte('s');
+    parser.processByte('o');
+    parser.processByte('m');
+    parser.processByte('e');
+    TEST_ASSERT(!parser.isIdle(), "Parser should be accumulating without #");
+
+    // Send a valid packet to verify parser can recover
+    parser.reset();
+    const uint8_t validPacket[] = { '$', 's', '#', '7', '3' };
+    GDBPacketParser::ParseResult result = GDBPacketParser::ParseResult::Incomplete;
+    for (size_t i = 0; i < sizeof(validPacket); i++)
+        result = parser.processByte(validPacket[i]);
+    TEST_ASSERT(result == GDBPacketParser::ParseResult::CompletePacket, "Parser should work after reset");
+
+    // Test 2: # before $
+    parser.reset();
+    parser.processByte('#');
+    TEST_ASSERT(parser.isIdle(), "Parser should ignore # when idle");
+
+    // Test 3: Random bytes before $
+    parser.reset();
+    parser.processByte('x');
+    parser.processByte('y');
+    parser.processByte('z');
+    TEST_ASSERT(parser.isIdle(), "Parser should ignore random bytes when idle");
+
+    dataLogLn("GDB Packet Parser malformed packets tests completed");
+}
+
+static void testGDBPacketParserInvalidHexChecksum()
+{
+    dataLogLn("=== Testing GDB Packet Parser - Invalid Hex in Checksum ===");
+
+    GDBPacketParser parser;
+
+    // Test with non-hex characters in checksum: $s#ZZ
+    const uint8_t invalidHexPacket[] = { '$', 's', '#', 'Z', 'Z' };
+    GDBPacketParser::ParseResult result = GDBPacketParser::ParseResult::Incomplete;
+
+    for (size_t i = 0; i < sizeof(invalidHexPacket); i++)
+        result = parser.processByte(invalidHexPacket[i]);
+
+    // Should detect invalid hex in checksum
+    TEST_ASSERT(result == GDBPacketParser::ParseResult::Error, "Invalid hex should fail validation");
+    TEST_ASSERT(parser.getError() == GDBPacketParser::ErrorReason::InvalidHexInChecksum, "Should report invalid hex error");
+    TEST_ASSERT(!parser.isIdle(), "Parser should not be idle after error (caller must reset)");
+
+    dataLogLn("GDB Packet Parser invalid hex checksum tests completed");
+}
+
+static void testGDBPacketParserErrorStateGuard()
+{
+    dataLogLn("=== Testing GDB Packet Parser - Error State Guard ===");
+
+    GDBPacketParser parser;
+
+    // Trigger a checksum mismatch error
+    const uint8_t invalidPacket[] = { '$', 's', '#', 'F', 'F' };
+    GDBPacketParser::ParseResult result = GDBPacketParser::ParseResult::Incomplete;
+    for (size_t i = 0; i < sizeof(invalidPacket); i++)
+        result = parser.processByte(invalidPacket[i]);
+
+    TEST_ASSERT(result == GDBPacketParser::ParseResult::Error, "Should be in error state");
+    TEST_ASSERT(parser.getError() == GDBPacketParser::ErrorReason::ChecksumMismatch, "Should have checksum error");
+
+    // Try to process more bytes without reset - should reject
+    result = parser.processByte('$');
+    TEST_ASSERT(result == GDBPacketParser::ParseResult::Error, "Should reject bytes while in error state");
+
+    result = parser.processByte('s');
+    TEST_ASSERT(result == GDBPacketParser::ParseResult::Error, "Should still reject bytes in error state");
+
+    // Reset should clear error state
+    parser.reset();
+    TEST_ASSERT(parser.getError() == GDBPacketParser::ErrorReason::None, "Reset should clear error");
+
+    // Now should work normally
+    const uint8_t validPacket[] = { '$', 's', '#', '7', '3' };
+    result = GDBPacketParser::ParseResult::Incomplete;
+    for (size_t i = 0; i < sizeof(validPacket); i++)
+        result = parser.processByte(validPacket[i]);
+
+    TEST_ASSERT(result == GDBPacketParser::ParseResult::CompletePacket, "Should work after reset");
+    TEST_ASSERT(parser.getCompletedPacket() == "s"_s, "Should parse correctly after error recovery");
+
+    dataLogLn("GDB Packet Parser error state guard tests completed");
+}
+
+static void testGDBPacketParserEmptyPayload()
+{
+    dataLogLn("=== Testing GDB Packet Parser - Empty Payload ===");
+
+    GDBPacketParser parser;
+
+    // Test empty payload packet: $#00 (checksum of empty string is 0x00)
+    const uint8_t emptyPacket[] = { '$', '#', '0', '0' };
+    GDBPacketParser::ParseResult result = GDBPacketParser::ParseResult::Incomplete;
+
+    for (size_t i = 0; i < sizeof(emptyPacket); i++)
+        result = parser.processByte(emptyPacket[i]);
+
+    TEST_ASSERT(result == GDBPacketParser::ParseResult::CompletePacket, "Empty payload should be valid");
+    StringView packet = parser.getCompletedPacket();
+    TEST_ASSERT(packet.isEmpty(), "Empty payload packet should have zero length");
+
+    dataLogLn("GDB Packet Parser empty payload tests completed");
+}
+
+static void testGDBPacketParserConsecutivePackets()
+{
+    dataLogLn("=== Testing GDB Packet Parser - Consecutive Packets ===");
+
+    GDBPacketParser parser;
+
+    // Test two packets back-to-back: $s#73$c#63
+    const uint8_t consecutivePackets[] = {
+        '$', 's', '#', '7', '3', // First packet: step
+        '$', 'c', '#', '6', '3' // Second packet: continue
+    };
+
+    int packetsReceived = 0;
+    for (size_t i = 0; i < sizeof(consecutivePackets); i++) {
+        auto result = parser.processByte(consecutivePackets[i]);
+        if (result == GDBPacketParser::ParseResult::CompletePacket) {
+            packetsReceived++;
+            StringView packet = parser.getCompletedPacket();
+            if (packetsReceived == 1)
+                TEST_ASSERT(packet == "s"_s, "First packet should be 's'");
+            else if (packetsReceived == 2)
+                TEST_ASSERT(packet == "c"_s, "Second packet should be 'c'");
+        }
+    }
+
+    TEST_ASSERT(packetsReceived == 2, "Should receive exactly 2 consecutive packets");
+
+    dataLogLn("GDB Packet Parser consecutive packets tests completed");
+}
+
+static void testGDBPacketParserMultipleInterrupts()
+{
+    dataLogLn("=== Testing GDB Packet Parser - Multiple Interrupts ===");
+
+    GDBPacketParser parser;
+
+    // Test multiple consecutive interrupts: 0x03 0x03 0x03
+    const uint8_t multipleInterrupts[] = { 0x03, 0x03, 0x03 };
+
+    int interruptsReceived = 0;
+    for (size_t i = 0; i < sizeof(multipleInterrupts); i++) {
+        auto result = parser.processByte(multipleInterrupts[i]);
+        if (result == GDBPacketParser::ParseResult::CompletePacket) {
+            interruptsReceived++;
+            StringView packet = parser.getCompletedPacket();
+            TEST_ASSERT(packet.length() == 1 && packet[0] == 0x03, "Each should be interrupt packet");
+        }
+    }
+
+    TEST_ASSERT(interruptsReceived == 3, "Should receive exactly 3 interrupts");
+    TEST_ASSERT(parser.isIdle(), "Parser should be idle after interrupts");
+
+    dataLogLn("GDB Packet Parser multiple interrupts tests completed");
+}
+
+static void testGDBPacketParserEdgeSizePayloads()
+{
+    dataLogLn("=== Testing GDB Packet Parser - Edge Size Payloads ===");
+
+    GDBPacketParser parser;
+
+    // Test payload exactly at buffer limit
+    // bufferSize = 4096, need room for payload + '#' + 2 checksum bytes
+    // Maximum payload = 4096 - 3 = 4093 bytes
+    const size_t maxPayloadSize = 4093;
+
+    parser.processByte('$');
+
+    uint8_t checksum = 0;
+    for (size_t i = 0; i < maxPayloadSize; i++) {
+        uint8_t byte = 'A';
+        parser.processByte(byte);
+        checksum += byte;
+    }
+
+    parser.processByte('#');
+
+    char checksumHigh = (checksum >> 4) < 10 ? '0' + (checksum >> 4) : 'a' + (checksum >> 4) - 10;
+    char checksumLow = (checksum & 0xF) < 10 ? '0' + (checksum & 0xF) : 'a' + (checksum & 0xF) - 10;
+
+    parser.processByte(static_cast<uint8_t>(checksumHigh));
+    auto result = parser.processByte(static_cast<uint8_t>(checksumLow));
+
+    TEST_ASSERT(result == GDBPacketParser::ParseResult::CompletePacket, "Max size payload should succeed");
+    StringView packet = parser.getCompletedPacket();
+    TEST_ASSERT(packet.length() == maxPayloadSize, "Max payload should have correct length");
+
+    dataLogLn("GDB Packet Parser edge size payload tests completed");
+}
+
+void testGDBPacketParser()
+{
+    testGDBPacketParserBasic();
+    testGDBPacketParserMultiPacket();
+    testGDBPacketParserPartialPacket();
+    testGDBPacketParserChecksumValidation();
+    testGDBPacketParserInterrupt();
+    testGDBPacketParserReset();
+    testGDBPacketParserBufferOverflow();
+    testGDBPacketParserMalformedPackets();
+    testGDBPacketParserInvalidHexChecksum();
+    testGDBPacketParserErrorStateGuard();
+    testGDBPacketParserEmptyPayload();
+    testGDBPacketParserConsecutivePackets();
+    testGDBPacketParserMultipleInterrupts();
+    testGDBPacketParserEdgeSizePayloads();
+}
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/debugger/tests/GDBPacketParserTest.h
+++ b/Source/JavaScriptCore/wasm/debugger/tests/GDBPacketParserTest.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+/* Runs all GDB Packet Parser tests.
+   Uses assertion-based testing - will crash on failure. */
+void testGDBPacketParser();

--- a/Source/JavaScriptCore/wasm/debugger/testwasmdebugger.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/testwasmdebugger.cpp
@@ -32,6 +32,7 @@
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 #include "ExecutionHandlerTest.h"
+#include "GDBPacketParserTest.h"
 #include "InitializeThreading.h"
 #include "Options.h"
 #include "TestUtilities.h"
@@ -290,6 +291,9 @@ static int runAllTests()
 {
     dataLogLn("Starting WASM Debugger Test Suite");
     dataLogLn("===============================================");
+
+    dataLogLn("\n--- GDB Packet Parser Tests ---");
+    testGDBPacketParser();
 
     dataLogLn("\n--- VirtualAddress Infrastructure Tests ---");
     testWASMVirtualAddressConstants();

--- a/Source/WebKit/WebProcess/Inspector/WasmDebuggerDispatcher.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WasmDebuggerDispatcher.cpp
@@ -75,7 +75,7 @@ void WasmDebuggerDispatcher::dispatchMessage(const String& message)
         return;
     }
 
-    debugServer.handleRawPacket(message);
+    debugServer.handlePacket(message);
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### a28a23365a05e414e2ede8466677cbd2a13c2817
<pre>
[JSC][WASM][Debugger] Extract GDB packet parser to handle multi-packet recv() calls
<a href="https://bugs.webkit.org/show_bug.cgi?id=305540">https://bugs.webkit.org/show_bug.cgi?id=305540</a>
<a href="https://rdar.apple.com/168199542">rdar://168199542</a>

Reviewed by Yusuke Suzuki.

recv() can return multiple packets or partial packets in a single call
(e.g., &quot;$s#73\x03&quot; contains both a step packet and an interrupt). The
previous implementation assumed one packet per recv(), causing missed
packets and protocol errors.

This patch extracts packet parsing into a dedicated GDBPacketParser class
implementing a byte-by-byte state machine. Both TCP socket mode and Remote
Web Inspector mode now use the same handlePacket() API after their
respective packet parsing.

Tests:
* Source/JavaScriptCore/wasm/debugger/tests/GDBPacketParserTest.cpp: Added.
(testGDBPacketParserBasic):
(testGDBPacketParserMultiPacket):
(testGDBPacketParserPartialPacket):
(testGDBPacketParserChecksumValidation):
(testGDBPacketParserInterrupt):
(testGDBPacketParserReset):
(testGDBPacketParserBufferOverflow):
(testGDBPacketParserMalformedPackets):
(testGDBPacketParserInvalidHexChecksum):
(testGDBPacketParserErrorStateGuard):
(testGDBPacketParserEmptyPayload):
(testGDBPacketParserConsecutivePackets):
(testGDBPacketParserMultipleInterrupts):
(testGDBPacketParserEdgeSizePayloads):

Canonical link: <a href="https://commits.webkit.org/305718@main">https://commits.webkit.org/305718@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bbbba38c0fb1ea3959f9008928d32cadc715ce91

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139157 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11530 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/654 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147284 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8c99dd85-5437-4a6c-b928-afff5e2a4901) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12237 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11681 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106528 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3fa77c79-34a8-416a-ba68-b1252e0607bb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142104 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9250 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124642 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87395 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1e3af9bc-c04c-4a6d-b355-0d955a0c894f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8796 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/6626 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7576 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/131130 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118249 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/544 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150063 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11215 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/554 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114916 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11228 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9486 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115229 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29292 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9168 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120992 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66117 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11258 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/519 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/170428 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10993 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74915 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44372 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11196 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11045 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->