### PR TITLE
[Cocoa] YouTube will continue to play after locking screen or after a system interruption

### DIFF
--- a/LayoutTests/media/media-session/interruption-sends-pause-action-expected.txt
+++ b/LayoutTests/media/media-session/interruption-sends-pause-action-expected.txt
@@ -1,0 +1,8 @@
+RUN(navigator.mediaSession.setPositionState({position: 0, duration: 100, plyabackRate: 1}))
+RUN(navigator.mediaSession.playbackState = "playing")
+RUN(internals.beginMediaSessionInterruption("system"))
+Promise resolved OK
+RUN(internals.endMediaSessionInterruption("mayresumeplaying"))
+Promise resolved OK
+END OF TEST
+

--- a/LayoutTests/media/media-session/interruption-sends-pause-action.html
+++ b/LayoutTests/media/media-session/interruption-sends-pause-action.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>interruption-sends-pause-action</title>
+    <script src="../video-test.js"></script>
+    <script>
+    window.addEventListener('load', event => {
+        runTest().then(endTest).catch(failTest);
+    })
+
+    var pauseActionPromise;
+    var playActionPromise;
+
+    async function runTest() {
+
+        pauseActionPromise = new Promise(resolve => {
+            navigator.mediaSession.setActionHandler('pause',  action => {
+                resolve()
+            });
+        });
+
+        playActionPromise = new Promise(resolve => {
+            navigator.mediaSession.setActionHandler('play', action => {
+                resolve()
+            });
+        });
+
+        run('navigator.mediaSession.setPositionState({position: 0, duration: 100, plyabackRate: 1})');
+        run('navigator.mediaSession.playbackState = "playing"');
+        run('internals.beginMediaSessionInterruption("system")');
+        await shouldResolve(pauseActionPromise);
+
+        run('internals.endMediaSessionInterruption("mayresumeplaying")');
+        await shouldResolve(playActionPromise);
+    }
+    </script>
+</head>

--- a/Source/WebCore/Modules/mediasession/MediaMetadata.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaMetadata.cpp
@@ -260,9 +260,10 @@ void MediaMetadata::refreshArtworkImage()
 
 void MediaMetadata::tryNextArtworkImage(uint32_t index, Vector<Pair>&& artworks)
 {
-    if (!m_session)
+    RefPtr session = m_session.get();
+    if (!session)
         return;
-    RefPtr document = m_session->document();
+    RefPtr document = session->document();
     if (!document)
         return;
 
@@ -306,8 +307,8 @@ void MediaMetadata::setTrackIdentifier(const String& identifier)
 
 void MediaMetadata::metadataUpdated()
 {
-    if (m_session)
-        m_session->metadataUpdated(*this);
+    if (RefPtr session = m_session.get())
+        session->metadataUpdated(*this);
 }
 
 }

--- a/Source/WebCore/bindings/js/JSMediaSessionCustom.cpp
+++ b/Source/WebCore/bindings/js/JSMediaSessionCustom.cpp
@@ -36,7 +36,7 @@ namespace WebCore {
 template <typename Visitor>
 void JSMediaSession::visitAdditionalChildren(Visitor& visitor)
 {
-    wrapped().visitActionHandlers(visitor);
+    SUPPRESS_UNCOUNTED_ARG wrapped().visitActionHandlers(visitor);
 }
 
 DEFINE_VISIT_ADDITIONAL_CHILDREN(JSMediaSession);

--- a/Source/WebCore/platform/LogMessages.in
+++ b/Source/WebCore/platform/LogMessages.in
@@ -86,7 +86,7 @@ DOCUMENTLOADER_STOPLOADING, "[pageID=%" PRIu64 ", frameID=%" PRIu64 ", isMainFra
 
 MEDIASESSIONMANAGERCOCOA_SESSIONCANPRODUCEAUDIOCHANGED, "MediaSessionManagerCocoa::sessionCanProduceAudioChanged", (), DEFAULT, Media
 MEDIASESSIONMANAGERCOCOA_CLIENTCHARACTERISTICSCHANGED, "MediaSessionManagerCocoa::clientCharacteristicsChanged, session ID = %" PRIu64, (uint64_t), DEFAULT, Media
-MEDIASESSIONMANAGERCOCOA_UPDATESESSIONSTATE, "MediaSessionManagerCocoa::updateSessionState: AudioCapture(%d), AudioTrack(%d), Video(%d), Audio(%d), VideoAudio(%d), WebAudio(%d)", (int, int, int, int, int, int), DEFAULT, Media
+MEDIASESSIONMANAGERCOCOA_UPDATESESSIONSTATE, "MediaSessionManagerCocoa::updateSessionState: AudioCapture(%d), AudioTrack(%d), Video(%d), Audio(%d), VideoAudio(%d), WebAudio(%d), DOMMediaSession(%d)", (int, int, int, int, int, int, int), DEFAULT, Media
 
 MEDIASESSIONMANAGERINTERFACE_REMOVESESSION, "MediaSessionManagerInterface::removeSession, session ID = %" PRIu64 "", (uint64_t), DEFAULT, Media
 MEDIASESSIONMANAGERINTERFACE_SESSIONWILLENDPLAYBACK, "MediaSessionManagerInterface::sessionWillEndPlayback, session ID = %" PRIu64 "", (uint64_t), DEFAULT, Media

--- a/Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp
+++ b/Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp
@@ -130,6 +130,7 @@ void MediaSessionManagerInterface::resetRestrictions()
     m_restrictions[indexFromMediaType(PlatformMediaSession::MediaType::Audio)] = MediaSessionRestriction::NoRestrictions;
     m_restrictions[indexFromMediaType(PlatformMediaSession::MediaType::VideoAudio)] = MediaSessionRestriction::NoRestrictions;
     m_restrictions[indexFromMediaType(PlatformMediaSession::MediaType::WebAudio)] = MediaSessionRestriction::NoRestrictions;
+    m_restrictions[indexFromMediaType(PlatformMediaSession::MediaType::DOMMediaSession)] = MediaSessionRestriction::NoRestrictions;
 }
 
 bool MediaSessionManagerInterface::has(PlatformMediaSession::MediaType type) const

