### PR TITLE
dNR: fails to match separator `^` to end of URL in `urlFilter`

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.mm
@@ -1163,10 +1163,10 @@ static BOOL isArrayOfRequestMethodsValid(NSArray<NSString *> *requestMethods)
     // Documentation: https://developer.chrome.com/docs/extensions/reference/declarativeNetRequest/
 
     // Supported special charcters:
-    // '*' : Wildcard: Matches any number of characters.
-    // '|' : Left/right anchor: If used at either end of the pattern, specifies the beginning/end of the url respectively.
+    // '*'  : Wildcard: Matches any number of characters.
+    // '|'  : Left/right anchor: If used at either end of the pattern, specifies the beginning/end of the url respectively.
     // '||' : Domain name anchor: If used at the beginning of the pattern, specifies the start of a (sub-)domain of the URL.
-    // '^' : Separator character: This matches anything except a letter, a digit or one of the following: _ - . %.
+    // '^'  : Separator character: This matches anything except a letter, a digit or one of the following: _ - . %. This also match the end of the URL.
 
     // Therefore urlFilter is composed of the following parts: (optional Left/Domain name anchor) + pattern + (optional Right anchor).
     // All other regex special charaters are escaped in the pattern.
@@ -1183,10 +1183,22 @@ static BOOL isArrayOfRequestMethodsValid(NSArray<NSString *> *requestMethods)
     if (hasEndAnchor)
         chromeURLFilter = [chromeURLFilter substringToIndex:chromeURLFilter.length - 1];
 
+    BOOL hasEndSeparator = [chromeURLFilter hasSuffix:@"^"];
+    if (hasEndSeparator)
+        chromeURLFilter = [chromeURLFilter substringToIndex:chromeURLFilter.length - 1];
+
     NSString *regexFilter = escapeCharactersInString(chromeURLFilter, @"?+[(){}$|\\.");
 
     regexFilter = [regexFilter stringByReplacingOccurrencesOfString:@"*" withString:@".*"];
+
     regexFilter = [regexFilter stringByReplacingOccurrencesOfString:@"^" withString:@"[^a-zA-Z0-9_.%-]"];
+
+    if (hasEndSeparator) {
+        if (hasEndAnchor)
+            regexFilter = [regexFilter stringByAppendingString:@"([^a-zA-Z0-9_.%-])?"];
+        else
+            regexFilter = [regexFilter stringByAppendingString:@"([^a-zA-Z0-9_.%-].*)?$"];
+    }
 
     if (hasDomainNameAnchor)
         regexFilter = [@"^[^:]+://+([^:/]+\\.)?" stringByAppendingString:regexFilter];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm
@@ -29,9 +29,11 @@
 
 #import "HTTPServer.h"
 #import "TestNavigationDelegate.h"
+#import "TestResourceLoadDelegate.h"
 #import "WebExtensionUtilities.h"
 #import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/_WKFeature.h>
+#import <WebKit/_WKResourceLoadInfo.h>
 #import <WebKit/_WKWebExtensionDeclarativeNetRequestRule.h>
 #import <WebKit/_WKWebExtensionDeclarativeNetRequestTranslator.h>
 
@@ -2882,8 +2884,8 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, RuleConversionWithURLFilterAndReque
                 @"resource-type": @[ @"script" ],
             },
 #if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
-        @"_identifier": @1,
-        @"_rulesetIdentifier": @"Test Ruleset",
+            @"_identifier": @1,
+            @"_rulesetIdentifier": @"Test Ruleset",
 #endif
         };
 
@@ -2906,6 +2908,9 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, RuleConversionWithURLFilterAndReque
     testPattern(@"com", @"://www.*", @"://www\\..*com");
     testPattern(@"com", @"://www./foo/bar", @"://www\\..*com/foo/bar");
     testPattern(@"com", @"://www.*/foo/bar", @"://www\\..*com/foo/bar");
+
+    // URL filter contains a separator character
+    testPattern(@"apple.com", @"||apple.com/*.css^", @"^[^:]+://+([^:/]+\\.)?apple\\.com/.*\\.css([^a-zA-Z0-9_.%-].*)?$");
 
     // Concatenating the request domain and URL filter
     testPattern(@"com", @"/foo/bar", @"^[^:]+://+([^:/]+\\.)?com.*/foo/bar");
@@ -3491,6 +3496,203 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, URLFilterSpecialCharacters)
 
     // Testing separator character.
     testPattern(@"apple^com", @"apple[^a-zA-Z0-9_.%-]com");
