### PR TITLE
[threaded-animations] REGRESSION: scrolling https://scroll-driven-animations.style/ makes content disappear on iPad

### DIFF
--- a/LayoutTests/compositing/layer-creation/implicit-keyframes-animation-overlap-expected.txt
+++ b/LayoutTests/compositing/layer-creation/implicit-keyframes-animation-overlap-expected.txt
@@ -1,0 +1,2165 @@
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 430
+        (GraphicsLayer
+          (offsetFromRenderer width=-14 height=-14)
+          (position 34.00 66.00)
+          (anchor 0.06 0.89)
+          (bounds 228.00 128.00)
+          (drawsContent 1)
+        )
+        (GraphicsLayer
+          (position 40.00 70.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 50.00 70.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 60.00 70.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 70.00 70.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 80.00 70.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 90.00 70.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 100.00 70.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 110.00 70.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 120.00 70.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 130.00 70.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 140.00 70.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 150.00 70.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 160.00 70.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 170.00 70.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 180.00 70.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 190.00 70.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 200.00 70.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 210.00 70.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 220.00 70.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 230.00 70.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 240.00 70.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 250.00 70.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 260.00 70.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 270.00 70.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 280.00 70.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 290.00 70.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 300.00 70.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 310.00 70.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 320.00 70.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 330.00 70.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 340.00 70.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 350.00 70.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 360.00 70.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 40.00 80.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 50.00 80.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 60.00 80.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 70.00 80.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 80.00 80.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 90.00 80.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 100.00 80.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 110.00 80.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 120.00 80.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 130.00 80.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 140.00 80.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 150.00 80.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 160.00 80.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 170.00 80.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 180.00 80.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 190.00 80.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 200.00 80.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 210.00 80.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 220.00 80.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 230.00 80.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 240.00 80.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 250.00 80.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 260.00 80.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 270.00 80.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 280.00 80.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 290.00 80.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 300.00 80.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 310.00 80.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 320.00 80.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 330.00 80.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 340.00 80.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 350.00 80.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 360.00 80.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 40.00 90.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 50.00 90.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 60.00 90.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 70.00 90.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 80.00 90.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 90.00 90.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 100.00 90.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 110.00 90.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 120.00 90.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 130.00 90.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 140.00 90.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 150.00 90.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 160.00 90.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 170.00 90.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 180.00 90.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 190.00 90.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 200.00 90.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 210.00 90.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 220.00 90.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 230.00 90.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 240.00 90.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 250.00 90.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 260.00 90.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 270.00 90.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 280.00 90.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 290.00 90.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 300.00 90.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 310.00 90.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 320.00 90.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 330.00 90.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 340.00 90.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 350.00 90.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 360.00 90.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 40.00 100.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 50.00 100.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 60.00 100.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 70.00 100.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 80.00 100.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 90.00 100.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 100.00 100.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 110.00 100.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 120.00 100.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 130.00 100.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 140.00 100.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 150.00 100.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 160.00 100.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 170.00 100.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 180.00 100.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 190.00 100.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 200.00 100.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 210.00 100.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 220.00 100.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 230.00 100.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 240.00 100.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 250.00 100.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 260.00 100.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 270.00 100.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 280.00 100.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 290.00 100.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 300.00 100.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 310.00 100.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 320.00 100.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 330.00 100.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 340.00 100.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 350.00 100.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 360.00 100.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 40.00 110.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 50.00 110.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 60.00 110.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 70.00 110.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 80.00 110.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 90.00 110.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 100.00 110.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 110.00 110.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 120.00 110.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 130.00 110.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 140.00 110.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 150.00 110.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 160.00 110.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 170.00 110.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 180.00 110.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 190.00 110.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 200.00 110.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 210.00 110.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 220.00 110.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 230.00 110.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 240.00 110.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 250.00 110.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 260.00 110.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 270.00 110.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 280.00 110.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 290.00 110.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 300.00 110.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 310.00 110.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 320.00 110.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 330.00 110.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 340.00 110.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 350.00 110.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 360.00 110.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 40.00 120.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 50.00 120.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 60.00 120.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 70.00 120.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 80.00 120.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 90.00 120.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 100.00 120.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 110.00 120.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 120.00 120.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 130.00 120.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 140.00 120.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 150.00 120.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 160.00 120.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 170.00 120.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 180.00 120.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 190.00 120.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 200.00 120.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 210.00 120.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 220.00 120.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 230.00 120.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 240.00 120.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 250.00 120.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 260.00 120.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 270.00 120.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 280.00 120.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 290.00 120.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 300.00 120.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 310.00 120.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 320.00 120.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 330.00 120.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 340.00 120.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 350.00 120.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 360.00 120.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 40.00 130.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 50.00 130.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 60.00 130.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 70.00 130.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 80.00 130.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 90.00 130.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 100.00 130.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 110.00 130.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 120.00 130.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 130.00 130.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 140.00 130.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 150.00 130.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 160.00 130.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 170.00 130.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 180.00 130.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 190.00 130.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 200.00 130.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 210.00 130.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 220.00 130.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 230.00 130.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 240.00 130.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 250.00 130.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 260.00 130.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 270.00 130.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 280.00 130.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 290.00 130.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 300.00 130.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 310.00 130.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 320.00 130.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 330.00 130.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 340.00 130.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 350.00 130.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 360.00 130.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 40.00 140.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 50.00 140.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 60.00 140.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 70.00 140.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 80.00 140.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 90.00 140.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 100.00 140.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 110.00 140.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 120.00 140.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 130.00 140.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 140.00 140.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 150.00 140.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 160.00 140.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 170.00 140.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 180.00 140.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 190.00 140.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 200.00 140.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 210.00 140.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 220.00 140.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 230.00 140.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 240.00 140.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 250.00 140.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 260.00 140.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 270.00 140.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 280.00 140.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 290.00 140.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 300.00 140.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 310.00 140.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 320.00 140.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 330.00 140.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 340.00 140.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 350.00 140.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 360.00 140.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 40.00 150.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 50.00 150.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 60.00 150.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 70.00 150.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 80.00 150.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 90.00 150.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 100.00 150.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 110.00 150.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 120.00 150.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 130.00 150.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 140.00 150.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 150.00 150.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 160.00 150.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 170.00 150.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 180.00 150.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 190.00 150.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 200.00 150.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 210.00 150.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 220.00 150.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 230.00 150.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 240.00 150.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 250.00 150.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 260.00 150.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 270.00 150.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 280.00 150.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 290.00 150.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 300.00 150.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 310.00 150.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 320.00 150.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 330.00 150.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 340.00 150.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 350.00 150.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 360.00 150.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 40.00 160.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 50.00 160.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 60.00 160.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 70.00 160.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 80.00 160.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 90.00 160.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 100.00 160.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 110.00 160.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 120.00 160.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 130.00 160.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 140.00 160.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 150.00 160.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 160.00 160.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 170.00 160.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 180.00 160.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 190.00 160.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 200.00 160.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 210.00 160.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 220.00 160.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 230.00 160.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 240.00 160.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 250.00 160.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 260.00 160.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 270.00 160.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 280.00 160.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 290.00 160.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 300.00 160.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 310.00 160.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 320.00 160.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 330.00 160.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 340.00 160.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 350.00 160.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 360.00 160.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 40.00 170.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 50.00 170.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 60.00 170.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 70.00 170.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 80.00 170.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 90.00 170.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 100.00 170.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 110.00 170.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 120.00 170.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 130.00 170.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 140.00 170.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 150.00 170.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 160.00 170.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 170.00 170.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 180.00 170.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 190.00 170.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 200.00 170.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 210.00 170.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 220.00 170.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 230.00 170.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 240.00 170.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 250.00 170.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 260.00 170.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 270.00 170.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 280.00 170.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 290.00 170.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 300.00 170.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 310.00 170.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 320.00 170.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 330.00 170.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 340.00 170.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 350.00 170.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 360.00 170.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 40.00 180.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 50.00 180.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 60.00 180.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 70.00 180.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 80.00 180.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 90.00 180.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 100.00 180.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 110.00 180.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 120.00 180.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 130.00 180.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 140.00 180.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 150.00 180.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 160.00 180.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 170.00 180.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 180.00 180.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 190.00 180.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 200.00 180.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 210.00 180.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 220.00 180.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 230.00 180.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 240.00 180.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 250.00 180.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 260.00 180.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 270.00 180.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 280.00 180.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 290.00 180.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 300.00 180.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 310.00 180.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 320.00 180.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 330.00 180.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 340.00 180.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 350.00 180.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 360.00 180.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 40.00 190.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 50.00 190.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 60.00 190.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 70.00 190.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 80.00 190.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 90.00 190.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 100.00 190.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 110.00 190.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 120.00 190.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 130.00 190.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 140.00 190.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 150.00 190.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 160.00 190.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 170.00 190.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 180.00 190.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 190.00 190.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 200.00 190.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 210.00 190.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 220.00 190.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 230.00 190.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 240.00 190.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 250.00 190.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 260.00 190.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 270.00 190.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 280.00 190.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 290.00 190.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 300.00 190.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 310.00 190.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 320.00 190.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 330.00 190.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 340.00 190.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 350.00 190.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+        (GraphicsLayer
+          (position 360.00 190.00)
+          (bounds 4.00 4.00)
+          (contentsOpaque 1)
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/compositing/layer-creation/implicit-keyframes-animation-overlap.html
+++ b/LayoutTests/compositing/layer-creation/implicit-keyframes-animation-overlap.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+
+<html>
+<head>
+    <style>
+        .box {
+            width: 200px;
+            height: 100px;
+            background-color: blue;
+            margin: 80px 40px;
+            position: relative;
+            box-shadow: 0 0 10px black;
+            transform-origin: bottom left;
+            transition: transform 10s;
+        }
+        
+        .dot {
+            position: absolute;
+            top: 0;
+            left: 0;
+            height: 4px;
+            width: 4px;
+            background-color: silver;
+        }
+        
+        body.changed .box {
+            animation: move 10s linear;
+        }
+        
+        @keyframes move {
+            from { transform: translateX(100px) }
+            to { }
+        }
+    </style>
+    <script src="../resources/compositing-test-utils.js"></script>
+    <script>
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+
+        function runTest()
+        {
+            makeDots(50, 23);
+            
+            window.setTimeout(function() {
+                document.getElementById('target').addEventListener('animationstart', dumpLayersWithoutTransforms, false);
+                document.body.classList.add('changed');
+            }, 0);
+        }
+        
+        window.addEventListener('load', runTest, false);
+    </script>
+</head>
+<body>
+
+    <div id="target" class="box">
+    </div>
+<pre id="layers"></pre>
+</body>
+</html>

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -2558,15 +2558,23 @@ bool KeyframeEffect::computeExtentOfTransformAnimation(LayoutRect& bounds) const
         return true;
     };
 
+    bool computedBoundsForFromKeyframe = false;
+    bool computedBoundsForToKeyframe = false;
     for (const auto& keyframe : m_blendingKeyframes) {
         if (!animatablePropertiesContainTransformRelatedProperty(keyframe.properties()))
             continue;
+
+        auto offset = keyframe.offset();
+        if (!offset)
+            computedBoundsForFromKeyframe = true;
+        if (offset == 1.0)
+            computedBoundsForToKeyframe = true;
 
         auto blendedStyleForKeyframe = RenderStyle::clonePtr(*unanimatedStyle);
 
         ComputedEffectTiming computedTiming;
         computedTiming.currentIteration = 0;
-        computedTiming.progress = keyframe.offset();
+        computedTiming.progress = offset;
 
         setAnimatedPropertiesInStyle(*blendedStyleForKeyframe, computedTiming);
 
@@ -2574,7 +2582,7 @@ bool KeyframeEffect::computeExtentOfTransformAnimation(LayoutRect& bounds) const
             return false;
     }
 
-    if (m_blendingKeyframes.hasImplicitKeyframes()) {
+    if (!computedBoundsForFromKeyframe || !computedBoundsForToKeyframe) {
         if (!addStyleToCumulativeBounds(*unanimatedStyle))
             return false;
     }


### PR DESCRIPTION
#### 28e155992e27804fca34327a04c65d2188b122cc
<pre>
[threaded-animations] REGRESSION: scrolling <a href="https://scroll-driven-animations.style/">https://scroll-driven-animations.style/</a> makes content disappear on iPad
<a href="https://bugs.webkit.org/show_bug.cgi?id=305654">https://bugs.webkit.org/show_bug.cgi?id=305654</a>
<a href="https://rdar.apple.com/168132265">rdar://168132265</a>

Reviewed by Simon Fraser.

The various cards on the home page for <a href="https://scroll-driven-animations.style/">https://scroll-driven-animations.style/</a>, a site containing a
number of Scroll-driven Animations demos, are animated as follows:

    @keyframes appear {
        from {
                opacity: 0;
                translate: 0 -50% 0;
                clip-path: inset(100% 100% 0% 0%);
        }
        to {
                opacity: 1;
                clip-path: inset(0% 0% 0% 0%);
        }
    }

You&apos;ll notice that the `translate` property is specified in the &quot;from&quot; keyframe but not in the &quot;to&quot;
keyframe, making the &quot;to&quot; keyframe implicit. Unfortunately, this trips up the computation of the
transform animation extent we enhanced in 303045@main to account for individual transform properties.

Indeed, we simply used `BlendingKeyframes::hasImplicitKeyframes()` to determine whether there were
an implicit keyframe to account for, but in this case, there is a &quot;to&quot; keyframe defined, it simply
does not provide a value for any transform-related properties.

We now check if we&apos;ve found explicit &quot;from&quot; and &quot;to&quot; keyframes and, if we have not, account for
the underlying style as the missing keyframe.

A new test checks this behavior with an empty &quot;to&quot; keyframe. Its result was checked visually
with layer borders enabled and it failed as expected prior to this patch.

Test: compositing/layer-creation/implicit-keyframes-animation-overlap.html

* LayoutTests/compositing/layer-creation/implicit-keyframes-animation-overlap-expected.txt: Added.
* LayoutTests/compositing/layer-creation/implicit-keyframes-animation-overlap.html: Added.
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::computeExtentOfTransformAnimation const):

Canonical link: <a href="https://commits.webkit.org/305743@main">https://commits.webkit.org/305743@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da00ce06062389102e98d816ba544ba6c509f244

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139229 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11605 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/731 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147356 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141102 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12312 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11755 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106589 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3d7310ab-5f46-405b-a0a3-5ad90cb445f6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142176 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9318 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124719 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87449 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d234b726-fa8d-4433-94c4-aad7e45fcced) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8868 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6637 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7653 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118324 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/617 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150138 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11289 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/635 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114983 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11302 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9555 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115288 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9352 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121064 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66207 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21479 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11332 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/594 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11066 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74998 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11269 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11119 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->