--- a/Source/WebCore/platform/audio/MediaSessionManagerInterface.h
+++ b/Source/WebCore/platform/audio/MediaSessionManagerInterface.h
@@ -205,7 +205,7 @@ protected:
 private:
     bool has(PlatformMediaSessionMediaType) const;
 
-    std::array<MediaSessionRestrictions, static_cast<unsigned>(PlatformMediaSessionMediaType::WebAudio) + 1> m_restrictions;
+    std::array<MediaSessionRestrictions, static_cast<unsigned>(PlatformMediaSessionMediaType::DOMMediaSession) + 1> m_restrictions;
 
     std::optional<bool> m_supportsSpatialAudioPlayback;
     std::optional<PlatformMediaSessionInterruptionType> m_currentInterruption;

--- a/Source/WebCore/platform/audio/PlatformMediaSession.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSession.cpp
@@ -87,18 +87,20 @@ String convertEnumerationToString(PlatformMediaSession::InterruptionType type)
 
 String convertEnumerationToString(PlatformMediaSession::MediaType mediaType)
 {
-    static const std::array<NeverDestroyed<String>, 5> values {
+    static const std::array<NeverDestroyed<String>, 6> values {
         MAKE_STATIC_STRING_IMPL("None"),
         MAKE_STATIC_STRING_IMPL("Video"),
         MAKE_STATIC_STRING_IMPL("VideoAudio"),
         MAKE_STATIC_STRING_IMPL("Audio"),
         MAKE_STATIC_STRING_IMPL("WebAudio"),
+        MAKE_STATIC_STRING_IMPL("DOMMediaSession"),
     };
     static_assert(!static_cast<size_t>(PlatformMediaSession::MediaType::None), "PlatformMediaSession::MediaType::None is not 0 as expected");
     static_assert(static_cast<size_t>(PlatformMediaSession::MediaType::Video) == 1, "PlatformMediaSession::MediaType::Video is not 1 as expected");
     static_assert(static_cast<size_t>(PlatformMediaSession::MediaType::VideoAudio) == 2, "PlatformMediaSession::MediaType::VideoAudio is not 2 as expected");
     static_assert(static_cast<size_t>(PlatformMediaSession::MediaType::Audio) == 3, "PlatformMediaSession::MediaType::Audio is not 3 as expected");
     static_assert(static_cast<size_t>(PlatformMediaSession::MediaType::WebAudio) == 4, "PlatformMediaSession::MediaType::WebAudio is not 4 as expected");
+    static_assert(static_cast<size_t>(PlatformMediaSession::MediaType::DOMMediaSession) == 5, "PlatformMediaSession::MediaType::DOMMediaSession is not 4 as expected");
 
     ASSERT(static_cast<size_t>(mediaType) < std::size(values));
     return values[static_cast<size_t>(mediaType)];

--- a/Source/WebCore/platform/audio/PlatformMediaSessionTypes.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionTypes.h
@@ -39,6 +39,7 @@ enum class PlatformMediaSessionMediaType : uint8_t {
     VideoAudio,
     Audio,
     WebAudio,
+    DOMMediaSession,
 };
 
 enum class PlatformMediaSessionState : uint8_t {

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
@@ -104,6 +104,7 @@ void MediaSessionManagerCocoa::updateSessionState()
     int audioCount = 0;
     int webAudioCount = 0;
     int audioMediaStreamTrackCount = 0;
+    int domMediaSessionCount = 0;
     int captureCount = countActiveAudioCaptureSources();
 
     bool hasAudibleAudioOrVideoMediaType = false;
@@ -113,6 +114,9 @@ void MediaSessionManagerCocoa::updateSessionState()
         auto type = session.mediaType();
         switch (type) {
         case PlatformMediaSession::MediaType::None:
+            break;
+        case PlatformMediaSession::MediaType::DOMMediaSession:
+            ++domMediaSessionCount;
             break;
         case PlatformMediaSession::MediaType::Video:
             ++videoCount;
@@ -148,7 +152,7 @@ void MediaSessionManagerCocoa::updateSessionState()
         }
     });
 
-    MEDIASESSIONMANAGER_RELEASE_LOG(UPDATESESSIONSTATE, captureCount, audioMediaStreamTrackCount, videoCount, audioCount, videoAudioCount, webAudioCount);
+    MEDIASESSIONMANAGER_RELEASE_LOG(UPDATESESSIONSTATE, captureCount, audioMediaStreamTrackCount, videoCount, audioCount, videoAudioCount, webAudioCount, domMediaSessionCount);
 
     Ref sharedSession = AudioSession::singleton();
     if (!m_defaultBufferSize)


### PR DESCRIPTION
#### e6e420dcded4f5246920464c9e469ce74d460982
<pre>
[Cocoa] YouTube will continue to play after locking screen or after a system interruption
<a href="https://rdar.apple.com/166265637">rdar://166265637</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=305592">https://bugs.webkit.org/show_bug.cgi?id=305592</a>

Reviewed by Eric Carlson.

When an interruption occurs, either from the system or from a WebKit policy,
WebKit will pause a playing &lt;video&gt; or &lt;audio&gt; element. However, web apps just
see that their video or audio paused, and can try to re-start it. Rather than
just pausing upon interruption, indicate to web apps that use MediaSession that
they should move to a &quot;paused&quot; state by calling the action handler for &quot;pause&quot;.
Web apps should react as if the user hit the pause key on their keyboard or
used the button on their headphones to pause.

Test: media/media-session/interruption-sends-pause-action.html

* LayoutTests/media/media-session/interruption-sends-pause-action-expected.txt: Added.
* LayoutTests/media/media-session/interruption-sends-pause-action.html: Added.
* Source/WebCore/Modules/mediasession/MediaSession.cpp:
(WebCore::MediaSession::MediaSession):
(WebCore::MediaSession::setPlaybackState):
(WebCore::MediaSession::mayResumePlayback):
(WebCore::MediaSession::suspendPlayback):
(WebCore::MediaSession::isPlaying const):
(WebCore::MediaSession::isEnded const):
(WebCore::MediaSession::mediaSessionDuration const):
(WebCore::MediaSession::mediaSessionGroupIdentifier const):
* Source/WebCore/Modules/mediasession/MediaSession.h:
* Source/WebCore/platform/LogMessages.in:
* Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp:
(WebCore::MediaSessionManagerInterface::resetRestrictions):
* Source/WebCore/platform/audio/MediaSessionManagerInterface.h:
* Source/WebCore/platform/audio/PlatformMediaSession.cpp:
(WebCore::convertEnumerationToString):
* Source/WebCore/platform/audio/PlatformMediaSessionTypes.h:
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::MediaSessionManagerCocoa::updateSessionState):

Canonical link: <a href="https://commits.webkit.org/305995@main">https://commits.webkit.org/305995@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a328d35bf9952f042cee4ed8358a85bc37bdc40

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139911 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12292 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1422 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148054 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92981 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141784 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13002 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12444 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107133 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77975 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142861 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10027 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125299 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88013 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9679 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7186 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8343 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118900 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1301 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150839 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11977 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1367 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115548 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11990 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10265 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115863 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29461 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10660 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121779 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66982 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12019 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1253 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11759 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75706 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11955 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11807 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->