### PR TITLE
[JSC] Handle `StringCodePointAt` in Abastract Interpreter

### DIFF
--- a/JSTests/microbenchmarks/string-codePointAt-constant-folding.js
+++ b/JSTests/microbenchmarks/string-codePointAt-constant-folding.js
@@ -1,0 +1,14 @@
+const str1 = "a".repeat(10000);
+const index1 = 9999;
+
+const str2 = "Hello, World";
+const index2 = 2;
+
+const str3 = "𠮷野家";
+const index3 = 0;
+
+for (let i = 0; i < 1e6; i++) {
+  str1.codePointAt(index1); 
+  str2.codePointAt(index2);
+  str3.codePointAt(index3);
+}

--- a/JSTests/stress/string-codePointAt-constant-folding.js
+++ b/JSTests/stress/string-codePointAt-constant-folding.js
@@ -1,0 +1,45 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected: ${expected}, actual: ${actual}`);
+}
+
+for (var i = 0; i < testLoopCount; i++) {
+    // ASCII characters
+    shouldBe("hello".codePointAt(0), 104);  // 'h'
+    shouldBe("hello".codePointAt(1), 101);  // 'e'
+    shouldBe("hello".codePointAt(4), 111);  // 'o'
+
+    // BMP characters (Japanese)
+    shouldBe("あいう".codePointAt(0), 0x3042);  // 'あ'
+    shouldBe("あいう".codePointAt(1), 0x3044);  // 'い'
+    shouldBe("あいう".codePointAt(2), 0x3046);  // 'う'
+
+    // Surrogate pairs (emoji) - codePointAt returns the full code point
+    shouldBe("😀".codePointAt(0), 0x1F600);  // full emoji code point
+    shouldBe("😀".codePointAt(1), 0xDE00);   // low surrogate (when accessed directly)
+
+    // Surrogate pairs in string context
+    shouldBe("😀test".codePointAt(0), 0x1F600);  // emoji
+    shouldBe("😀test".codePointAt(1), 0xDE00);   // low surrogate
+    shouldBe("😀test".codePointAt(2), 116);      // 't'
+
+    // Mixed characters
+    shouldBe("a😀b".codePointAt(0), 97);      // 'a'
+    shouldBe("a😀b".codePointAt(1), 0x1F600); // emoji
+    shouldBe("a😀b".codePointAt(2), 0xDE00);  // low surrogate
+    shouldBe("a😀b".codePointAt(3), 98);      // 'b'
+
+    // Multiple surrogate pairs
+    shouldBe("𠮷野家".codePointAt(0), 0x20BB7);  // '𠮷' (surrogate pair)
+    shouldBe("𠮷野家".codePointAt(1), 0xDFB7);   // low surrogate
+    shouldBe("𠮷野家".codePointAt(2), 0x91CE);   // '野'
+    shouldBe("𠮷野家".codePointAt(3), 0x5BB6);   // '家'
+
+    // Out of bounds - should return undefined
+    shouldBe("hello".codePointAt(5), undefined);
+    shouldBe("hello".codePointAt(100), undefined);
+    shouldBe("hello".codePointAt(-1), undefined);
+
+    // Empty string
+    shouldBe("".codePointAt(0), undefined);
+}

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -524,17 +524,6 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncCharCodeAt, (JSGlobalObject* globalObjec
     return JSValue::encode(jsNaN());
 }
 
-static inline char32_t codePointAt(const String& string, unsigned position, unsigned length)
-{
-    RELEASE_ASSERT(position < length);
-    if (string.is8Bit())
-        return string.span8()[position];
-    char32_t character;
-    auto characters = string.span16();
-    U16_NEXT(characters, position, length, character);
-    return character;
-}
-
 JSC_DEFINE_HOST_FUNCTION(stringProtoFuncCodePointAt, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();

--- a/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
@@ -1573,6 +1573,17 @@ ALWAYS_INLINE JSString* replace(VM& vm, JSGlobalObject* globalObject, JSValue th
     RELEASE_AND_RETURN(scope, replaceUsingStringSearch<replaceMode>(vm, globalObject, string, thisString, WTF::move(searchString), replaceValue));
 }
 
+ALWAYS_INLINE char32_t codePointAt(const String& string, unsigned position, unsigned length)
+{
+    RELEASE_ASSERT(position < length);
+    if (string.is8Bit())
+        return string.span8()[position];
+    char32_t character;
+    auto characters = string.span16();
+    U16_NEXT(characters, position, length, character);
+    return character;
+}
+
 } // namespace JSC
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END


### PR DESCRIPTION
#### 986543b9d0e8d703e20936ad8b1d1211b5edb30c
<pre>
[JSC] Handle `StringCodePointAt` in Abastract Interpreter
<a href="https://bugs.webkit.org/show_bug.cgi?id=305629">https://bugs.webkit.org/show_bug.cgi?id=305629</a>

Reviewed by Yusuke Suzuki.

This patch changes to handle `String#codePointAt` in DFGAbstractInterpreter.

                                             TipOfTree                  Patched

string-codePointAt-constant-folding        1.4612+-0.0974     ^      1.0053+-0.0306        ^ definitely 1.4535x faster

Tests: JSTests/microbenchmarks/string-codePointAt-constant-folding.js
       JSTests/stress/string-codePointAt-constant-folding.js

* JSTests/microbenchmarks/string-codePointAt-constant-folding.js: Added.
* JSTests/stress/string-codePointAt-constant-folding.js: Added.
(shouldBe):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::codePointAt): Deleted.
* Source/JavaScriptCore/runtime/StringPrototypeInlines.h:
(JSC::codePointAt):

Canonical link: <a href="https://commits.webkit.org/305839@main">https://commits.webkit.org/305839@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8ec5f5e758d93803aa7e1bb32610707d924d28a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139180 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11554 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/677 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147307 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92247 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12261 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11704 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106542 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77595 "2 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142127 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9273 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124660 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87409 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8820 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6587 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7601 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/131153 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118272 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/563 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150086 "Built successfully") | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11238 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/572 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114933 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11251 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9503 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115247 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29357 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9241 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121010 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66140 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11281 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/537 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/170451 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11016 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74938 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44377 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11219 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11068 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->