### PR TITLE
[Gardening:[macOS] TestWebKitAPI.KeyboardEventTests.UserTextInputEvent is flaky timeout

### DIFF
--- a/Tools/TestWebKitAPI/Tests/mac/KeyboardEventTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/KeyboardEventTests.mm
@@ -147,7 +147,12 @@ TEST(KeyboardEventTests, TerminateWebContentProcessDuringKeyEventHandling)
     Util::runFor(25_ms);
 }
 
+// FIXME when rdar://168322007 is resolved.
+#if PLATFORM(MAC)
+TEST(KeyboardEventTests, DISABLED_UserTextInputEvent)
+#else
 TEST(KeyboardEventTests, UserTextInputEvent)
+#endif
 {
     RetainPtr webView = adoptNS([TestWKWebView new]);
     [webView addToTestWindow];


### PR DESCRIPTION
#### 31b27d94477bbd697759f9c1e847ced72010f93b
<pre>
[Gardening:[macOS] TestWebKitAPI.KeyboardEventTests.UserTextInputEvent is flaky timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=305665">https://bugs.webkit.org/show_bug.cgi?id=305665</a>
<a href="https://rdar.apple.com/168322007">rdar://168322007</a>

Unreviewed test gardening

Skipping flaky timing out test till it&apos;s fixed.

* Tools/TestWebKitAPI/Tests/mac/KeyboardEventTests.mm:
(TestWebKitAPI::TEST(KeyboardEventTests, UserTextInputEvent)):

Canonical link: <a href="https://commits.webkit.org/305732@main">https://commits.webkit.org/305732@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd26f9044f8c2bd80234167976530af6f2fd5782

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139266 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11642 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/768 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147393 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dfa29634-ddae-4fb4-a9c3-e50b6b00997f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141139 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12349 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11792 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106619 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/78ba2a00-790e-443c-937c-357712f1db89) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142213 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9351 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124737 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87480 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/68fe7075-642b-4777-9f10-697f30a7114b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8896 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6668 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7690 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118354 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/637 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150175 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11326 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/655 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/115013 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11339 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/9586 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115320 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29298 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9415 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121084 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66244 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11369 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11103 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11306 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11156 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->