### PR TITLE
[GTK] Web process translatable strings are not in system locale

### DIFF
--- a/Source/WebKit/WebProcess/gtk/WebProcessMainGtk.cpp
+++ b/Source/WebKit/WebProcess/gtk/WebProcessMainGtk.cpp
@@ -30,6 +30,7 @@
 #include "AuxiliaryProcessMain.h"
 #include "WebProcess.h"
 #include <libintl.h>
+#include <locale.h>
 
 #if !USE(GTK4) && USE(CAIRO)
 #include <gtk/gtk.h>
@@ -86,6 +87,9 @@ public:
 #if !USE(GTK4) && USE(CAIRO)
         gtk_init(nullptr, nullptr);
 #endif
+
+        if (!setlocale(LC_ALL, ""))
+            g_warning("Locale not supported by C library.\n\tUsing the fallback 'C' locale.");
 
         bindtextdomain(GETTEXT_PACKAGE, LOCALEDIR);
         bind_textdomain_codeset(GETTEXT_PACKAGE, "UTF-8");


### PR DESCRIPTION
#### 83dcbbf140b0cab88e45c32ce4bdb6fe38a2e0ed
<pre>
[GTK] Web process translatable strings are not in system locale
<a href="https://bugs.webkit.org/show_bug.cgi?id=305632">https://bugs.webkit.org/show_bug.cgi?id=305632</a>

Reviewed by Michael Catanzaro.

This is because we no longer call gtk_init() from the web process, that
called setlocale() for us. Now we need to explicit call setlocale() to use
the system locale.

* Source/WebKit/WebProcess/gtk/WebProcessMainGtk.cpp:

Canonical link: <a href="https://commits.webkit.org/305801@main">https://commits.webkit.org/305801@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79ec6d8db4b890c28fe47626e4c924bf10b3eb07

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139189 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11563 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/686 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147316 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92256 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12270 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11713 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106551 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77599 "1 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142136 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9280 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124668 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87418 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8827 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6597 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7610 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118279 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150095 "Built successfully") | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11247 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/580 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114940 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11260 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9513 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115254 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9270 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121018 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66150 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21512 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11290 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/545 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11025 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74947 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11228 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11077 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->