### PR TITLE
AX: Convert ASSERT and ASSERT_NOT_REACHED to AX_ASSERT equivalents

### DIFF
--- a/Source/WebCore/accessibility/AXGeometryManager.cpp
+++ b/Source/WebCore/accessibility/AXGeometryManager.cpp
@@ -69,9 +69,7 @@ std::optional<IntRect> AXGeometryManager::cachedRectForID(AXID axID)
 
 bool AXGeometryManager::cacheRectIfNeeded(AXID axID, IntRect&& rect)
 {
-    // We shouldn't call this method on a geometry manager that has no page ID.
-    AX_DEBUG_ASSERT(m_cache->pageID());
-    AX_DEBUG_ASSERT(AXObjectCache::isIsolatedTreeEnabled());
+    AX_ASSERT(AXObjectCache::isIsolatedTreeEnabled());
 
     auto rectIterator = m_cachedRects.find(axID);
 

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -246,7 +246,7 @@ void AXLogger::log(const String& collectionName, const AXObjectCache::DeferredCo
         [&size] (const WeakListHashSet<Element, WeakPtrImplWithEventTargetData>& typedCollection) { size = typedCollection.computeSize(); },
         [&size] (const WeakHashMap<Element, String, WeakPtrImplWithEventTargetData>& typedCollection) { size = typedCollection.computeSize(); },
         [] (auto&) {
-            ASSERT_NOT_REACHED();
+            AX_ASSERT_NOT_REACHED();
             return;
         });
     if (size)
@@ -591,7 +591,7 @@ TextStream& operator<<(WTF::TextStream& stream, const TextUnderElementMode& mode
         childrenInclusion = "IncludeNameFromContentsChildren"_s;
         break;
     default:
-        ASSERT_NOT_REACHED();
+        AX_ASSERT_NOT_REACHED();
         break;
     }
 
@@ -1279,7 +1279,7 @@ TextStream& operator<<(TextStream& stream, const AXCoreObject& object)
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 TextStream& operator<<(TextStream& stream, AXIsolatedTree& tree)
 {
-    ASSERT(!isMainThread());
+    AX_ASSERT(!isMainThread());
     TextStream::GroupScope groupScope(stream);
     stream << "treeID " << tree.treeID();
     stream.dumpProperty("rootNodeID"_s, tree.rootNode()->objectID());
@@ -1292,7 +1292,7 @@ TextStream& operator<<(TextStream& stream, AXIsolatedTree& tree)
 
 void streamIsolatedSubtreeOnMainThread(TextStream& stream, const AXIsolatedTree& tree, AXID objectID, const OptionSet<AXStreamOptions>& options)
 {
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
 
     stream.increaseIndent();
     TextStream::GroupScope groupScope(stream);

--- a/Source/WebCore/accessibility/AXLoggerBase.h
+++ b/Source/WebCore/accessibility/AXLoggerBase.h
@@ -43,12 +43,17 @@ bool isAccessibilityLogChannelEnabled();
     } \
 } while (0)
 
-// Enable this in order to get debug asserts, which are called too frequently to be enabled
-// by default.
-#define AX_DEBUG_ASSERTS_ENABLED 0
+#ifndef AX_ASSERTS_ENABLED
+#define AX_ASSERTS_ENABLED 0
+#endif
 
-#if AX_DEBUG_ASSERTS_ENABLED
-#define AX_DEBUG_ASSERT(assertion) ASSERT(assertion)
+#if AX_ASSERTS_ENABLED
+// Prefer these asserts to the debug assert equivalents.
+// RELEASE_ASSERT and similar are preferable to these asserts for cases where we want to assert
+// in all configurations.
+#define AX_ASSERT(assertion) RELEASE_ASSERT(assertion)
+#define AX_ASSERT_NOT_REACHED(assertion) RELEASE_ASSERT_NOT_REACHED(assertion)
 #else
-#define AX_DEBUG_ASSERT(assertion) ((void)0)
+#define AX_ASSERT(assertion) ASSERT(assertion)
+#define AX_ASSERT_NOT_REACHED(assertion) ASSERT_NOT_REACHED(assertion)
 #endif

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -163,7 +163,7 @@ static bool isSecureFieldOrContainedBySecureField(AccessibilityObject& object)
 
 static bool rendererNeedsDeferredUpdate(const RenderObject& renderer)
 {
-    ASSERT(!renderer.beingDestroyed());
+    AX_ASSERT(!renderer.beingDestroyed());
     Ref document = renderer.document();
     return renderer.needsLayout() || document->needsStyleRecalc() || document->inRenderTreeUpdate() || (document->view() && document->view()->layoutContext().isInRenderTreeLayout());
 }
@@ -221,13 +221,13 @@ std::atomic<bool> AXObjectCache::gShouldRepostNotificationsForTests = false;
 
 bool AXObjectCache::accessibilityEnhancedUserInterfaceEnabled()
 {
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
     return gAccessibilityEnhancedUserInterfaceEnabled;
 }
 
 void AXObjectCache::setEnhancedUserInterfaceAccessibility(bool flag)
 {
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
     gAccessibilityEnhancedUserInterfaceEnabled = flag;
 #if PLATFORM(MAC)
     if (flag)
@@ -270,7 +270,7 @@ AXObjectCache::AXObjectCache(LocalFrame& localFrame, Document* document)
 #ifndef NDEBUG
     AXLOG(makeString("frameID "_s, m_frameID.loggingString()));
 #endif
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
 
 #if !LOG_DISABLED || !RELEASE_LOG_DISABLED
     setAccessibilityLogChannelEnabled(LOG_CHANNEL(Accessibility).state != logChannelStateOff);
@@ -368,7 +368,7 @@ bool AXObjectCache::modalElementHasAccessibleContent(Element& element)
     // Unless you're trying to compute the new modal node, determining whether an element
     // has accessible content is as easy as !getOrCreate(element)->unignoredChildren().isEmpty().
     // So don't call this method on anything besides modal elements.
-    ASSERT(isModalElement(element));
+    AX_ASSERT(isModalElement(element));
 
     // Because computing any object's unignored children is dependent on whether a modal is on the page,
     // we'll need to walk the DOM and find non-ignored AX objects manually.
@@ -411,7 +411,7 @@ void AXObjectCache::updateCurrentModalNode()
 
         // Pick the document active modal <dialog> element if it exists.
         if (RefPtr activeModalDialog = document->activeModalDialog()) {
-            ASSERT(m_modalElements.contains(activeModalDialog.get()));
+            AX_ASSERT(m_modalElements.contains(activeModalDialog.get()));
             return activeModalDialog.unsafeGet();
         }
 
@@ -542,7 +542,7 @@ AccessibilityObject* AXObjectCache::focusedObjectForPage(const Page* page)
     return focusedObjectForLocalFrame();
 #endif
 
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
 
     if (!gAccessibilityEnabled)
         return nullptr;
@@ -563,7 +563,7 @@ AccessibilityObject* AXObjectCache::focusedObjectForPage(const Page* page)
 
 AccessibilityObject* AXObjectCache::focusedObjectForLocalFrame()
 {
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
 
     if (!gAccessibilityEnabled)
         return nullptr;
@@ -610,7 +610,7 @@ AccessibilityObject* AXObjectCache::focusedObjectForNode(Node* focusedNode)
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 void AXObjectCache::setIsolatedTreeFocusedObject(AccessibilityObject* focus)
 {
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
 
     if (auto tree = AXIsolatedTree::treeForFrameID(m_frameID))
         tree->setFocusedNodeID(focus ? std::optional { focus->objectID() } : std::nullopt);
@@ -725,10 +725,10 @@ AccessibilityObject* AXObjectCache::getOrCreate(Widget& widget)
         newObject = AccessibilityScrollbar::create(AXID::generate(), *scrollbar, *this);
 
     // Will crash later if we have two objects for the same widget.
-    ASSERT(!get(widget));
+    AX_ASSERT(!get(widget));
 
     // Ensure we weren't given an unsupported widget type.
-    ASSERT(newObject);
+    AX_ASSERT(newObject);
     if (!newObject)
         return nullptr;
 
@@ -739,10 +739,10 @@ AccessibilityObject* AXObjectCache::getOrCreate(Widget& widget)
 AccessibilityObject* AXObjectCache::getOrCreateSlow(Node& node, IsPartOfRelation isPartOfRelation)
 {
     // `get` for this Node should've been attempted before calling this method.
-    ASSERT(!get(node));
+    AX_ASSERT(!get(node));
 
 #if ENABLE_ACCESSIBILITY_LOCAL_FRAME
-    ASSERT(&node.document() == document());
+    AX_ASSERT(&node.document() == document());
 #endif
 
     bool isYouTubeReplacement = false;
@@ -816,7 +816,7 @@ AccessibilityObject* AXObjectCache::getOrCreateSlow(Node& node, IsPartOfRelation
     RefPtr newObject = createFromNode(node);
 
     // Will crash later if we have two objects for the same node.
-    ASSERT(!get(node));
+    AX_ASSERT(!get(node));
     cacheAndInitializeWrapper(*newObject, &node);
     // Compute the object's initial ignored status.
     newObject->recomputeIsIgnored();
@@ -864,7 +864,7 @@ AccessibilityObject* AXObjectCache::getOrCreate(RenderObject& renderer)
 RefPtr<AXIsolatedTree> AXObjectCache::getOrCreateIsolatedTree()
 {
     AXTRACE(makeString("AXObjectCache::getOrCreateIsolatedTree 0x"_s, hex(reinterpret_cast<uintptr_t>(this))));
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
 
     RefPtr tree = AXIsolatedTree::treeForFrameID(m_frameID);
     if (tree) {
@@ -911,7 +911,7 @@ void AXObjectCache::buildIsolatedTree()
 
 void AXObjectCache::setIsolatedTree(Ref<AXIsolatedTree> tree)
 {
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
     if (RefPtr frame = m_document ? m_document->frame() : nullptr)
         frame->loader().client().setIsolatedTree(WTF::move(tree));
 }
@@ -1024,7 +1024,7 @@ void AXObjectCache::remove(AXID axID)
 void AXObjectCache::remove(RenderObject& renderer)
 {
     AXTRACE(makeString("AXObjectCache::remove RenderObject* 0x"_s, hex(reinterpret_cast<uintptr_t>(this))));
-    ASSERT(!renderer.node() || !m_renderObjectIdMapping.contains(renderer));
+    AX_ASSERT(!renderer.node() || !m_renderObjectIdMapping.contains(renderer));
 
     if (RefPtr node = renderer.node()) {
         // We only delete objects with nodes when their DOM node is destroyed, not their renderer.
@@ -1130,7 +1130,7 @@ void AXObjectCache::onRendererCreated(Node& node)
 {
     CheckedPtr renderer = node.renderer();
     if (!renderer) [[unlikely]] {
-        ASSERT_NOT_REACHED();
+        AX_ASSERT_NOT_REACHED();
         return;
     }
 
@@ -1314,7 +1314,7 @@ void AXObjectCache::handleChildrenChanged(AccessibilityObject& object)
         if (children.isEmpty())
             return;
 
-        ASSERT(children.size() == 1);
+        AX_ASSERT(children.size() == 1);
         handleChildrenChanged(downcast<AccessibilityObject>(children[0].get()));
     } else if (auto* menuListPopup = dynamicDowncast<AccessibilityMenuListPopup>(object)) {
         menuListPopup->handleChildrenChanged();
@@ -1635,7 +1635,7 @@ void AXObjectCache::notificationPostTimerFired()
         // Notifications should only be sent after the renderer has finished
         if (auto* renderObject = dynamicDowncast<AccessibilityRenderObject>(note.first.get())) {
             if (auto* renderer = renderObject->renderer())
-                ASSERT(!renderer->view().frameView().layoutContext().layoutState());
+                AX_ASSERT(!renderer->view().frameView().layoutContext().layoutState());
         }
 #endif
 
@@ -1724,7 +1724,7 @@ void AXObjectCache::postNotification(AccessibilityObject* object, Document* docu
 {
     AXTRACE(makeString("AXObjectCache::postNotification 0x"_s, hex(reinterpret_cast<uintptr_t>(this))));
     AXLOG(std::make_pair(object, notification));
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
 
     stopCachingComputedObjectAttributes();
 
@@ -1754,7 +1754,7 @@ void AXObjectCache::postNotification(AccessibilityObject& object, AXNotification
     AXTRACE(makeString("AXObjectCache::postNotification 0x"_s, hex(reinterpret_cast<uintptr_t>(this))));
     auto dataNotification = AXNotificationWithData(notification);
     AXLOG(std::make_pair(Ref { object }, dataNotification));
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
 
     stopCachingComputedObjectAttributes();
 
@@ -2167,8 +2167,8 @@ void AXObjectCache::onAccessibilityPaintFinished()
             // other renderers. The LineRange struct we have built expects the start and end line indices to be
             // relative to just this renderer, so normalize them by getting the first line index for this renderer.
             size_t firstLineIndexForRenderer = textBox->lineIndex();
-            ASSERT(firstLineIndexForRenderer <= iterator->value.startLineIndex);
-            ASSERT(firstLineIndexForRenderer <= iterator->value.endLineIndex);
+            AX_ASSERT(firstLineIndexForRenderer <= iterator->value.startLineIndex);
+            AX_ASSERT(firstLineIndexForRenderer <= iterator->value.endLineIndex);
             iterator->value.startLineIndex -= firstLineIndexForRenderer;
             iterator->value.endLineIndex -= firstLineIndexForRenderer;
         }
@@ -2661,7 +2661,7 @@ void AXObjectCache::postTextReplacementNotificationForTextControl(HTMLTextFormCo
 
 static AXTextChangeContext secureContext(AccessibilityObject& object, AXTextChangeContext& context)
 {
-    ASSERT(isSecureFieldOrContainedBySecureField(object));
+    AX_ASSERT(isSecureFieldOrContainedBySecureField(object));
 
     // FIXME: Add a better way to retrieve the maskingCharacter for secure fields.
     String value = object.secureFieldValue();
@@ -2689,7 +2689,7 @@ bool AXObjectCache::enqueuePasswordNotification(AccessibilityObject& object, AXT
 
     RefPtr observableObject = object.observableObject();
     if (!observableObject) {
-        ASSERT_NOT_REACHED();
+        AX_ASSERT_NOT_REACHED();
         // Return true even though the enqueue didn't happen because this is a password field and caller shouldn't post a notification unless it is queued.
         return true;
     }
@@ -2933,7 +2933,7 @@ void AXObjectCache::handleRoleChanged(Element& element, const AtomString& oldVal
 {
     AXTRACE("AXObjectCache::handleRoleChanged"_s);
     AXLOG(makeString("oldValue "_s, oldValue, " new value "_s, newValue));
-    ASSERT(oldValue != newValue);
+    AX_ASSERT(oldValue != newValue);
 
     RefPtr object = get(element);
     if (!object)
@@ -3054,7 +3054,7 @@ void AXObjectCache::handleAttributeChange(Element* element, const QualifiedName&
 
     enum class TableProperty : uint8_t { Exposed = 1 << 0, CellSlots = 1 << 1 };
     auto recomputeParentTableProperties = [this] (Element* element, OptionSet<TableProperty> properties) {
-        ASSERT(!properties.isEmpty());
+        AX_ASSERT(!properties.isEmpty());
 
         if (!properties.contains(TableProperty::CellSlots)) {
             // If we're re-computing the exposed state of the table, we only need to do work for non-ARIA tables, allowing us to
@@ -3075,7 +3075,7 @@ void AXObjectCache::handleAttributeChange(Element* element, const QualifiedName&
     if (!shouldProcessAttributeChange(element, attrName))
         return;
     // The remaining code in this method relies on shouldProcessAttributeChange null-checking element.
-    ASSERT(element);
+    AX_ASSERT(element);
 
     if (relationAttributes().contains(attrName))
         updateRelations(*element, attrName);
@@ -3910,7 +3910,7 @@ TextMarkerData AXObjectCache::textMarkerDataForNextCharacterOffset(const Charact
 
 AXTextMarker AXObjectCache::nextTextMarker(const AXTextMarker& marker)
 {
-    ASSERT(m_id == marker.treeID());
+    AX_ASSERT(m_id == marker.treeID());
     return textMarkerDataForNextCharacterOffset(marker);
 }
 
@@ -3942,7 +3942,7 @@ TextMarkerData AXObjectCache::textMarkerDataForPreviousCharacterOffset(const Cha
 
 AXTextMarker AXObjectCache::previousTextMarker(const AXTextMarker& marker)
 {
-    ASSERT(m_id == marker.treeID());
+    AX_ASSERT(m_id == marker.treeID());
     return textMarkerDataForPreviousCharacterOffset(marker);
 }
 
@@ -4038,7 +4038,7 @@ AccessibilityObject* AXObjectCache::objectForTextMarkerData(const TextMarkerData
     Node* node = object->node();
     if (!node)
         return nullptr;
-    ASSERT(object.get() == getOrCreate(*node));
+    AX_ASSERT(object.get() == getOrCreate(*node));
     return getOrCreate(*node);
 }
 
@@ -4049,7 +4049,7 @@ std::optional<TextMarkerData> AXObjectCache::textMarkerDataForVisiblePosition(co
 
     Position position = visiblePosition.deepEquivalent();
     RefPtr node = position.anchorNode();
-    ASSERT(node);
+    AX_ASSERT(node);
     if (!node)
         return std::nullopt;
 
@@ -4117,7 +4117,7 @@ std::optional<TextMarkerData> AXObjectCache::textMarkerDataForVisiblePosition(co
             previousEndDomOffset = textBox->maximumCaretOffset();
             previousLineIndex = newLineIndex;
         }
-        ASSERT(domOffset >= differenceBetweenDomAndRenderedOffsets);
+        AX_ASSERT(domOffset >= differenceBetweenDomAndRenderedOffsets);
         unsigned renderedOffset = domOffset - differenceBetweenDomAndRenderedOffsets;
         return createFromRendererAndOffset(const_cast<RenderText&>(*renderText), renderedOffset);
     }
@@ -4799,7 +4799,7 @@ void AXObjectCache::performDeferredCacheUpdate(ForceLayout forceLayout)
         return;
 
     // It's unexpected for this function to run in the middle of a render tree or style update.
-    ASSERT(!Accessibility::inRenderTreeOrStyleUpdate(*document));
+    AX_ASSERT(!Accessibility::inRenderTreeOrStyleUpdate(*document));
 
     if (!document->view())
         return;
@@ -5033,10 +5033,10 @@ void AXObjectCache::handleDeferredNotification(const DeferredNotificationData& d
     if (CheckedPtr renderer = data.renderer.get()) {
         // The point of deferring the notification is to post it when style and layout
         // are clean, so this function should not be called unless this is true.
-        ASSERT(!needsLayoutOrStyleRecalc(renderer->document()) && !renderer->needsLayout());
+        AX_ASSERT(!needsLayoutOrStyleRecalc(renderer->document()) && !renderer->needsLayout());
         postNotification(getOrCreate(*renderer), data.notification);
     } else if (RefPtr element = data.element.get()) {
-        ASSERT(!needsLayoutOrStyleRecalc(element->document()));
+        AX_ASSERT(!needsLayoutOrStyleRecalc(element->document()));
         postNotification(getOrCreate(*element), data.notification);
     }
 }
@@ -5126,7 +5126,7 @@ void AXObjectCache::updateIsolatedTree(const Vector<std::pair<Ref<AccessibilityO
             tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::BrailleRoleDescription });
             break;
         case AXNotification::CellSlotsChanged:
-            ASSERT(notification.first->isTable());
+            AX_ASSERT(notification.first->isTable());
             tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::CellSlots });
             break;
         case AXNotification::CheckedStateChanged:
@@ -5364,7 +5364,7 @@ void AXObjectCache::onPaint(const Widget& widget, IntRect&& paintRect) const
 
 void AXObjectCache::onPaint(const RenderText& renderText, size_t lineIndex)
 {
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
 
     auto ensureResult = m_mostRecentlyPaintedText.ensure(renderText, [&] {
         return LineRange(lineIndex, lineIndex);
@@ -5504,7 +5504,7 @@ AccessibilityObject* AXObjectCache::rootWebArea()
 
 AXTreeData AXObjectCache::treeData(std::optional<OptionSet<AXStreamOptions>> additionalOptions)
 {
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
 
     AXTreeData data;
     TextStream stream(TextStream::LineMode::MultipleLine);
@@ -5664,7 +5664,7 @@ bool AXObjectCache::addRelation(Element& origin, Element& target, AXRelation rel
     AXLOG(makeString("origin: "_s, origin.debugDescription(), " target: "_s, target.debugDescription(), " relation "_s, static_cast<uint8_t>(relation)));
 
     if (!validRelation(origin, target, relation)) {
-        ASSERT_NOT_REACHED();
+        AX_ASSERT_NOT_REACHED();
         return false;
     }
 
@@ -5866,7 +5866,7 @@ void AXObjectCache::updateRelationsIfNeeded()
 
 void AXObjectCache::updateRelationsForTree(ContainerNode& rootNode)
 {
-    ASSERT(!rootNode.parentNode());
+    AX_ASSERT(!rootNode.parentNode());
     for (Ref element : descendantsOfType<Element>(rootNode)) {
         if (!canHaveRelations(element.get()))
             continue;
@@ -5956,7 +5956,7 @@ void AXObjectCache::updateRelations(Element& origin, const QualifiedName& attrib
 
     auto relation = attributeToRelationType(attribute);
     if (relation == AXRelation::None) {
-        ASSERT_NOT_REACHED();
+        AX_ASSERT_NOT_REACHED();
         return;
     }
 
@@ -6052,7 +6052,7 @@ AXTextChange AXObjectCache::textChangeForEditType(AXTextEditType type)
     case AXTextEditTypeAttributesChange:
         return AXTextChange::AttributesChanged;
     case AXTextEditTypeUnknown:
-        ASSERT_NOT_REACHED();
+        AX_ASSERT_NOT_REACHED();
         return AXTextChange::Inserted;
     }
 }

--- a/Source/WebCore/accessibility/AXObjectCacheInlines.h
+++ b/Source/WebCore/accessibility/AXObjectCacheInlines.h
@@ -50,7 +50,7 @@ inline bool CharacterOffset::isEqual(const CharacterOffset& other) const
 template<typename U>
 inline Vector<Ref<AXCoreObject>> AXObjectCache::objectsForIDs(const U& axIDs) const
 {
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
 
     CheckedPtr cache = this;
     return WTF::compactMap(axIDs, [cache](auto& axID) -> std::optional<Ref<AXCoreObject>> {

--- a/Source/WebCore/accessibility/AXSearchManager.cpp
+++ b/Source/WebCore/accessibility/AXSearchManager.cpp
@@ -445,7 +445,7 @@ std::optional<AXTextMarkerRange> AXSearchManager::findMatchingRange(Accessibilit
     // Currently, this method only supports searching for the next/previous misspelling.
     // FIXME: support other types of ranges, like italicized.
     if (criteria.searchKeys.size() != 1 || criteria.searchKeys[0] != AccessibilitySearchKey::MisspelledWord || criteria.resultsLimit != 1) {
-        ASSERT_NOT_REACHED();
+        AX_ASSERT_NOT_REACHED();
         return std::nullopt;
     }
 
@@ -457,9 +457,9 @@ std::optional<AXTextMarkerRange> AXSearchManager::findMatchingRange(Accessibilit
 
     bool forward = criteria.searchDirection == AccessibilitySearchDirection::Next;
     if (match(*startObject, criteria)) {
-        ASSERT(m_misspellingRanges.contains(startObject->objectID()));
+        AX_ASSERT(m_misspellingRanges.contains(startObject->objectID()));
         const auto& ranges = m_misspellingRanges.get(startObject->objectID());
-        ASSERT(!ranges.isEmpty());
+        AX_ASSERT(!ranges.isEmpty());
 
         AXTextMarkerRange startRange { startObject->treeID(), startObject->objectID(), criteria.startRange };
         if (forward) {
@@ -479,9 +479,9 @@ std::optional<AXTextMarkerRange> AXSearchManager::findMatchingRange(Accessibilit
     auto objects = findMatchingObjectsInternal(criteria);
     if (!objects.isEmpty()) {
         Ref object = objects[0];
-        ASSERT(m_misspellingRanges.contains(object->objectID()));
+        AX_ASSERT(m_misspellingRanges.contains(object->objectID()));
         const auto& ranges = m_misspellingRanges.get(object->objectID());
-        ASSERT(!ranges.isEmpty());
+        AX_ASSERT(!ranges.isEmpty());
         return forward ? ranges[0] : ranges.last();
     }
     return std::nullopt;

--- a/Source/WebCore/accessibility/AXSearchManager.h
+++ b/Source/WebCore/accessibility/AXSearchManager.h
@@ -111,7 +111,7 @@ private:
     }
     void setLastRevealAttemptTimedOut(bool newValue)
     {
-        ASSERT(!isMainThread());
+        AX_ASSERT(!isMainThread());
         m_lastRevealAttemptTimedOut = newValue;
     }
 

--- a/Source/WebCore/accessibility/AXStitchGroup.h
+++ b/Source/WebCore/accessibility/AXStitchGroup.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/AXID.h>
+#include <WebCore/AXLoggerBase.h>
 #include <wtf/FixedVector.h>
 
 namespace WebCore {
@@ -50,14 +51,14 @@ public:
         : m_members(members)
         , m_representativeID(representativeID)
     {
-        ASSERT(isValid());
+        AX_ASSERT(isValid());
     }
 
     explicit AXStitchGroup(Vector<AXID>&& members, AXID representativeID)
         : m_members(WTF::move(members))
         , m_representativeID(representativeID)
     {
-        ASSERT(isValid());
+        AX_ASSERT(isValid());
     }
 
     bool isEmpty() const { return m_members.isEmpty(); }

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -27,6 +27,7 @@
 
 #include "AXIsolatedObject.h"
 #include "AXLogger.h"
+#include "AXLoggerBase.h"
 #include "AXObjectCache.h"
 #include "AXTreeStore.h"
 #include "AXTreeStoreInlines.h"
@@ -59,9 +60,9 @@ static std::optional<AXID> nodeID(AXObjectCache& cache, Node* node)
 
 TextMarkerData::TextMarkerData(AXObjectCache& cache, const VisiblePosition& visiblePosition, int charStart, int charOffset, bool ignoredParam, TextMarkerOrigin originParam)
 {
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
 #if ENABLE(AX_THREAD_TEXT_APIS)
-    ASSERT(!AXObjectCache::shouldCreateAXThreadCompatibleMarkers());
+    AX_ASSERT(!AXObjectCache::shouldCreateAXThreadCompatibleMarkers());
 #endif
 
     zeroBytes(*this);
@@ -80,7 +81,7 @@ TextMarkerData::TextMarkerData(AXObjectCache& cache, const VisiblePosition& visi
 
 TextMarkerData::TextMarkerData(AXObjectCache& cache, const CharacterOffset& characterOffsetParam, bool ignoredParam, TextMarkerOrigin originParam)
 {
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
 
     zeroBytes(*this);
 
@@ -108,13 +109,13 @@ TextMarkerData::TextMarkerData(AXObjectCache& cache, const CharacterOffset& char
 
 AXTextMarker::AXTextMarker(const VisiblePosition& visiblePosition, TextMarkerOrigin origin)
 {
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
 
     if (visiblePosition.isNull())
         return;
 
     RefPtr node = visiblePosition.deepEquivalent().anchorNode();
-    ASSERT(node);
+    AX_ASSERT(node);
     if (!node)
         return;
 
@@ -128,7 +129,7 @@ AXTextMarker::AXTextMarker(const VisiblePosition& visiblePosition, TextMarkerOri
 
 AXTextMarker::AXTextMarker(const CharacterOffset& characterOffset, TextMarkerOrigin origin)
 {
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
 
     if (characterOffset.isNull())
         return;
@@ -139,7 +140,7 @@ AXTextMarker::AXTextMarker(const CharacterOffset& characterOffset, TextMarkerOri
 
 AXTextMarker::operator VisiblePosition() const
 {
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
 
     WeakPtr cache = AXTreeStore<AXObjectCache>::axObjectCacheForID(treeID());
     if (!cache)
@@ -150,7 +151,7 @@ AXTextMarker::operator VisiblePosition() const
 
 AXTextMarker::operator CharacterOffset() const
 {
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
 
     if (isIgnored() || isNull())
         return { };
@@ -187,7 +188,7 @@ static Node* nodeAndOffsetForReplacedNode(Node& replacedNode, int& offset, int c
 
 std::optional<BoundaryPoint> AXTextMarker::boundaryPoint() const
 {
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
 
     CharacterOffset characterOffset = *this;
     if (characterOffset.isNull())
@@ -258,19 +259,19 @@ AXTextMarkerRange::AXTextMarkerRange(const VisibleSelection& selection)
     : m_start(selection.visibleStart())
     , m_end(selection.visibleEnd())
 {
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
 }
 
 AXTextMarkerRange::AXTextMarkerRange(const VisiblePositionRange& range)
     : m_start(range.start)
     , m_end(range.end)
 {
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
 }
 
 AXTextMarkerRange::AXTextMarkerRange(const std::optional<SimpleRange>& range)
 {
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
 
     if (!range)
         return;
@@ -328,7 +329,7 @@ AXTextMarkerRange::AXTextMarkerRange(std::optional<AXID> treeID, std::optional<A
 
 AXTextMarkerRange::operator VisiblePositionRange() const
 {
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
     if (!m_start || !m_end)
         return { };
     return { m_start, m_end };
@@ -336,7 +337,7 @@ AXTextMarkerRange::operator VisiblePositionRange() const
 
 std::optional<SimpleRange> AXTextMarkerRange::simpleRange() const
 {
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
 
     auto startBoundaryPoint = m_start.boundaryPoint();
     if (!startBoundaryPoint)
@@ -356,7 +357,7 @@ std::optional<CharacterRange> AXTextMarkerRange::characterRange() const
         return std::nullopt;
 
     if (m_start.m_data.characterOffset > m_end.m_data.characterOffset) {
-        ASSERT_NOT_REACHED();
+        AX_ASSERT_NOT_REACHED();
         return std::nullopt;
     }
     return { { m_start.m_data.characterOffset, m_end.m_data.characterOffset - m_start.m_data.characterOffset } };
@@ -649,7 +650,7 @@ String AXTextMarkerRange::toString(IncludeListMarkerText includeListMarkerText, 
 #if ENABLE(AX_THREAD_TEXT_APIS)
 AXTextMarker AXTextMarker::convertToDomOffset() const
 {
-    ASSERT(!isMainThread());
+    AX_ASSERT(!isMainThread());
 
     if (!isValid())
         return { };
@@ -859,7 +860,7 @@ bool AXTextMarker::atLineBoundaryForDirection(AXDirection direction, const AXTex
 
 unsigned AXTextMarker::offsetFromRoot() const
 {
-    ASSERT(!isMainThread());
+    AX_ASSERT(!isMainThread());
 
     if (!isValid())
         return 0;
@@ -913,7 +914,7 @@ unsigned AXTextMarker::offsetFromRoot() const
 
 AXTextMarker AXTextMarker::nextMarkerFromOffset(unsigned offset, ForceSingleOffsetMovement forceSingleOffsetMovement, std::optional<AXID> stopAtID) const
 {
-    ASSERT(!isMainThread());
+    AX_ASSERT(!isMainThread());
 
     if (!isValid())
         return { };
@@ -934,7 +935,7 @@ AXTextMarker AXTextMarker::nextMarkerFromOffset(unsigned offset, ForceSingleOffs
 
 AXTextMarker AXTextMarker::findLastBefore(std::optional<AXID> stopAtID) const
 {
-    ASSERT(!isMainThread());
+    AX_ASSERT(!isMainThread());
 
     if (!isValid())
         return { };
@@ -962,7 +963,7 @@ AXTextMarker AXTextMarker::findLastBefore(std::optional<AXID> stopAtID) const
 
 AXTextMarkerRange AXTextMarker::rangeWithSameStyle() const
 {
-    ASSERT(!isMainThread());
+    AX_ASSERT(!isMainThread());
 
     if (!isValid())
         return { };
@@ -1015,7 +1016,7 @@ static FloatRect viewportRelativeFrameFromRuns(Ref<AXIsolatedObject> object, uns
 
 FloatRect AXTextMarkerRange::viewportRelativeFrame() const
 {
-    ASSERT(!isMainThread());
+    AX_ASSERT(!isMainThread());
 
     auto start = m_start.toTextRunMarker();
     if (!start.isValid())
@@ -1045,7 +1046,7 @@ FloatRect AXTextMarkerRange::viewportRelativeFrame() const
 
 AXTextMarkerRange AXTextMarkerRange::convertToDomOffsetRange() const
 {
-    ASSERT(!isMainThread());
+    AX_ASSERT(!isMainThread());
 
     return {
         m_start.convertToDomOffset(),
@@ -1055,7 +1056,7 @@ AXTextMarkerRange AXTextMarkerRange::convertToDomOffsetRange() const
 
 const AXTextRuns* AXTextMarker::runs() const
 {
-    ASSERT(!isMainThread());
+    AX_ASSERT(!isMainThread());
 
     RefPtr object = isolatedObject();
     return object ? object->textRuns() : nullptr;
@@ -1176,12 +1177,12 @@ AXTextMarker AXTextMarker::findLine(AXDirection direction, AXTextUnitBoundary bo
             if (adjacentRunIndex != notFound && adjacentRunIndex > runIndex && adjacentRunIndex - runIndex > 1) {
                 // The scenario we're trying to detect should only have resulted in one run / line being skipped.
                 // Our affinity flip won't result in the correct behavior if we've somehow jumped >2 lines.
-                ASSERT(adjacentRunIndex - runIndex == 2);
+                AX_ASSERT(adjacentRunIndex - runIndex == 2);
                 // This scenario really should only happen with single "entity" runs (where an entity could be an ASCII
                 // character, or a multi-byte emoji that occupies multiple indices but is one atomic entity).
                 AX_BROKEN_ASSERT(!currentRuns->containsOnlyASCII || (currentRuns->runLength(runIndex) == 1 && currentRuns->runLength(adjacentRunIndex) == 1));
                 // The next line end is simply the adjacent marker with an upstream affinity (with an ASSERT to verify this).
-                ASSERT(currentRuns->indexForOffset(adjacentMarker.offset(), Affinity::Upstream) == runIndex + 1);
+                AX_ASSERT(currentRuns->indexForOffset(adjacentMarker.offset(), Affinity::Upstream) == runIndex + 1);
                 adjacentMarker.setAffinity(Affinity::Upstream);
                 return adjacentMarker;
             }
@@ -1514,7 +1515,7 @@ AXTextMarkerRange AXTextMarker::lineRange(LineRangeType type, IncludeTrailingLin
         return { WTF::move(startMarker), WTF::move(endMarker) };
     }
 
-    ASSERT(type == LineRangeType::Right);
+    AX_ASSERT(type == LineRangeType::Right);
 
     // Move forwards off a line end (because this a "right-line" request).
     auto startMarker = atLineEnd() ? findMarker(AXDirection::Next) : *this;
@@ -1663,7 +1664,7 @@ AXIsolatedObject* findObjectWithRuns(AXIsolatedObject& start, AXDirection direct
         }
         return current.unsafeGet();
     }
-    ASSERT(direction == AXDirection::Previous);
+    AX_ASSERT(direction == AXDirection::Previous);
 
     auto previousInPreOrder = [&] (AXIsolatedObject& object) -> AXIsolatedObject* {
         if (RefPtr sibling = object.previousSiblingIncludingIgnored(/* updateChildrenIfNeeded */ true)) {

--- a/Source/WebCore/accessibility/AXTextRun.cpp
+++ b/Source/WebCore/accessibility/AXTextRun.cpp
@@ -91,7 +91,7 @@ unsigned AXTextRuns::domOffset(unsigned renderedTextOffset) const
     for (size_t i = 0; i < size(); i++) {
         const auto& domOffsets = at(i).domOffsets();
         for (const auto& domOffsetPair : domOffsets) {
-            ASSERT(domOffsetPair[0] >= previousEndDomOffset);
+            AX_ASSERT(domOffsetPair[0] >= previousEndDomOffset);
             if (domOffsetPair[0] < previousEndDomOffset)
                 return renderedTextOffset;
             // domOffsetPair[0] represents the start DOM offset of this run. Subtracting it
@@ -119,7 +119,7 @@ unsigned AXTextRuns::domOffset(unsigned renderedTextOffset) const
     }
     // We were provided with a rendered-text offset that didn't actually fit into our
     // runs. This should never happen.
-    ASSERT_NOT_REACHED();
+    AX_ASSERT_NOT_REACHED();
     return renderedTextOffset;
 }
 
@@ -139,8 +139,8 @@ FloatRect AXTextRuns::localRect(unsigned start, unsigned end, FontOrientation or
         float totalAdvance = 0;
         unsigned startIndexInRun = startIndex - offsetOfFirstCharacterInRun;
         unsigned endIndexInRun = endIndex - offsetOfFirstCharacterInRun;
-        ASSERT(startIndexInRun <= endIndexInRun);
-        ASSERT(endIndexInRun <= characterAdvances.size());
+        AX_ASSERT(startIndexInRun <= endIndexInRun);
+        AX_ASSERT(endIndexInRun <= characterAdvances.size());
         endIndexInRun = std::min(endIndexInRun, static_cast<unsigned>(characterAdvances.size()));
         for (size_t i = startIndexInRun; i < endIndexInRun; i++)
             totalAdvance += (float)characterAdvances[i];
@@ -162,7 +162,7 @@ FloatRect AXTextRuns::localRect(unsigned start, unsigned end, FontOrientation or
             unsigned measuredWidthInDirection = 0;
             if (i == runIndexOfSmallerOffset) {
                 unsigned offsetOfFirstCharacterInRun = !i ? 0 : runLengthSumTo(i - 1);
-                ASSERT(smallerOffset >= offsetOfFirstCharacterInRun);
+                AX_ASSERT(smallerOffset >= offsetOfFirstCharacterInRun);
                 if (smallerOffset < offsetOfFirstCharacterInRun)
                     smallerOffset = offsetOfFirstCharacterInRun;
                 // Measure the characters in this run (accomplished by smallerOffset - offsetOfFirstCharacterInRun)
@@ -199,7 +199,7 @@ FloatRect AXTextRuns::localRect(unsigned start, unsigned end, FontOrientation or
             } else if (i == runIndexOfLargerOffset) {
                 // We're measuring the end of the range, so measure from the first character in the run up to largerOffset.
                 unsigned offsetOfFirstCharacterInRun = !i ? 0 : runLengthSumTo(i - 1);
-                ASSERT(largerOffset >= offsetOfFirstCharacterInRun);
+                AX_ASSERT(largerOffset >= offsetOfFirstCharacterInRun);
                 if (largerOffset < offsetOfFirstCharacterInRun)
                     largerOffset = offsetOfFirstCharacterInRun;
 

--- a/Source/WebCore/accessibility/AXTextRun.h
+++ b/Source/WebCore/accessibility/AXTextRun.h
@@ -28,6 +28,7 @@
 #if ENABLE(AX_THREAD_TEXT_APIS)
 
 #include <CoreText/CTFont.h>
+#include <WebCore/AXLoggerBase.h>
 #include <WebCore/FloatRect.h>
 #include <WebCore/TextAffinity.h>
 #include <WebCore/TextFlags.h>
@@ -102,7 +103,7 @@ struct AXTextRun {
     {
         // Runs should have a non-zero length (i.e. endIndex should strictly be greater than startIndex).
         // This is important because several parts of AXTextMarker rely on this assumption.
-        ASSERT(endIndex > startIndex);
+        AX_ASSERT(endIndex > startIndex);
     }
 
     const FixedVector<std::array<uint16_t, 2>>& domOffsets() const { return textRunDomOffsets; }

--- a/Source/WebCore/accessibility/AXTreeStore.cpp
+++ b/Source/WebCore/accessibility/AXTreeStore.cpp
@@ -36,7 +36,7 @@ namespace WebCore {
 template<>
 void AXTreeStore<AXIsolatedTree>::applyPendingChangesForAllIsolatedTrees()
 {
-    ASSERT(!isMainThread());
+    AX_ASSERT(!isMainThread());
 
     Locker locker { AXTreeStore<AXIsolatedTree>::s_storeLock };
     auto& map = AXTreeStore<AXIsolatedTree>::isolatedTreeMap();

--- a/Source/WebCore/accessibility/AXTreeStore.h
+++ b/Source/WebCore/accessibility/AXTreeStore.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <WebCore/AXCoreObject.h>
+#include <WebCore/AXLoggerBase.h>
 #include <WebCore/ActivityState.h>
 #include <wtf/HashMap.h>
 #include <wtf/Lock.h>
@@ -93,7 +94,7 @@ private:
 template<typename T>
 inline AXID AXTreeStore<T>::generateNewID()
 {
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
 
     std::optional<AXID> axID;
     do {

--- a/Source/WebCore/accessibility/AXTreeStoreInlines.h
+++ b/Source/WebCore/accessibility/AXTreeStoreInlines.h
@@ -31,7 +31,7 @@ namespace WebCore {
 template<typename T>
 inline void AXTreeStore<T>::set(AXID axID, const AXTreeWeakPtr& tree)
 {
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
 
     switchOn(tree,
         [&] (const WeakPtr<AXObjectCache>& typedTree) {
@@ -49,7 +49,7 @@ inline void AXTreeStore<T>::set(AXID axID, const AXTreeWeakPtr& tree)
 template<typename T>
 inline void AXTreeStore<T>::add(AXID axID, const AXTreeWeakPtr& tree)
 {
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
 
     switchOn(tree,
         [&] (const WeakPtr<AXObjectCache>& typedTree) {
@@ -109,7 +109,7 @@ inline RefPtr<AXIsolatedTree> AXTreeStore<T>::isolatedTreeForID(std::optional<AX
 template<typename T>
 inline HashMap<AXID, WeakPtr<AXObjectCache>>& AXTreeStore<T>::liveTreeMap()
 {
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
 
     static NeverDestroyed<HashMap<AXID, WeakPtr<AXObjectCache>>> map;
     return map;

--- a/Source/WebCore/accessibility/AXUtilities.cpp
+++ b/Source/WebCore/accessibility/AXUtilities.cpp
@@ -146,7 +146,7 @@ bool hasAnyRole(Element& element, Vector<StringView>&& roles)
         return false;
 
     for (const auto& role : roles) {
-        AX_DEBUG_ASSERT(!role.isEmpty());
+        AX_ASSERT(!role.isEmpty());
         if (SpaceSplitString::spaceSplitStringContainsValue(roleValue, role, SpaceSplitString::ShouldFoldCase::Yes))
             return true;
     }
@@ -467,7 +467,7 @@ String roleToString(AccessibilityRole role)
     case AccessibilityRole::WebArea:
         return "WebArea"_s;
     }
-    ASSERT_NOT_REACHED();
+    AX_ASSERT_NOT_REACHED();
     return ""_s;
 }
 
@@ -497,7 +497,7 @@ std::optional<CursorType> cursorTypeFrom(const StyleProperties& properties)
 
 RefPtr<Node> lastNode(const FixedVector<AXID>& axIDs, AXObjectCache& cache)
 {
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
 
     for (auto axID = axIDs.rbegin(); axID != axIDs.rend(); ++axID) {
         if (RefPtr object = cache.objectForID(*axID)) {

--- a/Source/WebCore/accessibility/AccessibilityListBoxOption.cpp
+++ b/Source/WebCore/accessibility/AccessibilityListBoxOption.cpp
@@ -29,6 +29,7 @@
 #include "config.h"
 #include "AccessibilityListBoxOption.h"
 
+#include "AXLoggerBase.h"
 #include "AXObjectCacheInlines.h"
 #include "AccessibilityObjectInlines.h"
 #include "ContainerNodeInlines.h"
@@ -146,7 +147,7 @@ String AccessibilityListBoxOption::stringValue() const
 
 Element* AccessibilityListBoxOption::actionElement() const
 {
-    ASSERT(is<HTMLElement>(m_node.get()));
+    AX_ASSERT(is<HTMLElement>(m_node.get()));
     return dynamicDowncast<Element>(m_node.get());
 }
 

--- a/Source/WebCore/accessibility/AccessibilityMenuList.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMenuList.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "AccessibilityMenuList.h"
 
+#include "AXLoggerBase.h"
 #include "AXNotifications.h"
 #include "AccessibilityObjectInlines.h"
 #include "AXObjectCache.h"
@@ -95,8 +96,8 @@ void AccessibilityMenuList::addChildren()
 {
     // This class sets its children once in the create function, and should never
     // have dirty or uninitialized children afterwards.
-    ASSERT(m_childrenInitialized);
-    ASSERT(!m_childrenDirty);
+    AX_ASSERT(m_childrenInitialized);
+    AX_ASSERT(!m_childrenDirty);
 }
 
 bool AccessibilityMenuList::isCollapsed() const
@@ -128,8 +129,8 @@ void AccessibilityMenuList::didUpdateActiveOption(int optionIndex)
 
     const auto& childObjects = unignoredChildren();
     if (!childObjects.isEmpty()) {
-        ASSERT(childObjects.size() == 1);
-        ASSERT(is<AccessibilityMenuListPopup>(childObjects[0].get()));
+        AX_ASSERT(childObjects.size() == 1);
+        AX_ASSERT(is<AccessibilityMenuListPopup>(childObjects[0].get()));
 
         // We might be calling this method in situations where the renderers for list items
         // associated to the menu list have not been created (e.g. they might be rendered

--- a/Source/WebCore/accessibility/AccessibilityMenuListOption.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMenuListOption.cpp
@@ -111,12 +111,12 @@ LayoutRect AccessibilityMenuListOption::elementRect() const
 {
     RefPtr parent = parentObject();
     // Our parent should've been set to be a menu-list popup before this method is called.
-    ASSERT(parent && parent->isMenuListPopup());
+    AX_ASSERT(parent && parent->isMenuListPopup());
     if (!parent)
         return boundingBoxRect();
 
     RefPtr grandparent = parent->parentObject();
-    ASSERT(!grandparent || grandparent->isMenuList());
+    AX_ASSERT(!grandparent || grandparent->isMenuList());
 
     return grandparent ? grandparent->elementRect() : boundingBoxRect();
 }

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -148,13 +148,13 @@ Ref<AccessibilityNodeObject> AccessibilityNodeObject::create(AXID axID, Node* no
 
 AccessibilityNodeObject::~AccessibilityNodeObject()
 {
-    ASSERT(isDetached());
+    AX_ASSERT(isDetached());
 }
 
 void AccessibilityNodeObject::init()
 {
 #ifndef NDEBUG
-    ASSERT(!m_initialized);
+    AX_ASSERT(!m_initialized);
     m_initialized = true;
 #endif
     m_ariaRole = determineAriaRoleAttribute();
@@ -231,7 +231,7 @@ AccessibilityObject* AccessibilityNodeObject::nextSibling() const
 AccessibilityObject* AccessibilityNodeObject::ownerParentObject() const
 {
     auto owners = this->owners();
-    AX_DEBUG_ASSERT(owners.size() <= 1);
+    AX_ASSERT(owners.size() <= 1);
     return owners.size() ? dynamicDowncast<AccessibilityObject>(owners.first().get()) : nullptr;
 }
 
@@ -383,7 +383,7 @@ AccessibilityRole AccessibilityNodeObject::determineListRoleWithCleanChildren()
     if (!isAccessibilityList())
         return AccessibilityRole::Unknown;
 
-    ASSERT(!needsToUpdateChildren() && childrenInitialized());
+    AX_ASSERT(!needsToUpdateChildren() && childrenInitialized());
 
     // Directory is mapped to list for now, but does not adhere to the same heuristics.
     if (ariaRoleAttribute() == AccessibilityRole::Directory)
@@ -685,7 +685,7 @@ AccessibilityRole AccessibilityNodeObject::determineAccessibilityRoleFromNode(Tr
 AccessibilityRole AccessibilityNodeObject::roleFromInputElement(const HTMLInputElement& input) const
 {
     AXTRACE("AccessibilityNodeObject::roleFromInputElement"_s);
-    ASSERT(dynamicDowncast<HTMLInputElement>(node()) == &input);
+    AX_ASSERT(dynamicDowncast<HTMLInputElement>(node()) == &input);
 
     if (input.isTextButton())
         return buttonRoleType();
@@ -788,7 +788,7 @@ void AccessibilityNodeObject::addChildren()
 {
     // If the need to add more children in addition to existing children arises,
     // childrenChanged should have been called, leaving the object with no children.
-    ASSERT(!m_childrenInitialized);
+    AX_ASSERT(!m_childrenInitialized);
     m_childrenInitialized = true;
 
     auto clearDirtySubtree = makeScopeExit([&] {
@@ -944,7 +944,7 @@ bool AccessibilityNodeObject::computeIsIgnored() const
 #ifndef NDEBUG
     // Double-check that an AccessibilityObject is never accessed before
     // it's been initialized.
-    ASSERT(m_initialized);
+    AX_ASSERT(m_initialized);
 #endif
     if (isTree())
         return isIgnoredByDefault();
@@ -2250,7 +2250,7 @@ AXCoreObject::AccessibilityChildrenVector AccessibilityNodeObject::visibleRows()
 void AccessibilityNodeObject::addTableChildrenAndCellSlots()
 {
     // isExposableTable() should've been checked before this method was even called.
-    ASSERT(isExposableTable());
+    AX_ASSERT(isExposableTable());
 
     if (!isExposableTable()) [[unlikely]]
         return;
@@ -4007,7 +4007,7 @@ Vector<AXStitchGroup> AccessibilityNodeObject::stitchGroups() const
 
                     // Avoid doing the wrong thing when !renderText->hasRenderedText() is only true
                     // because it has dirty layout. We should not run this function when layout is dirty.
-                    ASSERT(!renderText || !renderText->needsLayout() || !renderText->text().length());
+                    AX_ASSERT(!renderText || !renderText->needsLayout() || !renderText->text().length());
 
                     if (!renderText || !renderText->hasRenderedText())
                         continue;
@@ -4085,7 +4085,7 @@ String AccessibilityNodeObject::stringValue() const
             if (RefPtr object = cache->objectForID(axID)) {
                 // The only objects preceeding the group representative in the accessibility tree are renderer-only
                 // objects like list markers and CSS generated content.
-                ASSERT(!object->node());
+                AX_ASSERT(!object->node());
                 if (CheckedPtr renderListMarker = dynamicDowncast<RenderListMarker>(object->renderer()))
                     builder.append(renderListMarker->textWithSuffix());
             }
@@ -4625,7 +4625,7 @@ static bool childrenContainOnlyStaticText(const AccessibilityObject::Accessibili
 
 bool AccessibilityNodeObject::isLabelContainingOnlyStaticText() const
 {
-    ASSERT(isNativeLabel());
+    AX_ASSERT(isNativeLabel());
 
     // m_containsOnlyStaticTextDirty is set (if necessary) by addChildren(), so update our children before checking the flag.
     const_cast<AccessibilityNodeObject*>(this)->updateChildrenIfNecessary();

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -136,7 +136,7 @@ AccessibilityObject::AccessibilityObject(AXID axID, AXObjectCache& cache)
 
 AccessibilityObject::~AccessibilityObject()
 {
-    ASSERT(isDetached());
+    AX_ASSERT(isDetached());
 }
 
 String AccessibilityObject::debugDescriptionInternal(bool verbose, std::optional<OptionSet<AXDebugStringOption>> debugOptions) const
@@ -220,7 +220,7 @@ OptionSet<AXAncestorFlag> AccessibilityObject::computeAncestorFlags() const
 OptionSet<AXAncestorFlag> AccessibilityObject::computeAncestorFlagsWithTraversal() const
 {
     // If this object's flags are initialized, this traversal is unnecessary. Use AccessibilityObject::ancestorFlags() instead.
-    ASSERT(!ancestorFlagsAreInitialized());
+    AX_ASSERT(!ancestorFlagsAreInitialized());
 
     OptionSet<AXAncestorFlag> computedFlags;
     computedFlags.set(AXAncestorFlag::FlagsInitialized, true);
@@ -243,7 +243,7 @@ bool AccessibilityObject::matchesAncestorFlag(AXAncestorFlag flag) const
     case AXAncestorFlag::IsInRow:
         return role == AccessibilityRole::Row;
     default:
-        ASSERT_NOT_REACHED();
+        AX_ASSERT_NOT_REACHED();
         return false;
     }
 }
@@ -510,7 +510,7 @@ AccessibilityObject* AccessibilityObject::displayContentsParent() const
 
 AccessibilityObject* AccessibilityObject::nextSiblingUnignored(unsigned limit) const
 {
-    ASSERT(limit);
+    AX_ASSERT(limit);
 
     for (auto sibling = iterator(nextSibling()); limit && sibling; --limit, ++sibling) {
         if (!sibling->isIgnored())
@@ -521,7 +521,7 @@ AccessibilityObject* AccessibilityObject::nextSiblingUnignored(unsigned limit) c
 
 AccessibilityObject* AccessibilityObject::previousSiblingUnignored(unsigned limit) const
 {
-    ASSERT(limit);
+    AX_ASSERT(limit);
 
     for (auto sibling = iterator(previousSibling()); limit && sibling; --limit, --sibling) {
         if (!sibling->isIgnored())
@@ -532,7 +532,7 @@ AccessibilityObject* AccessibilityObject::previousSiblingUnignored(unsigned limi
 
 FloatRect AccessibilityObject::convertFrameToSpace(const FloatRect& frameRect, AccessibilityConversionSpace conversionSpace) const
 {
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
 
     // Find the appropriate scroll view to use to convert the contents to the window.
     RefPtr parentAccessibilityScrollView = ancestorAccessibilityScrollView(false /* includeSelf */);
@@ -905,7 +905,7 @@ std::optional<SimpleRange> AccessibilityObject::visibleCharacterRangeInternal(Si
             // looping infinitely. It would be better if we understood *why* nextLineEndPosition
             // is returning the same position, but do this for now. If you hit this assert, please
             // file a bug with steps to reproduce.
-            ASSERT_NOT_REACHED();
+            AX_ASSERT_NOT_REACHED();
             break;
         }
 
@@ -1156,7 +1156,7 @@ Vector<String> AccessibilityObject::performTextOperation(const AccessibilityText
     for (const auto& range : operation.textRanges) {
         auto textOperationRange = textOperationRangeFromRange(range);
         if (!textOperationRange) {
-            ASSERT_NOT_REACHED();
+            AX_ASSERT_NOT_REACHED();
             return result;
         }
 
@@ -1376,7 +1376,7 @@ IntRect AccessibilityObject::boundsForRange(const SimpleRange& range) const
 
 IntPoint AccessibilityObject::linkClickPoint()
 {
-    ASSERT(isLink());
+    AX_ASSERT(isLink());
     /* A link bounding rect can contain points that are not part of the link.
      For instance, a link that starts at the end of a line and finishes at the
      beginning of the next line will have a bounding rect that includes the
@@ -1419,7 +1419,7 @@ IntPoint AccessibilityObject::clickPointFromElementRect() const
 
 IntRect AccessibilityObject::boundingBoxForQuads(RenderObject* obj, const Vector<FloatQuad>& quads)
 {
-    ASSERT(obj);
+    AX_ASSERT(obj);
     if (!obj)
         return IntRect();
 
@@ -1467,7 +1467,7 @@ bool AccessibilityObject::press()
     if (!pressElement || actionElement->isDescendantOf(*pressElement))
         pressElement = actionElement;
 
-    ASSERT(pressElement);
+    AX_ASSERT(pressElement);
     // Prefer the hit test element, if it is inside the target element.
     if (hitTestElement && hitTestElement->isDescendantOf(*pressElement))
         pressElement = WTF::move(hitTestElement);
@@ -2683,7 +2683,7 @@ static void initializeRoleMap()
 {
     if (gAriaRoleMap)
         return;
-    ASSERT(!gAriaReverseRoleMap);
+    AX_ASSERT(!gAriaReverseRoleMap);
 
     const std::array roles {
         RoleEntry { "alert"_s, AccessibilityRole::ApplicationAlert },
@@ -3055,7 +3055,7 @@ bool AccessibilityObject::isTabItemSelected() const
 
 unsigned AccessibilityObject::textLength() const
 {
-    ASSERT(isTextControl());
+    AX_ASSERT(isTextControl());
     return text().length();
 }
 
@@ -3371,7 +3371,7 @@ bool AccessibilityObject::supportsExpanded() const
             case CommandType::RequestClose:
                 break;
             default:
-                ASSERT_NOT_REACHED();
+                AX_ASSERT_NOT_REACHED();
                 break;
             }
         }

--- a/Source/WebCore/accessibility/AccessibilityProgressIndicator.cpp
+++ b/Source/WebCore/accessibility/AccessibilityProgressIndicator.cpp
@@ -21,6 +21,7 @@
 #include "config.h"
 #include "AccessibilityProgressIndicator.h"
 
+#include "AXLoggerBase.h"
 #include "AXObjectCacheInlines.h"
 #include "AccessibilityObjectInlines.h"
 #include "FloatConversion.h"
@@ -40,13 +41,13 @@ using namespace HTMLNames;
 AccessibilityProgressIndicator::AccessibilityProgressIndicator(AXID axID, RenderObject& renderer, AXObjectCache& cache)
     : AccessibilityRenderObject(axID, renderer, cache)
 {
-    ASSERT(is<RenderProgress>(renderer) || is<RenderMeter>(renderer) || is<HTMLProgressElement>(renderer.node()) || is<HTMLMeterElement>(renderer.node()));
+    AX_ASSERT(is<RenderProgress>(renderer) || is<RenderMeter>(renderer) || is<HTMLProgressElement>(renderer.node()) || is<HTMLMeterElement>(renderer.node()));
 }
 
 AccessibilityProgressIndicator::AccessibilityProgressIndicator(AXID axID, Element& element, AXObjectCache& cache)
     : AccessibilityRenderObject(axID, element, cache)
 {
-    ASSERT(is<HTMLProgressElement>(element) || is<HTMLMeterElement>(element));
+    AX_ASSERT(is<HTMLProgressElement>(element) || is<HTMLMeterElement>(element));
 }
 
 Ref<AccessibilityProgressIndicator> AccessibilityProgressIndicator::create(AXID axID, RenderObject& renderer, AXObjectCache& cache)

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -169,12 +169,12 @@ AccessibilityRenderObject::AccessibilityRenderObject(AXID axID, Node& node, AXOb
     : AccessibilityNodeObject(axID, &node, cache)
 {
     // We should only ever create an instance of this class with a node if that node has no renderer (i.e. because of display:contents).
-    ASSERT(!node.renderer());
+    AX_ASSERT(!node.renderer());
 }
 
 AccessibilityRenderObject::~AccessibilityRenderObject()
 {
-    ASSERT(isDetached());
+    AX_ASSERT(isDetached());
 }
 
 Ref<AccessibilityRenderObject> AccessibilityRenderObject::create(AXID axID, RenderObject& renderer, AXObjectCache& cache)
@@ -343,7 +343,7 @@ static inline RenderObject* childBeforeConsideringContinuations(RenderInline* re
         }
     }
 
-    ASSERT_NOT_REACHED();
+    AX_ASSERT_NOT_REACHED();
     return nullptr;
 }
 
@@ -370,7 +370,7 @@ AccessibilityObject* AccessibilityRenderObject::previousSibling() const
         // Case 2: Anonymous block parent of the end of a continuation - skip all the way to before
         // the parent of the start, since everything in between will be linked up via the continuation.
         auto* firstParent = startOfContinuations(*renderBlock->firstChild())->parent();
-        ASSERT(firstParent);
+        AX_ASSERT(firstParent);
         while (firstChildIsInlineContinuation(*firstParent))
             firstParent = startOfContinuations(*firstParent->firstChild())->parent();
         previousSibling = firstParent->previousSibling();
@@ -416,7 +416,7 @@ AccessibilityObject* AccessibilityRenderObject::nextSibling() const
         // Case 2: Anonymous block parent of the start of a continuation - skip all the way to
         // after the parent of the end, since everything in between will be linked up via the continuation.
         auto* lastParent = endOfContinuations(*renderBlock->lastChild())->parent();
-        ASSERT(lastParent);
+        AX_ASSERT(lastParent);
         while (lastChildHasContinuation(*lastParent))
             lastParent = endOfContinuations(*lastParent->lastChild())->parent();
         nextSibling = lastParent->nextSibling();
@@ -1186,7 +1186,7 @@ static bool webAreaIsPresentational(RenderObject* renderer)
 bool AccessibilityRenderObject::computeIsIgnored() const
 {
 #ifndef NDEBUG
-    ASSERT(m_initialized);
+    AX_ASSERT(m_initialized);
 #endif
 
     if (!m_renderer)
@@ -1267,7 +1267,7 @@ bool AccessibilityRenderObject::computeIsIgnored() const
         // Text elements with no rendered text, or only whitespace should not be part of the AX tree.
         if (!renderText->hasRenderedText()) {
             // Layout must be clean to make the right decision here (because hasRenderedText() can return false solely because layout is dirty).
-            ASSERT(!renderText->needsLayout() || !renderText->text().length());
+            AX_ASSERT(!renderText->needsLayout() || !renderText->text().length());
             return true;
         }
 
@@ -1545,7 +1545,7 @@ CharacterRange AccessibilityRenderObject::documentBasedSelectedTextRange() const
 
 String AccessibilityRenderObject::selectedText() const
 {
-    ASSERT(isTextControl());
+    AX_ASSERT(isTextControl());
 
     if (isSecureField())
         return String(); // need to return something distinct from empty string
@@ -1560,7 +1560,7 @@ String AccessibilityRenderObject::selectedText() const
 
 CharacterRange AccessibilityRenderObject::selectedTextRange() const
 {
-    ASSERT(isTextControl());
+    AX_ASSERT(isTextControl());
 
     // Use the text control native range if it's a native object.
     if (isNativeTextControl() && m_renderer) {
@@ -1713,7 +1713,7 @@ AXTextRuns AccessibilityRenderObject::textRuns()
 
     auto domOffset = [] (unsigned value) -> uint16_t {
         // It shouldn't be possible for any textbox to have more than 65535 characters.
-        ASSERT(value <= std::numeric_limits<uint16_t>::max());
+        AX_ASSERT(value <= std::numeric_limits<uint16_t>::max());
         return static_cast<uint16_t>(value);
     };
 
@@ -1784,7 +1784,7 @@ AXTextRuns AccessibilityRenderObject::textRuns()
 
 AXTextRunLineID AccessibilityRenderObject::listMarkerLineID() const
 {
-    ASSERT(role() == AccessibilityRole::ListMarker);
+    AX_ASSERT(role() == AccessibilityRole::ListMarker);
     return { renderer() ? renderer()->containingBlock() : nullptr, 0 };
 }
 
@@ -1797,7 +1797,7 @@ String AccessibilityRenderObject::listMarkerText() const
 
 int AccessibilityRenderObject::insertionPointLineNumber() const
 {
-    ASSERT(isTextControl());
+    AX_ASSERT(isTextControl());
 
     // Use the text control native range if it's a native object.
     if (isNativeTextControl() && m_renderer) {
@@ -1856,7 +1856,7 @@ void AccessibilityRenderObject::setSelectedTextRange(CharacterRange&& range)
         textControl->focus(focusOptions);
         textControl->setSelectionRange(range.location, range.location + range.length);
     } else if (m_renderer) {
-        ASSERT(node());
+        AX_ASSERT(node());
         Ref node = *this->node();
         auto elementRange = simpleRange();
         auto start = visiblePositionForIndexUsingCharacterIterator(node.get(), range.location);
@@ -1966,7 +1966,7 @@ AXCoreObject::AccessibilityChildrenVector AccessibilityRenderObject::documentLin
     for (unsigned i = 0; RefPtr current = links->item(i); ++i) {
         if (current->renderer()) {
             RefPtr axObject = cache->getOrCreate(*current);
-            ASSERT(axObject);
+            AX_ASSERT(axObject);
             if (!axObject->isIgnored() && axObject->isLink())
                 result.append(axObject.releaseNonNull());
         } else {
@@ -2727,7 +2727,7 @@ AccessibilitySVGObject* AccessibilityRenderObject::remoteSVGRootElement(CreateIf
         return nullptr;
 
     RefPtr rootSVGObject = createIfNecessary == CreateIfNecessary::Yes ? cache->getOrCreate(*rendererRoot) : cache->get(rendererRoot);
-    ASSERT(createIfNecessary == CreateIfNecessary::No || rootSVGObject);
+    AX_ASSERT(createIfNecessary == CreateIfNecessary::No || rootSVGObject);
     return dynamicDowncast<AccessibilitySVGObject>(rootSVGObject).unsafeGet();
 }
 
@@ -2775,7 +2775,7 @@ void AccessibilityRenderObject::addCanvasChildren()
 
     // If it's a canvas, it won't have rendered children, but it might have accessible fallback content.
     // Clear m_childrenInitialized because AccessibilityNodeObject::addChildren will expect it to be false.
-    ASSERT(!m_children.size());
+    AX_ASSERT(!m_children.size());
     m_childrenInitialized = false;
     AccessibilityNodeObject::addChildren();
 }
@@ -2919,7 +2919,7 @@ void AccessibilityRenderObject::addChildren()
     }
     // If the need to add more children in addition to existing children arises,
     // childrenChanged should have been called, leaving the object with no children.
-    AX_DEBUG_ASSERT(!m_childrenInitialized);
+    AX_ASSERT(!m_childrenInitialized);
     m_childrenInitialized = true;
 
     auto scopeExit = makeScopeExit([this, protectedThis = Ref { *this }] {
@@ -3157,7 +3157,7 @@ bool AccessibilityRenderObject::hasUnderline() const
 
 String AccessibilityRenderObject::secureFieldValue() const
 {
-    ASSERT(isSecureField());
+    AX_ASSERT(isSecureField());
 
     // Look for the RenderText object in the RenderObject tree for this input field.
     RenderObject* renderer = node()->renderer();
@@ -3191,8 +3191,8 @@ void AccessibilityRenderObject::scrollTo(const IntPoint& point) const
         return;
 
     // FIXME: is point a ScrollOffset or ScrollPosition? Test in RTL overflow.
-    ASSERT(box->layer());
-    ASSERT(box->layer()->scrollableArea());
+    AX_ASSERT(box->layer());
+    AX_ASSERT(box->layer()->scrollableArea());
     box->layer()->scrollableArea()->scrollToOffset(point);
 }
 

--- a/Source/WebCore/accessibility/AccessibilitySVGObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySVGObject.cpp
@@ -344,7 +344,7 @@ AccessibilityObject* AccessibilitySVGObject::parentObject() const
 {
     if (m_parent) {
         // If a parent was set because this is a remote SVG resource, use that.
-        ASSERT(m_isSVGRoot);
+        AX_ASSERT(m_isSVGRoot);
         return m_parent.get();
     }
 

--- a/Source/WebCore/accessibility/AccessibilitySVGObject.h
+++ b/Source/WebCore/accessibility/AccessibilitySVGObject.h
@@ -27,6 +27,7 @@
 
 #pragma once
 
+#include "AXLoggerBase.h"
 #include "AccessibilityRenderObject.h"
 #include <wtf/WeakPtr.h>
 
@@ -71,7 +72,7 @@ private:
 
 inline void AccessibilitySVGObject::setParent(AccessibilityRenderObject* parent)
 {
-    ASSERT(m_isSVGRoot);
+    AX_ASSERT(m_isSVGRoot);
     m_parent = parent;
 }
 

--- a/Source/WebCore/accessibility/AccessibilityScrollView.cpp
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "AccessibilityScrollView.h"
 
+#include "AXLoggerBase.h"
 #include "AXObjectCacheInlines.h"
 #include "AXLocalFrame.h"
 #include "AXRemoteFrame.h"
@@ -54,7 +55,7 @@ AccessibilityScrollView::AccessibilityScrollView(AXID axID, ScrollView& view, AX
 
 AccessibilityScrollView::~AccessibilityScrollView()
 {
-    ASSERT(isDetached());
+    AX_ASSERT(isDetached());
 }
 
 bool AccessibilityScrollView::isRoot() const
@@ -380,7 +381,7 @@ void AccessibilityScrollView::addRemoteFrameChild()
 
 void AccessibilityScrollView::addChildren()
 {
-    ASSERT(!m_childrenInitialized);
+    AX_ASSERT(!m_childrenInitialized);
     m_childrenInitialized = true;
 
 #if ENABLE_ACCESSIBILITY_LOCAL_FRAME

--- a/Source/WebCore/accessibility/AccessibilitySlider.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySlider.cpp
@@ -30,6 +30,7 @@
 #include "AccessibilitySlider.h"
 
 #include "AccessibilityObjectInlines.h"
+#include "AXLoggerBase.h"
 #include "AXObjectCache.h"
 #include "ContainerNodeInlines.h"
 #include "FrameDestructionObserverInlines.h"
@@ -82,7 +83,7 @@ std::optional<AccessibilityOrientation> AccessibilitySlider::explicitOrientation
 
 void AccessibilitySlider::addChildren()
 {
-    ASSERT(!m_childrenInitialized);
+    AX_ASSERT(!m_childrenInitialized);
     m_childrenInitialized = true;
     auto clearDirtySubtree = makeScopeExit([&] {
         m_subtreeDirty = false;
@@ -110,7 +111,7 @@ void AccessibilitySlider::addChildren()
 AccessibilityObject* AccessibilitySlider::elementAccessibilityHitTest(const IntPoint& point) const
 {
     if (m_children.size()) {
-        ASSERT(m_children.size() == 1);
+        AX_ASSERT(m_children.size() == 1);
         if (Ref { m_children[0] }->elementRect().contains(point))
             return dynamicDowncast<AccessibilityObject>(m_children[0].get());
     }

--- a/Source/WebCore/accessibility/AccessibilitySpinButton.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySpinButton.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "AccessibilitySpinButton.h"
 
+#include "AXLoggerBase.h"
 #include "AXObjectCache.h"
 #include "AccessibilityObjectInlines.h"
 #include "ContainerNodeInlines.h"
@@ -62,21 +63,21 @@ AccessibilitySpinButton::~AccessibilitySpinButton() = default;
 
 AccessibilitySpinButtonPart* AccessibilitySpinButton::incrementButton()
 {
-    ASSERT(m_childrenInitialized);
+    AX_ASSERT(m_childrenInitialized);
     RELEASE_ASSERT(m_children.size() == 2);
     return &downcast<AccessibilitySpinButtonPart>(m_children[0].get());
 }
 
 AccessibilitySpinButtonPart* AccessibilitySpinButton::decrementButton()
 {
-    ASSERT(m_childrenInitialized);
+    AX_ASSERT(m_childrenInitialized);
     RELEASE_ASSERT(m_children.size() == 2);
     return &downcast<AccessibilitySpinButtonPart>(m_children[1].get());
 }
 
 LayoutRect AccessibilitySpinButton::elementRect() const
 {
-    ASSERT(m_spinButtonElement);
+    AX_ASSERT(m_spinButtonElement);
 
     CheckedPtr renderer = m_spinButtonElement ? m_spinButtonElement->renderer() : nullptr;
     if (!renderer)
@@ -91,14 +92,14 @@ void AccessibilitySpinButton::addChildren()
 {
     // This class sets its children once in the create function, and should never
     // have dirty or uninitialized children afterwards.
-    ASSERT(m_childrenInitialized);
-    ASSERT(!m_subtreeDirty);
-    ASSERT(!m_childrenDirty);
+    AX_ASSERT(m_childrenInitialized);
+    AX_ASSERT(!m_subtreeDirty);
+    AX_ASSERT(!m_childrenDirty);
 }
 
 void AccessibilitySpinButton::step(int amount)
 {
-    ASSERT(m_spinButtonElement);
+    AX_ASSERT(m_spinButtonElement);
     if (RefPtr element = m_spinButtonElement.get())
         element->step(amount);
 }

--- a/Source/WebCore/accessibility/AccessibilityTableColumn.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableColumn.cpp
@@ -29,6 +29,7 @@
 #include "config.h"
 #include "AccessibilityTableColumn.h"
 
+#include "AXLoggerBase.h"
 #include "AXObjectCache.h"
 #include "AccessibilityObjectInlines.h"
 #include "AccessibilityNodeObject.h"
@@ -89,7 +90,7 @@ bool AccessibilityTableColumn::computeIsIgnored() const
 
 void AccessibilityTableColumn::addChildren()
 {
-    ASSERT(!m_childrenInitialized);
+    AX_ASSERT(!m_childrenInitialized);
     m_childrenInitialized = true;
 
     RefPtr parentTable = dynamicDowncast<AccessibilityNodeObject>(m_parent.get());

--- a/Source/WebCore/accessibility/AccessibilityTableHeaderContainer.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableHeaderContainer.cpp
@@ -29,6 +29,7 @@
 #include "config.h"
 #include "AccessibilityTableHeaderContainer.h"
 
+#include "AXLoggerBase.h"
 #include "AXObjectCache.h"
 #include "AccessibilityObjectInlines.h"
 #include "AccessibilityNodeObject.h"
@@ -63,7 +64,7 @@ bool AccessibilityTableHeaderContainer::computeIsIgnored() const
 
 void AccessibilityTableHeaderContainer::addChildren()
 {
-    ASSERT(!m_childrenInitialized);
+    AX_ASSERT(!m_childrenInitialized);
 
     m_childrenInitialized = true;
     RefPtr parentTable = dynamicDowncast<AccessibilityNodeObject>(m_parent.get());

--- a/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
@@ -26,6 +26,7 @@
 #import "config.h"
 #import "AXCoreObject.h"
 
+#import "AXLoggerBase.h"
 #import "AXObjectCache.h"
 #import "AXTreeStoreInlines.h"
 #import "AccessibilityObjectInlines.h"
@@ -292,8 +293,7 @@ RetainPtr<NSMutableAttributedString> AXCoreObject::createAttributedString(String
     // attributedStringSetCompositionAttributes(string.get(), node, textRange);
 
     if (spellCheck == AXCoreObject::SpellCheck::Yes) {
-        RefPtr node = this->node();
-        if (AXObjectCache::shouldSpellCheck() && node) {
+        if (RefPtr node = AXObjectCache::shouldSpellCheck() ? this->node() : nullptr) {
             // FIXME: This eagerly resolves misspellings, and since it requires a node, we will
             // never do this if `this` is an AXIsolatedObject`. We might need to figure out how
             // to spellcheck off the main-thread.
@@ -493,7 +493,7 @@ bool AXCoreObject::isEmptyGroup()
 
 AXCoreObject::AccessibilityChildrenVector AXCoreObject::crossFrameSortedDescendants(size_t limit, PreSortedObjectType type) const
 {
-    ASSERT(type == PreSortedObjectType::LiveRegion || type == PreSortedObjectType::WebArea);
+    AX_ASSERT(type == PreSortedObjectType::LiveRegion || type == PreSortedObjectType::WebArea);
     auto sortedObjects = type == PreSortedObjectType::LiveRegion ? allSortedLiveRegions() : allSortedNonRootWebAreas();
     AXCoreObject::AccessibilityChildrenVector results;
     for (const Ref<AXCoreObject>& object : sortedObjects) {

--- a/Source/WebCore/accessibility/cocoa/AXTextMarkerCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AXTextMarkerCocoa.mm
@@ -47,12 +47,12 @@ AXTextMarker::AXTextMarker(PlatformTextMarkerData platformData)
 
 #if PLATFORM(MAC)
     if (CFGetTypeID(platformData) != AXTextMarkerGetTypeID()) {
-        ASSERT_NOT_REACHED();
+        AX_ASSERT_NOT_REACHED();
         return;
     }
 
     if (AXTextMarkerGetLength(platformData) != sizeof(m_data)) {
-        ASSERT_NOT_REACHED();
+        AX_ASSERT_NOT_REACHED();
         return;
     }
 
@@ -75,7 +75,7 @@ RetainPtr<PlatformTextMarkerData> AXTextMarker::platformData() const
 // FIXME: There's a lot of duplicated code between this function and AXTextMarkerRange::toString().
 RetainPtr<NSAttributedString> AXTextMarkerRange::toAttributedString(AXCoreObject::SpellCheck spellCheck) const
 {
-    ASSERT(!isMainThread());
+    AX_ASSERT(!isMainThread());
 
     auto start = m_start.toTextRunMarker();
     if (!start.isValid())
@@ -152,7 +152,7 @@ RetainPtr<NSAttributedString> AXTextMarkerRange::toAttributedString(AXCoreObject
 AXTextMarkerRange::AXTextMarkerRange(AXTextMarkerRangeRef textMarkerRangeRef)
 {
     if (!textMarkerRangeRef || CFGetTypeID(textMarkerRangeRef) != AXTextMarkerRangeGetTypeID()) {
-        ASSERT_NOT_REACHED();
+        AX_ASSERT_NOT_REACHED();
         return;
     }
 
@@ -193,7 +193,6 @@ RetainPtr<NSArray> AXTextMarkerRange::platformData() const
         return nil;
 
     RefPtr object = downcast<AccessibilityObject>(m_start.object());
-    ASSERT(object); // Since *this is not null.
     auto* cache = object->axObjectCache();
     if (!cache)
         return nil;

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -30,6 +30,7 @@
 
 #import "AXAttributeCacheScope.h"
 #import "AXLogger.h"
+#import "AXLoggerBase.h"
 #import "AXNotifications.h"
 #import "AXObjectCacheInlines.h"
 #import "AXSearchManager.h"
@@ -264,7 +265,7 @@ static AccessibilityObjectWrapper* AccessibilityUnignoredAncestor(AccessibilityO
 - (void)dealloc
 {
     // We should have been detached before deallocated.
-    ASSERT(!self.axBackingObject);
+    AX_ASSERT(!self.axBackingObject);
     [super dealloc];
 }
 
@@ -1073,7 +1074,7 @@ static AccessibilityObjectWrapper *ancestorWithRole(const AXCoreObject& descenda
         return false;
     }
 
-    ASSERT_NOT_REACHED();
+    AX_ASSERT_NOT_REACHED();
     return false;
 }
 
@@ -1085,7 +1086,7 @@ static AccessibilityObjectWrapper *ancestorWithRole(const AXCoreObject& descenda
     if (m_isAccessibilityElement == IsAccessibilityElement::Unknown)
         m_isAccessibilityElement = [self determineIsAccessibilityElement] ? IsAccessibilityElement::Yes : IsAccessibilityElement::No;
 
-    ASSERT(m_isAccessibilityElement != IsAccessibilityElement::Unknown);
+    AX_ASSERT(m_isAccessibilityElement != IsAccessibilityElement::Unknown);
     switch (m_isAccessibilityElement) {
     case IsAccessibilityElement::Yes:
         return YES;
@@ -1112,7 +1113,7 @@ static AccessibilityObjectWrapper *ancestorWithRole(const AXCoreObject& descenda
 
 static void appendStringToResult(NSMutableString *result, NSString *string)
 {
-    ASSERT(result);
+    AX_ASSERT(result);
     if (![string length])
         return;
     if ([result length])
@@ -1555,7 +1556,7 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
         case AccessibilityButtonState::Mixed:
             return @"2";
         }
-        ASSERT_NOT_REACHED();
+        AX_ASSERT_NOT_REACHED();
         return @"0";
     }
 
@@ -1564,10 +1565,12 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
 
     // If self has the header trait, value should be the heading level.
     if (self.accessibilityTraits & self._axHeaderTrait) {
-        auto* heading = Accessibility::findAncestor(backingObject.get(), true, [] (const auto& ancestor) {
+        RefPtr heading = Accessibility::findAncestor(backingObject.get(), true, [] (const auto& ancestor) {
             return ancestor.role() == AccessibilityRole::Heading;
         });
-        ASSERT(heading);
+        // If we have the header trait, we should either be a heading, or have a heading ancestor.
+        // Not finding one means our traits our stale.
+        AX_ASSERT(heading);
 
         if (heading)
             return [NSString stringWithFormat:@"%d", heading->headingLevel()];
@@ -1866,7 +1869,7 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
         return nil;
 
     // The only object without a parent wrapper at this point should be a scroll view.
-    ASSERT(self.axBackingObject->isScrollView());
+    AX_ASSERT(self.axBackingObject->isScrollView());
 
     // Verify this is the top document. If not, we might need to go through the platform widget.
     auto* frameView = self.axBackingObject->documentFrameView();
@@ -1912,7 +1915,7 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
     // The parentView should have an accessibilityContainer, if the UIKit accessibility bundle was loaded.
     // The exception is DRT, which tests accessibility without the entire system turning accessibility on. Hence,
     // this check should be valid for everything except DRT.
-    ASSERT([parentView accessibilityContainer] || WTF::CocoaApplication::isDumpRenderTree());
+    AX_ASSERT([parentView accessibilityContainer] || WTF::CocoaApplication::isDumpRenderTree());
 
     return [parentView accessibilityContainer];
 }
@@ -1990,7 +1993,7 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
 
     return createNSArray(self.axBackingObject->flowToObjects(), [] (auto&& child) -> id {
         auto wrapper = child->wrapper();
-        ASSERT(wrapper);
+        AX_ASSERT(wrapper);
 
         if (child->isAttachment()) {
             if (auto attachmentView = wrapper.attachmentView)
@@ -2022,7 +2025,7 @@ static NSArray *accessibleElementsForObjects(const AXCoreObject::AccessibilityCh
 
     return createNSArray(self.axBackingObject->detailedByObjects(), [] (auto&& detailedByObject) -> id {
         auto wrapper = detailedByObject->wrapper();
-        ASSERT(wrapper);
+        AX_ASSERT(wrapper);
         return wrapper;
     }).autorelease();
 }
@@ -2104,7 +2107,7 @@ static NSArray *accessibleElementsForObjects(const AXCoreObject::AccessibilityCh
     if (![self _prepareAccessibilityCall])
         return nil;
 
-    ASSERT([self isAttachment]);
+    AX_ASSERT([self isAttachment]);
     Widget* widget = self.axBackingObject->widgetForAttachmentView();
     if (!widget)
         return nil;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -30,6 +30,7 @@
 
 #include <WebCore/AXCoreObject.h>
 #include <WebCore/AXIsolatedTree.h>
+#include <WebCore/AXLoggerBase.h>
 #include <WebCore/AXObjectCache.h>
 #include <WebCore/AXTreeStoreInlines.h>
 #include <WebCore/IntPoint.h>
@@ -625,7 +626,7 @@ private:
 
         RefPtr<AccessibilityObject> axObjectOnMainThread() const
         {
-            ASSERT(isMainThread());
+            AX_ASSERT(isMainThread());
 
             CheckedPtr cache = m_tree->axObjectCache();
             return cache ? cache->objectForID(m_axID) : nullptr;
@@ -668,7 +669,7 @@ inline T AXIsolatedObject::propertyValue(AXProperty property) const
 
     return WTF::switchOn(m_properties[index].second,
         [] (const T& typedValue) { return typedValue; },
-        [] (auto&) { ASSERT_NOT_REACHED();
+        [] (auto&) { AX_ASSERT_NOT_REACHED();
             return T(); }
     );
 }
@@ -688,7 +689,7 @@ inline bool AXIsolatedObject::hasPropertyFlag(AXPropertyFlag flag) const
 
 inline bool AXIsolatedObject::hasPropertyFlag(AXProperty property) const
 {
-    ASSERT(static_cast<uint16_t>(property) <= lastPropertyFlagIndex);
+    AX_ASSERT(static_cast<uint16_t>(property) <= lastPropertyFlagIndex);
     uint16_t propertyIndex = static_cast<uint16_t>(property);
     return hasPropertyFlag(static_cast<AXPropertyFlag>(1 << propertyIndex));
 }

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -448,7 +448,7 @@ public:
     AXObjectCache* axObjectCache() const;
     constexpr AXGeometryManager* geometryManager() const { return m_geometryManager.get(); }
 
-    AXIsolatedObject* rootNode() { ASSERT(!isMainThread()); return m_rootNode.get(); }
+    AXIsolatedObject* rootNode() { AX_ASSERT(!isMainThread()); return m_rootNode.get(); }
     std::optional<AXID> pendingRootNodeID();
     RefPtr<AXIsolatedObject> rootWebArea();
     std::optional<AXID> focusedNodeID();
@@ -457,7 +457,7 @@ public:
     bool unsafeHasObjectForID(AXID axID) const;
     inline AXIsolatedObject* objectForID(AXID axID) const
     {
-        AX_DEBUG_ASSERT(!isMainThread());
+        AX_ASSERT(!isMainThread());
 
         auto iterator = m_readerThreadNodeMap.find(axID);
         if (iterator != m_readerThreadNodeMap.end())
@@ -734,14 +734,14 @@ std::optional<AXPropertyFlag> convertToPropertyFlag(AXProperty);
 
 inline AXObjectCache* AXIsolatedTree::axObjectCache() const
 {
-    AX_DEBUG_ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
     return m_axObjectCache.get();
 }
 
 template<typename U>
 inline Vector<Ref<AXCoreObject>> AXIsolatedTree::objectsForIDs(const U& axIDs)
 {
-    ASSERT(!isMainThread());
+    AX_ASSERT(!isMainThread());
 
     Vector<Ref<AXCoreObject>> result;
     result.reserveInitialCapacity(axIDs.size());

--- a/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
+++ b/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
@@ -221,7 +221,7 @@ AXCoreObject::AccessibilityChildrenVector AXIsolatedObject::allSortedNonRootWebA
 
 std::optional<NSRange> AXIsolatedObject::visibleCharacterRange() const
 {
-    ASSERT(!isMainThread());
+    AX_ASSERT(!isMainThread());
 
     RefPtr tree = this->tree();
     if (!tree)
@@ -410,7 +410,7 @@ std::optional<String> AXIsolatedObject::platformStringValue() const
 
 unsigned AXIsolatedObject::textLength() const
 {
-    ASSERT(isTextControl());
+    AX_ASSERT(isTextControl());
 
 #if ENABLE(AX_THREAD_TEXT_APIS)
     if (AXObjectCache::useAXThreadTextApis())
@@ -483,7 +483,7 @@ RetainPtr<NSAttributedString> AXIsolatedObject::attributedStringForTextMarkerRan
         [result removeAttribute:NSAccessibilityMarkedMisspelledTextAttribute range:resultRange];
     } else if (AXObjectCache::shouldSpellCheck()) {
         // For ITM, we should only ever eagerly spellcheck for testing purposes.
-        ASSERT(_AXGetClientForCurrentRequestUntrusted() == kAXClientTypeWebKitTesting);
+        AX_ASSERT(_AXGetClientForCurrentRequestUntrusted() == kAXClientTypeWebKitTesting);
         // We're going to spellcheck, so remove AXDidSpellCheck: NO.
         [result removeAttribute:NSAccessibilityDidSpellCheckAttribute range:resultRange];
         performFunctionOnMainThreadAndWait([result = RetainPtr { result }, &resultRange] (AccessibilityObject* axObject) {
@@ -496,8 +496,8 @@ RetainPtr<NSAttributedString> AXIsolatedObject::attributedStringForTextMarkerRan
 
 void AXIsolatedObject::setPreventKeyboardDOMEventDispatch(bool value)
 {
-    ASSERT(!isMainThread());
-    ASSERT(isWebArea());
+    AX_ASSERT(!isMainThread());
+    AX_ASSERT(isWebArea());
 
     setProperty(AXProperty::PreventKeyboardDOMEventDispatch, value);
     performFunctionOnMainThread([value] (auto* object) {
@@ -507,8 +507,8 @@ void AXIsolatedObject::setPreventKeyboardDOMEventDispatch(bool value)
 
 void AXIsolatedObject::setCaretBrowsingEnabled(bool value)
 {
-    ASSERT(!isMainThread());
-    ASSERT(isWebArea());
+    AX_ASSERT(!isMainThread());
+    AX_ASSERT(isWebArea());
 
     setProperty(AXProperty::CaretBrowsingEnabled, value);
     performFunctionOnMainThread([value] (auto* object) {
@@ -520,7 +520,7 @@ void AXIsolatedObject::setCaretBrowsingEnabled(bool value)
 // and not cached because we don't expect AX clients to ever request them.
 IntPoint AXIsolatedObject::clickPoint()
 {
-    ASSERT(_AXGetClientForCurrentRequestUntrusted() != kAXClientTypeVoiceOver);
+    AX_ASSERT(_AXGetClientForCurrentRequestUntrusted() != kAXClientTypeVoiceOver);
 
     return Accessibility::retrieveValueFromMainThread<IntPoint>([context = mainThreadContext()] () -> IntPoint {
         if (RefPtr object = context.axObjectOnMainThread())
@@ -531,7 +531,7 @@ IntPoint AXIsolatedObject::clickPoint()
 
 bool AXIsolatedObject::pressedIsPresent() const
 {
-    ASSERT(_AXGetClientForCurrentRequestUntrusted() != kAXClientTypeVoiceOver);
+    AX_ASSERT(_AXGetClientForCurrentRequestUntrusted() != kAXClientTypeVoiceOver);
 
     return Accessibility::retrieveValueFromMainThread<bool>([context = mainThreadContext()] () -> bool {
         if (RefPtr object = context.axObjectOnMainThread())
@@ -542,7 +542,7 @@ bool AXIsolatedObject::pressedIsPresent() const
 
 Vector<String> AXIsolatedObject::determineDropEffects() const
 {
-    ASSERT(_AXGetClientForCurrentRequestUntrusted() != kAXClientTypeVoiceOver);
+    AX_ASSERT(_AXGetClientForCurrentRequestUntrusted() != kAXClientTypeVoiceOver);
 
     return Accessibility::retrieveValueFromMainThread<Vector<String>>([context = mainThreadContext()] () -> Vector<String> {
         if (RefPtr object = context.axObjectOnMainThread())
@@ -553,7 +553,7 @@ Vector<String> AXIsolatedObject::determineDropEffects() const
 
 int AXIsolatedObject::layoutCount() const
 {
-    ASSERT(_AXGetClientForCurrentRequestUntrusted() != kAXClientTypeVoiceOver);
+    AX_ASSERT(_AXGetClientForCurrentRequestUntrusted() != kAXClientTypeVoiceOver);
 
     return Accessibility::retrieveValueFromMainThread<int>([context = mainThreadContext()] () -> int {
         if (RefPtr object = context.axObjectOnMainThread())
@@ -564,7 +564,7 @@ int AXIsolatedObject::layoutCount() const
 
 Vector<String> AXIsolatedObject::classList() const
 {
-    ASSERT(_AXGetClientForCurrentRequestUntrusted() != kAXClientTypeVoiceOver);
+    AX_ASSERT(_AXGetClientForCurrentRequestUntrusted() != kAXClientTypeVoiceOver);
 
     return Accessibility::retrieveValueFromMainThread<Vector<String>>([context = mainThreadContext()] () -> Vector<String> {
         if (RefPtr object = context.axObjectOnMainThread())
@@ -575,7 +575,7 @@ Vector<String> AXIsolatedObject::classList() const
 
 String AXIsolatedObject::computedRoleString() const
 {
-    ASSERT(_AXGetClientForCurrentRequestUntrusted() != kAXClientTypeVoiceOver);
+    AX_ASSERT(_AXGetClientForCurrentRequestUntrusted() != kAXClientTypeVoiceOver);
 
     return Accessibility::retrieveValueFromMainThread<String>([context = mainThreadContext()] () -> String {
         if (RefPtr object = context.axObjectOnMainThread())

--- a/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
+++ b/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
@@ -30,6 +30,7 @@
 
 #import "AXIsolatedObject.h"
 #import "AXLiveRegionManager.h"
+#import "AXLoggerBase.h"
 #import "AXNotifications.h"
 #import "AXObjectCacheInlines.h"
 #import "AXSearchManager.h"
@@ -372,7 +373,7 @@ void AXObjectCache::postPlatformNotification(AccessibilityObject& object, AXNoti
 
 void AXObjectCache::postPlatformAnnouncementNotification(const String& message)
 {
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
 
     processQueuedIsolatedNodeUpdates();
 
@@ -390,7 +391,7 @@ void AXObjectCache::postPlatformAnnouncementNotification(const String& message)
 
 void AXObjectCache::postPlatformARIANotifyNotification(AccessibilityObject& object, const AriaNotifyData& notificationData)
 {
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
 
     processQueuedIsolatedNodeUpdates();
 
@@ -572,7 +573,7 @@ void AXObjectCache::postTextSelectionChangePlatformNotification(AccessibilityObj
 
 static void addTextMarkerForVisiblePosition(NSMutableDictionary *change, AXObjectCache& cache, const VisiblePosition& position)
 {
-    ASSERT(!position.isNull());
+    AX_ASSERT(!position.isNull());
 
     if (RetainPtr marker = textMarkerForVisiblePosition(&cache, position))
         [change setObject:(__bridge id)marker.get() forKey:NSAccessibilityTextChangeValueStartMarker];
@@ -752,7 +753,7 @@ bool AXObjectCache::isIsolatedTreeEnabled()
         return true;
 
     if (!isMainThread()) {
-        ASSERT(_AXUIElementRequestServicedBySecondaryAXThread());
+        AX_ASSERT(_AXUIElementRequestServicedBySecondaryAXThread());
         enabled = true;
     } else {
         enabled = DeprecatedGlobalSettings::isAccessibilityIsolatedTreeEnabled() // Used to turn off in apps other than Safari, e.g., Mail.
@@ -822,7 +823,7 @@ AXCoreObject::AccessibilityChildrenVector AXObjectCache::sortedNonRootWebAreas()
 
 void AXObjectCache::addSortedObjects(Vector<Ref<AccessibilityObject>>&& objectsToSort, PreSortedObjectType type)
 {
-    ASSERT(type == PreSortedObjectType::LiveRegion || type == PreSortedObjectType::WebArea);
+    AX_ASSERT(type == PreSortedObjectType::LiveRegion || type == PreSortedObjectType::WebArea);
 
     if (!m_sortedIDListsInitialized) {
         // Once the sorted ID lists have been initialized for the first time, we rely
@@ -878,7 +879,7 @@ void AXObjectCache::addSortedObjects(Vector<Ref<AccessibilityObject>>&& objectsT
         if (shouldAppend) {
             // There's no reason to ever add the same object twice, as that means we walked over it twice
             // in our pre-order tree traversal.
-            ASSERT(!sortedList.contains(current->objectID()));
+            AX_ASSERT(!sortedList.contains(current->objectID()));
             sortedList.appendIfNotContains(current->objectID());
 
             if (sortedList.size() >= totalExpectedObjectCount)
@@ -889,7 +890,7 @@ void AXObjectCache::addSortedObjects(Vector<Ref<AccessibilityObject>>&& objectsT
 
 #if ASSERT_ENABLED
     for (const auto& object : objectsToSort)
-        ASSERT(sortedList.contains(object->objectID()));
+        AX_ASSERT(sortedList.contains(object->objectID()));
 #endif
 }
 
@@ -920,10 +921,10 @@ void AXObjectCache::initializeSortedIDLists()
         if (current->supportsLiveRegion()) {
             // There's no reason to ever add the same object twice, as that means we walked over it twice
             // in our pre-order tree traversal.
-            ASSERT(!m_sortedLiveRegionIDs.contains(current->objectID()));
+            AX_ASSERT(!m_sortedLiveRegionIDs.contains(current->objectID()));
             m_sortedLiveRegionIDs.appendIfNotContains(current->objectID());
         } else if (current->isWebArea()) {
-            ASSERT(!m_sortedNonRootWebAreaIDs.contains(current->objectID()));
+            AX_ASSERT(!m_sortedNonRootWebAreaIDs.contains(current->objectID()));
             m_sortedNonRootWebAreaIDs.appendIfNotContains(current->objectID());
         }
     }
@@ -949,22 +950,22 @@ RetainPtr<AXTextMarkerRangeRef> textMarkerRangeFromMarkers(AXTextMarkerRef start
     if (!startMarker || !endMarker)
         return nil;
 
-    ASSERT(CFGetTypeID((__bridge CFTypeRef)startMarker) == AXTextMarkerGetTypeID());
-    ASSERT(CFGetTypeID((__bridge CFTypeRef)endMarker) == AXTextMarkerGetTypeID());
+    AX_ASSERT(CFGetTypeID((__bridge CFTypeRef)startMarker) == AXTextMarkerGetTypeID());
+    AX_ASSERT(CFGetTypeID((__bridge CFTypeRef)endMarker) == AXTextMarkerGetTypeID());
     return adoptCF(AXTextMarkerRangeCreate(kCFAllocatorDefault, startMarker, endMarker));
 }
 
 static RetainPtr<AXTextMarkerRef> AXTextMarkerRangeStart(AXTextMarkerRangeRef textMarkerRange)
 {
-    ASSERT(textMarkerRange);
-    ASSERT(CFGetTypeID((__bridge CFTypeRef)textMarkerRange) == AXTextMarkerRangeGetTypeID());
+    AX_ASSERT(textMarkerRange);
+    AX_ASSERT(CFGetTypeID((__bridge CFTypeRef)textMarkerRange) == AXTextMarkerRangeGetTypeID());
     return adoptCF(AXTextMarkerRangeCopyStartMarker(textMarkerRange));
 }
 
 static RetainPtr<AXTextMarkerRef> AXTextMarkerRangeEnd(AXTextMarkerRangeRef textMarkerRange)
 {
-    ASSERT(textMarkerRange);
-    ASSERT(CFGetTypeID((__bridge CFTypeRef)textMarkerRange) == AXTextMarkerRangeGetTypeID());
+    AX_ASSERT(textMarkerRange);
+    AX_ASSERT(CFGetTypeID((__bridge CFTypeRef)textMarkerRange) == AXTextMarkerRangeGetTypeID());
     return adoptCF(AXTextMarkerRangeCopyEndMarker(textMarkerRange));
 }
 
@@ -973,12 +974,12 @@ static TextMarkerData getBytesFromAXTextMarker(AXTextMarkerRef textMarker)
     if (!textMarker)
         return { };
 
-    ASSERT(CFGetTypeID(textMarker) == AXTextMarkerGetTypeID());
+    AX_ASSERT(CFGetTypeID(textMarker) == AXTextMarkerGetTypeID());
     if (CFGetTypeID(textMarker) != AXTextMarkerGetTypeID())
         return { };
 
     TextMarkerData textMarkerData;
-    ASSERT(AXTextMarkerGetLength(textMarker) == sizeof(textMarkerData));
+    AX_ASSERT(AXTextMarkerGetLength(textMarker) == sizeof(textMarkerData));
     if (AXTextMarkerGetLength(textMarker) != sizeof(textMarkerData))
         return { };
 
@@ -988,7 +989,7 @@ static TextMarkerData getBytesFromAXTextMarker(AXTextMarkerRef textMarker)
 
 AccessibilityObject* accessibilityObjectForTextMarker(AXObjectCache* cache, AXTextMarkerRef textMarker)
 {
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
     if (!cache || !textMarker)
         return nullptr;
 
@@ -1000,7 +1001,7 @@ AccessibilityObject* accessibilityObjectForTextMarker(AXObjectCache* cache, AXTe
 
 AXTextMarkerRef textMarkerForVisiblePosition(AXObjectCache* cache, const VisiblePosition& visiblePos)
 {
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
     if (!cache)
         return nil;
 
@@ -1012,7 +1013,7 @@ AXTextMarkerRef textMarkerForVisiblePosition(AXObjectCache* cache, const Visible
 
 VisiblePosition visiblePositionForTextMarker(AXObjectCache* cache, AXTextMarkerRef textMarker)
 {
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
     if (!cache || !textMarker)
         return { };
 
@@ -1024,7 +1025,7 @@ VisiblePosition visiblePositionForTextMarker(AXObjectCache* cache, AXTextMarkerR
 
 AXTextMarkerRangeRef textMarkerRangeFromVisiblePositions(AXObjectCache* cache, const VisiblePosition& startPosition, const VisiblePosition& endPosition)
 {
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
     if (!cache)
         return nil;
 
@@ -1035,7 +1036,7 @@ AXTextMarkerRangeRef textMarkerRangeFromVisiblePositions(AXObjectCache* cache, c
 
 VisiblePositionRange visiblePositionRangeForTextMarkerRange(AXObjectCache* cache, AXTextMarkerRangeRef textMarkerRange)
 {
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
 
     return {
         visiblePositionForTextMarker(cache, AXTextMarkerRangeStart(textMarkerRange).get()),
@@ -1047,7 +1048,7 @@ VisiblePositionRange visiblePositionRangeForTextMarkerRange(AXObjectCache* cache
 
 AXTextMarkerRef textMarkerForCharacterOffset(AXObjectCache* cache, const CharacterOffset& characterOffset, TextMarkerOrigin origin)
 {
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
 
     if (!cache)
         return nil;
@@ -1060,7 +1061,7 @@ AXTextMarkerRef textMarkerForCharacterOffset(AXObjectCache* cache, const Charact
 
 CharacterOffset characterOffsetForTextMarker(AXObjectCache* cache, AXTextMarkerRef textMarker)
 {
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
     if (!cache || !textMarker)
         return { };
 
@@ -1072,7 +1073,7 @@ CharacterOffset characterOffsetForTextMarker(AXObjectCache* cache, AXTextMarkerR
 
 AXTextMarkerRef startOrEndTextMarkerForRange(AXObjectCache* cache, const std::optional<SimpleRange>& range, bool isStart)
 {
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
     if (!cache || !range)
         return nil;
 
@@ -1084,7 +1085,7 @@ AXTextMarkerRef startOrEndTextMarkerForRange(AXObjectCache* cache, const std::op
 
 AXTextMarkerRangeRef textMarkerRangeFromRange(AXObjectCache* cache, const std::optional<SimpleRange>& range)
 {
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
     if (!cache)
         return nil;
 
@@ -1095,7 +1096,7 @@ AXTextMarkerRangeRef textMarkerRangeFromRange(AXObjectCache* cache, const std::o
 
 std::optional<SimpleRange> rangeForTextMarkerRange(AXObjectCache* cache, AXTextMarkerRangeRef textMarkerRange)
 {
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
     if (!cache || !textMarkerRange)
         return std::nullopt;
 

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
@@ -276,7 +276,7 @@ NSArray *makeNSArray(const WebCore::AXCoreObject::AccessibilityChildrenVector& c
 
 - (id)initWithAccessibilityObject:(AccessibilityObject&)axObject
 {
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
 
     if (!(self = [super init]))
         return nil;
@@ -289,15 +289,15 @@ NSArray *makeNSArray(const WebCore::AXCoreObject::AccessibilityChildrenVector& c
     // Once a wrapper becomes associated with an object, it shouldn't ever be associated with any other one.
     // The only acceptable scenario is when a new instance of the "same" object (as determined by the objectID)
     // is created and attached to this wrapper, replacing it.
-    ASSERT(!m_axObject || m_axObject->objectID() == axObject.objectID());
+    AX_ASSERT(!m_axObject || m_axObject->objectID() == axObject.objectID());
     m_axObject = axObject;
 }
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 - (void)attachIsolatedObject:(AXIsolatedObject&)newObject
 {
-    ASSERT(!isMainThread());
-    ASSERT(!m_isolatedObject || m_isolatedObject->objectID() == newObject.objectID());
+    AX_ASSERT(!isMainThread());
+    AX_ASSERT(!m_isolatedObject || m_isolatedObject->objectID() == newObject.objectID());
 
     m_isolatedObject = newObject;
     m_isolatedObjectInitialized = true;
@@ -311,7 +311,7 @@ NSArray *makeNSArray(const WebCore::AXCoreObject::AccessibilityChildrenVector& c
 
 - (void)detach
 {
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
     m_axObject = nullptr;
 }
 
@@ -395,10 +395,10 @@ NSArray *makeNSArray(const WebCore::AXCoreObject::AccessibilityChildrenVector& c
         return m_axObject.get();
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-    AX_DEBUG_ASSERT(AXObjectCache::isIsolatedTreeEnabled());
+    AX_ASSERT(AXObjectCache::isIsolatedTreeEnabled());
     return m_isolatedObject.get();
 #else
-    ASSERT_NOT_REACHED();
+    AX_ASSERT_NOT_REACHED();
     return nullptr;
 #endif
 }
@@ -543,7 +543,7 @@ static void convertPathToScreenSpaceFunction(PathConversionInfo& conversion, con
 
 - (id)_accessibilityWebDocumentView
 {
-    ASSERT_NOT_REACHED();
+    AX_ASSERT_NOT_REACHED();
     // Overridden by sub-classes
     return nil;
 }
@@ -616,7 +616,7 @@ std::optional<SimpleRange> makeDOMRange(Document* document, NSRange range)
 
 - (NSArray<NSDictionary *> *)lineRectsAndText
 {
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
 
     RefPtr backingObject = dynamicDowncast<AccessibilityObject>(self.baseUpdateBackingStore);
     if (!backingObject)
@@ -713,13 +713,13 @@ std::optional<SimpleRange> makeDOMRange(Document* document, NSRange range)
 
 - (NSString *)accessibilityPlatformMathSubscriptKey
 {
-    ASSERT_NOT_REACHED();
+    AX_ASSERT_NOT_REACHED();
     return nil;
 }
 
 - (NSString *)accessibilityPlatformMathSuperscriptKey
 {
-    ASSERT_NOT_REACHED();
+    AX_ASSERT_NOT_REACHED();
     return nil;
 }
 
@@ -749,7 +749,7 @@ std::optional<SimpleRange> makeDOMRange(Document* document, NSRange range)
 {
     // We're only going to behave properly in this method if we're on the main-thread, since
     // that's the only time casting to AccessibilityObject is going to be successful.
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
 
     RefPtr axObject = dynamicDowncast<AccessibilityObject>(self.axBackingObject);
     if (!axObject)
@@ -798,7 +798,7 @@ static bool isValueTypeSupported(id value)
 
 static NSArray *arrayRemovingNonSupportedTypes(NSArray *array)
 {
-    ASSERT([array isKindOfClass:[NSArray class]]);
+    AX_ASSERT([array isKindOfClass:[NSArray class]]);
     auto mutableArray = adoptNS([array mutableCopy]);
     for (NSUInteger i = 0; i < [mutableArray count];) {
         id value = [mutableArray objectAtIndex:i];
@@ -819,7 +819,7 @@ static NSDictionary *dictionaryRemovingNonSupportedTypes(NSDictionary *dictionar
 {
     if (!dictionary)
         return nil;
-    ASSERT([dictionary isKindOfClass:[NSDictionary class]]);
+    AX_ASSERT([dictionary isKindOfClass:[NSDictionary class]]);
     auto mutableDictionary = adoptNS([dictionary mutableCopy]);
     for (NSString *key in dictionary) {
         id value = [dictionary objectForKey:key];
@@ -836,7 +836,7 @@ static NSDictionary *dictionaryRemovingNonSupportedTypes(NSDictionary *dictionar
 - (void)accessibilityPostedNotification:(NSString *)notificationName userInfo:(NSDictionary *)userInfo
 {
     if (accessibilityShouldRepostNotifications) {
-        ASSERT(notificationName);
+        AX_ASSERT(notificationName);
         userInfo = dictionaryRemovingNonSupportedTypes(userInfo);
         NSDictionary *info = [NSDictionary dictionaryWithObjectsAndKeys:notificationName, @"notificationName", userInfo, @"userInfo", nil];
         [[NSNotificationCenter defaultCenter] postNotificationName:NSAccessibilityDRTNotificationNotification object:self userInfo:info];

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -171,7 +171,7 @@ static inline NSInteger gmtToLocalTimeOffset(DateComponentsType type)
 
 - (void)detach
 {
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
 
     // If the IsolatedObject is initialized, do not UnregisterUniqueIdForUIElement here because the wrapper may be in the middle of serving a request on the AX thread.
     // The IsolatedObject is capable to tend to some requests after the live object is gone.
@@ -223,7 +223,7 @@ static inline BOOL AXObjectIsTextMarkerRange(id object)
 
 static IntRect screenToContents(AXCoreObject& axObject, IntRect&& rect)
 {
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
 
     RefPtr document = axObject.document();
     RefPtr frameView = document ? document->view() : nullptr;
@@ -318,7 +318,7 @@ static AccessibilityTextOperation accessibilityTextOperationForParameterizedAttr
 
     if ([markerRanges isKindOfClass:[NSArray class]]) {
         operation.textRanges = makeVector(markerRanges.get(), [&axObjectCache] (id markerRange) {
-            ASSERT(AXObjectIsTextMarkerRange(markerRange));
+            AX_ASSERT(AXObjectIsTextMarkerRange(markerRange));
             return rangeForTextMarkerRange(axObjectCache, (AXTextMarkerRangeRef)markerRange);
         });
     }
@@ -2361,7 +2361,7 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 
 - (void)_accessibilityPerformPressAction
 {
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
     RefPtr<AXCoreObject> backingObject = self.updateObjectBackingStore;
     if (!backingObject)
         return;
@@ -2437,7 +2437,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (void)_accessibilityShowContextMenu
 {
     AXTRACE("WebAccessibilityObjectWrapper _accessibilityShowContextMenu"_s);
-    ASSERT(isMainThread());
+    AX_ASSERT(isMainThread());
 
     RefPtr<AccessibilityObject> backingObject = dynamicDowncast<AccessibilityObject>(self.axBackingObject);
     if (!backingObject) {
@@ -2605,7 +2605,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
     // handle the command
     if ([attributeName isEqualToString:NSAccessibilitySelectedTextMarkerRangeAttribute]) {
-        ASSERT(textMarkerRange);
+        AX_ASSERT(textMarkerRange);
         Accessibility::performFunctionOnMainThread([textMarkerRange = retainPtr(textMarkerRange), protectedSelf = retainPtr(self)] {
             if (RefPtr<AXCoreObject> backingObject = protectedSelf.get().axBackingObject)
                 backingObject->setSelectedVisiblePositionRange(AXTextMarkerRange { textMarkerRange.get() });
@@ -2780,7 +2780,7 @@ enum class TextUnit {
         case TextUnit::Paragraph:
             return inputMarker.paragraphRange().platformData().autorelease();
         default:
-            ASSERT_NOT_REACHED();
+            AX_ASSERT_NOT_REACHED();
             return nil;
         }
     }
@@ -2810,7 +2810,7 @@ enum class TextUnit {
             range = cache->paragraphForCharacterOffset(marker);
             break;
         default:
-            ASSERT_NOT_REACHED();
+            AX_ASSERT_NOT_REACHED();
             break;
         }
 
@@ -2833,7 +2833,7 @@ enum class TextUnit {
                 rangeType = LineRangeType::Right;
                 break;
             default:
-                ASSERT_NOT_REACHED();
+                AX_ASSERT_NOT_REACHED();
                 break;
             }
             return AXTextMarker { textMarker }.lineRange(rangeType).platformData().bridgingAutorelease();
@@ -2858,7 +2858,7 @@ enum class TextUnit {
             visiblePositionRange = backingObject->rightLineVisiblePositionRange(marker);
             break;
         default:
-            ASSERT_NOT_REACHED();
+            AX_ASSERT_NOT_REACHED();
             break;
         }
 
@@ -2925,7 +2925,7 @@ enum class TextUnit {
         case TextUnit::PreviousLineStart:
             return textMarkerForVisiblePosition(cache.get(), backingObject->previousLineStartPosition(oldMarker));
         default:
-            ASSERT_NOT_REACHED();
+            AX_ASSERT_NOT_REACHED();
             break;
         }
 
@@ -3030,10 +3030,10 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 
             auto criteria = accessibilityTextCriteriaForParameterizedAttribute(protectedDictionary.get());
             criteria.second.textRanges = backingObject->findTextRanges(criteria.first);
-            ASSERT(criteria.second.textRanges.size() <= 1);
+            AX_ASSERT(criteria.second.textRanges.size() <= 1);
             return backingObject->performTextOperation(criteria.second);
         });
-        ASSERT(result.size() <= 1);
+        AX_ASSERT(result.size() <= 1);
         if (result.size() > 0)
             return result[0].createNSString().autorelease();
         return @"";
@@ -3107,7 +3107,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
             && criteria.searchKeys.contains(AccessibilitySearchKey::AnyType)
             && (!criteria.visibleOnly || backingObject->isVisible())) {
             RetainPtr remoteFrameChildren = children(*backingObject);
-            ASSERT([remoteFrameChildren count] == 1);
+            AX_ASSERT([remoteFrameChildren count] == 1);
             if ([remoteFrameChildren count] == 1) {
                 NSUInteger includedChildrenCount = std::min([remoteFrameChildren count], NSUInteger(criteria.resultsLimit));
                 widgetChildren = [remoteFrameChildren subarrayWithRange:NSMakeRange(0, includedChildrenCount)];


### PR DESCRIPTION
#### 9730b6f01701dc3bc576dc61038b5bfaf9d824de
<pre>
AX: Convert ASSERT and ASSERT_NOT_REACHED to AX_ASSERT equivalents
<a href="https://bugs.webkit.org/show_bug.cgi?id=305593">https://bugs.webkit.org/show_bug.cgi?id=305593</a>
<a href="https://rdar.apple.com/168247761">rdar://168247761</a>

Reviewed by Joshua Hoffman.

With this commit, we convert ASSERT to AX_ASSERT and ASSERT_NOT_REACHED to AX_ASSERT_NOT_REACHED(). Then, when new
compiler flag AX_ASSERTS_ENABLED is set, these AX_ asserts are release asserts (and debug asserts if it&apos;s off).

The idea is then that anyone working on WebKit accessibility can create a local, git-ignored config file to turn this
flag on, getting stringent asserts in release builds. This is preferable to building debug because debug builds can
be extremely slow when using VoiceOver, making for a painful experience.

* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::stitchGroupFromGroups const):
(WebCore::AXCoreObject::verifyChildrenIndexInParent const):
(WebCore::AXCoreObject::indexInSiblings const):
(WebCore::AXCoreObject::nextUnignoredSibling const):
(WebCore::AXCoreObject::selectedChildren):
(WebCore::AXCoreObject::listboxSelectedChildren):
(WebCore::AXCoreObject::selectedRows):
(WebCore::AXCoreObject::selectedListItems):
(WebCore::AXCoreObject::activeDescendant const):
(WebCore::AXCoreObject::partialOrder):
* Source/WebCore/accessibility/AXGeometryManager.cpp:
(WebCore::AXGeometryManager::cacheRectIfNeeded):
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::AXLogger::log):
(WebCore::operator&lt;&lt;):
(WebCore::streamIsolatedSubtreeOnMainThread):
* Source/WebCore/accessibility/AXLoggerBase.h:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::rendererNeedsDeferredUpdate):
(WebCore::AXObjectCache::accessibilityEnhancedUserInterfaceEnabled):
(WebCore::AXObjectCache::setEnhancedUserInterfaceAccessibility):
(WebCore::AXObjectCache::AXObjectCache):
(WebCore::AXObjectCache::modalElementHasAccessibleContent):
(WebCore::AXObjectCache::updateCurrentModalNode):
(WebCore::AXObjectCache::focusedObjectForPage):
(WebCore::AXObjectCache::focusedObjectForLocalFrame):
(WebCore::AXObjectCache::setIsolatedTreeFocusedObject):
(WebCore::AXObjectCache::getOrCreate):
(WebCore::AXObjectCache::getOrCreateSlow):
(WebCore::AXObjectCache::getOrCreateIsolatedTree):
(WebCore::AXObjectCache::setIsolatedTree):
(WebCore::AXObjectCache::remove):
(WebCore::AXObjectCache::onRendererCreated):
(WebCore::AXObjectCache::handleChildrenChanged):
(WebCore::AXObjectCache::notificationPostTimerFired):
(WebCore::AXObjectCache::postNotification):
(WebCore::AXObjectCache::onAccessibilityPaintFinished):
(WebCore::secureContext):
(WebCore::AXObjectCache::enqueuePasswordNotification):
(WebCore::AXObjectCache::handleRoleChanged):
(WebCore::AXObjectCache::handleAttributeChange):
(WebCore::AXObjectCache::nextTextMarker):
(WebCore::AXObjectCache::previousTextMarker):
(WebCore::AXObjectCache::objectForTextMarkerData):
(WebCore::AXObjectCache::textMarkerDataForVisiblePosition):
(WebCore::AXObjectCache::performDeferredCacheUpdate):
(WebCore::AXObjectCache::handleDeferredNotification):
(WebCore::AXObjectCache::updateIsolatedTree):
(WebCore::AXObjectCache::onPaint):
(WebCore::AXObjectCache::treeData):
(WebCore::AXObjectCache::addRelation):
(WebCore::AXObjectCache::updateRelationsForTree):
(WebCore::AXObjectCache::updateRelations):
(WebCore::AXObjectCache::textChangeForEditType):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AXObjectCacheInlines.h:
(WebCore::AXObjectCache::objectsForIDs const):
* Source/WebCore/accessibility/AXSearchManager.cpp:
(WebCore::AXSearchManager::findMatchingRange):
* Source/WebCore/accessibility/AXSearchManager.h:
(WebCore::AXSearchManager::setLastRevealAttemptTimedOut):
* Source/WebCore/accessibility/AXStitchGroup.h:
(WebCore::AXStitchGroup::AXStitchGroup):
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::TextMarkerData::TextMarkerData):
(WebCore::AXTextMarker::AXTextMarker):
(WebCore::AXTextMarker::operator VisiblePosition const):
(WebCore::AXTextMarker::operator CharacterOffset const):
(WebCore::AXTextMarker::boundaryPoint const):
(WebCore::AXTextMarkerRange::AXTextMarkerRange):
(WebCore::AXTextMarkerRange::operator VisiblePositionRange const):
(WebCore::AXTextMarkerRange::simpleRange const):
(WebCore::AXTextMarkerRange::characterRange const):
(WebCore::AXTextMarker::convertToDomOffset const):
(WebCore::AXTextMarker::offsetFromRoot const):
(WebCore::AXTextMarker::nextMarkerFromOffset const):
(WebCore::AXTextMarker::findLastBefore const):
(WebCore::AXTextMarker::rangeWithSameStyle const):
(WebCore::AXTextMarkerRange::viewportRelativeFrame const):
(WebCore::AXTextMarkerRange::convertToDomOffsetRange const):
(WebCore::AXTextMarker::runs const):
(WebCore::AXTextMarker::findLine const):
(WebCore::AXTextMarker::lineRange const):
(WebCore::Accessibility::findObjectWithRuns):
* Source/WebCore/accessibility/AXTextRun.cpp:
(WebCore::AXTextRuns::domOffset const):
(WebCore::AXTextRuns::localRect const):
* Source/WebCore/accessibility/AXTextRun.h:
(WebCore::AXTextRun::AXTextRun):
* Source/WebCore/accessibility/AXTreeStore.cpp:
(WebCore::AXTreeStore&lt;AXIsolatedTree&gt;::applyPendingChangesForAllIsolatedTrees):
* Source/WebCore/accessibility/AXTreeStore.h:
(WebCore::AXTreeStore&lt;T&gt;::generateNewID):
* Source/WebCore/accessibility/AXTreeStoreInlines.h:
(WebCore::AXTreeStore&lt;T&gt;::set):
(WebCore::AXTreeStore&lt;T&gt;::add):
(WebCore::AXTreeStore&lt;T&gt;::liveTreeMap):
* Source/WebCore/accessibility/AXUtilities.cpp:
(WebCore::hasAnyRole):
(WebCore::roleToString):
(WebCore::lastNode):
* Source/WebCore/accessibility/AccessibilityListBoxOption.cpp:
(WebCore::AccessibilityListBoxOption::actionElement const):
* Source/WebCore/accessibility/AccessibilityMenuList.cpp:
(WebCore::AccessibilityMenuList::addChildren):
(WebCore::AccessibilityMenuList::didUpdateActiveOption):
* Source/WebCore/accessibility/AccessibilityMenuListOption.cpp:
(WebCore::AccessibilityMenuListOption::elementRect const):
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::~AccessibilityNodeObject):
(WebCore::AccessibilityNodeObject::init):
(WebCore::AccessibilityNodeObject::ownerParentObject const):
(WebCore::AccessibilityNodeObject::determineListRoleWithCleanChildren):
(WebCore::AccessibilityNodeObject::roleFromInputElement const):
(WebCore::AccessibilityNodeObject::addChildren):
(WebCore::AccessibilityNodeObject::computeIsIgnored const):
(WebCore::AccessibilityNodeObject::addTableChildrenAndCellSlots):
(WebCore::AccessibilityNodeObject::stitchGroups const):
(WebCore::AccessibilityNodeObject::stringValue const):
(WebCore::AccessibilityNodeObject::isLabelContainingOnlyStaticText const):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::~AccessibilityObject):
(WebCore::AccessibilityObject::computeAncestorFlagsWithTraversal const):
(WebCore::AccessibilityObject::matchesAncestorFlag const):
(WebCore::AccessibilityObject::nextSiblingUnignored const):
(WebCore::AccessibilityObject::previousSiblingUnignored const):
(WebCore::AccessibilityObject::convertFrameToSpace const):
(WebCore::AccessibilityObject::visibleCharacterRangeInternal const):
(WebCore::AccessibilityObject::performTextOperation):
(WebCore::AccessibilityObject::linkClickPoint):
(WebCore::AccessibilityObject::boundingBoxForQuads):
(WebCore::AccessibilityObject::press):
(WebCore::initializeRoleMap):
(WebCore::AccessibilityObject::textLength const):
(WebCore::AccessibilityObject::supportsExpanded const):
* Source/WebCore/accessibility/AccessibilityProgressIndicator.cpp:
(WebCore::AccessibilityProgressIndicator::AccessibilityProgressIndicator):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::AccessibilityRenderObject):
(WebCore::AccessibilityRenderObject::~AccessibilityRenderObject):
(WebCore::childBeforeConsideringContinuations):
(WebCore::AccessibilityRenderObject::previousSibling const):
(WebCore::AccessibilityRenderObject::nextSibling const):
(WebCore::AccessibilityRenderObject::computeIsIgnored const):
(WebCore::AccessibilityRenderObject::selectedText const):
(WebCore::AccessibilityRenderObject::selectedTextRange const):
(WebCore::AccessibilityRenderObject::textRuns):
(WebCore::AccessibilityRenderObject::listMarkerLineID const):
(WebCore::AccessibilityRenderObject::insertionPointLineNumber const):
(WebCore::AccessibilityRenderObject::setSelectedTextRange):
(WebCore::AccessibilityRenderObject::documentLinks):
(WebCore::AccessibilityRenderObject::remoteSVGRootElement const):
(WebCore::AccessibilityRenderObject::addCanvasChildren):
(WebCore::AccessibilityRenderObject::addChildren):
(WebCore::AccessibilityRenderObject::secureFieldValue const):
(WebCore::AccessibilityRenderObject::scrollTo const):
* Source/WebCore/accessibility/AccessibilitySVGObject.cpp:
(WebCore::AccessibilitySVGObject::parentObject const):
* Source/WebCore/accessibility/AccessibilitySVGObject.h:
(WebCore::AccessibilitySVGObject::setParent):
* Source/WebCore/accessibility/AccessibilityScrollView.cpp:
(WebCore::AccessibilityScrollView::~AccessibilityScrollView):
(WebCore::AccessibilityScrollView::addChildren):
* Source/WebCore/accessibility/AccessibilitySlider.cpp:
(WebCore::AccessibilitySlider::addChildren):
(WebCore::AccessibilitySlider::elementAccessibilityHitTest const):
* Source/WebCore/accessibility/AccessibilitySpinButton.cpp:
(WebCore::AccessibilitySpinButton::incrementButton):
(WebCore::AccessibilitySpinButton::decrementButton):
(WebCore::AccessibilitySpinButton::elementRect const):
(WebCore::AccessibilitySpinButton::addChildren):
(WebCore::AccessibilitySpinButton::step):
* Source/WebCore/accessibility/AccessibilityTableColumn.cpp:
(WebCore::AccessibilityTableColumn::addChildren):
* Source/WebCore/accessibility/AccessibilityTableHeaderContainer.cpp:
(WebCore::AccessibilityTableHeaderContainer::addChildren):
* Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm:
(WebCore::AXCoreObject::createAttributedString const):
(WebCore::AXCoreObject::crossFrameSortedDescendants const):
* Source/WebCore/accessibility/cocoa/AXTextMarkerCocoa.mm:
(WebCore::AXTextMarker::AXTextMarker):
(WebCore::AXTextMarkerRange::toAttributedString const):
(WebCore::AXTextMarkerRange::AXTextMarkerRange):
(WebCore::AXTextMarkerRange::platformData const):
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper dealloc]):
(-[WebAccessibilityObjectWrapper determineIsAccessibilityElement]):
(-[WebAccessibilityObjectWrapper isAccessibilityElement]):
(appendStringToResult):
(-[WebAccessibilityObjectWrapper accessibilityValue]):
(-[WebAccessibilityObjectWrapper accessibilityContainer]):
(-[WebAccessibilityObjectWrapper _accessibilityWebDocumentView]):
(-[WebAccessibilityObjectWrapper accessibilityFlowToElements]):
(-[WebAccessibilityObjectWrapper accessibilityDetailsElements]):
(-[WebAccessibilityObjectWrapper attachmentView]):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::AXIsolatedObject):
(WebCore::AXIsolatedObject::updateFromData):
(WebCore::isDefaultValue):
(WebCore::AXIsolatedObject::associatedAXObject const):
(WebCore::AXIsolatedObject::detachRemoteParts):
(WebCore::AXIsolatedObject::isDetached const):
(WebCore::AXIsolatedObject::children):
(WebCore::AXIsolatedObject::setSelectedChildren):
(WebCore::AXIsolatedObject::colorValue const):
(WebCore::AXIsolatedObject::optionalAttributeValue const):
(WebCore::AXIsolatedObject::urlAttributeValue const):
(WebCore::AXIsolatedObject::pathAttributeValue const):
(WebCore::AXIsolatedObject::colorAttributeValue const):
(WebCore::AXIsolatedObject::fontAttributeValue const):
(WebCore::AXIsolatedObject::updateBackingStore):
(WebCore::AXIsolatedObject::rangeForCharacterRange const):
(WebCore::AXIsolatedObject::boundsForRange const):
(WebCore::AXIsolatedObject::visiblePositionForPoint const):
(WebCore::AXIsolatedObject::nextLineEndPosition const):
(WebCore::AXIsolatedObject::previousLineStartPosition const):
(WebCore::AXIsolatedObject::visiblePositionForIndex const):
(WebCore::AXIsolatedObject::indexForVisiblePosition const):
(WebCore::AXIsolatedObject::textUnderElement const):
(WebCore::AXIsolatedObject::misspellingRange const):
(WebCore::AXIsolatedObject::elementRect const):
(WebCore::AXIsolatedObject::relativeFrame const):
(WebCore::AXIsolatedObject::press):
(WebCore::AXIsolatedObject::isAccessibilityNodeObject const):
(WebCore::AXIsolatedObject::isAccessibilityRenderObject const):
(WebCore::AXIsolatedObject::isNativeTextControl const):
(WebCore::AXIsolatedObject::selection const):
(WebCore::AXIsolatedObject::setSelectedVisiblePositionRange const):
(WebCore::AXIsolatedObject::simpleRange const):
(WebCore::AXIsolatedObject::visiblePositionRange const):
(WebCore::AXIsolatedObject::visiblePositionRangeForLine const):
(WebCore::AXIsolatedObject::visiblePositionRangeForUnorderedPositions const):
(WebCore::AXIsolatedObject::leftLineVisiblePositionRange const):
(WebCore::AXIsolatedObject::rightLineVisiblePositionRange const):
(WebCore::AXIsolatedObject::styleRangeForPosition const):
(WebCore::AXIsolatedObject::lineRangeForPosition const):
(WebCore::AXIsolatedObject::lineForPosition const):
(WebCore::AXIsolatedObject::isMockObject const):
(WebCore::AXIsolatedObject::isNonNativeTextControl const):
(WebCore::AXIsolatedObject::isOffScreen const):
(WebCore::AXIsolatedObject::isPressed const):
(WebCore::AXIsolatedObject::isSelectedOptionActive const):
(WebCore::AXIsolatedObject::element const):
(WebCore::AXIsolatedObject::node const):
(WebCore::AXIsolatedObject::renderer const):
(WebCore::AXIsolatedObject::supportsHasPopup const):
(WebCore::AXIsolatedObject::supportsChecked const):
(WebCore::AXIsolatedObject::isModalNode const):
(WebCore::AXIsolatedObject::isTableCell const):
(WebCore::AXIsolatedObject::parentTableIfTableCell const):
(WebCore::AXIsolatedObject::parentTable const):
(WebCore::AXIsolatedObject::isTableRow const):
(WebCore::AXIsolatedObject::parentTableIfExposedTableRow const):
(WebCore::AXIsolatedObject::isDescendantOfRole const):
(WebCore::AXIsolatedObject::inheritsPresentationalRole const):
(WebCore::AXIsolatedObject::setAccessibleName):
(WebCore::AXIsolatedObject::text const):
(WebCore::AXIsolatedObject::textLength const):
(WebCore::AXIsolatedObject::axObjectCache const):
(WebCore::AXIsolatedObject::actionElement const):
(WebCore::AXIsolatedObject::widgetForAttachmentView const):
(WebCore::AXIsolatedObject::page const):
(WebCore::AXIsolatedObject::document const):
(WebCore::AXIsolatedObject::documentFrameView const):
(WebCore::AXIsolatedObject::clickPoint):
(WebCore::AXIsolatedObject::determineDropEffects const):
(WebCore::AXIsolatedObject::pressedIsPresent const):
(WebCore::AXIsolatedObject::layoutCount const):
(WebCore::AXIsolatedObject::classList const):
(WebCore::AXIsolatedObject::computedRoleString const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
(WebCore::AXIsolatedObject::propertyValue const):
(WebCore::AXIsolatedObject::hasPropertyFlag const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::AXIsolatedTree):
(WebCore::AXIsolatedTree::queueForDestruction):
(WebCore::AXIsolatedTree::createEmpty):
(WebCore::AXIsolatedTree::createEmptyContent):
(WebCore::AXIsolatedTree::create):
(WebCore::AXIsolatedTree::applyPendingRootNodeLocked):
(WebCore::AXIsolatedTree::storeTree):
(WebCore::AXIsolatedTree::reportLoadingProgress):
(WebCore::AXIsolatedTree::removeTreeForFrameID):
(WebCore::AXIsolatedTree::generateSubtree):
(WebCore::AXIsolatedTree::nodeChangeForObject):
(WebCore::AXIsolatedTree::queueChange):
(WebCore::AXIsolatedTree::addUnconnectedNode):
(WebCore::AXIsolatedTree::queueRemovals):
(WebCore::AXIsolatedTree::queueRemovalsLocked):
(WebCore::AXIsolatedTree::queueRemovalsAndUnresolvedChanges):
(WebCore::AXIsolatedTree::resolveAppends):
(WebCore::AXIsolatedTree::queueAppendsAndRemovals):
(WebCore::AXIsolatedTree::collectNodeChangesForSubtree):
(WebCore::AXIsolatedTree::updateNode):
(WebCore::AXIsolatedTree::objectChangedIgnoredState):
(WebCore::AXIsolatedTree::updatePropertiesForSelfAndDescendants):
(WebCore::AXIsolatedTree::updateNodeProperties):
(WebCore::AXIsolatedTree::overrideNodeProperties):
(WebCore::AXIsolatedTree::updateDependentProperties):
(WebCore::AXIsolatedTree::updateChildren):
(WebCore::AXIsolatedTree::setPageActivityState):
(WebCore::AXIsolatedTree::lockedPageActivityState const):
(WebCore::AXIsolatedTree::sortedLiveRegions):
(WebCore::AXIsolatedTree::sortedNonRootWebAreas):
(WebCore::AXIsolatedTree::setInitialSortedLiveRegions):
(WebCore::AXIsolatedTree::setInitialSortedNonRootWebAreas):
(WebCore::AXIsolatedTree::focusedNodeID):
(WebCore::AXIsolatedTree::focusedNode):
(WebCore::AXIsolatedTree::rootWebArea):
(WebCore::AXIsolatedTree::setPendingRootNodeIDLocked):
(WebCore::AXIsolatedTree::setFocusedNodeID):
(WebCore::AXIsolatedTree::updateRelations):
(WebCore::AXIsolatedTree::setSelectedTextMarkerRange):
(WebCore::AXIsolatedTree::updateLoadingProgress):
(WebCore::AXIsolatedTree::updateFrame):
(WebCore::AXIsolatedTree::updateRootScreenRelativePosition):
(WebCore::AXIsolatedTree::removeNode):
(WebCore::AXIsolatedTree::removeSubtreeFromNodeMap):
(WebCore::AXIsolatedTree::relatedObjectIDsFor):
(WebCore::AXIsolatedTree::applyPendingChangesUnlessQueuedForDestruction):
(WebCore::AXIsolatedTree::applyPendingChangesLocked):
(WebCore::AXIsolatedTree::sortedLiveRegionsDidChange):
(WebCore::AXIsolatedTree::sortedNonRootWebAreasDidChange):
(WebCore::AXIsolatedTree::queueNodeUpdate):
(WebCore::AXIsolatedTree::queueNodeRemoval):
(WebCore::AXIsolatedTree::processQueuedNodeUpdates):
(WebCore::AXIsolatedTree::firstMarker):
(WebCore::setPropertyIn):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
(WebCore::AXIsolatedTree::rootNode):
(WebCore::AXIsolatedTree::objectForID const):
(WebCore::AXIsolatedTree::axObjectCache const):
(WebCore::AXIsolatedTree::objectsForIDs):
* Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm:
(WebCore::AXIsolatedObject::visibleCharacterRange const):
(WebCore::AXIsolatedObject::textLength const):
(WebCore::AXIsolatedObject::attributedStringForTextMarkerRange const):
(WebCore::AXIsolatedObject::setPreventKeyboardDOMEventDispatch):
(WebCore::AXIsolatedObject::setCaretBrowsingEnabled):
(WebCore::AXIsolatedObject::clickPoint):
(WebCore::AXIsolatedObject::pressedIsPresent const):
(WebCore::AXIsolatedObject::determineDropEffects const):
(WebCore::AXIsolatedObject::layoutCount const):
(WebCore::AXIsolatedObject::classList const):
(WebCore::AXIsolatedObject::computedRoleString const):
* Source/WebCore/accessibility/mac/AXObjectCacheMac.mm:
(WebCore::AXObjectCache::postPlatformAnnouncementNotification):
(WebCore::AXObjectCache::postPlatformARIANotifyNotification):
(WebCore::addTextMarkerForVisiblePosition):
(WebCore::AXObjectCache::isIsolatedTreeEnabled):
(WebCore::AXObjectCache::addSortedObjects):
(WebCore::AXObjectCache::initializeSortedIDLists):
(WebCore::textMarkerRangeFromMarkers):
(WebCore::AXTextMarkerRangeStart):
(WebCore::AXTextMarkerRangeEnd):
(WebCore::getBytesFromAXTextMarker):
(WebCore::accessibilityObjectForTextMarker):
(WebCore::textMarkerForVisiblePosition):
(WebCore::visiblePositionForTextMarker):
(WebCore::textMarkerRangeFromVisiblePositions):
(WebCore::visiblePositionRangeForTextMarkerRange):
(WebCore::textMarkerForCharacterOffset):
(WebCore::characterOffsetForTextMarker):
(WebCore::startOrEndTextMarkerForRange):
(WebCore::textMarkerRangeFromRange):
(WebCore::rangeForTextMarkerRange):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm:
(-[WebAccessibilityObjectWrapperBase initWithAccessibilityObject:]):
(-[WebAccessibilityObjectWrapperBase attachAXObject:]):
(-[WebAccessibilityObjectWrapperBase attachIsolatedObject:]):
(-[WebAccessibilityObjectWrapperBase detach]):
(-[WebAccessibilityObjectWrapperBase axBackingObject]):
(-[WebAccessibilityObjectWrapperBase _accessibilityWebDocumentView]):
(-[WebAccessibilityObjectWrapperBase lineRectsAndText]):
(-[WebAccessibilityObjectWrapperBase accessibilityPlatformMathSubscriptKey]):
(-[WebAccessibilityObjectWrapperBase accessibilityPlatformMathSuperscriptKey]):
(-[WebAccessibilityObjectWrapperBase baseAccessibilityResolvedEditingStyles]):
(arrayRemovingNonSupportedTypes):
(dictionaryRemovingNonSupportedTypes):
(-[WebAccessibilityObjectWrapperBase accessibilityPostedNotification:userInfo:]):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper detach]):
(screenToContents):
(accessibilityTextOperationForParameterizedAttribute):
(-[WebAccessibilityObjectWrapper _accessibilityPerformPressAction]):
(-[WebAccessibilityObjectWrapper _accessibilityShowContextMenu]):
(-[WebAccessibilityObjectWrapper _accessibilitySetValue:forAttribute:]):
(-[WebAccessibilityObjectWrapper textMarkerRangeAtTextMarker:forUnit:]):
(-[WebAccessibilityObjectWrapper lineTextMarkerRangeForTextMarker:forUnit:]):
(-[WebAccessibilityObjectWrapper textMarkerForTextMarker:atUnit:]):
(-[WebAccessibilityObjectWrapper accessibilityAttributeValue:forParameter:]):

Canonical link: <a href="https://commits.webkit.org/305684@main">https://commits.webkit.org/305684@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1bb536116c27f5b8db69ec5b968be9f0ab312bd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139101 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11474 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/598 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147228 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a25f8dc2-7cee-4c08-967b-cfa35d017e8e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140973 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12181 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11625 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106481 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/416b9169-c60d-49eb-9b8f-fbd6b01e1cff) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142048 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9207 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124601 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87349 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8759 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6527 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7520 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118209 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/500 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150007 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11159 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/511 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114871 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11172 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9438 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115183 "Found 1 new API test failure: TestWTF:WTF_WorkQueue.ThreadSafetyAnalysisAssertIsCurrentWorks (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29274 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9083 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120950 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66061 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11201 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/479 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10937 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74859 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11140 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10989 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->