### PR TITLE
[GStreamer][WebRTC] Fix a couple vp9 layout tests

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2821,9 +2821,6 @@ imported/w3c/web-platform-tests/webrtc/RTCDTMFSender-ontonechange-long.https.htm
 imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-audio-jitterBufferTarget-stats.https.html [ Pass ]
 imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-video-jitterBufferTarget-stats.html [ Pass ]
 
-webkit.org/b/235885 webrtc/vp9.html [ Slow Failure ]
-webrtc/vp9-sw.html [ Failure ]
-
 # Also skipped on mac, timing out because relying on MediaStream::onactive event which is not exposed.
 webkit.org/b/151344 fast/mediastream/MediaStream-add-ended-tracks.html [ Skip ]
 

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -1907,7 +1907,7 @@ void configureMediaStreamAudioDecoder(GstElement* element)
         g_object_set(element, "max-errors", -1, nullptr);
 }
 
-void configureMediaStreamVideoDecoder(GstElement* element)
+String configureMediaStreamVideoDecoder(GstElement* element)
 {
     if (gstObjectHasProperty(element, "automatic-request-sync-points"_s))
         g_object_set(element, "automatic-request-sync-points", TRUE, nullptr);
@@ -1920,6 +1920,13 @@ void configureMediaStreamVideoDecoder(GstElement* element)
 
     if (gstObjectHasProperty(element, "max-errors"_s))
         g_object_set(element, "max-errors", -1, nullptr);
+
+    auto factoryName = CStringView::unsafeFromUTF8(GST_OBJECT_NAME(gst_element_get_factory(element)));
+    StringBuilder builder;
+    builder.append("GStreamer "_s, factoryName.span());
+    if (factoryName == "vp9dec"_s || factoryName == "vp8dec"_s)
+        builder.append(" (fallback from: libvpx)"_s);
+    return builder.toString();
 }
 
 void configureVideoRTPDepayloader(GstElement* element)

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -329,7 +329,7 @@ void configureVideoDecoderForHarnessing(const GRefPtr<GstElement>&);
 
 void configureMediaStreamAudioDecoder(GstElement*);
 
-void configureMediaStreamVideoDecoder(GstElement*);
+String configureMediaStreamVideoDecoder(GstElement*);
 void configureVideoRTPDepayloader(GstElement*);
 
 bool gstObjectHasProperty(GstObject*, ASCIILiteral name);

--- a/Source/WebCore/platform/graphics/gstreamer/MediaEngineConfigurationFactoryGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaEngineConfigurationFactoryGStreamer.cpp
@@ -35,7 +35,6 @@
 #include "MediaCapabilitiesEncodingInfo.h"
 #include "MediaDecodingConfiguration.h"
 #include "MediaEncodingConfiguration.h"
-#include "MediaPlayer.h"
 #include <wtf/Function.h>
 
 #if ENABLE(MEDIA_SOURCE)
@@ -61,6 +60,7 @@ void createMediaPlayerDecodingConfigurationGStreamer(MediaDecodingConfiguration&
     info.supported = lookupResult.isSupported;
     info.powerEfficient = lookupResult.isUsingHardware;
     info.configuration = WTF::move(configuration);
+    info.smooth = lookupResult.isSupported;
 
     callback(WTF::move(info));
 }
@@ -73,6 +73,7 @@ void createMediaPlayerEncodingConfigurationGStreamer(MediaEncodingConfiguration&
     info.supported = lookupResult.isSupported;
     info.powerEfficient = lookupResult.isUsingHardware;
     info.configuration = WTF::move(configuration);
+    info.smooth = lookupResult.isSupported;
 
     callback(WTF::move(info));
 }

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -3613,7 +3613,7 @@ void MediaPlayerPrivateGStreamer::configureVideoDecoder(GstElement* decoder)
     if (!isMediaStreamPlayer())
         return;
 
