### PR TITLE
Add support for ignoreCase URLPattern parameter in service worker matching rules

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6550,8 +6550,6 @@ imported/w3c/web-platform-tests/workers/modules/shared-worker-options-credential
 imported/w3c/web-platform-tests/xhr/abort-with-error.any.html [ Skip ]
 imported/w3c/web-platform-tests/xhr/send-after-setting-document-domain.htm [ Skip ]
 
-imported/w3c/web-platform-tests/service-workers/service-worker/static-router-race-network-and-fetch-handler.https.html [ Failure ]
-imported/w3c/web-platform-tests/service-workers/service-worker/static-router-subresource.https.html [ Failure ]
 imported/w3c/web-platform-tests/service-workers/service-worker/tentative/static-router/static-router-resource-timing.https.html [ Failure ]
 
 # This test needs proper promise handling in fullscreen to avoid the flaky console message:

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/static-router-main-resource.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/static-router-main-resource.https-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Main resource load matched with the condition
-FAIL Main resource load matched with the ignore case condition assert_equals: expected 0 but got 1
+PASS Main resource load matched with the ignore case condition
 PASS Main resource load matched without the ignore case condition
 PASS Main resource load not matched with the condition
 PASS Main resource load matched with the cache source

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/static-router-subresource.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/static-router-subresource.https-expected.txt
@@ -2,7 +2,7 @@
 PASS Subresource load not matched with URLPattern condition
 PASS Subresource load matched with URLPattern condition
 PASS Subresource cross origin load matched with URLPattern condition via constructed object
-FAIL Subresource load matched with ignoreCase URLPattern condition assert_equals: expected "Network\n" but got "olbaz"
+PASS Subresource load matched with ignoreCase URLPattern condition
 PASS Subresource load matched without ignoreCase URLPattern condition
 PASS Subresource load matched with URLPattern condition via URLPatternCompatible
 PASS Subresource cross origin load not matched with URLPattern condition via URLPatternCompatible

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -803,6 +803,8 @@ imported/w3c/web-platform-tests/service-workers/service-worker/static-router-mai
 imported/w3c/web-platform-tests/service-workers/service-worker/static-router-multiple-router-registrations.https.html [ Failure ]
 imported/w3c/web-platform-tests/service-workers/service-worker/static-router-mutiple-conditions.https.html [ Failure ]
 imported/w3c/web-platform-tests/service-workers/service-worker/static-router-no-fetch-handler.https.html [ Failure ]
+imported/w3c/web-platform-tests/service-workers/service-worker/static-router-race-network-and-fetch-handler.https.html [ Failure ]
+imported/w3c/web-platform-tests/service-workers/service-worker/static-router-subresource.https.html [ Failure ]
 
 # Needs rebasing and testing
 imported/w3c/web-platform-tests/service-workers/service-worker/fetch-canvas-tainting-video.https.html [ Failure ]

--- a/Source/WebCore/Modules/url-pattern/URLPattern.h
+++ b/Source/WebCore/Modules/url-pattern/URLPattern.h
@@ -73,12 +73,18 @@ public:
     const String& hash() const { return m_hashComponent.patternString(); }
 
     bool hasRegExpGroups() const;
+    bool shouldIgnoreCase() const { return m_shouldIgnoreCase; }
 
 private:
-    URLPattern();
-    ExceptionOr<void> compileAllComponents(ScriptExecutionContext&, URLPatternInit&&, const URLPatternOptions&);
+    explicit URLPattern(bool shouldIgnoreCase)
+        : m_shouldIgnoreCase(shouldIgnoreCase)
+    {
+    }
+
+    ExceptionOr<void> compileAllComponents(ScriptExecutionContext&, URLPatternInit&&);
     ExceptionOr<std::optional<URLPatternResult>> match(ScriptExecutionContext&, Variant<URL, URLPatternInput>&&, String&& baseURLString) const;
 
+    const bool m_shouldIgnoreCase;
     URLPatternUtilities::URLPatternComponent m_protocolComponent;
     URLPatternUtilities::URLPatternComponent m_usernameComponent;
     URLPatternUtilities::URLPatternComponent m_passwordComponent;

