### PR TITLE
[GTK][WPE][Coordinated Graphics] glClear the viewport with the opaque background color

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
@@ -115,11 +115,14 @@ AcceleratedSurface::AcceleratedSurface(WebPage& webPage, Function<void()>&& fram
     , m_swapChain(m_id)
     , m_isVisible(webPage.activityState().contains(ActivityState::IsVisible))
     , m_useExplicitSync(useExplicitSync())
-    , m_isOpaque(!webPage.backgroundColor().has_value() || webPage.backgroundColor()->isOpaque())
 {
+    {
+        Locker locker(m_backgroundColorLock);
+        m_backgroundColor = webPage.backgroundColor().value_or(Color::white);
+    }
 #if (PLATFORM(GTK) || ENABLE(WPE_PLATFORM)) && (USE(GBM) || OS(ANDROID))
     if (m_swapChain.type() == SwapChain::Type::EGLImage)
-        m_swapChain.setupBufferFormat(m_webPage->preferredBufferFormats(), m_isOpaque);
+        m_swapChain.setupBufferFormat(m_webPage->preferredBufferFormats(), isOpaque());
 #endif
 #if USE(WPE_RENDERER)
     if (m_swapChain.type() == SwapChain::Type::WPEBackend)
@@ -898,7 +901,7 @@ void AcceleratedSurface::preferredBufferFormatsDidChange()
     if (m_swapChain.type() != SwapChain::Type::EGLImage)
         return;
 
-    m_swapChain.setupBufferFormat(m_webPage->preferredBufferFormats(), m_isOpaque);
+    m_swapChain.setupBufferFormat(m_webPage->preferredBufferFormats(), isOpaque());
 }
 #endif
 
@@ -919,21 +922,26 @@ void AcceleratedSurface::visibilityDidChange(bool isVisible)
     }
 }
 
-bool AcceleratedSurface::backgroundColorDidChange()
+bool AcceleratedSurface::isOpaque()
 {
-    const auto& color = m_webPage->backgroundColor();
-    auto isOpaque = !color.has_value() || color->isOpaque();
-    if (m_isOpaque == isOpaque)
-        return false;
+    Locker locker(m_backgroundColorLock);
+    return m_backgroundColor.isOpaque();
+}
 
-    m_isOpaque = isOpaque;
+void AcceleratedSurface::backgroundColorDidChange()
+{
+    bool wasOpaque = isOpaque();
+    {
+        Locker locker(m_backgroundColorLock);
+        m_backgroundColor = m_webPage->backgroundColor().value_or(Color::white);
+    }
+    if (isOpaque() == wasOpaque)
+        return;
 
 #if (PLATFORM(GTK) || ENABLE(WPE_PLATFORM)) && (USE(GBM) || OS(ANDROID))
     if (m_swapChain.type() == SwapChain::Type::EGLImage)
-        m_swapChain.setupBufferFormat(m_webPage->preferredBufferFormats(), m_isOpaque);
+        m_swapChain.setupBufferFormat(m_webPage->preferredBufferFormats(), isOpaque());
 #endif
-
-    return true;
 }
 
 void AcceleratedSurface::releaseUnusedBuffersTimerFired()
@@ -1007,10 +1015,13 @@ void AcceleratedSurface::willRenderFrame(const IntSize& size)
     if (sizeDidChange)
         glViewport(0, 0, size.width(), size.height());
 
-    if (!m_isOpaque) {
+    if (isOpaque()) {
+        Locker locker(m_backgroundColorLock);
+        auto [r, g, b, a] = m_backgroundColor.toResolvedColorComponentsInColorSpace(WebCore::ColorSpace::SRGB);
+        glClearColor(r, g, b, 0);
+    } else
         glClearColor(0, 0, 0, 0);
-        glClear(GL_COLOR_BUFFER_BIT);
-    }
+    glClear(GL_COLOR_BUFFER_BIT);
 }
 
 void AcceleratedSurface::didRenderFrame()

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
@@ -28,6 +28,7 @@
 #if USE(COORDINATED_GRAPHICS)
 
 #include "MessageReceiver.h"
