### PR TITLE
[ iOS Release ] TestWebKitAPI.WKWebsiteDataStoreConfiguration.TotalQuotaRatioWithPersistedDomain (api-tests) is a flaky timeout

### DIFF
--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -555,7 +555,7 @@ void NetworkStorageManager::performEviction(HashMap<WebCore::SecurityOriginData,
         return a.second.lastAccessTime > b.second.lastAccessTime;
     });
 
-    uint64_t deletedOriginCount = 0;
+    Vector<WebCore::RegistrableDomain> deletedDomains;
     while (!sortedOriginRecords.isEmpty() && *m_totalUsage > *m_totalQuota) {
         auto [topOrigin, record] = sortedOriginRecords.takeLast();
         if (record.isActive || valueOrDefault(record.isPersisted))
@@ -568,11 +568,13 @@ void NetworkStorageManager::performEviction(HashMap<WebCore::SecurityOriginData,
         }
 
         m_totalUsage = *m_totalUsage - record.usage;
-        ++deletedOriginCount;
+        deletedDomains.append(WebCore::RegistrableDomain { topOrigin });
     }
 
-    UNUSED_PARAM(deletedOriginCount);
-    RELEASE_LOG(Storage, "%p - NetworkStorageManager::performEviction evicts %" PRIu64 " origins, current usage %" PRIu64 ", total quota %" PRIu64, this, deletedOriginCount, valueOrDefault(m_totalUsage), *m_totalQuota);
+    RELEASE_LOG(Storage, "%p - NetworkStorageManager::performEviction evicts %" PRIu64 " origins, current usage %" PRIu64 ", total quota %" PRIu64, this, static_cast<uint64_t>(deletedDomains.size()), valueOrDefault(m_totalUsage), *m_totalQuota);
+
+    if (!deletedDomains.isEmpty() && m_parentConnection)
+        IPC::Connection::send(*m_parentConnection, Messages::NetworkProcessProxy::DidPerformEvictionForDomains(m_sessionID, WTF::move(deletedDomains)), 0);
 }
 
 OriginQuotaManager::Parameters NetworkStorageManager::originQuotaManagerParameters(const WebCore::ClientOrigin& origin)

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -320,7 +320,7 @@ private:
     std::optional<uint64_t> m_totalQuota;
     bool m_isEvictionScheduled { false };
     UnifiedOriginStorageLevel m_unifiedOriginStorageLevel;
-    Markable<IPC::Connection::UniqueID> m_parentConnection;
+    const Markable<IPC::Connection::UniqueID> m_parentConnection;
     HashMap<IPC::Connection::UniqueID, HashSet<String>> m_temporaryBlobPathsByConnection WTF_GUARDED_BY_CAPABILITY(workQueue());
     using OriginPersistCompletionHandler = std::pair<WebCore::ClientOrigin, CompletionHandler<void(bool)>>;
     Vector<OriginPersistCompletionHandler> m_persistCompletionHandlers WTF_GUARDED_BY_CAPABILITY(workQueue());

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -113,6 +113,7 @@ public:
         , m_hasDidAllowPrivateTokenUsageByThirdPartyForTestingSelector([m_delegate.get() respondsToSelector:@selector(websiteDataStore:didAllowPrivateTokenUsageByThirdPartyForTesting:forResourceURL:)])
         , m_hasDidExceedMemoryFootprintThresholdSelector([m_delegate.get() respondsToSelector:@selector(websiteDataStore:domain:didExceedMemoryFootprintThreshold:withPageCount:processLifetime:inForeground:wasPrivateRelayed:canSuspend:)])
         , m_hasWebCryptoMasterKeySelector([m_delegate.get() respondsToSelector:@selector(webCryptoMasterKey:)])
+        , m_hasDidPerformEvictionForDomainsSelector([m_delegate.get() respondsToSelector:@selector(didEvictDataForDomains:)])
     {
     }
 
@@ -131,6 +132,18 @@ private:
                 return completionHandler(std::nullopt);
             completionHandler(makeVector(result));
         }).get()];
