### PR TITLE
Implement https://w3c.github.io/webrtc-extensions/#target-latency

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-extensions/targetLatency-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-extensions/targetLatency-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Valid targetLatency
+PASS Invalid targetLatency
+PASS Changing targetLatency
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-extensions/targetLatency.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-extensions/targetLatency.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>RTCConfiguration targetLatency</title>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+<script>
+test(() => {
+    let pc = new RTCPeerConnection({ });
+    assert_equals(pc.getConfiguration().targetLatency, "lowest");
+    pc.close();
+
+    pc = new RTCPeerConnection({ targetLatency: "lowest" });
+    assert_equals(pc.getConfiguration().targetLatency, "lowest");
+    pc.close();
+
+    pc = new RTCPeerConnection({ targetLatency: "none" });
+    assert_equals(pc.getConfiguration().targetLatency, "none");
+    pc.close();
+}, "Valid targetLatency");
+
+test(() => {
+    assert_throws_js(TypeError, () => new RTCPeerConnection({ targetLatency: "whatever" }));
+}, "Invalid targetLatency");
+
+test(() => {
+    let pc = new RTCPeerConnection({ targetLatency: "lowest" });
+    pc.setConfiguration({ });
+    pc.setConfiguration({ targetLatency: "lowest" });
+    assert_throws_js(TypeError, () => pc.setConfiguration({ targetLatency: "none" }));
+    pc.close();
+
+    pc = new RTCPeerConnection({ targetLatency: "none" });
+    pc.setConfiguration({ targetLatency: "none" });
+    assert_throws_js(TypeError, () => pc.setConfiguration({ }));
+    assert_throws_js(TypeError, () => pc.setConfiguration({ targetLatency: "lowest" }));
+    pc.close();
+}, "Changing targetLatency");
+</script>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2689,6 +2689,8 @@ webkit.org/b/235885 webrtc/remove-track.html [ Crash Failure ]
 # Stopping a transceiver is unsupported in GstWebRTC.
 imported/w3c/web-platform-tests/webrtc/protocol/transceiver-mline-recycling.html [ Failure ]
 
+webrtc/RTCConfiguration-targetLatency.html [ Failure ]
+
 # Specific to LibWebRTC:
 webkit.org/b/235885 webrtc/disable-encryption.html [ Skip ]
 webkit.org/b/235885 webrtc/libwebrtc/ [ Skip ]

--- a/LayoutTests/webrtc/RTCConfiguration-targetLatency-expected.txt
+++ b/LayoutTests/webrtc/RTCConfiguration-targetLatency-expected.txt
@@ -1,0 +1,3 @@
+
+PASS targetLatency and serviceClass
+

--- a/LayoutTests/webrtc/RTCConfiguration-targetLatency.html
+++ b/LayoutTests/webrtc/RTCConfiguration-targetLatency.html
@@ -1,0 +1,19 @@
+<!doctype html><!-- webkit-test-runner [ WebRTCSocketsServiceClassEnabled=true ] -->
+<meta charset=utf-8>
+<title>RTCConfiguration targetLatency</title>
+<script src='../resources/testharness.js'></script>
+<script src='../resources/testharnessreport.js'></script>
+<script>
+test(() => {
+    if (!window.internals)
+        return;
+
+    const pc1 = new RTCPeerConnection({ targetLatency: "lowest" });
+    assert_true(internals.hasPeerConnectionEnabledServiceClass(pc1));
+    pc1.close();
+
+    const pc2 = new RTCPeerConnection({ targetLatency: "none" });
+    assert_false(internals.hasPeerConnectionEnabledServiceClass(pc2));
+    pc2.close();
+}, "targetLatency and serviceClass");
+</script>

--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.h
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.h
@@ -73,6 +73,7 @@ class WeakPtrImplWithEventTargetData;
 
 struct MediaEndpointConfiguration;
 struct RTCAnswerOptions;
+struct RTCConfiguration;
 struct RTCDataChannelInit;
 struct RTCOfferOptions;
 struct RTCRtpTransceiverInit;
