### PR TITLE
REGRESSION(294844@main): svg/filters/feTile.svg is broken

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/reference/svg-filter-gradient-interpolation-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/reference/svg-filter-gradient-interpolation-ref.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Gradient interpolation in linearRGB and SRGB contexts</title>
+    <style type="text/css">
+    svg {
+        width: 500px;
+        height: 500px;
+    }
+    </style>
+</head>
+<body>
+    <p>The test passes if the two rects look identical</p>
+    <svg>
+        <defs>
+          <linearGradient id="gradient" gradientUnits="objectBoundingBox" x1="0" y1="0" x2="1" y2="0">
+              <stop offset="0" stop-color="white" />
+              <stop offset="1" stop-color="blue" />
+          </linearGradient>
+        </defs>
+
+        <rect x="10" y="10" width="200" height="200" style="fill:url(#gradient);"/>
+        <rect x="10" y="220" width="200" height="200" style="fill:url(#gradient);"/>
+    </svg>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/svg-filter-gradient-interpolation-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/svg-filter-gradient-interpolation-expected.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Gradient interpolation in linearRGB and SRGB contexts</title>
+    <style type="text/css">
+    svg {
+        width: 500px;
+        height: 500px;
+    }
+    </style>
+</head>
+<body>
+    <p>The test passes if the two rects look identical</p>
+    <svg>
+        <defs>
+          <linearGradient id="gradient" gradientUnits="objectBoundingBox" x1="0" y1="0" x2="1" y2="0">
+              <stop offset="0" stop-color="white" />
+              <stop offset="1" stop-color="blue" />
+          </linearGradient>
+        </defs>
+
+        <rect x="10" y="10" width="200" height="200" style="fill:url(#gradient);"/>
+        <rect x="10" y="220" width="200" height="200" style="fill:url(#gradient);"/>
+    </svg>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/svg-filter-gradient-interpolation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/svg-filter-gradient-interpolation.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Gradient interpolation in linearRGB and SRGB contexts</title>
+    <link rel="match" href="reference/svg-filter-gradient-interpolation-ref.html">
+    <meta name="fuzzy" content="maxDifference=0-13; totalPixels=0-32620">
+    <meta name="flags" content="svg">
+    <meta name="assert" content="Gradient interpolation should be the same with and without filters applied">
+    <style type="text/css">
+    svg {
+        width: 500px;
+        height: 500px;
+    }
+    </style>
+</head>
+<body>
+    <p>The test passes if the two rects look identical</p>
+    <svg>
+        <defs>
+          <linearGradient id="gradient" gradientUnits="objectBoundingBox" x1="0" y1="0" x2="1" y2="0">
+              <stop offset="0" stop-color="white" />
+              <stop offset="1" stop-color="blue" />
+          </linearGradient>
+
+          <filter primitiveUnits="objectBoundingBox" filterUnits="objectBoundingBox" id="filter_1">
+              <feTile />
+          </filter>
+        </defs>
+
+        <rect x="10" y="10" width="200" height="200" style="fill:url(#gradient); filter:url(#filter_1);"/>
+        <rect x="10" y="220" width="200" height="200" style="fill:url(#gradient);"/>
+    </svg>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/Gradient.h
+++ b/Source/WebCore/platform/graphics/Gradient.h
@@ -116,9 +116,7 @@ public:
 
 #if USE(CG)
     void paint(GraphicsContext&);
-    // If the DestinationColorSpace is present, the gradient may cache a platform renderer using colors converted into this colorspace,
-    // which can be more efficient to render since it avoids colorspace conversions when lower level frameworks render the gradient.
-    void paint(CGContextRef, std::optional<DestinationColorSpace> = { });
+    void paint(CGContextRef);
 #endif
 
 #if USE(SKIA)

--- a/Source/WebCore/platform/graphics/cg/GradientCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GradientCG.cpp
@@ -49,19 +49,13 @@ void Gradient::fill(GraphicsContext& context, const FloatRect& rect)
 
 void Gradient::paint(GraphicsContext& context)
 {
-    paint(context.platformContext(), context.colorSpace());
+    paint(context.platformContext());
 }
 
