### PR TITLE
[iPadOS] duckduckgo.com, docs.google.com: typing accented characters with dead keys breaks text input

### DIFF
--- a/LayoutTests/editing/input/ios/compose-accent-with-hardware-keyboard-when-preventing-keydown-expected.txt
+++ b/LayoutTests/editing/input/ios/compose-accent-with-hardware-keyboard-when-preventing-keydown-expected.txt
@@ -1,0 +1,10 @@
+
+This test verifies that dead keys don't break text input if keydown is prevented. To manually run the test, type Option+E and then O, and verify that ó is inserted.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS input.value is "óâÿ"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/input/ios/compose-accent-with-hardware-keyboard-when-preventing-keydown.html
+++ b/LayoutTests/editing/input/ios/compose-accent-with-hardware-keyboard-when-preventing-keydown.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true useHardwareKeyboardMode=true ] -->
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+input {
+    font-size: 16px;
+}
+</style>
+</head>
+<body onload="runTest()">
+<input type="text" id="input" autocapitalize="none" autocorrect="off" spellcheck="false">
+<pre id="description"></pre>
+<pre id="console"></pre>
+<script>
+jsTestIsAsync = true;
+
+async function runTest() {
+    description("This test verifies that dead keys don't break text input if keydown is prevented. To manually run the test, type Option+E and then O, and verify that ó is inserted.");
+
+    input = document.getElementById("input");
+    input.addEventListener("keydown", event => {
+        event.preventDefault();
+    });
+
+    await UIHelper.activateElementAndWaitForInputSession(input);
+
+    for (const [deadKey, unmodifiedCharacter] of [["e", "o"], ["i", "a"], ["u", "y"]]) {
+        await UIHelper.keyDown(deadKey, ["altKey"]);
+        await UIHelper.keyDown(unmodifiedCharacter);
+        await UIHelper.ensurePresentationUpdate();
+    }
+
+    shouldBeEqualToString("input.value", "óâÿ");
+
+    input.blur();
+    await UIHelper.waitForKeyboardToHide();
+    finishJSTest();
+}
+</script>
+</body>
+</html>

--- a/Source/WTF/wtf/text/CharacterProperties.h
+++ b/Source/WTF/wtf/text/CharacterProperties.h
@@ -174,6 +174,13 @@ inline bool isCurrencySymbol(char32_t character)
     return u_charType(character) == U_CURRENCY_SYMBOL;
 }
 
+inline bool isLetterOrSymbolModifier(char32_t character)
+{
+    // Includes letter accents and diacritics.
+    auto category = u_charType(character);
+    return category == U_MODIFIER_SYMBOL || category == U_MODIFIER_LETTER;
+}
+
 } // namespace WTF
 
 using WTF::isEmojiGroupCandidate;
@@ -195,3 +202,4 @@ using WTF::isCJKSymbolOrPunctuation;
 using WTF::isFullwidthMiddleDotPunctuation;
 using WTF::isCombiningMark;
 using WTF::isCurrencySymbol;
+using WTF::isLetterOrSymbolModifier;

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -149,6 +149,7 @@
 #include <wtf/Scope.h>
 #include <wtf/SetForScope.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/text/CharacterProperties.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/ParsingUtilities.h>
 #include <wtf/unicode/CharacterNames.h>
@@ -2306,7 +2307,27 @@ void Editor::confirmComposition()
 
     if (!m_compositionNode)
         return;
-    setComposition(m_compositionNode->data().substring(m_compositionStart, m_compositionEnd - m_compositionStart), ConfirmComposition);
+    setComposition(compositionText(), ConfirmComposition);
+}
+
+String Editor::compositionText() const
+{
+    if (!m_compositionNode)
+        return { };
+
+    return protectedCompositionNode()->data().substring(m_compositionStart, m_compositionEnd - m_compositionStart);
+}
+
+bool Editor::hasDeadKeyComposition() const
+{
+    if (!m_compositionNode)
+        return false;
+
+    if (m_compositionStart + 1 != m_compositionEnd)
+        return false;
+
+    auto compositionText = this->compositionText();
+    return compositionText.length() == 1 && isLetterOrSymbolModifier(compositionText[0]);
 }
 
 void Editor::confirmOrCancelCompositionAndNotifyClient()

--- a/Source/WebCore/editing/Editor.h
+++ b/Source/WebCore/editing/Editor.h
@@ -442,6 +442,7 @@ public:
     WEBCORE_EXPORT bool cancelCompositionIfSelectionIsInvalid();
     WEBCORE_EXPORT std::optional<SimpleRange> compositionRange() const;
     WEBCORE_EXPORT bool getCompositionSelection(unsigned& selectionStart, unsigned& selectionEnd) const;
