### PR TITLE
Web Audio WaveShaperNode: NaN input produces out-of-bounds read in processCurve()

### DIFF
--- a/LayoutTests/webaudio/WaveShaper/waveshaper-nan-infinity-handling-expected.txt
+++ b/LayoutTests/webaudio/WaveShaper/waveshaper-nan-infinity-handling-expected.txt
@@ -1,0 +1,28 @@
+Tests WaveShaperDSPKernel::processCurveWithData handling of NaN, Infinity, and normal input values.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS isNaN(output[0]) is false
+PASS isFinite(output[0]) is true
+PASS isNaN(output[1]) is false
+PASS isFinite(output[1]) is true
+PASS isNaN(output[2]) is false
+PASS isFinite(output[2]) is true
+PASS isNaN(output[3]) is false
+PASS isFinite(output[3]) is true
+PASS 0 is approximately 0
+PASS 0 is approximately 0
+PASS 0 is approximately 0
+PASS 0.5 is approximately 0.5
+PASS 1 is approximately 1
+PASS 0.5 is approximately 0.5
+PASS isFinite(output[1]) is true
+PASS 0.75 is approximately 0.75
+PASS isFinite(output[3]) is true
+PASS 0 is approximately 0
+PASS 0.5 is approximately 0.5
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/webaudio/WaveShaper/waveshaper-nan-infinity-handling.html
+++ b/LayoutTests/webaudio/WaveShaper/waveshaper-nan-infinity-handling.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<script>
+description("Tests WaveShaperDSPKernel::processCurveWithData handling of NaN, Infinity, and normal input values.");
+
+const curveSize = 256;
+const curve = Array.from({length: curveSize}, (_, i) => i / (curveSize - 1));
+
+function shouldBeCloseTo(actual, expected, tolerance) {
+    if (Math.abs(actual - expected) <= tolerance)
+        testPassed(actual + " is approximately " + expected);
+    else
+        testFailed(actual + " should be approximately " + expected);
+}
+
+// NaN Input
+output = internals.waveShaperProcessCurveWithData([NaN, NaN, NaN, NaN], curve);
+for (let i = 0; i < 4; i++) {
+    shouldBeFalse("isNaN(output[" + i + "])");
+    shouldBeTrue("isFinite(output[" + i + "])");
+}
+
+// Infinity Input
+output = internals.waveShaperProcessCurveWithData([Infinity], curve);
+shouldBeCloseTo(output[0], 0.0, 0.001);
+
+output = internals.waveShaperProcessCurveWithData([-Infinity], curve);
+shouldBeCloseTo(output[0], 0.0, 0.001);
+
+// Normal Input Range
+output = internals.waveShaperProcessCurveWithData([-1.0, 0.0, 1.0], curve);
+shouldBeCloseTo(output[0], curve[0], 0.001);
+shouldBeCloseTo(output[1], 0.5, 0.01);
+shouldBeCloseTo(output[2], curve[curveSize - 1], 0.001);
+
+// Mixed NaN and Valid Input
+output = internals.waveShaperProcessCurveWithData([0.0, NaN, 0.5, NaN], curve);
+shouldBeCloseTo(output[0], 0.5, 0.01);
+shouldBeTrue("isFinite(output[1])");
+shouldBeCloseTo(output[2], 0.75, 0.02);
+shouldBeTrue("isFinite(output[3])");
+
+// Empty Curve (passthrough)
+output = internals.waveShaperProcessCurveWithData([0.0, 0.5], []);
+shouldBeCloseTo(output[0], 0.0, 0.001);
+shouldBeCloseTo(output[1], 0.5, 0.001);
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/webaudio/WaveShaperDSPKernel.h
+++ b/Source/WebCore/Modules/webaudio/WaveShaperDSPKernel.h
@@ -50,12 +50,13 @@ public:
     // Oversampling requires more resources, so let's only allocate them if needed.
     void lazyInitializeOversampling();
 
+    // Apply the shaping curve.
+    WEBCORE_EXPORT static void processCurveWithData(std::span<const float> source, std::span<float> destination, std::span<const float> curveData);
+
 private:
     bool isWaveShaperDSPKernel() const final { return true; }
 
-    // Apply the shaping curve.
     void processCurve(std::span<const float> source, std::span<float> destination);
