### PR TITLE
Ensure that the preload scanner includes integrity metadata in requests.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/subresource-integrity/integrity-policy/preload-script-with-integrity.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/subresource-integrity/integrity-policy/preload-script-with-integrity.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Script with integrity in initial HTML should not trigger Integrity-Policy reports (tests preload scanner)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/subresource-integrity/integrity-policy/preload-script-with-integrity.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/subresource-integrity/integrity-policy/preload-script-with-integrity.https.html
@@ -1,0 +1,99 @@
+<!doctype html>
+<meta name="timeout" content="long">
+<title>Integrity-Policy: Preloaded scripts with integrity should not generate reports</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="/reporting/resources/report-helper.js"></script>
+
+<body>
+<script>
+  // This test verifies that scripts with valid integrity attributes that are
+  // in the initial HTML (and thus may be speculatively preloaded by the HTML
+  // parser's preload scanner) do NOT generate Integrity-Policy violation reports.
+  //
+  // Bug: https://bugs.webkit.org/show_bug.cgi?id=305461
+  // The issue was that the preload scanner wasn't passing the integrity attribute,
+  // causing reports to be generated even for scripts with valid SRI.
+
+  const {ORIGIN} = get_host_info();
+
+  promise_test(async t => {
+    const reporting_uuid = token();
+    const reporting_endpoint = `${ORIGIN}/reporting/resources/report.py`;
+
+    // Build the pipe parameter to add headers to the iframe response
+    // This sets up Integrity-Policy that would block/report scripts without integrity
+    const headers = [
+      `header(Integrity-Policy,blocked-destinations=\\(script\\)\\, endpoints=\\(integrity-endpoint\\))`,
+      `header(Integrity-Policy-Report-Only,blocked-destinations=\\(script\\)\\, endpoints=\\(integrity-endpoint-ro\\))`,
+      `header(Reporting-Endpoints, integrity-endpoint="${reporting_endpoint}?reportID=${reporting_uuid}"\\, integrity-endpoint-ro="${reporting_endpoint}?reportID=${reporting_uuid}-ro")`
+    ].join('|');
+
+    // Load the HTML page that contains the script with integrity directly in the markup
+    const iframe_url = `resources/page-with-integrity-script.html?pipe=${encodeURIComponent(headers)}`;
+
+    const iframe = document.createElement('iframe');
+    t.add_cleanup(() => iframe.remove());
+
+    // Wait for the iframe to load and send us results
+    const resultPromise = new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        reject(new Error('Timeout waiting for iframe to load'));
+      }, 10000);
+
+      window.addEventListener('message', function handler(e) {
+        if (e.data && e.data.loaded !== undefined) {
+          clearTimeout(timeout);
+          window.removeEventListener('message', handler);
+          resolve(e.data);
+        }
+      });
+    });
+
+    iframe.src = iframe_url;
+    document.body.appendChild(iframe);
+
+    const result = await resultPromise;
+
+    // Verify the script ran (integrity check passed)
+    assert_true(result.ran, 'Script with valid integrity should execute');
+
+    // Wait a bit for any reports to be sent
+    await new Promise(r => setTimeout(r, 1000));
+
+    // Check that no reports were sent to the reporting endpoint
+    // for the ran.js script (which has valid integrity)
+    let reportsForRanJs = [];
+    try {
+      const allReports = await pollReports(reporting_endpoint, reporting_uuid);
+      reportsForRanJs = allReports.filter(r =>
+        r.body && r.body.blockedURL && r.body.blockedURL.includes('ran.js')
+      );
+    } catch (e) {
+      // If pollReports fails (no reports), that's fine
+    }
+
+    assert_equals(reportsForRanJs.length, 0,
+      'No integrity-violation reports should be sent for scripts with valid integrity in the initial HTML');
+
+    // Also check report-only endpoint
+    let reportsForRanJsRO = [];
+    try {
+      const allReportsRO = await pollReports(reporting_endpoint, reporting_uuid + '-ro');
+      reportsForRanJsRO = allReportsRO.filter(r =>
+        r.body && r.body.blockedURL && r.body.blockedURL.includes('ran.js')
+      );
+    } catch (e) {
+      // If pollReports fails (no reports), that's fine
+    }
+
+    assert_equals(reportsForRanJsRO.length, 0,
+      'No integrity-violation reports should be sent to report-only endpoint for scripts with valid integrity');
+
+  }, 'Script with integrity in initial HTML should not trigger Integrity-Policy reports (tests preload scanner)');
+
+</script>
+</body>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/subresource-integrity/integrity-policy/resources/page-with-integrity-script.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/subresource-integrity/integrity-policy/resources/page-with-integrity-script.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Page with script that has integrity attribute</title>
+</head>
+<body>
+<!-- This script tag is in the initial HTML, so it will be seen by the preload scanner -->
+<script src="/content-security-policy/resources/ran.js"
+        integrity="sha384-tqyFpeo21WFM8HDeUtLqH20GUq/q3D1R6mqTzW3RtyTZ3dAYZJhC1wUcnkgOE2ak"
+        crossorigin="anonymous"></script>
+<script>
+  // Signal to parent that we've loaded
+  window.parent.postMessage({
+    ran: window.ran === true,
+    loaded: true
+  }, '*');
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
+++ b/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
@@ -180,6 +180,7 @@ public:
         auto request = makeUnique<PreloadRequest>(initiatorFor(m_tagId), m_urlToLoad, predictedBaseURL, type.value(), m_mediaAttribute, scriptType.value_or(ScriptType::Classic), m_referrerPolicy, m_fetchPriority);
         request->setCrossOriginMode(m_crossOriginMode);
         request->setNonce(m_nonceAttribute);
