### PR TITLE
[visionOS] `role=slider` elements should get InteractionRegions

### DIFF
--- a/LayoutTests/interaction-region/aria-roles-expected.txt
+++ b/LayoutTests/interaction-region/aria-roles-expected.txt
@@ -5,6 +5,7 @@ Menu option 2
 Menu option 3
 This works like a switch.
 This behaves like a textbox
+Custom slider
 (GraphicsLayer
   (anchor 0.00 0.00)
   (bounds 800.00 600.00)
@@ -31,6 +32,8 @@ This behaves like a textbox
         (interaction (0,132) width=800 height=20)
         (cornerRadius 8.00),
         (interaction (0,152) width=800 height=20)
+        (cornerRadius 8.00),
+        (interaction (0,172) width=800 height=20)
         (cornerRadius 8.00)])
       )
     )

--- a/LayoutTests/interaction-region/aria-roles.html
+++ b/LayoutTests/interaction-region/aria-roles.html
@@ -13,6 +13,7 @@
 </ul>
 <div role="switch">This works like a switch.</div>
 <div role="textbox">This behaves like a textbox</div>
+<div role="slider">Custom slider</div>
 <pre id="results"></pre>
 <script>
 document.body.addEventListener("click", function(e) {

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -177,6 +177,7 @@ static bool shouldAllowAccessibilityRoleAsPointerCursorReplacement(const Element
     case AccessibilityRole::MenuItemRadio:
     case AccessibilityRole::PopUpButton:
     case AccessibilityRole::RadioButton:
+    case AccessibilityRole::Slider:
     case AccessibilityRole::Switch:
     case AccessibilityRole::TextField:
     case AccessibilityRole::ToggleButton:


### PR DESCRIPTION
#### 284b38a3467de31915b2c365aebb8b9a40205bb8
<pre>
[visionOS] `role=slider` elements should get InteractionRegions
<a href="https://bugs.webkit.org/show_bug.cgi?id=305606">https://bugs.webkit.org/show_bug.cgi?id=305606</a>
&lt;<a href="https://rdar.apple.com/162690888">rdar://162690888</a>&gt;

Reviewed by Tim Horton.

We already maintain a list of ARIA roles that get InteractionRegions
regardless of the cursor check. Add `slider` to this list.

Tests: interaction-region/aria-roles.html

* LayoutTests/interaction-region/aria-roles-expected.txt:
* LayoutTests/interaction-region/aria-roles.html:
Update the test.

* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::shouldAllowAccessibilityRoleAsPointerCursorReplacement):
Add the extra role to the list in the existing function.

Canonical link: <a href="https://commits.webkit.org/305724@main">https://commits.webkit.org/305724@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6dfde707243b6ba9ee6e00100703ab216871842c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139122 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11495 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/619 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147249 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140994 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12202 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11646 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106498 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9a3eb9c6-66fc-4543-9d85-3a656073e444) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142069 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9222 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124613 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87365 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c276d02b-d2b3-418e-b159-bd606f4210ce) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8770 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6541 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7541 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118222 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/513 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150028 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11180 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/523 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114889 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11193 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9454 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115201 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29296 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9112 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120962 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66082 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11222 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/490 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10958 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74880 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11161 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11010 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->