### PR TITLE
REGRESSION(305008@main): ASAN_ILL | Style::Blending::blend; Interpolation::VisitedAffectedStyleTypeWrapper::interpolate; Style::Interpolation::interpolate

### DIFF
--- a/LayoutTests/fast/css/caret-color-auto-visited-style-crash-expected.txt
+++ b/LayoutTests/fast/css/caret-color-auto-visited-style-crash-expected.txt
@@ -1,0 +1,1 @@
+This passes if the test does not crash. Link

--- a/LayoutTests/fast/css/caret-color-auto-visited-style-crash.html
+++ b/LayoutTests/fast/css/caret-color-auto-visited-style-crash.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+  @keyframes test {
+    to { caret-color: blue; }
+  }
+  a:link { caret-color: green; }
+  a:visited { caret-color: auto; }
+  a { animation: test 1s linear infinite alternate; }
+</style>
+<script>
+  window.testRunner?.dumpAsText();
+</script>
+</head>
+<body>
+  This passes if the test does not crash.
+  <a href="https://example.com">Link</a>
+</body>
+</html>


### PR DESCRIPTION
#### d5a5bc3994198ba1a2084204c933c1b7fb24207e
<pre>
REGRESSION(305008@main): ASAN_ILL | Style::Blending::blend; Interpolation::VisitedAffectedStyleTypeWrapper::interpolate; Style::Interpolation::interpolate
<a href="https://bugs.webkit.org/show_bug.cgi?id=305409">https://bugs.webkit.org/show_bug.cgi?id=305409</a>
<a href="https://rdar.apple.com/168081655">rdar://168081655</a>

Reviewed by Antoine Quint.

Fixes a crash due to how the VisitedAffectedStyleTypeWrapper interpolation
wrapper worked when the unvisited and visited styles returned different
&quot;can interpolate&quot; values, acting as if both could interpolate if either
was able to. Instead, we now cache the individual responses and construct
separate contexts before calling interpolate.

Test: fast/css/caret-color-auto-visited-style-crash.html
* LayoutTests/fast/css/caret-color-auto-visited-style-crash-expected.txt: Added.
* LayoutTests/fast/css/caret-color-auto-visited-style-crash.html: Added.
* Source/WebCore/style/StyleInterpolationWrappers.h:

Canonical link: <a href="https://commits.webkit.org/305666@main">https://commits.webkit.org/305666@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4991d0e877a368839603c75389303e1ca73b60bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139094 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11467 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/591 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147220 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7427111f-611b-4c47-9e91-547ff08c7c6f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140966 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12174 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11618 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/106475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8ddce428-6fd2-4a6e-8e23-79f78b52ba55) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142041 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9194 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/124598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/87343 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c681bea8-b039-48bb-be77-2dc46af45603) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/8748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/6524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo-libwebrtc~~](https://ews-build.webkit.org/#/builders/166/builds/7513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/118197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150000 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11152 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/114868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11165 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/9435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/115179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/9082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/120946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/66054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21438 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11194 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/10930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74852 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/11133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/10982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->