### PR TITLE
[GLIB][Results DB] Define a more relevant configuration version value for WPE and GTK

### DIFF
--- a/Tools/Scripts/webkitpy/port/gtk_unittest.py
+++ b/Tools/Scripts/webkitpy/port/gtk_unittest.py
@@ -90,12 +90,17 @@ class GtkPortTest(port_testcase.PortTestCase):
 
     def test_default_upload_configuration(self):
         port = self.make_port()
+        port.host.filesystem.write_text_file(
+            '/mock-checkout/Source/cmake/OptionsGTK.cmake',
+            'SET_PROJECT_VERSION(2 51 4)\n'
+        )
         configuration = port.configuration_for_upload()
         self.assertEqual(configuration['architecture'], port.architecture())
         self.assertEqual(configuration['is_simulator'], False)
         self.assertEqual(configuration['platform'], 'GTK')
         self.assertEqual(configuration['style'], 'release')
         self.assertEqual(configuration['version_name'], 'Xvfb')
+        self.assertEqual(configuration['version'], '2.51')
 
     def test_gtk4_expectations_binary_only(self):
         port = self.make_port()

--- a/Tools/Scripts/webkitpy/port/wpe_unittest.py
+++ b/Tools/Scripts/webkitpy/port/wpe_unittest.py
@@ -85,11 +85,16 @@ class WPEPortTest(port_testcase.PortTestCase):
 
     def test_default_upload_configuration(self):
         port = self.make_port()
+        port.host.filesystem.write_text_file(
+            '/mock-checkout/Source/cmake/OptionsWPE.cmake',
+            'SET_PROJECT_VERSION(2 51 4)\n'
+        )
         configuration = port.configuration_for_upload()
         self.assertEqual(configuration['architecture'], port.architecture())
         self.assertEqual(configuration['is_simulator'], False)
         self.assertEqual(configuration['platform'], 'WPE')
         self.assertEqual(configuration['style'], 'release')
+        self.assertEqual(configuration['version'], '2.51')
 
     def test_browser_name_default_wihout_cog_built(self):
         port = self.make_port()


### PR DESCRIPTION
#### fb06b74340997b336b94f9ca8a88a42a0e66b11e
<pre>
[GLIB][Results DB] Define a more relevant configuration version value for WPE and GTK
<a href="https://bugs.webkit.org/show_bug.cgi?id=304547">https://bugs.webkit.org/show_bug.cgi?id=304547</a>

Reviewed by Carlos Alberto Lopez Perez.

Currently, webkitpy defaults to the operating system version for the
Upload configuration dict. While this works fine for Mac OS/iOS with its
named versions, in Linux ports this means that individual kernel
versions were used. So, a minor kernel update means a new configuration
series in the results database, making it harder to follow a test
series, as they are usually not that impactful for our tests.

This commit changes WebKitGTK and WPEWebKit to expose its public API
version MAJOR.MINOR numbers instead to the results database. This
gives us a much more stable series, with updates only every 6 months.

* Tools/Scripts/webkitpy/port/glib.py:
(GLibPort.environment_for_api_tests):
(GLibPort):
(GLibPort._webkit_version):
(GLibPort.configuration_for_upload):
* Tools/Scripts/webkitpy/port/gtk_unittest.py:
(GtkPortTest.test_default_upload_configuration):
* Tools/Scripts/webkitpy/port/wpe_unittest.py:
(WPEPortTest.test_default_upload_configuration):

Canonical link: <a href="https://commits.webkit.org/305707@main">https://commits.webkit.org/305707@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3031cb1404ed1988aca9f139b160d09d3716dcc6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139146 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11519 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/643 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147273 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141018 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12226 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11670 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106518 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142093 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9239 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124628 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87385 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/138491 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8785 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6559 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7565 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118237 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/530 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150052 "Built successfully") | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11204 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/540 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114906 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11217 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9475 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115219 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29287 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9134 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120978 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66106 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11246 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/505 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10982 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11185 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11034 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->