### PR TITLE
Change PDF background color from gray to white

### DIFF
--- a/LayoutTests/pdf/fullscreen-expected.txt
+++ b/LayoutTests/pdf/fullscreen-expected.txt
@@ -9,7 +9,7 @@ layer at (8,8) size 788x504
       RenderView at (0,0) size 784x500
     layer at (0,0) size 784x500
       RenderBlock {HTML} at (0,0) size 784x500
-        RenderBody {BODY} at (0,0) size 784x500 [bgcolor=#808080]
+        RenderBody {BODY} at (0,0) size 784x500 [bgcolor=#FFFFFF]
     layer at (0,0) size 784x500
       RenderEmbeddedObject {EMBED} at (0,0) size 784x500
     layer at (0,0) size 784x500

--- a/LayoutTests/pdf/load-pdf-twice-in-sequence-expected.txt
+++ b/LayoutTests/pdf/load-pdf-twice-in-sequence-expected.txt
@@ -14,7 +14,7 @@
             (GraphicsLayer
               (anchor 0.00 0.00)
               (bounds 300.00 300.00)
-              (backgroundColor #808080)
+              (backgroundColor #FFFFFF)
               (children 2
                 (GraphicsLayer
                   (anchor 0.00 0.00)
@@ -84,7 +84,7 @@
             (GraphicsLayer
               (anchor 0.00 0.00)
               (bounds 300.00 300.00)
-              (backgroundColor #808080)
+              (backgroundColor #FFFFFF)
               (children 2
                 (GraphicsLayer
                   (anchor 0.00 0.00)
@@ -138,7 +138,7 @@
             (GraphicsLayer
               (anchor 0.00 0.00)
               (bounds 300.00 300.00)
-              (backgroundColor #808080)
+              (backgroundColor #FFFFFF)
               (children 2
                 (GraphicsLayer
                   (anchor 0.00 0.00)

--- a/LayoutTests/pdf/pdf-in-embed-expected.txt
+++ b/LayoutTests/pdf/pdf-in-embed-expected.txt
@@ -14,7 +14,7 @@
             (GraphicsLayer
               (anchor 0.00 0.00)
               (bounds 300.00 300.00)
-              (backgroundColor #808080)
+              (backgroundColor #FFFFFF)
               (children 2
                 (GraphicsLayer
                   (anchor 0.00 0.00)

--- a/LayoutTests/pdf/pdf-in-styled-embed-expected.txt
+++ b/LayoutTests/pdf/pdf-in-styled-embed-expected.txt
@@ -17,7 +17,7 @@
               (position 68.00 68.00)
               (anchor 0.00 0.00)
               (bounds 300.00 300.00)
-              (backgroundColor #808080)
+              (backgroundColor #FFFFFF)
               (children 2
                 (GraphicsLayer
                   (anchor 0.00 0.00)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -1633,7 +1633,7 @@ String PDFPluginBase::annotationStyle() const
 
 Color PDFPluginBase::pluginBackgroundColor()
 {
-    static NeverDestroyed color = roundAndClampToSRGBALossy(RetainPtr { [CocoaColor grayColor].CGColor }.get());
+    static NeverDestroyed color = roundAndClampToSRGBALossy(RetainPtr { [CocoaColor whiteColor].CGColor }.get());
     return color.get();
 }
 


### PR DESCRIPTION
#### 15b05b24423820280fb1b918fa79d149aba29591
<pre>
Change PDF background color from gray to white
<a href="https://bugs.webkit.org/show_bug.cgi?id=305588">https://bugs.webkit.org/show_bug.cgi?id=305588</a>
<a href="https://rdar.apple.com/163509989">rdar://163509989</a>

Reviewed by Wenson Hsieh.

In a Liquid Glass world, the dark gray background in PDFs viewed in
Safari do not look great and are misaligned with other PDF viewing flows
in the system, particularly Preview.app. As such, this trivial patch
changes the PDF background color to white.

* LayoutTests/pdf/fullscreen-expected.txt:
* LayoutTests/pdf/load-pdf-twice-in-sequence-expected.txt:
* LayoutTests/pdf/pdf-in-embed-expected.txt:
* LayoutTests/pdf/pdf-in-styled-embed-expected.txt:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::pluginBackgroundColor):

Canonical link: <a href="https://commits.webkit.org/305691@main">https://commits.webkit.org/305691@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0855b6589213951d49ed6f52a6387fa2b6717028

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139114 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11487 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/611 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147241 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e801380e-6c0b-40fb-8271-55b6decaa11e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12194 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11638 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106491 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142061 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9208 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124608 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87359 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4b6b858d-2e31-439c-9e7f-086afef5ef6d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8760 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6537 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7533 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118210 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/508 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150020 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11172 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/518 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114881 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11185 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9449 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115193 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9100 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120957 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66074 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21451 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11214 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/486 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10950 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74872 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11153 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11002 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->