### PR TITLE
REGRESSION (297279@main): P3 colors can be mismatched between painted content, and layer backgrounds (see on book.stevejobsarchive.com).

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -293,6 +293,9 @@ http/tests/app-privacy-report/ [ Skip ]
 # Only partial support on Cocoa platforms.
 imported/w3c/web-platform-tests/speech-api/ [ Skip ]
 
+# Requires caLayerTreeAsText
+compositing/background-color/background-color-clamping.html [ Skip ]
+
 # Support for COEP violation reporting is missing.
 imported/w3c/web-platform-tests/html/cross-origin-opener-policy/reporting/access-reporting/
 imported/w3c/web-platform-tests/html/cross-origin-opener-policy/reporting/document-reporting/

--- a/LayoutTests/compositing/background-color/background-color-clamping-expected.txt
+++ b/LayoutTests/compositing/background-color/background-color-clamping-expected.txt
@@ -1,0 +1,37 @@
+
+(CALayer tree root
+  (layer bounds [x: 0 y: 0 width: 769 height: 830])
+  (layer position [x: 392.5 y: 392.5])
+  (sublayers
+    (
+      (layer bounds [x: 0 y: 0 width: 200 height: 200])
+      (layer position [x: 110 y: 110])
+      (sublayers
+        (
+          (layer bounds [x: 0 y: 0 width: 200 height: 200])
+          (layer anchorPoint [x: 0 y: 0])
+          (layer background color rgb(255, 255, 255)))))
+    (
+      (layer bounds [x: 0 y: 0 width: 200 height: 200])
+      (layer position [x: 110 y: 110])
+      (sublayers
+        (
+          (layer bounds [x: 0 y: 0 width: 200 height: 200])
+          (layer anchorPoint [x: 0 y: 0])
+          (layer background color rgb(0, 140, 214)))))
+    (
+      (layer bounds [x: 0 y: 0 width: 200 height: 200])
+      (layer position [x: 110 y: 110])
+      (sublayers
+        (
+          (layer bounds [x: 0 y: 0 width: 200 height: 200])
+          (layer anchorPoint [x: 0 y: 0])
+          (layer background color rgb(0, 255, 184)))))
+    (
+      (layer bounds [x: 0 y: 0 width: 200 height: 200])
+      (layer position [x: 110 y: 110])
+      (sublayers
+        (
+          (layer bounds [x: 0 y: 0 width: 200 height: 200])
+          (layer anchorPoint [x: 0 y: 0])
+          (layer background color rgb(0, 255, 166)))))))

--- a/LayoutTests/compositing/background-color/background-color-clamping.html
+++ b/LayoutTests/compositing/background-color/background-color-clamping.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .box {
+            margin: 10px;
+            width: 200px;
+            height: 200px;
+            will-change: transform;
+        }
+        
+        #layers {
+            will-change: transform;
+        }
+        
+        .unclampedrgb {
+            background-color: color(srgb 5 5 5);
+        }
+        
+        .displayp3 {
+            background-color: color(display-p3 0 0.537 0.815);
+        }
+
+        .displayp3hdr {
+            background-color: color(display-p3 0 1.537 0.815);
+        }
+
+        .xyz {
+            background-color: color(xyz-d50 0.2005 1.14089 0.4472);
+        }
+    </style>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+
+        window.addEventListener('load', async () => {
+            const results = document.getElementById('results');
+            results.textContent = await UIHelper.getCALayerTreeForCompositedElement(document.getElementById('layers'));
+
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }, false);
+    </script>
+</head>
+<body>
+    <section id="layers">
+        <div class="unclampedrgb box"></div>
+        <div class="displayp3 box"></div>
+        <div class="displayp3hdr box"></div>
+        <div class="xyz box"></div>
+    </section>
+<pre id="results"></pre>
+</body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -154,6 +154,9 @@ http/tests/media/modern-media-controls/overflow-support [ Pass ]
 # media/modern-media-controls/overflow-support [ Pass ]
 # media/modern-media-controls/tracks-support [ Pass ]
 
+# Uses caLayerTreeAsText
+compositing/background-color/background-color-clamping.html [ Pass ]
+
 media/media-webm-av1.html [ Skip ]
 
 media/media-source/media-managedmse-airplay.html [ Pass ]