--- a/Source/WebCore/PAL/pal/PALSwift/RegexpHelper.swift
+++ b/Source/WebCore/PAL/pal/PALSwift/RegexpHelper.swift
@@ -25,11 +25,11 @@ import Foundation
 import RegexBuilder
 
 public class RegexHelper {
-    public static func match(pattern: NSString, value: NSString) -> Bool {
+    public static func match(pattern: NSString, value: NSString, shouldIgnoreCase: Bool) -> Bool {
         guard let expression = try? Regex(pattern as String) else {
             return false
         }
         let swiftValue = value as String
-        return swiftValue.contains(expression)
+        return swiftValue.contains(shouldIgnoreCase ? expression.ignoresCase() : expression)
     }
 }

--- a/Source/WebCore/workers/service/InstallEvent.cpp
+++ b/Source/WebCore/workers/service/InstallEvent.cpp
@@ -52,6 +52,7 @@ static ExceptionOr<ServiceWorkerRoutePattern> toServiceWorkerRoutePattern(const 
         return Exception { ExceptionCode::TypeError, "Service Worker route url pattern has regexp groups"_s };
 
     return ServiceWorkerRoutePattern {
+        pattern.shouldIgnoreCase(),
         pattern.protocol(),
         pattern.username(),
         pattern.password(),

--- a/Source/WebCore/workers/service/ServiceWorkerRoute.h
+++ b/Source/WebCore/workers/service/ServiceWorkerRoute.h
@@ -45,6 +45,7 @@ struct ServiceWorkerRoutePattern {
 
     using Component = String;
 
+    bool shouldIgnoreCase { false };
     Component protocol;
     Component username;
     Component password;
@@ -85,7 +86,7 @@ std::optional<size_t> countRouterInnerConditions(const ServiceWorkerRouteConditi
 std::optional<ExceptionData> validateServiceWorkerRoute(ServiceWorkerRoute&);
 
 #if PLATFORM(COCOA)
-bool isRegexpMatching(const String& pattern, StringView value);
+bool isRegexpMatching(const String& pattern, StringView value, bool shouldIgnoreCase);
 #endif
 
 bool matchRouterCondition(const ServiceWorkerRouteCondition&, const FetchOptions&, const ResourceRequest&, bool isServiceWorkerRunning);

--- a/Source/WebCore/workers/service/ServiceWorkerRoute.mm
+++ b/Source/WebCore/workers/service/ServiceWorkerRoute.mm
@@ -37,10 +37,10 @@
 
 namespace WebCore {
 
-bool isRegexpMatching(const String& pattern, StringView value)
+bool isRegexpMatching(const String& pattern, StringView value, bool shouldIgnoreCase)
 {
 #if !defined(CLANG_WEBKIT_BRANCH)
-    return pal::RegexHelper::match(pattern.createNSString().get(), value.createNSString().get());
+    return pal::RegexHelper::match(pattern.createNSString().get(), value.createNSString().get(), shouldIgnoreCase);
 #else
     UNUSED_PARAM(pattern);
     UNUSED_PARAM(value);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -5298,6 +5298,7 @@ enum class WebCore::RunningStatus : bool
 
 header: <WebCore/ServiceWorkerRoute.h>
 [CustomHeader] struct WebCore::ServiceWorkerRoutePattern {
+    bool shouldIgnoreCase;
     String protocol;
     String username;
     String password;


### PR DESCRIPTION
#### 3a8fc06e2e25f38b2051ca2dd6c4a78bec5756c6
<pre>
Add support for ignoreCase URLPattern parameter in service worker matching rules
<a href="https://rdar.apple.com/167986524">rdar://167986524</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=305329">https://bugs.webkit.org/show_bug.cgi?id=305329</a>

Reviewed by Chris Dumez.

We store in URLPattern whether it should ignore case and add a getter.
We use that getter in InstallEvent to store whether ignoring case or not in ServiceWorkerRoutePattern.
We update isRegexpMatching to match w/o ingoring case.

Covered by rebased tests.

Canonical link: <a href="https://commits.webkit.org/305815@main">https://commits.webkit.org/305815@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cae6b3c5b964f82414bd45e4ab468af213e0d83b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139483 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11859 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/985 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147611 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92551 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a1b61c93-a57a-4d73-a99e-20a051ef03bb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141356 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12567 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/12339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106786 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/77750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/85c15452-1896-45e1-a3c2-49c8ccdbc9a9) 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/142759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9611 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124931 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87649 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6de097ed-d3f0-4bf0-9afd-ef03e1e03afb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9229 "Passed tests") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7909 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118538 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/912 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150394 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11543 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/928 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115188 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11557 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/12339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115499 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29340 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10012 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121357 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66549 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11587 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/865 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11323 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75253 "Failed to build and analyze WebKit") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11523 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11374 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->