### PR TITLE
AX: input type=button live regions don't announce changes

### DIFF
--- a/LayoutTests/accessibility/mac/live-regions/live-region-inputs-expected.txt
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-inputs-expected.txt
@@ -1,0 +1,21 @@
+This tests that button inputs that are live regions work as expected.
+
+Received announcement request:
+AnnouncementKey: Middle{
+    AXLanguage = en;
+}
+AXPriorityKey: 90
+AXAnnouncementIsLiveRegionKey: true
+
+Received announcement request:
+AnnouncementKey: End{
+    AXLanguage = en;
+}
+AXPriorityKey: 90
+AXAnnouncementIsLiveRegionKey: true
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/live-regions/live-region-inputs.html
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-inputs.html
@@ -1,0 +1,45 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAriaLiveRegionManagementEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/accessibility-helper.js"></script>
+<meta http-equiv="content-language" content="en">
+</head>
+<body>
+
+<input id="liveButton" type="button" value="Start" aria-live="assertive" />
+
+<script>
+var output = "This tests that button inputs that are live regions work as expected.\n\n";    
+var testFinished = false;
+var notificationCount = 0;
+
+function notificationCallback(object, notification, userInfo) {
+    if (notification == "AXAnnouncementRequested") {
+        output += `Received announcement request:\n${formatAnnouncementUserInfo(userInfo)}\n`;
+        notificationCount++;
+
+        if (notificationCount == 1)
+            document.getElementById("liveButton").setAttribute("value", "End");
+        else
+            testFinished = true;
+    }
+}
+
+if (accessibilityController) {
+    window.jsTestIsAsync = true;
+    accessibilityController.addNotificationListener(notificationCallback);
+    accessibilityController.accessibleElementById("liveButton");
+
+    document.getElementById("liveButton").value = "Middle";
+
+    setTimeout(async function() {
+        await waitFor(() => testFinished);
+        accessibilityController.removeNotificationListener();
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/live-regions/live-region-nested-input-expected.txt
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-nested-input-expected.txt
@@ -1,0 +1,21 @@
+This tests that button inputs that are in live regions work as expected.
+
+Received announcement request:
+AnnouncementKey: Middle{
+    AXLanguage = en;
+}
+AXPriorityKey: 10
+AXAnnouncementIsLiveRegionKey: true
+
+Received announcement request:
+AnnouncementKey: End{
+    AXLanguage = en;
+}
+AXPriorityKey: 10
+AXAnnouncementIsLiveRegionKey: true
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/live-regions/live-region-nested-input.html
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-nested-input.html
@@ -1,0 +1,47 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAriaLiveRegionManagementEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/accessibility-helper.js"></script>
+<meta http-equiv="content-language" content="en">
+</head>
+<body>
+
+<div role="group" aria-live="polite">
+    <input id="liveButton" type="button" value="Start"/>
+</div>
+
+<script>
+var output = "This tests that button inputs that are in live regions work as expected.\n\n";    
+var testFinished = false;
+var notificationCount = 0;
+
+function notificationCallback(object, notification, userInfo) {
+    if (notification == "AXAnnouncementRequested") {
+        output += `Received announcement request:\n${formatAnnouncementUserInfo(userInfo)}\n`;
+        notificationCount++;
+
+        if (notificationCount == 1)
+            document.getElementById("liveButton").setAttribute("value", "End");
+        else
+            testFinished = true;
+    }
+}
+
+if (accessibilityController) {
+    window.jsTestIsAsync = true;
+    accessibilityController.addNotificationListener(notificationCallback);
+    accessibilityController.accessibleElementById("liveButton");
+
+    document.getElementById("liveButton").value = "Middle";
+
+    setTimeout(async function() {
+        await waitFor(() => testFinished);
+        accessibilityController.removeNotificationListener();
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXLiveRegionManager.cpp
+++ b/Source/WebCore/accessibility/AXLiveRegionManager.cpp
@@ -200,12 +200,12 @@ LiveRegionSnapshot AXLiveRegionManager::buildLiveRegionSnapshot(AccessibilityObj
             for (auto& child : object.unignoredChildren())
                 collectDescendants(downcast<AccessibilityObject>(child.get()));
 
-            snapshot.objects.append({ object.objectID(), textForObject(object), object.languageIncludingAncestors(), WTF::move(descendants) });
+            snapshot.objects.append({ object.objectID(), object.announcementText(), object.languageIncludingAncestors(), WTF::move(descendants) });
             return;
         }
 
         if (shouldIncludeInSnapshot(object))
-            snapshot.objects.append({ object.objectID(), textForObject(object), object.languageIncludingAncestors(), { } });
+            snapshot.objects.append({ object.objectID(), object.announcementText(), object.languageIncludingAncestors(), { } });
         else {
             for (auto& child : object.unignoredChildren())
                 buildObjectList(downcast<AccessibilityObject>(child.get()));
@@ -248,18 +248,6 @@ bool AXLiveRegionManager::shouldIncludeInSnapshot(AccessibilityObject& object) c
         return true;
 
     return false;
-}
-
-String AXLiveRegionManager::textForObject(AccessibilityObject& object) const
-{
-    if (String description = object.description(); description.length())
-        return description;
-
-    TextUnderElementMode mode;
-    mode.includeListMarkers = IncludeListMarkerText::Yes;
-    // We want all of the text beneath this object when speaking live regions.
-    mode.descendIntoContainers = DescendIntoContainers::Yes;
-    return object.textUnderElement(mode);
 }
 
 AXLiveRegionManager::LiveRegionDiff AXLiveRegionManager::computeChanges(const Vector<LiveRegionObject>& oldObjects, const Vector<LiveRegionObject>& newObjects) const

--- a/Source/WebCore/accessibility/AXLiveRegionManager.h
+++ b/Source/WebCore/accessibility/AXLiveRegionManager.h
@@ -84,7 +84,6 @@ private:
 
     LiveRegionSnapshot buildLiveRegionSnapshot(AccessibilityObject&) const;
     bool shouldIncludeInSnapshot(AccessibilityObject&) const;
-    String textForObject(AccessibilityObject&) const;
     void postAnnouncementForChange(AccessibilityObject&, const LiveRegionSnapshot&, const LiveRegionSnapshot&);
     LiveRegionDiff computeChanges(const Vector<LiveRegionObject>&, const Vector<LiveRegionObject>&) const;
     AttributedString computeAnnouncement(const LiveRegionSnapshot&, const LiveRegionDiff&) const;

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -1591,6 +1591,13 @@ void AXObjectCache::childrenChanged(AccessibilityObject* object)
 void AXObjectCache::valueChanged(Element& element)
 {
     postNotification(&element, AXNotification::ValueChanged);
+
+    for (RefPtr ancestor = get(element); ancestor; ancestor = ancestor->parentObject()) {
+        if (ancestor->supportsLiveRegion()) {
+            postLiveRegionChangeNotification(*ancestor);
+            break;
+        }
+    }
 }
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -390,6 +390,8 @@ public:
     void accessibilityText(Vector<AccessibilityText>&) const override { };
     // A single method for getting a computed label for an AXObject. It condenses the nuances of accessibilityText. Used by Inspector.
     WEBCORE_EXPORT String computedLabel();
+    // Used by aria live regions for the text spoken via announcements.
+    String announcementText() const;
 
     // A programmatic way to set a name on an AccessibleObject.
     void setAccessibleName(const AtomString&) override { }

--- a/Source/WebCore/html/BaseButtonInputType.cpp
+++ b/Source/WebCore/html/BaseButtonInputType.cpp
@@ -32,6 +32,7 @@
 #include "config.h"
 #include "BaseButtonInputType.h"
 
+#include "AXObjectCache.h"
 #include "HTMLInputElement.h"
 #include "HTMLNames.h"
 #include "RenderButton.h"
@@ -68,8 +69,12 @@ bool BaseButtonInputType::storesValueSeparateFromAttribute()
 
 void BaseButtonInputType::setValue(const String& sanitizedValue, bool, TextFieldEventBehavior, TextControlSetValueSelection)
 {
-    ASSERT(element());
-    protectedElement()->setAttributeWithoutSynchronization(valueAttr, AtomString { sanitizedValue });
+    RefPtr element = this->element();
+    ASSERT(element);
+    element->setAttributeWithoutSynchronization(valueAttr, AtomString { sanitizedValue });
+
+    if (CheckedPtr cache = element->protectedDocument()->existingAXObjectCache())
+        cache->valueChanged(*element);
 }
 
 bool BaseButtonInputType::dirAutoUsesValue() const

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -794,6 +794,10 @@ void HTMLInputElement::attributeChanged(const QualifiedName& name, const AtomStr
         if (selfOrPrecedingNodesAffectDirAuto())
             updateEffectiveTextDirection();
         m_valueAttributeWasUpdatedAfterParsing = !m_parsingInProgress;
+
+        if (CheckedPtr cache = document().existingAXObjectCache())
+            cache->valueChanged(*this);
+
         break;
     case AttributeNames::nameAttr:
         removeFromRadioButtonGroup();


### PR DESCRIPTION
#### 2af7030a612173de4c61f50a9d845b41f3ba7551
<pre>
AX: input type=button live regions don&apos;t announce changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=305542">https://bugs.webkit.org/show_bug.cgi?id=305542</a>
<a href="https://rdar.apple.com/168200460">rdar://168200460</a>

Reviewed by Tyler Wilcock.

Inputs of type &quot;button&quot; that were live regions were not announcing changes. There are three
reasons for this:
- Button input types did not call AXObjectCache::valueChanged when the value changed.
- AXObjectCache::postLiveRegionChangeNotification was not called by AXObjectCache::valueChanged.
- Live region text computation didn&apos;t consider the title of an element, which is how buttons,
for example, expose their values.

After fixing these three issues, changing the value on a aria-live button will result in
an announcement.

Tests: accessibility/mac/live-regions/live-region-inputs.html
       accessibility/mac/live-regions/live-region-nested-input.html

* LayoutTests/accessibility/mac/live-regions/live-region-inputs-expected.txt: Added.
* LayoutTests/accessibility/mac/live-regions/live-region-inputs.html: Added.
* LayoutTests/accessibility/mac/live-regions/live-region-nested-input-expected.txt: Added.
* LayoutTests/accessibility/mac/live-regions/live-region-nested-input.html: Added.
* Source/WebCore/accessibility/AXLiveRegionManager.cpp:
(WebCore::AXLiveRegionManager::buildLiveRegionSnapshot const):
(WebCore::AXLiveRegionManager::textForObject const):
* Source/WebCore/accessibility/AXLiveRegionManager.h:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::valueChanged):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::announcementText const):
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/html/BaseButtonInputType.cpp:
(WebCore::BaseButtonInputType::setValue):
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::attributeChanged):

Canonical link: <a href="https://commits.webkit.org/305757@main">https://commits.webkit.org/305757@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a51b0b2cfb0c7bdb6468d2adf863ea58f86bd48d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139295 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11671 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/797 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147422 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/23095274-8b8d-4ee7-9f0f-d917f51d3a15) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141168 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12378 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11821 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106642 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/31cc047c-6679-44e1-b2bd-e53bdf8dae8f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142242 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9374 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124765 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87502 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/acda3e0c-c19a-47c5-beff-115bb0c0bc8f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8918 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6689 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7719 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118377 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/665 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150204 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11355 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/683 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115038 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11368 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9610 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115345 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29311 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9467 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121112 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66329 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11398 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/635 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11132 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75064 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11335 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11185 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->