--- a/LayoutTests/platform/ios/compositing/background-color/background-color-clamping-expected.txt
+++ b/LayoutTests/platform/ios/compositing/background-color/background-color-clamping-expected.txt
@@ -1,0 +1,37 @@
+
+(CALayer tree root
+  (layer bounds [x: 0 y: 0 width: 784 height: 830])
+  (layer position [x: 400 y: 400])
+  (sublayers
+    (
+      (layer bounds [x: 0 y: 0 width: 200 height: 200])
+      (layer position [x: 110 y: 110])
+      (sublayers
+        (
+          (layer bounds [x: 0 y: 0 width: 200 height: 200])
+          (layer anchorPoint [x: 0 y: 0])
+          (layer background color rgb(255, 255, 255)))))
+    (
+      (layer bounds [x: 0 y: 0 width: 200 height: 200])
+      (layer position [x: 110 y: 110])
+      (sublayers
+        (
+          (layer bounds [x: 0 y: 0 width: 200 height: 200])
+          (layer anchorPoint [x: 0 y: 0])
+          (layer background color rgb(0, 140, 214)))))
+    (
+      (layer bounds [x: 0 y: 0 width: 200 height: 200])
+      (layer position [x: 110 y: 110])
+      (sublayers
+        (
+          (layer bounds [x: 0 y: 0 width: 200 height: 200])
+          (layer anchorPoint [x: 0 y: 0])
+          (layer background color rgb(0, 255, 184)))))
+    (
+      (layer bounds [x: 0 y: 0 width: 200 height: 200])
+      (layer position [x: 110 y: 110])
+      (sublayers
+        (
+          (layer bounds [x: 0 y: 0 width: 200 height: 200])
+          (layer anchorPoint [x: 0 y: 0])
+          (layer background color rgb(0, 255, 166)))))))

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -63,6 +63,9 @@ imported/w3c/web-platform-tests/pointerevents [ Pass ]
 
 imported/w3c/web-platform-tests/speech-api [ Pass ]
 
+# Uses caLayerTreeAsText
+compositing/background-color/background-color-clamping.html [ Pass ]
+
 media/media-webm-av1.html [ Skip ]
 media/track/track-description-cue.html [ Pass ]
 media/track/track-extended-descriptions.html [ Pass ]

