### PR TITLE
Release assert in performLayout via WebPage::unapplyEditCommand through WebEditorClient::undo

### DIFF
--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -555,6 +555,7 @@ def serialized_identifiers():
         'WebKit::WebPageProxyIdentifier',
         'WebKit::WebTransportSessionIdentifier',
         'WebKit::WebURLSchemeHandlerIdentifier',
+        'WebKit::WebUndoStepID',
     ]
 
 
@@ -677,6 +678,7 @@ def types_that_cannot_be_forward_declared():
         'WebKit::WebExtensionTabQueryParameters',
         'WebKit::WebExtensionWindowParameters',
         'WebKit::WebTransportSessionIdentifier',
+        'WebKit::WebUndoStepID',
         'WebKit::XRDeviceIdentifier',
         'WTF::SystemMemoryPressureStatus',
     ] + types_that_must_be_moved())

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -174,6 +174,7 @@ template: struct WebKit::WebExtensionTabIdentifierType
 template: struct WebKit::WebExtensionWindowIdentifierType
 template: struct WebKit::WebPageProxyIdentifierType
 template: struct WebKit::WebURLSchemeHandlerIdentifierType
+template: struct WebKit::WebUndoStepIDType
 [WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder] class WTF::ObjectIdentifier {
     [Validator='WTF::ObjectIdentifierGenericBase<uint64_t>::isValidIdentifier(*toUInt64)'] uint64_t toUInt64()
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -221,11 +221,11 @@ messages -> WebPageProxy {
     ShouldGoToBackForwardListItemSync(WebCore::BackForwardItemIdentifier itemID) -> (enum:uint8_t WebCore::ShouldGoToHistoryItem shouldGoToHistoryItem) Synchronous
 
     # Undo/Redo messages
-    RegisterEditCommandForUndo(uint64_t commandID, String label) AllowedWhenWaitingForSyncReply
+    RegisterEditCommandForUndo(WebKit::WebUndoStepID commandID, String label) AllowedWhenWaitingForSyncReply
     ClearAllEditCommands()
     RegisterInsertionUndoGrouping()
     CanUndoRedo(enum:bool WebKit::UndoOrRedo undoOrRedo) -> (bool result) Synchronous
-    ExecuteUndoRedo(enum:bool WebKit::UndoOrRedo undoOrRedo) -> () Synchronous
+    ExecuteUndoRedo(enum:bool WebKit::UndoOrRedo undoOrRedo) -> (uint32_t undoVersion, Vector<std::pair<WebKit::WebUndoStepID, WebKit::UndoOrRedo>> pendingUndoRedo) Synchronous
 
     # Diagnostic messages logging
     LogDiagnosticMessageFromWebProcess(String message, String description, enum:bool WebCore::ShouldSample shouldSample)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5611,24 +5611,36 @@ void WebPage::removeWebEditCommand(WebUndoStepID stepID)
         undoStep->didRemoveFromUndoManager();
 }
 
-void WebPage::unapplyEditCommand(WebUndoStepID stepID)
+void WebPage::unapplyEditCommand(uint32_t undoVersion, WebUndoStepID stepID, CompletionHandler<void()>&& completionHandler)
 {
+    if (undoVersion < m_currentUndoVersion)
+        return completionHandler();
+
+    m_currentUndoVersion = undoVersion;
+
     RefPtr step = webUndoStep(stepID);
     if (!step)
-        return;
+        return completionHandler();
 
     step->protectedStep()->unapply();
+    completionHandler();
 }
 
-void WebPage::reapplyEditCommand(WebUndoStepID stepID)
+void WebPage::reapplyEditCommand(uint32_t undoVersion, WebUndoStepID stepID, CompletionHandler<void()>&& completionHandler)
 {
+    if (undoVersion < m_currentUndoVersion)
+        return completionHandler();
+
+    m_currentUndoVersion = undoVersion;
+
     RefPtr step = webUndoStep(stepID);
     if (!step)
-        return;
+        return completionHandler();
 
     setIsInRedo(true);
     step->protectedStep()->reapply();
     setIsInRedo(false);
+    completionHandler();
 }
 
 void WebPage::didRemoveEditCommand(WebUndoStepID commandID)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -539,6 +539,7 @@ struct WebPageCreationParameters;
 struct WebPageProxyIdentifierType;
 struct WebPreferencesStore;
 struct WebURLSchemeHandlerIdentifierType;
+struct WebUndoStepIDType;
 struct WebsitePoliciesData;
 
 template<typename T> class MonotonicObjectIdentifier;
@@ -568,7 +569,7 @@ using VisitedLinkTableIdentifier = ObjectIdentifier<VisitedLinkTableIdentifierTy
 using WKEventModifiers = uint32_t;
 using WebPageProxyIdentifier = ObjectIdentifier<WebPageProxyIdentifierType>;
 using WebURLSchemeHandlerIdentifier = ObjectIdentifier<WebURLSchemeHandlerIdentifierType>;
-using WebUndoStepID = uint64_t;
+using WebUndoStepID = ObjectIdentifier<WebUndoStepIDType>;
 
 enum class DisallowLayoutViewportHeightExpansionReason : uint8_t {
     ElementFullScreen       = 1 << 0,
@@ -746,6 +747,8 @@ public:
     WebUndoStep* webUndoStep(WebUndoStepID);
     void addWebUndoStep(WebUndoStepID, Ref<WebUndoStep>&&);
     void removeWebEditCommand(WebUndoStepID);
+    void unapplyEditCommand(uint32_t undoVersion, WebUndoStepID, CompletionHandler<void()>&&);
+    void reapplyEditCommand(uint32_t undoVersion, WebUndoStepID, CompletionHandler<void()>&&);
     bool isInRedo() const { return m_isInRedo; }
     void setIsInRedo(bool isInRedo) { m_isInRedo = isInRedo; }
 
@@ -2399,8 +2402,6 @@ private:
 
     void setMainFrameIsScrollable(bool);
 
-    void unapplyEditCommand(WebUndoStepID commandID);
-    void reapplyEditCommand(WebUndoStepID commandID);
     void didRemoveEditCommand(WebUndoStepID commandID);
 
     void updateLastNodeBeforeWritingSuggestions(const WebCore::KeyboardEvent&);
@@ -2795,6 +2796,7 @@ private:
     bool m_mayStartMediaWhenInWindow { false };
 
     HashMap<WebUndoStepID, RefPtr<WebUndoStep>> m_undoStepMap;
+    uint32_t m_currentUndoVersion { 0 };
 
 #if ENABLE(CONTEXT_MENUS)
     std::unique_ptr<API::InjectedBundle::PageContextMenuClient> m_contextMenuClient;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -294,9 +294,9 @@ messages -> WebPage WantsAsyncDispatchMessage {
 
     RequestFontAttributesAtSelectionStart() -> (struct WebCore::FontAttributes attributes)
 
-    DidRemoveEditCommand(uint64_t commandID)
-    ReapplyEditCommand(uint64_t commandID) AllowedWhenWaitingForSyncReply
-    UnapplyEditCommand(uint64_t commandID) AllowedWhenWaitingForSyncReply
+    DidRemoveEditCommand(WebKit::WebUndoStepID commandID)
+    ReapplyEditCommand(uint32_t undoVersion, WebKit::WebUndoStepID commandID) -> ()
+    UnapplyEditCommand(uint32_t undoVersion, WebKit::WebUndoStepID commandID) -> ()
 
     DidSetPageZoomFactor(double zoomFactor)
     DidSetTextZoomFactor(double zoomFactor)

--- a/Source/WebKit/WebProcess/WebPage/WebUndoStep.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebUndoStep.cpp
@@ -28,15 +28,9 @@
 
 namespace WebKit {
 
-static WebUndoStepID generateUndoStep()
-{
-    static WebUndoStepID uniqueEntryID = 1;
-    return uniqueEntryID++;
-}
-
 Ref<WebUndoStep> WebUndoStep::create(Ref<WebCore::UndoStep>&& step)
 {
-    return adoptRef(*new WebUndoStep(WTF::move(step), generateUndoStep()));
+    return adoptRef(*new WebUndoStep(WTF::move(step), WebUndoStepID::generate()));
 }
 
 WebUndoStep::~WebUndoStep() = default;

--- a/Source/WebKit/WebProcess/WebPage/WebUndoStepID.h
+++ b/Source/WebKit/WebProcess/WebPage/WebUndoStepID.h
@@ -25,4 +25,11 @@
 
 #pragma once
 
-using WebUndoStepID = uint64_t;
+#include <wtf/ObjectIdentifier.h>
+
+namespace WebKit {
+
+struct WebUndoStepIDType;
+using WebUndoStepID = ObjectIdentifier<WebUndoStepIDType>;
+
+} // namespace WebKit


### PR DESCRIPTION
#### b08cb7a8eb99d364368fa08ede6cf18b47235a20
<pre>
Release assert in performLayout via WebPage::unapplyEditCommand through WebEditorClient::undo
<a href="https://bugs.webkit.org/show_bug.cgi?id=305689">https://bugs.webkit.org/show_bug.cgi?id=305689</a>

Reviewed by Wenson Hsieh.

The bug was caused by undo/redo IPC from UI process being dispatched while WebContent process
is waiting on a sync IPC reply. Because sync IPCs are used to fetch resources, etc... while
layout or style update is happening, this can lead to release assert failures in various places.

This is an inherent IPC design flaw from when WebKit2 was initially brought up. We use a sync
IPC to trigger undo/redo from WebContent process (e.g. for execCommand(&apos;undo&apos;)) and undo/redo
request from UI process to WebContent for the very undo/redo started in WebContent process must
dispatch to avoid a dead lock.

This PR fixes this IPC design flaw by making undo/redo request from UI process no longer dispatch
while WebContent process is waiting for a sync reply. Instead, the IPC to trigger undo/redo from
WebContent process now obtains the list of undo/redo to execute from UI process. WebContent now
executes all the pending undo/redo requests from UI process when undo/redo request originating
from WebContent process completes.

Because there is a race condition between undo/redo requests being sent from UI process to
WebContent process and undo/redo requests being triggered in WebContent process, we introduce
the notion of &quot;undo version&quot; which monotonically increases whenever we trigger an undo or redo
in UI process. WebContent process ignores any undo/redo requests with an older undo version.

No new tests since we don&apos;t have a reliable test case.

* Source/WebKit/Scripts/webkit/messages.py:
(serialized_identifiers):
(types_that_cannot_be_forward_declared):
* Source/WebKit/Shared/WTFArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/WebEditCommandProxy.cpp:
(WebKit::WebEditCommandProxy::unapply):
(WebKit::WebEditCommandProxy::reapply):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::registerEditCommandForUndo):
(WebKit::WebPageProxy::executeUndoRedo):
(WebKit::WebPageProxy::addPendingUndoRedo):
(WebKit::WebPageProxy::removePendingUndoRedo):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp:
(WebKit::applyPendingUndoRedo):
(WebKit::WebEditorClient::undo):
(WebKit::WebEditorClient::redo):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::unapplyEditCommand):
(WebKit::WebPage::reapplyEditCommand):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKit/WebProcess/WebPage/WebUndoStep.cpp:
(WebKit::WebUndoStep::create):
(WebKit::generateUndoStep): Deleted.
* Source/WebKit/WebProcess/WebPage/WebUndoStepID.h:

Canonical link: <a href="https://commits.webkit.org/305778@main">https://commits.webkit.org/305778@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/784d10599104ffe6e17bc87210da0f9295ef175b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139353 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11729 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/855 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147480 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92420 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/28c771e8-848c-4e7f-b8bb-4572507d9339) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12436 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11879 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106691 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77663 "2 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5984a77c-835c-4a78-b161-d3c2227db34c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142300 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9454 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124819 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87553 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5fe05e65-9d69-48ea-8fee-0c55c8471b0e) 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/138698 "Found 1 webkitpy test failure: webkit.messages_unittest.GeneratedFileContentsTest.test_message_argument_description") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9024 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6743 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7777 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118431 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150263 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11413 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/763 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115087 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11426 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9694 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115395 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9666 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121193 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66400 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21500 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11456 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/711 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11190 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75122 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11393 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11243 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->