-void Gradient::paint(CGContextRef platformContext, std::optional<DestinationColorSpace> colorSpace)
+void Gradient::paint(CGContextRef platformContext)
 {
-    auto ensurePlatformRenderer = [&] {
-        if (m_platformRenderer && m_platformRenderer->colorSpace() == colorSpace)
-            return;
-
-        m_platformRenderer = GradientRendererCG { m_colorInterpolationMethod, m_stops.sorted(), colorSpace };
-    };
-
-    ensurePlatformRenderer();
+    if (!m_platformRenderer)
+        m_platformRenderer = GradientRendererCG { m_colorInterpolationMethod, m_stops.sorted() };
 
     WTF::switchOn(m_data,
         [&] (const LinearData& data) {

--- a/Source/WebCore/platform/graphics/cg/GradientRendererCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GradientRendererCG.cpp
@@ -35,17 +35,9 @@
 
 namespace WebCore {
 
-GradientRendererCG::GradientRendererCG(ColorInterpolationMethod colorInterpolationMethod, const GradientColorStops& stops, std::optional<DestinationColorSpace> destinationColorSpace)
-    : m_strategy { pickStrategy(colorInterpolationMethod, stops, destinationColorSpace) }
+GradientRendererCG::GradientRendererCG(ColorInterpolationMethod colorInterpolationMethod, const GradientColorStops& stops)
+    : m_strategy { pickStrategy(colorInterpolationMethod, stops) }
 {
-}
-
-std::optional<DestinationColorSpace> GradientRendererCG::colorSpace() const
-{
-    if (auto* gradient = std::get_if<Gradient>(&m_strategy))
-        return gradient->colorSpace;
-
-    return { };
 }
 
 // MARK: - Strategy selection.
@@ -60,7 +52,7 @@ static bool anyComponentIsNone(const GradientColorStops& stops)
     return false;
 }
 
-GradientRendererCG::Strategy GradientRendererCG::pickStrategy(ColorInterpolationMethod colorInterpolationMethod, const GradientColorStops& stops, std::optional<DestinationColorSpace> destinationColorSpace) const
+GradientRendererCG::Strategy GradientRendererCG::pickStrategy(ColorInterpolationMethod colorInterpolationMethod, const GradientColorStops& stops) const
 {
     return WTF::switchOn(colorInterpolationMethod.colorSpace,
         [&] (const ColorInterpolationMethod::SRGB&) -> Strategy {
@@ -68,7 +60,7 @@ GradientRendererCG::Strategy GradientRendererCG::pickStrategy(ColorInterpolation
             if (anyComponentIsNone(stops))
                 return makeShading(colorInterpolationMethod, stops);
 
-            return makeGradient(colorInterpolationMethod, stops, destinationColorSpace);
+            return makeGradient(colorInterpolationMethod, stops);
         },
         [&] (const auto&) -> Strategy {
             return makeShading(colorInterpolationMethod, stops);
@@ -78,39 +70,7 @@ GradientRendererCG::Strategy GradientRendererCG::pickStrategy(ColorInterpolation
 
 // MARK: - Gradient strategy.
 
-static ColorComponents<float, 4> getResolvedColorComponentsInColorSpace(const Color& color, const DestinationColorSpace& destinationColorSpace)
-{
-    static LazyNeverDestroyed<HashMap<Color, ColorComponents<float, 4>>> colorCache;
-    static LazyNeverDestroyed<DestinationColorSpace> cacheColorSpace;
-    static Lock colorCacheLock;
-
-    auto locker = Locker(colorCacheLock);
-
-    static std::once_flag onceFlag;
-    std::call_once(onceFlag, [&] {
-        colorCache.construct();
-        cacheColorSpace.construct(destinationColorSpace);
-    });
-
-    if (cacheColorSpace != destinationColorSpace) {
-        colorCache->clear();
-        cacheColorSpace.get() = destinationColorSpace;
-    }
-
-    auto result = colorCache->ensure(color, [&] {
-        return color.toResolvedColorComponentsInColorSpace(destinationColorSpace);
-    }).iterator->value;
-
-    const size_t maxCacheCount = 32;
-    if (colorCache->size() > maxCacheCount) {
-        auto iteratorToRemove = colorCache->random();
-        colorCache->remove(iteratorToRemove);
-    }
-
-    return result;
-}
-
-GradientRendererCG::Strategy GradientRendererCG::makeGradient(ColorInterpolationMethod colorInterpolationMethod, const GradientColorStops& stops, std::optional<DestinationColorSpace> destinationColorSpace) const
+GradientRendererCG::Strategy GradientRendererCG::makeGradient(ColorInterpolationMethod colorInterpolationMethod, const GradientColorStops& stops) const
 {
     ASSERT_UNUSED(colorInterpolationMethod, std::holds_alternative<ColorInterpolationMethod::SRGB>(colorInterpolationMethod.colorSpace));
 
@@ -154,19 +114,11 @@ GradientRendererCG::Strategy GradientRendererCG::makeGradient(ColorInterpolation
         // extended sRGB for all gradients.
         if (hasOnlyBoundedSRGBColorStops(stops)) {
             for (const auto& stop : stops) {
-                if (destinationColorSpace) {
-                    auto [r, g, b, a ] = getResolvedColorComponentsInColorSpace(stop.color, *destinationColorSpace);
-                    colorComponents.appendList({ r, g, b, a });
-                } else {
-                    auto [r, g, b, a] = stop.color.toColorTypeLossy<SRGBA<float>>().resolved();
-                    colorComponents.appendList({ r, g, b, a });
-                }
+                auto [r, g, b, a] = stop.color.toColorTypeLossy<SRGBA<float>>().resolved();
+                colorComponents.appendList({ r, g, b, a });
 
                 locations.append(stop.offset);
             }
-
-            if (destinationColorSpace)
-                return destinationColorSpace->platformColorSpace();
 
             return cachedCGColorSpaceSingleton<ColorSpaceFor<SRGBA<float>>>();
         }
@@ -204,7 +156,7 @@ GradientRendererCG::Strategy GradientRendererCG::makeGradient(ColorInterpolation
 
     apply139572277Workaround();
 
-    return Gradient { adoptCF(CGGradientCreateWithColorComponentsAndOptions(cgColorSpace.get(), colorComponents.span().data(), locations.span().data(), numberOfStops, gradientOptionsDictionary(colorInterpolationMethod))), destinationColorSpace };
+    return Gradient { adoptCF(CGGradientCreateWithColorComponentsAndOptions(cgColorSpace.get(), colorComponents.span().data(), locations.span().data(), numberOfStops, gradientOptionsDictionary(colorInterpolationMethod))) };
 }
 
 // MARK: - Shading strategy.

--- a/Source/WebCore/platform/graphics/cg/GradientRendererCG.h
+++ b/Source/WebCore/platform/graphics/cg/GradientRendererCG.h
@@ -44,18 +44,15 @@ struct ColorConvertedToInterpolationColorSpaceStop {
 
 class GradientRendererCG {
 public:
-    GradientRendererCG(ColorInterpolationMethod, const GradientColorStops&, std::optional<DestinationColorSpace>);
+    GradientRendererCG(ColorInterpolationMethod, const GradientColorStops&);
 
     void drawLinearGradient(CGContextRef, CGPoint startPoint, CGPoint endPoint, CGGradientDrawingOptions);
     void drawRadialGradient(CGContextRef, CGPoint startCenter, CGFloat startRadius, CGPoint endCenter, CGFloat endRadius, CGGradientDrawingOptions);
     void drawConicGradient(CGContextRef, CGPoint center, CGFloat angle);
 
-    std::optional<DestinationColorSpace> colorSpace() const;
-
 private:
     struct Gradient {
         RetainPtr<CGGradientRef> gradient;
-        std::optional<DestinationColorSpace> colorSpace;
     };
 
     struct Shading {
@@ -96,8 +93,8 @@ private:
 
     using Strategy = Variant<Gradient, Shading>;
 
-    Strategy pickStrategy(ColorInterpolationMethod, const GradientColorStops&, std::optional<DestinationColorSpace>) const;
-    Strategy makeGradient(ColorInterpolationMethod, const GradientColorStops&, std::optional<DestinationColorSpace>) const;
+    Strategy pickStrategy(ColorInterpolationMethod, const GradientColorStops&) const;
+    Strategy makeGradient(ColorInterpolationMethod, const GradientColorStops&) const;
     Strategy makeShading(ColorInterpolationMethod, const GradientColorStops&) const;
 
     Strategy m_strategy;


### PR DESCRIPTION
#### cfa5a1badcde481945df422fe62cd1abab721b3e
<pre>
REGRESSION(294844@main): svg/filters/feTile.svg is broken
<a href="https://bugs.webkit.org/show_bug.cgi?id=305066">https://bugs.webkit.org/show_bug.cgi?id=305066</a>
<a href="https://rdar.apple.com/167786547">rdar://167786547</a>

Reviewed by Matt Woodrow.

294844@main added caching of colors in gradients after converting to the destination colorspace, for performance.
However, this means that the gradient colors are now going to be interpolated in that destination space,
which gives in correct results, especially for linearRGB as used in filters. So revert the change, but add
tests.

Tests: imported/w3c/web-platform-tests/css/filter-effects/reference/svg-filter-gradient-interpolation-ref.html
       imported/w3c/web-platform-tests/css/filter-effects/svg-filter-gradient-interpolation.html

* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/reference/svg-filter-gradient-interpolation-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/svg-filter-gradient-interpolation-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/svg-filter-gradient-interpolation.html: Added.
* Source/WebCore/platform/graphics/Gradient.h:
* Source/WebCore/platform/graphics/cg/GradientCG.cpp:
(WebCore::Gradient::paint):
* Source/WebCore/platform/graphics/cg/GradientRendererCG.cpp:
(WebCore::GradientRendererCG::GradientRendererCG):
(WebCore::GradientRendererCG::pickStrategy const):
(WebCore::GradientRendererCG::makeGradient const):
(WebCore::GradientRendererCG::colorSpace const): Deleted.
(WebCore::getResolvedColorComponentsInColorSpace): Deleted.
* Source/WebCore/platform/graphics/cg/GradientRendererCG.h:

Canonical link: <a href="https://commits.webkit.org/309060@main">https://commits.webkit.org/309060@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8fb12e77b39ee85c501e0c0b4cf781d29c37fa9d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149182 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21895 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15465 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157870 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102613 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/12b51fd4-7571-4a3b-af8c-a46b473d8015) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151055 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22349 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21773 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115013 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81866 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152142 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17188 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133870 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95769 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cd97a077-03ec-4abc-90bf-174ef83e005c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16288 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14151 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5723 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125888 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11808 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160356 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3351 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13328 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; 37 flakes 1 failures; Uploaded test results; layout-tests (exception)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123058 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21697 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18187 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; layout-tests (exception)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123284 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33534 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21705 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133601 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/77906 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18527 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10349 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21307 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85122 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21039 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21187 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/21095 "Build was cancelled. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | | | | 
<!--EWS-Status-Bubble-End-->