### PR TITLE
Final step in fixing crash in WebKit::WebPopupMenu::didChangeSelectedIndex.

### DIFF
--- a/Source/WebCore/html/HTMLSelectElement.h
+++ b/Source/WebCore/html/HTMLSelectElement.h
@@ -47,12 +47,9 @@ class HTMLSelectElement : public HTMLFormControlElement, public PopupMenuClient,
 public:
     USING_CAN_MAKE_WEAKPTR(HTMLElement);
 
-    // CheckedPtr interface disambiguation.
-    uint32_t checkedPtrCount() const final { return HTMLFormControlElement::checkedPtrCount(); }
-    uint32_t checkedPtrCountWithoutThreadCheck() const final { return HTMLFormControlElement::checkedPtrCountWithoutThreadCheck(); }
-    void incrementCheckedPtrCount() const final { HTMLFormControlElement::incrementCheckedPtrCount(); }
-    void decrementCheckedPtrCount() const final { HTMLFormControlElement::decrementCheckedPtrCount(); }
-    void setDidBeginCheckedPtrDeletion() final { CanMakeCheckedPtr::setDidBeginCheckedPtrDeletion(); }
+    // PopupMenuClient ref-counting (disambiguate from FormAssociatedElement)
+    void ref() const final { HTMLFormControlElement::ref(); }
+    void deref() const final { HTMLFormControlElement::deref(); }
 
     static Ref<HTMLSelectElement> create(const QualifiedName&, Document&, HTMLFormElement*);
     static Ref<HTMLSelectElement> create(Document&);

--- a/Source/WebCore/html/SearchInputType.h
+++ b/Source/WebCore/html/SearchInputType.h
@@ -50,12 +50,9 @@ public:
         return adoptRef(*new SearchInputType(element));
     }
 
-    // CheckedPtr interface - resolve multiple inheritance ambiguity
-    uint32_t checkedPtrCount() const final { return BaseTextInputType::checkedPtrCount(); }
-    uint32_t checkedPtrCountWithoutThreadCheck() const final { return BaseTextInputType::checkedPtrCountWithoutThreadCheck(); }
-    void incrementCheckedPtrCount() const final { BaseTextInputType::incrementCheckedPtrCount(); }
-    void decrementCheckedPtrCount() const final { BaseTextInputType::decrementCheckedPtrCount(); }
-    void setDidBeginCheckedPtrDeletion() final { CanMakeCheckedPtr::setDidBeginCheckedPtrDeletion(); }
+    // PopupMenuClient ref-counting (disambiguating from InputType)
+    void ref() const final { BaseTextInputType::ref(); }
+    void deref() const final { BaseTextInputType::deref(); }
 
     // PopupMenuClient methods
     void valueChanged(unsigned listIndex, bool fireEvents = true) override;

--- a/Source/WebCore/platform/PopupMenuClient.h
+++ b/Source/WebCore/platform/PopupMenuClient.h
@@ -25,7 +25,6 @@
 #include <WebCore/LayoutUnit.h>
 #include <WebCore/PopupMenuStyle.h>
 #include <WebCore/ScrollTypes.h>
-#include <wtf/AbstractCanMakeCheckedPtr.h>
 #include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/Forward.h>
 
@@ -37,7 +36,7 @@ class HostWindow;
 class Scrollbar;
 class ScrollableArea;
 
