### PR TITLE
Web Inspector: Optimize substring operations in WI.SearchResultTreeElement

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/SearchResultTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SearchResultTreeElement.js
@@ -50,25 +50,29 @@ WI.SearchResultTreeElement = class SearchResultTreeElement extends WI.GeneralTre
 
         // Show some characters before the matching text (if there are enough) for context. TreeOutline takes care of the truncating
         // at the end of the string.
-        var modifiedTitle = null;
+        let trimStartIndex = 0;
+        let trimEndIndex = searchTermIndex + searchTermLength + charactersToShowAfterSearchMatch;
+        let highlightedTitle = document.createDocumentFragment();
+
         if (searchTermIndex > charactersToShowBeforeSearchMatch) {
-            modifiedTitle = ellipsis + title.substring(searchTermIndex - charactersToShowBeforeSearchMatch);
-            searchTermIndex = charactersToShowBeforeSearchMatch + 1;
-        } else
-            modifiedTitle = title;
+            trimStartIndex = searchTermIndex - charactersToShowBeforeSearchMatch;
+            searchTermIndex = charactersToShowBeforeSearchMatch;
 
-        modifiedTitle = modifiedTitle.truncateEnd(searchTermIndex + searchTermLength + charactersToShowAfterSearchMatch);
+            highlightedTitle.append(ellipsis);
+        }
 
-        var highlightedTitle = document.createDocumentFragment();
+        let modifiedTitle = title.substring(trimStartIndex, trimEndIndex);
 
         highlightedTitle.append(modifiedTitle.substring(0, searchTermIndex));
 
-        var highlightSpan = document.createElement("span");
+        let highlightSpan = highlightedTitle.appendChild(document.createElement("span"))
         highlightSpan.className = "highlighted";
         highlightSpan.append(modifiedTitle.substring(searchTermIndex, searchTermIndex + searchTermLength));
-        highlightedTitle.appendChild(highlightSpan);
 
         highlightedTitle.append(modifiedTitle.substring(searchTermIndex + searchTermLength));
+
+        if (trimEndIndex < title.length)
+            highlightedTitle.append(ellipsis);
 
         return highlightedTitle;
     }
@@ -77,12 +81,13 @@ WI.SearchResultTreeElement = class SearchResultTreeElement extends WI.GeneralTre
 
     get filterableData()
     {
-        return {text: [this.representedObject.title]};
+        // Intentionally not using this.representedObject.title because it could be the entire contents of a file for a minified file.
+        return {text: [this.mainTitle]};
     }
 
     get synthesizedTextValue()
     {
-        return this.representedObject.sourceCodeTextRange.synthesizedTextValue + ":" + this.representedObject.title;
+        return this.representedObject.sourceCodeTextRange.synthesizedTextValue + ":" + this.mainTitle;
     }
 
     // Protected


### PR DESCRIPTION
#### fa0025699702d941201aa100fc958556ba8672df
<pre>
Web Inspector: Optimize substring operations in WI.SearchResultTreeElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=305653">https://bugs.webkit.org/show_bug.cgi?id=305653</a>
<a href="https://rdar.apple.com/168311426">rdar://168311426</a>

Reviewed by BJ Burg and Devin Rousso.

WI.SearchResultTreeElement is given the entire line of text where a match occurs
along with a text range that identifies the match.

To show some context, a portion of the line is trimmed around the match.
For minified files, the line could be the entire contents of the file.

This patch reduces the number of string operations done on the line of text.

* Source/WebInspectorUI/UserInterface/Views/SearchResultTreeElement.js:
(WI.SearchResultTreeElement.truncateAndHighlightTitle):
(WI.SearchResultTreeElement.prototype.get filterableData):

Canonical link: <a href="https://commits.webkit.org/306486@main">https://commits.webkit.org/306486@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cacf51b69609268ebf1b56e28021c65735f097b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/141346 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/13730 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/3056 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/149924 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94445 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/14445 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/13885 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/149924 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94445 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/144297 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/14445 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/3056 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/149924 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/14445 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/168/builds/3056 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [⏳ 🛠 wpe-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/14445 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/3056 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/152314 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/13421 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/3056 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/152314 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13437 "Build is in progress. Recent messages:") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/13885 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/152314 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29829 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/3056 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/68619 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/13463 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/3056 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/13200 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/77176 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/13400 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/13246 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->