### PR TITLE
Dirty encoded image blobs are not replaced by clean encoded image blobs as expected

### DIFF
--- a/Source/WebCore/loader/cache/CachedImage.cpp
+++ b/Source/WebCore/loader/cache/CachedImage.cpp
@@ -622,7 +622,12 @@ void CachedImage::didReplaceSharedBufferContents()
     if (RefPtr image = m_image) {
         // Let the Image know that the FragmentedSharedBuffer has been rejigged, so it can let go of any references to the heap-allocated resource buffer.
         // FIXME(rdar://problem/24275617): It would be better if we could somehow tell the Image's decoder to swap in the new contents without destroying anything.
-        image->destroyDecodedData(true);
+        RefPtr data = m_data;
+        if (!image->tryReplaceData(data.releaseNonNull())) {
+            // If the image doesn't support replacing encoded data and re-decoding, then just
+            // destroy decoded data.
+            image->destroyDecodedData(true);
+        }
     }
     CachedResource::didReplaceSharedBufferContents();
 }

--- a/Source/WebCore/platform/graphics/BitmapImage.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImage.cpp
@@ -74,6 +74,11 @@ EncodedDataStatus BitmapImage::dataChanged(bool allDataReceived)
     return m_source->dataChanged(data(), allDataReceived);
 }
 
+void BitmapImage::dataReplaced()
+{
+    return m_source->dataReplaced(data());
+}
+
 void BitmapImage::destroyDecodedData(bool destroyAll)
 {
     m_source->destroyDecodedData(destroyAll);

--- a/Source/WebCore/platform/graphics/BitmapImage.h
+++ b/Source/WebCore/platform/graphics/BitmapImage.h
@@ -103,6 +103,9 @@ private:
     EncodedDataStatus dataChanged(bool allDataReceived) final;
     void destroyDecodedData(bool destroyAll = true) final;
 
+    bool canReplaceData() const final { return m_source->canReplaceData(); }
+    void dataReplaced() final;
+
     // Current ImageFrame
     bool currentFrameKnownToBeOpaque() const final { return !currentFrameHasAlpha(); }
     bool currentFrameIsComplete() const final { return m_source->currentImageFrame().isComplete(); }

--- a/Source/WebCore/platform/graphics/BitmapImageSource.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImageSource.cpp
@@ -121,7 +121,7 @@ EncodedDataStatus BitmapImageSource::dataChanged(FragmentedSharedBuffer* data, b
     return status;
 }
 
-void BitmapImageSource::destroyDecodedData(bool destroyAll)
+void BitmapImageSource::destroyDecodedFrames(bool destroyAll)
 {
     LOG(Images, "BitmapImageSource::%s - %p - url: %s. Decoded data with destroyAll = %d will be destroyed.", __FUNCTION__, this, sourceUTF8().data(), destroyAll);
 
@@ -142,6 +142,11 @@ void BitmapImageSource::destroyDecodedData(bool destroyAll)
     }
 
     decodedSizeReset(decodedSize);
+}
+
+void BitmapImageSource::destroyDecodedData(bool destroyAll)
+{
+    destroyDecodedFrames(destroyAll);
 
     // There's no need to throw away the decoder unless we're explicitly asked
     // to destroy all of the frames.
@@ -258,6 +263,18 @@ void BitmapImageSource::resetData()
 
     if (m_bitmapImage)
         setData(m_bitmapImage->data(), m_allDataReceived);
+}
+
+void BitmapImageSource::dataReplaced(FragmentedSharedBuffer* data)
+{
+    destroyDecodedFrames(true);
+
+    m_decoder = nullptr;
+    m_descriptor.clear();
+
+    // This function is only meant to replace complete data with an identical copy of that data (which is clean and backed by disk cache).
+    ASSERT(m_allDataReceived);
+    setData(data, true);
 }
 
 void BitmapImageSource::startAnimation()

--- a/Source/WebCore/platform/graphics/BitmapImageSource.h
+++ b/Source/WebCore/platform/graphics/BitmapImageSource.h
@@ -54,6 +54,8 @@ public:
     // Encoded and decoded data
     void destroyDecodedData(bool destroyAll) final;
     void resetData();
+    bool canReplaceData() const { return true; }
+    void dataReplaced(FragmentedSharedBuffer*) final;
     unsigned decodedSize() const { return m_decodedSize; }
     void didDecodeProperties(unsigned decodedPropertiesSize);
 
@@ -107,6 +109,7 @@ private:
     void decodedSizeDecreased(unsigned decodedSize);
     void decodedSizeReset(unsigned decodedSize);
     bool canDestroyDecodedData() const;
+    void destroyDecodedFrames(bool destroyAll);
 
     void clearFrameBufferCache();
 

--- a/Source/WebCore/platform/graphics/Image.cpp
+++ b/Source/WebCore/platform/graphics/Image.cpp
@@ -157,6 +157,19 @@ EncodedDataStatus Image::setData(RefPtr<FragmentedSharedBuffer>&& data, bool all
     return dataChanged(allDataReceived);
 }
 