@@ -231,6 +232,8 @@ public:
 
     WEBCORE_EXPORT void ref() const;
     WEBCORE_EXPORT void deref() const;
+
+    virtual bool shouldEnableServiceClass() const { return true; }
 
 protected:
     void doneGatheringCandidates();

--- a/Source/WebCore/Modules/mediastream/RTCConfiguration.h
+++ b/Source/WebCore/Modules/mediastream/RTCConfiguration.h
@@ -48,6 +48,8 @@ struct RTCConfiguration {
     RTCPMuxPolicy rtcpMuxPolicy;
     unsigned short iceCandidatePoolSize;
     Vector<Ref<RTCCertificate>> certificates;
+    enum class TargetLatency { Lowest, None };
+    TargetLatency targetLatency { TargetLatency::Lowest };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/RTCConfiguration.idl
+++ b/Source/WebCore/Modules/mediastream/RTCConfiguration.idl
@@ -53,6 +53,14 @@
 
 [
     Conditional=WEB_RTC,
+    EnabledBySetting=PeerConnectionEnabled
+] enum RTCConfigurationTargetLatency {
+  "lowest",
+  "none"
+};
+
+[
+    Conditional=WEB_RTC,
     EnabledBySetting=PeerConnectionEnabled,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
@@ -65,4 +73,5 @@
     // FIXME 169662: missing peerIdentity
     sequence<RTCCertificate> certificates;
     [EnforceRange] octet iceCandidatePoolSize = 0;
+    RTCConfigurationTargetLatency targetLatency = "lowest";
 };

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
@@ -599,12 +599,13 @@ ExceptionOr<void> RTCPeerConnection::initializeWithConfiguration(RTCConfiguratio
     if (certificates.hasException())
         return certificates.releaseException();
 
-    lazyInitialize(m_backend, PeerConnectionBackend::create(*this, { servers.releaseReturnValue(), configuration.iceTransportPolicy, configuration.bundlePolicy, configuration.rtcpMuxPolicy, configuration.iceCandidatePoolSize, certificates.releaseReturnValue() }));
+    lazyInitialize(m_backend, PeerConnectionBackend::create(*this, { servers.releaseReturnValue(), configuration.iceTransportPolicy, configuration.bundlePolicy, configuration.rtcpMuxPolicy, configuration.iceCandidatePoolSize, certificates.releaseReturnValue(), configuration.targetLatency == RTCConfiguration::TargetLatency::Lowest }));
 
     if (!m_backend)
         return Exception { ExceptionCode::InvalidAccessError, "Bad Configuration Parameters"_s };
 
     m_configuration = WTF::move(configuration);
+
     return { };
 }
 
@@ -631,6 +632,9 @@ ExceptionOr<void> RTCPeerConnection::setConfiguration(RTCConfiguration&& configu
                 return Exception { ExceptionCode::InvalidModificationError, "A certificate given in constructor is not present"_s };
         }
     }
