### PR TITLE
NEW TEST(305364@main) [macOS] TestWebKitAPI.NowPlayingControlsTests.NowPlayingUpdatesThrottled is flaky timeout and failure

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/NowPlayingControlsTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/NowPlayingControlsTests.mm
@@ -295,12 +295,7 @@ TEST(NowPlayingControlsTests, LazyRegisterAsNowPlayingApplication)
     ASSERT_FALSE(haveMediaSessionManager());
 }
 
-// FIXME when rdar://168157711 is resolved.
-#if PLATFORM(MAC)
-TEST(NowPlayingControlsTests, DISABLED_NowPlayingUpdatesThrottled)
-#else
 TEST(NowPlayingControlsTests, NowPlayingUpdatesThrottled)
-#endif
 {
     struct NowPlayingState {
         NowPlayingState(NowPlayingTestWebView *webView)
@@ -330,12 +325,13 @@ TEST(NowPlayingControlsTests, NowPlayingUpdatesThrottled)
     [configuration setMediaTypesRequiringUserActionForPlayback:WKAudiovisualMediaTypeNone];
     auto webView = adoptNS([[NowPlayingTestWebView alloc] initWithFrame:NSMakeRect(0, 0, 480, 320) configuration:configuration.get()]);
 
+    constexpr double internalTestStepTimout = 20;
     auto waitForEventOrTimeout = [&] (const char* eventName) -> bool {
         __block bool receivedEvent = false;
         [webView performAfterReceivingMessage:[NSString stringWithUTF8String:eventName] action:^{ receivedEvent = true; }];
 
         NSDate *startTime = [NSDate date];
-        while (!receivedEvent && [[NSDate date] timeIntervalSinceDate:startTime] < 10)
+        while (!receivedEvent && [[NSDate date] timeIntervalSinceDate:startTime] < internalTestStepTimout)
             TestWebKitAPI::Util::runFor(0.05_s);
 
         return receivedEvent;
@@ -362,7 +358,7 @@ TEST(NowPlayingControlsTests, NowPlayingUpdatesThrottled)
     NowPlayingState previousState = initialState;
     while ([[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate distantPast]]) {
 
-        if ([[NSDate date] timeIntervalSinceDate:startTime] > 10)
+        if ([[NSDate date] timeIntervalSinceDate:startTime] > internalTestStepTimout)
             break;
 
         NowPlayingState currentState(webView.get());


### PR DESCRIPTION
#### 7a19f9e0232cbcfd76940f007f6654c84822df1d
<pre>
NEW TEST(305364@main) [macOS] TestWebKitAPI.NowPlayingControlsTests.NowPlayingUpdatesThrottled is flaky timeout and failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=305493">https://bugs.webkit.org/show_bug.cgi?id=305493</a>
<a href="https://rdar.apple.com/168157711">rdar://168157711</a>

Unreviewed, just updating the internal timeout to 20 seconds.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/NowPlayingControlsTests.mm:
(TestWebKitAPI::TEST(NowPlayingControlsTests, NowPlayingUpdatesThrottled)):

Canonical link: <a href="https://commits.webkit.org/305681@main">https://commits.webkit.org/305681@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c10dfb9ecff62a71cce4b65f93cc4d03ff918d0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139137 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11510 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/634 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147264 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cb56aab8-6aab-41f0-87e9-04c6530afa4f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141009 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12217 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11661 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/106511 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cf16b3fa-e6bd-43f5-8f07-bcc5ac27fe7f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142084 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9229 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/124632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87378 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/434d14a6-6a3d-4071-a6ad-4a94fa26d5d8) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/8777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/6553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7556 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118229 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150043 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11195 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/114899 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11208 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9468 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/115212 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29272 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9122 "Passed tests") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/120982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/66097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11237 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10973 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11176 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/11025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->