+    }
+
+    void didEvictDataForDomains(const Vector<WebCore::RegistrableDomain>& domains) final
+    {
+        if (!m_hasDidPerformEvictionForDomainsSelector || !m_delegate)
+            return;
+
+        RetainPtr array = createNSArray(domains, [] (auto& domain) {
+            return domain.string().createNSString();
+        });
+
+        [m_delegate.get() didEvictDataForDomains:array.get()];
     }
 
     void requestStorageSpace(const WebCore::SecurityOriginData& topOrigin, const WebCore::SecurityOriginData& frameOrigin, uint64_t quota, uint64_t currentSize, uint64_t spaceRequired, CompletionHandler<void(std::optional<uint64_t>)>&& completionHandler) final
@@ -372,6 +385,7 @@ private:
     bool m_hasDidAllowPrivateTokenUsageByThirdPartyForTestingSelector { false };
     bool m_hasDidExceedMemoryFootprintThresholdSelector { false };
     bool m_hasWebCryptoMasterKeySelector { false };
+    bool m_hasDidPerformEvictionForDomainsSelector { false };
 };
 
 #if PLATFORM(IOS)

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreDelegate.h
@@ -73,4 +73,5 @@ WK_API_AVAILABLE(macos(10.15), ios(13.0))
 - (void)websiteDataStore:(WKWebsiteDataStore *)dataStore didAllowPrivateTokenUsageByThirdPartyForTesting:(BOOL)wasAllowed forResourceURL:(NSURL *)resourceURL;
 - (void)websiteDataStore:(WKWebsiteDataStore *)dataStore domain:(NSString *)registrableDomain didExceedMemoryFootprintThreshold:(size_t)footprint withPageCount:(NSUInteger)pageCount processLifetime:(NSTimeInterval)processLifetime inForeground:(BOOL)inForeground wasPrivateRelayed:(BOOL)wasPrivateRelayed canSuspend:(BOOL)canSuspend;
 - (void)webCryptoMasterKey:(void (^)(NSData *))completionHandler WK_API_AVAILABLE(macos(15.0), ios(18.0));
+- (void)didEvictDataForDomains:(NSArray<NSString *> *)domains;
 @end

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -2018,6 +2018,12 @@ void NetworkProcessProxy::addAllowedFilePaths(WebProcessProxy& webProcessProxy, 
         pathSet.add(path);
 }
 
+void NetworkProcessProxy::didPerformEvictionForDomains(PAL::SessionID sessionID, const Vector<RegistrableDomain>& domains)
+{
+    if (RefPtr store = websiteDataStoreFromSessionID(sessionID))
+        store->client().didEvictDataForDomains(domains);
+}
+
 #if USE(RUNNINGBOARD)
 void NetworkProcessProxy::wakeUpWebProcessForIPC(WebCore::ProcessIdentifier processIdentifier)
 {

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -400,6 +400,7 @@ private:
     void logDiagnosticMessageWithResult(WebPageProxyIdentifier, const String& message, const String& description, uint32_t result, WebCore::ShouldSample);
     void logDiagnosticMessageWithValue(WebPageProxyIdentifier, const String& message, const String& description, double value, unsigned significantFigures, WebCore::ShouldSample);
     void logTestingEvent(PAL::SessionID, const String& event);
+    void didPerformEvictionForDomains(PAL::SessionID, const Vector<RegistrableDomain>&);
 
 #if ENABLE(CONTENT_EXTENSIONS)
     void contentExtensionRules(UserContentControllerIdentifier);

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.messages.in
@@ -108,6 +108,8 @@ messages -> NetworkProcessProxy WantsDispatchMessage {
     DeleteWebsiteDataInWebProcessesForOrigin(OptionSet<WebKit::WebsiteDataType> websiteDataTypes, struct WebCore::ClientOrigin origin, PAL::SessionID sessionID, WebKit::WebPageProxyIdentifier webPageProxyID) -> ()
     ReloadExecutionContextsForOrigin(struct WebCore::ClientOrigin origin, PAL::SessionID sessionID, std::optional<WebCore::FrameIdentifier> triggeringFrame) -> ()
 
+    DidPerformEvictionForDomains(PAL::SessionID sessionID, Vector<WebCore::RegistrableDomain> domains)
+
 #if USE(RUNNINGBOARD)
     WakeUpWebProcessForIPC(WebCore::ProcessIdentifier processIdentifier)
 #endif

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreClient.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreClient.h
@@ -123,9 +123,14 @@ public:
     virtual void didExceedMemoryFootprintThreshold(size_t, const String&, unsigned, Seconds, bool, WebCore::WasPrivateRelayed, CanSuspend)
     {
     }
+
     virtual void webCryptoMasterKey(CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&& completionHandler)
     {
         return completionHandler(std::nullopt);
+    }
+
+    virtual void didEvictDataForDomains(const Vector<WebCore::RegistrableDomain>& domains)
+    {
     }
 };
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebsiteDatastore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebsiteDatastore.mm
@@ -37,6 +37,7 @@
 #import <WebKit/WebKit.h>
 #import <WebKit/_WKWebsiteDataSize.h>
 #import <WebKit/_WKWebsiteDataStoreConfiguration.h>
+#import <WebKit/_WKWebsiteDataStoreDelegate.h>
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/text/WTFString.h>
 
@@ -93,6 +94,34 @@ static bool usePersistentCredentialStorage = false;
     lastScriptMessage = message;
 }
 
