### PR TITLE
Try enabling Swift IPC layout test (reland)

### DIFF
--- a/Source/WebKit/Configurations/WebKit.xcconfig
+++ b/Source/WebKit/Configurations/WebKit.xcconfig
@@ -416,6 +416,18 @@ GENERATE_SINGLE_SWIFT_INTEROP_FILE = $(GENERATE_SINGLE_SWIFT_INTEROP_FILE_$(WK_G
 GENERATE_SINGLE_SWIFT_INTEROP_FILE_ = ;
 GENERATE_SINGLE_SWIFT_INTEROP_FILE_YES = GENERATE_SINGLE_SWIFT_INTEROP_FILE;
 
+// If (and only if) we've enabled IPC testing (on ASAN and debug builds, typically)
+// also enable testing of a Swift IPC receiver - but only if we're using a sufficiently
+// recent SDK.
+ENABLE_IPC_TESTING_SWIFT = ;
+ENABLE_IPC_TESTING_SWIFT[sdk=macosx*] = ENABLE_IPC_TESTING_SWIFT;
+ENABLE_IPC_TESTING_SWIFT[sdk=macosx14*] = ;
+ENABLE_IPC_TESTING_SWIFT[sdk=macosx15*] = ;
+ENABLE_IPC_TESTING_SWIFT[sdk=macosx26.0*] = ;
+ENABLE_IPC_TESTING_SWIFT[sdk=macosx26.1*] = ;
+ENABLE_IPC_TESTING_SWIFT[sdk=macosx26.2*] = ;
+ENABLE_IPC_TESTING_SWIFT[sdk=macosx26.3*] = ;
+
 // FIXME: (rdar://149474443) Swift/Cxx interop does not respect CLANG_CXX_LANGUAGE_STANDARD = "c++2b";
 // FIXME: (rdar://103177280) "-no-verify-emitted-module-interface;" is needed to workaround a SwiftVerifyEmittedModuleInterface bug
 OTHER_SWIFT_FLAGS = $(inherited) $(OTHER_SWIFT_FLAGS_SUPPORTS_SWIFT_OBJCXX_INTEROP_$(WK_SUPPORTS_SWIFT_OBJCXX_INTEROP)) $(OTHER_SWIFT_FLAGS_MARK_FOUNDATION_AS_OBJC_$(WK_GENERATE_SINGLE_SWIFT_INTEROP_FILE);


### PR DESCRIPTION
#### cf19c3da18f8d4eef13ba02a77d80643a6e0b778
<pre>
Try enabling Swift IPC layout test (reland)
<a href="https://bugs.webkit.org/show_bug.cgi?id=304433">https://bugs.webkit.org/show_bug.cgi?id=304433</a>
<a href="https://rdar.apple.com/166293273">rdar://166293273</a>

Reviewed by Elliott Williams.

This commit endeavours to enable a Swift CoreIPC message receiver test on a
very small permutation of platforms:

* Debug or ASAN or anything else where IPC tests are explicitly enabled;
* MacOS only;
* The most recent SDKs only.

Any such EWS builders matching that description will then run the layout
test in a mode where a Swift CoreIPC receiver is tested. This will be the
first time any builder has used Swift/C++ interop in the main WebKit
target.

This is a reland after clang modularisation issues prevented it from
working the first time as described in <a href="https://rdar.apple.com/168117540">rdar://168117540</a>.

Canonical link: <a href="https://commits.webkit.org/308195@main">https://commits.webkit.org/308195@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/916a86bf0a25a268cd35ca71de6a7df55082a6bd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146552 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19225 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12736 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155215 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99947 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b0fe9ac2-ca21-4027-8b37-fa1ab027b9eb) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19686 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19129 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112898 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80647 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1f20a064-7b74-4c20-b9c2-e52d7f7c7812) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149515 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15150 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131679 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93661 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c96b1001-32a8-471b-9688-f7de04d45daa) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14404 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12173 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2659 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123996 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157540 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/685 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10977 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120930 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19028 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15975 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121131 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31061 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19037 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131298 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74826 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16767 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8205 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18647 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82402 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18377 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18528 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18435 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->