### PR TITLE
[WPE] WPE Platform: add wpe_display_create_toplevel

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/WPEDisplay.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEDisplay.h
@@ -40,6 +40,7 @@
 #include <wpe/WPEKeymap.h>
 #include <wpe/WPEScreen.h>
 #include <wpe/WPESettings.h>
+#include <wpe/WPEToplevel.h>
 #include <wpe/WPEView.h>
 
 G_BEGIN_DECLS
@@ -75,6 +76,8 @@ struct _WPEDisplayClass
     gboolean                (* use_explicit_sync)            (WPEDisplay *display);
     WPEInputMethodContext  *(* create_input_method_context)  (WPEDisplay *display,
                                                               WPEView    *view);
+    WPEToplevel            *(* create_toplevel)              (WPEDisplay *display,
+                                                              guint       max_views);
     WPEGamepadManager      *(* create_gamepad_manager)       (WPEDisplay *display);
 
     gpointer padding[32];
@@ -122,6 +125,8 @@ WPE_API WPESettings             *wpe_display_get_settings                 (WPEDi
 WPE_API WPEAvailableInputDevices wpe_display_get_available_input_devices  (WPEDisplay *display);
 WPE_API void                     wpe_display_set_available_input_devices  (WPEDisplay *display,
                                                                            WPEAvailableInputDevices devices);
+WPE_API WPEToplevel             *wpe_display_create_toplevel              (WPEDisplay *display,
+                                                                           guint       max_views);
 WPE_API WPEGamepadManager       *wpe_display_create_gamepad_manager       (WPEDisplay *display);
 
 G_END_DECLS

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEToplevelDRM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEToplevelDRM.cpp
@@ -67,16 +67,3 @@ static void wpe_toplevel_drm_class_init(WPEToplevelDRMClass* toplevelDRMClass)
     WPEToplevelClass* toplevelClass = WPE_TOPLEVEL_CLASS(toplevelDRMClass);
     toplevelClass->get_screen = wpeToplevelDRMGetScreen;
 }
-
-/**
- * wpe_toplevel_drm_new:
- * @display: a #WPEDisplayDRM
- *
- * Create a new #WPEToplevel on @display.
- *
- * Returns: (transfer full): a #WPEToplevel
- */
-WPEToplevel* wpe_toplevel_drm_new(WPEDisplayDRM* display)
-{
-    return WPE_TOPLEVEL(g_object_new(WPE_TYPE_TOPLEVEL_DRM, "display", display, nullptr));
-}

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEToplevelDRM.h
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEToplevelDRM.h
@@ -39,8 +39,6 @@ G_BEGIN_DECLS
 #define WPE_TYPE_TOPLEVEL_DRM (wpe_toplevel_drm_get_type())
 WPE_API G_DECLARE_FINAL_TYPE (WPEToplevelDRM, wpe_toplevel_drm, WPE, TOPLEVEL_DRM, WPEToplevel)
 
-WPE_API WPEToplevel *wpe_toplevel_drm_new (WPEDisplayDRM *display);
-
 G_END_DECLS
 
 #endif /* WPEToplevelDRM_h */

--- a/Source/WebKit/WPEPlatform/wpe/headless/WPEDisplayHeadless.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/headless/WPEDisplayHeadless.cpp
@@ -82,12 +82,12 @@ static gboolean wpeDisplayHeadlessConnect(WPEDisplay*, GError**)
 
 static WPEView* wpeDisplayHeadlessCreateView(WPEDisplay* display)
 {
-    auto* view = WPE_VIEW(g_object_new(WPE_TYPE_VIEW_HEADLESS, "display", display, nullptr));
-    if (wpe_settings_get_boolean(wpe_display_get_settings(display), WPE_SETTING_CREATE_VIEWS_WITH_A_TOPLEVEL, nullptr)) {
-        GRefPtr<WPEToplevel> toplevel = adoptGRef(wpe_toplevel_headless_new(WPE_DISPLAY_HEADLESS(display)));
-        wpe_view_set_toplevel(view, toplevel.get());
-    }
-    return view;
+    return WPE_VIEW(g_object_new(WPE_TYPE_VIEW_HEADLESS, "display", display, nullptr));
+}
+
+static WPEToplevel* wpeDisplayHeadlessCreateToplevel(WPEDisplay* display, guint)
+{
+    return WPE_TOPLEVEL(g_object_new(WPE_TYPE_TOPLEVEL_HEADLESS, "display", display, nullptr));
 }
 
 static gpointer wpeDisplayHeadlessGetEGLDisplay(WPEDisplay* display, GError** error)