+
+    if (configuration.targetLatency != m_configuration.targetLatency)
+        return Exception { ExceptionCode::TypeError, "Configuration targetLatency is immutable"_s };
 
     if (!protectedBackend()->setConfiguration({ servers.releaseReturnValue(), configuration.iceTransportPolicy, configuration.bundlePolicy, configuration.rtcpMuxPolicy, configuration.iceCandidatePoolSize, { } }))
         return Exception { ExceptionCode::InvalidAccessError, "Bad Configuration Parameters"_s };

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h
@@ -81,7 +81,7 @@ class LibWebRTCMediaEndpoint final
 #endif
 {
 public:
-    static RefPtr<LibWebRTCMediaEndpoint> create(RTCPeerConnection&, LibWebRTCProvider&, Document&, webrtc::PeerConnectionInterface::RTCConfiguration&&);
+    static RefPtr<LibWebRTCMediaEndpoint> create(RTCPeerConnection&, LibWebRTCProvider&, Document&, webrtc::PeerConnectionInterface::RTCConfiguration&&, bool shouldEnableServiceClass);
     ~LibWebRTCMediaEndpoint();
 
     void restartIce();
@@ -131,8 +131,10 @@ public:
 
     void setPeerConnectionBackend(LibWebRTCPeerConnectionBackend&);
 
+    bool shouldEnableServiceClass() const { return m_rtcSocketFactory && m_rtcSocketFactory->shouldEnableServiceClass(); }
+
 private:
-    LibWebRTCMediaEndpoint(RTCPeerConnection&, LibWebRTCProvider&, Document&);
+    LibWebRTCMediaEndpoint(RTCPeerConnection&, LibWebRTCProvider&, Document&, bool shouldEnableServiceClass);
 
     // webrtc::PeerConnectionObserver API
     void OnSignalingChange(webrtc::PeerConnectionInterface::SignalingState) final;
@@ -184,7 +186,6 @@ private:
 #endif
 
     RefPtr<LibWebRTCPeerConnectionBackend> protectedPeerConnectionBackend() const;
-    RefPtr<webrtc::PeerConnectionInterface> createBackend(LibWebRTCProvider&, webrtc::PeerConnectionInterface::RTCConfiguration&&);
 
     WeakPtr<LibWebRTCPeerConnectionBackend> m_peerConnectionBackend;
     const Ref<webrtc::PeerConnectionFactoryInterface> m_peerConnectionFactory;

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
@@ -70,7 +70,8 @@ static const std::unique_ptr<PeerConnectionBackend> createLibWebRTCPeerConnectio
     auto& webRTCProvider = downcast<LibWebRTCProvider>(page->webRTCProvider());
     webRTCProvider.setEnableWebRTCEncryption(page->settings().webRTCEncryptionEnabled());
 
-    RefPtr endpoint = LibWebRTCMediaEndpoint::create(peerConnection, webRTCProvider, document, configurationFromMediaEndpointConfiguration(WTF::move(configuration)));
+    bool shouldEnableServiceClass = configuration.shouldEnableServiceClass;
+    RefPtr endpoint = LibWebRTCMediaEndpoint::create(peerConnection, webRTCProvider, document, configurationFromMediaEndpointConfiguration(WTF::move(configuration)), shouldEnableServiceClass);
     if (!endpoint)
         return nullptr;
 
@@ -422,6 +423,11 @@ void LibWebRTCPeerConnectionBackend::applyRotationForOutgoingVideoSources()
 std::optional<bool> LibWebRTCPeerConnectionBackend::canTrickleIceCandidates() const
 {
     return m_endpoint->canTrickleIceCandidates();
+}
+
+bool LibWebRTCPeerConnectionBackend::shouldEnableServiceClass() const
+{
+    return m_endpoint->shouldEnableServiceClass();
 }
 
 void LibWebRTCPeerConnectionBackend::startGatheringStatLogs(Function<void(String&&)>&& callback)

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.h
@@ -99,6 +99,8 @@ private:
 private:
     bool isLocalDescriptionSet() const final { return m_isLocalDescriptionSet; }
 
+    bool shouldEnableServiceClass() const final;
+
     void startGatheringStatLogs(Function<void(String&&)>&&) final;
     void stopGatheringStatLogs() final;
     void provideStatLogs(String&&);

--- a/Source/WebCore/platform/mediastream/MediaEndpointConfiguration.cpp
+++ b/Source/WebCore/platform/mediastream/MediaEndpointConfiguration.cpp
@@ -36,16 +36,6 @@
 
 namespace WebCore {
 
-MediaEndpointConfiguration::MediaEndpointConfiguration(Vector<IceServerInfo>&& iceServers, RTCIceTransportPolicy iceTransportPolicy, RTCBundlePolicy bundlePolicy, RTCPMuxPolicy rtcpMuxPolicy, unsigned short iceCandidatePoolSize, Vector<CertificatePEM>&& certificates)
-    : iceServers(WTF::move(iceServers))
-    , iceTransportPolicy(iceTransportPolicy)
-    , bundlePolicy(bundlePolicy)
-    , rtcpMuxPolicy(rtcpMuxPolicy)
-    , iceCandidatePoolSize(iceCandidatePoolSize)
-    , certificates(WTF::move(certificates))
-{
-}
-
 MediaEndpointConfiguration::IceServerInfo::IceServerInfo(Vector<URL>&& urls, const String& credential, const String& username)
     : urls(WTF::move(urls))
     , credential(credential)

--- a/Source/WebCore/platform/mediastream/MediaEndpointConfiguration.h
+++ b/Source/WebCore/platform/mediastream/MediaEndpointConfiguration.h
@@ -56,14 +56,13 @@ struct MediaEndpointConfiguration {
         String privateKey;
     };
 
-    MediaEndpointConfiguration(Vector<IceServerInfo>&&, RTCIceTransportPolicy, RTCBundlePolicy, RTCPMuxPolicy, unsigned short, Vector<CertificatePEM>&&);
-
     Vector<IceServerInfo> iceServers;
     RTCIceTransportPolicy iceTransportPolicy;
     RTCBundlePolicy bundlePolicy;
     RTCPMuxPolicy rtcpMuxPolicy;
     unsigned short iceCandidatePoolSize;
     Vector<CertificatePEM> certificates;
+    bool shouldEnableServiceClass { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.cpp
@@ -279,7 +279,7 @@ void LibWebRTCProvider::disableNonLocalhostConnections()
     m_disableNonLocalhostConnections = true;
 }
 
-std::unique_ptr<LibWebRTCProvider::SuspendableSocketFactory> LibWebRTCProvider::createSocketFactory(String&& /* userAgent */, ScriptExecutionContextIdentifier, bool /* isFirstParty */, RegistrableDomain&&)
+std::unique_ptr<LibWebRTCProvider::SuspendableSocketFactory> LibWebRTCProvider::createSocketFactory(String&& /* userAgent */, ScriptExecutionContextIdentifier, bool /* isFirstParty */, RegistrableDomain&&, bool)
 {
     return nullptr;
 }

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.h
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.h
@@ -121,8 +121,9 @@ public:
         virtual void suspend() { };
         virtual void resume() { };
         virtual void disableRelay() { };
+        virtual bool shouldEnableServiceClass() { return true; }
     };
-    virtual std::unique_ptr<SuspendableSocketFactory> createSocketFactory(String&& /* userAgent */, ScriptExecutionContextIdentifier, bool /* isFirstParty */, RegistrableDomain&&);
+    virtual std::unique_ptr<SuspendableSocketFactory> createSocketFactory(String&& /* userAgent */, ScriptExecutionContextIdentifier, bool /* isFirstParty */, RegistrableDomain&&, bool /* enableServiceClass */);
 
 protected:
     LibWebRTCProvider();

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1999,6 +1999,10 @@ void Internals::setEnableWebRTCEncryption(bool value)
 #endif
 }
 
