### PR TITLE
Reduce unsafeness in Styleable.h

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
@@ -79,6 +79,5 @@ style/StyleResolver.cpp
 style/StyleResolver.h
 style/StyleScope.h
 style/StyleTreeResolver.h
-style/Styleable.h
 style/calc/StyleCalculationTree+Conversion.h
 svg/properties/SVGPropertyOwnerRegistry.h

--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -45,7 +45,6 @@ style/StyleRelations.h
 style/StyleResolver.cpp
 style/StyleScope.h
 style/StyleScopeRuleSets.h
-style/Styleable.h
 svg/properties/SVGPropertyOwnerRegistry.h
 xml/XPathGrammar.cpp
 xml/XPathGrammar.h

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -636,7 +636,6 @@ style/StyleScopeRuleSets.cpp
 style/StyleTreeResolver.cpp
 style/StyleUpdate.cpp
 style/Styleable.cpp
-style/Styleable.h
 style/computed/StyleComputedStyle.cpp
 style/computed/StyleComputedStyleBase.cpp
 style/values/color/StyleColor.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -784,7 +784,6 @@ style/StyleSheetContentsCache.cpp
 style/StyleTreeResolver.cpp
 style/StyleUpdate.cpp
 style/Styleable.cpp
-style/Styleable.h
 style/UserAgentStyle.cpp
 style/computed/StyleComputedStyle.cpp
 style/computed/StyleComputedStyleBase.cpp

--- a/Source/WebCore/animation/AcceleratedEffectStackUpdater.cpp
+++ b/Source/WebCore/animation/AcceleratedEffectStackUpdater.cpp
@@ -76,7 +76,7 @@ void AcceleratedEffectStackUpdater::update()
 
 void AcceleratedEffectStackUpdater::scheduleUpdateForTarget(const Styleable& target)
 {
-    m_targetsPendingUpdate.add({ &target.element, target.pseudoElementIdentifier });
+    m_targetsPendingUpdate.add({ target.element.ptr(), target.pseudoElementIdentifier });
 }
 
 } // namespace WebCore

--- a/Source/WebCore/animation/CSSAnimation.cpp
+++ b/Source/WebCore/animation/CSSAnimation.cpp
@@ -194,7 +194,7 @@ void CSSAnimation::syncStyleOriginatedTimeline()
     suspendEffectInvalidation();
 
     ASSERT(owningElement());
-    Ref document = owningElement()->element.document();
+    Ref document = owningElement()->element->document();
 
     WTF::switchOn(m_backingStyleAnimation.timeline(),
         [&](const CSS::Keyword::Auto&) {

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -126,7 +126,7 @@ static inline void invalidateElement(const std::optional<const Styleable>& style
     if (!styleable)
         return;
 
-    Ref element = styleable->element;
+    Ref element = styleable->element.get();
     if (!element->document().inStyleRecalc())
         element->invalidateStyleForAnimation();
 }
@@ -1098,7 +1098,7 @@ ExceptionOr<void> KeyframeEffect::setKeyframes(JSGlobalObject& lexicalGlobalObje
 
         // Need a full style invalidation since the new keyframes may interact differently with the base style.
         if (auto target = targetStyleable())
-            target->element.invalidateStyleInternal();
+            target->element->invalidateStyleInternal();
     }
 
     return processKeyframesResult;
@@ -1569,7 +1569,7 @@ void KeyframeEffect::setTarget(RefPtr<Element>&& newTarget)
     auto& previousTargetStyleable = targetStyleable();
     RefPtr<Element> protector;
     if (previousTargetStyleable)
-        protector = previousTargetStyleable->element;
+        protector = previousTargetStyleable->element.get();
     m_target = WTF::move(newTarget);
     didChangeTargetStyleable(previousTargetStyleable);
 }

--- a/Source/WebCore/animation/ScrollTimeline.cpp
+++ b/Source/WebCore/animation/ScrollTimeline.cpp
@@ -147,16 +147,16 @@ RefPtr<Element> ScrollTimeline::source() const
                     // quirks mode, but the scrolling element in that case is the <body> element, so we must
                     // make sure to return Document::scrollingElement() in case the document element is
                     // returned by enclosingScrollableContainer() but it was not explicitly set as the source.
-                    return &source->element == documentElement ? nearestSource : document->scrollingElement();
+                    return source->element.ptr() == documentElement ? nearestSource : document->scrollingElement();
                 }
             }
         }
         return nullptr;
     }
     case Scroller::Root:
-        return source->element.protectedDocument()->scrollingElement();
+        return source->element->protectedDocument()->scrollingElement();
     case Scroller::Self:
-        return &source->element;
+        return source->element.ptr();
     }
 
     ASSERT_NOT_REACHED();
@@ -181,12 +181,12 @@ void ScrollTimeline::setSource(const Styleable& styleable)
     auto previousSource = m_source.element();
     m_source = styleable;
 
-    if (previousSource && &previousSource->document() == &styleable.element.document())
+    if (previousSource && &previousSource->document() == &styleable.element->document())
         return;
 
     removeTimelineFromDocument(previousSource.get());
 
-    styleable.element.protectedDocument()->ensureTimelinesController().addTimeline(*this);
+    styleable.element->protectedDocument()->ensureTimelinesController().addTimeline(*this);
 }
 
 void ScrollTimeline::removeTimelineFromDocument(Element* element)
@@ -200,7 +200,7 @@ void ScrollTimeline::removeTimelineFromDocument(Element* element)
 AnimationTimelinesController* ScrollTimeline::controller() const
 {
     if (auto stylable = m_source.styleable())
-        return &stylable->element.document().ensureTimelinesController();
+        return &stylable->element->document().ensureTimelinesController();
     return nullptr;
 }
 
@@ -289,7 +289,7 @@ AnimationTimeline::ShouldUpdateAnimationsAndSendEvents ScrollTimeline::documentW
 {
     cacheCurrentTime();
     auto source = m_source.styleable();
-    if (source && source->element.isConnected())
+    if (source && source->element->isConnected())
         return AnimationTimeline::ShouldUpdateAnimationsAndSendEvents::Yes;
     return AnimationTimeline::ShouldUpdateAnimationsAndSendEvents::No;
 }
@@ -320,7 +320,7 @@ void ScrollTimeline::updateCurrentTimeIfStale()
     }
 
     if (needsStyleUpdate)
-        source->element.protectedDocument()->updateStyleIfNeeded();
+        source->element->protectedDocument()->updateStyleIfNeeded();
 }
 
 void ScrollTimeline::setTimelineScopeElement(const Element& element)
