### PR TITLE
[run-webkit-tests] Run wk1 and wk2 tests in a single invocation

### DIFF
--- a/LayoutTests/fast/harness/results.html
+++ b/LayoutTests/fast/harness/results.html
@@ -639,15 +639,17 @@ class TestResults
 };
 
 class TestResultsController
-{        
-    constructor(containerElement, testResults)
+{
+    constructor(containerElement, testResults, pathPrefix)
     {
         this.containerElement = containerElement;
         this.testResults = testResults;
+        this.pathPrefix = pathPrefix || '';
+        this.containerElement._controller = this;
 
         this.shouldToggleImages = true;
         this._togglingImageInterval = null;
-        
+
         this._updatePageTitle();
 
         this.buildResultsTables();
@@ -825,10 +827,10 @@ class TestResultsController
         return document.getElementById('unexpected-results').checked;
     }
 
-    static _testListHeader(title)
+    _testListHeader(title)
     {
         let header = document.createElement('h1');
-        header.innerHTML = title + ' (<span class=test-list-count></span>): <a href="#" class=flag-all onclick="controller.flagAll(this)">flag all</a>';
+        header.innerHTML = title + ' (<span class=test-list-count></span>): <a href="#" class=flag-all onclick="flagAllForElement(this)">flag all</a>';
         return header;
     }
 
@@ -903,30 +905,33 @@ class TestResultsController
 
     testLink(testResult)
     {
-        return '<a class=test-link onclick="controller.checkServerIsRunning(event)" href="' + this.layoutTestURL(testResult) + '">' + testResult.name + '</a><span class=flag onclick="controller.unflag(this)"> \u2691</span>';
+        return '<a class=test-link onclick="checkServerIsRunningForElement(event)" href="' + this.layoutTestURL(testResult) + '">' + testResult.name + '</a><span class=flag onclick="unflagForElement(this)"> \u2691</span>';
     }
     
     expandButtonSpan()
     {
-        return '<span class=expand-button onclick="controller.toggleExpectations(this)"><span class=expand-button-text>+</span></span>';
+        return '<span class=expand-button onclick="toggleExpectationsForElement(this)"><span class=expand-button-text>+</span></span>';
     }
-    
-    static resultLink(testPrefix, suffix, contents)
+
+    resultLink(testPrefix, suffix, contents)
     {
-        return '<a class=result-link href="' + encodeURI(testPrefix + suffix) + '" data-prefix="' + testPrefix + '">' + contents + '</a> ';
+        // Don't add pathPrefix for absolute paths (http://, https://, file://)
+        let isAbsolutePath = testPrefix.match(/^(https?|file):\/\//);
+        let path = isAbsolutePath ? testPrefix : (this.pathPrefix + testPrefix);
+        return '<a class=result-link href="' + encodeURI(path + suffix) + '" data-prefix="' + testPrefix + '">' + contents + '</a> ';
     }
 
     textResultLinks(prefix)
     {
-        let html = TestResultsController.resultLink(prefix, '-expected.txt', 'expected') +
-            TestResultsController.resultLink(prefix, '-actual.txt', 'actual') +
-            TestResultsController.resultLink(prefix, '-diff.txt', 'diff');
+        let html = this.resultLink(prefix, '-expected.txt', 'expected') +
+            this.resultLink(prefix, '-actual.txt', 'actual') +
+            this.resultLink(prefix, '-diff.txt', 'diff');
 
         if (this.testResults.hasPrettyPatch())
-            html += TestResultsController.resultLink(prefix, '-pretty-diff.html', 'pretty diff');
+            html += this.resultLink(prefix, '-pretty-diff.html', 'pretty diff');
 
         if (this.testResults.hasWDiff())
-            html += TestResultsController.resultLink(prefix, '-wdiff.html', 'wdiff');
+            html += this.resultLink(prefix, '-wdiff.html', 'wdiff');
 
         return html;
     }
@@ -1066,8 +1071,9 @@ class TestResultsController
 
         // FIXME: this is all pretty confusing. Simplify.
         if (this.shouldToggleImages) {
+            let self = this;
             Utils.forEach(document.querySelectorAll('table:not(#missing-table) tbody:not([mismatchreftest]) a[href$=".png"]'), TestResultsController._convertToTogglingHandler(function(prefix) {
-                return TestResultsController.resultLink(prefix, '-diffs.html', 'images');
+                return self.resultLink(prefix, '-diffs.html', 'images');
             }));
             Utils.forEach(document.querySelectorAll('table:not(#missing-table) tbody:not([mismatchreftest]) img[src$=".png"]'), TestResultsController._convertToTogglingHandler(TestResultsController._togglingImage));
         } else {
@@ -1250,9 +1256,9 @@ class SectionBuilder {
     build()
     {
         TestResults.sortByName(this._tests);
-        
+
         let section = document.createElement('section');
-        section.appendChild(TestResultsController._testListHeader(this.sectionTitle()));
+        section.appendChild(this._resultsController._testListHeader(this.sectionTitle()));
         if (this.hideWhenShowingUnexpectedResultsOnly())
             section.classList.add('expected');
 
@@ -1435,19 +1441,19 @@ class FailuresSectionBuilder extends SectionBuilder {
     appendAudioFailureLinks(testResult, cell)
     {
         let prefix = Utils.testPrefix(testResult.name);
-        cell.innerHTML += TestResultsController.resultLink(prefix, '-expected.wav', 'expected audio')
-            + TestResultsController.resultLink(prefix, '-actual.wav', 'actual audio')
-            + TestResultsController.resultLink(prefix, '-diff.txt', 'textual diff');
+        cell.innerHTML += this._resultsController.resultLink(prefix, '-expected.wav', 'expected audio')
+            + this._resultsController.resultLink(prefix, '-actual.wav', 'actual audio')
+            + this._resultsController.resultLink(prefix, '-diff.txt', 'textual diff');
     }
-    
+
     appendActualOnlyLinks(testResult, cell)
     {
         let prefix = Utils.testPrefix(testResult.name);
         if (testResult.isMissingAudio())
-            cell.innerHTML += TestResultsController.resultLink(prefix, '-actual.wav', 'audio result');
+            cell.innerHTML += this._resultsController.resultLink(prefix, '-actual.wav', 'audio result');
 
         if (testResult.isMissingText())
-            cell.innerHTML += TestResultsController.resultLink(prefix, '-actual.txt', 'result');
+            cell.innerHTML += this._resultsController.resultLink(prefix, '-actual.txt', 'result');
     }
 
     imageResultLinks(testResult, testPrefix, resultToken)
@@ -1457,27 +1463,27 @@ class FailuresSectionBuilder extends SectionBuilder {
             let testExtension = Utils.splitExtension(testResult.name)[1];
 
             if (testResult.isMismatchRefTest()) {
-                result += TestResultsController.resultLink(this._resultsController.layoutTestsBasePath() + testPrefix, '-expected-mismatch' + testExtension, 'ref mismatch');
-                result += TestResultsController.resultLink(testPrefix, '-actual.png', 'actual');
+                result += this._resultsController.resultLink(this._resultsController.layoutTestsBasePath() + testPrefix, '-expected-mismatch' + testExtension, 'ref mismatch');
+                result += this._resultsController.resultLink(testPrefix, '-actual.png', 'actual');
             } else {
                 if (testResult.isMatchRefTest())
-                    result += TestResultsController.resultLink(this._resultsController.layoutTestsBasePath() + testPrefix, '-expected' + testExtension, 'reference');
+                    result += this._resultsController.resultLink(this._resultsController.layoutTestsBasePath() + testPrefix, '-expected' + testExtension, 'reference');
 
                 if (this._resultsController.shouldToggleImages)
-                    result += TestResultsController.resultLink(testPrefix, '-diffs.html', 'images');
+                    result += this._resultsController.resultLink(testPrefix, '-diffs.html', 'images');
                 else {
-                    result += TestResultsController.resultLink(testPrefix, '-expected.png', 'expected');
-                    result += TestResultsController.resultLink(testPrefix, '-actual.png', 'actual');
+                    result += this._resultsController.resultLink(testPrefix, '-expected.png', 'expected');
+                    result += this._resultsController.resultLink(testPrefix, '-actual.png', 'actual');
                 }
 
                 const diff = Math.max(testResult.info.image_diff_percent, 0.01).toFixed(2);
-                result += TestResultsController.resultLink(testPrefix, '-diff.png', `diff (${diff}%)`);
+                result += this._resultsController.resultLink(testPrefix, '-diff.png', `diff (${diff}%)`);
             }
         }
-        
+
         if (testResult.hasMissingResult() && testResult.isMissingImage())
-            result += TestResultsController.resultLink(testPrefix, '-actual.png', 'png result');
-        
+            result += this._resultsController.resultLink(testPrefix, '-actual.png', 'png result');
+
         return result;
     }
 };
@@ -1526,7 +1532,7 @@ class TestsWithStdErrSectionBuilder extends SectionBuilder {
 
     fillTestResultCell(testResult, cell)
     {
-        cell.innerHTML = TestResultsController.resultLink(Utils.testPrefix(testResult.name), '-stderr.txt', 'stderr');
+        cell.innerHTML = this._resultsController.resultLink(Utils.testPrefix(testResult.name), '-stderr.txt', 'stderr');
     }
 };
 
@@ -1545,8 +1551,8 @@ class CrashingTestsSectionBuilder extends SectionBuilder {
 
     fillTestResultCell(testResult, cell)
     {
-        cell.innerHTML = TestResultsController.resultLink(Utils.testPrefix(testResult.name), '-crash-log.txt', 'crash log')
-                       + TestResultsController.resultLink(Utils.testPrefix(testResult.name), '-sample.txt', 'sample');
+        cell.innerHTML = this._resultsController.resultLink(Utils.testPrefix(testResult.name), '-crash-log.txt', 'crash log')
+                       + this._resultsController.resultLink(Utils.testPrefix(testResult.name), '-sample.txt', 'sample');
     }
 };
 
@@ -1554,7 +1560,7 @@ class OtherCrashesSectionBuilder extends SectionBuilder {
     sectionTitle() { return 'Other crashes'; }
     fillTestResultCell(testResult, cell)
     {
-        cell.innerHTML = TestResultsController.resultLink(Utils.testPrefix(testResult.name), '-crash-log.txt', 'crash log');
+        cell.innerHTML = this._resultsController.resultLink(Utils.testPrefix(testResult.name), '-crash-log.txt', 'crash log');
     }
 
     createHistoryCell(testResult)
@@ -1873,14 +1879,24 @@ class OptionWriter {
     }
 };
 
-let testResults;
-function ADD_RESULTS(input)
+let resultsByVariant = {};
+
+function ADD_RESULTS(arg1, arg2)
 {
-    testResults = new TestResults(input);
+    if (arguments.length === 1) {
+        input = arg1;
+        subdirectory = '';
+    } else {
+        subdirectory = arg1;
+        input = arg2;
+    }
+
+    resultsByVariant[subdirectory] = new TestResults(input);
 }
 </script>
 
 <script src="full_results.json"></script>
+<script src="wk1/full_results.json" onerror="this.remove()"></script>
 
 <script>
 
@@ -2085,20 +2101,106 @@ function handleMouseDown(e)
 
 document.addEventListener('mousedown', handleMouseDown, false);
 
-let controller;
+function getControllerForElement(element)
+{
+    let node = element;
+    while (node) {
+        if (node._controller)
+            return node._controller;
+        node = node.parentNode;
+    }
+    return controller;
+}
+
+function toggleExpectationsForElement(element)
+{
+    let ctrl = getControllerForElement(element);
+    if (ctrl)
+        ctrl.toggleExpectations(element);
+}
+
+function checkServerIsRunningForElement(event)
+{
+    let ctrl = getControllerForElement(event.target);
+    if (ctrl)
+        ctrl.checkServerIsRunning(event);
+}
+
+function unflagForElement(element)
+{
+    let ctrl = getControllerForElement(element);
+    if (ctrl)
+        ctrl.unflag(element);
+}
+
+function flagAllForElement(element)
+{
+    let ctrl = getControllerForElement(element);
+    if (ctrl)
+        ctrl.flagAll(element);
+}
+
+let controllersByVariant = {};
 let pixelZoomer;
 let testNavigator;
 
 function generatePage()
 {
     let container = document.getElementById('main-content');
+    let variants = Object.keys(resultsByVariant).sort();
+    let hasMultipleVariants = variants.length > 1;
 
-    controller = new TestResultsController(container, testResults);
+    // Default variant (empty string) always comes first if it exists
+    let defaultVariantIndex = variants.indexOf('');
+    if (defaultVariantIndex > 0) {
+        variants.splice(defaultVariantIndex, 1);
+        variants.unshift('');
+    }
+
+    for (let i = 0; i < variants.length; i++) {
+        let variant = variants[i];
+        let testResults = resultsByVariant[variant];
+
+        // Add header for each variant when there are multiple
+        if (hasMultipleVariants) {
+            let variantHeader = document.createElement('h1');
+            if (variant === '') {
+                variantHeader.textContent = 'WebKit Results';
+            } else if (variant === 'wk1') {
+                variantHeader.textContent = 'WebKitLegacy Results';
+            } else {
+                variantHeader.textContent = 'Results for ' + variant;
+            }
+
+            if (i > 0) {
+                variantHeader.style.marginTop = '3em';
+                variantHeader.style.borderTop = '3px solid #ccc';
+                variantHeader.style.paddingTop = '1em';
+            } else {
+                variantHeader.style.marginBottom = '0.5em';
+            }
+            container.appendChild(variantHeader);
+        }
+
+        let variantContainer = document.createElement('div');
+        variantContainer.id = variant ? (variant + '-results') : 'main-results';
+        container.appendChild(variantContainer);
+
+        let pathPrefix = variant ? (variant + '/') : '';
+        controllersByVariant[variant] = new TestResultsController(variantContainer, testResults, pathPrefix);
+    }
+
     pixelZoomer = new PixelZoomer();
     testNavigator = new TestNavigator();
 
     OptionWriter.apply();
 }
+
+Object.defineProperty(window, 'controller', {
+    get: function() {
+        return controllersByVariant[''] || controllersByVariant[Object.keys(controllersByVariant)[0]];
+    }
+});
 
 window.addEventListener('load', generatePage, false);
 

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/manager.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/manager.py
@@ -36,6 +36,7 @@ objects to the Manager. The Manager then aggregates the TestFailures to
 create a final report.
 """
 
+import copy
 import csv
 import json
 import logging
@@ -85,17 +86,21 @@ class Manager(object):
         """Initialize test runner data structures.
 
         Args:
-          port: an object implementing port-specific
+          port: base port for configuration
           options: a dictionary of command line options
           printer: a Printer object to record updates to.
         """
-        self._port = port
+        self._base_port = port
+        self._port = port  # Will be updated per driver in run()
         fs = port.host.filesystem
         self._filesystem = fs
         self._options = options
         self._printer = printer
+        self._driver_names = options.driver_names
+        self._subdirectories = self._compute_subdirectories(self._driver_names, port)
+        self._current_driver_name = None  # Set during driver loop in run()
         self._expectations = OrderedDict()
-        self._results_directory = self._port.results_directory()
+        self._results_directory = self._base_port.results_directory()
         self._finder = LayoutTestFinder(self._port, self._options)
         self._runner = None
 
@@ -108,9 +113,57 @@ class Manager(object):
                 except (ValueError, IOError):
                     pass
 
+    @staticmethod
+    def _compute_subdirectories(driver_names, base_port):
+        """Compute subdirectory mapping for each driver.
+
+        Args:
+            driver_names: list of driver names (e.g., ['WebKitTestRunner', 'DumpRenderTree'])
+            base_port: port instance used to determine driver types
+
+        Returns:
+            dict mapping driver_name -> subdirectory (None for main directory)
+        """
+        subdirectories = {}
+        for driver_name in driver_names:
+            if 'WebKitTestRunner' in driver_name:
+                subdirectories[driver_name] = None
+            elif base_port.is_webkitlegacy_driver(driver_name):
+                subdirectories[driver_name] = 'wk1'
+            else:
+                subdirectories[driver_name] = driver_name
+
+        if len(subdirectories) == 1:
+            subdirectories = {name: None for name in subdirectories.keys()}
+
+        return subdirectories
+
+    def _create_port_for_driver(self, driver_name):
+        """Create a port instance configured for a specific driver.
+
+        Args:
+            driver_name: name of the driver (e.g., 'WebKitTestRunner', 'DumpRenderTree')
+
+        Returns:
+            A Port instance configured for the specified driver
+        """
+        driver_options = copy.copy(self._options)
+        driver_options.driver_names = [driver_name]
+
+        subdirectory = self._subdirectories.get(driver_name)
+        if subdirectory:
+            # Set results directory to subdirectory for this driver
+            driver_options.results_directory = self._filesystem.join(
+                self._base_port.results_directory(),
+                subdirectory
+            )
+
+        return self._base_port.host.port_factory.get(driver_options.platform, driver_options)
+
     def _collect_tests(self,
                        paths,  # type: List[str]
                        device_type_list,  # type: List[Optional[DeviceType]]
+                       driver_name,  # type: str
                        ):
         aggregate_tests = set()  # type: Set[Test]
         aggregate_tests_to_run = set()  # type: Set[Test]
@@ -126,9 +179,9 @@ class Manager(object):
             test_names = [test.test_path for test in tests]
 
             self._printer.write_update(u'Parsing expectations {}...'.format(for_device_type))
-            self._expectations[device_type] = test_expectations.TestExpectations(self._port, test_names, force_expectations_pass=self._options.force, device_type=device_type)
-            self._expectations[device_type].parse_all_expectations()
-            self._expectations[device_type].add_test_list_expectations(self._finder.get_test_list_expectations())
+            self._expectations[(driver_name, device_type)] = test_expectations.TestExpectations(self._port, test_names, force_expectations_pass=self._options.force, device_type=device_type)
+            self._expectations[(driver_name, device_type)].parse_all_expectations()
+            self._expectations[(driver_name, device_type)].add_test_list_expectations(self._finder.get_test_list_expectations())
 
             tests_to_run = self._tests_to_run(tests, device_type=device_type)
             tests_to_run_by_device[device_type] = [test for test in tests_to_run if test not in aggregate_tests_to_run]
@@ -222,7 +275,7 @@ class Manager(object):
     def _tests_to_run(self, tests, device_type):
         test_names = {test.test_path for test in tests}
         test_names_to_skip = self._skip_tests(test_names,
-                                              self._expectations[device_type],
+                                              self._expectations[(self._current_driver_name, device_type)],
                                               {test.test_path for test in tests if test.needs_any_server})
         tests_to_run = [test for test in tests if test.test_path not in test_names_to_skip]
 
@@ -271,12 +324,12 @@ class Manager(object):
         )
 
     def _test_is_slow(self, test_file, device_type):
-        if self._expectations[device_type].model().has_modifier(test_file, test_expectations.SLOW):
+        if self._expectations[(self._current_driver_name, device_type)].model().has_modifier(test_file, test_expectations.SLOW):
             return True
         return "slow" in self._tests_options.get(test_file, [])
 
     def _test_should_dump_jsconsolelog_in_stderr(self, test_file, device_type):
-        return self._expectations[device_type].model().has_modifier(test_file, test_expectations.DUMPJSCONSOLELOGINSTDERR)
+        return self._expectations[(self._current_driver_name, device_type)].model().has_modifier(test_file, test_expectations.DUMPJSCONSOLELOGINSTDERR)
 
     def _multiply_test_inputs(self, test_inputs, repeat_each, iterations):
         if repeat_each == 1:
@@ -323,186 +376,236 @@ class Manager(object):
                     _log.critical('--test-list file "{}" not found'.format(list_path))
                     return test_run_results.RunDetails(exit_code=-1)
 
-        device_type_list = self._port.supported_device_types()
-        tests_to_run_by_device, aggregate_tests_to_skip = self._collect_tests(args, device_type_list)
-
-        aggregate_tests_to_run = set()  # type: Set[Test]
-        for v in tests_to_run_by_device.values():
-            aggregate_tests_to_run.update(v)
-
-        skipped_tests_by_path = defaultdict(set)
-        for test in aggregate_tests_to_skip:
-            skipped_tests_by_path[test.test_path].add(test)
-
-        # If a test is marked skipped, but was explicitly requested, run it anyways.
-        # However, tests explicitly marked [ Skip ] in a --test-list file should stay skipped.
-        if self._options.skipped != 'always':
-            test_list_skip_paths = self._finder.get_test_list_skip_paths()
-            _, explicitly_specified_tests = self._finder.find_tests_for_specified_files(self._options, args)
-            for test in explicitly_specified_tests:
-                path = test.test_path
-                if path in skipped_tests_by_path and path not in test_list_skip_paths:
-                    skipped_tests = skipped_tests_by_path[path]
-                    tests_to_run_by_device[device_type_list[0]].extend(skipped_tests)
-                    aggregate_tests_to_run |= skipped_tests
-                    aggregate_tests_to_skip -= skipped_tests
-                    del skipped_tests_by_path[path]
-
-        aggregate_tests = aggregate_tests_to_run | aggregate_tests_to_skip
-
-        self._printer.print_found(len(aggregate_tests),
-                                  len(aggregate_tests_to_run),
-                                  self._options.repeat_each,
-                                  self._options.iterations)
-        start_time = time.time()
-
-        # Check to see if all tests we are running are skipped.
-        if aggregate_tests == aggregate_tests_to_skip:
-            # XXX: this is currently identical to the follow if, which likely isn't intended
-            _log.error("All tests skipped.")
-            return test_run_results.RunDetails(exit_code=0, skipped_all_tests=True)
-
-        # Check to make sure we have no tests to run that are not skipped.
-        if not aggregate_tests_to_run:
-            _log.critical('No tests to run.')
-            return test_run_results.RunDetails(exit_code=-1)
-
-        self._printer.write_update("Checking build ...")
-        if not self._port.check_build():
-            _log.error("Build check failed")
-            return test_run_results.RunDetails(exit_code=-1)
-
-        if self._options.clobber_old_results:
-            self._clobber_old_results()
-
-        # Create the output directory if it doesn't already exist.
-        self._port.host.filesystem.maybe_make_directory(self._results_directory)
-
-        needs_http = (any(test.needs_http_server for tests in itervalues(tests_to_run_by_device) for test in tests) or self._options.load_in_cross_origin_iframe)
-        needs_web_platform_test_server = any(test.needs_wpt_server for tests in itervalues(tests_to_run_by_device) for test in tests)
-        needs_websockets = any(test.needs_websocket_server for tests in itervalues(tests_to_run_by_device) for test in tests)
-        self._runner = LayoutTestRunner(self._options, self._port, self._printer, self._results_directory,
-                                        needs_http=needs_http, needs_web_platform_test_server=needs_web_platform_test_server, needs_websockets=needs_websockets)
-
-        initial_results = None
-        retry_results = None
-        enabled_pixel_tests_in_retry = False
-
+        overall_initial_results = None
+        overall_retry_results = None
+        overall_enabled_pixel_tests_in_retry = False
+        overall_start_time = time.time()
         max_child_processes_for_run = 1
-        child_processes_option_value = int(self._options.child_processes or 0)
-        uploads = []
+        all_uploads = []
 
-        for i, device_type in enumerate(device_type_list):
-            specified_child_processes = (
-                child_processes_option_value
-                or self._port.default_child_processes(device_type=device_type)
-            )
+        for driver_name in self._driver_names:
+            self._current_driver_name = driver_name
+            self._port = self._create_port_for_driver(driver_name)
+            subdirectory = self._subdirectories.get(driver_name)
 
-            max_child_processes = self._port.max_child_processes(
-                device_type=device_type
-            )
+            self._results_directory = self._port.results_directory()
+            self._finder = LayoutTestFinder(self._port, self._options)
 
-            if i > 0 and self._port.is_simulator():
-                # Limit the number of simulators we end up booting by only using one for
-                # all devices after the first, assuming we run the vast majority of
-                # tests on the first device.
-                max_child_processes = min(1, max_child_processes)
+            device_type_list = self._port.supported_device_types()
+            tests_to_run_by_device, aggregate_tests_to_skip = self._collect_tests(args, device_type_list, driver_name)
 
-            self._options.child_processes = min(
-                max_child_processes, specified_child_processes
-            )
+            aggregate_tests_to_run = set()  # type: Set[Test]
+            for v in tests_to_run_by_device.values():
+                aggregate_tests_to_run.update(v)
 
-            _log.info('')
-            if not self._options.child_processes:
-                skipped_by_default = (
-                    specified_child_processes == 0 and max_child_processes > 0
-                )
+            skipped_tests_by_path = defaultdict(set)
+            for test in aggregate_tests_to_skip:
+                skipped_tests_by_path[test.test_path].add(test)
 
-                if skipped_by_default:
-                    skip_reason = 'skipped by default'
-                else:
-                    skip_reason = 'not available'
+            # If a test is marked skipped, but was explicitly requested, run it anyways.
+            # However, tests explicitly marked [ Skip ] in a --test-list file should stay skipped.
+            if self._options.skipped != 'always':
+                test_list_skip_paths = self._finder.get_test_list_skip_paths()
+                _, explicitly_specified_tests = self._finder.find_tests_for_specified_files(self._options, args)
+                for test in explicitly_specified_tests:
+                    path = test.test_path
+                    if path in skipped_tests_by_path and path not in test_list_skip_paths:
+                        skipped_tests = skipped_tests_by_path[path]
+                        tests_to_run_by_device[device_type_list[0]].extend(skipped_tests)
+                        aggregate_tests_to_run |= skipped_tests
+                        aggregate_tests_to_skip -= skipped_tests
+                        del skipped_tests_by_path[path]
 
-                _log.info(
-                    'Skipping {} because {} is {}'.format(
-                        pluralize(len(tests_to_run_by_device[device_type]), 'test'),
-                        str(device_type),
-                        skip_reason,
-                    )
-                )
-                _log.info('')
-                continue
+            aggregate_tests = aggregate_tests_to_run | aggregate_tests_to_skip
 
-            max_child_processes_for_run = max(self._options.child_processes, max_child_processes_for_run)
+            self._printer.print_found(len(aggregate_tests),
+                                      len(aggregate_tests_to_run),
+                                      self._options.repeat_each,
+                                      self._options.iterations)
+            start_time = time.time()
 
-            self._printer.print_baseline_search_path(device_type=device_type)
+            # Check to see if all tests we are running are skipped.
+            if aggregate_tests == aggregate_tests_to_skip:
+                # XXX: this is currently identical to the follow if, which likely isn't intended
+                _log.error("All tests skipped.")
+                return test_run_results.RunDetails(exit_code=0, skipped_all_tests=True)
 
-            _log.info(u'Running {}{}'.format(pluralize(len(tests_to_run_by_device[device_type]), 'test'), u' for {}'.format(device_type) if device_type else ''))
-            _log.info('')
-            start_time_for_device = time.time()
-            if not tests_to_run_by_device[device_type]:
-                continue
-
-            test_inputs = [self._test_input_for_file(test, device_type=device_type)
-                           for test in tests_to_run_by_device[device_type]]
-
-            if not self._set_up_run(test_inputs, device_type=device_type):
+            # Check to make sure we have no tests to run that are not skipped.
+            if not aggregate_tests_to_run:
+                _log.critical('No tests to run.')
                 return test_run_results.RunDetails(exit_code=-1)
 
-            configuration = self._port.configuration_for_upload(self._port.target_host(0))
-            if not configuration.get('flavor', None):  # The --result-report-flavor argument should override wk1/wk2
-                configuration['flavor'] = 'wk1' if self._port.is_webkitlegacy() else 'wk2'
-            temp_initial_results, temp_retry_results, temp_enabled_pixel_tests_in_retry = self._run_test_subset(test_inputs, device_type=device_type)
+            self._printer.write_update("Checking build ...")
+            if not self._port.check_build():
+                _log.error("Build check failed")
+                return test_run_results.RunDetails(exit_code=-1)
 
-            skipped_results = TestRunResults(self._expectations[device_type], len(aggregate_tests_to_skip))
-            for skipped_test in set(aggregate_tests_to_skip):
-                skipped_result = test_results.TestResult(skipped_test.test_path)
-                skipped_result.type = test_expectations.SKIP
-                skipped_results.add(skipped_result, expected=True)
-            temp_initial_results = temp_initial_results.merge(skipped_results)
+            if self._options.clobber_old_results:
+                self._clobber_old_results()
 
-            if self._options.report_urls:
-                self._printer.writeln('\n')
-                self._printer.write_update('Preparing upload data ...')
+            # Create the output directory if it doesn't already exist.
+            self._port.host.filesystem.maybe_make_directory(self._results_directory)
 
-                upload = Upload(
-                    suite=self._options.suite or 'layout-tests',
-                    configuration=configuration,
-                    details=Upload.create_details(options=self._options),
-                    commits=self._port.commits_for_upload(),
-                    timestamp=start_time,
-                    run_stats=Upload.create_run_stats(
-                        start_time=start_time_for_device,
-                        end_time=time.time(),
-                        tests_skipped=temp_initial_results.remaining + temp_initial_results.expected_skips,
-                    ),
-                    results=self._results_to_upload_json_trie(self._expectations[device_type], temp_initial_results),
+            needs_http = (any(test.needs_http_server for tests in itervalues(tests_to_run_by_device) for test in tests) or self._options.load_in_cross_origin_iframe)
+            needs_web_platform_test_server = any(test.needs_wpt_server for tests in itervalues(tests_to_run_by_device) for test in tests)
+            needs_websockets = any(test.needs_websocket_server for tests in itervalues(tests_to_run_by_device) for test in tests)
+            self._runner = LayoutTestRunner(self._options, self._port, self._printer, self._results_directory,
+                                            needs_http=needs_http, needs_web_platform_test_server=needs_web_platform_test_server, needs_websockets=needs_websockets)
+
+            initial_results = None
+            retry_results = None
+            enabled_pixel_tests_in_retry = False
+
+            child_processes_option_value = int(self._options.child_processes or 0)
+            uploads = []
+
+            for i, device_type in enumerate(device_type_list):
+                specified_child_processes = (
+                    child_processes_option_value
+                    or self._port.default_child_processes(device_type=device_type)
                 )
-                for hostname in self._options.report_urls:
-                    self._printer.write_update('Uploading to {} ...'.format(hostname))
-                    if not upload.upload(hostname, log_line_func=self._printer.writeln):
-                        num_failed_uploads += 1
+
+                max_child_processes = self._port.max_child_processes(
+                    device_type=device_type
+                )
+
+                if i > 0 and self._port.is_simulator():
+                    # Limit the number of simulators we end up booting by only using one for
+                    # all devices after the first, assuming we run the vast majority of
+                    # tests on the first device.
+                    max_child_processes = min(1, max_child_processes)
+
+                self._options.child_processes = min(
+                    max_child_processes, specified_child_processes
+                )
+                self._port.set_option('child_processes', self._options.child_processes)
+
+                _log.info('')
+                if not self._options.child_processes:
+                    skipped_by_default = (
+                        specified_child_processes == 0 and max_child_processes > 0
+                    )
+
+                    if skipped_by_default:
+                        skip_reason = 'skipped by default'
                     else:
-                        uploads.append(upload)
-                self._printer.writeln('Uploads completed!')
+                        skip_reason = 'not available'
 
-            initial_results = initial_results.merge(temp_initial_results) if initial_results else temp_initial_results
-            retry_results = retry_results.merge(temp_retry_results) if retry_results else temp_retry_results
-            enabled_pixel_tests_in_retry |= temp_enabled_pixel_tests_in_retry
+                    _log.info(
+                        'Skipping {} because {} is {}'.format(
+                            pluralize(len(tests_to_run_by_device[device_type]), 'test'),
+                            str(device_type),
+                            skip_reason,
+                        )
+                    )
+                    _log.info('')
+                    continue
 
-            if (initial_results and (initial_results.interrupted or initial_results.keyboard_interrupted)) or \
-                    (retry_results and (retry_results.interrupted or retry_results.keyboard_interrupted)):
+                max_child_processes_for_run = max(self._options.child_processes, max_child_processes_for_run)
+
+                self._printer.print_baseline_search_path(device_type=device_type)
+
+                _log.info(u'Running {}{}'.format(pluralize(len(tests_to_run_by_device[device_type]), 'test'), u' for {}'.format(device_type) if device_type else ''))
+                _log.info('')
+                start_time_for_device = time.time()
+                if not tests_to_run_by_device[device_type]:
+                    continue
+
+                test_inputs = [self._test_input_for_file(test, device_type=device_type)
+                               for test in tests_to_run_by_device[device_type]]
+
+                if not self._set_up_run(test_inputs, device_type=device_type):
+                    return test_run_results.RunDetails(exit_code=-1)
+
+                configuration = self._port.configuration_for_upload(self._port.target_host(0))
+                if not configuration.get('flavor', None):  # The --result-report-flavor argument should override wk1/wk2
+                    configuration['flavor'] = 'wk1' if self._port.is_webkitlegacy() else 'wk2'
+                temp_initial_results, temp_retry_results, temp_enabled_pixel_tests_in_retry = self._run_test_subset(test_inputs, device_type=device_type)
+
+                skipped_results = TestRunResults(self._expectations[(self._current_driver_name, device_type)], len(aggregate_tests_to_skip))
+                for skipped_test in set(aggregate_tests_to_skip):
+                    skipped_result = test_results.TestResult(skipped_test.test_path)
+                    skipped_result.type = test_expectations.SKIP
+                    skipped_results.add(skipped_result, expected=True)
+                temp_initial_results = temp_initial_results.merge(skipped_results)
+
+                if self._options.report_urls:
+                    self._printer.writeln('\n')
+                    self._printer.write_update('Preparing upload data ...')
+
+                    upload = Upload(
+                        suite=self._options.suite or 'layout-tests',
+                        configuration=configuration,
+                        details=Upload.create_details(options=self._options),
+                        commits=self._port.commits_for_upload(),
+                        timestamp=start_time,
+                        run_stats=Upload.create_run_stats(
+                            start_time=start_time_for_device,
+                            end_time=time.time(),
+                            tests_skipped=temp_initial_results.remaining + temp_initial_results.expected_skips,
+                        ),
+                        results=self._results_to_upload_json_trie(self._expectations[(self._current_driver_name, device_type)], temp_initial_results),
+                    )
+                    for hostname in self._options.report_urls:
+                        self._printer.write_update('Uploading to {} ...'.format(hostname))
+                        if not upload.upload(hostname, log_line_func=self._printer.writeln):
+                            num_failed_uploads += 1
+                        else:
+                            all_uploads.append(upload)
+                    self._printer.writeln('Uploads completed!')
+
+                initial_results = initial_results.merge(temp_initial_results) if initial_results else temp_initial_results
+                retry_results = retry_results.merge(temp_retry_results) if retry_results else temp_retry_results
+                enabled_pixel_tests_in_retry |= temp_enabled_pixel_tests_in_retry
+
+                if (initial_results and (initial_results.interrupted or initial_results.keyboard_interrupted)) or (retry_results and (retry_results.interrupted or retry_results.keyboard_interrupted)):
+                    break
+
+            if initial_results and not self._options.dry_run:
+                driver_expectations = OrderedDict()
+                for (drv_name, dev_type), expectations in self._expectations.items():
+                    if drv_name == driver_name:
+                        driver_expectations[dev_type] = expectations
+
+                summarized_results_for_driver = test_run_results.summarize_results(
+                    self._port, driver_expectations, initial_results, retry_results, enabled_pixel_tests_in_retry
+                )
+                self._save_json_files(summarized_results_for_driver, initial_results, subdirectory)
+
+            self._runner.stop_servers()
+
+            if initial_results:
+                if overall_initial_results:
+                    overall_initial_results = overall_initial_results.merge(initial_results)
+                else:
+                    overall_initial_results = initial_results
+
+            if retry_results:
+                if overall_retry_results:
+                    overall_retry_results = overall_retry_results.merge(retry_results)
+                else:
+                    overall_retry_results = retry_results
+
+            overall_enabled_pixel_tests_in_retry |= enabled_pixel_tests_in_retry
+
+            if initial_results and (initial_results.interrupted or initial_results.keyboard_interrupted):
                 break
+
 
         # Used for final logging, max_child_processes_for_run is most relevant here.
         self._options.child_processes = max_child_processes_for_run
 
-        self._runner.stop_servers()
+        if overall_initial_results:
+            for test_name, result in overall_initial_results.unexpected_results_by_name.items():
+                overall_initial_results.results_by_name[test_name] = result
+        if overall_retry_results:
+            for test_name, result in overall_retry_results.unexpected_results_by_name.items():
+                overall_retry_results.results_by_name[test_name] = result
 
         end_time = time.time()
-        result = self._end_test_run(start_time, end_time, initial_results, retry_results, enabled_pixel_tests_in_retry)
+        result = self._end_test_run(overall_start_time, end_time, overall_initial_results, overall_retry_results, overall_enabled_pixel_tests_in_retry)
 
-        if self._options.report_urls and uploads:
+        if self._options.report_urls and all_uploads:
             self._printer.writeln('\n')
             self._printer.write_update('Preparing to upload test archive ...')
 
@@ -510,7 +613,7 @@ class Manager(object):
                 archive = self._filesystem.join(temp, 'test-archive')
                 shutil.make_archive(archive, 'zip', self._results_directory)
 
-                for upload in uploads:
+                for upload in all_uploads:
                     for hostname in self._options.report_urls:
                         self._printer.write_update('Uploading archive to {} ...'.format(hostname))
                         if not upload.upload_archive(hostname, self._filesystem.open_binary_file_for_reading(archive + '.zip'), log_line_func=self._printer.writeln):
@@ -574,27 +677,34 @@ class Manager(object):
             self._look_for_new_crash_logs(retry_results, start_time)
 
         _log.debug("summarizing results")
-        summarized_results = test_run_results.summarize_results(self._port, self._expectations, initial_results, retry_results, enabled_pixel_tests_in_retry)
+        flat_expectations = OrderedDict()
+        for key, exp in self._expectations.items():
+            device_type = key[1] if isinstance(key, tuple) else key
+            if device_type not in flat_expectations:
+                flat_expectations[device_type] = exp
+        summarized_results = test_run_results.summarize_results(self._port, flat_expectations, initial_results, retry_results, enabled_pixel_tests_in_retry)
         self._printer.print_results(end_time - start_time, initial_results, summarized_results)
 
         exit_code = -1
         if not self._options.dry_run:
             self._port.print_leaks_summary()
             self._output_perf_metrics(end_time - start_time, initial_results)
-            self._save_json_files(summarized_results, initial_results)
 
-            results_path = self._filesystem.join(self._results_directory, "results.html")
-            self._copy_results_html_file("results.html", results_path)
+            if len(self._driver_names) > 1 or not any(self._subdirectories.values()):
+                results_path = self._filesystem.join(self._base_port.results_directory(), "results.html")
+                self._copy_results_html_file("results.html", results_path)
 
-            treemap_path = self._filesystem.join(self._results_directory, "test-duration-treemap.html")
-            self._copy_results_html_file("test-duration-treemap.html", treemap_path)
+                treemap_path = self._filesystem.join(self._base_port.results_directory(), "test-duration-treemap.html")
+                self._copy_results_html_file("test-duration-treemap.html", treemap_path)
 
             if initial_results.keyboard_interrupted:
                 exit_code = INTERRUPTED_EXIT_STATUS
             else:
                 if self._options.show_results and (initial_results.unexpected_results_by_name or
                     (self._options.full_results_html and initial_results.total_failures)):
-                    self._port.show_results_html_file(results_path)
+                    if len(self._driver_names) > 1 or not any(self._subdirectories.values()):
+                        results_path = self._filesystem.join(self._base_port.results_directory(), "results.html")
+                        self._port.show_results_html_file(results_path)
                 exit_code = self._port.exit_code_from_summarized_results(summarized_results)
         return test_run_results.RunDetails(exit_code, summarized_results, initial_results, retry_results, enabled_pixel_tests_in_retry)
 
@@ -609,7 +719,7 @@ class Manager(object):
         new_test_inputs = self._multiply_test_inputs(test_inputs, repeat_each, iterations)
 
         assert self._runner is not None
-        return self._runner.run_tests(self._expectations[device_type], new_test_inputs, num_workers, retrying, device_type)
+        return self._runner.run_tests(self._expectations[(self._current_driver_name, device_type)], new_test_inputs, num_workers, retrying, device_type)
 
     def _clean_up_run(self):
         _log.debug("Flushing stdout")
@@ -718,13 +828,14 @@ class Manager(object):
                 ), results_trie)
         return results_trie
 
-    def _save_json_files(self, summarized_results, initial_results):
+    def _save_json_files(self, summarized_results, initial_results, subdirectory=None):
         """Writes the results of the test run as JSON files into the results
         dir and upload the files to the appengine server.
 
         Args:
           summarized_results: dict of results
           initial_results: full summary object
+          subdirectory: optional subdirectory name for variant results (e.g., 'wk1')
         """
         _log.debug("Writing JSON files in %s." % self._results_directory)
 
@@ -734,7 +845,12 @@ class Manager(object):
 
         full_results_path = self._filesystem.join(self._results_directory, "full_results.json")
         # We write full_results.json out as jsonp because we need to load it from a file url and WebKit doesn't allow that.
-        json_results_generator.write_json(self._filesystem, summarized_results, full_results_path, callback="ADD_RESULTS")
+        json_string = json.dumps(summarized_results, separators=(',', ':'))
+        if subdirectory:
+            jsonp_string = "ADD_RESULTS('{}',{});".format(subdirectory, json_string)
+        else:
+            jsonp_string = "ADD_RESULTS({});".format(json_string)
+        self._filesystem.write_text_file(full_results_path, jsonp_string)
 
     def _copy_results_html_file(self, filename, destination_path):
         base_dir = self._port.path_from_webkit_base('LayoutTests', 'fast', 'harness')
@@ -762,15 +878,15 @@ class Manager(object):
 
     def _print_expectation_line_for_test(self, format_string, test, device_type):
         test_path = test.test_path
-        main_line = self._expectations[device_type].model().get_expectation_line(test_path)
+        main_line = self._expectations[(self._current_driver_name, device_type)].model().get_expectation_line(test_path)
         if not self._options.verbose:
             print(format_string.format(test_path,
                                        "",
                                        main_line.expected_behavior,
-                                       self._expectations[device_type].readable_filename_and_line_number(main_line),
+                                       self._expectations[(self._current_driver_name, device_type)].readable_filename_and_line_number(main_line),
                                        main_line.original_string or ''))
         else:
-            lines = self._expectations[device_type].model().get_expectation_lines(test_path)
+            lines = self._expectations[(self._current_driver_name, device_type)].model().get_expectation_lines(test_path)
             before_main_line = True
             decision = ""
             for line in lines:
@@ -784,7 +900,7 @@ class Manager(object):
                 print(format_string.format(test_path,
                                            decision,
                                            line.expected_behavior,
-                                           self._expectations[device_type].readable_filename_and_line_number(line),
+                                           self._expectations[(self._current_driver_name, device_type)].readable_filename_and_line_number(line),
                                            line.original_string or ''))
 
     def _print_expectations_for_subset(self, device_type, test_col_width, tests_to_run, tests_to_skip=None):
@@ -801,8 +917,6 @@ class Manager(object):
             self._print_expectation_line_for_test(format_string, test, device_type=device_type)
 
     def print_expectations(self, args):
-        device_type_list = self._port.supported_device_types()
-
         if self._options.test_list:
             for list_path in self._options.test_list:
                 if not self._port.host.filesystem.isfile(list_path):
@@ -810,153 +924,174 @@ class Manager(object):
                     _log.critical('--test-list file "{}" not found'.format(list_path))
                     return -1
 
-        tests_to_run_by_device, aggregate_tests_to_skip = self._collect_tests(args, device_type_list)
+        worst_exit_code = 0
 
-        aggregate_tests_to_run = set()
-        for v in tests_to_run_by_device.values():
-            aggregate_tests_to_run.update(v)
-        aggregate_tests = aggregate_tests_to_run | aggregate_tests_to_skip
+        # Loop over all drivers (like Manager.run() does)
+        for driver_name in self._driver_names:
+            self._current_driver_name = driver_name
+            self._port = self._create_port_for_driver(driver_name)
+            self._results_directory = self._port.results_directory()
+            self._finder = LayoutTestFinder(self._port, self._options)
 
-        self._printer.print_found(len(aggregate_tests), len(aggregate_tests_to_run), self._options.repeat_each, self._options.iterations)
-        test_col_width = max(len(test.test_path) for test in aggregate_tests) + 1
+            device_type_list = self._port.supported_device_types()
+            tests_to_run_by_device, aggregate_tests_to_skip = self._collect_tests(args, device_type_list, driver_name)
 
-        self._print_expectations_for_subset(device_type_list[0], test_col_width, tests_to_run_by_device[device_type_list[0]], aggregate_tests_to_skip)
+            aggregate_tests_to_run = set()
+            for v in tests_to_run_by_device.values():
+                aggregate_tests_to_run.update(v)
+            aggregate_tests = aggregate_tests_to_run | aggregate_tests_to_skip
 
-        for device_type in device_type_list[1:]:
-            self._print_expectations_for_subset(device_type, test_col_width, tests_to_run_by_device[device_type])
+            self._printer.print_found(len(aggregate_tests), len(aggregate_tests_to_run), self._options.repeat_each, self._options.iterations)
+            test_col_width = max(len(test.test_path) for test in aggregate_tests) + 1
 
-        return 0
+            self._print_expectations_for_subset(device_type_list[0], test_col_width, tests_to_run_by_device[device_type_list[0]], aggregate_tests_to_skip)
+
+            for device_type in device_type_list[1:]:
+                self._print_expectations_for_subset(device_type, test_col_width, tests_to_run_by_device[device_type])
+
+        return worst_exit_code
 
     def print_summary(self, args):
-        device_type_list = self._port.supported_device_types()
-        test_stats = {}
-
         if self._options.test_list:
             for list_path in self._options.test_list:
                 if not self._port.host.filesystem.isfile(list_path):
                     _log.critical('')
                     _log.critical('--test-list file "{}" not found'.format(list_path))
-                    return test_run_results.RunDetails(exit_code=-1)
+                    return -1
 
-        self._collect_tests(args, device_type_list)
+        worst_exit_code = 0
 
-        for device_type, expectations in self._expectations.items():
-            test_stats[device_type] = {'__root__': {'count': 0, 'skip': 0, 'pass': 0, 'flaky': 0, 'fail': 0, 'has_tests': False}}
-            device_test_stats = test_stats[device_type]
+        # Loop over all drivers (like Manager.run() does)
+        for driver_name in self._driver_names:
+            self._current_driver_name = driver_name
+            self._port = self._create_port_for_driver(driver_name)
+            self._results_directory = self._port.results_directory()
+            self._finder = LayoutTestFinder(self._port, self._options)
 
-            model = expectations.model()
-            tests_skipped = model.get_tests_with_result_type(test_expectations.SKIP)
-            tests_passing = model.get_tests_with_result_type(test_expectations.PASS)
-            tests_flaky = model.get_tests_with_result_type(test_expectations.FLAKY)
-            tests_misc_fail = model.get_tests_with_result_type(test_expectations.FAIL)
+            device_type_list = self._port.supported_device_types()
+            test_stats = {}
 
-            def _increment_stat(dirname, test_name, test_in_directory):
-                if dirname in device_test_stats:
-                    device_test_stats[dirname]['count'] += 1
-                else:
-                    device_test_stats[dirname] = {'count': 1, 'skip': 0, 'pass': 0, 'flaky': 0, 'fail': 0, 'has_tests': False}
+            self._collect_tests(args, device_type_list, driver_name)
 
-                if test_name in tests_skipped:
-                    device_test_stats[dirname]['skip'] += 1
-                if test_name in tests_passing:
-                    device_test_stats[dirname]['pass'] += 1
-                if test_name in tests_flaky:
-                    device_test_stats[dirname]['flaky'] += 1
-                if test_name in tests_misc_fail:
-                    device_test_stats[dirname]['fail'] += 1
-                device_test_stats[dirname]['has_tests'] = device_test_stats[dirname]['has_tests'] or test_in_directory
+            for (drv_name, device_type), expectations in self._expectations.items():
+                if drv_name != driver_name:
+                    continue
+                test_stats[device_type] = {'__root__': {'count': 0, 'skip': 0, 'pass': 0, 'flaky': 0, 'fail': 0, 'has_tests': False}}
+                device_test_stats = test_stats[device_type]
 
-            for test_name in expectations._full_test_list:
-                path = test_name
-                test_in_directory = True
-                while path != '':
-                    path = os.path.dirname(path)
-                    _increment_stat(path or '__root__', test_name, test_in_directory)
-                    test_in_directory = False
+                model = expectations.model()
+                tests_skipped = model.get_tests_with_result_type(test_expectations.SKIP)
+                tests_passing = model.get_tests_with_result_type(test_expectations.PASS)
+                tests_flaky = model.get_tests_with_result_type(test_expectations.FLAKY)
+                tests_misc_fail = model.get_tests_with_result_type(test_expectations.FAIL)
 
-            print('')
-            print('Summary of test expectations {}in layout test directories:'.format(u'for {} '.format(device_type) if device_type else ''))
-            root = device_test_stats['__root__']
-            print('    {} total tests'.format(root['count']))
-            print('    {} pass'.format(root['pass']))
-            print('    {} are skipped'.format(root['skip']))
-            print('    {} are flaky'.format(root['flaky']))
-            print('    {} fail for other reasons'.format(root['fail']))
+                def _increment_stat(dirname, test_name, test_in_directory):
+                    if dirname in device_test_stats:
+                        device_test_stats[dirname]['count'] += 1
+                    else:
+                        device_test_stats[dirname] = {'count': 1, 'skip': 0, 'pass': 0, 'flaky': 0, 'fail': 0, 'has_tests': False}
 
-            print('')
-            print('Per directory results:')
-            print('(* means there are no tests in that specific directory)')
-            print('')
-            row_format = u'    {0:50s}{1:>8d}{2:>8d}{3:>8d}{4:>8d}{5:>8d}'
-            srow_format = row_format.replace('d', 's')
-            print(srow_format.format('DIRECTORY', 'TOTAL', 'PASS', 'SKIP', 'FLAKY', 'FAIL'))
-            print(srow_format.format('---------', '-----', '----', '----', '-----', '----'))
+                    if test_name in tests_skipped:
+                        device_test_stats[dirname]['skip'] += 1
+                    if test_name in tests_passing:
+                        device_test_stats[dirname]['pass'] += 1
+                    if test_name in tests_flaky:
+                        device_test_stats[dirname]['flaky'] += 1
+                    if test_name in tests_misc_fail:
+                        device_test_stats[dirname]['fail'] += 1
+                    device_test_stats[dirname]['has_tests'] = device_test_stats[dirname]['has_tests'] or test_in_directory
 
-            def _should_include_dir_in_report(dirname):
-                num_dirs = dirname.count('/')
-                if num_dirs > 0:
-                    if num_dirs > 1:
-                        if num_dirs > 2:
-                            if num_dirs > 3:
+                for test_name in expectations._full_test_list:
+                    path = test_name
+                    test_in_directory = True
+                    while path != '':
+                        path = os.path.dirname(path)
+                        _increment_stat(path or '__root__', test_name, test_in_directory)
+                        test_in_directory = False
+
+                print('')
+                print('Summary of test expectations {}in layout test directories:'.format(u'for {} '.format(device_type) if device_type else ''))
+                root = device_test_stats['__root__']
+                print('    {} total tests'.format(root['count']))
+                print('    {} pass'.format(root['pass']))
+                print('    {} are skipped'.format(root['skip']))
+                print('    {} are flaky'.format(root['flaky']))
+                print('    {} fail for other reasons'.format(root['fail']))
+
+                print('')
+                print('Per directory results:')
+                print('(* means there are no tests in that specific directory)')
+                print('')
+                row_format = u'    {0:50s}{1:>8d}{2:>8d}{3:>8d}{4:>8d}{5:>8d}'
+                srow_format = row_format.replace('d', 's')
+                print(srow_format.format('DIRECTORY', 'TOTAL', 'PASS', 'SKIP', 'FLAKY', 'FAIL'))
+                print(srow_format.format('---------', '-----', '----', '----', '-----', '----'))
+
+                def _should_include_dir_in_report(dirname):
+                    num_dirs = dirname.count('/')
+                    if num_dirs > 0:
+                        if num_dirs > 1:
+                            if num_dirs > 2:
+                                if num_dirs > 3:
+                                    return False
+                                elif not re.match(r'^(imported/w3c/web-platform-tests)/', dirname):
+                                    return False
+                            elif not re.match(r'(imported|http|platform)/', dirname):
                                 return False
-                            elif not re.match(r'^(imported/w3c/web-platform-tests)/', dirname):
-                                return False
-                        elif not re.match(r'(imported|http|platform)/', dirname):
+                        elif not re.match(r'^(fast|platform|imported|http)/', dirname):
                             return False
-                    elif not re.match(r'^(fast|platform|imported|http)/', dirname):
-                        return False
-                return True
+                    return True
 
-            for dirname in sorted(device_test_stats.keys()):
-                if not _should_include_dir_in_report(dirname):
-                    continue
-
-                truncated_dirname = re.sub(r'^.*(.{47})$', '...\\g<1>', dirname if device_test_stats[dirname]['has_tests'] else '{}*'.format(dirname))
-                count = device_test_stats[dirname]['count']
-                passing = device_test_stats[dirname]['pass']
-                skip = device_test_stats[dirname]['skip']
-                flaky = device_test_stats[dirname]['flaky']
-                fail = device_test_stats[dirname]['fail']
-                if passing == count:
-                    # Don't print this line if an ancestor directory is all pass also
-                    ancestor_dirname = os.path.dirname(dirname)
-                    while ancestor_dirname and ancestor_dirname not in device_test_stats:
-                        ancestor_dirname = os.path.dirname(ancestor_dirname)
-                    if ancestor_dirname and device_test_stats[ancestor_dirname]['pass'] == device_test_stats[ancestor_dirname]['count']:
+                for dirname in sorted(device_test_stats.keys()):
+                    if not _should_include_dir_in_report(dirname):
                         continue
-                    print(srow_format.format(truncated_dirname, str(count), u"██ PASS", u' ███████', u'████████', u'████████'))
-                    continue
-                elif skip == count:
-                    # Don't print this line if an ancestor directory is all skip also
-                    ancestor_dirname = os.path.dirname(dirname)
-                    while ancestor_dirname and ancestor_dirname not in device_test_stats:
-                        ancestor_dirname = os.path.dirname(ancestor_dirname)
-                    if ancestor_dirname and device_test_stats[ancestor_dirname]['skip'] == device_test_stats[ancestor_dirname]['count']:
+
+                    truncated_dirname = re.sub(r'^.*(.{47})$', '...\\g<1>', dirname if device_test_stats[dirname]['has_tests'] else '{}*'.format(dirname))
+                    count = device_test_stats[dirname]['count']
+                    passing = device_test_stats[dirname]['pass']
+                    skip = device_test_stats[dirname]['skip']
+                    flaky = device_test_stats[dirname]['flaky']
+                    fail = device_test_stats[dirname]['fail']
+                    if passing == count:
+                        # Don't print this line if an ancestor directory is all pass also
+                        ancestor_dirname = os.path.dirname(dirname)
+                        while ancestor_dirname and ancestor_dirname not in device_test_stats:
+                            ancestor_dirname = os.path.dirname(dirname)
+                        if ancestor_dirname and device_test_stats[ancestor_dirname]['pass'] == device_test_stats[ancestor_dirname]['count']:
+                            continue
+                        print(srow_format.format(truncated_dirname, str(count), u"██ PASS", u' ███████', u'████████', u'████████'))
                         continue
-                    print(srow_format.format(truncated_dirname, str(count), u'░░░░░░░', u"░░░ SKIP", u' ░░░░░░░', u'░░░░░░░░'))
-                    continue
-                print(row_format.format(truncated_dirname, count, passing, skip, flaky, fail))
+                    elif skip == count:
+                        # Don't print this line if an ancestor directory is all skip also
+                        ancestor_dirname = os.path.dirname(dirname)
+                        while ancestor_dirname and ancestor_dirname not in device_test_stats:
+                            ancestor_dirname = os.path.dirname(dirname)
+                        if ancestor_dirname and device_test_stats[ancestor_dirname]['skip'] == device_test_stats[ancestor_dirname]['count']:
+                            continue
+                        print(srow_format.format(truncated_dirname, str(count), u'░░░░░░░', u"░░░ SKIP", u' ░░░░░░░', u'░░░░░░░░'))
+                        continue
+                    print(row_format.format(truncated_dirname, count, passing, skip, flaky, fail))
 
-        with open('layout_tests.csv', 'w') as csvfile:
-            writer = csv.writer(csvfile, delimiter=',', quoting=csv.QUOTE_MINIMAL)
+            with open('layout_tests.csv', 'w') as csvfile:
+                writer = csv.writer(csvfile, delimiter=',', quoting=csv.QUOTE_MINIMAL)
 
-            header_row_1 = [''] * 2
-            header_row_2 = ["Directory", "Total"]
-            for device_type in sorted(device_type_list):
-                header_row_1.append('{}{}'.format(self._port.name(), ', {}'.format(device_type) if device_type else ''))
-                header_row_1.extend([''] * 3)
-                header_row_2.extend(['Pass', 'Skip', 'Flaky', 'Fail'])
-            writer.writerow(header_row_1)
-            writer.writerow(header_row_2)
-
-            a_device_test_stat = test_stats[device_type_list[0]]
-            for dirname in sorted(a_device_test_stat.keys()):
-                if not _should_include_dir_in_report(dirname):
-                    continue
-                row = [dirname, a_device_test_stat[dirname]['count']]
+                header_row_1 = [''] * 2
+                header_row_2 = ["Directory", "Total"]
                 for device_type in sorted(device_type_list):
-                    stats = test_stats[device_type][dirname]
-                    row.extend([stats['pass'], stats['skip'], stats['flaky'], stats['fail']])
-                writer.writerow(row)
+                    header_row_1.append('{}{}'.format(self._port.name(), ', {}'.format(device_type) if device_type else ''))
+                    header_row_1.extend([''] * 3)
+                    header_row_2.extend(['Pass', 'Skip', 'Flaky', 'Fail'])
+                writer.writerow(header_row_1)
+                writer.writerow(header_row_2)
 
-        return 0
+                a_device_test_stat = test_stats[device_type_list[0]]
+                for dirname in sorted(a_device_test_stat.keys()):
+                    if not _should_include_dir_in_report(dirname):
+                        continue
+                    row = [dirname, a_device_test_stat[dirname]['count']]
+                    for device_type in sorted(device_type_list):
+                        stats = test_stats[device_type][dirname]
+                        row.extend([stats['pass'], stats['skip'], stats['flaky'], stats['fail']])
+                    writer.writerow(row)
+
+        return worst_exit_code

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/manager_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/manager_unittest.py
@@ -51,7 +51,7 @@ class ManagerTest(unittest.TestCase):
     def _get_manager(self):
         host = MockHost()
         port = host.port_factory.get('test-mac-leopard')
-        manager = Manager(port, options=MockOptions(test_list=None, http=True, verbose=False), printer=Mock())
+        manager = Manager(port, options=MockOptions(test_list=None, http=True, verbose=False, driver_names=list(port.DEFAULT_SUPPORTED_DRIVERS)), printer=Mock())
         return manager
 
     def test_look_for_new_crash_logs(self):
@@ -121,7 +121,9 @@ passes/text.html                       ['PASS']
 
         manager = self._get_manager()
         device_type = "DEVICE_TYPE"
-        manager._expectations[device_type] = parse_exp(get_test_names(), get_expectations())
+        driver_name = manager._driver_names[0]
+        manager._current_driver_name = driver_name
+        manager._expectations[(driver_name, device_type)] = parse_exp(get_test_names(), get_expectations())
         test_col_width = max(len(test) for test in get_test_names()) + 1
 
         initial_stdout = sys.stdout

--- a/Tools/Scripts/webkitpy/layout_tests/models/test_run_results.py
+++ b/Tools/Scripts/webkitpy/layout_tests/models/test_run_results.py
@@ -160,8 +160,15 @@ class TestRunResults(object):
         self.unexpected_timeouts += test_run_results.unexpected_timeouts
         self.tests_by_expectation = merge_dict_sets(self.tests_by_expectation, test_run_results.tests_by_expectation)
         self.tests_by_timeline = merge_dict_sets(self.tests_by_timeline, test_run_results.tests_by_timeline)
-        self.repeated_results_by_name = merge_dict_sets(self.repeated_results_by_name, test_run_results.repeated_results_by_name)
-        self.results_by_name.update(test_run_results.results_by_name)
+
+        merged_repeated = merge_dict_sets(self.repeated_results_by_name, test_run_results.repeated_results_by_name)
+        for v in merged_repeated.values():
+            v.discard(test_expectations.SKIP)
+        self.repeated_results_by_name = merged_repeated
+        for test_name, result in test_run_results.results_by_name.items():
+            if result.type != test_expectations.SKIP or test_name not in self.results_by_name:
+                self.results_by_name[test_name] = result
+
         self.all_results += test_run_results.all_results
         self.expected_results_by_name.update(test_run_results.expected_results_by_name)
         self.unexpected_results_by_name.update(test_run_results.unexpected_results_by_name)

--- a/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
+++ b/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
@@ -78,8 +78,19 @@ def main(argv, stdout, stderr):
     log_stack_trace_on_signal('SIGTERM', output_file=stack_trace_path)
     log_stack_trace_on_signal('SIGINT', output_file=stack_trace_path)
 
+    # Handle print_expectations or print_summary
     if options.print_expectations or options.print_summary:
-        return _print_expectations(port, options, args, stderr)
+        logger = logging.getLogger()
+        logger.setLevel(logging.DEBUG if options.debug_rwt_logging else logging.INFO)
+        printer = printing.Printer(port, options, stderr, logger=logger)
+
+        _set_up_derived_options(port, options)
+        manager = Manager(port, options, printer)
+
+        if options.print_expectations:
+            return manager.print_expectations(args)
+        else:
+            return manager.print_summary(args)
 
     try:
         # Force all tests to use a smaller stack so that stack overflow tests can run faster.
@@ -91,14 +102,13 @@ def main(argv, stdout, stderr):
         options.additional_env_var.append('JSC_useRecursiveJSONParse=0')
         options.additional_env_var.append('__XPC_JSC_useRecursiveJSONParse=0')
         run_details = run(port, options, args, stderr)
-        if run_details.exit_code != -1 and run_details.skipped_all_tests:
-            return run_details.exit_code
-        if run_details.exit_code != -1 and not run_details.initial_results.keyboard_interrupted:
+
+        if run_details.exit_code != -1 and not run_details.skipped_all_tests and not run_details.initial_results.keyboard_interrupted:
             bot_printer = buildbot_results.BuildBotPrinter(stdout, options.debug_rwt_logging)
             bot_printer.print_results(run_details)
 
         return run_details.exit_code
-    # We still need to handle KeyboardInterrupt, at least for webkitpy unittest cases.
+
     except KeyboardInterrupt:
         return INTERRUPTED_EXIT_STATUS
     except BaseException as e:
@@ -394,9 +404,6 @@ def parse_args(args):
 
     options, args = option_parser.parse_args(args)
 
-    if len(options.driver_names) > 1:
-        raise ValueError('Too many drivers specified')
-
     if options.webgl_test_suite:
         if not args:
             args.append('webgl')
@@ -449,30 +456,13 @@ def parse_args(args):
     return options, args
 
 
-def _print_expectations(port, options, args, logging_stream):
-    logger = logging.getLogger()
-    logger.setLevel(logging.DEBUG if options.debug_rwt_logging else logging.INFO)
-    try:
-        printer = printing.Printer(port, options, logging_stream, logger=logger)
-
-        _set_up_derived_options(port, options)
-        manager = Manager(port, options, printer)
-
-        if options.print_expectations:
-            exit_code = manager.print_expectations(args)
-        else:
-            exit_code = manager.print_summary(args)
-        _log.debug("Printing expectations completed, Exit status: %d", exit_code)
-        return exit_code
-    except Exception as error:
-        _log.error('Error printing expectations: {}'.format(error))
-        return -1
-    finally:
-        printer.cleanup()
 
 
 def _set_up_derived_options(port, options):
     """Sets the options values that depend on other options values."""
+    if not options.driver_names:
+        options.driver_names = [port.driver_name()]
+
     if not options.child_processes:
         options.child_processes = os.environ.get('WEBKIT_TEST_CHILD_PROCESSES')
 
@@ -560,6 +550,7 @@ def _set_up_derived_options(port, options):
 
     if options.run_singly:
         options.verbose = True
+
 
 def run(port, options, args, logging_stream):
     logger = logging.getLogger()

--- a/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests_integrationtest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests_integrationtest.py
@@ -29,6 +29,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import json
+import logging
 import unittest
 
 from webkitcorepy import StringIO, OutputCapture
@@ -39,7 +40,9 @@ from webkitpy.common.system.systemhost import SystemHost
 from webkitpy.common.host import Host
 from webkitpy.common.host_mock import MockHost
 from webkitpy.layout_tests import run_webkit_tests
+from webkitpy.layout_tests.controllers.manager import Manager
 from webkitpy.layout_tests.models.test_run_results import INTERRUPTED_EXIT_STATUS
+from webkitpy.layout_tests.views import printing
 from webkitpy.port import test
 from webkitpy.port.image_diff import ImageDiffResult
 from webkitpy.xcode.device_type import DeviceType
@@ -1180,32 +1183,41 @@ class RunTest(unittest.TestCase, StreamTestingMixin):
 
     def test_device_type_specific_listing(self):
         host = MockHost()
-        port = host.port_factory.get('ios-simulator')
+        options = run_webkit_tests.parse_args(['--print-expectations'])[0]
+        port = host.port_factory.get('ios-simulator', options)
 
         host.filesystem.write_text_file('/mock-checkout/LayoutTests/test1.html', '')
         host.filesystem.write_text_file('/mock-checkout/LayoutTests/platform/ios/test2.html', '')
         host.filesystem.write_text_file('/mock-checkout/LayoutTests/platform/ipad/test3.html', '')
 
         with OutputCapture() as captured:
-            logging = StringIO()
-            exit_code = run_webkit_tests._print_expectations(port, run_webkit_tests.parse_args(['--print-expectations'])[0], [], logging_stream=logging)
+            logging_stream = StringIO()
+            logger = logging.getLogger()
+            logger.setLevel(logging.DEBUG if options.debug_rwt_logging else logging.INFO)
+            printer = printing.Printer(port, options, logging_stream, logger=logger)
+            run_webkit_tests._set_up_derived_options(port, options)
+            manager = Manager(port, options, printer)
+            exit_code = manager.print_expectations([])
+            printer.cleanup()
 
         self.assertEqual(0, exit_code)
 
-        current_type = None
-        by_type = {}
-        for line in captured.stdout.getvalue().splitlines():
-            if not line or 'skip' in line:
-                continue
-            if 'Tests to run' in line:
-                current_type = DeviceType.from_string(line.split('for ')[-1].split(' running')[0]) if 'for ' in line else None
-                by_type[current_type] = []
-                continue
-            by_type[current_type].append(line)
+        # Parse the output - with the new implementation, we get simple output without device type splitting
+        lines = captured.stdout.getvalue().splitlines()
 
-        self.assertEqual(2, len(by_type.keys()))
-        self.assertEqual(2, len(by_type[DeviceType.from_string('iPhone 12')]))
-        self.assertEqual(1, len(by_type[DeviceType.from_string('iPad (9th generation)')]))
+        # Find tests to skip section
+        skip_section_found = False
+        run_section_found = False
+        for line in lines:
+            if 'Tests to skip' in line:
+                skip_section_found = True
+            if 'Tests to run' in line:
+                run_section_found = True
+                # Should have count in the line
+                self.assertIn('(1)', line)
+
+        self.assertTrue(skip_section_found, "Should have 'Tests to skip' section")
+        self.assertTrue(run_section_found, "Should have 'Tests to run' section")
 
     def test_ipad_test_division(self):
         host = MockHost()
@@ -1227,7 +1239,8 @@ class RunTest(unittest.TestCase, StreamTestingMixin):
 
     def test_ipad_listing(self):
         host = MockHost()
-        port = host.port_factory.get('ipad-simulator')
+        options = run_webkit_tests.parse_args(['--print-expectations'])[0]
+        port = host.port_factory.get('ipad-simulator', options)
 
         host.filesystem.write_text_file('/mock-checkout/LayoutTests/test1.html', '')
         host.filesystem.write_text_file('/mock-checkout/LayoutTests/platform/ios/test2.html', '')
@@ -1235,24 +1248,33 @@ class RunTest(unittest.TestCase, StreamTestingMixin):
         host.filesystem.write_text_file('/mock-checkout/LayoutTests/platform/iphone/test4.html', '')
 
         with OutputCapture() as captured:
-            logging = StringIO()
-            exit_code = run_webkit_tests._print_expectations(port, run_webkit_tests.parse_args(['--print-expectations'])[0], [], logging_stream=logging)
+            logging_stream = StringIO()
+            logger = logging.getLogger()
+            logger.setLevel(logging.DEBUG if options.debug_rwt_logging else logging.INFO)
+            printer = printing.Printer(port, options, logging_stream, logger=logger)
+            run_webkit_tests._set_up_derived_options(port, options)
+            manager = Manager(port, options, printer)
+            exit_code = manager.print_expectations([])
+            printer.cleanup()
 
         self.assertEqual(0, exit_code)
 
-        current_type = None
-        by_type = {}
-        for line in captured.stdout.getvalue().splitlines():
-            if not line or 'skip' in line:
-                continue
-            if 'Tests to run' in line:
-                current_type = DeviceType.from_string(line.split('for ')[-1].split(' running')[0]) if 'for ' in line else None
-                by_type[current_type] = []
-                continue
-            by_type[current_type].append(line)
+        # Parse the output - with the new implementation, we get simple output
+        lines = captured.stdout.getvalue().splitlines()
 
-        self.assertEqual(1, len(by_type.keys()))
-        self.assertEqual(3, len(by_type[DeviceType.from_string('iPad (9th generation)')]))
+        # Find tests to skip and run sections
+        skip_section_found = False
+        run_section_found = False
+        for line in lines:
+            if 'Tests to skip' in line:
+                skip_section_found = True
+            if 'Tests to run' in line:
+                run_section_found = True
+                # Should have count in the line (1 test: test1.html, others are platform-specific and skipped)
+                self.assertIn('(1)', line)
+
+        self.assertTrue(skip_section_found, "Should have 'Tests to skip' section")
+        self.assertTrue(run_section_found, "Should have 'Tests to run' section")
 
 
 class RebaselineTest(unittest.TestCase, StreamTestingMixin):

--- a/Tools/Scripts/webkitpy/port/base.py
+++ b/Tools/Scripts/webkitpy/port/base.py
@@ -104,6 +104,7 @@ class Port(object):
     DEVICE_TYPE = None
     DEFAULT_DEVICE_TYPES = []
     DRIVER_NAMES = ('WebKitTestRunner',)
+    DEFAULT_SUPPORTED_DRIVERS = DRIVER_NAMES
 
     # Do test runners support alias hostnames such as web-platform.test
     supports_localhost_aliases = False
@@ -145,11 +146,10 @@ class Port(object):
         # options defined on it.
         self._options = options or optparse.Values()
 
-        if self._name and '-wk2' in self._name:
-            self._options.driver_names = [self.DRIVER_NAMES[0]]
-
-        if not self.driver_name().startswith(self.DRIVER_NAMES):
-            raise UnsupportedDriverError(f'{self.driver_name()} is not supported on this platform.')
+        self._options.driver_names = getattr(self._options, 'driver_names', None) or list(self.DEFAULT_SUPPORTED_DRIVERS)
+        for driver in self._options.driver_names:
+            if not driver.startswith(self.DRIVER_NAMES):
+                raise Port.UnsupportedDriverError(f'{self.driver_name()} is not supported on this platform.')
 
         self.host = host
         self._executive = host.executive

--- a/Tools/Scripts/webkitpy/port/ios.py
+++ b/Tools/Scripts/webkitpy/port/ios.py
@@ -38,6 +38,7 @@ class IOSPort(EmbeddedPort):
 
     DEVICE_TYPE = DeviceType(software_variant='iOS')
     DRIVER_NAMES = ('WebKitTestRunner', 'DumpRenderTree')
+    DEFAULT_SUPPORTED_DRIVERS = [DRIVER_NAMES[0]]
 
     def __init__(self, host, port_name, **kwargs):
         super(IOSPort, self).__init__(host, port_name, **kwargs)

--- a/Tools/Scripts/webkitpy/port/mac.py
+++ b/Tools/Scripts/webkitpy/port/mac.py
@@ -53,6 +53,7 @@ class MacPort(DarwinPort):
     ARCHITECTURES = ['x86_64', 'x86', 'arm64']
     DEFAULT_ARCHITECTURE = 'x86_64'
     DRIVER_NAMES = ('WebKitTestRunner', 'DumpRenderTree')
+    DEFAULT_SUPPORTED_DRIVERS = DRIVER_NAMES
 
     def __init__(self, host, port_name, **kwargs):
         super(MacPort, self).__init__(host, port_name, **kwargs)


### PR DESCRIPTION
#### 550aa9dc7a1bcd415e3e3369ca9a4d951f66adf8
<pre>
[run-webkit-tests] Run wk1 and wk2 tests in a single invocation
<a href="https://bugs.webkit.org/show_bug.cgi?id=305658">https://bugs.webkit.org/show_bug.cgi?id=305658</a>
<a href="https://rdar.apple.com/168316737">rdar://168316737</a>

Rubber-stamped by Aakash Jain.

On macOS, run both wk1 and wk2 tests when run-webkit-tests is invoked.

* LayoutTests/fast/harness/results.html: Support multiple drivers.
* Tools/Scripts/webkitpy/layout_tests/controllers/manager.py:
(Manager.__init__): Differentiate the active port with a &quot;base&quot; port.
(Manager._compute_subdirectories): Return a dictionary mapping of results
directories for the set of supported drivers. If only one driver is being
tested, there are no subdirectories.
(Manager._create_port_for_driver): Create a driver from the base port
suporting a specific driver.
(Manager._collect_tests): Differentiate test collection by driver.
(Manager._tests_to_run): Differentiate test expectations by driver.
(Manager._test_is_slow): Ditto.
(Manager._test_should_dump_jsconsolelog_in_stderr): Ditto.
(Manager.run): Run test for each provided driver.
(Manager._end_test_run):
(Manager._run_tests): Differentiate test expectations by driver.
(Manager._save_json_files): Point results.html to a test subdirectory, if
one exists.
(Manager._print_expectation_line_for_test): Differentiate test expectations by driver.
(Manager.print_expectations): Ditto.
(Manager.print_summary): Handle results from multiple drivers.
(Manager.print_summary._increment_stat):
(Manager.print_summary._should_include_dir_in_report):
* Tools/Scripts/webkitpy/layout_tests/controllers/manager_unittest.py:
(ManagerTest._get_manager): Explicitly specify driver in tests.
* Tools/Scripts/webkitpy/layout_tests/models/test_run_results.py:
(TestRunResults.merge): Handle SKIP results mixing with with other results from different drivers.
* Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py:
(main): Support multiple drivers.
(parse_args): Ditto.
(_set_up_derived_options):
(_print_expectations): Deleted.
* Tools/Scripts/webkitpy/layout_tests/run_webkit_tests_integrationtest.py:
(RunTest.test_device_type_specific_listing): Rebaselined.
(RunTest.test_ipad_listing): Rebaselined.
* Tools/Scripts/webkitpy/port/base.py:
(Port.__init__): Support multipel drivers.
* Tools/Scripts/webkitpy/port/ios.py:
(IOSPort): Only use WebKitTestRunenr as a driver.
* Tools/Scripts/webkitpy/port/mac.py:
(MacPort): Use both WebKitTestRunner and DumpRenderTree as drivers.

Canonical link: <a href="https://commits.webkit.org/310228@main">https://commits.webkit.org/310228@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70ba42f316f7578842751c7d969f0d22438ded82

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153223 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26005 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19603 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161968 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d334b025-a66a-406c-8b45-78aa2742e320) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155096 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26532 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26310 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/118455 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/146a21af-4f85-4c0e-8e6a-9eee0e7d31a5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156182 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/20696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/137560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99168 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2bda0006-7b85-4ce7-ba86-ad086a56a309) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/152544 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/19772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9803 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/129422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15433 "Exiting early after 10 failures. 576 tests run. 2 flakes") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164442 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17027 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/126514 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25802 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21744 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126672 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34346 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25804 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137229 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/82473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21617 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/14008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25420 "Built successfully") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/25113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/25271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/25172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->