+bool Internals::hasPeerConnectionEnabledServiceClass(const RTCPeerConnection& connection)
+{
+    return connection.protectedBackend()->shouldEnableServiceClass();
+}
 #endif // ENABLE(WEB_RTC)
 
 #if ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -808,6 +808,7 @@ public:
     uint64_t sframeCounter(const RTCRtpSFrameTransform&);
     uint64_t sframeKeyId(const RTCRtpSFrameTransform&);
     void setEnableWebRTCEncryption(bool);
+    bool hasPeerConnectionEnabledServiceClass(const RTCPeerConnection&);
 #endif
 
     String getImageSourceURL(Element&);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1116,6 +1116,7 @@ enum ContentsFormat {
     [Conditional=WEB_RTC] undefined stopPeerConnection(RTCPeerConnection connection);
     [Conditional=WEB_RTC] undefined clearPeerConnectionFactory();
     [Conditional=WEB_RTC] undefined setEnableWebRTCEncryption(boolean enabled);
+    [Conditional=WEB_RTC] boolean hasPeerConnectionEnabledServiceClass(RTCPeerConnection connection);
 
     [Conditional=VIDEO] undefined simulateSystemSleep();
     [Conditional=VIDEO] undefined simulateSystemWake();

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.cpp
@@ -117,6 +117,7 @@ private:
     std::unique_ptr<webrtc::AsyncDnsResolverInterface> CreateAsyncDnsResolver() final;
     void suspend() final;
     void resume() final;
+    bool shouldEnableServiceClass() final { return m_flags.enableServiceClass; }
 
 private:
     WebPageProxyIdentifier m_pageIdentifier;
@@ -175,7 +176,7 @@ void LibWebRTCProvider::startedNetworkThread()
     WebProcess::singleton().protectedLibWebRTCNetwork()->setAsActive();
 }
 