+#include <WebCore/Color.h>
 #include <WebCore/Damage.h>
 #include <WebCore/IntSize.h>
 #include <wtf/RunLoop.h>
@@ -129,7 +130,7 @@ public:
 #endif
 
     void visibilityDidChange(bool);
-    bool backgroundColorDidChange();
+    void backgroundColorDidChange();
 
 private:
     AcceleratedSurface(WebPage&, Function<void()>&& frameCompleteHandler);
@@ -142,6 +143,8 @@ private:
 #endif
     void frameDone();
     void releaseUnusedBuffersTimerFired();
+
+    bool isOpaque();
 
     class RenderTarget {
         WTF_MAKE_TZONE_ALLOCATED(RenderTarget);
@@ -381,7 +384,8 @@ private:
     RenderTarget* m_target { nullptr };
     bool m_isVisible { false };
     bool m_useExplicitSync { false };
-    std::atomic<bool> m_isOpaque { true };
+    Lock m_backgroundColorLock;
+    WebCore::Color m_backgroundColor WTF_GUARDED_BY_LOCK(m_backgroundColorLock);
     std::unique_ptr<RunLoop::Timer> m_releaseUnusedBuffersTimer;
 #if ENABLE(DAMAGE_TRACKING)
     std::optional<WebCore::Damage> m_frameDamage;


### PR DESCRIPTION
#### 37b89d0c7a9e3068c4d30e2dcddd7b4bde93076d
<pre>
[GTK][WPE][Coordinated Graphics] glClear the viewport with the opaque background color
<a href="https://bugs.webkit.org/show_bug.cgi?id=305560">https://bugs.webkit.org/show_bug.cgi?id=305560</a>

Reviewed by NOBODY (OOPS!).

Coordinated Graphics supports async scrolling. It scrolls even while the main
thread is blocked. If it scrolled to the outside of coverage area, there were
no tiles. It showed rendering glitches for the area without tiles.

If the background color is specified to semi-transparent color, the viewport is
cleared with black transparent. Thus, this problem doesn&apos;t occur. If the
background color was not specified or specified to an opaque color, this
problem occured.

Clear the viewport with the opaque background color.

* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp:
(WebKit::AcceleratedSurface::AcceleratedSurface):
(WebKit::AcceleratedSurface::preferredBufferFormatsDidChange):
(WebKit::AcceleratedSurface::isOpaque):
(WebKit::AcceleratedSurface::backgroundColorDidChange):
(WebKit::AcceleratedSurface::willRenderFrame):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37b89d0c7a9e3068c4d30e2dcddd7b4bde93076d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139190 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11564 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/687 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147317 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92257 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12271 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11714 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106552 "Found 48 new test failures: compositing/transitions/transform-on-large-layer.html fast/forms/range/range-set-value-repaint.html fast/images/async-image-background-image-repeated.html fast/mediastream/video-rotation.html fast/repaint/iframe-from-display-none-repaint.html http/tests/media/media-source/media-source-video-fit-fill.html imported/blink/compositing/layer-creation/incremental-destruction.html imported/blink/compositing/squashing/invalidate-on-grouped-mapping-reorder.html imported/w3c/web-platform-tests/css/css-anchor-position/position-try-switch-from-fixed-anchor.html imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-after-scroll-in-document.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77601 "1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142137 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9279 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124669 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87419 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8826 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6596 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7611 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118278 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150096 "Built successfully") | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11248 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/581 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114941 "Found 19 new test failures: fast/forms/range/range-set-value-repaint.html fast/images/async-image-background-image-repeated.html fast/mediastream/video-rotation.html http/tests/media/media-source/media-source-video-fit-fill.html imported/blink/compositing/squashing/invalidate-on-grouped-mapping-reorder.html imported/mozilla/svg/outer-svg-border-and-padding-01.svg imported/w3c/web-platform-tests/css/css-anchor-position/position-try-switch-from-fixed-anchor.html imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-after-scroll-in-document.html imported/w3c/web-platform-tests/css/css-backgrounds/animations/background-color-animation-will-change-contents.html imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-dynamic-002.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11261 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9512 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115255 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9265 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121019 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66151 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11291 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/546 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11026 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74948 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11229 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11078 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->