### PR TITLE
[macOS] Extraneous focus event makes TestWebKitAPI.WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginAndEndEditingEventsInReadOnlyField flaky

### DIFF
--- a/LayoutTests/fast/forms/focus-option-control-on-page.html
+++ b/LayoutTests/fast/forms/focus-option-control-on-page.html
@@ -1,6 +1,7 @@
 <!DOCTYPE HTML>
 <html>
 <head>
+<script src="../../resources/ui-helper.js"></script>
 <script src="../../resources/js-test-pre.js"></script>
 </head>
 <body onload="onLoad()">
@@ -15,13 +16,15 @@ description('https://bugs.webkit.org/show_bug.cgi?id=68412 - This test checks to
 var iteration = 0;
 var modifiers;
 var result;
-function startTest() {
+async function startTest() {
     debug("Pressing tab 4 times:");
     modifiers = undefined;
     testRunner.focusWebView(runKeyPresses);
 }
 
-function runKeyPresses() {
+async function runKeyPresses() {
+    await UIHelper.ensurePresentationUpdate();
+
     result = '';
     for (var i = 0; i < 4; ++i) {
         result += ' /' + (i + 1) + ':';

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -6599,7 +6599,8 @@ bool Document::setFocusedElement(Element* newFocusedElement, const FocusOptions&
             }
 
             // Dispatch the blur event and let the node do any other blur related activities (important for text fields)
-            oldFocusedElement->dispatchBlurEvent(newFocusedElement);
+            if (RefPtr page = this->page(); page && page->focusController().isFocused())
+                oldFocusedElement->dispatchBlurEvent(newFocusedElement);
 
             if (m_focusedElement) {
                 // handler shifted focus
@@ -6679,7 +6680,8 @@ bool Document::setFocusedElement(Element* newFocusedElement, const FocusOptions&
         }
 
         // Dispatch the focus event and let the node do any other focus related activities (important for text fields)
-        focusedElement->dispatchFocusEvent(oldFocusedElement.copyRef(), options);
+        if (RefPtr page = this->page(); page && page->focusController().isFocused())
+            focusedElement->dispatchFocusEvent(oldFocusedElement.copyRef(), options);
 
         if (m_focusedElement != focusedElement) {
             // handler shifted focus

--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.h
@@ -110,6 +110,7 @@ class Color;
 - (void)moveSelectionToEndOfParagraph;
 - (void)extendSelectionToEndOfParagraph;
 - (void)insertTextSuggestion:(UITextSuggestion *)textSuggestion;
+- (void)focusInWindow;
 #if HAVE(UI_WK_DOCUMENT_CONTEXT)
 - (UIWKDocumentContext *)synchronouslyRequestDocumentContext:(UIWKDocumentRequest *)request;
 #endif

--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.mm
@@ -300,6 +300,12 @@ static NSString *overrideBundleIdentifier(id, SEL)
     [self.textInputContentView insertTextSuggestion:textSuggestion];
 }
 
+- (void)focusInWindow
+{
+    [[self window] makeKeyWindow];
+    [self becomeFirstResponder];
+}
+
 #if HAVE(UI_WK_DOCUMENT_CONTEXT)
 
 - (UIWKDocumentContext *)synchronouslyRequestDocumentContext:(UIWKDocumentRequest *)request
@@ -1490,6 +1496,12 @@ static UIWindowScene *windowScene()
 
 - (void)evaluateJavaScriptAndWaitForInputSessionToChange:(NSString *)script inFrame:(WKFrameInfo *)frame
 {
+#if PLATFORM(IOS_FAMILY)
+    [[self window] makeKeyWindow];
+    [[self textInputContentView] becomeFirstResponder];
+    [self waitForNextPresentationUpdate];
+#endif
+
     auto initialChangeCount = _inputSessionChangeCount;
     BOOL hasEmittedWarning = NO;
     NSTimeInterval secondsToWaitUntilWarning = 2;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/BundleFormDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/BundleFormDelegate.mm
@@ -32,6 +32,7 @@
 #import "Helpers/PlatformUtilities.h"
 #import "Helpers/Test.h"
 #import "Helpers/cocoa/TestNavigationDelegate.h"
+#import "Helpers/cocoa/TestWKWebView.h"
 #import "Helpers/cocoa/WKWebViewConfigurationExtras.h"
 #import <WebKit/WKProcessPoolPrivate.h>
 #import <WebKit/WKWebViewPrivate.h>
@@ -81,7 +82,7 @@ TEST(WebKit, WKWebProcessPlugInWithoutRegisteredCustomClass)
     auto configuration = retainPtr([WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"BundleFormDelegatePlugIn"]);
     [[configuration processPool] _setObject:@YES forBundleParameter:@"FormDelegateShouldAddCustomClass"];
 
-    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView _setInputDelegate:delegate.get()];
     [webView loadHTMLString:@"<input></input><select><option selected>foo</option><option>bar</option></select>" baseURL:nil];
     [webView _test_waitForDidFinishNavigation];
@@ -90,6 +91,10 @@ TEST(WebKit, WKWebProcessPlugInWithoutRegisteredCustomClass)
     _WKRemoteObjectInterface *interface = [_WKRemoteObjectInterface remoteObjectInterfaceWithProtocol:@protocol(BundleFormDelegateProtocol)];
     [[webView _remoteObjectRegistry] registerExportedObject:object.get() interface:interface];
 
+#if PLATFORM(IOS_FAMILY)
+    [webView focusInWindow];
+    [webView waitForNextPresentationUpdate];
+#endif
     [webView evaluateJavaScript:@"document.querySelector('input').focus()" completionHandler:nil];
 
     userObject = nil;
@@ -111,7 +116,7 @@ TEST(WebKit, WKWebProcessPlugInWithRegisteredCustomClass)
         configureJSCForTesting:NO]);
     [[configuration processPool] _setObject:@YES forBundleParameter:@"FormDelegateShouldAddCustomClass"];
 
-    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView _setInputDelegate:delegate.get()];
     [webView loadHTMLString:@"<input></input><select><option selected>foo</option><option>bar</option></select>" baseURL:nil];
     [webView _test_waitForDidFinishNavigation];
@@ -120,6 +125,10 @@ TEST(WebKit, WKWebProcessPlugInWithRegisteredCustomClass)
     _WKRemoteObjectInterface *interface = [_WKRemoteObjectInterface remoteObjectInterfaceWithProtocol:@protocol(BundleFormDelegateProtocol)];
     [[webView _remoteObjectRegistry] registerExportedObject:object.get() interface:interface];
 
+#if PLATFORM(IOS_FAMILY)
+    [webView focusInWindow];
+    [webView waitForNextPresentationUpdate];
+#endif
     [webView evaluateJavaScript:@"document.querySelector('input').focus()" completionHandler:nil];
     
     userObject = nil;
@@ -139,7 +148,7 @@ TEST(WebKit, WKWebProcessPlugInWithUnregisteredCustomClass)
         configureJSCForTesting:NO]);
     [[configuration processPool] _setObject:@YES forBundleParameter:@"FormDelegateShouldAddCustomClass"];
 
-    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView _setInputDelegate:delegate.get()];
     [webView loadHTMLString:@"<input></input><select><option selected>foo</option><option>bar</option></select>" baseURL:nil];
     [webView _test_waitForDidFinishNavigation];
