### PR TITLE
[WPE] WPE Platform: stop rendering when the view is removed from the toplevel

### DIFF
--- a/LayoutTests/platform/wpe-legacy-api/TestExpectations
+++ b/LayoutTests/platform/wpe-legacy-api/TestExpectations
@@ -92,6 +92,9 @@ fast/forms/input-text-max-length-emojis.html [ Failure ]
 
 webkit.org/b/188509 fast/dom/Window/window-resize-update-scrollbars.html [ Timeout ]
 
+# Doesn't support removeViewFromWindow()
+media/no-fullscreen-when-hidden.html [ Skip ]
+
 #//////////////////////////////////////////////////////////////////////////////////////////
 # End of Triaged Expectations
 #//////////////////////////////////////////////////////////////////////////////////////////

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -188,7 +188,6 @@ webkit.org/b/298588 fast/media/mq-pointer.html [ Skip ]
 
 # Pending to create bug.
 [ Release ] fast/events/prevent-default-prevents-interaction-with-scrollbars.html [ Failure Pass ]
-media/no-fullscreen-when-hidden.html [ Failure ]
 media/video-background-tab-playback.html [ Failure ]
 media/video-muted-holds-sleep-assertion.html [ Failure ]
 media/video-unmuted-after-play-holds-sleep-assertion.html [ Failure ]

--- a/Source/WebKit/UIProcess/wpe/AcceleratedBackingStore.h
+++ b/Source/WebKit/UIProcess/wpe/AcceleratedBackingStore.h
@@ -95,6 +95,7 @@ private:
     void renderPendingBuffer();
     void bufferRendered();
     void bufferReleased(WPEBuffer*);
+    void toplevelChanged();
 
     WeakPtr<WebPageProxy> m_webPage;
     GRefPtr<WPEView> m_wpeView;

--- a/Tools/WebKitTestRunner/wpe/PlatformWebViewClientWPE.h
+++ b/Tools/WebKitTestRunner/wpe/PlatformWebViewClientWPE.h
@@ -33,6 +33,7 @@
 
 typedef struct _WPEDisplay WPEDisplay;
 typedef struct _WPEBuffer WPEBuffer;
+typedef struct _WPEToplevel WPEToplevel;
 
 namespace WTR {
 
@@ -52,6 +53,7 @@ private:
 
     PlatformImage snapshot() override;
 
+    GRefPtr<WPEToplevel> m_toplevel;
     GRefPtr<WPEBuffer> m_buffer;
 };
 


### PR DESCRIPTION
#### 4b246bba0575c6caf84bf74ad00b6abef60da93a
<pre>
[WPE] WPE Platform: stop rendering when the view is removed from the toplevel
<a href="https://bugs.webkit.org/show_bug.cgi?id=305630">https://bugs.webkit.org/show_bug.cgi?id=305630</a>

Reviewed by Adrian Perez de Castro.

The web process rendering is properly stopped because the view is
unmapped when removed from the toplevel, but the UI process still tries
to render any pending buffer. AcceleratedBackingStore now checks if the
view has a toplevel before rendering the pending buffer and monitors the
view toplevel property. When the view gets a toplevel and there&apos;s a
pending buffer it calls renderPendingBuffer().
This patch also implements addToWindow/removeFromWindow in WKTR.

Fixes: media/no-fullscreen-when-hidden.html

* LayoutTests/platform/wpe-legacy-api/TestExpectations:
* LayoutTests/platform/wpe/TestExpectations:
* Source/WebKit/UIProcess/wpe/AcceleratedBackingStore.cpp:
(WebKit::m_legacyMainFrameProcess):
(WebKit::AcceleratedBackingStore::renderPendingBuffer):
(WebKit::AcceleratedBackingStore::bufferRendered):
(WebKit::AcceleratedBackingStore::toplevelChanged):
* Source/WebKit/UIProcess/wpe/AcceleratedBackingStore.h:
* Tools/WebKitTestRunner/wpe/PlatformWebViewClientWPE.cpp:
(WTR::PlatformWebViewClientWPE::PlatformWebViewClientWPE):
(WTR::toplevelContainsView):
(WTR::PlatformWebViewClientWPE::addToWindow):
(WTR::PlatformWebViewClientWPE::removeFromWindow):
(WTR::PlatformWebViewClientWPE::size):
(WTR::PlatformWebViewClientWPE::resize):
* Tools/WebKitTestRunner/wpe/PlatformWebViewClientWPE.h:

Canonical link: <a href="https://commits.webkit.org/305804@main">https://commits.webkit.org/305804@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6bee2d4a2ca02715711dc1420ab658b8a79ecb5b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139185 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11559 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/682 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147312 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92252 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141057 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12266 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11709 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106547 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77597 "1 flakes 7 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142132 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9275 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124664 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87414 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8822 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6592 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7606 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118274 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/567 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150091 "Built successfully") | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11243 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/576 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114936 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11256 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9508 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115250 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9253 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121014 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66145 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21513 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11286 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/541 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11021 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74943 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11224 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11073 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->