### PR TITLE
[ New-Tests ][ iPhone ] 2X TestWebKitAPI.SmartLists (API-Tests) are constant failures (301651)

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartLists.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartLists.mm
@@ -353,22 +353,16 @@ TEST(SmartLists, InsertingSpaceAfterLargeNumberDoesNotGenerateOrderedList)
     runTest(input, expectedHTML.createNSString().get(), @"//body/text()", input.length);
 }
 
-// FIXME: rdar://163664100 ([ iOS26 iPhone ] 2X TestWebKitAPI.SmartLists (API-Tests) are constant failures (301651))
-#if PLATFORM(IOS)
-TEST(SmartLists, DISABLED_InsertingListMergesWithPreviousListIfPossible)
-#else
 TEST(SmartLists, InsertingListMergesWithPreviousListIfPossible)
-#endif
 {
     static constexpr auto expectedHTML = R"""(
-    <body>
-        <ol start="1" style="list-style-type: decimal;">
+    <body contenteditable="">
+        <ol start="1" style="list-style-type: decimal;" class="Apple-decimal-list">
             <li>A</li>
             <li>B</li>
             <li>C</li>
         </ol>
-    </body>
-    )"""_s;
+    </body>)"""_s;
 
     RetainPtr input = @""
     "1. A\n"
@@ -380,21 +374,15 @@ TEST(SmartLists, InsertingListMergesWithPreviousListIfPossible)
     runTest(input.get(), expectedHTML.createNSString().get(), @"//body/ol/li[3]/text()", 1);
 }
 
-// FIXME: rdar://163664100 ([ iOS26 iPhone ] 2X TestWebKitAPI.SmartLists (API-Tests) are constant failures (301651))
-#if PLATFORM(IOS)
-TEST(SmartLists, DISABLED_InsertingSpaceInsideListElementDoesNotActivateSmartLists)
-#else
 TEST(SmartLists, InsertingSpaceInsideListElementDoesNotActivateSmartLists)
-#endif
 {
     static constexpr auto expectedHTML = R"""(
-    <body>
-        <ul>
+    <body contenteditable="">
+        <ul style="list-style-type: disc;" class="Apple-disc-list">
             <li>A</li>
             <li>1. Hi</li>
         </ul>
-    </body>
-    )"""_s;
+    </body>)"""_s;
 
     runTest(@"* A\n1. Hi", expectedHTML.createNSString().get(), @"//body/ul/li[2]/text()", @"1. Hi".length);
 }


### PR DESCRIPTION
#### d546e59b99737ed218e241ce73f9883f898781ae
<pre>
[ New-Tests ][ iPhone ] 2X TestWebKitAPI.SmartLists (API-Tests) are constant failures (301651)
<a href="https://bugs.webkit.org/show_bug.cgi?id=301651">https://bugs.webkit.org/show_bug.cgi?id=301651</a>
<a href="https://rdar.apple.com/163664100">rdar://163664100</a>

Reviewed by Tim Horton and Richard Robinson.

These two SmartLists API tests failed on iOS due to the expected HTML
strings being incorrect. The original input resulted in a different
actual HTML but the test does not check for the expected vs actual HTML,
only render trees.

The expected HTML is used to create the SmartListsTestConfiguration, which
is used to obtain the test result. While the reason is still unknown, this incorrect
expected HTML resulted in differing render trees between iOS and macOS (potentially
due to contenteditable applying different styling between platforms). The macOS
version of the test passed previously because the macOS render tree unexpectedly
matched the incorrect expected render tree.

To fix this, correct the expected HTML strings.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartLists.mm:
((SmartLists, InsertingSpaceAfterLargeNumberDoesNotGenerateOrderedList)):
((SmartLists, InsertingListMergesWithPreviousListIfPossible)):
((SmartLists, InsertingSpaceInsideListElementDoesNotActivateSmartLists)):
((SmartLists, DISABLED_InsertingListMergesWithPreviousListIfPossible)(SmartLists, InsertingListMergesWithPreviousListIfPossible)): Deleted.
((SmartLists, DISABLED_InsertingSpaceInsideListElementDoesNotActivateSmartLists)(SmartLists, InsertingSpaceInsideListElementDoesNotActivateSmartLists)): Deleted.

Canonical link: <a href="https://commits.webkit.org/305898@main">https://commits.webkit.org/305898@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3fb437dc8c184e162a11cc579e66b3114dea2aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139733 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12110 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1238 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147871 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/644ad7b5-1e9b-4bd6-8a0c-22dd8e2eb1f4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141606 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12818 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/12261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/106996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/deee410d-0fb1-4a15-86db-3342140bdec8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142680 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/9864 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/125152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87867 "Found 1 new API test failure: WPE/TestWebKitWebXR:/webkit/WebKitWebXR/leave-immersive-mode (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/99b6d2ed-7252-4721-9a11-88bad315f5f5) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/9527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8160 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/118746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1149 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150653 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11794 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1205 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/115402 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11808 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/12261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115719 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10479 "Passed tests") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/121639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/66799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21554 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11838 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/1114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/11578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/11774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11625 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->