@@ -148,6 +157,10 @@ TEST(WebKit, WKWebProcessPlugInWithUnregisteredCustomClass)
     _WKRemoteObjectInterface *interface = [_WKRemoteObjectInterface remoteObjectInterfaceWithProtocol:@protocol(BundleFormDelegateProtocol)];
     [[webView _remoteObjectRegistry] registerExportedObject:object.get() interface:interface];
 
+#if PLATFORM(IOS_FAMILY)
+    [webView focusInWindow];
+    [webView waitForNextPresentationUpdate];
+#endif
     [webView evaluateJavaScript:@"document.querySelector('input').focus()" completionHandler:nil];
 
     userObject = nil;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FindInPage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FindInPage.mm
@@ -839,6 +839,10 @@ TEST(WebKit, ScrollToFoundRangeDoesNotFocusElement)
     }];
     [webView _setInputDelegate:inputDelegate.get()];
 
+#if PLATFORM(IOS_FAMILY)
+    [webView focusInWindow];
+    [webView waitForNextPresentationUpdate];
+#endif
     [webView evaluateJavaScript:@"document.getElementById('input').focus()" completionHandler:nil];
     TestWebKitAPI::Util::run(&inputFocused);
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FocusWebView.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FocusWebView.mm
@@ -370,6 +370,50 @@ TEST(FocusWebView, DoNotFocusWebViewWhenUnparented)
     EXPECT_FALSE(calledFocusWebView);
 }
 