+bool Image::tryReplaceData(Ref<FragmentedSharedBuffer>&& data)
+{
+    if (!canReplaceData())
+        return false;
+
+    // replaceData should only be called with an identical copy of previously set encoded data.
+    ASSERT(m_encodedImageData && *m_encodedImageData == data.get());
+    m_encodedImageData = WTF::move(data);
+    dataReplaced();
+
+    return true;
+}
+
 URL Image::sourceURL() const
 {
     return imageObserver() ? imageObserver()->sourceUrl() : URL();

--- a/Source/WebCore/platform/graphics/Image.h
+++ b/Source/WebCore/platform/graphics/Image.h
@@ -111,7 +111,11 @@ public:
     virtual ImageOrientation orientation() const { return ImageOrientation::Orientation::FromImage; }
 
     WEBCORE_EXPORT EncodedDataStatus setData(RefPtr<FragmentedSharedBuffer>&& data, bool allDataReceived);
-    virtual EncodedDataStatus dataChanged(bool /*allDataReceived*/) { return EncodedDataStatus::Unknown; }
+    virtual EncodedDataStatus dataChanged(bool /* allDataReceived */) { return EncodedDataStatus::Unknown; }
+
+    // Can be called after final setData() to replace encoded data with an identical copy of the
+    // data (e.g. to replace a dirty copy of the data with a clean copy of the data).
+    bool tryReplaceData(Ref<FragmentedSharedBuffer>&& data);
 
     virtual String uti() const { return String(); } // null string if unknown
     virtual String filenameExtension() const { return String(); } // null string if unknown
@@ -191,6 +195,9 @@ protected:
 
     // Supporting tiled drawing
     virtual std::optional<Color> singlePixelSolidColor() const;
+
+    virtual bool canReplaceData() const { return false; }
+    virtual void dataReplaced() { }
 
 private:
     RefPtr<FragmentedSharedBuffer> m_encodedImageData;

--- a/Source/WebCore/platform/graphics/ImageSource.h
+++ b/Source/WebCore/platform/graphics/ImageSource.h
@@ -42,6 +42,9 @@ public:
     virtual EncodedDataStatus dataChanged(FragmentedSharedBuffer*, bool) { RELEASE_ASSERT_NOT_REACHED(); return EncodedDataStatus::Unknown; }
     virtual void destroyDecodedData(bool) { RELEASE_ASSERT_NOT_REACHED(); }
 
+    virtual bool canReplaceData() const { return false; }
+    virtual void dataReplaced(FragmentedSharedBuffer*) { RELEASE_ASSERT_NOT_REACHED(); }
+
     // Animation
     virtual void startAnimation() { }
     virtual void stopAnimation() { }


### PR DESCRIPTION
#### 9e8f5212b01ad782bb58df709760a521ca90662d
<pre>
Dirty encoded image blobs are not replaced by clean encoded image blobs as expected
<a href="https://bugs.webkit.org/show_bug.cgi?id=305589">https://bugs.webkit.org/show_bug.cgi?id=305589</a>
<a href="https://rdar.apple.com/168246161">rdar://168246161</a>

Reviewed by Said Abou-Hallawa.

After caching a blob in the disk cache, we pass a handle to the clean mmap&apos;d blob back to WebProcess
via the `NetworkProcessConnection::DidCacheResource` message. As part of handling this message we
try to replace the dirty encoded blob with the clean encoded blob (in
`CachedResource::tryReplaceEncodedData`). This all seems to work as expected.

However, for CachedImages, there is an Image object that hangs on to the dirty encoded data
(`m_encodedImageData` member) which we never reset. The net effect of this is that there&apos;s still one
reference to the dirty encoded data blob for CachedImages even after the dirty =&gt; clean buffer swap
occurs, so the dirty buffer never goes away.

Fix this by having CachedImage swap the dirty buffer for the clean buffer in the Image object in
`didReplaceSharedBufferContents`.

* Source/WebCore/loader/cache/CachedImage.cpp:
(WebCore::CachedImage::didReplaceSharedBufferContents):
* Source/WebCore/platform/graphics/BitmapImage.cpp:
(WebCore::BitmapImage::dataReplaced):
* Source/WebCore/platform/graphics/BitmapImage.h:
* Source/WebCore/platform/graphics/BitmapImageSource.cpp:
(WebCore::BitmapImageSource::destroyDecodedFrames):
(WebCore::BitmapImageSource::destroyDecodedData):
(WebCore::BitmapImageSource::dataReplaced):
* Source/WebCore/platform/graphics/BitmapImageSource.h:
* Source/WebCore/platform/graphics/Image.cpp:
(WebCore::Image::tryReplaceData):
* Source/WebCore/platform/graphics/Image.h:
(WebCore::Image::dataChanged):
(WebCore::Image::canReplaceData const):
(WebCore::Image::dataReplaced):
* Source/WebCore/platform/graphics/ImageSource.h:
(WebCore::ImageSource::canReplaceData const):
(WebCore::ImageSource::dataReplaced):

Canonical link: <a href="https://commits.webkit.org/306036@main">https://commits.webkit.org/306036@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0cb5022a42bc3b83409bad2b023e91ac9ae81a6f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139947 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12328 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1458 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148090 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93017 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/79583d48-63a9-487e-8e16-208fc8749e8a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141820 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13038 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12480 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107156 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77982 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/56cdd57a-55b7-433a-a9ed-8f1c63b80c12) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142897 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10051 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125332 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88036 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c34ff673-fc30-4af5-9cf8-85f55a23e60e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9702 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7219 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8379 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118923 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1335 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150877 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12013 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1401 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115579 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12026 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10299 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115894 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29487 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10693 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121813 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67018 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12055 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1287 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11795 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75742 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11991 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11843 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->