+    bool hasDeadKeyComposition() const;
 
     // getting international text input composition state (for use by LegacyInlineTextBox)
     Text* compositionNode() const { return m_compositionNode.get(); }
@@ -691,6 +692,7 @@ private:
     void selectComposition();
     enum SetCompositionMode { ConfirmComposition, CancelComposition };
     void setComposition(const String&, SetCompositionMode);
+    String compositionText() const;
 
     void changeSelectionAfterCommand(const VisibleSelection& newSelection, OptionSet<FrameSelection::SetSelectionOption>);
 

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -4301,7 +4301,8 @@ bool EventHandler::internalKeyEvent(const PlatformKeyboardEvent& initialKeyEvent
     // If frame changed as a result of keydown dispatch, then return early to avoid sending a subsequent keypress message to the new frame.
     bool changedFocusedFrame = frame->page() && frame.ptr() != frame->page()->focusController().focusedOrMainFrame();
     bool keydownResult = keydown->defaultHandled() || keydown->defaultPrevented() || changedFocusedFrame;
-    if (keydownResult && !backwardCompatibilityMode)
+    bool requiresKeyPressEvent = backwardCompatibilityMode || frame->protectedEditor()->hasDeadKeyComposition();
+    if (keydownResult && !requiresKeyPressEvent)
         return keydownResult;
 
     // Focus may have changed during keydown handling, so refetch element.


### PR DESCRIPTION
#### bca963b6a79c3e680f9766769d796daf067e1540
<pre>
[iPadOS] duckduckgo.com, docs.google.com: typing accented characters with dead keys breaks text input
<a href="https://bugs.webkit.org/show_bug.cgi?id=305578">https://bugs.webkit.org/show_bug.cgi?id=305578</a>
<a href="https://rdar.apple.com/167230597">rdar://167230597</a>

Reviewed by Abrar Rahman Protyasha.

On iOS, inserting accented characters using dead keys only sets marked text upon the initial key
press of `Option + {e|i|u}`, etc. The second character which actually inserts the dead key isn&apos;t
actually handled by system IME, but rather gets dispatched as normal text entry (but with a modified
character, like é or ü, as the input text). In contrast, on macOS, both the first and second
key presses are handled by system IME.

On websites like duckduckgo.com or docs.google.com, which call `preventDefault()` on the `keydown`
event during IME, this causes text input to be prevented when using dead keys on iOS, but not on
macOS (or in other browser engines). As a result, this breaks all text input when using a hardware
keyboard on iOS if the website prevents `keydown`, after pressing `Option` and any dead key modifier
like e, i, u, etc.

To fix this, we align the behavior of dead keys when using a hardware keyboard on iOS to other
engines (as well as macOS WebKit) by forcing the key event to be interpreted by the system in the
case where the IME range is a single modifier (e.g. &quot;´&quot;, &quot;¨&quot;, &quot;ˆ&quot;) based on the editor&apos;s active
composition range, even if the `keydown` was prevented. Note that because the `isComposing()` flag
is set, we will still avoid dispatching `keypress` in this scenario (which is consistent with macOS
as well as other browsers).

Test: editing/input/ios/compose-accent-with-hardware-keyboard-when-preventing-keydown.html

* LayoutTests/editing/input/ios/compose-accent-with-hardware-keyboard-when-preventing-keydown-expected.txt: Added.
* LayoutTests/editing/input/ios/compose-accent-with-hardware-keyboard-when-preventing-keydown.html: Added.

Add a layout test to exercise the change, by typing several different accented (or otherwise
modified) characters with a hardware keyboard.

* Source/WTF/wtf/text/CharacterProperties.h:
(WTF::isLetterOrSymbolModifier):
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::confirmComposition):
(WebCore::Editor::compositionText const):
(WebCore::Editor::hasDeadKeyComposition const):

Add a helper method to determine whether the existing IME composition range consists of a single
modifier character, inserted by a dead key.

* Source/WebCore/editing/Editor.h:
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::internalKeyEvent):

See above for more details.

Canonical link: <a href="https://commits.webkit.org/305672@main">https://commits.webkit.org/305672@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45012d4bbe84c0e0e26a5018587c3cecdabc33f5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139073 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11446 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/569 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147199 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ac0a6f48-402e-4fcd-a198-06befbddf3cc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140945 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12152 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11597 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106456 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b6a57556-7ae4-4967-b2d8-89e54f4a8547) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142020 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9182 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124576 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87324 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/445125e9-8b11-4247-a289-cbf20d482237) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8738 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6507 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7492 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/131046 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118187 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/473 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149979 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/137674 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11129 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/484 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114850 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11144 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9415 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115161 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29267 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9055 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120923 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66033 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11173 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/455 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/170344 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10909 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74831 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/44360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11112 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10961 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->