+TEST(FocusWebView, NoFocusEventsForBackgroundWindow)
+{
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+
+    NSString *html = @"<!DOCTYPE html>"
+        "<html>"
+        "<body>"
+        "<input id='input' type='text'>"
+        "<script>"
+        "let focusEventCount = 0;"
+        "input.addEventListener('focus', () => {"
+        "    focusEventCount++;"
+        "});"
+        "function getFocusEventCount() { return focusEventCount; }"
+        "</script>"
+        "</body>"
+        "</html>";
+    [webView synchronouslyLoadHTMLString:html];
+
+    [[webView window] resignKeyWindow];
+    [webView objectByEvaluatingJavaScript:@"input.focus()"];
+    [[webView window] makeKeyWindow];
+#if PLATFORM(IOS_FAMILY)
+    // iOS requires that the window manually be made first responder to be focused.
+    [webView becomeFirstResponder];
+#endif
+    [webView waitForNextPresentationUpdate];
+
+#if PLATFORM(MAC)
+    // FIXME: rdar://168467484 (Blur and Focus events should only be dispatched if the window is both active and focused.)
+    // Expected count is 1, not 2. On Mac, input.focus() flips IsFocused before the window is active (via
+    // Widget::setFocus → MakeFirstResponder), causing an extra dispatch. iOS's Widget::setFocus is a no-op.
+    // This extra focus event on Mac will be correctly suppressed with rdar://168467484.
+    int expectedFocusEventCount = 2;
+#else
+    int expectedFocusEventCount = 1;
+#endif
+
+    NSNumber *focusEventCount = [webView objectByEvaluatingJavaScript:@"getFocusEventCount()"];
+    EXPECT_EQ([focusEventCount intValue], expectedFocusEventCount);
+}
+
+
 class CrossOriginIframeRelinquishToChromeTests : public ::testing::TestWithParam<bool> {
 public:
     bool siteIsolationEnabled() const { return GetParam(); }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -77,6 +77,12 @@
 #import <MobileCoreServices/MobileCoreServices.h>
 #endif
 
+#if PLATFORM(MAC)
+@interface NSApplication ()
+- (void)_setKeyWindow:(NSWindow *)newKeyWindow;
+@end
+#endif
+
 #if ENABLE(IMAGE_ANALYSIS)
 #import "Helpers/cocoa/ImageAnalysisTestingUtilities.h"
 #import <pal/spi/cocoa/VisionKitCoreSPI.h>
@@ -7489,8 +7495,12 @@ TEST(SiteIsolation, AdvanceFocusAcrossFrames)
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
     [navigationDelegate waitForDidFinishNavigation];
 
+    [[webView window] makeKeyWindow];
+    [NSApp _setKeyWindow:[webView window]];
+    [[webView window] makeFirstResponder:webView.get()];
+    [webView waitForNextPresentationUpdate];
+
     NSArray *expectedMessages = @[
-        @"main - focus div1",
         @"main - focus div1",
         @"main - focus div2",
         @"iframe - focus div1",
@@ -7503,10 +7513,7 @@ TEST(SiteIsolation, AdvanceFocusAcrossFrames)
     Util::run(&messageReceived);
     EXPECT_TRUE([mostRecentMessage isEqualToString:expectedMessages[currentExpected++]]);
     messageReceived = false;
-    Util::run(&messageReceived);
-    EXPECT_TRUE([mostRecentMessage isEqualToString:expectedMessages[currentExpected++]]);
 
-    messageReceived = false;
     [webView typeCharacter:'\t'];
     Util::run(&messageReceived);
     EXPECT_TRUE([mostRecentMessage isEqualToString:expectedMessages[currentExpected++]]);
@@ -8246,6 +8253,7 @@ TEST(SiteIsolation, SelectMultiplePickerLocationInCrossOriginIframe)
     [navigationDelegate waitForDidFinishNavigation];
     [webView waitForNextPresentationUpdate];
 
+    [webView focusInWindow];
     [webView evaluateJavaScript:@"document.querySelector('select').focus()" inFrame:[webView firstChildFrame] completionHandler:nil];
 
     Util::run(&pickerPresented);
@@ -9244,6 +9252,7 @@ TEST(SiteIsolation, NoRedundantFocusPolicyCallbackAfterBlurAndRefocusInCrossOrig
 
     // Focus the input in the cross-origin iframe. Use WithUserGesture because Element::focus()
     // is a no-op for cross-origin non-main-frame iframes without a user gesture.
+    [webView focusInWindow];
     [webView objectByEvaluatingJavaScriptWithUserGesture:@"document.getElementById('input').focus()" inFrame:[webView firstChildFrame]];
     Util::run(&didFocusPolicy);
     EXPECT_EQ(1, focusPolicyCallCount);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UserContentController.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UserContentController.mm
@@ -1392,6 +1392,10 @@ TEST(WKUserContentController, BeforeBlurEvent)
         "shadowRoot.querySelector('#text1').focus();"
         "</script>"];
 
+#if PLATFORM(IOS_FAMILY)
+    [webView focusInWindow];
+    [webView waitForNextPresentationUpdate];
+#endif
     [webView evaluateJavaScript:@"shadowRoot.querySelector('#text2').focus()" completionHandler:nil];
     EXPECT_WK_STREQ([webView _test_waitForAlert], "blur-pass");
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKContentViewEditingActions.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKContentViewEditingActions.mm
@@ -147,6 +147,9 @@ TEST(WebKit, CaptureTextFromCamera)
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [webView _setInputDelegate:inputDelegate.get()];
 
+#if PLATFORM(IOS_FAMILY)
+    [webView focusInWindow];
+#endif
     [webView synchronouslyLoadHTMLString:@"<input style='display: block; font-size: 100px;' value='foo' autofocus><input value='bar' readonly>"];
     [webView waitForNextPresentationUpdate];
     EXPECT_EQ([webView targetForAction:@selector(captureTextFromCamera:) withSender:nil], [webView textInputContentView]);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewFirstResponderTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewFirstResponderTests.mm
@@ -47,6 +47,8 @@
     if (!(self = [super initWithFrame:frame]))
         return nil;
 
+    [self focusInWindow];
+
     bool doneFocusing = false;
     _inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     [_inputDelegate setFocusStartsInputSessionPolicyHandler:[&] (WKWebView *, id <_WKFocusedElementInfo>) {

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WritingSuggestions.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WritingSuggestions.mm
@@ -70,6 +70,11 @@
 
 - (void)focusElementAndEnsureEditorStateUpdate:(NSString *)element
 {
+#if PLATFORM(IOS_FAMILY)
+    [[self window] makeKeyWindow];
+    [self waitForNextPresentationUpdate];
+#endif
+
     NSString *script = [NSString stringWithFormat:@"%@.focus()", element];
     [self evaluateJavaScriptAndWaitForInputSessionToChange:script];
     [self waitForNextPresentationUpdate];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/_WKInputDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/_WKInputDelegate.mm
@@ -187,6 +187,8 @@ TEST(WebKit, FocusedElementInfo)
     RetainPtr delegate = adoptNS([[InputDelegate alloc] init]);
     [webView _setInputDelegate:delegate.get()];
 
+    [webView focusInWindow];
+
     __block RetainPtr<id <_WKFocusedElementInfo>> currentElement;
     [delegate setShouldStartInputSessionHandler:^BOOL(id<_WKFocusedElementInfo> element) {
         currentElement = element;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/_WKWebAuthenticationPanel.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/_WKWebAuthenticationPanel.mm
@@ -578,10 +578,14 @@ TEST(WebAuthenticationPanel, PanelTwice)
     auto webView = setUpTestWebViewForTestAuthenticationPanel();
     RetainPtr delegate = adoptNS([[TestWebAuthenticationPanelUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
+#if PLATFORM(IOS_FAMILY)
+    [webView focusInWindow];
+#endif
     [webView focus];
 
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
     Util::run(&webAuthenticationPanelRan);
+    [webView waitForMessage:@"Succeeded!"];
     Util::run(&webAuthenticationPanelSucceded);
 
     reset();

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/AutocorrectionTestsIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/AutocorrectionTestsIOS.mm
@@ -73,6 +73,7 @@ TEST(AutocorrectionTests, FontAtCaretWhenUsingUICTFontTextStyle)
 
     [webView _setInputDelegate:inputDelegate.get()];
     [webView _setEditable:YES];
+    [webView focusInWindow];
     [webView synchronouslyLoadHTMLString:@"<meta name='viewport' content='width=device-width, initial-scale=1'>"
         "<body style='font-size: 16px; font-family: UICTFontTextStyleBody; font-weight: bold;'>"
         "<em>Wulk</em>"
@@ -139,6 +140,9 @@ TEST(AutocorrectionTests, AutocorrectionContextDoesNotIncludeNewlineInTextField)
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568)]);
     [webView synchronouslyLoadTestPageNamed:@"autofocused-text-input"];
 
+    [webView focusInWindow];
+    [webView waitForNextPresentationUpdate];
+
     auto contextBeforeTyping = [webView autocorrectionContext];
     EXPECT_TRUE(contextBeforeTyping.contextBeforeSelection.isEmpty());
     EXPECT_TRUE(contextBeforeTyping.selectedText.isEmpty());
@@ -163,6 +167,7 @@ TEST(AutocorrectionTests, MultiWordAutocorrectionFromStartOfText)
         return _WKFocusStartsInputSessionPolicyAllow;
     }];
     [webView _setInputDelegate:inputDelegate.get()];
+    [webView focusInWindow];
     [webView synchronouslyLoadHTMLString:@"<input id='input' value='Helol wordl'></input>"];
     [webView objectByEvaluatingJavaScript:@"input.focus(); input.setSelectionRange(0, 0)"];
     TestWebKitAPI::Util::run(&startedInputSession);
@@ -187,6 +192,7 @@ TEST(AutocorrectionTests, DoNotLearnCorrectionsAfterChangingInputTypeFromPasswor
         return _WKFocusStartsInputSessionPolicyAllow;
     }];
     [webView _setInputDelegate:inputDelegate.get()];
+    [webView focusInWindow];
     [webView synchronouslyLoadHTMLString:@"<input id='first' type='password'></input><input id='second'></input>"];
     [webView stringByEvaluatingJavaScript:@"let first = document.querySelector('#first'); first.type = 'text'; first.focus();"];
     TestWebKitAPI::Util::run(&startedInputSession);
@@ -302,6 +308,9 @@ TEST(AutocorrectionTests, AutocorrectionContextBeforeAndAfterEditing)
 
     [webView _setInputDelegate:inputDelegate.get()];
     [webView synchronouslyLoadTestPageNamed:@"autofocused-text-input"];
+
+    [webView focusInWindow];
+    [webView waitForNextPresentationUpdate];
 
     auto *contentView = [webView textInputContentView];
     auto contextBeforeInsertingText = [webView autocorrectionContext];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/FocusPreservationTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/FocusPreservationTests.mm
@@ -61,6 +61,7 @@ TEST(FocusPreservationTests, PreserveAndRestoreFocus)
     });
 
     TestWKWebView *webView = webViewAndDelegate.first.get();
+    [webView focusInWindow];
     [webView evaluateJavaScript:@"document.querySelector('input').focus()" completionHandler:nil];
     Util::run(&inputFocused);
 
@@ -85,6 +86,7 @@ TEST(FocusPreservationTests, UserCanDismissInputViewRegardlessOfFocusPreservatio
         inputFocused = true;
     });
 
+    [webView focusInWindow];
     [webView evaluateJavaScript:@"document.querySelector('input').focus()" completionHandler:nil];
     Util::run(&inputFocused);
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/KeyboardInputTestsIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/KeyboardInputTestsIOS.mm
@@ -251,6 +251,8 @@ static RetainPtr<TestWKWebView> webViewWithAutofocusedInput(const RetainPtr<Test
 {
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
 
+    [webView focusInWindow];
+
     __block bool doneWaiting = false;
     [inputDelegate setFocusStartsInputSessionPolicyHandler:^_WKFocusStartsInputSessionPolicy(WKWebView *, id <_WKFocusedElementInfo>) {
         doneWaiting = true;
@@ -808,6 +810,7 @@ TEST(KeyboardInputTests, TestWebViewAdditionalContextForNonAutofillCredentialTyp
 TEST(KeyboardInputTests, AsyncFocusRequiresStrongPasswordAssistanceAfterBlurNoStartSession)
 {
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    [webView focusInWindow];
     RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
 
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[&] (WKWebView *, id<_WKFocusedElementInfo>) -> _WKFocusStartsInputSessionPolicy {
@@ -951,6 +954,7 @@ TEST(KeyboardInputTests, DoNotRegisterActionsInOverriddenUndoManager)
 TEST(KeyboardInputTests, NewUndoGroupClosesPreviousTypingCommand)
 {
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
+    [webView focusInWindow];
     RetainPtr inputDelegate = adoptNS([TestInputDelegate new]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[](WKWebView *, id<_WKFocusedElementInfo>) {
         return _WKFocusStartsInputSessionPolicyAllow;
@@ -1022,6 +1026,7 @@ TEST(KeyboardInputTests, EditableWebViewRequiresKeyboardWhenFirstResponder)
     ClassMethodSwizzler hardwareKeyboardModeSwizzler { UIKeyboard.class, @selector(isInHardwareKeyboardMode), returnNo };
 
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    [webView focusInWindow];
     RetainPtr delegate = adoptNS([TestInputDelegate new]);
     [webView _setInputDelegate:delegate.get()];
     [delegate setFocusStartsInputSessionPolicyHandler:[](WKWebView *, id <_WKFocusedElementInfo>) {
@@ -1159,6 +1164,7 @@ TEST(KeyboardInputTests, NoCrashWithEmptyAttributedMarkedText)
 TEST(KeyboardInputTests, CharactersAroundCaretSelection)
 {
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    [webView focusInWindow];
     RetainPtr delegate = adoptNS([TestInputDelegate new]);
     [webView _setInputDelegate:delegate.get()];
 
@@ -1257,6 +1263,7 @@ TEST(KeyboardInputTests, MarkedTextSegmentsWithUnderlines)
 TEST(KeyboardInputTests, HasTextAfterFocusingTextField)
 {
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 600)]);
+    [webView focusInWindow];
 
     enum class HasText : bool { No, Yes };
     __block Vector<std::pair<WKInputType, HasText>, 3> results;
@@ -1389,6 +1396,7 @@ TEST(KeyboardInputTests, AutocorrectionIndicatorColorNotAffectedByAuthorDefinedA
 TEST(KeyboardInputTests, SetConversationContext)
 {
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
+    [webView focusInWindow];
     RetainPtr conversationContext = adoptNS([UIMailConversationContext new]);
     [webView setConversationContext:conversationContext.get()];
 
@@ -1438,6 +1446,7 @@ TEST(KeyboardInputTests, DeviceEIDAndIMEIAutoFill)
     [WKWebView _setApplicationBundleIdentifier:@"org.webkit.SomeTelephonyApp"];
 
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    [webView focusInWindow];
     RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     RetainPtr inputDelegate = adoptNS([TestInputDelegate new]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[](WKWebView *, id<_WKFocusedElementInfo>) {

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/ModalDialogDuringOverlappingFocus.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/ModalDialogDuringOverlappingFocus.mm
@@ -59,6 +59,7 @@ TEST(ModalDialogDuringOverlappingFocus, AlertNotDeferredAfterFIFOAsyncFocusCompl
     }];
 
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    [webView focusInWindow];
     [webView _setInputDelegate:inputDelegate.get()];
 
     __block bool alertDelivered = false;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/ScrollViewScrollabilityTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/ScrollViewScrollabilityTests.mm
@@ -52,6 +52,8 @@ static RetainPtr<TestWKWebView> webViewWithAutofocusedInput(const RetainPtr<Test
         return _WKFocusStartsInputSessionPolicyAllow;
     }];
     [webView _setInputDelegate:inputDelegate.get()];
+    [webView focusInWindow];
+    [webView waitForNextPresentationUpdate];
     [webView synchronouslyLoadHTMLString:nonScrollableWithInputDocumentMarkup];
 
     TestWebKitAPI::Util::run(&doneWaiting);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/SelectionModifyByParagraphBoundary.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/SelectionModifyByParagraphBoundary.mm
@@ -45,6 +45,7 @@ TEST(SelectionTests, ModifyByParagraphBoundary)
 
     [webView _setInputDelegate:inputDelegate.get()];
     [webView _setEditable:YES];
+    [webView focusInWindow];
     [webView synchronouslyLoadHTMLString:@"<meta name='viewport' content='width=device-width, initial-scale=1'><body contenteditable>hello<div id='blankLine'><br></div><div id='lastLine'>world</div></body>"];
     [webView evaluateJavaScriptAndWaitForInputSessionToChange:@"document.body.focus()"];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/UIWKInteractionViewProtocol.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/UIWKInteractionViewProtocol.mm
@@ -189,12 +189,16 @@ TEST(UIWKInteractionViewProtocol, SelectPositionAtPointInFocusedElementStartsInp
 
     // 1. Focus element
     [webView synchronouslyLoadHTMLString:@"<body style='margin: 0; padding: 0'><div contenteditable='true' style='height: 200px; width: 200px'></div></body>"];
+    [webView focusInWindow];
     [webView stringByEvaluatingJavaScript:@"document.querySelector('div').focus()"];
     TestWebKitAPI::Util::run(&didCallDecidePolicyForFocusedElement);
 
     // 2. Focus the element again via selecting a position at a point inside it.
     didCallDecidePolicyForFocusedElement = false;
-    [webView becomeFirstResponder];
+
+    // Resign first so that the next focusInWindow will re-fire the focus event that induces DecidePolicyForFocusedElement.
+    [webView resignFirstResponder];
+    [webView focusInWindow];
     [webView selectPositionAtPoint:CGPointMake(8, 8)];
     TestWebKitAPI::Util::run(&didCallDecidePolicyForFocusedElement);
 }
@@ -233,6 +237,7 @@ static std::pair<RetainPtr<TestWKWebView>, RetainPtr<TestInputDelegate>> setUpEd
     }];
 
     [webView synchronouslyLoadTestPageNamed:@"editable-responsive-body"];
+    [webView focusInWindow];
     TestWebKitAPI::Util::run(&didStartInputSession);
     return { WTF::move(webView), WTF::move(inputDelegate) };
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/WKWebViewAutofillTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/WKWebViewAutofillTests.mm
@@ -265,6 +265,7 @@ TEST(WKWebViewAutoFillTests, AutoFillRequiresInputSession)
         done = true;
         return _WKFocusStartsInputSessionPolicyAuto;
     }];
+    [webView focusInWindow];
     [webView synchronouslyLoadHTMLString:@"<input id='user' type='email'><input id='password' type='password'>"];
     [webView stringByEvaluatingJavaScript:@"user.focus()"];
     Util::run(&done);
@@ -290,6 +291,7 @@ TEST(WKWebViewAutoFillTests, AutoFillPreservesTextSuggestion)
         EXPECT_EQ(customSuggestion.get(), suggestion);
         insertedSuggestion = true;
     }];
+    [webView focusInWindow];
     [webView synchronouslyLoadHTMLString:@"<input id='user' type='email'>"];
     [webView stringByEvaluatingJavaScript:@"user.focus()"];
     Util::run(&doneFocusing);

--- a/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/DateTimeInputsAccessoryViewTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/DateTimeInputsAccessoryViewTests.mm
@@ -34,6 +34,7 @@ IGNORE_WARNINGS_BEGIN("deprecated-implementations")
 #import "Helpers/PlatformUtilities.h"
 #import "UIKitSPIForTesting.h"
 #import "Helpers/ios/UserInterfaceSwizzler.h"
+#import <WebKit/WebViewPrivate.h>
 #import <wtf/RetainPtr.h>
 
 @interface DateTimeInputsTestsLoadingDelegate : NSObject <UIWebViewDelegate>
@@ -74,6 +75,9 @@ static void runTestWithInputType(NSString *type)
     [uiWebView loadHTMLString:elementString baseURL:nil];
     TestWebKitAPI::Util::run(&didFinishLoad);
 
+    [uiWindow makeKeyWindow];
+    [uiWebView becomeFirstResponder];
+    [[uiWebView _browserView] becomeFirstResponder];
     [uiWebView stringByEvaluatingJavaScriptFromString:@"document.getElementsByTagName('input')[0].focus();"];
     EXPECT_TRUE([[[uiWebView _browserView] inputView] isKindOfClass:[UIDatePicker class]]);
 }


### PR DESCRIPTION
#### 2c871431bb18397f559c8dcfa3488e7e80609965
<pre>
[macOS] Extraneous focus event makes TestWebKitAPI.WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginAndEndEditingEventsInReadOnlyField flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=304029">https://bugs.webkit.org/show_bug.cgi?id=304029</a>
<a href="https://rdar.apple.com/166329314">rdar://166329314</a>

Reviewed by Wenson Hsieh.

We shouldn&apos;t dispatch blur or focus events from Javascript when the window is in the background.
The events should only be dispatched when the page&apos;s focus controller indicates the window is focused.

Tests: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/BundleFormDelegate.mm
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FindInPage.mm
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FocusWebView.mm
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UserContentController.mm
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKContentViewEditingActions.mm
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewFirstResponderTests.mm
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WritingSuggestions.mm
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WritingTools.mm
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/_WKInputDelegate.mm
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/_WKWebAuthenticationPanel.mm
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/AutocorrectionTestsIOS.mm
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/FocusPreservationTests.mm
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/KeyboardInputTestsIOS.mm
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/ModalDialogDuringOverlappingFocus.mm
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/ScrollViewScrollabilityTests.mm
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/SelectionModifyByParagraphBoundary.mm
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/UIWKInteractionViewProtocol.mm
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/WKWebViewAutofillTests.mm
       Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/DateTimeInputsAccessoryViewTests.mm

* LayoutTests/fast/forms/focus-option-control-on-page.html:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setFocusedElement):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _setFocused:]):
* Source/WebKitLegacy/mac/WebView/WebViewPrivate.h:
* Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.h:
* Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.mm:
(-[TestWKWebView evaluateJavaScriptAndWaitForInputSessionToChange:inFrame:]):
(-[TestWKWebView focusInWindow]):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/BundleFormDelegate.mm:
(TEST(WebKit, WKWebProcessPlugInWithoutRegisteredCustomClass)):
(TEST(WebKit, WKWebProcessPlugInWithRegisteredCustomClass)):
(TEST(WebKit, WKWebProcessPlugInWithUnregisteredCustomClass)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FindInPage.mm:
(TEST(WebKit, ScrollToFoundRangeDoesNotFocusElement)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FocusWebView.mm:
(TestWebKitAPI::NoFocusEventsForBackgroundWindow)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, AdvanceFocusAcrossFrames)):
(TestWebKitAPI::(SiteIsolation, SelectMultiplePickerLocationInCrossOriginIframe)):
(TestWebKitAPI::(SiteIsolation, NoRedundantFocusPolicyCallbackAfterBlurAndRefocusInCrossOriginIframe)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UserContentController.mm:
(TEST(WKUserContentController, BeforeBlurEvent)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKContentViewEditingActions.mm:
(TEST(WebKit, CaptureTextFromCamera)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewFirstResponderTests.mm:
(-[FirstResponderTestingView initWithFrame:]):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WritingSuggestions.mm:
(-[WritingSuggestionsWebAPIWKWebView focusElementAndEnsureEditorStateUpdate:]):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WritingTools.mm:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/_WKInputDelegate.mm:
(TEST(WebKit, FocusedElementInfo)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/_WKWebAuthenticationPanel.mm:
(TestWebKitAPI::TEST(WebAuthenticationPanel, PanelTwice)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/AutocorrectionTestsIOS.mm:
(TEST(AutocorrectionTests, FontAtCaretWhenUsingUICTFontTextStyle)):
(TEST(AutocorrectionTests, AutocorrectionContextDoesNotIncludeNewlineInTextField)):
(TEST(AutocorrectionTests, MultiWordAutocorrectionFromStartOfText)):
(TEST(AutocorrectionTests, DoNotLearnCorrectionsAfterChangingInputTypeFromPassword)):
(TEST(AutocorrectionTests, AutocorrectionContextBeforeAndAfterEditing)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/FocusPreservationTests.mm:
(TestWebKitAPI::TEST(FocusPreservationTests, PreserveAndRestoreFocus)):
(TestWebKitAPI::TEST(FocusPreservationTests, UserCanDismissInputViewRegardlessOfFocusPreservationCount)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/KeyboardInputTestsIOS.mm:
(webViewWithAutofocusedInput):
(TestWebKitAPI::TEST(KeyboardInputTests, AsyncFocusRequiresStrongPasswordAssistanceAfterBlurNoStartSession)):
(TestWebKitAPI::TEST(KeyboardInputTests, NewUndoGroupClosesPreviousTypingCommand)):
(TestWebKitAPI::TEST(KeyboardInputTests, EditableWebViewRequiresKeyboardWhenFirstResponder)):
(TestWebKitAPI::TEST(KeyboardInputTests, CharactersAroundCaretSelection)):
(TestWebKitAPI::TEST(KeyboardInputTests, HasTextAfterFocusingTextField)):
(TestWebKitAPI::TEST(KeyboardInputTests, SetConversationContext)):
(TestWebKitAPI::TEST(KeyboardInputTests, DeviceEIDAndIMEIAutoFill)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/ModalDialogDuringOverlappingFocus.mm:
(TestWebKitAPI::TEST(ModalDialogDuringOverlappingFocus, AlertNotDeferredAfterFIFOAsyncFocusCompletions)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/ScrollViewScrollabilityTests.mm:
(TestWebKitAPI::webViewWithAutofocusedInput):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/SelectionModifyByParagraphBoundary.mm:
(TEST(SelectionTests, ModifyByParagraphBoundary)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/UIWKInteractionViewProtocol.mm:
(TestWebKitAPI::TEST(UIWKInteractionViewProtocol, SelectPositionAtPointInFocusedElementStartsInputSession)):
(TestWebKitAPI::setUpEditableWebViewAndWaitForInputSession):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/WKWebViewAutofillTests.mm:
(TestWebKitAPI::TEST(WKWebViewAutoFillTests, AutoFillRequiresInputSession)):
(TestWebKitAPI::TEST(WKWebViewAutoFillTests, AutoFillPreservesTextSuggestion)):
* Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/DateTimeInputsAccessoryViewTests.mm:
(runTestWithInputType):

Canonical link: <a href="https://commits.webkit.org/315736@main">https://commits.webkit.org/315736@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f4d9142c1eb17b14dfbf7e52592105c85af516e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169687 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43609 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36974 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179046 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127399 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171553 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/45170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43238 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132234 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93147 "1 flakes 14 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172646 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152612 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112737 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/33974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32370 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27743 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32011 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181645 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34353 "Found 1 new failure in page/Navigation.cpp") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36536 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140681 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43265 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152082 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140516 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43954 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28991 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108203 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25889 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35783 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115719 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42464 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7084 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41857 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42112 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42000 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->