+    testPattern(@"||apple.com/*.css^", @"^[^:]+://+([^:/]+\\.)?apple\\.com/.*\\.css([^a-zA-Z0-9_.%-].*)?$");
+}
+
+static NSString *percentEncodedPathQueryAndFragmentForURL(NSURL *url)
+{
+    if (!url)
+        return nil;
+
+    NSURLComponents *components = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:YES];
+    if (!components)
+        return nil;
+
+    NSString *result = components.percentEncodedPath ?: @"";
+
+    if (components.percentEncodedQuery)
+        result = [result stringByAppendingFormat:@"?%@", components.percentEncodedQuery];
+
+    if (components.percentEncodedFragment)
+        result = [result stringByAppendingFormat:@"#%@", components.percentEncodedFragment];
+
+    return result;
+}
+
+TEST(WKWebExtensionAPIDeclarativeNetRequest, URLFilterSpecialCharacterRuleList)
+{
+    struct URLExpectation {
+        String url;
+        bool shouldBeAllowed;
+        std::optional<bool> wasAllowed;
+    };
+
+    auto *rules = @(R"JSON(
+        [
+            { "id" : 1, "priority": 1, "action" : { "type" : "block" }, "condition" : { "urlFilter" : "||localhost:*/path/file.txt^" } },
+            { "id" : 2, "priority": 1, "action" : { "type" : "block" }, "condition" : { "urlFilter" : "example*^123|" } },
+            { "id" : 3, "priority": 1, "action" : { "type" : "block" }, "condition" : { "urlFilter" : "example*456|" } },
+            { "id" : 4, "priority": 1, "action" : { "type" : "block" }, "condition" : { "urlFilter" : "separatorEnd^|" } },
+            { "id" : 5, "priority": 1, "action" : { "type" : "block" }, "condition" : { "urlFilter" : "pipeSeparator%7C^" } },
+        ]
+    )JSON");
+
+    // Declare the URLs that will be fetched and their expected behavior. Test
+    // cases must be percent encoded in order for request verification complete
+    // as expected.
+    __block Vector<URLExpectation> urlExpectations {
+        // Root path serves `mainRequestBody`
+        { "/"_s, true, std::nullopt },
+        // Basic match of complex urlFilter pattern
+        { "/path/file.txt"_s, false, std::nullopt },
+        // urlFilter handling of uncollapsed path separators
+        { "/path//file.txt"_s, true, std::nullopt },
+        // urlFilter with a terminal separator character (^) - matching characters
+        { "/path/file.txt?"_s, false, std::nullopt },
+        { "/path/file.txt?query=true"_s, false, std::nullopt },
+        { "/path/file.txt/"_s, false, std::nullopt },
+        { "/path/file.txt/?"_s, false, std::nullopt },
+        { "/path/file.txt&"_s, false, std::nullopt },
+        // urlFilter with a terminal separator character (^) - non-matching characters
+        { "/path/file.txtfoo"_s, true, std::nullopt },
+        { "/path/file.txt%20"_s, true, std::nullopt },
+        { "/path/file.txt%25"_s, true, std::nullopt },
+        { "/path/file.txt."_s, true, std::nullopt },
+        { "/path/file.txtX"_s, true, std::nullopt },
+        // urlFilter with a mid-pattern separator character (^) and terminal right anchor (|)
+        { "/123"_s, true, std::nullopt },
+        { "/example?123"_s, false, std::nullopt },
+        { "/example/123"_s, false, std::nullopt },
+        { "/example_123"_s, true, std::nullopt },
+        { "/example/path/123"_s, false, std::nullopt },
+        { "/example?1234"_s, true, std::nullopt },
+        // urlFilter with a wildcard (*) and terminal right anchor (|)
+        { "/example?456"_s, false, std::nullopt },
+        { "/example/456"_s, false, std::nullopt },
+        { "/example_456"_s, false, std::nullopt },
+        { "/example/path/456"_s, false, std::nullopt },
+        { "/example/path/456?"_s, true, std::nullopt },
+        { "/example456"_s, false, std::nullopt },
+        // urlFilter with terminal separator charactor and right anchor (^|)
+        { "/separatorEnd"_s, false, std::nullopt },
+        { "/separatorEnd?"_s, false, std::nullopt },
+        { "/separatorEnd?allowed"_s, true, std::nullopt },
+        // urlFilter with pseudo right anchor (| or %7C) and terminal separator charactor (^)
+        { "/pipeSeparator"_s, true, std::nullopt },
+        { "/pipeSeparator%7C"_s, false, std::nullopt },
+        { "/pipeSeparator%7C?query"_s, false, std::nullopt },
+    };
+
+    NSMutableArray *mainRequestScriptLines = [NSMutableArray arrayWithArray:@[
+        @"<script>",
+        @"    async function fetchSubresources()",
+        @"    {",
+    ]];
+
+    // Dynamically construct the fetch script based on urlExpectations
+    for (const auto& expectation : urlExpectations)
+        [mainRequestScriptLines addObject:[NSString stringWithFormat:@"        try { await fetch('%s') } catch(e) { }", expectation.url.utf8().data()]];
+
+    [mainRequestScriptLines addObjectsFromArray:@[
+        @"        browser.test.sendMessage('Requests Complete');",
+        @"    }",
+        @"    fetchSubresources();",
+        @"</script>",
+    ]];
+
+    auto mainRequestBody = Util::constructScript(mainRequestScriptLines);
+
+    TestWebKitAPI::HTTPServer server(HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> ConnectionTask {
+        while (true) {
+            auto request = co_await connection.awaitableReceiveHTTPRequest();
+            auto path = TestWebKitAPI::HTTPServer::parsePath(request);
+            HTTPResponse response;
+
+            if (path == "/"_s)
+                response = { { { "Content-Type"_s, "text/html"_s } }, mainRequestBody };
+            else
+                response = { { { "Content-Type"_s, "text/plain"_s } }, "OK"_s };
+
+            co_await connection.awaitableSend(response.serialize());
+        }
+    });
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.sendMessage('Load Tab');"
+    ]);
+
+    auto *declarativeNetRequestManifest = @{
+        @"manifest_version": @3,
+        @"permissions": @[ @"declarativeNetRequest" ],
+        @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO },
+        @"declarative_net_request": @{
+            @"rule_resources": @[
+                @{
+                    @"id": @"urlFilterSpecialCharacterRules",
+                    @"enabled": @YES,
+                    @"path": @"rules.json"
+                }
+            ]
+        }
+    };
+
+    auto manager = Util::loadExtension(declarativeNetRequestManifest, @{ @"background.js": backgroundScript, @"rules.json": rules });
+
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionDeclarativeNetRequest];
+
+    [manager runUntilTestMessage:@"Load Tab"];
+
+    auto webView = manager.get().defaultTab.webView;
+    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    auto resourceLoadDelegate = adoptNS([TestResourceLoadDelegate new]);
+
+    // Record blocked URLs
+    navigationDelegate.get().contentRuleListPerformedAction = ^(WKWebView *, NSString *identifier, _WKContentRuleListAction *action, NSURL *url) {
+        String urlPath = percentEncodedPathQueryAndFragmentForURL(url);
+
+        for (auto& expectation : urlExpectations) {
+            if (expectation.url == urlPath) {
+                expectation.wasAllowed = false;
+                return;
+            }
+        }
+
+        // URL not in our expectations
+        EXPECT_TRUE(false) << "Unexpected blocked URL: " << urlPath.utf8().data();
+    };
+
+    // Record allowed URLs
+    resourceLoadDelegate.get().didCompleteWithError = ^(WKWebView *webView, _WKResourceLoadInfo *loadInfo, NSError *error, NSURLResponse *response) {
+        String urlPath = percentEncodedPathQueryAndFragmentForURL(loadInfo.originalURL);
+
+        for (auto& expectation : urlExpectations) {
+            if (expectation.url == urlPath) {
+                expectation.wasAllowed = true;
+                return;
+            }
+        }
+
+        // URL not in our expectations
+        EXPECT_TRUE(false) << "Unexpected allowed URL: " << urlPath.utf8().data();
+    };
+
+    webView.navigationDelegate = navigationDelegate.get();
+    webView._resourceLoadDelegate = resourceLoadDelegate.get();
+
+    [webView loadRequest:server.requestWithLocalhost()];
+
+    [manager runUntilTestMessage:@"Requests Complete"];
+
+    // Verify all URLs were requested and had the expected behavior
+    for (const auto& expectation : urlExpectations) {
+        EXPECT_TRUE(expectation.wasAllowed.has_value()) << "URL was not requested: \"" << expectation.url.utf8().data() << "\"";
+        if (expectation.wasAllowed.has_value()) {
+            EXPECT_EQ(expectation.wasAllowed.value(), expectation.shouldBeAllowed)
+                << "URL " << expectation.url.utf8().data()
+                << " was " << (expectation.wasAllowed.value() ? "allowed" : "blocked")
+                << " but should have been " << (expectation.shouldBeAllowed ? "allowed" : "blocked");
+        }
+    }
 }
 
 TEST(WKWebExtensionAPIDeclarativeNetRequest, UnacceptableResourceTypeForAllowAllRequests)


