### PR TITLE
[Unified PDF] [iOS] Reintroduce shadows under the page background layer

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.cpp
@@ -1146,6 +1146,15 @@ TextStream& operator<<(TextStream& ts, const GraphicsLayer::CustomAppearance& cu
     return ts;
 }
 
+void GraphicsLayer::setShadowPath(const Path& path)
+{
+#if USE(CA)
+    m_shadowPath = path;
+#else
+    UNUSED_PARAM(path);
+#endif
+}
+
 String GraphicsLayer::layerTreeAsText(OptionSet<LayerTreeAsTextOptions> options, uint32_t baseIndent) const
 {
     TextStream ts(TextStream::LineMode::MultipleLine, TextStream::Formatting::SVGStyleRect);

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -550,6 +550,8 @@ public:
     virtual void purgeFrontBufferForTesting() { }
     virtual void purgeBackBufferForTesting() { }
 
+    virtual void setShadowPath(const Path&);
+
 protected:
     WEBCORE_EXPORT explicit GraphicsLayer(Type, GraphicsLayerClient&);
 
@@ -696,6 +698,7 @@ protected:
 
     EventRegion m_eventRegion;
 #if USE(CA)
+    Path m_shadowPath;
     MediaPlayerVideoGravity m_videoGravity { MediaPlayerVideoGravity::ResizeAspect };
     WindRule m_shapeLayerWindRule { WindRule::NonZero };
     Path m_shapeLayerPath;

--- a/Source/WebCore/platform/graphics/Path.h
+++ b/Source/WebCore/platform/graphics/Path.h
@@ -49,7 +49,7 @@ public:
     Path(PathSegment&&);
     WEBCORE_EXPORT Path(Vector<PathSegment>&&);
     explicit Path(const Vector<FloatPoint>& points);
-    Path(Ref<PathImpl>&&);
+    WEBCORE_EXPORT Path(Ref<PathImpl>&&);
 
     Path(const Path&) = default;
     Path(Path&&) = default;

--- a/Source/WebCore/platform/graphics/PathSegment.h
+++ b/Source/WebCore/platform/graphics/PathSegment.h
@@ -56,7 +56,7 @@ public:
         PathCloseSubpath
     >;
 
-    PathSegment(Data&&);
+    WEBCORE_EXPORT PathSegment(Data&&);
 
     bool operator==(const PathSegment&) const = default;
 

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -2345,6 +2345,9 @@ void GraphicsLayerCA::commitLayerChangesBeforeSublayers(CommitState& commitState
     if (m_uncommittedChanges & ContentsScalingFiltersChanged)
         updateContentsScalingFilters();
 
+    if (m_uncommittedChanges & ShadowPathChanged)
+        updateShadowPath();
+
     if (m_uncommittedChanges & ChildrenChanged) {
         updateSublayerList();
         // Sublayers may set this flag again, so clear it to avoid always updating sublayers in commitLayerChangesAfterSublayers().
@@ -4729,6 +4732,7 @@ ASCIILiteral GraphicsLayerCA::layerChangeAsString(LayerChange layerChange)
     case LayerChange::DrawsHDRContentChanged: return "DrawsHDRContentChanged"_s;
     case LayerChange::TonemappingEnabledChanged: return "TonemappingEnabledChanged"_s;
 #endif
+    case LayerChange::ShadowPathChanged: return "ShadowPathChanged"_s;
     }
     ASSERT_NOT_REACHED();
     return ""_s;
@@ -4918,6 +4922,7 @@ void GraphicsLayerCA::changeLayerTypeTo(PlatformCALayer::LayerType newLayerType)
         | ContentsRectsChanged
         | SeparatedChanged
 #endif
+        | ShadowPathChanged
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION) || HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
         | CoverageRectChanged);
 #else
