### PR TITLE
[GStreamer][WebRTC] String handling improvements in ICE candidate SDP parser

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
@@ -275,10 +275,10 @@ std::optional<RTCIceCandidate::Fields> parseIceCandidateSDP(const String& sdp)
     NextSDPField nextSdpField { NextSDPField::None };
 
     for (auto token : view.split(' ')) {
-        auto tokenString = token.toStringWithoutCopying();
+        auto tokenString = token.toString();
         switch (i) {
         case 0:
-            foundation = tokenString;
+            foundation = WTF::move(tokenString);
             break;
         case 1:
             if (auto value = parseInteger<unsigned>(token))
@@ -289,7 +289,7 @@ std::optional<RTCIceCandidate::Fields> parseIceCandidateSDP(const String& sdp)
             }
             break;
         case 2:
-            transport = tokenString;
+            transport = WTF::move(tokenString);
             break;
         case 3:
             if (auto value = parseInteger<unsigned>(token))
@@ -300,7 +300,7 @@ std::optional<RTCIceCandidate::Fields> parseIceCandidateSDP(const String& sdp)
             }
             break;
         case 4:
-            address = tokenString;
+            address = WTF::move(tokenString);
             break;
         case 5:
             if (auto value = parseInteger<unsigned>(token))
@@ -331,16 +331,16 @@ std::optional<RTCIceCandidate::Fields> parseIceCandidateSDP(const String& sdp)
                     type = tokenString;
                     break;
                 case NextSDPField::Raddr:
-                    relatedAddress = tokenString;
+                    relatedAddress = WTF::move(tokenString);
                     break;
                 case NextSDPField::Rport:
                     relatedPort = parseInteger<unsigned>(token).value_or(0);
                     break;
                 case NextSDPField::TcpType:
-                    tcptype = tokenString;
+                    tcptype = WTF::move(tokenString);
                     break;
                 case NextSDPField::Ufrag:
-                    usernameFragment = tokenString;
+                    usernameFragment = WTF::move(tokenString);
                     break;
                 case NextSDPField::Generation:
                     // Unsupported.
@@ -364,16 +364,16 @@ std::optional<RTCIceCandidate::Fields> parseIceCandidateSDP(const String& sdp)
     fields.priority = priority;
     fields.protocol = toRTCIceProtocol(transport);
     if (!address.isEmpty()) {
-        fields.address = address;
+        fields.address = WTF::move(address);
         fields.port = port;
     }
     fields.type = toRTCIceCandidateType(type);
     fields.tcpType = toRTCIceTcpCandidateType(tcptype);
     if (!relatedAddress.isEmpty()) {
-        fields.relatedAddress = relatedAddress;
+        fields.relatedAddress = WTF::move(relatedAddress);
         fields.relatedPort = relatedPort;
     }
-    fields.usernameFragment = usernameFragment;
+    fields.usernameFragment = WTF::move(usernameFragment);
     return fields;
 }
 


### PR DESCRIPTION
#### e3bbf376857bbc89ee727670af424b80e06d3679
<pre>
[GStreamer][WebRTC] String handling improvements in ICE candidate SDP parser
<a href="https://bugs.webkit.org/show_bug.cgi?id=305703">https://bugs.webkit.org/show_bug.cgi?id=305703</a>

Reviewed by Xabier Rodriguez-Calvar.

Use owned strings for ICE candidate SDP string tokens, they&apos;re then moved to corresponding
RTCIceCandidate::Fields storage after parsing.

Manually tested on <a href="https://livekit.io/webrtc/browser-test">https://livekit.io/webrtc/browser-test</a> which displayed garbage ICE candidates
data without this patch.

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp:
(WebCore::parseIceCandidateSDP):

Canonical link: <a href="https://commits.webkit.org/305818@main">https://commits.webkit.org/305818@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eecc96e6a73d736f02aac79a87abf2c434b1198c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139344 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11720 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/846 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147471 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92411 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141217 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12427 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11870 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106683 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77655 "1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142291 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9435 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124809 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87545 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8996 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6733 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7768 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118422 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/726 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150254 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11404 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/744 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115079 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11417 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9674 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115387 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29345 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9614 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121173 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66388 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11447 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/692 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11181 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75113 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11384 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11234 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->