-    configureMediaStreamVideoDecoder(decoder);
+    m_videoDecoderName = configureMediaStreamVideoDecoder(decoder);
 
     auto sinkPad = adoptGRef(gst_element_get_static_pad(decoder, "sink"));
     gst_pad_add_probe(sinkPad.get(), static_cast<GstPadProbeType>(GST_PAD_PROBE_TYPE_BUFFER), [](GstPad*, GstPadProbeInfo* info, gpointer userData) -> GstPadProbeReturn {
@@ -3660,6 +3660,7 @@ void MediaPlayerPrivateGStreamer::configureVideoDecoder(GstElement* decoder)
 
                 if (player->m_totalVideoDecodeTime.isValid())
                     gst_structure_set(structure, "total-decode-time", G_TYPE_DOUBLE, player->m_totalVideoDecodeTime.toDouble(), nullptr);
+                gst_structure_set(structure, "decoder-implementation", G_TYPE_STRING, player->m_videoDecoderName.utf8().data(), nullptr);
                 GST_PAD_PROBE_INFO_DATA(info) = query;
                 return GST_PAD_PROBE_HANDLED;
             }

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -688,6 +688,7 @@ private:
     // Specific to MediaStream playback.
     MediaTime m_startTime;
     std::optional<MediaTime> m_pausedTime;
+    String m_videoDecoderName;
 
     void setupCodecProbe(GstElement*);
     Lock m_codecsLock;

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp
@@ -230,7 +230,8 @@ GRefPtr<GstElement> GStreamerIncomingTrackProcessor::incomingTrackProcessor()
         if (!classifiers.contains("Decoder"_s) || !classifiers.contains("Video"_s))
             return;
 
-        configureMediaStreamVideoDecoder(element);
+        auto self = reinterpret_cast<GStreamerIncomingTrackProcessor*>(userData);
+        self->m_videoDecoderName = configureMediaStreamVideoDecoder(element);
         webkitGstTraceProcessingTimeForElement(element);
 
         auto sinkPad = adoptGRef(gst_element_get_static_pad(element, "sink"));
@@ -392,6 +393,8 @@ const GstStructure* GStreamerIncomingTrackProcessor::stats()
 
     if (m_totalVideoDecodeTime.isValid())
         gst_structure_set(m_stats.get(), "total-decode-time", G_TYPE_DOUBLE, m_totalVideoDecodeTime.toDouble(), nullptr);
+
+    gst_structure_set(m_stats.get(), "decoder-implementation", G_TYPE_STRING, m_videoDecoderName.utf8().data(), nullptr);
 
     return m_stats.get();
 }

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.h
@@ -81,6 +81,8 @@ private:
 
     // https://www.w3.org/TR/webrtc-stats/#dom-rtcinboundrtpstreamstats-totaldecodetime
     MediaTime m_totalVideoDecodeTime { MediaTime::zeroTime() };
+
+    String m_videoDecoderName;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 94e341c030b0345a1fb8eea0a274d6a70629441d
<pre>
[GStreamer][WebRTC] Fix a couple vp9 layout tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=305692">https://bugs.webkit.org/show_bug.cgi?id=305692</a>

Reviewed by Xabier Rodriguez-Calvar.

These tests were failing for two reasons:
- the MediaDecodingInfo `smooth` field wasn&apos;t filled.
- The internals.gatherDecoderImplementationName() function wasn&apos;t implemented for the GStreamer
ports. It now returns a string similar to the libwebrtc backend. The decoderImplementation stats
field is also no longer filled because it is sensible to fingerprinting.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::preprocessStats):
(WebCore::GStreamerMediaEndpoint::gatherDecoderImplementationName):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp:
(WebCore::GStreamerStatsCollector::GStreamerStatsCollector):
(WebCore::RTCStatsReport::InboundRtpStreamStats::InboundRtpStreamStats):
(WebCore::GStreamerStatsCollector::gatherStats):
(WebCore::GStreamerStatsCollector::getStats):
(WebCore::GStreamerStatsCollector::gatherDecoderImplementationName):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.h:
(WebCore::GStreamerStatsCollector::setElement):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::configureMediaStreamVideoDecoder):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h:
* Source/WebCore/platform/graphics/gstreamer/MediaEngineConfigurationFactoryGStreamer.cpp:
(WebCore::createMediaPlayerDecodingConfigurationGStreamer):
(WebCore::createMediaPlayerEncodingConfigurationGStreamer):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::configureVideoDecoder):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp:
(WebCore::GStreamerIncomingTrackProcessor::incomingTrackProcessor):
(WebCore::GStreamerIncomingTrackProcessor::stats):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.h:

Canonical link: <a href="https://commits.webkit.org/305811@main">https://commits.webkit.org/305811@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c7e81a038e26b8918a38e89c9c5409ff452f313

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139332 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11708 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/834 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147459 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92399 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141205 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12415 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11858 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106673 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77649 "1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142279 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9416 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124798 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87535 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8969 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6721 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7756 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118410 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/706 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150242 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11392 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/725 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115069 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11405 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9653 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115377 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29342 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9568 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121154 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66370 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11435 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/673 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11169 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75101 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11372 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11222 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->