### PR TITLE
Remove the `ImageAnimationControlEnabled` feature flag

### DIFF
--- a/LayoutTests/fast/images/animations-resume-from-last-displayed-frame.html
+++ b/LayoutTests/fast/images/animations-resume-from-last-displayed-frame.html
@@ -59,7 +59,6 @@
             internals.clearMemoryCache();
             internals.settings.setWebkitImageReadyEventEnabled(true);
             internals.settings.setAnimatedImageAsyncDecodingEnabled(true);
-            internals.settings.setImageAnimationControlEnabled(true);
             internals.setImageAnimationEnabled(false);
         }
 

--- a/LayoutTests/fast/images/individual-animation-toggle.html
+++ b/LayoutTests/fast/images/individual-animation-toggle.html
@@ -28,7 +28,6 @@ var gif = document.getElementById("gif");
 window.onload = async function() {
     if (!window.internals)
         return;
-    internals.settings.setImageAnimationControlEnabled(true);
 
     debug("Pausing animations page-wide.");
     internals.setImageAnimationEnabled(false);
@@ -47,7 +46,6 @@ window.onload = async function() {
     await shouldBecomeEqual("internals.isImageAnimating(gif)", "true");
 
     internals.setImageAnimationEnabled(true);
-    internals.settings.setImageAnimationControlEnabled(false);
 
     internals.clearMemoryCache();
     finishJSTest();

--- a/LayoutTests/fast/images/mac/animation-context-menu-items-presence.html
+++ b/LayoutTests/fast/images/mac/animation-context-menu-items-presence.html
@@ -21,7 +21,6 @@ window.addEventListener("load", () => {
   window.jsTestIsAsync = true;
   if (!window.internals)
     return;
-  internals.settings.setImageAnimationControlEnabled(true);
 
   eventSender.mouseMoveTo(1, 1);
   eventSender.contextClick().filter(item => item.title).forEach((item) => {
@@ -30,7 +29,6 @@ window.addEventListener("load", () => {
       debug(`FAIL: Unexpected context menu item ${item.title}.`);
   });
 
-  internals.settings.setImageAnimationControlEnabled(false);
   internals.clearMemoryCache();
   finishJSTest();
 });

--- a/LayoutTests/fast/images/mac/play-all-pause-all-animations-context-menu-items.html
+++ b/LayoutTests/fast/images/mac/play-all-pause-all-animations-context-menu-items.html
@@ -22,7 +22,6 @@ window.addEventListener("load", () => {
   window.jsTestIsAsync = true;
   if (!window.internals)
     return;
-  internals.settings.setImageAnimationControlEnabled(true);
   internals.settings.setAllowAnimationControlsOverride(true);
 
   shouldBecomeEqual("internals.isImageAnimating(img)", "true", () => {
@@ -36,7 +35,6 @@ window.addEventListener("load", () => {
       internals.settings.setAllowAnimationControlsOverride(false);
 
       shouldBecomeEqual("internals.isImageAnimating(img)", "true", () => {
-        internals.settings.setImageAnimationControlEnabled(false);
         internals.clearMemoryCache();
         finishJSTest();
       });

--- a/LayoutTests/fast/images/mac/play-pause-individual-animation-context-menu-items.html
+++ b/LayoutTests/fast/images/mac/play-pause-individual-animation-context-menu-items.html
@@ -24,7 +24,6 @@ window.addEventListener("load", () => {
   window.jsTestIsAsync = true;
   if (!window.internals)
     return;
-  internals.settings.setImageAnimationControlEnabled(true);
   internals.settings.setAllowAnimationControlsOverride(true);
 
   // Verify initial animation play-state.
@@ -46,7 +45,6 @@ window.addEventListener("load", () => {
     await shouldBecomeEqual("internals.isImageAnimating(png)", "true");
 
     internals.settings.setAllowAnimationControlsOverride(false);
-    internals.settings.setImageAnimationControlEnabled(false);
     internals.clearMemoryCache();
     finishJSTest();
   });

--- a/LayoutTests/fast/images/page-wide-animation-toggle.html
+++ b/LayoutTests/fast/images/page-wide-animation-toggle.html
@@ -16,7 +16,6 @@ var image = document.getElementById("img");
 window.onload = async function() {
     if (!window.internals)
         return;
-    internals.settings.setImageAnimationControlEnabled(true);
 
     debug("Pausing page-wide animation.");
     internals.setImageAnimationEnabled(false);
@@ -34,7 +33,6 @@ window.onload = async function() {
     internals.setImageAnimationEnabled(true);
     await shouldBecomeEqual("internals.isImageAnimating(image)", "true");
 
-    internals.settings.setImageAnimationControlEnabled(false);
     internals.clearMemoryCache();
     finishJSTest();
 };

--- a/LayoutTests/fast/images/pagewide-play-pause-animateTransform-svg-animation.html
+++ b/LayoutTests/fast/images/pagewide-play-pause-animateTransform-svg-animation.html
@@ -28,7 +28,6 @@ window.onload = function() {
   if (!window.internals)
     return;
   debug("Disabling animations.");
-  window.internals.settings.setImageAnimationControlEnabled(true);
   window.internals.setImageAnimationEnabled(false);
 
   svgElement = document.getElementById("svg");

--- a/LayoutTests/fast/images/pagewide-play-pause-offscreen-animations.html
+++ b/LayoutTests/fast/images/pagewide-play-pause-offscreen-animations.html
@@ -50,7 +50,6 @@ window.jsTestIsAsync = true;
 window.onload = function() {
   if (!window.internals)
     return;
-  internals.settings.setImageAnimationControlEnabled(true);
 
   setTimeout(async () => {
     testOutput += "Verifying animations are initially playing.\n\n";
@@ -65,7 +64,6 @@ window.onload = function() {
     // Wait for the page to update.
     await new Promise(resolve => setTimeout(resolve, 10));
     internals.setImageAnimationEnabled(true);
-    internals.settings.setImageAnimationControlEnabled(false);
     await verifyAnimationsArePaused(true);
 
     testOutput += "Scrolling to make animations visible again. They should resume automatically because page-wide animation is enabled.\n\n";

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3655,21 +3655,6 @@ ImageAnalysisDuringFindInPageEnabled:
     WebCore:
       default: false
 
-ImageAnimationControlEnabled:
-  type: bool
-  status: stable
-  category: animation
-  humanReadableName: "Image Animation Control"
-  humanReadableDescription: "Enable controls for image animations"
-  condition: ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
-
 ImageCaptureEnabled:
   type: bool
   status: stable

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -862,9 +862,6 @@ bool HTMLImageElement::allowsAnimation() const
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
 void HTMLImageElement::setAllowsAnimation(std::optional<bool> allowsAnimation)
 {
-    if (!document().settings().imageAnimationControlEnabled())
-        return;
-
     if (RefPtr image = this->image()) {
         image->setAllowsAnimation(allowsAnimation);
         if (CheckedPtr renderer = this->renderer())

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -1069,7 +1069,7 @@ void ContextMenuController::populate()
 
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
     auto canAddAnimationControls = [&] () -> bool {
-        if (!frame->page() || !frame->page()->settings().imageAnimationControlEnabled())
+        if (!frame->page())
             return false;
 
         return Image::systemAllowsAnimationControls() || frame->page()->settings().allowAnimationControlsOverride();

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2674,9 +2674,6 @@ bool Page::shouldUpdateAccessibilityRegions() const
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
 void Page::setImageAnimationEnabled(bool enabled)
 {
-    if (!settings().imageAnimationControlEnabled())
-        return;
-
     // This method overrides any individually set animation play-states (so we need to do work even if `enabled` is
     // already equal to `m_imageAnimationEnabled` because there may be individually playing or paused images).
     m_imageAnimationEnabled = enabled;

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1207,9 +1207,6 @@ bool Internals::isImageAnimating(HTMLImageElement& element)
 void Internals::setImageAnimationEnabled(bool enabled)
 {
     if (auto* page = contextDocument() ? contextDocument()->page() : nullptr) {
-        if (!page->settings().imageAnimationControlEnabled())
-            return;
-
         // We need to set this here to mimic the behavior of the AX preference changing
         Image::setSystemAllowsAnimationControls(!enabled);
         page->setImageAnimationEnabled(enabled);

--- a/Source/WebKit/Shared/ios/InteractionInformationAtPosition.h
+++ b/Source/WebKit/Shared/ios/InteractionInformationAtPosition.h
@@ -63,7 +63,7 @@ struct InteractionInformationAtPosition {
 #if ENABLE(MODEL_PROCESS)
         bool isInteractiveModel,
 #endif
-        bool isAttachment, bool isAnimatedImage, bool isAnimating, bool canShowAnimationControls, bool isPausedVideo, bool isElement, bool isContentEditable, Markable<WebCore::ScrollingNodeID>&& containerScrollingNodeID,
+        bool isAttachment, bool isAnimatedImage, bool isAnimating, bool isPausedVideo, bool isElement, bool isContentEditable, Markable<WebCore::ScrollingNodeID>&& containerScrollingNodeID,
 #if ENABLE(DATA_DETECTION)
         bool isDataDetectorLink,
 #endif
@@ -103,7 +103,6 @@ struct InteractionInformationAtPosition {
     bool isAttachment { false };
     bool isAnimatedImage { false };
     bool isAnimating { false };
-    bool canShowAnimationControls { false };
     bool isPausedVideo { false };
     bool isElement { false };
     bool isContentEditable { false };

--- a/Source/WebKit/Shared/ios/InteractionInformationAtPosition.mm
+++ b/Source/WebKit/Shared/ios/InteractionInformationAtPosition.mm
@@ -38,7 +38,7 @@ InteractionInformationAtPosition::InteractionInformationAtPosition(InteractionIn
 #if ENABLE(MODEL_PROCESS)
     bool isInteractiveModel,
 #endif
-    bool isAttachment, bool isAnimatedImage, bool isAnimating, bool canShowAnimationControls, bool isPausedVideo, bool isElement, bool isContentEditable, Markable<WebCore::ScrollingNodeID>&& containerScrollingNodeID,
+    bool isAttachment, bool isAnimatedImage, bool isAnimating, bool isPausedVideo, bool isElement, bool isContentEditable, Markable<WebCore::ScrollingNodeID>&& containerScrollingNodeID,
 #if ENABLE(DATA_DETECTION)
     bool isDataDetectorLink,
 #endif
@@ -74,7 +74,6 @@ InteractionInformationAtPosition::InteractionInformationAtPosition(InteractionIn
         , isAttachment(isAttachment)
         , isAnimatedImage(isAnimatedImage)
         , isAnimating(isAnimating)
-        , canShowAnimationControls(canShowAnimationControls)
         , isPausedVideo(isPausedVideo)
         , isElement(isElement)
         , isContentEditable(isContentEditable)

--- a/Source/WebKit/Shared/ios/InteractionInformationAtPosition.serialization.in
+++ b/Source/WebKit/Shared/ios/InteractionInformationAtPosition.serialization.in
@@ -49,7 +49,6 @@ struct WebKit::InteractionInformationAtPosition {
     bool isAttachment;
     bool isAnimatedImage;
     bool isAnimating;
-    bool canShowAnimationControls;
     bool isPausedVideo;
     bool isElement;
     bool isContentEditable;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKActivatedElementInfo.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKActivatedElementInfo.h
@@ -53,7 +53,6 @@ WK_CLASS_AVAILABLE(macos(10.10), ios(8.0))
 #endif // defined(TARGET_OS_VISION) && TARGET_OS_VISION & __VISION_OS_VERSION_MIN_REQUIRED >= 20000
 #if TARGET_OS_IPHONE
 @property (nonatomic, readonly) BOOL isAnimating;
-@property (nonatomic, readonly) BOOL canShowAnimationControls;
 @property (nonatomic, readonly) NSDictionary *userInfo WK_API_AVAILABLE(ios(11.0));
 @property (nonatomic, readonly, copy) UIImage *image;
 #else

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKActivatedElementInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKActivatedElementInfo.mm
@@ -48,7 +48,6 @@
 #if PLATFORM(IOS_FAMILY)
     RetainPtr<NSDictionary> _userInfo;
     BOOL _isAnimating;
-    BOOL _canShowAnimationControls;
     Vector<WebCore::ElementAnimationContext> _animationsUnderElement;
 #endif
     BOOL _animatedImage;
@@ -90,7 +89,6 @@
     _ID = information.idAttribute.createNSString().get();
     _animatedImage = information.isAnimatedImage;
     _isAnimating = information.isAnimating;
-    _canShowAnimationControls = information.canShowAnimationControls;
     _isImage = information.isImage;
     _isUsingAlternateURLForImage = isUsingAlternateURLForImage;
 #if ENABLE(SPATIAL_IMAGE_DETECTION)
@@ -137,11 +135,11 @@
     Vector<WebCore::ElementAnimationContext> animationsAtPoint;
 #endif
 
-    return [self _initWithType:type URL:url imageURL:imageURL location:information.request.point title:information.title.createNSString().get() ID:information.idAttribute.createNSString().get() rect:information.bounds image:image imageMIMEType:information.imageMIMEType.createNSString().get() isAnimatedImage:information.isAnimatedImage isAnimating:information.isAnimating canShowAnimationControls:information.canShowAnimationControls animationsUnderElement:animationsAtPoint userInfo:userInfo];
+    return [self _initWithType:type URL:url imageURL:imageURL location:information.request.point title:information.title.createNSString().get() ID:information.idAttribute.createNSString().get() rect:information.bounds image:image imageMIMEType:information.imageMIMEType.createNSString().get() isAnimatedImage:information.isAnimatedImage isAnimating:information.isAnimating animationsUnderElement:animationsAtPoint userInfo:userInfo];
 }
 #endif // PLATFORM(IOS_FAMILY)
 
-- (instancetype)_initWithType:(_WKActivatedElementType)type URL:(NSURL *)url imageURL:(NSURL *)imageURL location:(const WebCore::IntPoint&)location title:(NSString *)title ID:(NSString *)ID rect:(CGRect)rect image:(WebCore::ShareableBitmap*)image imageMIMEType:(NSString *)imageMIMEType isAnimatedImage:(BOOL)isAnimatedImage isAnimating:(BOOL)isAnimating canShowAnimationControls:(BOOL)canShowAnimationControls animationsUnderElement:(Vector<WebCore::ElementAnimationContext>)animationsUnderElement userInfo:(NSDictionary *)userInfo
+- (instancetype)_initWithType:(_WKActivatedElementType)type URL:(NSURL *)url imageURL:(NSURL *)imageURL location:(const WebCore::IntPoint&)location title:(NSString *)title ID:(NSString *)ID rect:(CGRect)rect image:(WebCore::ShareableBitmap*)image imageMIMEType:(NSString *)imageMIMEType isAnimatedImage:(BOOL)isAnimatedImage isAnimating:(BOOL)isAnimating animationsUnderElement:(Vector<WebCore::ElementAnimationContext>)animationsUnderElement userInfo:(NSDictionary *)userInfo
 {
     if (!(self = [super init]))
         return nil;
@@ -158,7 +156,6 @@
 #if PLATFORM(IOS_FAMILY)
     _userInfo = adoptNS([userInfo copy]);
     _isAnimating = isAnimating;
-    _canShowAnimationControls = canShowAnimationControls;
     _animationsUnderElement = animationsUnderElement;
 #endif
     _animatedImage = isAnimatedImage;
@@ -217,11 +214,6 @@
 - (BOOL)isAnimating
 {
     return _isAnimating;
-}
-
-- (BOOL)canShowAnimationControls
-{
-    return _canShowAnimationControls;
 }
 
 - (const Vector<WebCore::ElementAnimationContext>&)_animationsUnderElement

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKActivatedElementInfoInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKActivatedElementInfoInternal.h
@@ -44,7 +44,7 @@ class ShareableBitmap;
 - (instancetype)_initWithType:(_WKActivatedElementType)type URL:(NSURL *)url imageURL:(NSURL *)imageURL information:(const WebKit::InteractionInformationAtPosition&)information;
 - (instancetype)_initWithType:(_WKActivatedElementType)type URL:(NSURL *)url image:(WebCore::ShareableBitmap*)image information:(const WebKit::InteractionInformationAtPosition&)information;
 - (instancetype)_initWithType:(_WKActivatedElementType)type URL:(NSURL *)url imageURL:(NSURL *)imageURL userInfo:(NSDictionary *)userInfo information:(const WebKit::InteractionInformationAtPosition&)information;
-- (instancetype)_initWithType:(_WKActivatedElementType)type URL:(NSURL *)url imageURL:(NSURL *)imageURL location:(const WebCore::IntPoint&)location title:(NSString *)title ID:(NSString *)ID rect:(CGRect)rect image:(WebCore::ShareableBitmap*)image imageMIMEType:(NSString *)imageMIMEType isAnimatedImage:(BOOL)isAnimatedImage isAnimating:(BOOL)isAnimating canShowAnimationControls:(BOOL)canShowAnimationControls animationsUnderElement:(Vector<WebCore::ElementAnimationContext>)animationsUnderElement userInfo:(NSDictionary *)userInfo;
+- (instancetype)_initWithType:(_WKActivatedElementType)type URL:(NSURL *)url imageURL:(NSURL *)imageURL location:(const WebCore::IntPoint&)location title:(NSString *)title ID:(NSString *)ID rect:(CGRect)rect image:(WebCore::ShareableBitmap*)image imageMIMEType:(NSString *)imageMIMEType isAnimatedImage:(BOOL)isAnimatedImage isAnimating:(BOOL)isAnimating animationsUnderElement:(Vector<WebCore::ElementAnimationContext>)animationsUnderElement userInfo:(NSDictionary *)userInfo;
 #endif // PLATFORM(IOS_FAMILY)
 
 @property (nonatomic, readonly) NSString *imageMIMEType;

--- a/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm
+++ b/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm
@@ -549,7 +549,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 {
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
     BOOL hasAnimation = elementInfo.isAnimatedImage || !elementInfo._animationsUnderElement.isEmpty();
-    if (!hasAnimation || !elementInfo.canShowAnimationControls)
+    if (!hasAnimation)
         return;
 
     if (![_delegate respondsToSelector:@selector(_allowAnimationControls)] || ![_delegate _allowAnimationControls])

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -8942,8 +8942,6 @@ void WebPage::synchronizeCORSDisablingPatternsWithNetworkProcess()
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
 void WebPage::isAnyAnimationAllowedToPlayDidChange(bool anyAnimationCanPlay)
 {
-    if (!m_page->settings().imageAnimationControlEnabled())
-        return;
     send(Messages::WebPageProxy::IsAnyAnimationAllowedToPlayDidChange(anyAnimationCanPlay));
 }
 #endif

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -3900,7 +3900,6 @@ static CursorContext cursorContext(const HitTestResult& hitTestResult, const Int
 static void animationPositionInformation(WebPage& page, const InteractionInformationRequest& request, const HitTestResult& hitTestResult, InteractionInformationAtPosition& info)
 {
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
-    info.canShowAnimationControls = page.corePage() && page.corePage()->settings().imageAnimationControlEnabled();
     if (!request.gatherAnimations)
         return;
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/AnimationControl.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/AnimationControl.mm
@@ -50,7 +50,6 @@ TEST(WebKit, PlayAllPauseAllAnimationSupport)
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration addToWindow:YES]);
 
     [webView synchronouslyLoadHTMLString:@"<img id='imgOne' src='test-mse.mp4'><img id='imgTwo' src='test-without-audio-track.mp4'>"];
-    [webView stringByEvaluatingJavaScript:@"window.internals.settings.setImageAnimationControlEnabled(true)"];
 
     // Wait for the animations to become paused (explicitly exercising the completionHandler).
     static bool isDone = false;
@@ -76,7 +75,6 @@ TEST(WebKit, IsAnyAnimationAllowedToPlayBehaviorWithIndividualAnimationControl)
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration addToWindow:YES]);
 
     [webView synchronouslyLoadHTMLString:@"<img id='imgOne' src='test-mse.mp4'><img id='imgTwo' src='test-without-audio-track.mp4'>"];
-    [webView stringByEvaluatingJavaScript:@"window.internals.settings.setImageAnimationControlEnabled(true)"];
     [webView stringByEvaluatingJavaScript:@"window.internals.setImageAnimationEnabled(false)"];
 
     while (isAnimating(@"imgOne", webView) || isAnimating(@"imgTwo", webView))

--- a/Tools/TestWebKitAPI/Tests/ios/ActionSheetTests.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/ActionSheetTests.mm
@@ -423,7 +423,6 @@ static void playPauseAnimationTest(NSString *testFilename)
     auto observer = adoptNS([[ActionSheetObserver alloc] init]);
     [webView setUIDelegate:observer.get()];
     [webView synchronouslyLoadTestPageNamed:testFilename];
-    [webView stringByEvaluatingJavaScript:@"window.internals.settings.setImageAnimationControlEnabled(true)"];
     // Pause animations globally to establish a known state.
     [webView stringByEvaluatingJavaScript:@"window.internals.setImageAnimationEnabled(false)"];
 
@@ -457,7 +456,6 @@ TEST(ActionSheetTests, PlayPauseAnimationSheetActionsNotPresentByDefault)
     auto observer = adoptNS([[ActionSheetObserver alloc] init]);
     [webView setUIDelegate:observer.get()];
     [webView synchronouslyLoadTestPageNamed:@"img-animation-in-anchor"];
-    [webView stringByEvaluatingJavaScript:@"window.internals.settings.setImageAnimationControlEnabled(true)"];
 
     __block bool done = false;
     [observer setPresentationHandler:^(_WKActivatedElementInfo *element, NSArray *actions) {


### PR DESCRIPTION
#### af855a40ed3d9bd4469f9577d1a5df6c11167860
<pre>
Remove the `ImageAnimationControlEnabled` feature flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=305648">https://bugs.webkit.org/show_bug.cgi?id=305648</a>

Reviewed by Tyler Wilcock.

Canonical link: <a href="https://commits.webkit.org/306024@main">https://commits.webkit.org/306024@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd689a80f0aad13f1348c6ef2e007aea11f76c76

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140113 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12493 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1623 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148263 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/93189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141985 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13205 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12646 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107268 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/93189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143062 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10161 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125456 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88160 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9809 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7340 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8544 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/132086 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119034 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1463 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151050 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/909 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12180 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1531 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115695 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12193 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10434 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116020 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10974 "Passed tests") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121938 "Exiting early after 10 failures. 285 tests run. 1 flakes") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/67189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21630 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12221 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1414 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/171385 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11963 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75919 "Built successfully") | [⏳ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12158 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12008 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->