### PR TITLE
[Swift in WebKit] Fix the WebKit internal module

### DIFF
--- a/Source/WebCore/WebCore_Private.modulemap
+++ b/Source/WebCore/WebCore_Private.modulemap
@@ -4,12 +4,12 @@ framework module WebCore_Private [system] {
         export *
     }
 
-    explicit module Core {
+    module Core {
         umbrella "PrivateHeaders"
 
         requires cplusplus
 
-        explicit module * {
+        module * {
             export *
         }
     }

--- a/Source/WebKit/Modules/Internal/WebKitInternal.h
+++ b/Source/WebKit/Modules/Internal/WebKitInternal.h
@@ -25,15 +25,17 @@
 
 // Add project-level Objective-C header files here to be able to access them from within Swift sources.
 
-#import <wtf/Platform.h>
-
-#import "UIWindowScene+Extras.h"
-#import "WKMaterialHostingSupport.h"
-#import "WKMouseDeviceObserver.h"
-#import "WKPreferencesInternal.h"
-#import "WKScrollGeometry.h"
-#import "WKSeparatedImageView.h"
-#import "WKUIDelegateInternal.h"
-#import "WKWebViewConfigurationInternal.h"
-#import "WKWebViewInternal.h"
-#import "_WKTextExtractionInternal.h"
+//#import <wtf/Platform.h>
+//
+//#import "UIWindowScene+Extras.h"
+//#import "WKMaterialHostingSupport.h"
+//#import "WKMouseDeviceObserver.h"
+//#import "WKPreferencesInternal.h"
+//#import "WKScrollGeometry.h"
+//#import "WKSeparatedImageView.h"
+//#import "WKUIDelegateInternal.h"
+//#import "WKWebViewConfigurationInternal.h"
+//#import "WKWebViewInternal.h"
+//#import "_WKTextExtractionInternal.h"
+//#import "IPCTesterReceiverMessages.h"
+//#import "UIProcess/SwiftDemoLogoConfirmation.h"

--- a/Source/WebKit/Modules/Internal/WebKitInternalCxx.h
+++ b/Source/WebKit/Modules/Internal/WebKitInternalCxx.h
@@ -25,5 +25,5 @@
 
 // Add project-level C++ header files here to be able to access them from within Swift sources.
 
-#import "IPCTesterReceiverMessages.h"
-#import "UIProcess/SwiftDemoLogoConfirmation.h"
+//#import "IPCTesterReceiverMessages.h"
+//#import "UIProcess/SwiftDemoLogoConfirmation.h"

--- a/Source/WebKit/Modules/Internal/module.modulemap
+++ b/Source/WebKit/Modules/Internal/module.modulemap
@@ -1,13 +1,83 @@
-// FIXME: this modulemap needs work as discussed in https://github.com/WebKit/WebKit/pull/54322
-module WebKit_Internal {
-    module WebKit_Internal_Objc {
-        header "WebKitInternal.h"
+module WebKit_Internal [system] {
+     module UIWindowSceneExtras {
+        header "../../UIProcess/Cocoa/UIWindowScene+Extras.h"
         export *
-        requires objc
     }
-    module WebKit_Internal_Cxx {
-        header "WebKitInternalCxx.h"
+
+     module WKMaterialHostingSupport {
+        header "../../Platform/cocoa/WKMaterialHostingSupport.h"
         export *
-        requires cplusplus20
     }
+
+     module WKMouseDeviceObserver {
+        header  "../../UIProcess/ios/WKMouseDeviceObserver.h"
+        export *
+    }
+
+     module WKPreferencesInternal {
+        header  "../../UIProcess/API/Cocoa/WKPreferencesInternal.h"
+        export *
+    }
+
+     module WKScrollGeometry {
+        header  "../../UIProcess/API/Cocoa/WKScrollGeometry.h"
+        export *
+    }
+
+     module WKSeparatedImageView {
+       header "../../UIProcess/Cocoa/Separated/WKSeparatedImageView.h"
+       export *
+   }
+
+     module WKUIDelegateInternal {
+       header "../../UIProcess/API/Cocoa/WKUIDelegateInternal.h"
+       export *
+   }
+
+     module WKWebViewConfigurationInternal {
+       header "../../UIProcess/API/Cocoa/WKWebViewConfigurationInternal.h"
+       export *
+   }
+
+     module APIPageConfiguration {
+         header "../../UIProcess/API/APIPageConfiguration.h"
+         export *
+     }
+
+     module WKWebViewInternal {
+       header "../../UIProcess/API/Cocoa/WKWebViewInternal.h"
+       export *
+   }
+
+     module _WKTextExtractionInternal {
+       header "../../UIProcess/API/Cocoa/_WKTextExtractionInternal.h"
+       export *
+   }
+
+     module WebsiteData {
+       header "../../Shared/WebsiteData/WebsiteData.h"
+       export *
+   }
+
+     module WebPushMessage {
+       header "../../Shared/WebPushMessage.h"
+       export *
+   }
+
+     module WKObject {
+         header "../../Shared/cocoa/WKObject.h"
+         export *
+     }
+
+     module WebProcessProxy {
+         header "../../UIProcess/WebProcessProxy.h"
+         export *
+     }
+
+     module Connection {
+         header "../../Platform/IPC/Connection.h"
+         export *
+     }
+
+     export *
 }

--- a/Source/WebKit/Platform/cocoa/WKMaterialHostingSupport.swift
+++ b/Source/WebKit/Platform/cocoa/WKMaterialHostingSupport.swift
@@ -23,7 +23,7 @@
 
 #if HAVE_MATERIAL_HOSTING
 
-internal import WebKit_Internal
+internal import WebKit_Internal.WKMaterialHostingSupport
 
 #if USE_APPLE_INTERNAL_SDK
 #if canImport(UIKit)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContextMenuElementInfoAdapter.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContextMenuElementInfoAdapter.swift
@@ -24,7 +24,6 @@
 #if ENABLE_SWIFTUI && compiler(>=6.0)
 
 public import Foundation
-internal import WebKit_Internal
 
 // SPI for the cross-import overlay.
 // swift-format-ignore: AllPublicDeclarationsHaveDocumentation

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration+Extras.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration+Extras.swift
@@ -24,7 +24,6 @@
 #if ENABLE_SWIFTUI && compiler(>=6.0)
 
 import Foundation
-internal import WebKit_Internal
 
 extension WKWebViewConfiguration {
     convenience init(_ wrapped: WebPage.Configuration) {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationInternal.h
@@ -25,8 +25,8 @@
 
 #import <WebKit/WKWebViewConfigurationPrivate.h>
 
-#ifdef __cplusplus
-#if !__has_feature(modules)
+//#ifdef __cplusplus
+//#if !__has_feature(modules)
 
 #import "APIPageConfiguration.h"
 #import "WKObject.h"
@@ -56,8 +56,8 @@ _WKDragLiftDelay toWKDragLiftDelay(WebKit::DragLiftDelay);
 WebKit::DragLiftDelay fromWKDragLiftDelay(_WKDragLiftDelay);
 #endif
 
-#endif // !__has_feature(modules)
-#endif // __cplusplus
+//#endif // !__has_feature(modules)
+//#endif // __cplusplus
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences+Extras.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences+Extras.swift
@@ -24,7 +24,6 @@
 #if ENABLE_SWIFTUI && compiler(>=6.0)
 
 import Foundation
-internal import WebKit_Internal
 
 extension WKWebpagePreferences.ContentMode {
     init(_ wrapped: WebPage.NavigationPreferences.ContentMode) {

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKRectEdge+Extras.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKRectEdge+Extras.swift
@@ -24,7 +24,7 @@
 #if ENABLE_SWIFTUI && compiler(>=6.0)
 
 import Foundation
-internal import WebKit_Internal
+internal import WebKit_Private
 
 extension _WKRectEdge {
     init(_ cocoaEdge: NSDirectionalRectEdge) {

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.swift
@@ -25,7 +25,7 @@
 
 import Foundation
 #if compiler(>=6.0)
-internal import WebKit_Internal
+internal import WebKit_Internal._WKTextExtractionInternal
 #else
 @_implementationOnly import WebKit_Internal
 #endif

--- a/Source/WebKit/UIProcess/API/Swift/URLSchemeHandler.swift
+++ b/Source/WebKit/UIProcess/API/Swift/URLSchemeHandler.swift
@@ -24,7 +24,7 @@
 #if ENABLE_SWIFTUI && compiler(>=6.0)
 
 import Foundation
-internal import WebKit_Internal
+internal import WebKit_Internal.WKWebViewConfigurationInternal
 
 /// A type representing a valid URL scheme.
 ///

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+Configuration.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+Configuration.swift
@@ -24,7 +24,6 @@
 #if ENABLE_SWIFTUI && compiler(>=6.0)
 
 import Foundation
-internal import WebKit_Internal
 
 extension WebPage {
     /// A configuration type that specifies the preferences and behaviors of a webpage.

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+FrameInfo.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+FrameInfo.swift
@@ -24,7 +24,6 @@
 #if ENABLE_SWIFTUI && compiler(>=6.0)
 
 import Foundation
-internal import WebKit_Internal
 
 extension WebPage {
     /// A type that contains information about a frame on a webpage.

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+NavigationPreferences.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+NavigationPreferences.swift
@@ -24,7 +24,6 @@
 #if ENABLE_SWIFTUI && compiler(>=6.0)
 
 import Foundation
-internal import WebKit_Internal
 
 extension WebPage {
     /// A type that specifies the behaviors to use when loading and rendering page content.

--- a/Source/WebKit/UIProcess/Cocoa/UIWindowScene+Extras.h
+++ b/Source/WebKit/UIProcess/Cocoa/UIWindowScene+Extras.h
@@ -23,6 +23,8 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#import <wtf/Platform.h>
+
 #if ENABLE(SCENE_GEOMETRY_UPDATE)
 
 #import <Foundation/Foundation.h>

--- a/Source/WebKit/UIProcess/Cocoa/WKUIDelegateAdapter.swift
+++ b/Source/WebKit/UIProcess/Cocoa/WKUIDelegateAdapter.swift
@@ -25,7 +25,7 @@
 
 import Foundation
 internal import WebKit_Private
-internal import WebKit_Internal
+internal import WebKit_Internal.WKUIDelegateInternal
 
 #if os(macOS) && !targetEnvironment(macCatalyst)
 @_spiOnly import WebKit_Private._WKContextMenuElementInfo

--- a/Source/WebKit/UIProcess/Cocoa/WKURLSchemeHandlerAdapter.swift
+++ b/Source/WebKit/UIProcess/Cocoa/WKURLSchemeHandlerAdapter.swift
@@ -24,7 +24,6 @@
 #if ENABLE_SWIFTUI && compiler(>=6.0)
 
 import Foundation
-internal import WebKit_Internal
 
 final class WKURLSchemeHandlerAdapter: NSObject, WKURLSchemeHandler {
     init(_ wrapped: any URLSchemeHandler) {

--- a/Source/WebKit/UIProcess/Cocoa/WebPageWebView.swift
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageWebView.swift
@@ -24,7 +24,7 @@
 #if ENABLE_SWIFTUI && compiler(>=6.0)
 
 import Foundation
-internal import WebKit_Internal
+internal import WebKit_Internal.WKWebViewInternal
 
 // SPI for the cross-import overlay.
 // swift-format-ignore: AllPublicDeclarationsHaveDocumentation

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -28,6 +28,7 @@
 #include "AppPrivacyReport.h"
 #include "AuxiliaryProcessProxy.h"
 #include "BackgroundFetchState.h"
+#include "APICustomProtocolManagerClient.h"
 #include "DataTaskIdentifier.h"
 #include "IdentifierTypes.h"
 #include "NetworkResourceLoadIdentifier.h"
@@ -59,7 +60,7 @@ class FormDataReference;
 }
 
 namespace API {
-class CustomProtocolManagerClient;
+//class CustomProtocolManagerClient;
 class DataTask;
 }
 

--- a/Source/WebKit/UIProcess/WKMouseDeviceObserver.swift
+++ b/Source/WebKit/UIProcess/WKMouseDeviceObserver.swift
@@ -24,7 +24,7 @@
 #if HAVE_MOUSE_DEVICE_OBSERVATION
 
 @_weakLinked internal import GameController
-internal import WebKit_Internal
+internal import WebKit_Internal.WKMouseDeviceObserver
 
 @objc
 @implementation

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "WebPermissionControllerProxy.h"
 #include "APIUserInitiatedAction.h"
 #include "AuxiliaryProcessProxy.h"
 #include "BackgroundProcessResponsivenessTimer.h"
@@ -103,7 +104,6 @@ struct CryptoKeyData;
 struct NotificationData;
 struct PluginInfo;
 struct PrewarmInformation;
-struct WebProcessCreationParameters;
 class SecurityOriginData;
 struct WrappedCryptoKey;
 
@@ -132,11 +132,12 @@ class VisitedLinkStore;
 class WebBackForwardListItem;
 class WebCompiledContentRuleList;
 class WebCompiledContentRuleListData;
+struct WebProcessCreationParameters;
 class WebFrameProxy;
 class WebLockRegistryProxy;
 class WebPageGroup;
 class WebPageProxy;
-class WebPermissionControllerProxy;
+//class WebPermissionControllerProxy;
 class WebPreferences;
 class WebProcessPool;
 class WebUserContentControllerProxy;


### PR DESCRIPTION
#### 5fbe90b880e33f43b6ee88e2cb8b0450fd643b95
<pre>
[Swift in WebKit] Fix the WebKit internal module
<a href="https://bugs.webkit.org/show_bug.cgi?id=305625">https://bugs.webkit.org/show_bug.cgi?id=305625</a>
<a href="https://rdar.apple.com/168281680">rdar://168281680</a>

Reviewed by NOBODY (OOPS!).

Draft

* Source/WebCore/WebCore_Private.modulemap:
* Source/WebKit/Modules/Internal/WebKitInternal.h:
* Source/WebKit/Modules/Internal/WebKitInternalCxx.h:
* Source/WebKit/Modules/Internal/module.modulemap:
* Source/WebKit/Platform/cocoa/WKMaterialHostingSupport.swift:
* Source/WebKit/UIProcess/API/Cocoa/WKContextMenuElementInfoAdapter.swift:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration+Extras.swift:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences+Extras.swift:
* Source/WebKit/UIProcess/API/Cocoa/_WKRectEdge+Extras.swift:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.swift:
* Source/WebKit/UIProcess/API/Swift/URLSchemeHandler.swift:
* Source/WebKit/UIProcess/API/Swift/WebPage+Configuration.swift:
* Source/WebKit/UIProcess/API/Swift/WebPage+FrameInfo.swift:
* Source/WebKit/UIProcess/API/Swift/WebPage+NavigationPreferences.swift:
* Source/WebKit/UIProcess/Cocoa/UIWindowScene+Extras.h:
* Source/WebKit/UIProcess/Cocoa/WKUIDelegateAdapter.swift:
* Source/WebKit/UIProcess/Cocoa/WKURLSchemeHandlerAdapter.swift:
* Source/WebKit/UIProcess/Cocoa/WebPageWebView.swift:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/WKMouseDeviceObserver.swift:
* Source/WebKit/UIProcess/WebProcessProxy.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5fbe90b880e33f43b6ee88e2cb8b0450fd643b95

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139171 "23 style errors") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11546 "Hash 5fbe90b8 for PR 56693 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/668 "Hash 5fbe90b8 for PR 56693 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147298 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92238 "Failed to checkout and rebase branch from PR 56693") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/46a7eb6c-d7c2-42e1-94af-ba3a04eb32da) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141043 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12251 "Hash 5fbe90b8 for PR 56693 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11695 "Hash 5fbe90b8 for PR 56693 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106535 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/92238 "Failed to checkout and rebase branch from PR 56693") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c85643ba-06c7-48f1-b31a-262e5a932dd1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142118 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/12251 "Hash 5fbe90b8 for PR 56693 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/668 "Hash 5fbe90b8 for PR 56693 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87402 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/01004614-4ec8-4147-b548-8255e738e036) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/12251 "Hash 5fbe90b8 for PR 56693 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/168/builds/668 "Hash 5fbe90b8 for PR 56693 does not build (failure)") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7591 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/12251 "Hash 5fbe90b8 for PR 56693 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/668 "Hash 5fbe90b8 for PR 56693 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150077 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11229 "Hash 5fbe90b8 for PR 56693 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/668 "Hash 5fbe90b8 for PR 56693 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114924 "Passed tests") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11242 "Hash 5fbe90b8 for PR 56693 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/11695 "Hash 5fbe90b8 for PR 56693 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115237 "Passed tests") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/668 "Hash 5fbe90b8 for PR 56693 does not build (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66131 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11272 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/668 "Hash 5fbe90b8 for PR 56693 does not build (failure)") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11007 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74929 "Failed to build and analyze WebKit") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11210 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11059 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->