+@end
+
+@interface WKWebsiteDataStoreTotalQuotaDelegate : NSObject<_WKWebsiteDataStoreDelegate>
+- (NSArray<NSString *> *)lastEvictedDomains;
+- (void)waitForDataEviction;
+@end
+
+@implementation WKWebsiteDataStoreTotalQuotaDelegate {
+    bool _evicted;
+    RetainPtr<NSArray<NSString *>> _lastEvictedDomains;
+}
+
+- (NSArray<NSString *> *)lastEvictedDomains
+{
+    return _lastEvictedDomains.get();
+}
+
+- (void)waitForDataEviction
+{
+    TestWebKitAPI::Util::run(&_evicted);
+    _evicted = false;
+}
+
+- (void)didEvictDataForDomains:(NSArray<NSString *> *)domains
+{
+    _lastEvictedDomains = domains;
+    _evicted = true;
+}
 @end
 
 namespace TestWebKitAPI {
@@ -1073,16 +1102,11 @@ static NSString *htmlStringForTotalQuotaRatioTest(uint64_t size, bool shouldPers
     </script>", size, shouldPersist ? "navigator.storage.persist()" : "new String('success')"];
 }
 
-// FIXME when rdar://154214201 is resolved.
-#if PLATFORM(IOS)
-TEST(WKWebsiteDataStoreConfiguration, DISABLED_TotalQuotaRatioWithPersistedDomain)
-#else
-TEST(WKWebsiteDataStoreConfiguration, TotalQuotaRatioWithPersistedDomain)
-#endif
+TEST(WKWebsiteDataStoreTotalQuota, EvictionSkipsPersistedDomain)
 {
     done = false;
     receivedScriptMessage = false;
-    auto uuid = adoptNS([[NSUUID alloc] initWithUUIDString:@"68753a44-4d6f-1226-9c60-0050e4c00067"]);
+    RetainPtr uuid = adoptNS([[NSUUID alloc] initWithUUIDString:@"68753a44-4d6f-1226-9c60-0050e4c00067"]);
     [WKWebsiteDataStore _removeDataStoreWithIdentifier:uuid.get() completionHandler:^(NSError *error) {
         done = true;
         EXPECT_NULL(error);
@@ -1090,85 +1114,122 @@ TEST(WKWebsiteDataStoreConfiguration, TotalQuotaRatioWithPersistedDomain)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:uuid.get()]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:uuid.get()]);
     RetainPtr<NSURL> generalStorageDirectory = websiteDataStoreConfiguration.get().generalStorageDirectory;
     // Set total quota to be 50000 bytes.
-    [websiteDataStoreConfiguration.get() setTotalQuotaRatio:[NSNumber numberWithDouble:0.5]];
-    [websiteDataStoreConfiguration.get() setVolumeCapacityOverride:[NSNumber numberWithDouble:100000]];
-    [websiteDataStoreConfiguration.get() setOriginQuotaRatio:[NSNumber numberWithDouble:0.5]];
+    [websiteDataStoreConfiguration setTotalQuotaRatio:[NSNumber numberWithDouble:0.5]];
+    [websiteDataStoreConfiguration setVolumeCapacityOverride:[NSNumber numberWithDouble:100000]];
+    [websiteDataStoreConfiguration setOriginQuotaRatio:[NSNumber numberWithDouble:0.5]];
     // Mark first.com eligible for persistent storage.
-    [websiteDataStoreConfiguration.get() setStandaloneApplicationURL:[NSURL URLWithString:@"https://first.com"]];
+    [websiteDataStoreConfiguration setStandaloneApplicationURL:[NSURL URLWithString:@"https://first.com"]];
 
-    auto handler = adoptNS([[WKWebsiteDataStoreMessageHandler alloc] init]);
-    auto websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+    RetainPtr websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+    RetainPtr websiteDataStoreDelegate = adoptNS([[WKWebsiteDataStoreTotalQuotaDelegate alloc] init]);
+    websiteDataStore.get()._delegate = websiteDataStoreDelegate.get();
+    RetainPtr handler = adoptNS([[WKWebsiteDataStoreMessageHandler alloc] init]);
+    // ITP must be enabled for setting persisted domain.
     [websiteDataStore _setResourceLoadStatisticsEnabled:YES];
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
     [configuration setWebsiteDataStore:websiteDataStore.get()];
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    [webView loadHTMLString:htmlStringForTotalQuotaRatioTest(20000, true) baseURL:[NSURL URLWithString:@"https://first.com"]];
-    TestWebKitAPI::Util::run(&receivedScriptMessage);
-    receivedScriptMessage = false;
-    // first.com is allowed to be persisted.
-    EXPECT_WK_STREQ(@"true", [lastScriptMessage body]);
-
-    [webView loadHTMLString:htmlStringForTotalQuotaRatioTest(20000, true) baseURL:[NSURL URLWithString:@"https://second.com"]];
-    TestWebKitAPI::Util::run(&receivedScriptMessage);
-    receivedScriptMessage = false;
-    EXPECT_WK_STREQ(@"false", [lastScriptMessage body]);
-
-    [webView loadHTMLString:htmlStringForTotalQuotaRatioTest(40000, true) baseURL:[NSURL URLWithString:@"https://third.com"]];
-    TestWebKitAPI::Util::run(&receivedScriptMessage);
-    receivedScriptMessage = false;
-    EXPECT_WK_STREQ(@"false", [lastScriptMessage body]);
-
-    __block bool isEvicted = false;
-    // Eviction happens asynchronously in network process so keep checking until it is done.
-    while (!isEvicted) {
-        [websiteDataStore fetchDataRecordsOfTypes:[NSSet setWithObject:WKWebsiteDataTypeFetchCache] completionHandler:^(NSArray<WKWebsiteDataRecord *> *records) {
-            if (records.count == 2u) {
-                auto sortFunction = ^(WKWebsiteDataRecord *record1, WKWebsiteDataRecord *record2) {
-                    return [record1.displayName compare:record2.displayName];
-                };
-                auto sortedRecords = [records sortedArrayUsingComparator:sortFunction];
-                EXPECT_WK_STREQ(@"first.com", [[sortedRecords objectAtIndex:0] displayName]);
-                EXPECT_WK_STREQ(@"third.com", [[sortedRecords objectAtIndex:1] displayName]);
-                isEvicted = true;
-            }
-            done = true;
-        }];
-        TestWebKitAPI::Util::run(&done);
-        done = false;
+    // Create separate views to make sure the visited origin is no longer active and will be eligible for eviction.
+    @autoreleasepool {
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+        receivedScriptMessage = false;
+        [webView loadHTMLString:htmlStringForTotalQuotaRatioTest(20000, true) baseURL:[NSURL URLWithString:@"https://first.com"]];
+        TestWebKitAPI::Util::run(&receivedScriptMessage);
+        // first.com is allowed to be persisted.
+        EXPECT_WK_STREQ(@"true", [lastScriptMessage body]);
     }
 
-    // Persisted flag of first.com is cleared when its data is deleted.
+    @autoreleasepool {
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+        receivedScriptMessage = false;
+        [webView loadHTMLString:htmlStringForTotalQuotaRatioTest(20000, true) baseURL:[NSURL URLWithString:@"https://second.com"]];
+        TestWebKitAPI::Util::run(&receivedScriptMessage);
+        receivedScriptMessage = false;
+        EXPECT_WK_STREQ(@"false", [lastScriptMessage body]);
+    }
+
+    @autoreleasepool {
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+        receivedScriptMessage = false;
+        [webView loadHTMLString:htmlStringForTotalQuotaRatioTest(40000, true) baseURL:[NSURL URLWithString:@"https://third.com"]];
+        TestWebKitAPI::Util::run(&receivedScriptMessage);
+        EXPECT_WK_STREQ(@"false", [lastScriptMessage body]);
+    }
+
+    [websiteDataStoreDelegate waitForDataEviction];
+    NSArray<NSString *> *evictedDomains = [websiteDataStoreDelegate.get().lastEvictedDomains sortedArrayUsingSelector:@selector(compare:)];
+    EXPECT_EQ(evictedDomains.count, 1u);
+    NSString *domainsString = [evictedDomains componentsJoinedByString:@", "];
+    EXPECT_WK_STREQ(@"second.com", domainsString);
+}
+
+TEST(WKWebsiteDataStoreTotalQuota, ClearPersistedDomain)
+{
+    done = false;
+    receivedScriptMessage = false;
+    RetainPtr uuid = adoptNS([[NSUUID alloc] initWithUUIDString:@"68753a44-4d6f-1226-9c60-0050e4c00067"]);
+    [WKWebsiteDataStore _removeDataStoreWithIdentifier:uuid.get() completionHandler:^(NSError *error) {
+        done = true;
+        EXPECT_NULL(error);
+    }];
+    TestWebKitAPI::Util::run(&done);
+    done = false;
+
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:uuid.get()]);
+    [websiteDataStoreConfiguration setTotalQuotaRatio:[NSNumber numberWithDouble:0.5]];
+    [websiteDataStoreConfiguration setVolumeCapacityOverride:[NSNumber numberWithDouble:100000]];
+    [websiteDataStoreConfiguration setOriginQuotaRatio:[NSNumber numberWithDouble:0.5]];
+    // Mark first.com eligible for persistent storage.
+    [websiteDataStoreConfiguration setStandaloneApplicationURL:[NSURL URLWithString:@"https://first.com"]];
+    RetainPtr websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+    RetainPtr websiteDataStoreDelegate = adoptNS([[WKWebsiteDataStoreTotalQuotaDelegate alloc] init]);
+    websiteDataStore.get()._delegate = websiteDataStoreDelegate.get();
+    RetainPtr handler = adoptNS([[WKWebsiteDataStoreMessageHandler alloc] init]);
+    [websiteDataStore _setResourceLoadStatisticsEnabled:YES];
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
+    [configuration setWebsiteDataStore:websiteDataStore.get()];
+
+    @autoreleasepool {
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+        [webView loadHTMLString:htmlStringForTotalQuotaRatioTest(20000, true) baseURL:[NSURL URLWithString:@"https://first.com"]];
+        TestWebKitAPI::Util::run(&receivedScriptMessage);
+        receivedScriptMessage = false;
+        // Persisted flag is set for first.com.
+        EXPECT_WK_STREQ(@"true", [lastScriptMessage body]);
+    }
+
+    // Persisted flag of first.com should be cleared when its data is deleted.
     [websiteDataStore removeDataOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] modifiedSince:[NSDate distantPast] completionHandler:^() {
         done = true;
     }];
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    [webView loadHTMLString:htmlStringForTotalQuotaRatioTest(20000, false) baseURL:[NSURL URLWithString:@"https://first.com"]];
-    TestWebKitAPI::Util::run(&receivedScriptMessage);
-    receivedScriptMessage = false;
-    EXPECT_WK_STREQ(@"success", [lastScriptMessage body]);
-
-    [webView loadHTMLString:htmlStringForTotalQuotaRatioTest(45000, false) baseURL:[NSURL URLWithString:@"https://third.com"]];
-    TestWebKitAPI::Util::run(&receivedScriptMessage);
-    receivedScriptMessage = false;
-    EXPECT_WK_STREQ(@"success", [lastScriptMessage body]);
-
-    while (!isEvicted) {
-        [websiteDataStore fetchDataRecordsOfTypes:[NSSet setWithObject:WKWebsiteDataTypeFetchCache] completionHandler:^(NSArray<WKWebsiteDataRecord *> *records) {
-            if (records.count == 1u) {
-                EXPECT_WK_STREQ(@"third.com", [[records objectAtIndex:0] displayName]);
-                isEvicted = true;
-            }
-            done = true;
-        }];
-        TestWebKitAPI::Util::run(&done);
-        done = false;
+    @autoreleasepool {
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+        [webView loadHTMLString:htmlStringForTotalQuotaRatioTest(20000, false) baseURL:[NSURL URLWithString:@"https://first.com"]];
+        TestWebKitAPI::Util::run(&receivedScriptMessage);
+        receivedScriptMessage = false;
+        EXPECT_WK_STREQ(@"success", [lastScriptMessage body]);
     }
+
+    @autoreleasepool {
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+        [webView loadHTMLString:htmlStringForTotalQuotaRatioTest(45000, false) baseURL:[NSURL URLWithString:@"https://third.com"]];
+        TestWebKitAPI::Util::run(&receivedScriptMessage);
+        receivedScriptMessage = false;
+        EXPECT_WK_STREQ(@"success", [lastScriptMessage body]);
+    }
+
+    [websiteDataStoreDelegate waitForDataEviction];
+    NSArray<NSString *> *evictedDomains = [websiteDataStoreDelegate.get().lastEvictedDomains sortedArrayUsingSelector:@selector(compare:)];
+    EXPECT_EQ(evictedDomains.count, 1u);
+    NSString *domainsString = [evictedDomains componentsJoinedByString:@", "];
+    EXPECT_WK_STREQ(@"first.com", domainsString);
 }
 
 TEST(WKWebsiteDataStoreConfiguration, TotalQuotaRatioInvalidValue)


