### PR TITLE
Web Inspector: Color picker should have explicit format and gamut toggles for better discoverability

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Models/Color.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Color.js
@@ -769,6 +769,43 @@ WI.Color = class Color
         return true;
     }
 
+    getNextValidHEXFormat()
+    {
+        const hexFormats = [
+            {format: WI.Color.Format.ShortHEX, title: WI.UIString("Format: Short Hex")},
+            {format: WI.Color.Format.ShortHEXAlpha, title: WI.UIString("Format: Short Hex with Alpha")},
+            {format: WI.Color.Format.HEX, title: WI.UIString("Format: Hex")},
+            {format: WI.Color.Format.HEXAlpha, title: WI.UIString("Format: Hex with Alpha")},
+        ];
+
+        let hexMatchesColor = (hexInfo) => {
+            let nextIsSimple = hexInfo.format === WI.Color.Format.ShortHEX || hexInfo.format === WI.Color.Format.HEX;
+            if (nextIsSimple && !this.simple)
+                return false;
+
+            let nextIsShort = hexInfo.format === WI.Color.Format.ShortHEX || hexInfo.format === WI.Color.Format.ShortHEXAlpha;
+            if (nextIsShort && !this.canBeSerializedAsShortHEX())
+                return false;
+
+            return true;
+        };
+
+        let currentColorIsHEX = hexFormats.some((info) => info.format === this.format);
+
+        for (let i = 0; i < hexFormats.length; ++i) {
+            if (currentColorIsHEX && this.format !== hexFormats[i].format)
+                continue;
+
+            for (let j = ~~currentColorIsHEX; j < hexFormats.length; ++j) {
+                let nextIndex = (i + j) % hexFormats.length;
+                if (hexMatchesColor(hexFormats[nextIndex]))
+                    return hexFormats[nextIndex];
+            }
+            return null;
+        }
+        return hexFormats[0];
+    }
+
     // Private
 
     _toOriginalString()

--- a/Source/WebInspectorUI/UserInterface/Views/ColorPicker.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ColorPicker.css
@@ -97,15 +97,16 @@
     margin: 0 0.25em;
 }
 
-.color-picker > .color-inputs-wrapper > .pick-color-from-screen {
+.color-picker > .color-inputs-wrapper > :is(.pick-color-from-screen, .format-options) {
     width: 16px;
     height: 16px;
     color: var(--glyph-color);
     opacity: var(--glyph-opacity);
 }
 
+.color-picker > .color-inputs-wrapper > :is(.pick-color-from-screen, .format-options):active,
 .color-picker > .color-inputs-wrapper > .pick-color-from-screen.active {
-    color: var(--glyph-color-active);
+    color: var(--glyph-color-pressed);
 }
 
 .color-picker > .variable-color-swatches {


### PR DESCRIPTION
#### 21391bb5cf6b734a83ccf04468f4a50be3dc2148
<pre>
Web Inspector: Color picker should have explicit format and gamut toggles for better discoverability
<a href="https://bugs.webkit.org/show_bug.cgi?id=305557">https://bugs.webkit.org/show_bug.cgi?id=305557</a>
<a href="https://rdar.apple.com/168216591">rdar://168216591</a>

Reviewed by Devin Rousso.

Add a gear icon to the color picker popover that shows a context menu with
format and gamut conversion options, matching the existing InlineSwatch
context menu behavior.

* Source/WebInspectorUI/UserInterface/Models/Color.js:
(WI.Color.prototype.getNextValidHEXFormat):
* Source/WebInspectorUI/UserInterface/Views/ColorPicker.css:
(.color-picker &gt; .color-inputs-wrapper &gt; :is(.pick-color-from-screen, .format-options)):
(.color-picker &gt; .color-inputs-wrapper &gt; :is(.pick-color-from-screen, .format-options):active,):
(.color-picker &gt; .color-inputs-wrapper &gt; .pick-color-from-screen): Deleted.
(.color-picker &gt; .color-inputs-wrapper &gt; .pick-color-from-screen.active): Deleted.
* Source/WebInspectorUI/UserInterface/Views/ColorPicker.js:
(WI.ColorPicker.addContextMenuFormatItems):
(WI.ColorPicker.prototype._changeFormat):
(WI.ColorPicker.prototype._populateFormatContextMenu):
(WI.ColorPicker):
* Source/WebInspectorUI/UserInterface/Views/InlineSwatch.js:
(WI.InlineSwatch.prototype._handleContextMenuEvent):
(WI.InlineSwatch.prototype._getNextValidHEXFormat.hexMatchesCurrentColor): Deleted.
(WI.InlineSwatch.prototype._getNextValidHEXFormat): Deleted.

Canonical link: <a href="https://commits.webkit.org/306691@main">https://commits.webkit.org/306691@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4eca95a11a7f5e70c70c8a160075d5366c0edfa4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142050 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14446 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/4562 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150660 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15164 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14599 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109190 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/894a8fdf-5df1-4db9-9259-b66bfd1098e7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144999 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11721 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/127163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90087 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/05d336af-4ae9-41da-828f-1722d6c8b1fe) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11262 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8923 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/716 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120592 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/3448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153033 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14125 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/4083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/117265 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14147 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12321 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117585 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29967 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13625 "Passed tests") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/124260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/69825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14174 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/3357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/13906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77890 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/14110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13951 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->