-
     // Use up-sampling, process at the higher sample-rate, then down-sample.
     void processCurve2x(std::span<const float> source, std::span<float> destination);
     void processCurve4x(std::span<const float> source, std::span<float> destination);

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -357,6 +357,7 @@
 
 #if ENABLE(WEB_AUDIO)
 #include "AudioContext.h"
+#include "WaveShaperDSPKernel.h"
 #endif
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
@@ -5394,6 +5395,13 @@ void Internals::setAudioContextRestrictions(AudioContext& context, StringView re
             restrictions.add(AudioContext::BehaviorRestrictionFlags::RequirePageConsentForAudioStartRestriction);
     }
     context.addBehaviorRestriction(restrictions);
+}
+
+Vector<float> Internals::waveShaperProcessCurveWithData(Vector<float> source, Vector<float> curve)
+{
+    Vector<float> destination(source.size(), 0.0f);
+    WaveShaperDSPKernel::processCurveWithData(std::span { source }, std::span { destination }, std::span { curve });
+    return destination;
 }
 
 void Internals::useMockAudioDestinationCocoa()

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -619,6 +619,9 @@ public:
     // BaseAudioContext lifetime testing.
     static uint64_t baseAudioContextIdentifier(const BaseAudioContext&);
     static bool isBaseAudioContextAlive(uint64_t contextID);
+
+    Vector<float> waveShaperProcessCurveWithData(Vector<float> source, Vector<float> curve);
+
 #endif
 
     unsigned numberOfIntersectionObservers(const Document&) const;

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -894,6 +894,8 @@ enum ContentsFormat {
     [Conditional=WEB_AUDIO] unsigned long long baseAudioContextIdentifier(BaseAudioContext context);
     [Conditional=WEB_AUDIO] boolean isBaseAudioContextAlive(unsigned long long contextID);
 
+    [Conditional=WEB_AUDIO] sequence<unrestricted float> waveShaperProcessCurveWithData(sequence<unrestricted float> source, sequence<unrestricted float> curve);
+
     DOMString counterValue(Element element);
     long pageNumber(Element element, optional unrestricted float pageWidth = 800, optional unrestricted float pageHeight = 600);
     sequence<DOMString> shortcutIconURLs();


### PR DESCRIPTION
#### c0bd74757c6e571109d7d4bbb89de17e56bc5705
<pre>
Web Audio WaveShaperNode: NaN input produces out-of-bounds read in processCurve()
<a href="https://bugs.webkit.org/show_bug.cgi?id=305612">https://bugs.webkit.org/show_bug.cgi?id=305612</a>
<a href="https://rdar.apple.com/164364161">rdar://164364161</a>

Reviewed by Youenn Fablet.

NaN input samples bypass range checks since NaN comparisons always return false, causing
std::floor(NaN) to produce NaN which converts to a garbage unsigned index, resulting in an
out-of-bounds read.

Fix by guarding non-finite inputs and outputting silence (0.0f). Also clamp valid inputs to [-1, 1]
for additional safety.

The static helper processCurveWithData is introduced to allow unit testing the algorithm in
isolation without needing to instantiate a WaveShaperProcessor.

* LayoutTests/webaudio/WaveShaper/waveshaper-nan-infinity-handling-expected.txt: Added.
* LayoutTests/webaudio/WaveShaper/waveshaper-nan-infinity-handling.html: Added.
* Source/WebCore/Modules/webaudio/WaveShaperDSPKernel.cpp:
(WebCore::WaveShaperDSPKernel::processCurve):
(WebCore::WaveShaperDSPKernel::processCurveWithData):
* Source/WebCore/Modules/webaudio/WaveShaperDSPKernel.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::waveShaperProcessCurveWithData):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Canonical link: <a href="https://commits.webkit.org/305955@main">https://commits.webkit.org/305955@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f55fca0678d100c57ef1042fd40af2ebdd532ca3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139139 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11512 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/636 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147266 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92206 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/50b8acbd-3a81-4367-9357-012908d43d2d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141011 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12219 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11663 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106514 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77586 "layout-tests (failure)") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8bfa6687-2265-43e8-b317-66c442f78f8e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142086 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9233 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124631 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87381 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/90e676a6-98ac-4992-b24f-d59508b4ba87) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8781 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6556 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7558 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118233 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/533 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150045 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11197 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/543 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114902 "Found 1 new test failure: scrollbars/corner-resizer-window-inactive.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11210 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9471 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115215 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29440 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9124 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120981 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/66099 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11239 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/508 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10975 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74897 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11178 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11027 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->