### PR DESCRIPTION
#### 07961d8b5400f87a576fcbea1d1fc0bbaacda673
<pre>
[ iOS Release ] TestWebKitAPI.WKWebsiteDataStoreConfiguration.TotalQuotaRatioWithPersistedDomain (api-tests) is a flaky timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=294918">https://bugs.webkit.org/show_bug.cgi?id=294918</a>
<a href="https://rdar.apple.com/154214201">rdar://154214201</a>

Reviewed by Per Arne Vollan.

It seems the test could run slow if system is busy (e.g. other tests are running in parallel), so split it into two
tests so the tests have a higher chance to finish before timeout.

Also, this patch adds a new delegate callback for storage eviction, so that the tests do not need to keep pulling data
records to guess if eviction has happened.

* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::performEviction):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreDelegate.h:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::didPerformEvictionForDomains):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.messages.in:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreClient.h:
(WebKit::WebsiteDataStoreClient::didEvictDataForDomains):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebsiteDatastore.mm:
(-[WKWebsiteDataStoreTotalQuotaDelegate lastEvictedDomains]):
(-[WKWebsiteDataStoreTotalQuotaDelegate waitForDataEviction]):
(-[WKWebsiteDataStoreTotalQuotaDelegate didEvictDataForDomains:]):
(TestWebKitAPI::(WKWebsiteDataStoreTotalQuota, EvictionSkipsPersistedDomain)):
(TestWebKitAPI::(WKWebsiteDataStoreTotalQuota, ClearPersistedDomain)):
(TestWebKitAPI::(WKWebsiteDataStoreConfiguration, DISABLED_TotalQuotaRatioWithPersistedDomain)(WKWebsiteDataStoreConfiguration, TotalQuotaRatioWithPersistedDomain)): Deleted.

Canonical link: <a href="https://commits.webkit.org/310830@main">https://commits.webkit.org/310830@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc8c806bd336822ba16a6ea7098cf8e4a4db430c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155050 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28310 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21469 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163810 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/108521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156923 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28449 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28158 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119958 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/108521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158009 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22221 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139237 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100651 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21306 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19345 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11636 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130968 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17080 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166286 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/10009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18689 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128060 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27854 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23384 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128198 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34792 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27778 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138873 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84487 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23075 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15668 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27470 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91574 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27049 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27279 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27121 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->