-class PopupMenuClient : public AbstractCanMakeCheckedPtr  {
+class PopupMenuClient : public AbstractRefCountedAndCanMakeWeakPtr<PopupMenuClient>  {
 public:
     virtual ~PopupMenuClient() = default;
     virtual void valueChanged(unsigned listIndex, bool fireEvents = true) = 0;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPopupMenu.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPopupMenu.cpp
@@ -58,7 +58,7 @@ void WebPopupMenu::disconnectClient()
 
 void WebPopupMenu::didChangeSelectedIndex(int newIndex)
 {
-    CheckedPtr popupClient = m_popupClient;
+    RefPtr popupClient = m_popupClient;
     if (!popupClient)
         return;
 
@@ -69,13 +69,13 @@ void WebPopupMenu::didChangeSelectedIndex(int newIndex)
 
 void WebPopupMenu::setTextForIndex(int index)
 {
-    if (CheckedPtr popupClient = m_popupClient)
+    if (RefPtr popupClient = m_popupClient)
         popupClient->setTextFromItem(index);
 }
 
 Vector<WebPopupItem> WebPopupMenu::populateItems()
 {
-    CheckedPtr popupClient = m_popupClient;
+    RefPtr popupClient = m_popupClient;
     return Vector<WebPopupItem>(popupClient->listSize(), [&](size_t i) {
         if (popupClient->itemIsSeparator(i))
             return WebPopupItem(WebPopupItem::Type::Separator);
@@ -91,7 +91,7 @@ void WebPopupMenu::show(const IntRect& rect, LocalFrameView& view, int selectedI
 {
     // FIXME: We should probably inform the client to also close the menu.
     Vector<WebPopupItem> items = populateItems();
-    CheckedPtr popupClient = m_popupClient;
+    RefPtr popupClient = m_popupClient;
     RefPtr page = m_page.get();
 
     if (items.isEmpty() || !page) {
@@ -115,7 +115,7 @@ void WebPopupMenu::show(const IntRect& rect, LocalFrameView& view, int selectedI
 void WebPopupMenu::hide()
 {
     RefPtr page = m_page.get();
-    CheckedPtr popupClient = m_popupClient;
+    RefPtr popupClient = m_popupClient;
     if (!page || !popupClient)
         return;
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPopupMenu.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPopupMenu.h
@@ -62,7 +62,7 @@ private:
     Vector<WebPopupItem> populateItems();
     void setUpPlatformData(const WebCore::IntRect& pageCoordinates, PlatformPopupMenuData&);
 
-    CheckedPtr<WebCore::PopupMenuClient> m_popupClient;
+    RefPtr<WebCore::PopupMenuClient> m_popupClient;
     WeakPtr<WebPage> m_page;
 };
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebPopupMenuMac.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebPopupMenuMac.mm
@@ -38,7 +38,7 @@ using namespace WebCore;
 void WebPopupMenu::setUpPlatformData(const IntRect&, PlatformPopupMenuData& data)
 {
 #if USE(APPKIT)
-    CheckedPtr popupClient = m_popupClient;
+    RefPtr popupClient = m_popupClient;
     std::optional<InstalledFont> font = popupClient->menuStyle().checkedFont()->primaryFont()->toSerializableInstalledFont();
     if (!font) {
         double pointSize = popupClient->menuStyle().checkedFont()->primaryFont()->platformData().size();

--- a/Source/WebKitLegacy/mac/WebCoreSupport/PopupMenuMac.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/PopupMenuMac.h
@@ -39,9 +39,9 @@ public:
 private:
     void clear();
     void populate();
-    CheckedPtr<WebCore::PopupMenuClient> checkedClient() const { return m_client; }
+    RefPtr<WebCore::PopupMenuClient> protectedClient() const { return m_client; }
 
-    CheckedPtr<WebCore::PopupMenuClient> m_client;
+    RefPtr<WebCore::PopupMenuClient> m_client;
     RetainPtr<NSPopUpButtonCell> m_popup;
 };
 


### PR DESCRIPTION
#### cf9cd69e0cb71aeecaf6655d67e88440bafc1e28
<pre>
Final step in fixing crash in WebKit::WebPopupMenu::didChangeSelectedIndex.
<a href="https://bugs.webkit.org/show_bug.cgi?id=305681">https://bugs.webkit.org/show_bug.cgi?id=305681</a>
<a href="https://rdar.apple.com/162142276">rdar://162142276</a>

Reviewed by Wenson Hsieh.

After the refactors in 305556@main and 305728@main
we are now able to make PopupMenuClient a
RefPtr instead of a CheckedPtr. This will allow
us to check if a PopupMenuClient exists, and move
on if it doesn&apos;t, instead of crashing.

* Source/WebCore/html/HTMLSelectElement.h:
* Source/WebCore/html/SearchInputType.h:
* Source/WebCore/platform/PopupMenuClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebPopupMenu.cpp:
(WebKit::WebPopupMenu::didChangeSelectedIndex):
(WebKit::WebPopupMenu::setTextForIndex):
(WebKit::WebPopupMenu::populateItems):
(WebKit::WebPopupMenu::show):
(WebKit::WebPopupMenu::hide):
* Source/WebKit/WebProcess/WebCoreSupport/WebPopupMenu.h:
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebPopupMenuMac.mm:
(WebKit::WebPopupMenu::setUpPlatformData):
* Source/WebKitLegacy/mac/WebCoreSupport/PopupMenuMac.h:
(PopupMenuMac::protectedClient const):
(PopupMenuMac::checkedClient const): Deleted.
* Source/WebKitLegacy/mac/WebCoreSupport/PopupMenuMac.mm:
(PopupMenuMac::populate):
(PopupMenuMac::show):
(PopupMenuMac::hide):

Canonical link: <a href="https://commits.webkit.org/305910@main">https://commits.webkit.org/305910@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9722395d1cc709b46ab37276951322bf569575ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139706 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12082 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1210 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147844 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92774 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8080f89f-28a7-41e2-ab44-056274379fe1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141579 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12791 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12233 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106977 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77877 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6d8c5136-624c-438b-8040-b989cded7c7e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142653 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9843 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125124 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87844 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/95e32efe-8741-4f9e-b3bb-8744ff3a9197) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9503 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7022 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8133 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118728 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1122 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150625 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11767 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1176 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115383 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11781 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10079 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115696 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29401 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10454 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121602 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66772 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11811 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1086 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11551 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75489 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11747 "Built successfully") | | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11598 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | | | 
<!--EWS-Status-Bubble-End-->