### PR TITLE
REGRESSION(293848@main): In certain circumstances, -webkit-box-shadow (and perhaps other prefixed and/or cascade-alias properties) does not transition

### DIFF
--- a/LayoutTests/fast/animation/webkit-box-shadow-inline-style-cache-expected.txt
+++ b/LayoutTests/fast/animation/webkit-box-shadow-inline-style-cache-expected.txt
@@ -1,0 +1,5 @@
+START: Testing -webkit-box-shadow
+CHECKING FOR element.getAnimations()
+1 ANIMATIONS FOUND: [object CSSTransition]
+
+

--- a/LayoutTests/fast/animation/webkit-box-shadow-inline-style-cache.html
+++ b/LayoutTests/fast/animation/webkit-box-shadow-inline-style-cache.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+  .transitioning {
+    width: 400px;
+    height: 400px;
+    background-color: red;
+    transition: all 2s;
+  }
+</style>
+</head>
+<body>
+<div id="target" class="transitioning"></div>
+<pre id="log"></pre>
+<script>
+  window.testRunner?.dumpAsText();
+
+  function log(msg) {
+    document.getElementById('log').append(new Text(msg + "\n"));
+  }
+
+  function test_property(property, start, end) {
+    try {
+      log(`START: Testing ${property}`);
+
+      var div = document.getElementById("target");
+      document.body.appendChild(div);
+
+      div.style = `${property}: ${start}`;
+
+      getComputedStyle(div).marginLeft;
+
+      div.style = `${property}: ${end}`;
+
+      log("CHECKING FOR element.getAnimations()")
+      if (div.getAnimations().length == 0)
+        log("NO ANIMATIONS FOUND");
+      else
+        log(`${div.getAnimations().length} ANIMATIONS FOUND: ${div.getAnimations()}`);
+
+      log(``)
+
+    } catch (exception) {
+      log(`EXCEPTION: ${property} -- ${exception}\n`);
+    }
+  }
+
+  window.addEventListener("load", function(event) {
+    test_property("-webkit-box-shadow", "0 0 0 rgba(0, 0, 0, 0)", "10px 5px 5px blue");
+  });
+</script>
+</body>
+</html>

--- a/Source/WebCore/style/MatchResultCache.cpp
+++ b/Source/WebCore/style/MatchResultCache.cpp
@@ -135,7 +135,7 @@ PropertyCascade::IncludedProperties MatchResultCache::computeAndUpdateChangedPro
         if (propertyID < firstLowPriorityProperty || propertyID == CSSPropertyLineHeight)
             return PropertyCascade::normalProperties();
 
-        result.ids.append(propertyID);
+        result.ids.append(cascadeAliasProperty(propertyID));
     }
 
     return result;

--- a/Source/WebCore/style/PropertyCascade.h
+++ b/Source/WebCore/style/PropertyCascade.h
@@ -63,7 +63,7 @@ public:
 
     struct IncludedProperties {
         OptionSet<PropertyType> types;
-        // Ids are mutually exclusive with types. They are low-priority only.
+        // Ids are mutually exclusive with types. They are low-priority only and have any cascade aliases resolved.
         Vector<CSSPropertyID, 4> ids { };
 
         bool isEmpty() const { return !types && ids.isEmpty(); }


### PR DESCRIPTION
#### 2885103512745ed9bd5bd1d9fde9122626921b15
<pre>
REGRESSION(293848@main): In certain circumstances, -webkit-box-shadow (and perhaps other prefixed and/or cascade-alias properties) does not transition
<a href="https://bugs.webkit.org/show_bug.cgi?id=304347">https://bugs.webkit.org/show_bug.cgi?id=304347</a>
<a href="https://rdar.apple.com/167144768">rdar://167144768</a>

Reviewed by Alan Baradlay.

Cascade aliases like -webkit-box-shadow did not work correctly with inline match result cache.

Test: fast/animation/webkit-box-shadow-inline-style-cache.html
* LayoutTests/fast/animation/webkit-box-shadow-inline-style-cache-expected.txt: Added.
* LayoutTests/fast/animation/webkit-box-shadow-inline-style-cache.html: Added.
* Source/WebCore/style/MatchResultCache.cpp:

We need to resolve cascade alias properties in IncludedProperties.

(WebCore::Style::MatchResultCache::computeAndUpdateChangedProperties):
* Source/WebCore/style/PropertyCascade.h:

Canonical link: <a href="https://commits.webkit.org/305660@main">https://commits.webkit.org/305660@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c41b9e1e6a152fa5ef342c6df6f71faa9b4fd1b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139069 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11442 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/565 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147195 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/41f693f4-321b-4ace-9da8-9e3f0f1ac08e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140941 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12147 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11593 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/106454 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ccc041d4-e861-411f-b8bb-7e938db2aa43) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142016 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9173 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/124577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87322 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a96d3c3f-3876-4208-b4fc-88550dc855eb) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/8729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/6504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7488 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/118178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149975 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11125 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/114849 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11140 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9412 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115160 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29257 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9051 "Passed tests") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/120924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/66029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11169 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10905 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74827 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11108 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10957 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->