### PR TITLE
Reduce fragmentation of small uncached network resources

### DIFF
--- a/Source/WebCore/platform/SharedMemory.h
+++ b/Source/WebCore/platform/SharedMemory.h
@@ -54,7 +54,7 @@ class FragmentedSharedBuffer;
 class ProcessIdentity;
 class SharedBuffer;
 
-enum class MemoryLedger { None, Default, Network, Media, Graphics, Neural };
+enum class MemoryLedger : uint8_t { None, Default, Network, Media, Graphics, Neural };
 enum class SharedMemoryProtection : bool { ReadOnly, ReadWrite };
 
 WEBCORE_EXPORT bool isMemoryAttributionDisabled();

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -2266,7 +2266,11 @@ void NetworkResourceLoader::sendDidReceiveDataMessage(const FragmentedSharedBuff
     updateBytesTransferredOverNetwork(bytesTransferredOverNetwork);
 #endif
 
-    send(Messages::WebResourceLoader::DidReceiveData(IPC::SharedBufferReference(buffer), bytesTransferredOverNetwork));
+    // Transfer memory footprint of the buffer to the receiving WebProcess. We have to use the
+    // default ledger rather than the network ledger here since the latter requires an entitlement.
+    auto data = IPC::SharedBufferReference { buffer };
+    data.transferOwnershipToReceiver(WebCore::MemoryLedger::Default);
+    send(Messages::WebResourceLoader::DidReceiveData(WTF::move(data), bytesTransferredOverNetwork));
 }
 
 #if ENABLE(CONTENT_EXTENSIONS)

--- a/Source/WebKit/Platform/IPC/SharedBufferReference.cpp
+++ b/Source/WebKit/Platform/IPC/SharedBufferReference.cpp
@@ -48,6 +48,9 @@ SharedBufferReference::SharedBufferReference(std::optional<SerializableBuffer>&&
     if (!serializableBuffer->handle)
         return;
 
+    if (auto ledger = serializableBuffer->ledger)
+        serializableBuffer->handle->takeOwnershipOfMemory(*ledger);
+
     auto sharedMemoryBuffer = SharedMemory::map(WTF::move(*serializableBuffer->handle), SharedMemory::Protection::ReadOnly);
     if (!sharedMemoryBuffer || sharedMemoryBuffer->size() < serializableBuffer->size)
         return;
@@ -61,9 +64,9 @@ auto SharedBufferReference::serializableBuffer() const -> std::optional<Serializ
     if (isNull())
         return std::nullopt;
     if (!m_size)
-        return SerializableBuffer { 0, std::nullopt };
+        return SerializableBuffer { 0, std::nullopt, std::nullopt };
     auto sharedMemoryBuffer = m_memory ? m_memory : SharedMemory::copyBuffer(Ref { *m_buffer });
-    return SerializableBuffer { m_size, sharedMemoryBuffer->createHandle(SharedMemory::Protection::ReadOnly) };
+    return SerializableBuffer { m_size, sharedMemoryBuffer->createHandle(SharedMemory::Protection::ReadOnly), m_ledger };
 }
 #endif
 

--- a/Source/WebKit/Platform/IPC/SharedBufferReference.h
+++ b/Source/WebKit/Platform/IPC/SharedBufferReference.h
@@ -58,6 +58,7 @@ public:
     struct SerializableBuffer {
         uint64_t size;
         std::optional<WebCore::SharedMemory::Handle> handle;
+        std::optional<WebCore::MemoryLedger> ledger;
     };
     SharedBufferReference(std::optional<SerializableBuffer>&&);
 #endif
@@ -70,6 +71,8 @@ public:
     size_t size() const { return m_size; }
     bool isEmpty() const { return !size(); }
     bool isNull() const { return isEmpty() && !m_buffer; }
+
+    void transferOwnershipToReceiver(WebCore::MemoryLedger ledger) { m_ledger = ledger; }
 
 #if USE(UNIX_DOMAIN_SOCKETS)
     RefPtr<WebCore::FragmentedSharedBuffer> buffer() const { return m_buffer; }