### PR DESCRIPTION
#### 708061a0763a677c5fc4de2ec77969225f26c964
<pre>
dNR: fails to match separator `^` to end of URL in `urlFilter`
<a href="https://bugs.webkit.org/show_bug.cgi?id=297838">https://bugs.webkit.org/show_bug.cgi?id=297838</a>

Reviewed by NOBODY (OOPS!).

Previously, the separator character (`^`) only matched when an allowed character
was present; it did not match the end of the URL as expected. This change
adjusts the regular expression used internally to either match an allowed
character or the end of the URL.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm

* Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.mm:
(-[_WKWebExtensionDeclarativeNetRequestRule
_regexURLFilterForChromeURLFilter:]): Updated internal RegExp used to match the
separator character.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest,
RuleConversionWithURLFilterAndRequestDomains)): Added a new test case to check
separator character handling.
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest,
URLFilterSpecialCharacters)): Updated existing test case to match the new RegExp
pattern.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7947544d74b88e63a1bc28bdbcf815b835d5f11d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141259 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13643 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2957 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149833 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94356 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143132 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14354 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13796 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108524 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78565 "2 flakes 8 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144210 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11072 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126415 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89429 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10647 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8256 "Passed tests") | [⏳ 🛠 wpe-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119908 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIDeclarativeNetRequest.URLFilterSpecialCharacterRuleList (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2391 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152227 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13329 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2835 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116622 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13345 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11638 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116962 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13008 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123067 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/68503 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13372 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2447 "5 flakes 2 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13111 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77078 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13310 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13155 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->