### PR TITLE
[WebXR] The viewer space must be a reference space

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXRSession.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSession.cpp
@@ -76,7 +76,7 @@ WebXRSession::WebXRSession(Document& document, WebXRSystem& system, XRSessionMod
     , m_device(device)
     , m_requestedFeatures(WTF::move(requestedFeatures))
     , m_activeRenderState(WebXRRenderState::create(mode))
-    , m_viewerReferenceSpace(WebXRViewerSpace::create(document, *this))
+    , m_viewerReferenceSpace(WebXRReferenceSpace::create(document, *this, XRReferenceSpaceType::Viewer))
     , m_timeOrigin(MonotonicTime::now())
     , m_views(device.views(mode))
 {

--- a/Source/WebCore/Modules/webxr/WebXRSession.h
+++ b/Source/WebCore/Modules/webxr/WebXRSession.h
@@ -54,7 +54,7 @@ class XRFrameRequestCallback;
 class WebCoreOpaqueRoot;
 class WebXRSystem;
 class WebXRView;
-class WebXRViewerSpace;
+class WebXRReferenceSpace;
 struct XRCanvasConfiguration;
 struct XRRenderStateInit;
 
@@ -114,7 +114,7 @@ public:
 
     const Vector<PlatformXR::Device::ViewData>& views() const { return m_views; }
     const PlatformXR::FrameData& frameData() const { return m_frameData; }
-    const WebXRViewerSpace& viewerReferenceSpace() const { return m_viewerReferenceSpace; }
+    const WebXRReferenceSpace& viewerReferenceSpace() const { return m_viewerReferenceSpace; }
     bool posesCanBeReported(const Document&) const;
     
 #if ENABLE(WEBXR_HANDS)
@@ -174,7 +174,7 @@ private:
     FeatureList m_requestedFeatures;
     RefPtr<WebXRRenderState> m_activeRenderState;
     RefPtr<WebXRRenderState> m_pendingRenderState;
-    const Ref<WebXRViewerSpace> m_viewerReferenceSpace;
+    const Ref<WebXRReferenceSpace> m_viewerReferenceSpace;
     MonotonicTime m_timeOrigin;
 
     unsigned m_nextCallbackId { 1 };

--- a/Source/WebCore/Modules/webxr/WebXRSpace.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSpace.cpp
@@ -72,24 +72,6 @@ ScriptExecutionContext* WebXRSpace::scriptExecutionContext() const
     return ContextDestructionObserver::scriptExecutionContext();
 }
 
-WTF_MAKE_TZONE_ALLOCATED_IMPL(WebXRViewerSpace);
-
-WebXRViewerSpace::WebXRViewerSpace(Document& document, WebXRSession& session)
-    : WebXRSpace(document, WebXRRigidTransform::create())
-    , m_session(session)
-{
-}
-
-WebXRViewerSpace::~WebXRViewerSpace() = default;
-
-std::optional<TransformationMatrix> WebXRViewerSpace::nativeOrigin() const
-{
-    if (!m_session)
-        return std::nullopt;
-    return WebXRFrame::matrixFromPose(m_session->frameData().origin);
-}
-
-
 } // namespace WebCore
 
 #endif // ENABLE(WEBXR)

--- a/Source/WebCore/Modules/webxr/WebXRSpace.h
+++ b/Source/WebCore/Modules/webxr/WebXRSpace.h
@@ -78,34 +78,6 @@ private:
     const Ref<WebXRRigidTransform> m_originOffset;
 };
 
-// https://immersive-web.github.io/webxr/#xrsession-viewer-reference-space
-// This is a helper class to implement the viewer space owned by a WebXRSession.
-// It avoids a circular reference between the session and the reference space.
-class WebXRViewerSpace : public RefCounted<WebXRViewerSpace>, public WebXRSpace {
-    WTF_MAKE_TZONE_ALLOCATED(WebXRViewerSpace);
-public:
-    static Ref< WebXRViewerSpace> create(Document& document, WebXRSession& session)
-    {
-        return adoptRef(*new WebXRViewerSpace(document, session));
-    }
-    virtual ~WebXRViewerSpace();
-
-    // ContextDestructionObserver.
-    void ref() const final { RefCounted::ref(); }
-    void deref() const final { RefCounted::deref(); }
-
-private:
-    WebXRViewerSpace(Document&, WebXRSession&);
-
-    WebXRSession* session() const final { return m_session.get(); }
-    std::optional<TransformationMatrix> nativeOrigin() const final;
-
-    void refEventTarget() final { ref(); }
-    void derefEventTarget() final { deref(); }
-
-    WeakPtr<WebXRSession> m_session;
-};
-
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_EVENTTARGET(WebXRSpace)


### PR DESCRIPTION
#### c413077ad66c79d54adcc9996656a3336d46dea7
<pre>
[WebXR] The viewer space must be a reference space
<a href="https://bugs.webkit.org/show_bug.cgi?id=305644">https://bugs.webkit.org/show_bug.cgi?id=305644</a>

Reviewed by Dan Glastonbury.

The current code defines the viewer space as a XRSpace. However the
specs clearly state that it must be a reference space, see
<a href="https://immersive-web.github.io/webxr/#xrsession-viewer-reference-space.">https://immersive-web.github.io/webxr/#xrsession-viewer-reference-space.</a>

There is no need to create a new class, we can just create a reference
space with viewer type. There are no circular dependencies either
because the space just holds a weak pointer to the session.

No new tests required, there is already coverage for the viewer
reference space, we&apos;re just replacing the class that will represent it.

* Source/WebCore/Modules/webxr/WebXRSession.cpp:
(WebCore::WebXRSession::WebXRSession):
* Source/WebCore/Modules/webxr/WebXRSession.h:
* Source/WebCore/Modules/webxr/WebXRSpace.cpp:
(WebCore::WebXRViewerSpace::WebXRViewerSpace): Deleted.
(WebCore::WebXRViewerSpace::nativeOrigin const): Deleted.
* Source/WebCore/Modules/webxr/WebXRSpace.h:
(WebCore::WebXRViewerSpace::create): Deleted.

Canonical link: <a href="https://commits.webkit.org/305805@main">https://commits.webkit.org/305805@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b559c926442615e2432a36dc24eeef8ea2599ff0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139213 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11587 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/717 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147340 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92280 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141085 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12295 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11737 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106576 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77609 "1 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142160 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9306 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124698 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87436 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8857 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6621 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7634 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118312 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/594 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150119 "Built successfully") | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11272 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/612 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114968 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11284 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9539 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115273 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29336 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9317 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121041 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66188 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11314 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/573 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11049 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74982 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11252 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11102 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->