@@ -5391,6 +5396,20 @@ void GraphicsLayerCA::purgeBackBufferForTesting()
 {
     if (RefPtr layer = primaryLayer())
         layer->purgeBackBufferForTesting();
+}
+
+void GraphicsLayerCA::setShadowPath(const Path& path)
+{
+    if (m_shadowPath.definitelyEqual(path))
+        return;
+
+    GraphicsLayer::setShadowPath(path);
+    noteLayerPropertyChanged(ShadowPathChanged);
+}
+
+void GraphicsLayerCA::updateShadowPath()
+{
+    m_layer->setShadowPath(m_shadowPath);
 }
 
 void GraphicsLayerCA::markFrontBufferVolatileForTesting()

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -245,6 +245,8 @@ public:
     WEBCORE_EXPORT void purgeFrontBufferForTesting() override;
     WEBCORE_EXPORT void purgeBackBufferForTesting() override;
 
+    WEBCORE_EXPORT void setShadowPath(const Path&) override;
+
 private:
     bool isGraphicsLayerCA() const override { return true; }
 
@@ -539,6 +541,7 @@ private:
     void updateBackdropFilters(CommitState&);
     void updateBackdropFiltersRect();
     void updateBackdropRoot();
+    void updateShadowPath();
 
     void updateBlendMode();
 
@@ -682,6 +685,7 @@ private:
         DrawsHDRContentChanged                  = 1LLU << 47,
         TonemappingEnabledChanged               = 1LLU << 48,
 #endif
+        ShadowPathChanged                       = 1LLU << 49,
     };
     typedef uint64_t LayerChangeFlags;
     static ASCIILiteral layerChangeAsString(LayerChange);

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
@@ -292,6 +292,9 @@ public:
     virtual float cornerRadius() const = 0;
     virtual void setCornerRadius(float) = 0;
 
+    virtual Path shadowPath() const = 0;
+    virtual void setShadowPath(const Path&) = 0;
+
     virtual void setAntialiasesEdges(bool) = 0;
 
     virtual MediaPlayerVideoGravity videoGravity() const = 0;

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.h
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.h
@@ -162,6 +162,9 @@ public:
     float cornerRadius() const override;
     void setCornerRadius(float) override;
 
+    Path shadowPath() const override;
+    void setShadowPath(const Path&) override;
+
     void setAntialiasesEdges(bool) override;
 
     MediaPlayerVideoGravity videoGravity() const override;

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
@@ -385,6 +385,7 @@ Ref<PlatformCALayer> PlatformCALayerCocoa::clone(PlatformCALayerClient* owner) c
     newLayer->setBackdropRootIsOpaque(backdropRootIsOpaque());
     newLayer->copyFiltersFrom(*this);
     newLayer->updateCustomAppearance(customAppearance());
+    newLayer->setShadowPath(shadowPath());
 
     if (type == PlatformCALayer::LayerType::LayerTypeAVPlayerLayer) {
         ASSERT(PAL::isAVFoundationFrameworkAvailable() && [newLayer->platformLayer() isKindOfClass:PAL::getAVPlayerLayerClassSingleton()]);
@@ -1002,6 +1003,20 @@ void PlatformCALayerCocoa::setCornerRadius(float value)
     [m_layer setCornerRadius:value];
     if (value)
         [m_layer setCornerCurve:kCACornerCurveCircular];
+    END_BLOCK_OBJC_EXCEPTIONS
+}
+
+Path PlatformCALayerCocoa::shadowPath() const
+{
+    BEGIN_BLOCK_OBJC_EXCEPTIONS
+    return { PathCG::create(adoptCF(CGPathCreateMutableCopy([m_layer shadowPath]))) };
+    END_BLOCK_OBJC_EXCEPTIONS
+}
+
+void PlatformCALayerCocoa::setShadowPath(const Path& path)
+{
+    BEGIN_BLOCK_OBJC_EXCEPTIONS
+    [m_layer setShadowPath:path.platformPath()];
     END_BLOCK_OBJC_EXCEPTIONS
 }
 

