### PR TITLE
[AutoFill Debugging] Markdown text extraction output contains unnecessary newlines

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-markdown-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-markdown-expected.txt
@@ -6,12 +6,6 @@ This is a list:
 - foo
 - bar
 - baz
-On sale for
-£10.99
-This
-~~text~~
-has a
-~~line through it~~
-. The price
-~~was \~\~$50~~
+On [sale](https://webkit.org/) for
+£10.99 This ~~text~~ has a ~~line through it~~. The price ~~was \~\~$50~~
 <!-- version=2 -->

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-markdown.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-markdown.html
@@ -22,7 +22,7 @@ body.done {
     <li>bar</li>
     <li>baz</li>
 </ul>
-On sale for
+On <a href="https://webkit.org">sale</a> for
 <p>
     <sup>£</sup>
     10

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm
@@ -479,9 +479,8 @@ TEST(TextExtractionTests, NodesToSkip)
     }()];
 
     NSArray<NSString *> *lines = [debugText componentsSeparatedByString:@"\n"];
-    EXPECT_EQ([lines count], 3u);
-    EXPECT_WK_STREQ("Test", lines[0]);
-    EXPECT_WK_STREQ("0", lines[1]);
+    EXPECT_EQ([lines count], 2u);
+    EXPECT_WK_STREQ("Test 0", lines[0]);
 }
 
 TEST(TextExtractionTests, RequestJSHandleForNodeIdentifier)


### PR DESCRIPTION
#### bb0ebb73d1f0a1d1be8137db528f9c06e595f1b7
<pre>
[AutoFill Debugging] Markdown text extraction output contains unnecessary newlines
<a href="https://bugs.webkit.org/show_bug.cgi?id=305656">https://bugs.webkit.org/show_bug.cgi?id=305656</a>
<a href="https://rdar.apple.com/168313431">rdar://168313431</a>

Reviewed by Abrar Rahman Protyasha.

Make a small adjustment to the markdown output format, when transforming text extraction items into
pure text. Instead of always emitting `\n` between different items, if the adjacent items share the
same block container index, we can instead emit a space (or none at all if there is already
whitespace, or the next character is a punctuation character).

* LayoutTests/fast/text-extraction/debug-text-extraction-markdown-expected.txt:

Rebaseline an existing test; also add an inline anchor element, to check that a space is inserted
between text and the start of a link.

* LayoutTests/fast/text-extraction/debug-text-extraction-markdown.html:
* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::shouldEmitExtraSpace):
(WebKit::TextExtractionAggregator::takeResults):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm:
(TestWebKitAPI::TEST(TextExtractionTests, NodesToSkip)):

Rebaseline another API test.

Canonical link: <a href="https://commits.webkit.org/305734@main">https://commits.webkit.org/305734@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39d99f7454f1f0481a52cbc3e1a2f23d2f39d789

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139259 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11635 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/761 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147386 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141132 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12342 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11785 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106614 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142206 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9347 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124732 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87475 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8893 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6662 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7683 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118351 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/631 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150168 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11319 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/649 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115007 "Found 1 new test failure: scrollbars/corner-resizer-window-inactive.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11332 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9580 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115314 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29301 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9406 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121078 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66237 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11362 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/606 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11096 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75028 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11299 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11149 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->