### PR TITLE
[JSC][WASM][Debugger] Avoid RefPtr operations during thread suspension to fix deadlock

### DIFF
--- a/Source/JavaScriptCore/runtime/JSLock.h
+++ b/Source/JavaScriptCore/runtime/JSLock.h
@@ -93,6 +93,17 @@ public:
             return m_ownerThread;
         return std::nullopt;
     }
+
+    // Returns the owner thread's UID without creating temporary RefPtr objects.
+    // This avoids ref counting operations that can cause lock contention
+    // with thread suspension. Returns std::nullopt if there is no owner thread.
+    std::optional<uint64_t> ownerThreadUID() const
+    {
+        if (!m_hasOwnerThread)
+            return std::nullopt;
+        return m_ownerThread->uid();
+    }
+
     bool currentThreadIsHoldingLock() { return m_hasOwnerThread && m_ownerThread.get() == &Thread::currentSingleton(); }
 
     void willDestroyVM(VM*);

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -1085,6 +1085,7 @@ public:
     void logEvent(CodeBlock*, const char* summary, const Func& func);
 
     std::optional<RefPtr<Thread>> ownerThread() const { return m_apiLock->ownerThread(); }
+    std::optional<uint64_t> ownerThreadUID() const { return m_apiLock->ownerThreadUID(); }
 
     ALWAYS_INLINE VMTraps& traps() { return m_threadContext.traps(); }
     ALWAYS_INLINE const VMTraps& traps() const { return m_threadContext.traps(); }

--- a/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.cpp
@@ -876,9 +876,9 @@ void ExecutionHandler::sendErrorReply(ProtocolError error) { m_debugServer.sendE
 
 uint64_t ExecutionHandler::threadId(const VM& vm)
 {
-    auto ownerThread = vm.ownerThread();
-    RELEASE_ASSERT(ownerThread && *ownerThread);
-    return (*ownerThread)->uid();
+    auto uid = vm.ownerThreadUID();
+    RELEASE_ASSERT(uid.has_value());
+    return *uid;
 }
 
 DebugState* ExecutionHandler::debuggeeState() const { return m_debuggee->debugState(); }


### PR DESCRIPTION
#### 4a78281a5504f78bcfbfda4fb6a99b3a591b8379
<pre>
[JSC][WASM][Debugger] Avoid RefPtr operations during thread suspension to fix deadlock
<a href="https://bugs.webkit.org/show_bug.cgi?id=305674">https://bugs.webkit.org/show_bug.cgi?id=305674</a>
<a href="https://rdar.apple.com/168319182">rdar://168319182</a>

Reviewed by Yusuke Suzuki.

The WASM debugger can deadlock when Thread #8 suspends Thread #4 via
thread_suspend() while Thread #4 is in the middle of ref counting operations.
The suspended thread may hold a WordLock (used for thread-safe ref counting),
and when the suspending thread tries to create a RefPtr copy, it blocks
waiting for the same lock.

The deadlock sequence:
1. Thread #4 acquires WordLock in strongDeref() destructor
2. Thread #8 suspends Thread #4 via thread_suspend() Mach kernel trap
3. Thread #4 is frozen mid-unlock, WordLock never released
4. Thread #8&apos;s lambda calls vm.apiLock().ownerThread(), creating RefPtr copy
5. RefPtr copy triggers strongRef() which tries to acquire same WordLock
6. Deadlock: Thread #4 suspended holding lock, Thread #8 blocked waiting

The fix adds ownerThreadUID() methods that return the thread UID directly
without creating temporary RefPtr objects, avoiding all ref counting
operations and the associated lock contention.

Canonical link: <a href="https://commits.webkit.org/305766@main">https://commits.webkit.org/305766@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f75ab5cac656f84d2a772327eb0f3753092c312a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139290 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11666 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/792 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147417 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92357 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e3c4c2cb-de23-4365-905c-a2e2a0f82152) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12373 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11816 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106644 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77628 "2 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ae3ee0ab-de02-40de-a772-add75cf92ed5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142237 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9376 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124761 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87504 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d4c7c20c-8df5-4824-a5ae-013a58cceb01) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8920 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6687 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7714 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/131263 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118379 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/661 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150199 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/79 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11350 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/679 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115043 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11363 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9608 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115350 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29315 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9459 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121108 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66268 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11393 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/631 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/170561 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11127 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75059 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44391 "Found 1 new JSC binary failure: testb3, Found 8 new JSC stress test failures: wasm.yaml/wasm/stress/wasm-js-string-builtins-signature-validation.js.default-wasm, wasm.yaml/wasm/stress/wasm-js-string-builtins-signature-validation.js.wasm-bbq, wasm.yaml/wasm/stress/wasm-js-string-builtins-signature-validation.js.wasm-bbq-no-consts, wasm.yaml/wasm/stress/wasm-js-string-builtins-signature-validation.js.wasm-collect-continuously, wasm.yaml/wasm/stress/wasm-js-string-builtins-signature-validation.js.wasm-eager, wasm.yaml/wasm/stress/wasm-js-string-builtins-signature-validation.js.wasm-eager-jettison, wasm.yaml/wasm/stress/wasm-js-string-builtins-signature-validation.js.wasm-no-cjit, wasm.yaml/wasm/stress/wasm-js-string-builtins-signature-validation.js.wasm-slow-memory (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11330 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11180 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->