--- a/Source/WebKit/Shared/RemoteLayerTree/LayerProperties.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/LayerProperties.h
@@ -62,6 +62,7 @@ enum class LayerChangeIndex : size_t {
 #if HAVE(CORE_MATERIAL)
     AppleVisualEffectChanged,
 #endif
+    ShadowPathChanged,
 };
 
 enum class LayerChange : uint64_t {
@@ -122,6 +123,7 @@ enum class LayerChange : uint64_t {
 #if HAVE(CORE_MATERIAL)
     AppleVisualEffectChanged            = 1LLU << static_cast<size_t>(LayerChangeIndex::AppleVisualEffectChanged),
 #endif
+    ShadowPathChanged                   = 1LLU << static_cast<size_t>(LayerChangeIndex::ShadowPathChanged),
 };
 
 struct RemoteLayerBackingStoreOrProperties {
@@ -225,6 +227,7 @@ struct LayerProperties {
 #if HAVE(CORE_MATERIAL)
     WebCore::AppleVisualEffectData appleVisualEffectData;
 #endif
+    WebCore::Path shadowPath;
 };
 
 }

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
@@ -79,6 +79,7 @@ header: "RemoteLayerTreeTransaction.h"
 #if HAVE(CORE_MATERIAL)
     AppleVisualEffectChanged
 #endif
+    ShadowPathChanged
 };
 
 header: "RemoteLayerBackingStore.h"
@@ -242,6 +243,7 @@ headers: "LayerProperties.h" "PlatformCALayerRemote.h"
 #if HAVE(CORE_MATERIAL)
     [OptionalTupleBit=WebKit::LayerChange::AppleVisualEffectChanged] WebCore::AppleVisualEffectData appleVisualEffectData;
 #endif
+    [OptionalTupleBit=WebKit::LayerChange::ShadowPathChanged] WebCore::Path shadowPath;
 };
 
 using WebKit::LayerHostingContextID = uint32_t;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
@@ -553,6 +553,12 @@ void RemoteLayerTreePropertyApplier::applyPropertiesToLayer(CALayer *layer, Remo
     if (properties.changedProperties & LayerChange::AppleVisualEffectChanged)
         updateAppleVisualEffect(layer, layerTreeNode, properties.appleVisualEffectData);
 #endif
+
+    if (properties.changedProperties & LayerChange::ShadowPathChanged) {
+        BEGIN_BLOCK_OBJC_EXCEPTIONS
+        [layer setShadowPath:properties.shadowPath.protectedPlatformPath().get()];
+        END_BLOCK_OBJC_EXCEPTIONS
+    }
 }
 
 void RemoteLayerTreePropertyApplier::applyProperties(RemoteLayerTreeNode& node, RemoteLayerTreeHost* layerTreeHost, const LayerProperties& properties, const RelatedLayerMap& relatedLayers)

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
@@ -246,6 +246,9 @@ static void dumpChangedLayers(TextStream& ts, const LayerPropertiesMap& changedL
         if (layerProperties.changedProperties & LayerChange::AppleVisualEffectChanged)
             ts.dumpProperty("appleVisualEffectData"_s, layerProperties.appleVisualEffectData);
 #endif
+
+        if (layerProperties.changedProperties & LayerChange::ShadowPathChanged)
+            ts.dumpProperty("shadowPath"_s, layerProperties.shadowPath.isEmpty() ? "empty" : "set");
     }
 }
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm
@@ -1181,9 +1181,11 @@ void PDFDiscretePresentationController::updateLayersOnLayoutChange(FloatSize doc
 
         pageContainerLayer->setPosition(destinationRect.location());
         pageContainerLayer->setSize(destinationRect.size());
+        pageContainerLayer->setShadowPath(shadowPathForLayer(*pageContainerLayer));
 
         RefPtr pageBackgroundLayer = pageBackgroundLayerForPageContainerLayer(*pageContainerLayer);
         pageBackgroundLayer->setSize(pageBounds.size());
+        pageBackgroundLayer->setShadowPath(shadowPathForLayer(*pageBackgroundLayer));
         pageBackgroundLayer->setTransform(documentScaleTransform);
     };
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.h
@@ -44,6 +44,7 @@ enum class GraphicsLayerType : uint8_t;
 enum class TiledBackingScrollability : uint8_t;
 class GraphicsLayer;
 class GraphicsLayerClient;