@@ -169,6 +169,7 @@ static void wpe_display_headless_class_init(WPEDisplayHeadlessClass* displayHead
     WPEDisplayClass* displayClass = WPE_DISPLAY_CLASS(displayHeadlessClass);
     displayClass->connect = wpeDisplayHeadlessConnect;
     displayClass->create_view = wpeDisplayHeadlessCreateView;
+    displayClass->create_toplevel = wpeDisplayHeadlessCreateToplevel;
     displayClass->get_egl_display = wpeDisplayHeadlessGetEGLDisplay;
     displayClass->get_drm_device = wpeDisplayHeadlessGetDRMDevice;
 }

--- a/Source/WebKit/WPEPlatform/wpe/headless/WPEToplevelHeadless.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/headless/WPEToplevelHeadless.cpp
@@ -75,16 +75,3 @@ static void wpe_toplevel_headless_class_init(WPEToplevelHeadlessClass* toplevelH
     toplevelClass->resize = wpeToplevelHeadlessResize;
     toplevelClass->set_fullscreen = wpeToplevelHeadlessSetFullscreen;
 }
-
-/**
- * wpe_toplevel_headless_new:
- * @display: a #WPEDisplayHeadless
- *
- * Create a new #WPEToplevel on @display.
- *
- * Returns: (transfer full): a #WPEToplevel
- */
-WPEToplevel* wpe_toplevel_headless_new(WPEDisplayHeadless* display)
-{
-    return WPE_TOPLEVEL(g_object_new(WPE_TYPE_TOPLEVEL_HEADLESS, "display", display, nullptr));
-}

--- a/Source/WebKit/WPEPlatform/wpe/headless/WPEToplevelHeadless.h
+++ b/Source/WebKit/WPEPlatform/wpe/headless/WPEToplevelHeadless.h
@@ -39,8 +39,6 @@ G_BEGIN_DECLS
 #define WPE_TYPE_TOPLEVEL_HEADLESS (wpe_toplevel_headless_get_type())
 WPE_API G_DECLARE_FINAL_TYPE (WPEToplevelHeadless, wpe_toplevel_headless, WPE, TOPLEVEL_HEADLESS, WPEToplevel)
 
-WPE_API WPEToplevel *wpe_toplevel_headless_new (WPEDisplayHeadless *display);
-
 G_END_DECLS
 
 #endif /* WPEToplevelHeadless_h */

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp
@@ -496,14 +496,12 @@ static gboolean wpeDisplayWaylandConnect(WPEDisplay* display, GError** error)
 
 static WPEView* wpeDisplayWaylandCreateView(WPEDisplay* display)
 {
-    auto* view = WPE_VIEW(g_object_new(WPE_TYPE_VIEW_WAYLAND, "display", display, nullptr));
+    return WPE_VIEW(g_object_new(WPE_TYPE_VIEW_WAYLAND, "display", display, nullptr));
+}
 
-    if (wpe_settings_get_boolean(wpe_display_get_settings(display), WPE_SETTING_CREATE_VIEWS_WITH_A_TOPLEVEL, nullptr)) {
-        GRefPtr<WPEToplevel> toplevel = adoptGRef(wpe_toplevel_wayland_new(WPE_DISPLAY_WAYLAND(display), 1));
-        wpe_view_set_toplevel(view, toplevel.get());
-    }
-
-    return view;
+static WPEToplevel* wpeDisplayWaylandCreateToplevel(WPEDisplay* display, guint maxViews)
+{
+    return WPE_TOPLEVEL(g_object_new(WPE_TYPE_TOPLEVEL_WAYLAND, "display", display, "max-views", maxViews, nullptr));
 }
 
 static WPEInputMethodContext* wpeDisplayWaylandCreateInputMethodContext(WPEDisplay* display, WPEView* view)