--- a/Source/WebCore/Configurations/AllowedSPI-legacy.toml
+++ b/Source/WebCore/Configurations/AllowedSPI-legacy.toml
@@ -530,7 +530,6 @@ symbols = [
     "CGColorSpaceEqualToColorSpace",
     "CGColorTransformConvertColorComponents",
     "CGColorTransformCreate",
-    "CGContextCopyDeviceColorSpace",
     "CGContextCreateWithDelegate",
     "CGContextDelegateCreate",
     "CGContextDelegateGetInfo",

--- a/Source/WebCore/Configurations/AllowedSPI.toml
+++ b/Source/WebCore/Configurations/AllowedSPI.toml
@@ -75,6 +75,13 @@ symbols = [
 ]
 
 [[temporary-usage]]
+request = "rdar://168834967"
+cleanup = "rdar://168834815"
+symbols = [
+    "CGContextGetColorSpace",
+]
+
+[[temporary-usage]]
 request = "rdar://161402565"
 cleanup = "rdar://161402756"
 symbols = [

--- a/Source/WebCore/PAL/pal/spi/cg/CoreGraphicsSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cg/CoreGraphicsSPI.h
@@ -85,6 +85,7 @@ typedef CF_ENUM (int32_t, CGContextDelegateCallbackName)
     deDrawGlyphs = 8,
     deBeginLayer = 17,
     deEndLayer = 18,
+    deGetColorSpace = 30,
 };
 
 typedef const struct CGColorTransform* CGColorTransformRef;
@@ -396,7 +397,7 @@ typedef bool (^CGPDFAnnotationDrawCallbackType)(CGContextRef context, CGPDFPageR
 void CGContextDrawPDFPageWithAnnotations(CGContextRef, CGPDFPageRef, CGPDFAnnotationDrawCallbackType);
 void CGContextDrawPathDirect(CGContextRef, CGPathDrawingMode, CGPathRef, const CGRect* boundingBox);
 
-CGColorSpaceRef CGContextCopyDeviceColorSpace(CGContextRef);
+CGColorSpaceRef CGContextGetColorSpace(CGContextRef);
 CFPropertyListRef CGColorSpaceCopyPropertyList(CGColorSpaceRef);
 CGError CGSNewRegionWithRect(const CGRect*, CGRegionRef*);
 CGError CGSPackagesEnableConnectionOcclusionNotifications(CGSConnectionID, bool flag, bool* outCurrentVisibilityState);

--- a/Source/WebCore/platform/graphics/Color.h
+++ b/Source/WebCore/platform/graphics/Color.h
@@ -309,7 +309,7 @@ bool outOfLineComponentsEqualIgnoringSemanticColor(const Color&, const Color&);
 
 #if USE(CG)
 WEBCORE_EXPORT RetainPtr<CGColorRef> cachedCGColor(const Color&);
-WEBCORE_EXPORT RetainPtr<CGColorRef> cachedSDRCGColorForColorspace(const Color&, const DestinationColorSpace&);
+WEBCORE_EXPORT RetainPtr<CGColorRef> cachedCGColorInDestinationStandardRange(const Color&, const DestinationColorSpace&);
 WEBCORE_EXPORT ColorComponents<float, 4> platformConvertColorComponents(ColorSpace, ColorComponents<float, 4>, const DestinationColorSpace&);
 WEBCORE_EXPORT std::optional<SRGBA<uint8_t>> roundAndClampToSRGBALossy(CGColorRef);
 #endif

--- a/Source/WebCore/platform/graphics/ColorConversion.h
+++ b/Source/WebCore/platform/graphics/ColorConversion.h
@@ -47,7 +47,6 @@ template<typename Output, typename Input> Output convertColorCarryingForwardMiss
 ColorComponents<float, 4> convertAndResolveColorComponents(ColorSpace inputColorSpace, ColorComponents<float, 4> inputColorComponents, ColorSpace outputColorSpace);
 ColorComponents<float, 4> convertAndResolveColorComponents(ColorSpace inputColorSpace, ColorComponents<float, 4> inputColorComponents, const DestinationColorSpace& outputColorSpace);
 
-
 // All color types, other than XYZA or those inheriting from RGBType, must implement
 // the following conversions to and from their "Reference" color.
 //

--- a/Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorder.h
+++ b/Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorder.h
@@ -63,6 +63,8 @@ public:
     void recordDrawImage(CGRenderingStateRef, CGGStateRef, CGRect, CGImageRef);
     void recordDrawPath(CGRenderingStateRef, CGGStateRef, CGPathDrawingMode, CGPathRef);
 
+    CGColorSpaceRef colorSpace() const;
+
 private:
     UniqueRef<GraphicsContext> createInternalContext();
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -53,6 +53,7 @@
 #import "_WKFrameHandleInternal.h"
 #import "_WKInspectorInternal.h"
 #import <WebCore/BoxSides.h>
+#import <WebCore/Color.h>
 #import <WebCore/NowPlayingInfo.h>
 #import <WebCore/ScrollingNodeID.h>
 #import <WebCore/ValidationBubble.h>
@@ -213,6 +214,9 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 
     if (layer.opacity != 1.0)
         ts.dumpProperty("layer opacity"_s, makeString(layer.opacity));
+
+    if (layer.backgroundColor)
+        ts.dumpProperty("layer background color"_s, WebCore::Color::createAndPreserveColorSpace(RetainPtr { layer.backgroundColor }.get()));
 
     if (layer.cornerRadius != 0.0)
         ts.dumpProperty("layer cornerRadius"_s, makeString(layer.cornerRadius));

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -192,6 +192,14 @@ void WebPageProxy::didCommitLayerTree(const RemoteLayerTreeTransaction& layerTre
     }
 }
 
+WebCore::DestinationColorSpace WebPageProxy::colorSpace() const
+{
+    if (RefPtr pageClient = this->pageClient())
+        return pageClient->colorSpace();
+
+    return WebCore::DestinationColorSpace::SRGB();
+}
+
 void WebPageProxy::didCommitMainFrameData(const MainFrameData& mainFrameData, const TransactionID& transactionID)
 {
     themeColorChanged(mainFrameData.themeColor);

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -527,8 +527,6 @@ public:
 
     virtual CGRect boundsOfLayerInLayerBackedWindowCoordinates(CALayer *) const = 0;
 
-    virtual WebCore::DestinationColorSpace colorSpace() = 0;
-
     virtual bool useFormSemanticContext() const = 0;
     
     virtual NSView *viewForPresentingRevealPopover() const = 0;
@@ -556,6 +554,8 @@ public:
     virtual void scrollingNodeScrollViewDidScroll(WebCore::ScrollingNodeID) = 0;
 
     virtual CocoaWindow *platformWindow() const = 0;
+
+    virtual WebCore::DestinationColorSpace colorSpace() = 0;
 #endif
 
     virtual void reconcileEnclosingScrollViewContentOffset(EditorState&) { };

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1588,8 +1588,6 @@ public:
 #if PLATFORM(MAC)
     bool useFormSemanticContext() const;
     void semanticContextDidChange();
-
-    WebCore::DestinationColorSpace colorSpace();
 #endif
 
     void effectiveAppearanceDidChange();
@@ -1611,6 +1609,8 @@ public:
     RefPtr<WebCore::SharedBuffer> dataSelectionForPasteboard(const String& pasteboardType);
     void makeFirstResponder();
     void assistiveTechnologyMakeFirstResponder();
+
+    WebCore::DestinationColorSpace colorSpace() const;
 
 #if ENABLE(MULTI_REPRESENTATION_HEIC)
     void insertMultiRepresentationHEIC(NSData *, NSString *);

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -40,6 +40,7 @@ OBJC_CLASS WKContentView;
 OBJC_CLASS WKEditorUndoTarget;
 
 namespace WebCore {
+class DestinationColorSpace;
 enum class DOMPasteAccessCategory : uint8_t;
 enum class DOMPasteAccessResponse : uint8_t;
 struct PromisedAttachmentInfo;
@@ -80,6 +81,8 @@ private:
     bool isViewInWindow() override;
     bool isViewVisibleOrOccluded() override;
     bool isVisuallyIdle() override;
+    WebCore::DestinationColorSpace colorSpace() override;
+
     void processDidExit() override;
     void processWillSwap() override;
     void didRelaunchProcess() override;
@@ -392,6 +395,7 @@ private:
 
     WeakObjCPtr<WKContentView> m_contentView;
     RetainPtr<WKEditorUndoTarget> m_undoTarget;
+    std::optional<WebCore::DestinationColorSpace> m_colorSpace;
 };
 } // namespace WebKit
 

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -226,6 +226,14 @@ bool PageClientImpl::isVisuallyIdle()
     return !isActiveViewVisible();
 }
 