+class Path;
 };
 
 namespace WebKit {
@@ -140,7 +141,8 @@ protected:
     void clearAsyncRenderer();
 
     bool shouldUseInProcessBackingStore() const;
-    bool shouldAddPageBackgroundLayerShadow() const;
+
+    WebCore::Path shadowPathForLayer(const WebCore::GraphicsLayer&) const;
 
     const Ref<UnifiedPDFPlugin> m_plugin;
     RefPtr<AsyncPDFRenderer> m_asyncRenderer;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm
@@ -36,6 +36,9 @@
 #include <WebCore/GraphicsLayer.h>
 #include <WebCore/GraphicsLayerFactory.h>
 #include <WebCore/LocalFrameView.h>
+#include <WebCore/Path.h>
+#include <WebCore/PathSegment.h>
+#include <WebCore/PathSegmentData.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -97,6 +100,12 @@ RefPtr<GraphicsLayer> PDFPresentationController::createGraphicsLayer(const Strin
     return graphicsLayer;
 }
 
+WebCore::Path PDFPresentationController::shadowPathForLayer(const WebCore::GraphicsLayer& layer) const
+{
+    FloatRect bounds { layer.boundsOrigin(), layer.size() };
+    return { { WebCore::PathSegment { WebCore::PathRect { bounds } } } };
+}
+
 RefPtr<GraphicsLayer> PDFPresentationController::makePageContainerLayer(PDFDocumentLayout::PageIndex pageIndex)
 {
     auto addLayerShadow = [](GraphicsLayer& layer, IntPoint shadowOffset, const Color& shadowColor, int shadowStdDeviation) {
@@ -129,26 +138,13 @@ RefPtr<GraphicsLayer> PDFPresentationController::makePageContainerLayer(PDFDocum
     pageBackgroundLayer->setAllowsTiling(false);
     pageBackgroundLayer->setNeedsDisplay(); // We only need to paint this layer once when page backgrounds change.
 
-    if (shouldAddPageBackgroundLayerShadow()) {
-        addLayerShadow(*pageContainerLayer, containerShadowOffset, containerShadowColor, containerShadowStdDeviation);
-        // FIXME: <https://webkit.org/b/276981> Need to add a 1px black border with alpha 0.0586.
-        addLayerShadow(*pageBackgroundLayer, shadowOffset, shadowColor, shadowStdDeviation);
-    }
+    addLayerShadow(*pageContainerLayer, containerShadowOffset, containerShadowColor, containerShadowStdDeviation);
+    // FIXME: <https://webkit.org/b/276981> Need to add a 1px black border with alpha 0.0586.
+    addLayerShadow(*pageBackgroundLayer, shadowOffset, shadowColor, shadowStdDeviation);
 
     pageContainerLayer->addChild(*pageBackgroundLayer);
 
     return pageContainerLayer;
-}
-
-bool PDFPresentationController::shouldAddPageBackgroundLayerShadow() const
-{
-#if PLATFORM(MAC)
-    return true;
-#else
-    // FIXME (288384): Remove this method and unconditionally add shadows behind the page once we figure out
-    // how to maintain a stable framerate during device rotation.
-    return false;
-#endif
 }
 
 RefPtr<GraphicsLayer> PDFPresentationController::pageBackgroundLayerForPageContainerLayer(GraphicsLayer& pageContainerLayer)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
@@ -237,9 +237,11 @@ void PDFScrollingPresentationController::updatePageBackgroundLayers()
 
         pageContainerLayer->setPosition(destinationRect.location());
         pageContainerLayer->setSize(destinationRect.size());
+        pageContainerLayer->setShadowPath(shadowPathForLayer(pageContainerLayer.get()));
 
         auto pageBackgroundLayer = pageContainerLayer->children()[0];
         pageBackgroundLayer->setSize(pageBoundsRect.size());
+        pageBackgroundLayer->setShadowPath(shadowPathForLayer(pageBackgroundLayer.get()));
 
         TransformationMatrix documentScaleTransform;
         documentScaleTransform.scale(documentLayout.scale());

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
@@ -199,6 +199,9 @@ public:
     float cornerRadius() const override;
     void setCornerRadius(float) override;
 
+    WebCore::Path shadowPath() const override;
+    void setShadowPath(const WebCore::Path&) override;
+
     void setAntialiasesEdges(bool) override;
 
     WebCore::MediaPlayerVideoGravity videoGravity() const override;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
@@ -968,6 +968,20 @@ void PlatformCALayerRemote::setCornerRadius(float value)
     m_properties.notePropertiesChanged(LayerChange::CornerRadiusChanged);
 }
 
+WebCore::Path PlatformCALayerRemote::shadowPath() const
+{
+    return m_properties.shadowPath;
+}
+
+void PlatformCALayerRemote::setShadowPath(const WebCore::Path& path)
+{
+    if (m_properties.shadowPath.definitelyEqual(path))
+        return;
+
+    m_properties.shadowPath = path;
+    m_properties.notePropertiesChanged(LayerChange::ShadowPathChanged);
+}
+
 void PlatformCALayerRemote::setAntialiasesEdges(bool antialiases)
 {
     if (antialiases == m_properties.antialiasesEdges)


### PR DESCRIPTION
#### da7921e81ff8dd117debc87f7f7fced226329357
<pre>
[Unified PDF] [iOS] Reintroduce shadows under the page background layer
<a href="https://bugs.webkit.org/show_bug.cgi?id=288384">https://bugs.webkit.org/show_bug.cgi?id=288384</a>
<a href="https://rdar.apple.com/146036887">rdar://146036887</a>

Reviewed by Tim Horton.

Page background shadows were previously disabled on iOS (291001@main)
because our naive drop shadow implementation required 4 offscreen passes
of the CALayers in question. In this patch, we restore page background
shadows in UnifiedPDFPlugin, primarily by setting an explicit shadow
path on the platform layers. Note that the we do this in conjunction to
the original drop shadow filter operation approach, since that mechanism
sets the appropriate shadow radius/color/offset on the platform layers.

Doing so necessitated introducing support to set shadow paths in general
on a WebCore::GraphicsLayer object. The majority of this patch is simple
plumbing that teaches WebCore/platform/graphics how to set/update shadow
paths.

* Source/WebCore/platform/graphics/GraphicsLayer.cpp:
(WebCore::GraphicsLayer::setShadowPath):
* Source/WebCore/platform/graphics/GraphicsLayer.h:
* Source/WebCore/platform/graphics/Path.h:
* Source/WebCore/platform/graphics/PathSegment.h:
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::commitLayerChangesBeforeSublayers):
(WebCore::GraphicsLayerCA::ensureStructuralLayer):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
* Source/WebCore/platform/graphics/ca/PlatformCALayer.h:
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.h:
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm:
(WebCore::PlatformCALayerCocoa::clone const):
(WebCore::PlatformCALayerCocoa::shadowPath const):
(WebCore::PlatformCALayerCocoa::setShadowPath):
* Source/WebKit/Shared/RemoteLayerTree/LayerProperties.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::RemoteLayerTreePropertyApplier::applyPropertiesToLayer):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm:
(WebKit::dumpChangedLayers):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm:
(WebKit::PDFDiscretePresentationController::updateLayersOnLayoutChange):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm:
(WebKit::PDFPresentationController::shadowPathForLayer const):
(WebKit::PDFPresentationController::makePageContainerLayer):
(WebKit::PDFPresentationController::shouldAddPageBackgroundLayerShadow const): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm:
(WebKit::PDFScrollingPresentationController::updatePageBackgroundLayers):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm:
(WebKit::PlatformCALayerRemote::shadowPath const):
(WebKit::PlatformCALayerRemote::setShadowPath):

Canonical link: <a href="https://commits.webkit.org/305692@main">https://commits.webkit.org/305692@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07149e2bdb4fb5e3e92d80fbedafad084a8368dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139082 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11455 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/579 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147208 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92107 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c7b976ae-4022-41f3-a89e-8fec16a17f1a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140954 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12161 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11606 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106470 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92107 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142029 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9184 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124588 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87338 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/29534ba5-6321-4cfe-9f8b-e987dce4cc93) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8740 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6517 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7501 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118189 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/485 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149988 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11140 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/496 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114859 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11153 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9425 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115170 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9069 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120935 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66042 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21450 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11182 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/467 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10918 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74840 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11121 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10970 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->