@@ -667,6 +665,7 @@ static void wpe_display_wayland_class_init(WPEDisplayWaylandClass* displayWaylan
     WPEDisplayClass* displayClass = WPE_DISPLAY_CLASS(displayWaylandClass);
     displayClass->connect = wpeDisplayWaylandConnect;
     displayClass->create_view = wpeDisplayWaylandCreateView;
+    displayClass->create_toplevel = wpeDisplayWaylandCreateToplevel;
     displayClass->create_input_method_context = wpeDisplayWaylandCreateInputMethodContext;
     displayClass->get_egl_display = wpeDisplayWaylandGetEGLDisplay;
     displayClass->get_keymap = wpeDisplayWaylandGetKeymap;

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWayland.cpp
@@ -923,20 +923,6 @@ struct zwp_linux_surface_synchronization_v1* wpeToplevelWaylandGetSurfaceSync(WP
 }
 
 /**
- * wpe_toplevel_wayland_new:
- * @display: a #WPEDisplayWayland
- * @max_views: the maximum number of views allowed, or 0 for no limit
- *
- * Create a new #WPEToplevel on @display with @max_views allowed
- *
- * Returns: (transfer full): a #WPEToplevel
- */
-WPEToplevel* wpe_toplevel_wayland_new(WPEDisplayWayland* display, guint maxViews)
-{
-    return WPE_TOPLEVEL(g_object_new(WPE_TYPE_TOPLEVEL_WAYLAND, "display", display, "max-views", maxViews, nullptr));
-}
-
-/**
  * wpe_toplevel_wayland_get_wl_surface: (skip)
  * @toplevel: a #WPEToplevelWayland
  *

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWayland.h
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWayland.h
@@ -40,8 +40,6 @@ G_BEGIN_DECLS
 #define WPE_TYPE_TOPLEVEL_WAYLAND (wpe_toplevel_wayland_get_type())
 WPE_API G_DECLARE_FINAL_TYPE (WPEToplevelWayland, wpe_toplevel_wayland, WPE, TOPLEVEL_WAYLAND, WPEToplevel)
 
-WPE_API WPEToplevel       *wpe_toplevel_wayland_new            (WPEDisplayWayland  *display,
-                                                                guint               max_views);
 WPE_API struct wl_surface *wpe_toplevel_wayland_get_wl_surface (WPEToplevelWayland *toplevel);
 
 G_END_DECLS

--- a/Tools/TestWebKitAPI/glib/WPEPlatform/mock/WPEDisplayMock.cpp
+++ b/Tools/TestWebKitAPI/glib/WPEPlatform/mock/WPEDisplayMock.cpp
@@ -86,15 +86,12 @@ static gboolean wpeDisplayMockConnect(WPEDisplay* display, GError** error)
 
 static WPEView* wpeDisplayMockCreateView(WPEDisplay* display)
 {
-    auto* view = WPE_VIEW(g_object_new(WPE_TYPE_VIEW_MOCK, "display", display, nullptr));
+    return WPE_VIEW(g_object_new(WPE_TYPE_VIEW_MOCK, "display", display, nullptr));
+}
 
-    if (wpe_settings_get_boolean(wpe_display_get_settings(display), WPE_SETTING_CREATE_VIEWS_WITH_A_TOPLEVEL, nullptr)) {
-        WPEToplevel* toplevel = wpeToplevelMockNew(WPE_DISPLAY_MOCK(display), 1);
-        wpe_view_set_toplevel(view, toplevel);
-        g_object_unref(toplevel);
-    }
-
-    return view;
+static WPEToplevel* wpeDisplayMockCreateToplevel(WPEDisplay* display, guint maxViews)
+{
+    return WPE_TOPLEVEL(g_object_new(WPE_TYPE_TOPLEVEL_MOCK, "display", display, "max-views", maxViews, nullptr));
 }
 
 static WPEInputMethodContext* wpeDisplayMockCreateInputMethodContext(WPEDisplay* display, WPEView*)
@@ -177,6 +174,7 @@ static void wpe_display_mock_class_init(WPEDisplayMockClass* displayMockClass)
     WPEDisplayClass* displayClass = WPE_DISPLAY_CLASS(displayMockClass);
     displayClass->connect = wpeDisplayMockConnect;
     displayClass->create_view = wpeDisplayMockCreateView;
+    displayClass->create_toplevel = wpeDisplayMockCreateToplevel;
     displayClass->create_input_method_context = wpeDisplayMockCreateInputMethodContext;
     displayClass->get_egl_display = wpeDisplayMockGetEGLDisplay;
     displayClass->get_keymap = wpeDisplayMockGetKeymap;

--- a/Tools/TestWebKitAPI/glib/WPEPlatform/mock/WPEToplevelMock.cpp
+++ b/Tools/TestWebKitAPI/glib/WPEPlatform/mock/WPEToplevelMock.cpp
@@ -141,11 +141,6 @@ static void wpe_toplevel_mock_class_init(WPEToplevelMockClass* toplevelMockClass
     toplevelClass->get_preferred_buffer_formats = wpeToplevelMockGetPreferredBufferFormats;
 }
 
-WPEToplevel* wpeToplevelMockNew(WPEDisplayMock* display, guint maxViews)
-{
-    return WPE_TOPLEVEL(g_object_new(WPE_TYPE_TOPLEVEL_MOCK, "display", display, "max-views", maxViews, nullptr));
-}
-
 void wpeToplevelMockSwitchToScreen(WPEToplevelMock* toplevel, guint screen)
 {
     toplevel->priv->currentScreen = screen;

--- a/Tools/TestWebKitAPI/glib/WPEPlatform/mock/WPEToplevelMock.h
+++ b/Tools/TestWebKitAPI/glib/WPEPlatform/mock/WPEToplevelMock.h
@@ -34,7 +34,6 @@ G_BEGIN_DECLS
 #define WPE_TYPE_TOPLEVEL_MOCK (wpe_toplevel_mock_get_type())
 G_DECLARE_FINAL_TYPE(WPEToplevelMock, wpe_toplevel_mock, WPE, TOPLEVEL_MOCK, WPEToplevel)
 
-WPEToplevel* wpeToplevelMockNew(WPEDisplayMock*, guint);
 void wpeToplevelMockSwitchToScreen(WPEToplevelMock*, guint);
 void wpeToplevelMockSetActive(WPEToplevelMock*, gboolean);
 G_END_DECLS


### PR DESCRIPTION
#### 430ffe2d947cc6819a5ea30a8aa091f55a46779c
<pre>
[WPE] WPE Platform: add wpe_display_create_toplevel
<a href="https://bugs.webkit.org/show_bug.cgi?id=305549">https://bugs.webkit.org/show_bug.cgi?id=305549</a>

Reviewed by Nikolas Zimmermann.

And remove the platform specific constructors. This way it&apos;s possible to
create a toplevel using the common API which allows the inspector to
work when the application is handling toplevels.

* Source/WebKit/UIProcess/Inspector/wpe/WebInspectorUIProxyWPE.cpp:
(WebKit::WebInspectorUIProxy::platformCreateFrontendPage):
* Source/WebKit/WPEPlatform/wpe/WPEDisplay.cpp:
(wpeDisplayCreateView):
(wpe_display_create_toplevel):
* Source/WebKit/WPEPlatform/wpe/WPEDisplay.h:
* Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.cpp:
(wpeDisplayDRMCreateView):
(wpeDisplayDRMCreateToplevel):
(wpe_display_drm_class_init):
* Source/WebKit/WPEPlatform/wpe/drm/WPEToplevelDRM.cpp:
(wpe_toplevel_drm_class_init):
(wpe_toplevel_drm_new): Deleted.
* Source/WebKit/WPEPlatform/wpe/drm/WPEToplevelDRM.h:
* Source/WebKit/WPEPlatform/wpe/headless/WPEDisplayHeadless.cpp:
(wpeDisplayHeadlessCreateView):
(wpeDisplayHeadlessCreateToplevel):
(wpe_display_headless_class_init):
* Source/WebKit/WPEPlatform/wpe/headless/WPEToplevelHeadless.cpp:
(wpe_toplevel_headless_class_init):
(wpe_toplevel_headless_new): Deleted.
* Source/WebKit/WPEPlatform/wpe/headless/WPEToplevelHeadless.h:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp:
(wpeDisplayWaylandCreateView):
(wpeDisplayWaylandCreateToplevel):
(wpe_display_wayland_class_init):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWayland.cpp:
(wpe_toplevel_wayland_new): Deleted.
* Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWayland.h:
* Tools/TestWebKitAPI/glib/WPEPlatform/mock/WPEDisplayMock.cpp:
(wpeDisplayMockCreateView):
(wpeDisplayMockCreateToplevel):
(wpe_display_mock_class_init):
* Tools/TestWebKitAPI/glib/WPEPlatform/mock/WPEToplevelMock.cpp:
(wpeToplevelMockNew): Deleted.
* Tools/TestWebKitAPI/glib/WPEPlatform/mock/WPEToplevelMock.h:

Canonical link: <a href="https://commits.webkit.org/305638@main">https://commits.webkit.org/305638@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c9b3e84ff130c7ef0558ebe7db823c1ea18d47a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139012 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11379 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/499 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147131 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140885 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12088 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11535 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106401 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141959 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9130 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124519 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87275 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8688 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6447 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7432 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118131 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/418 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149917 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11064 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/424 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114793 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11082 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9351 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115112 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8999 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120869 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65966 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21419 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11111 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/400 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10847 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74760 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11050 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10898 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->