### PR TITLE
REGRESSION (iOS 26): Unable to dismiss software keyboard using Done button after presenting AutoFill credentials picker

### DIFF
--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
@@ -158,7 +158,7 @@ enum class TapHandlingResult : uint8_t;
 
 - (void)_incrementFocusPreservationCount;
 - (void)_decrementFocusPreservationCount;
-- (NSUInteger)_resetFocusPreservationCount;
+- (void)_resetFocusPreservationCountAndReleaseActiveFocusState;
 
 - (void)_setOpaqueInternal:(BOOL)opaque;
 - (NSString *)_contentSizeCategory;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -6228,9 +6228,7 @@ static void logTextInteraction(const char* methodName, UIGestureRecognizer *loup
 
 - (void)accessoryViewDone:(WKFormAccessoryView *)view
 {
-    if ([_webView _resetFocusPreservationCount])
-        RELEASE_LOG_ERROR(ViewState, "Keyboard dismissed with nonzero focus preservation count; check for unbalanced calls to -_incrementFocusPreservationCount");
-
+    [_webView _resetFocusPreservationCountAndReleaseActiveFocusState];
     [self stopRelinquishingFirstResponderToFocusedElement];
     [self endEditingAndUpdateFocusAppearanceWithReason:EndEditingReasonAccessoryDone];
     _page->setIsShowingInputViewForFocusedElement(false);
@@ -8447,7 +8445,7 @@ static RetainPtr<NSObject <WKFormPeripheral>> createInputPeripheralWithView(WebK
         return;
     }
 
-    [_webView _resetFocusPreservationCount];
+    [_webView _resetFocusPreservationCountAndReleaseActiveFocusState];
 
     _focusRequiresStrongPasswordAssistance = NO;
     _additionalContextForStrongPasswordAssistance = nil;
@@ -8620,7 +8618,7 @@ static RetainPtr<NSObject <WKFormPeripheral>> createInputPeripheralWithView(WebK
 {
     SetForScope isBlurringFocusedElementForScope { _isBlurringFocusedElement, YES };
 
-    [_webView _resetFocusPreservationCount];
+    [_webView _resetFocusPreservationCountAndReleaseActiveFocusState];
 
     [self _endEditing];
 

--- a/Tools/TestWebKitAPI/Tests/ios/FocusPreservationTests.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/FocusPreservationTests.mm
@@ -89,6 +89,7 @@ TEST(FocusPreservationTests, UserCanDismissInputViewRegardlessOfFocusPreservatio
     Util::run(&inputFocused);
 
     [[webView textInputContentView] _preserveFocusWithToken:NSUUID.UUID destructively:YES];
+    [webView _retainActiveFocusedState];
     // Simulates a user tapping on the Done button above the keyboard.
     [webView dismissFormAccessoryView];
     [webView waitForNextPresentationUpdate];


### PR DESCRIPTION
#### 594434191685038c40d35424ca1d8a78ecbbcab9
<pre>
REGRESSION (iOS 26): Unable to dismiss software keyboard using Done button after presenting AutoFill credentials picker
<a href="https://bugs.webkit.org/show_bug.cgi?id=305617">https://bugs.webkit.org/show_bug.cgi?id=305617</a>
<a href="https://rdar.apple.com/162423793">rdar://162423793</a>

Reviewed by Abrar Rahman Protyasha.

After the changes in <a href="https://rdar.apple.com/140125213">rdar://140125213</a>, Safari AutoFill now invokes `-_retainActiveFocusedState` with
no corresponding logic to release the state by calling the block, when the user presents the
credentials picker (i.e. tapping the key icon). This causes active focused state to leak
indefinitely, preventing the user from ever dismissing the keyboard in that web view.

This patches hardens WebKit against this type of API (mis)use, by forcibly resetting the active
focus state count (and logging an error on behalf of the client) in the case where the keyboard is
being dismissed by the user with a nonzero focus state count.

Test: FocusPreservationTests.UserCanDismissInputViewRegardlessOfFocusPreservationCount

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _resetFocusPreservationCountAndReleaseActiveFocusState]):

Rename this method, now that it clears out both focus preservation and active focus state counts.

(-[WKWebView _retainActiveFocusedState]):

Make the callback robust in the case where `_activeFocusedStateRetainCount` is already 0, which can
occur in this case where the client leaks active focused state retainment and the user tries to
manually dismiss the keyboard.

(-[WKWebView _resetFocusPreservationCount]): Deleted.
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView accessoryViewDone:]):
(-[WKContentView _elementDidFocus:userIsInteracting:blurPreviousNode:activityStateChanges:userObject:]):
(-[WKContentView _elementDidBlur]):
* Tools/TestWebKitAPI/Tests/ios/FocusPreservationTests.mm:
(TestWebKitAPI::TEST(FocusPreservationTests, UserCanDismissInputViewRegardlessOfFocusPreservationCount)):

Tweak an existing test to additionally make sure that leaking `-_retainActiveFocusedState` won&apos;t
cause the software keyboard to become un-dismissable by the user.

Canonical link: <a href="https://commits.webkit.org/305694@main">https://commits.webkit.org/305694@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/876b087c12be49f8c7b40ca7e8267509b87ccac2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139153 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11526 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/650 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147280 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7fb551af-847b-42d2-8ea1-bf2be8c1adf9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141025 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12233 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11677 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106524 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d4031311-d103-4965-9fdc-fa36a1574e4f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142100 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9246 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124638 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87391 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eea45cbe-71a7-454d-91ce-5ee64055fb7c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8792 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6566 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7572 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118245 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/540 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150059 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11211 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/550 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114912 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11224 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9482 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115225 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29279 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9156 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120988 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66113 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11254 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/515 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10989 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74911 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11192 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11041 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->