### PR TITLE
Fix DeclarativeNetRequest cross-site redirect issue with Enhanced Security

### DIFF
--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -565,6 +565,8 @@ private:
     const Ref<DocumentPrefetcher> m_documentPrefetcher;
 
     Function<bool()> m_pendingDispatchNavigateEvent;
+
+    bool m_needsCancellationForContentRuleListCrossOriginRedirect { false };
 };
 
 // This function is called by createWindow() in JSDOMWindowBase.cpp, for example, for

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
@@ -42,6 +42,7 @@
 
 - (instancetype)initForExtension:(WKWebExtension *)extension;
 - (instancetype)initForExtension:(WKWebExtension *)extension extensionControllerConfiguration:(WKWebExtensionControllerConfiguration *)configuration;
+- (instancetype)initForExtension:(WKWebExtension *)extension extensionControllerConfiguration:(WKWebExtensionControllerConfiguration *)configuration usesEnhancedSecurity:(BOOL)usesEnhancedSecurity;
 
 @property (nonatomic, strong) WKWebExtension *extension;
 @property (nonatomic, strong) WKWebExtensionContext *context;
@@ -110,7 +111,8 @@
 
 @interface TestWebExtensionWindow : NSObject <WKWebExtensionWindow>
 
-- (instancetype)initWithExtensionController:(WKWebExtensionController *)extensionController usesPrivateBrowsing:(BOOL)usesPrivateBrowsing NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithExtensionController:(WKWebExtensionController *)extensionController usesPrivateBrowsing:(BOOL)usesPrivateBrowsing;
+- (instancetype)initWithExtensionController:(WKWebExtensionController *)extensionController usesPrivateBrowsing:(BOOL)usesPrivateBrowsing usesEnhancedSecurity:(BOOL)usesEnhancedSecurity NS_DESIGNATED_INITIALIZER;
 
 @property (nonatomic, copy) NSArray<TestWebExtensionTab *> *tabs;
 @property (nonatomic, strong) TestWebExtensionTab *activeTab;
@@ -133,6 +135,7 @@
 @property (nonatomic) CGRect screenFrame;
 
 @property (nonatomic, readonly, getter=isUsingPrivateBrowsing) BOOL usingPrivateBrowsing;
+@property (nonatomic, readonly, getter=isUsingEnhancedSecurity) BOOL usingEnhancedSecurity;
 
 @property (nonatomic, copy) void (^didFocus)(void);
 @property (nonatomic, copy) void (^didClose)(void);
@@ -163,8 +166,8 @@ void performWithAppearance(Appearance, void (^block)(void));
 
 #endif
 
-RetainPtr<TestWebExtensionManager> parseExtension(NSDictionary *manifest, NSDictionary *resources, WKWebExtensionControllerConfiguration * = nil);
-RetainPtr<TestWebExtensionManager> loadExtension(NSDictionary *manifest, NSDictionary *resources, WKWebExtensionControllerConfiguration * = nil);
+RetainPtr<TestWebExtensionManager> parseExtension(NSDictionary *manifest, NSDictionary *resources, WKWebExtensionControllerConfiguration * = nil, BOOL usesEnhancedSecurity = NO);
+RetainPtr<TestWebExtensionManager> loadExtension(NSDictionary *manifest, NSDictionary *resources, WKWebExtensionControllerConfiguration * = nil, BOOL usesEnhancedSecurity = NO);
 void loadAndRunExtension(NSDictionary *manifest, NSDictionary *resources, WKWebExtensionControllerConfiguration * = nil);
 
 } // namespace TestWebKitAPI::Util


### PR DESCRIPTION
#### c740257eb4358031c7d049378d9e8cf76ba2408f
<pre>
Fix DeclarativeNetRequest cross-site redirect issue with Enhanced Security
<a href="https://bugs.webkit.org/show_bug.cgi?id=305405">https://bugs.webkit.org/show_bug.cgi?id=305405</a>
<a href="https://rdar.apple.com/168079499">rdar://168079499</a>

Reviewed by Timothy Hatcher.

When enabling the EnhancedSecurityHeuristics flag, the following test began
to fail:

* WKWebExtensionAPIDeclarativeNetRequest.RedirectRule

This test performs a cross-site redirect from localhost -&gt; 127.0.0.1 via
a web extension using the DeclarativeNetRequest API, which is handled
within the WebContent process. When such a redirect occurs, the WebContent
process opts to perform a new load and cancel the existing load.

When Enhanced Security is enabled, this cross-site redirect occurs in the
newly selected Enhanced Security process, which is only alive due to this
provisional load. When the current provisional load is cleared, to perform
the new navigation policy check, the UI process decides that our WebContent
process can be torn down now.

This change handles this case by marking the new FrameLoadRequest as being
related to such a ContentRuleList cross-site redirect. Then, when we clear
the current provisional load and send the DidFailProvisionalLoad message
to the UI process, we can check if this is a Cancellation error, and that
it was due to such a cross-site redirect, and if so, indicate to the UI
process that we will be handling this load failure internally. This is a
similar mechanism to how HTTPS upgrade fallbacks are handled.

Testing this is quite difficult - the only case I&apos;ve managed to reliably
produce this is by using the extension API and having Enhanced Security
enabled. Rather than duplicating this into EnhancedSecurityPolicies, I&apos;ve
added some plumbing that allows us to enable the EnhancedSecurityHeuristics
flag in the TestWebExtensionManager related code, and we now test this
RedirectRule test both with and without EnhancedSecurityHeuristics.

Tests: Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm
       Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
       Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm

* Source/WebCore/loader/FrameLoadRequest.h:
(WebCore::FrameLoadRequestBase::isCrossOriginContentRuleListRedirect const):
(WebCore::FrameLoadRequestBase::setIsCrossOriginContentRuleListRedirect):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::load):
(WebCore::FrameLoader::checkLoadCompleteForThisFrame):
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::requestResource):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm:
(TestWebKitAPI::runRedirectRule):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRule)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRuleWithEnhancedSecurity)):
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h:
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm:
(-[TestWebExtensionManager initForExtension:extensionControllerConfiguration:]):
(-[TestWebExtensionManager initForExtension:extensionControllerConfiguration:usesEnhancedSecurity:]):
(-[TestWebExtensionTab initWithWindow:extensionController:]):
(-[TestWebExtensionWindow initWithExtensionController:usesPrivateBrowsing:]):
(-[TestWebExtensionWindow initWithExtensionController:usesPrivateBrowsing:usesEnhancedSecurity:]):
(TestWebKitAPI::Util::parseExtension):
(TestWebKitAPI::Util::loadExtension):

Canonical link: <a href="https://commits.webkit.org/306005@main">https://commits.webkit.org/306005@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c774ae97288c239c8f66a493467512bd5f85ff6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139865 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12246 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1376 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148007 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92934 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8b40cc2a-187d-49b7-8b13-82e3c6be66ad) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141738 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12956 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12398 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107097 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77951 "2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142815 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9978 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125256 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87976 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7f7357db-44b2-4791-8f74-cdc403ae4b5c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9631 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7141 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8297 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118851 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1258 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150791 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11931 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1324 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115510 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11943 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10219 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115825 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29471 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10611 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121736 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/66936 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11973 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1211 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11713 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75660 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11909 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11761 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->