+        request->setIntegrity(m_integrityAttribute);
         request->setScriptIsAsync(m_scriptIsAsync);
 
         // According to the spec, the module tag ignores the "charset" attribute as the same to the worker's
@@ -281,6 +282,9 @@ private:
                 break;
             } else if (match(attributeName, nonceAttr)) {
                 m_nonceAttribute = attributeValue.toString();
+                break;
+            } else if (match(attributeName, integrityAttr)) {
+                m_integrityAttribute = attributeValue.toString();
                 break;
             } else if (match(attributeName, referrerpolicyAttr)) {
                 m_referrerPolicy = parseReferrerPolicy(attributeValue, ReferrerPolicySource::ReferrerPolicyAttribute).value_or(ReferrerPolicy::EmptyString);
@@ -439,6 +443,7 @@ private:
     String m_asAttribute;
     String m_typeAttribute;
     String m_languageAttribute;
+    String m_integrityAttribute;
     String m_lazyloadAttribute;
     bool m_metaIsViewport;
     bool m_metaIsDisabledAdaptations;

--- a/Source/WebCore/html/parser/HTMLResourcePreloader.cpp
+++ b/Source/WebCore/html/parser/HTMLResourcePreloader.cpp
@@ -70,6 +70,7 @@ CachedResourceRequest PreloadRequest::resourceRequest(Document& document)
         options.referrerPolicy = m_referrerPolicy;
     options.fetchPriority = m_fetchPriority;
     options.nonce = m_nonceAttribute;
+    options.integrity = m_integrityAttribute;
     auto request = createPotentialAccessControlRequest(completeURL(document), WTF::move(options), document, crossOriginMode);
     request.setInitiatorType(m_initiatorType);
 

--- a/Source/WebCore/html/parser/HTMLResourcePreloader.h
+++ b/Source/WebCore/html/parser/HTMLResourcePreloader.h
@@ -56,6 +56,7 @@ public:
     void setCharset(const String& charset) { m_charset = charset.isolatedCopy(); }
     void setCrossOriginMode(const String& mode) { m_crossOriginMode = mode; }
     void setNonce(const String& nonce) { m_nonceAttribute = nonce; }
+    void setIntegrity(const String& integrity) { m_integrityAttribute = integrity; }
     void setScriptIsAsync(bool value) { m_scriptIsAsync = value; }
     CachedResource::Type resourceType() const { return m_resourceType; }
 
@@ -70,6 +71,7 @@ private:
     String m_mediaAttribute;
     String m_crossOriginMode;
     String m_nonceAttribute;
+    String m_integrityAttribute;
     bool m_scriptIsAsync { false };
     ScriptType m_scriptType;
     ReferrerPolicy m_referrerPolicy;


### PR DESCRIPTION
#### 59c1484d0d9e3130ce0decbb5b56747a029a0dcd
<pre>
Ensure that the preload scanner includes integrity metadata in requests.
<a href="https://bugs.webkit.org/show_bug.cgi?id=305461">https://bugs.webkit.org/show_bug.cgi?id=305461</a>

Reviewed by Ryosuke Niwa.

The reported bug exposed that the preload scanner doesn&apos;t currently set the correct integrity metadata, resulting in sent reports.
This PR fixes that by setting the right metadata and adding a test for that.

Test: imported/w3c/web-platform-tests/subresource-integrity/integrity-policy/preload-script-with-integrity.https.html

* LayoutTests/imported/w3c/web-platform-tests/subresource-integrity/integrity-policy/preload-script-with-integrity.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/subresource-integrity/integrity-policy/preload-script-with-integrity.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/subresource-integrity/integrity-policy/resources/page-with-integrity-script.html: Added.
* Source/WebCore/html/parser/HTMLPreloadScanner.cpp:
(WebCore::TokenPreloadScanner::StartTagScanner::createPreloadRequest): Set integrity on request.
(WebCore::TokenPreloadScanner::StartTagScanner::processAttribute): Set integrity on request.
* Source/WebCore/html/parser/HTMLResourcePreloader.cpp:
(WebCore::PreloadRequest::resourceRequest): Set integrity on request.
* Source/WebCore/html/parser/HTMLResourcePreloader.h:
(WebCore::PreloadRequest::setIntegrity): Set integrity on request.

Canonical link: <a href="https://commits.webkit.org/305689@main">https://commits.webkit.org/305689@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/474a5ba1a88b6ab359f7302d14fb07612d0d25a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139013 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11380 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/500 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147132 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92040 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140886 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12089 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11536 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106403 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77551 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141960 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9131 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124526 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87277 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8689 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6450 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7433 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118132 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/425 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149918 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11065 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/431 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114794 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11083 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9355 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115113 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29277 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9000 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120876 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65967 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11112 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/406 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10848 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74761 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11051 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10899 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->