@@ -401,7 +401,7 @@ void ScrollTimeline::animationTimingDidChange(WebAnimation& animation)
     if (!source || !animation.pending() || animation.isEffectInvalidationSuspended())
         return;
 
-    if (RefPtr page = source->element.protectedDocument()->page())
+    if (RefPtr page = source->element->protectedDocument()->page())
         page->scheduleRenderingUpdate(RenderingUpdateStep::Animations);
 }
 
@@ -421,7 +421,7 @@ bool ScrollTimeline::computeCanBeAccelerated() const
 void ScrollTimeline::scheduleAcceleratedRepresentationUpdate()
 {
     if (auto source = m_source.styleable()) {
-        if (RefPtr page = source->element.protectedDocument()->page()) {
+        if (RefPtr page = source->element->protectedDocument()->page()) {
             if (auto* acceleratedTimelinesUpdater = page->acceleratedTimelinesUpdater())
                 acceleratedTimelinesUpdater->scrollTimelineDidChange(*this);
         }

--- a/Source/WebCore/animation/StyleOriginatedAnimation.cpp
+++ b/Source/WebCore/animation/StyleOriginatedAnimation.cpp
@@ -45,7 +45,7 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(StyleOriginatedAnimation);
 
 StyleOriginatedAnimation::StyleOriginatedAnimation(const Styleable& styleable)
-    : WebAnimation(styleable.element.document())
+    : WebAnimation(styleable.element->document())
     , m_owningElement(styleable.element)
     , m_owningPseudoElementIdentifier(styleable.pseudoElementIdentifier)
 {

--- a/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
+++ b/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
@@ -99,7 +99,7 @@ static bool containsElement(const Vector<WeakStyleable>& timelineScopeElements, 
 
 ScrollTimeline* StyleOriginatedTimelinesController::determineTreeOrder(const Vector<Ref<ScrollTimeline>>& ancestorTimelines, const Styleable& styleable, const Vector<WeakStyleable>& timelineScopeElements)
 {
-    RefPtr element = styleable.element;
+    RefPtr element = styleable.element.ptr();
     while (element) {
         Vector<Ref<ScrollTimeline>> matchedTimelines;
         for (auto& timeline : ancestorTimelines) {
@@ -148,8 +148,8 @@ ScrollTimeline* StyleOriginatedTimelinesController::determineTimelineForElement(
         auto styleableForTimeline = originatingStyleableIncludingTimelineScope(timeline).styleable();
         if (!styleableForTimeline)
             continue;
-        Ref protectedElementForTimeline { styleableForTimeline->element };
-        if (&styleableForTimeline->element == &styleable.element || Ref { styleable.element }->isComposedTreeDescendantOf(protectedElementForTimeline.get()))
+        Ref protectedElementForTimeline { styleableForTimeline->element.get() };
+        if (styleableForTimeline->element.ptr() == styleable.element.ptr() || Ref { styleable.element.get() }->isComposedTreeDescendantOf(protectedElementForTimeline.get()))
             matchedTimelines.append(timeline);
     }
     if (matchedTimelines.isEmpty())
@@ -173,18 +173,18 @@ void StyleOriginatedTimelinesController::updateTimelineForTimelineScope(const Re
 
     for (auto& entry : m_timelineScopeEntries) {
         if (auto entryElement = entry.second.styleable()) {
-            Ref protectedEntryElement { entryElement->element };
-            if (Ref { timelineElement->element }->isComposedTreeDescendantOf(protectedEntryElement.get()) && (entry.first.type == Style::NameScope::Type::All || entry.first.names.contains(CustomIdentifier { name })))
+            Ref protectedEntryElement { entryElement->element.get() };
+            if (Ref { timelineElement->element.get() }->isComposedTreeDescendantOf(protectedEntryElement.get()) && (entry.first.type == Style::NameScope::Type::All || entry.first.names.contains(CustomIdentifier { name })))
                 matchedTimelineScopeElements.appendIfNotContains(*entryElement);
         }
     }
-    RefPtr element = timelineElement->element;
+    RefPtr element = timelineElement->element.ptr();
     while (element) {
         auto it = matchedTimelineScopeElements.findIf([element] (const Styleable& entry) {
-            return &entry.element == element;
+            return entry.element.ptr() == element;
         });
         if (it != notFound) {
-            Ref protectedTimelineScopeElement { matchedTimelineScopeElements.at(it).element };
+            Ref protectedTimelineScopeElement { matchedTimelineScopeElements.at(it).element.get() };
             timeline->setTimelineScopeElement(protectedTimelineScopeElement.get());
             return;
         }
@@ -371,7 +371,7 @@ void StyleOriginatedTimelinesController::attachAnimation(CSSAnimation& animation
             for (auto timelineScopeElement : timelineScopeElements) {
                 ASSERT(timelineScopeElement.element());
                 Ref protectedTimelineScopeElement { *timelineScopeElement.element() };
-                if (*target == timelineScopeElement.styleable() || Ref { target->element }->isComposedTreeDescendantOf(protectedTimelineScopeElement.get()))
+                if (*target == timelineScopeElement.styleable() || Ref { target->element.get() }->isComposedTreeDescendantOf(protectedTimelineScopeElement.get()))
                     return true;
             }
             return false;
@@ -411,8 +411,8 @@ static void updateTimelinesForTimelineScope(Vector<Ref<ScrollTimeline>> entries,
 {
     for (auto& entry : entries) {
         if (auto entryElement = originatingElementExcludingTimelineScope(entry).styleable()) {
-            Ref protectedElement { styleable.element };
-            if (Ref { entryElement->element }->isComposedTreeDescendantOf(protectedElement.get()))
+            Ref protectedElement { styleable.element.get() };
+            if (Ref { entryElement->element.get() }->isComposedTreeDescendantOf(protectedElement.get()))
                 entry->setTimelineScopeElement(protectedElement.get());
         }
     }
@@ -431,7 +431,7 @@ void StyleOriginatedTimelinesController::updateNamedTimelineMapForTimelineScope(
         HashSet<Ref<ScrollTimeline>> namedTimelinesToUnregister;
         for (auto& entry : m_nameToTimelineMap) {
             for (auto& timeline : entry.value) {
-                if (timeline->timelineScopeDeclaredElement() == &styleable.element) {
+                if (timeline->timelineScopeDeclaredElement() == styleable.element.ptr()) {
                     timeline->clearTimelineScopeDeclaredElement();
                     // Make sure to track this time to be unregistered in a separate
                     // step as it would modify the map we're currently iterating over.
@@ -507,7 +507,7 @@ void StyleOriginatedTimelinesController::styleableWasRemoved(const Styleable& st
             if (RefPtr cssAnimation = dynamicDowncast<CSSAnimation>(animation.get())) {
                 if (auto owningElement = cssAnimation->owningElement()) {
                     attachAnimation(*cssAnimation, AllowsDeferral::Yes);
-                    Ref { owningElement->element }->invalidateStyleForAnimation();
+                    Ref { owningElement->element.get() }->invalidateStyleForAnimation();
                 }
             }
         }

--- a/Source/WebCore/animation/ViewTimeline.cpp
+++ b/Source/WebCore/animation/ViewTimeline.cpp
@@ -166,7 +166,7 @@ ExceptionOr<ViewTimeline::SpecifiedViewTimelineInsets> ViewTimeline::validateSpe
 const Element* ViewTimeline::subject() const
 {
     if (auto subject = m_subject.styleable())
-        return &subject->element;
+        return subject->element.ptr();
     return nullptr;
 }
 
@@ -188,18 +188,18 @@ void ViewTimeline::setSubject(const Styleable& styleable)
     auto previousSubject = m_subject.element();
     m_subject = styleable;
 
-    if (previousSubject && &previousSubject->document() == &styleable.element.document())
+    if (previousSubject && &previousSubject->document() == &styleable.element->document())
         return;
 
     removeTimelineFromDocument(previousSubject.get());
 
-    styleable.element.protectedDocument()->ensureTimelinesController().addTimeline(*this);
+    styleable.element->protectedDocument()->ensureTimelinesController().addTimeline(*this);
 }
 
 AnimationTimelinesController* ViewTimeline::controller() const
 {
     if (auto subject = m_subject.styleable())
-        return &subject->element.document().ensureTimelinesController();
+        return &subject->element->document().ensureTimelinesController();
     return nullptr;
 }
 
@@ -308,7 +308,7 @@ void ViewTimeline::cacheCurrentTime()
             return { };
 
         CheckedPtr sourceRenderer = sourceScrollerRenderer();
-        CheckedPtr sourceScrollableArea = scrollableAreaForSourceRenderer(sourceRenderer.get(), subject->element.document());
+        CheckedPtr sourceScrollableArea = scrollableAreaForSourceRenderer(sourceRenderer.get(), subject->element->document());
         if (!sourceScrollableArea)
             return { };
 
@@ -339,7 +339,7 @@ void ViewTimeline::cacheCurrentTime()
         auto subjectSize = scrollDirection.isVertical ? subjectBounds.height() : subjectBounds.width();
 
         if (m_specifiedInsets) {
-            RefPtr subjectElement { &subject->element };
+            RefPtr subjectElement { subject->element.ptr() };
 
             auto computedInset = [&](const CSSPrimitiveValue& specifiedInset) {
                 return Style::deprecatedToStyleFromCSSValue<Style::ViewTimelineInsetItem::Length>(subjectElement, specifiedInset).value_or(Style::ViewTimelineInsetItem::Length { CSS::Keyword::Auto { } });
@@ -435,7 +435,7 @@ Style::SingleAnimationRange ViewTimeline::defaultRange() const
 RefPtr<Element> ViewTimeline::bindingsSource() const
 {
     if (auto subject = m_subject.styleable())
-        subject->element.protectedDocument()->updateStyleIfNeeded();
+        subject->element->protectedDocument()->updateStyleIfNeeded();
     return ScrollTimeline::bindingsSource();
 }
 

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -1932,7 +1932,7 @@ bool WebAnimation::isSkippedContentAnimation() const
         return false;
     if (auto animation = dynamicDowncast<StyleOriginatedAnimation>(this)) {
         if (auto element = animation->owningElement())
-            return element->element.renderer() && element->element.renderer()->isSkippedContent();
+            return element->element->renderer() && element->element->renderer()->isSkippedContent();
     }
     return false;
 }

--- a/Source/WebCore/animation/WebAnimationUtilities.cpp
+++ b/Source/WebCore/animation/WebAnimationUtilities.cpp
@@ -109,8 +109,8 @@ static bool compareStyleOriginatedAnimationOwningElementPositionsInDocumentTreeO
         }
     };
 
-    Ref aReferenceElement = a.element;
-    Ref bReferenceElement = b.element;
+    Ref aReferenceElement = a.element.get();
+    Ref bReferenceElement = b.element.get();
 
     if (aReferenceElement.ptr() == bReferenceElement.ptr()) {
         if (isNamedViewTransitionPseudoElement(a.pseudoElementIdentifier) && isNamedViewTransitionPseudoElement(b.pseudoElementIdentifier) && a.pseudoElementIdentifier->nameArgument != b.pseudoElementIdentifier->nameArgument) {

--- a/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
+++ b/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
@@ -264,7 +264,7 @@ void ContentVisibilityDocumentState::updateAnimations(const Element& element, Is
         if (!styleOriginatedAnimation)
             continue;
         auto owningElement = styleOriginatedAnimation->owningElement();
-        if (!owningElement || !owningElement->element.isShadowIncludingDescendantOf(&element))
+        if (!owningElement || !owningElement->element->isShadowIncludingDescendantOf(&element))
             continue;
 
         if (RefPtr timeline = styleOriginatedAnimation->timeline())

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -11080,7 +11080,7 @@ void Document::keyframesRuleDidChange(const String& name)
             continue;
 
         auto owningElement = cssAnimation->owningElement();
-        if (!owningElement || !owningElement->element.isConnected() || &owningElement->element.document() != this)
+        if (!owningElement || !owningElement->element->isConnected() || &owningElement->element->document() != this)
             continue;
 
         cssAnimation->keyframesRuleDidChange();

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -556,7 +556,7 @@ ExceptionOr<void> ViewTransition::captureOldState()
             if (rendererIsFragmented(renderer))
                 return { };
 
-            if (auto name = effectiveViewTransitionName(renderer, Ref { styleable->element }, document()->styleScope(), isCrossDocument()); !name.isNull()) {
+            if (auto name = effectiveViewTransitionName(renderer, Ref { styleable->element.get() }, document()->styleScope(), isCrossDocument()); !name.isNull()) {
                 if (auto check = checkDuplicateViewTransitionName(name, usedTransitionNames); check.hasException())
                     return check.releaseException();
 
@@ -581,7 +581,7 @@ ExceptionOr<void> ViewTransition::captureOldState()
 
         auto styleable = Styleable::fromRenderer(renderer);
         ASSERT(styleable);
-        Ref element = styleable->element;
+        Ref element = styleable->element.get();
         capture.classList = effectiveViewTransitionClassList(renderer, element, document()->styleScope());
 
         auto transitionName = effectiveViewTransitionName(renderer, element, document()->styleScope(), isCrossDocument());
@@ -631,7 +631,7 @@ ExceptionOr<void> ViewTransition::captureNewState()
             if (rendererIsFragmented(renderer))
                 return { };
 
-            Ref element = styleable->element;
+            Ref element = styleable->element.get();
             if (auto name = effectiveViewTransitionName(renderer, element, document()->styleScope(), isCrossDocument()); !name.isNull()) {
                 if (auto check = checkDuplicateViewTransitionName(name, usedTransitionNames); check.hasException())
                     return check.releaseException();
@@ -903,7 +903,7 @@ void ViewTransition::copyElementBaseProperties(RenderLayerModelObject& renderer,
 {
     std::optional<const Styleable> styleable = Styleable::fromRenderer(renderer);
     ASSERT(styleable);
-    Style::Extractor styleExtractor { &styleable->element, false, styleable->pseudoElementIdentifier };
+    Style::Extractor styleExtractor { styleable->element.ptr(), false, styleable->pseudoElementIdentifier };
 
     static constexpr auto transitionProperties = std::to_array<CSSPropertyID>({
         CSSPropertyWritingMode,
@@ -1060,7 +1060,7 @@ RenderViewTransitionCapture* ViewTransition::viewTransitionNewPseudoForCapturedE
     auto styleable = Styleable::fromRenderer(renderer);
     if (!styleable)
         return nullptr;
-    auto capturedName = Ref { styleable->element }->viewTransitionCapturedName(styleable->pseudoElementIdentifier);
+    auto capturedName = Ref { styleable->element.get() }->viewTransitionCapturedName(styleable->pseudoElementIdentifier);
     if (capturedName.isNull())
         return nullptr;
 

--- a/Source/WebCore/inspector/InspectorInstrumentation.h
+++ b/Source/WebCore/inspector/InspectorInstrumentation.h
@@ -1493,7 +1493,7 @@ inline bool InspectorInstrumentation::isWebGLProgramHighlighted(WebGLRenderingCo
 inline void InspectorInstrumentation::willApplyKeyframeEffect(const Styleable& target, KeyframeEffect& effect, const ComputedEffectTiming& computedTiming)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (RefPtr agents = instrumentingAgents(target.element.document()))
+    if (RefPtr agents = instrumentingAgents(target.element->document()))
         willApplyKeyframeEffectImpl(*agents, target, effect, computedTiming);
 }
 

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -590,7 +590,7 @@ void InspectorDOMAgent::discardBindings()
 
 static RefPtr<Element> elementToPushForStyleable(const Styleable& styleable)
 {
-    Ref element = styleable.element;
+    Ref element = styleable.element.get();
     // FIXME: We want to get rid of PseudoElement.
     if (styleable.pseudoElementIdentifier) {
         if (styleable.pseudoElementIdentifier->type == PseudoElementType::Before)
@@ -604,7 +604,7 @@ static RefPtr<Element> elementToPushForStyleable(const Styleable& styleable)
 Inspector::Protocol::DOM::NodeId InspectorDOMAgent::pushStyleableElementToFrontend(const Styleable& styleable)
 {
     RefPtr element = elementToPushForStyleable(styleable);
-    return pushNodeToFrontend(element ? element.get() : &styleable.element);
+    return pushNodeToFrontend(element ? element.get() : styleable.element.ptr());
 }
 
 Inspector::Protocol::DOM::NodeId InspectorDOMAgent::pushNodeToFrontend(Node* nodeToPush)
@@ -760,7 +760,7 @@ Inspector::Protocol::DOM::NodeId InspectorDOMAgent::pushNodePathToFrontend(Node*
 Ref<Inspector::Protocol::DOM::Styleable> InspectorDOMAgent::pushStyleablePathToFrontend(Inspector::Protocol::ErrorString errorString, const Styleable& styleable)
 {
     RefPtr element = elementToPushForStyleable(styleable);
-    auto nodeId = pushNodePathToFrontend(errorString, element ? element.get() : &styleable.element);
+    auto nodeId = pushNodePathToFrontend(errorString, element ? element.get() : styleable.element.ptr());
 
     auto protocolStyleable = Inspector::Protocol::DOM::Styleable::create()
         .setNodeId(nodeId)

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -2308,7 +2308,7 @@ bool Quirks::shouldPreventKeyframeEffectAcceleration(const KeyframeEffect& effec
         return false;
 
     auto target = Ref { effect }->targetStyleable();
-    return target && Ref { target->element }->localName() == "ea-network-nav"_s;
+    return target && Ref { target->element.get() }->localName() == "ea-network-nav"_s;
 }
 
 bool Quirks::shouldEnterNativeFullscreenWhenCallingElementRequestFullscreenQuirk() const

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -1708,7 +1708,7 @@ HashMap<AnchorPositionedKey, size_t> AnchorPositionEvaluator::recordLastSuccessf
         ASSERT(styleable);
 
         if (auto usedPositionOptionIndex = positionTryBox.style().usedPositionOptionIndex())
-            lastSuccessfulPositionOptionMap.add({ styleable->element, styleable->pseudoElementIdentifier }, *usedPositionOptionIndex);
+            lastSuccessfulPositionOptionMap.add({ styleable->element.ptr(), styleable->pseudoElementIdentifier }, *usedPositionOptionIndex);
     }
 
     return lastSuccessfulPositionOptionMap;

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -173,7 +173,7 @@ ResolvedStyle TreeResolver::styleForStyleable(const Styleable& styleable, Resolu
     if (resolutionType == ResolutionType::AnimationOnly && styleable.lastStyleChangeEventStyle() && !styleable.hasPropertiesOverridenAfterAnimation())
         return { RenderStyle::clonePtr(*styleable.lastStyleChangeEventStyle()) };
 
-    Ref element = styleable.element;
+    Ref element = styleable.element.get();
 
     if (auto optionStyle = tryChoosePositionOption(styleable, resolutionContext))
         return WTF::move(*optionStyle);
@@ -756,7 +756,7 @@ const RenderStyle* TreeResolver::parentBoxStyleForPseudoElement(const ElementUpd
 
 ElementUpdate TreeResolver::createAnimatedElementUpdate(ResolvedStyle&& resolvedStyle, const Styleable& styleable, OptionSet<Change> parentChanges, const ResolutionContext& resolutionContext, IsInDisplayNoneTree isInDisplayNoneTree)
 {
-    Ref element = styleable.element;
+    Ref element = styleable.element.get();
     Ref document = element->document();
     auto* currentStyle = element->renderOrDisplayContentsStyle(styleable.pseudoElementIdentifier);
 
@@ -866,7 +866,7 @@ ElementUpdate TreeResolver::createAnimatedElementUpdate(ResolvedStyle&& resolved
             styleable.setHasPropertiesOverridenAfterAnimation(!overriddenAnimatedProperties.isEmpty());
         }
 
-        Adjuster adjuster(document, *resolutionContext.parentStyle, resolutionContext.parentBoxStyle, !styleable.pseudoElementIdentifier ? &styleable.element : nullptr);
+        Adjuster adjuster(document, *resolutionContext.parentStyle, resolutionContext.parentBoxStyle, !styleable.pseudoElementIdentifier ? styleable.element.ptr() : nullptr);
         adjuster.adjustAnimatedStyle(*animatedStyle, animationImpact);
 
         return { WTF::move(animatedStyle), animationImpact };
@@ -986,7 +986,7 @@ std::unique_ptr<RenderStyle> TreeResolver::resolveAgainInDifferentContext(const 
         m_document.get(),
         &parentStyle,
         resolutionContext.documentElementStyle,
-        &styleable.element,
+        styleable.element.ptr(),
         &m_treeResolutionState,
         WTF::move(positionTryFallback)
     };
@@ -1003,7 +1003,7 @@ std::unique_ptr<RenderStyle> TreeResolver::resolveAgainInDifferentContext(const 
     if (newStyle->display() == DisplayType::None)
         return nullptr;
 
-    Adjuster adjuster(m_document, parentStyle, resolutionContext.parentBoxStyle, !styleable.pseudoElementIdentifier ? &styleable.element : nullptr);
+    Adjuster adjuster(m_document, parentStyle, resolutionContext.parentBoxStyle, !styleable.pseudoElementIdentifier ? styleable.element.ptr() : nullptr);
     adjuster.adjust(*newStyle);
 
     return newStyle;
@@ -1011,7 +1011,7 @@ std::unique_ptr<RenderStyle> TreeResolver::resolveAgainInDifferentContext(const 
 
 const RenderStyle& TreeResolver::parentAfterChangeStyle(const Styleable& styleable, const ResolutionContext& resolutionContext) const
 {
-    if (RefPtr parentElement = !styleable.pseudoElementIdentifier ? parent().element : &styleable.element) {
+    if (RefPtr parentElement = !styleable.pseudoElementIdentifier ? parent().element : styleable.element.ptr()) {
         if (auto* afterChangeStyle = parentElement->lastStyleChangeEventStyle({ }))
             return *afterChangeStyle;
     }
@@ -1774,7 +1774,7 @@ std::optional<ResolvedStyle> TreeResolver::tryChoosePositionOption(const Styleab
     }
 
     // We can't test for overflow before the box has been positioned.
-    auto* anchorPositionedState = m_treeResolutionState.anchorPositionedStates.get({ &styleable.element, styleable.pseudoElementIdentifier });
+    auto* anchorPositionedState = m_treeResolutionState.anchorPositionedStates.get({ styleable.element.ptr(), styleable.pseudoElementIdentifier });
     if (anchorPositionedState && anchorPositionedState->stage < AnchorPositionResolutionStage::Positioned)
         return ResolvedStyle { options.currentOption() };
 
@@ -1824,7 +1824,7 @@ void TreeResolver::updateForPositionVisibility(RenderStyle& style, const Styleab
                 return true;
         }
         if (style.positionVisibility().contains(PositionVisibilityValue::AnchorsValid)) {
-            auto* anchorPositionedState = m_treeResolutionState.anchorPositionedStates.get({ &styleable.element, styleable.pseudoElementIdentifier });
+            auto* anchorPositionedState = m_treeResolutionState.anchorPositionedStates.get({ styleable.element.ptr(), styleable.pseudoElementIdentifier });
             if (anchorPositionedState) {
                 for (auto& anchorElement : anchorPositionedState->anchorElements.values()) {
                     if (!anchorElement)
@@ -1864,7 +1864,7 @@ void TreeResolver::saveBeforeResolutionStyleForInterleaving(const Element& eleme
 
 bool TreeResolver::hasUnresolvedAnchorPosition(const Styleable& styleable) const
 {
-    auto* anchorPositionedState = m_treeResolutionState.anchorPositionedStates.get({ &styleable.element, styleable.pseudoElementIdentifier });
+    auto* anchorPositionedState = m_treeResolutionState.anchorPositionedStates.get({ styleable.element.ptr(), styleable.pseudoElementIdentifier });
     if (anchorPositionedState && anchorPositionedState->stage < AnchorPositionResolutionStage::Resolved)
         return true;
 
@@ -1873,7 +1873,7 @@ bool TreeResolver::hasUnresolvedAnchorPosition(const Styleable& styleable) const
 
 bool TreeResolver::hasResolvedAnchorPosition(const Styleable& styleable) const
 {
-    auto* anchorPositionedState = m_treeResolutionState.anchorPositionedStates.get({ &styleable.element, styleable.pseudoElementIdentifier });
+    auto* anchorPositionedState = m_treeResolutionState.anchorPositionedStates.get({ styleable.element.ptr(), styleable.pseudoElementIdentifier });
     if (anchorPositionedState && anchorPositionedState->stage >= AnchorPositionResolutionStage::Resolved)
         return true;
 
@@ -1882,7 +1882,7 @@ bool TreeResolver::hasResolvedAnchorPosition(const Styleable& styleable) const
 
 bool TreeResolver::isTryingPositionOption(const Styleable& styleable) const
 {
-    if (auto it = m_positionOptions.find({ styleable.element, styleable.pseudoElementIdentifier }); it != m_positionOptions.end())
+    if (auto it = m_positionOptions.find({ styleable.element.ptr(), styleable.pseudoElementIdentifier }); it != m_positionOptions.end())
         return !it->value.chosen;
 
     return false;

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -116,31 +116,31 @@ const std::optional<const Styleable> Styleable::fromRenderer(const RenderElement
 RenderElement* Styleable::renderer() const
 {
     if (!pseudoElementIdentifier)
-        return element.renderer();
+        return element->renderer();
 
     switch (pseudoElementIdentifier->type) {
     case PseudoElementType::After:
-        if (auto* afterPseudoElement = element.afterPseudoElement())
+        if (auto* afterPseudoElement = element->afterPseudoElement())
             return afterPseudoElement->renderer();
         break;
     case PseudoElementType::Backdrop:
-        if (auto* hostRenderer = element.renderer())
+        if (auto* hostRenderer = element->renderer())
             return hostRenderer->backdropRenderer().get();
         break;
     case PseudoElementType::Before:
-        if (auto* beforePseudoElement = element.beforePseudoElement())
+        if (auto* beforePseudoElement = element->beforePseudoElement())
             return beforePseudoElement->renderer();
         break;
     case PseudoElementType::Marker:
-        if (auto* renderListItem = dynamicDowncast<RenderListItem>(element.renderer())) {
+        if (auto* renderListItem = dynamicDowncast<RenderListItem>(element->renderer())) {
             auto* markerRenderer = renderListItem->markerRenderer();
             if (markerRenderer && !markerRenderer->style().hasUsedContentNone())
                 return markerRenderer;
         }
         break;
     case PseudoElementType::ViewTransition:
-        if (element.renderer() && element.renderer()->isDocumentElementRenderer()) {
-            if (WeakPtr containingBlock = element.renderer()->view().viewTransitionContainingBlock())
+        if (element->renderer() && element->renderer()->isDocumentElementRenderer()) {
+            if (WeakPtr containingBlock = element->renderer()->view().viewTransitionContainingBlock())
                 return containingBlock->firstChildBox();
         }
         break;
@@ -148,11 +148,11 @@ RenderElement* Styleable::renderer() const
     case PseudoElementType::ViewTransitionImagePair:
     case PseudoElementType::ViewTransitionNew:
     case PseudoElementType::ViewTransitionOld: {
-        if (!element.renderer() || !element.renderer()->isDocumentElementRenderer())
+        if (!element->renderer() || !element->renderer()->isDocumentElementRenderer())
             return nullptr;
 
         // Find the right ::view-transition-group().
-        WeakPtr correctGroup = element.renderer()->view().viewTransitionGroupForName(pseudoElementIdentifier->nameArgument);
+        WeakPtr correctGroup = element->renderer()->view().viewTransitionGroupForName(pseudoElementIdentifier->nameArgument);
         if (!correctGroup)
             return nullptr;
 
@@ -243,7 +243,7 @@ bool Styleable::isRunningAcceleratedTransformRelatedAnimation() const
 bool Styleable::hasRunningAcceleratedAnimations() const
 {
     if (auto* effectStack = keyframeEffectStack()) {
-        if (effectStack->hasAcceleratedEffects(element.document().settings()))
+        if (effectStack->hasAcceleratedEffects(element->document().settings()))
             return true;
     }
 
@@ -299,7 +299,7 @@ void Styleable::animationWasRemoved(WebAnimation& animation) const
 void Styleable::elementWasRemoved() const
 {
     cancelStyleOriginatedAnimations();
-    if (CheckedPtr styleOriginatedTimelinesController = element.protectedDocument()->styleOriginatedTimelinesController())
+    if (CheckedPtr styleOriginatedTimelinesController = element->protectedDocument()->styleOriginatedTimelinesController())
         styleOriginatedTimelinesController->styleableWasRemoved(*this);
 }
 
@@ -313,7 +313,7 @@ void Styleable::willChangeRenderer() const
 
 OptionSet<AnimationImpact> Styleable::applyKeyframeEffects(RenderStyle& targetStyle, HashSet<AnimatableCSSProperty>& affectedProperties, const RenderStyle* previousLastStyleChangeEventStyle, const Style::ResolutionContext& resolutionContext) const
 {
-    return element.ensureKeyframeEffectStack(pseudoElementIdentifier).applyKeyframeEffects(targetStyle, affectedProperties, previousLastStyleChangeEventStyle, resolutionContext);
+    return element->ensureKeyframeEffectStack(pseudoElementIdentifier).applyKeyframeEffects(targetStyle, affectedProperties, previousLastStyleChangeEventStyle, resolutionContext);
 }
 
 void Styleable::cancelStyleOriginatedAnimations() const
@@ -321,11 +321,11 @@ void Styleable::cancelStyleOriginatedAnimations() const
     // It is important we don't cancel style-originated animations when entering the page cache
     // since any JS wrapper that is kept alive in the page cache could be associated with an animation
     // that itself has not been kept alive (or rather canceled) when entering the page cache.
-    if (element.protectedDocument()->backForwardCacheState() != Document::NotInBackForwardCache)
+    if (element->protectedDocument()->backForwardCacheState() != Document::NotInBackForwardCache)
         return;
 
     cancelStyleOriginatedAnimations({ });
-    if (CheckedPtr styleOriginatedTimelinesController = element.protectedDocument()->styleOriginatedTimelinesController())
+    if (CheckedPtr styleOriginatedTimelinesController = element->protectedDocument()->styleOriginatedTimelinesController())
         styleOriginatedTimelinesController->unregisterNamedTimelinesAssociatedWithElement(*this);
 }
 
@@ -384,7 +384,7 @@ void Styleable::updateCSSAnimations(const RenderStyle* currentStyle, const Rende
 
     auto& currentAnimationList = newStyle.animations();
     auto& previousAnimationList = keyframeEffectStack.cssAnimationList();
-    if (!element.hasPendingKeyframesUpdate(pseudoElementIdentifier) && previousAnimationList && !previousAnimationList->isInitial() && newStyle.hasAnimations() && *previousAnimationList == newStyle.animations() && !animationListContainsNewlyValidAnimation(newStyle.animations()))
+    if (!element->hasPendingKeyframesUpdate(pseudoElementIdentifier) && previousAnimationList && !previousAnimationList->isInitial() && newStyle.hasAnimations() && *previousAnimationList == newStyle.animations() && !animationListContainsNewlyValidAnimation(newStyle.animations()))
         return;
 
     CSSAnimationCollection newAnimations;
@@ -452,7 +452,7 @@ void Styleable::updateCSSAnimations(const RenderStyle* currentStyle, const Rende
 
     keyframeEffectStack.setCSSAnimationList(Style::Animations { currentAnimationList });
 
-    element.cssAnimationsDidUpdate(pseudoElementIdentifier);
+    element->cssAnimationsDidUpdate(pseudoElementIdentifier);
 }
 
 static KeyframeEffect* keyframeEffectForElementAndProperty(const Styleable& styleable, const AnimatableCSSProperty& property)
@@ -571,7 +571,7 @@ static void updateCSSTransitionsForStyleableAndProperty(const Styleable& styleab
     if (animation && !isDeclarative)
         return;
 
-    Ref document = styleable.element.document();
+    Ref document = styleable.element->document();
 
     auto hasMatchingTransitionProperty = false;
     auto matchingTransitionDuration = 0.0;
@@ -807,11 +807,11 @@ void Styleable::updateCSSTransitions(const RenderStyle& currentStyle, const Rend
             }
         }
 
-        if (auto* properties = element.runningTransitionsByProperty(pseudoElementIdentifier)) {
+        if (auto* properties = element->runningTransitionsByProperty(pseudoElementIdentifier)) {
             for (const auto& [property, transition] : *properties)
                 addProperty(property);
         }
-        if (auto* properties = element.completedTransitionsByProperty(pseudoElementIdentifier)) {
+        if (auto* properties = element->completedTransitionsByProperty(pseudoElementIdentifier)) {
             for (const auto& [property, transition] : *properties)
                 addProperty(property);
         }
@@ -851,13 +851,13 @@ void Styleable::updateCSSScrollTimelines(const RenderStyle* currentStyle, const 
 
         auto& currentTimelines = afterChangeStyle.scrollTimelines();
         for (auto& currentTimeline : currentTimelines)
-            currentTimeline->setSource(&element);
+            currentTimeline->setSource(element.ptr());
 
         if (!currentStyle)
             return;
 
         for (auto& previousTimeline : currentStyle->scrollTimelines()) {
-            if (!currentTimelines.contains(previousTimeline) && previousTimeline->source() == &element)
+            if (!currentTimelines.contains(previousTimeline) && previousTimeline->source() == element.ptr())
                 previousTimeline->setSource(nullptr);
         }
     };
@@ -866,7 +866,7 @@ void Styleable::updateCSSScrollTimelines(const RenderStyle* currentStyle, const 
         if (currentStyle && currentStyle->scrollTimelineNames() == afterChangeStyle.scrollTimelineNames() && currentStyle->scrollTimelineAxes() == afterChangeStyle.scrollTimelineAxes())
             return;
 
-        CheckedRef styleOriginatedTimelinesController = element.protectedDocument()->ensureStyleOriginatedTimelinesController();
+        CheckedRef styleOriginatedTimelinesController = element->protectedDocument()->ensureStyleOriginatedTimelinesController();
 
         auto& currentTimelineNames = afterChangeStyle.scrollTimelineNames();
         auto& currentTimelineAxes = afterChangeStyle.scrollTimelineAxes();
@@ -895,13 +895,13 @@ void Styleable::updateCSSViewTimelines(const RenderStyle* currentStyle, const Re
 
         auto& currentTimelines = afterChangeStyle.viewTimelines();
         for (auto& currentTimeline : currentTimelines)
-            currentTimeline->setSubject(&element);
+            currentTimeline->setSubject(element.ptr());
 
         if (!currentStyle)
             return;
 
         for (auto& previousTimeline : currentStyle->viewTimelines()) {
-            if (!currentTimelines.contains(previousTimeline) && previousTimeline->subject() == &element)
+            if (!currentTimelines.contains(previousTimeline) && previousTimeline->subject() == element.ptr())
                 previousTimeline->setSubject(nullptr);
         }
     };
@@ -910,7 +910,7 @@ void Styleable::updateCSSViewTimelines(const RenderStyle* currentStyle, const Re
         if ((currentStyle && currentStyle->viewTimelineNames() == afterChangeStyle.viewTimelineNames()) && (currentStyle && currentStyle->viewTimelineAxes() == afterChangeStyle.viewTimelineAxes()) && (currentStyle && currentStyle->viewTimelineInsets() == afterChangeStyle.viewTimelineInsets()))
             return;
 
-        CheckedRef styleOriginatedTimelinesController = element.protectedDocument()->ensureStyleOriginatedTimelinesController();
+        CheckedRef styleOriginatedTimelinesController = element->protectedDocument()->ensureStyleOriginatedTimelinesController();
 
         auto& currentTimelineNames = afterChangeStyle.viewTimelineNames();
         auto& currentTimelineAxes = afterChangeStyle.viewTimelineAxes();
@@ -951,16 +951,16 @@ void Styleable::queryContainerDidChange() const
 
 bool Styleable::capturedInViewTransition() const
 {
-    return !element.viewTransitionCapturedName(pseudoElementIdentifier).isNull();
+    return !element->viewTransitionCapturedName(pseudoElementIdentifier).isNull();
 }
 
 void Styleable::setCapturedInViewTransition(AtomString captureName)
 {
-    element.setViewTransitionCapturedName(pseudoElementIdentifier, captureName);
+    element->setViewTransitionCapturedName(pseudoElementIdentifier, captureName);
     if (CheckedPtr renderer = this->renderer()) {
         bool changed = renderer->setCapturedInViewTransition(!captureName.isNull());
         if (changed)
-            element.invalidateStyleAndLayerComposition();
+            element->invalidateStyleAndLayerComposition();
     }
 }
 

--- a/Source/WebCore/style/Styleable.h
+++ b/Source/WebCore/style/Styleable.h
@@ -33,7 +33,6 @@
 
 namespace WebCore {
 
-class Element;
 class KeyframeEffectStack;
 class RenderElement;
 class RenderStyle;
@@ -47,7 +46,7 @@ enum class IsInDisplayNoneTree : bool;
 }
 
 struct Styleable {
-    Element& element;
+    WeakRef<Element, WeakPtrImplWithEventTargetData> element;
     std::optional<Style::PseudoElementIdentifier> pseudoElementIdentifier;
 
     Styleable(Element& element, const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
@@ -62,11 +61,11 @@ struct Styleable {
 
     bool operator==(const Styleable& other) const
     {
-        return (&element == &other.element && pseudoElementIdentifier == other.pseudoElementIdentifier);
+        return (element.ptr() == other.element.ptr() && pseudoElementIdentifier == other.pseudoElementIdentifier);
     }
 
     RenderElement* renderer() const;
-    Ref<Element> protectedElement() const { return element; }
+    Ref<Element> protectedElement() const { return element.get(); }
 
     std::unique_ptr<RenderStyle> computeAnimatedStyle() const;
 
@@ -86,89 +85,89 @@ struct Styleable {
 
     KeyframeEffectStack* keyframeEffectStack() const
     {
-        return element.keyframeEffectStack(pseudoElementIdentifier);
+        return protectedElement()->keyframeEffectStack(pseudoElementIdentifier);
     }
 
     KeyframeEffectStack& ensureKeyframeEffectStack() const
     {
-        return element.ensureKeyframeEffectStack(pseudoElementIdentifier);
+        return protectedElement()->ensureKeyframeEffectStack(pseudoElementIdentifier);
     }
 
     bool hasKeyframeEffects() const
     {
-        return element.hasKeyframeEffects(pseudoElementIdentifier);
+        return protectedElement()->hasKeyframeEffects(pseudoElementIdentifier);
     }
 
     OptionSet<AnimationImpact> applyKeyframeEffects(RenderStyle& targetStyle, HashSet<AnimatableCSSProperty>& affectedProperties, const RenderStyle* previousLastStyleChangeEventStyle, const Style::ResolutionContext&) const;
 
     const AnimationCollection* animations() const
     {
-        return element.animations(pseudoElementIdentifier);
+        return protectedElement()->animations(pseudoElementIdentifier);
     }
 
     bool hasCompletedTransitionForProperty(const AnimatableCSSProperty& property) const
     {
-        return element.hasCompletedTransitionForProperty(pseudoElementIdentifier, property);
+        return protectedElement()->hasCompletedTransitionForProperty(pseudoElementIdentifier, property);
     }
 
     bool hasRunningTransitionForProperty(const AnimatableCSSProperty& property) const
     {
-        return element.hasRunningTransitionForProperty(pseudoElementIdentifier, property);
+        return protectedElement()->hasRunningTransitionForProperty(pseudoElementIdentifier, property);
     }
 
     bool hasRunningTransitions() const
     {
-        return element.hasRunningTransitions(pseudoElementIdentifier);
+        return protectedElement()->hasRunningTransitions(pseudoElementIdentifier);
     }
 
     AnimationCollection& ensureAnimations() const
     {
-        return element.ensureAnimations(pseudoElementIdentifier);
+        return protectedElement()->ensureAnimations(pseudoElementIdentifier);
     }
 
     AnimatableCSSPropertyToTransitionMap& ensureCompletedTransitionsByProperty() const
     {
-        return element.ensureCompletedTransitionsByProperty(pseudoElementIdentifier);
+        return protectedElement()->ensureCompletedTransitionsByProperty(pseudoElementIdentifier);
     }
 
     AnimatableCSSPropertyToTransitionMap& ensureRunningTransitionsByProperty() const
     {
-        return element.ensureRunningTransitionsByProperty(pseudoElementIdentifier);
+        return protectedElement()->ensureRunningTransitionsByProperty(pseudoElementIdentifier);
     }
 
     CSSAnimationCollection& animationsCreatedByMarkup() const
     {
-        return element.animationsCreatedByMarkup(pseudoElementIdentifier);
+        return protectedElement()->animationsCreatedByMarkup(pseudoElementIdentifier);
     }
 
     void setAnimationsCreatedByMarkup(CSSAnimationCollection&& collection) const
     {
-        element.setAnimationsCreatedByMarkup(pseudoElementIdentifier, WTF::move(collection));
+        protectedElement()->setAnimationsCreatedByMarkup(pseudoElementIdentifier, WTF::move(collection));
     }
 
     const RenderStyle* lastStyleChangeEventStyle() const
     {
-        return element.lastStyleChangeEventStyle(pseudoElementIdentifier);
+        return protectedElement()->lastStyleChangeEventStyle(pseudoElementIdentifier);
     }
 
     void setLastStyleChangeEventStyle(std::unique_ptr<const RenderStyle>&& style) const
     {
-        element.setLastStyleChangeEventStyle(pseudoElementIdentifier, WTF::move(style));
+        protectedElement()->setLastStyleChangeEventStyle(pseudoElementIdentifier, WTF::move(style));
     }
 
     bool hasPropertiesOverridenAfterAnimation() const
     {
-        return element.hasPropertiesOverridenAfterAnimation(pseudoElementIdentifier);
+        return protectedElement()->hasPropertiesOverridenAfterAnimation(pseudoElementIdentifier);
     }
 
     void setHasPropertiesOverridenAfterAnimation(bool value) const
     {
-        element.setHasPropertiesOverridenAfterAnimation(pseudoElementIdentifier, value);
+        protectedElement()->setHasPropertiesOverridenAfterAnimation(pseudoElementIdentifier, value);
     }
 
     void keyframesRuleDidChange() const
     {
-        element.keyframesRuleDidChange(pseudoElementIdentifier);
+        protectedElement()->keyframesRuleDidChange(pseudoElementIdentifier);
     }
 
     void queryContainerDidChange() const;
@@ -202,14 +201,14 @@ public:
 
     WeakStyleable& operator=(const Styleable& styleable)
     {
-        m_element = styleable.element;
+        m_element = styleable.element.ptr();
         m_pseudoElementIdentifier = styleable.pseudoElementIdentifier;
         return *this;
     }
 
     WeakStyleable(const Styleable& styleable)
     {
-        m_element = styleable.element;
+        m_element = styleable.element.ptr();
         m_pseudoElementIdentifier = styleable.pseudoElementIdentifier;
     }
 


### PR DESCRIPTION
#### 8384148582cf49a0133ee27136a0cb78e07d6493
<pre>
Reduce unsafeness in Styleable.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=305596">https://bugs.webkit.org/show_bug.cgi?id=305596</a>
<a href="https://rdar.apple.com/168251232">rdar://168251232</a>

Reviewed by NOBODY (OOPS!).

Apply Safer CPP rules.

* Source/WebCore/style/Styleable.h:
(WebCore::Styleable::keyframeEffectStack const):
(WebCore::Styleable::ensureKeyframeEffectStack const):
(WebCore::Styleable::hasKeyframeEffects const):
(WebCore::Styleable::animations const):
(WebCore::Styleable::hasCompletedTransitionForProperty const):
(WebCore::Styleable::hasRunningTransitionForProperty const):
(WebCore::Styleable::hasRunningTransitions const):
(WebCore::Styleable::ensureAnimations const):
(WebCore::Styleable::ensureCompletedTransitionsByProperty const):
(WebCore::Styleable::ensureRunningTransitionsByProperty const):
(WebCore::Styleable::animationsCreatedByMarkup const):
(WebCore::Styleable::setAnimationsCreatedByMarkup const):
(WebCore::Styleable::lastStyleChangeEventStyle const):
(WebCore::Styleable::setLastStyleChangeEventStyle const):
(WebCore::Styleable::hasPropertiesOverridenAfterAnimation const):
(WebCore::Styleable::setHasPropertiesOverridenAfterAnimation const):
(WebCore::Styleable::keyframesRuleDidChange const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8384148582cf49a0133ee27136a0cb78e07d6493

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139105 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11478 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/602 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147232 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92172 "Failed to checkout and rebase branch from PR 56667") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a3b55960-8f83-4f22-9f50-4281e9f684e7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140977 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12185 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11629 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106485 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/92172 "Failed to checkout and rebase branch from PR 56667") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142052 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9206 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124600 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87353 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7d3e0700-edc1-4656-b408-15fae084828e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8758 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6531 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7524 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118208 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/498 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150011 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11163 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/509 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114877 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11176 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9442 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115189 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9089 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120948 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66065 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11205 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/478 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10941 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74863 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11144 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10993 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->