### PR TITLE
Remove the deprecated LOCAL_REFERENCE macro

### DIFF
--- a/Source/WTF/wtf/InlineASM.h
+++ b/Source/WTF/wtf/InlineASM.h
@@ -57,9 +57,6 @@
 #define LABEL_REFERENCE(name) GLOBAL_REFERENCE(name)
 #endif
 
-// Deprecated: misleading name. Will be removed once the dependency in WebKitAdditions is gone.
-#define LOCAL_REFERENCE(name) LABEL_REFERENCE(name)
-
 #if OS(DARWIN)
     // Mach-O platform
 #define HIDE_SYMBOL(name) ".private_extern _" #name


### PR DESCRIPTION
#### 89c11845fe738672cbbd3c30e5315bbe32da08a6
<pre>
Remove the deprecated LOCAL_REFERENCE macro
<a href="https://bugs.webkit.org/show_bug.cgi?id=305667">https://bugs.webkit.org/show_bug.cgi?id=305667</a>
<a href="https://rdar.apple.com/168325392">rdar://168325392</a>

Reviewed by Yusuke Suzuki.

The fix for <a href="https://bugs.webkit.org/show_bug.cgi?id=305489">https://bugs.webkit.org/show_bug.cgi?id=305489</a> renamed the macro
LOCAL_REFERENCE in InlineASM.h to LABEL_REFERENCE because the original name was misleading
(the reference it was producing was not local). However, the old macro was left in the
header as deprecated because of a dependency in WebKitAdditions. Now that the dependency
was updated to use the new name, we can remove the old one.

The patch removes the deprecated macro.

Testing: verified by the build process and existing tests.
Canonical link: <a href="https://commits.webkit.org/305764@main">https://commits.webkit.org/305764@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c24cc3b05e8fbf307cbe7c87566e799d1684075

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139325 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11701 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/827 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147452 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92392 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/02d9273e-31d8-41ad-8b32-0dcc93ef1144) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12408 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11851 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106665 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/77641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b8384760-15ec-42c2-910f-77b9108e655e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142272 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9399 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124791 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87527 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7c50dfa9-b562-4bb0-aabc-0bd8ad135b5d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8944 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6714 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7749 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/131298 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118402 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/692 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150235 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/116 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11385 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/710 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115061 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11398 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9638 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115369 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29314 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9522 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121140 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66360 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11428 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/659 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/170596 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11162 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75094 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44396 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11365 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11215 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->