### PR TITLE
[threaded-animations] REGRESSION: Animations jitter after device rotation on https://codepen.io/utilitybend/full/RwqBymL

### DIFF
--- a/LayoutTests/webanimations/threaded-animations/view-timeline-subject-metrics-change-reflected-on-remote-progress-based-timeline-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/view-timeline-subject-metrics-change-reflected-on-remote-progress-based-timeline-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A remote progress-based timeline is updated when a view timeline's subject changes metrics.
+

--- a/LayoutTests/webanimations/threaded-animations/view-timeline-subject-metrics-change-reflected-on-remote-progress-based-timeline.html
+++ b/LayoutTests/webanimations/threaded-animations/view-timeline-subject-metrics-change-reflected-on-remote-progress-based-timeline.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<body>
+<style>
+
+body {
+    height: 2000px;
+}
+
+.subject {
+    position: absolute;
+    top: calc(100vw - 50px);
+    width: 100px;
+    height: 100px;
+    background-color: black;
+}
+
+</style>
+
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<script src="../../imported/w3c/web-platform-tests/web-animations/testcommon.js"></script>
+<script src="threaded-animations-utils.js"></script>
+
+<script>
+
+const make_subject = t => {
+    const subject = createDiv(t);
+    subject.className = "subject";
+    return subject;
+};
+
+promise_test(async t => {
+    const maxScrollTop = document.documentElement.scrollHeight - window.innerHeight;
+    window.scrollTo(0, maxScrollTop / 2);
+
+    const subject = make_subject(t);
+    const timeline = new ViewTimeline({ subject });
+    const animation = subject.animate({ translate: '100px' }, { timeline });
+    await animationAcceleration(animation);
+    const initialTimeline = await UIHelper.remoteTimeline(timeline);
+    assert_not_equals(initialTimeline, undefined, "Remote timeline was created.");
+
+    subject.style.height = "200px";
+    await threadedAnimationsCommit();
+    const updatedTimeline = await UIHelper.remoteTimeline(timeline);
+    assert_not_equals(updatedTimeline.currentTime, initialTimeline.currentTime, "Changing a timeline's subject size changes the remote timeline's current time.");
+}, "A remote progress-based timeline is updated when a view timeline's subject changes metrics.");
+
+</script>
+</body>

--- a/Source/WebCore/animation/ScrollTimeline.cpp
+++ b/Source/WebCore/animation/ScrollTimeline.cpp
@@ -420,8 +420,8 @@ bool ScrollTimeline::computeCanBeAccelerated() const
 
 void ScrollTimeline::scheduleAcceleratedRepresentationUpdate()
 {
-    if (auto source = m_source.styleable()) {
-        if (RefPtr page = source->element.protectedDocument()->page()) {
+    if (RefPtr source = this->source()) {
+        if (RefPtr page = source->protectedDocument()->page()) {
             if (auto* acceleratedTimelinesUpdater = page->acceleratedTimelinesUpdater())
                 acceleratedTimelinesUpdater->scrollTimelineDidChange(*this);
         }


### PR DESCRIPTION
#### f9a893b0dbefc3ebdf27746ab6629ae650e73885
<pre>
[threaded-animations] REGRESSION: Animations jitter after device rotation on <a href="https://codepen.io/utilitybend/full/RwqBymL">https://codepen.io/utilitybend/full/RwqBymL</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=305642">https://bugs.webkit.org/show_bug.cgi?id=305642</a>
<a href="https://rdar.apple.com/167043842">rdar://167043842</a>

Reviewed by Anne van Kesteren.

In the demo <a href="https://codepen.io/utilitybend/full/RwqBymL">https://codepen.io/utilitybend/full/RwqBymL</a>, elements use a view timeline to run animated effects as the user
scrolls. However, when the demo is viewed on an iPad and the device is rotated, there are all kinds of odd artifacts. This
is due to the view timeline&apos;s remote counterpart in the remote layer tree not being updated as the demo&apos;s layout changes
upon rotation.

We have a system in place to detect when a scroll timeline or view timeline has its source or subject element change metrics,
which among other things will update the resolution data held by that timeline&apos;s remote counterpart. However, the remote update
only worked for scroll timelines and failed for view timelines. Indeed, in `ScrollTimeline::scheduleAcceleratedRepresentationUpdate()`
we would go through `ScrollTimeline::m_source` to access the document associated with that timeline, but view timelines will not
have a source explicitly set, but only a subject, which is used to compute the source.

All we need to do is to call `ScrollTimeline::source()` which will return the computed source for both scroll and view timelines.

We add a new test to check this works indeed.

Test: webanimations/threaded-animations/view-timeline-subject-metrics-change-reflected-on-remote-progress-based-timeline.html

* LayoutTests/webanimations/threaded-animations/view-timeline-subject-metrics-change-reflected-on-remote-progress-based-timeline-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/view-timeline-subject-metrics-change-reflected-on-remote-progress-based-timeline.html: Added.
* Source/WebCore/animation/ScrollTimeline.cpp:
(WebCore::ScrollTimeline::scheduleAcceleratedRepresentationUpdate):

Canonical link: <a href="https://commits.webkit.org/305721@main">https://commits.webkit.org/305721@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ccfd300d7500d7330dc604a109c9f7aa14d24d83

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139231 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11607 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/733 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147358 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141104 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12314 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11757 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/106591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142178 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/9321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/124715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/87451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/8871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/6639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7655 "Failed to checkout and rebase branch from PR 56711") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/118327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150140 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11291 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/114984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11304 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/9557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/115289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/9354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/121060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/66209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21466 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11334 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11068 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/75000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11271 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11121 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->