+WebCore::DestinationColorSpace PageClientImpl::colorSpace()
+{
+    if (!m_colorSpace)
+        m_colorSpace = screenColorSpace(nullptr);
+
+    return *m_colorSpace;
+}
+
 void PageClientImpl::processDidExit()
 {
     [contentView() _processDidExit];

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -382,11 +382,6 @@ void WebPageProxy::semanticContextDidChange()
     protect(legacyMainFrameProcess())->send(Messages::WebPage::SemanticContextDidChange(useFormSemanticContext()), webPageIDInMainFrameProcess());
 }
 
-WebCore::DestinationColorSpace WebPageProxy::colorSpace()
-{
-    return protect(pageClient())->colorSpace();
-}
-
 void WebPageProxy::registerUIProcessAccessibilityTokens(WebCore::AccessibilityRemoteToken elementToken, WebCore::AccessibilityRemoteToken windowToken)
 {
     if (!hasRunningProcess())

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
@@ -95,7 +95,7 @@ std::optional<WebCore::DestinationColorSpace> RemoteLayerTreeContext::displayCol
 {
     if (RefPtr drawingArea = m_webPage->drawingArea())
         return drawingArea->displayColorSpace();
-    
+
     return { };
 }
 


### PR DESCRIPTION
#### d6203e5d590d1c6378593373a9f70ef210e86829
<pre>
REGRESSION (297279@main): P3 colors can be mismatched between painted content, and layer backgrounds (see on book.stevejobsarchive.com).
<a href="https://bugs.webkit.org/show_bug.cgi?id=305683">https://bugs.webkit.org/show_bug.cgi?id=305683</a>
<a href="https://rdar.apple.com/166725679">rdar://166725679</a>

Reviewed by Sam Weinig.

<a href="https://book.stevejobsarchive.com">https://book.stevejobsarchive.com</a> used a display-p3 color in CSS, and this was used both
for painted backgrounds, and for &quot;simple container&quot; layers where we set it as layer.backgroundColor.

This bug was introduced by 297279@main, which added clamping of the colors in the painting
path to sRGB, but not in the layer backgroundColor path, which also caused colors to no longer
paint as P3.

The fix is to convert out-of-line colors into a clamping colorspace, which is DisplayP3 if
the output colorspace is wide gamut, or SRGB. This happens only before colors go into the cache,
so is not super hot code. We also need to used the clamped color for layer background colors in
`RemoteLayerTreePropertyApplier::applyPropertiesToLayer()` so that they match the paint-time clamp.

Rename `cachedSDRCGColorForColorspace()` to `createCGColorInDestinationStandardRange()` to be more
accurate.

We also need a fix in `DrawGlyphsRecorder`, so that text being rendered in P3 respects the
colorspace of the target context to avoid clamping. We implement the `deGetColorSpace` callback,
have `GraphicsContextCG::colorSpace()` use `CGContextGetColorSpace()`, and have the buffer in
`DrawGlyphsRecorder::drawOTSVGRun()` use the right colorspace.

On iOS we need to get to the display colorspace in `RemoteLayerTreePropertyApplier::applyPropertiesToLayer()`,
so expose `WebPageProxy::colorSpace()` for Cocoa platforms, and cache it in PageClientImpl() because
fetching it involves calling `MediaToolbox_MTShouldPlayHDRVideo()`.

* LayoutTests/TestExpectations:
* LayoutTests/compositing/background-color/background-color-clamping-expected.txt: Added.
* LayoutTests/compositing/background-color/background-color-clamping.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/ios/compositing/background-color/background-color-clamping-expected.txt: Added.
* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/Configurations/AllowedSPI-legacy.toml:
* Source/WebCore/Configurations/AllowedSPI.toml:
* Source/WebCore/PAL/pal/spi/cg/CoreGraphicsSPI.h:
* Source/WebCore/platform/graphics/Color.h:
* Source/WebCore/platform/graphics/ColorConversion.h:
* Source/WebCore/platform/graphics/cg/ColorCG.cpp:
(WTF::RetainPtr&lt;CGColorRef&gt;&gt;::createValueForKey):
(WebCore::createCGColorInDestinationStandardRange):
(WebCore::cachedCGColorInDestinationStandardRange):
(WebCore::createSDRCGColorForColorspace): Deleted.
(WebCore::cachedSDRCGColorForColorspace): Deleted.
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::setCGFillColor):
(WebCore::GraphicsContextCG::colorSpace const):
(WebCore::GraphicsContextCG::setCGDropShadow):
(WebCore::GraphicsContextCG::didUpdateState):
* Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorder.cpp:
(WebCore::getColorSpace):
(WebCore::DrawGlyphsRecorder::createInternalContext):
(WebCore::DrawGlyphsRecorder::colorSpace const):
(WebCore::DrawGlyphsRecorder::drawOTSVGRun):
* Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorder.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::RemoteLayerTreePropertyApplier::applyPropertiesToLayer):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(dumpCALayer): Dump background color.
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::colorSpace const):
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::colorSpace):
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::colorSpace): Deleted.
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm:
(WebKit::RemoteLayerTreeContext::displayColorSpace const):

Canonical link: <a href="https://commits.webkit.org/306261@main">https://commits.webkit.org/306261@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/457fb03b80c361047f7378f9dc8554fa6a918f94

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140801 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13184 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2364 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149188 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/93889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142674 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13895 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13337 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108016 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/93889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143752 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10730 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126043 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88919 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10339 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7903 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9234 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/119585 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2046 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151764 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12871 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2235 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116284 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12886 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11208 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116620 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29654 "Built successfully and passed tests") | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12612 "Found 4 new test failures: interaction-region/interaction-layers-culling-layer-type-change.html interaction-region/interaction-layers-culling.html platform/visionos/transforms/separated-update.html platform/visionos/transforms/separated-video.html (failure)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122686 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/68011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12914 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12653 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76614 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/12852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12697 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->