### PR TITLE
https://urlpattern.spec.whatwg.org/#build-a-url-pattern-from-a-web-idl-value needs to set baseURL it not provided

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/static-router-subresource.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/static-router-subresource.https-expected.txt
@@ -2,10 +2,10 @@
 PASS Subresource load not matched with URLPattern condition
 PASS Subresource load matched with URLPattern condition
 PASS Subresource cross origin load matched with URLPattern condition via constructed object
-FAIL Subresource load matched with ignoreCase URLPattern condition assert_equals: expected "Network\n" but got "tvlbp"
+FAIL Subresource load matched with ignoreCase URLPattern condition assert_equals: expected "Network\n" but got "olbaz"
 PASS Subresource load matched without ignoreCase URLPattern condition
 PASS Subresource load matched with URLPattern condition via URLPatternCompatible
-FAIL Subresource cross origin load not matched with URLPattern condition via URLPatternCompatible promise_test: Unhandled rejection with value: object "TypeError: Load failed"
+PASS Subresource cross origin load not matched with URLPattern condition via URLPatternCompatible
 PASS Subresource load matched with URLPattern condition via string
 PASS Subresource cross origin load not matched with URLPattern condition via string
 PASS Subresource load matched with RequestMode condition

--- a/Source/WebCore/Modules/url-pattern/URLPattern.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPattern.cpp
@@ -284,6 +284,8 @@ ExceptionOr<Ref<URLPattern>> URLPattern::create(ScriptExecutionContext& context,
     return switchOn(WTF::move(value), [&](RefPtr<URLPattern>&& pattern) -> ExceptionOr<Ref<URLPattern>> {
         return pattern.releaseNonNull();
     }, [&](URLPatternInit&& init) -> ExceptionOr<Ref<URLPattern>> {
+        if (init.baseURL.isNull())
+            init.baseURL = baseURL;
         return URLPattern::create(context, WTF::move(init), { }, { });
     }, [&](String&& string) -> ExceptionOr<Ref<URLPattern>> {
         return URLPattern::create(context, WTF::move(string), String { baseURL }, { });


### PR DESCRIPTION
#### 0c77ce65e80f2da7e811ca15054a58763c326764
<pre>
<a href="https://urlpattern.spec.whatwg.org/#build-a-url-pattern-from-a-web-idl-value">https://urlpattern.spec.whatwg.org/#build-a-url-pattern-from-a-web-idl-value</a> needs to set baseURL it not provided
<a href="https://rdar.apple.com/168203276">rdar://168203276</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=305544">https://bugs.webkit.org/show_bug.cgi?id=305544</a>

Reviewed by Chris Dumez.

We add the missing initialization step.
Covered by rebased test.

Canonical link: <a href="https://commits.webkit.org/305802@main">https://commits.webkit.org/305802@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93b16767db95c432fb89ddc024371123f3f6ae47

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139177 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11551 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/674 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147304 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92244 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/657b0afa-cbfd-4562-bb5d-6ac1864717a1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141049 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12258 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11701 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106541 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77592 "1 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2f92b361-47ae-4f51-9624-af9a732b3486) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142124 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9270 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124656 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87408 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/468e9aee-faf6-4d92-afe6-998eda249cae) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8817 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6585 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7598 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118269 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/559 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150083 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11235 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/568 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114930 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11248 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9501 "Found 1 new test failure: imported/w3c/web-platform-tests/media-source/mediasource-changetype-play.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115243 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29334 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9231 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121006 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66137 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11278 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/533 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11013 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74935 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11216 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11065 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->