@@ -92,6 +95,7 @@ private:
     size_t m_size { 0 };
     mutable RefPtr<WebCore::FragmentedSharedBuffer> m_buffer;
     RefPtr<WebCore::SharedMemory> m_memory; // Only set on the receiver side and if m_size isn't 0.
+    std::optional<WebCore::MemoryLedger> m_ledger;
 };
 
 } // namespace IPC

--- a/Source/WebKit/Platform/IPC/SharedBufferReference.serialization.in
+++ b/Source/WebKit/Platform/IPC/SharedBufferReference.serialization.in
@@ -26,6 +26,7 @@ header: "SharedBufferReference.h"
 [Nested, RValue] struct IPC::SharedBufferReference::SerializableBuffer {
     uint64_t size;
     std::optional<WebCore::SharedMemory::Handle> handle;
+    std::optional<WebCore::MemoryLedger> ledger;
 };
 #endif
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2591,6 +2591,16 @@ header: <wtf/MachSendRight.h>
     uint64_t m_size;
 };
 
+header: <WebCore/SharedMemory.h>
+[CustomHeader] enum class WebCore::MemoryLedger : uint8_t {
+    None,
+    Default,
+    Network,
+    Media,
+    Graphics,
+    Neural
+};
+
 header: <WebCore/TextIndicator.h>
 [CustomHeader] struct WebCore::TextIndicatorData {
     WebCore::FloatRect selectionRectInRootViewCoordinates;


### PR DESCRIPTION
#### ca15e3c5791874c4a2a289e2ab011a62a2dc91d2
<pre>
Reduce fragmentation of small uncached network resources
<a href="https://bugs.webkit.org/show_bug.cgi?id=305574">https://bugs.webkit.org/show_bug.cgi?id=305574</a>
<a href="https://rdar.apple.com/168231289">rdar://168231289</a>

Reviewed by Sihui Liu.

Small resources fetched over the network can end up on their own VM page, leading to internal
fragmentation since the default page size on some devices is 16KB. Mitigate this by copying small
resources to malloc&apos;d memory. This is a ~0.3% win on Membuster5.

Also, transfer ownership of the network data from NetworkProcess to WebProcess so that the footprint
is accounted to the web page that requested the data. This investigation started because I was
trying to figure out why there was so much unmapped footprint in NetworkProcess. Excess unmapped
footprint in NetworkProcess can cause it to jetsam, which is bad because it&apos;s a process that&apos;s
shared by all WebProcesses.

* Source/WebCore/platform/SharedMemory.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::sendDidReceiveDataMessage):
* Source/WebKit/Platform/IPC/SharedBufferReference.cpp:
(IPC::SharedBufferReference::SharedBufferReference):
(IPC::SharedBufferReference::serializableBuffer const):
* Source/WebKit/Platform/IPC/SharedBufferReference.h:
(IPC::SharedBufferReference::transferOwnershipToReceiver):
* Source/WebKit/Platform/IPC/SharedBufferReference.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/Network/WebResourceLoader.cpp:
(WebKit::WebResourceLoader::didReceiveData):

Canonical link: <a href="https://commits.webkit.org/305957@main">https://commits.webkit.org/305957@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5a649d5a8ba143086a50aafc7e68841714c651b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139729 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12106 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1234 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147867 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92797 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/64d1766a-6488-4215-b707-ab4ec596bace) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141602 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12814 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12257 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106995 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77886 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0cd71b68-b2a7-451c-bfc2-857501ee652d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142676 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9865 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125144 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87866 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9c1eefe7-aed3-4f32-af26-52e1a23d4878) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9528 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7035 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8156 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118747 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1140 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150649 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11790 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1196 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115399 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11804 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10096 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115716 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29441 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10481 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121632 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66795 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11834 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1104 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11574 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75512 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11770 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11621 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->