-std::unique_ptr<LibWebRTCProvider::SuspendableSocketFactory> LibWebRTCProvider::createSocketFactory(String&& userAgent, ScriptExecutionContextIdentifier identifier, bool isFirstParty, RegistrableDomain&& domain)
+std::unique_ptr<LibWebRTCProvider::SuspendableSocketFactory> LibWebRTCProvider::createSocketFactory(String&& userAgent, ScriptExecutionContextIdentifier identifier, bool isFirstParty, RegistrableDomain&& domain, bool enableServiceClass)
 {
     Ref webPage { m_webPage.get() };
     auto factory = makeUnique<RTCSocketFactory>(webPage->webPageProxyIdentifier(), WTF::move(userAgent), identifier, isFirstParty, WTF::move(domain));
@@ -184,7 +185,7 @@ std::unique_ptr<LibWebRTCProvider::SuspendableSocketFactory> LibWebRTCProvider::
     if (!page || !page->settings().webRTCSocketsProxyingEnabled())
         factory->disableRelay();
 
-    if (page && page->settings().webRTCSocketsServiceClassEnabled())
+    if (page && page->settings().webRTCSocketsServiceClassEnabled() && enableServiceClass)
         factory->enableServiceClass();
 
     return factory;

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.h
@@ -72,7 +72,7 @@ public:
 private:
     bool isLibWebRTCProvider() const final { return true; }
 
-    std::unique_ptr<SuspendableSocketFactory> createSocketFactory(String&& /* userAgent */, WebCore::ScriptExecutionContextIdentifier, bool /* isFirstParty */, WebCore::RegistrableDomain&&) final;
+    std::unique_ptr<SuspendableSocketFactory> createSocketFactory(String&& /* userAgent */, WebCore::ScriptExecutionContextIdentifier, bool /* isFirstParty */, WebCore::RegistrableDomain&&, bool /* enableServiceClass */) final;
 
     webrtc::scoped_refptr<webrtc::PeerConnectionInterface> createPeerConnection(WebCore::ScriptExecutionContextIdentifier, webrtc::PeerConnectionObserver&, webrtc::PacketSocketFactory*, webrtc::PeerConnectionInterface::RTCConfiguration&&) final;
 


### PR DESCRIPTION
#### 521581dbc7966e8d108a1ec0012aa8347ba3253e
<pre>
Implement <a href="https://w3c.github.io/webrtc-extensions/#target-latency">https://w3c.github.io/webrtc-extensions/#target-latency</a>
<a href="https://rdar.apple.com/168225793">rdar://168225793</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=305564">https://bugs.webkit.org/show_bug.cgi?id=305564</a>

Reviewed by Eric Carlson.

We add RTCConfiguration.targetLatency and compute whether enabling service class accordingly.
We remove some no longer needed code.
We add an internal API to  query whether service class is enabled for a given peer connection and use that in a test to validate that passing the parameter works fine.

Covered by added tests.

Canonical link: <a href="https://commits.webkit.org/306062@main">https://commits.webkit.org/306062@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aecefbe0108d9c293172245aa1de160d29ded87d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139880 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12261 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1391 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148022 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92949 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/37d0564e-4c8f-4910-8f27-03392f23136e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141753 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12971 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12413 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107109 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77958 "1 flakes 2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142830 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9993 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125271 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87988 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/331bb54b-276a-4afc-8dc3-190a6d0176bb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9646 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7155 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8312 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118866 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1273 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150806 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11946 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1339 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115522 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11958 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10233 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115837 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29502 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10620 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121751 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66951 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11988 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1226 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11728 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75675 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11924 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11776 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->