### PR TITLE
Replace RefPtr with Ref in Vector in JSC, take 2

### DIFF
--- a/Source/JavaScriptCore/assembler/AbstractMacroAssembler.h
+++ b/Source/JavaScriptCore/assembler/AbstractMacroAssembler.h
@@ -1222,8 +1222,8 @@ protected:
 
     Vector<std::pair<Label, String>> m_comments;
 
-    Vector<RefPtr<SharedTask<void(LinkBuffer&)>>> m_linkTasks;
-    Vector<RefPtr<SharedTask<void(LinkBuffer&)>>> m_lateLinkTasks;
+    Vector<Ref<SharedTask<void(LinkBuffer&)>>> m_linkTasks;
+    Vector<Ref<SharedTask<void(LinkBuffer&)>>> m_lateLinkTasks;
 
     friend class LinkBuffer;
 }; // class AbstractMacroAssembler

--- a/Source/JavaScriptCore/assembler/LinkBuffer.h
+++ b/Source/JavaScriptCore/assembler/LinkBuffer.h
@@ -412,8 +412,8 @@ private:
     bool m_isRewriting { false };
     Profile m_profile { Profile::Uncategorized };
     CodePtr<LinkBufferPtrTag> m_code;
-    Vector<RefPtr<SharedTask<void(LinkBuffer&)>>> m_linkTasks;
-    Vector<RefPtr<SharedTask<void(LinkBuffer&)>>> m_lateLinkTasks;
+    Vector<Ref<SharedTask<void(LinkBuffer&)>>> m_linkTasks;
+    Vector<Ref<SharedTask<void(LinkBuffer&)>>> m_lateLinkTasks;
 
     static size_t s_profileCummulativeLinkedSizes[numberOfProfiles];
     static size_t s_profileCummulativeLinkedCounts[numberOfProfiles];

--- a/Source/JavaScriptCore/jit/JITPlan.h
+++ b/Source/JavaScriptCore/jit/JITPlan.h
@@ -139,7 +139,7 @@ protected:
     VM* m_vm;
     CodeBlock* m_codeBlock;
     CheckedPtr<JITWorklistThread> m_thread;
-    Vector<RefPtr<SharedTask<void()>>> m_mainThreadFinalizationTasks;
+    Vector<Ref<SharedTask<void()>>> m_mainThreadFinalizationTasks;
     CString m_signpostMessage; // Non-null iff Options::useCompilerSignpost()
 };
 

--- a/Source/JavaScriptCore/jit/JITWorklist.cpp
+++ b/Source/JavaScriptCore/jit/JITWorklist.cpp
@@ -241,7 +241,7 @@ auto JITWorklist::completeAllReadyPlansForVM(VM& vm, JITCompilationKey requested
 
     DeferGC deferGC(vm);
 
-    Vector<RefPtr<JITPlan>, 8> myReadyPlans;
+    Vector<Ref<JITPlan>, 8> myReadyPlans;
     State resultingState = removeAllReadyPlansForVM(vm, myReadyPlans, requestedKey);
     for (auto& plan : myReadyPlans) {
         dataLogLnIf(Options::verboseCompilationQueue(), *this, ": Completing ", plan->key());
@@ -317,7 +317,7 @@ void JITWorklist::cancelAllPlansForVM(VM& vm)
 
     waitUntilAllPlansForVMAreReady(vm);
 
-    Vector<RefPtr<JITPlan>, 8> myReadyPlans;
+    Vector<Ref<JITPlan>, 8> myReadyPlans;
     removeAllReadyPlansForVM(vm, myReadyPlans, { });
     for (auto& plan : myReadyPlans) {
         ASSERT(plan->stage() == JITPlanStage::Ready);
@@ -407,13 +407,13 @@ void JITWorklist::dump(const AbstractLocker& locker, PrintStream& out) const
         ", Num Active Threads = ", m_numberOfActiveThreads, "/", m_threads.size(), "]");
 }
 
-JITWorklist::State JITWorklist::removeAllReadyPlansForVM(VM& vm, Vector<RefPtr<JITPlan>, 8>& myReadyPlans, JITCompilationKey requestedKey)
+JITWorklist::State JITWorklist::removeAllReadyPlansForVM(VM& vm, Vector<Ref<JITPlan>, 8>& myReadyPlans, JITCompilationKey requestedKey)
 {
     DeferGC deferGC(vm);
     Locker locker { *m_lock };
 
     bool isCompiled = false;
-    m_readyPlans.removeAllMatching([&](RefPtr<JITPlan> plan) {
+    m_readyPlans.removeAllMatching([&](Ref<JITPlan> plan) {
         if (plan->vm() != &vm)
             return false;
         if (plan->stage() != JITPlanStage::Ready)
@@ -466,12 +466,9 @@ void JITWorklist::removeMatchingPlansForVM(VM& vm, const MatchFunction& matches)
     bool didCancelPlans = !deadPlanKeys.isEmpty();
     for (JITCompilationKey key : deadPlanKeys)
         m_plans.take(key)->cancel();
-    for (unsigned i = 0; i < m_readyPlans.size(); ++i) {
-        if (m_readyPlans[i]->stage() != JITPlanStage::Canceled)
-            continue;
-        m_readyPlans[i--] = m_readyPlans.last();
-        m_readyPlans.removeLast();
-    }
+    m_readyPlans.removeAllMatching([](auto& plan) {
+        return plan->stage() == JITPlanStage::Canceled;
+    });
     if (didCancelPlans)
         m_planCompiledOrCancelled.notifyAll();
 }

--- a/Source/JavaScriptCore/jit/JITWorklist.h
+++ b/Source/JavaScriptCore/jit/JITWorklist.h
@@ -99,7 +99,7 @@ private:
     template<typename MatchFunction>
     void removeMatchingPlansForVM(VM&, const MatchFunction&);
 
-    State removeAllReadyPlansForVM(VM&, Vector<RefPtr<JITPlan>, 8>&, JITCompilationKey);
+    State removeAllReadyPlansForVM(VM&, Vector<Ref<JITPlan>, 8>&, JITCompilationKey);
 
     void dump(const AbstractLocker&, PrintStream&) const;
 
@@ -122,7 +122,7 @@ private:
 
     // Used to quickly find which plans have been compiled and are ready to
     // be completed.
-    Vector<RefPtr<JITPlan>, 16> m_readyPlans;
+    Vector<Ref<JITPlan>, 16> m_readyPlans;
 
     Lock m_suspensionLock;
     Box<Lock> m_lock;

--- a/Source/JavaScriptCore/jit/JITWorklistThread.cpp
+++ b/Source/JavaScriptCore/jit/JITWorklistThread.cpp
@@ -155,7 +155,7 @@ auto JITWorklistThread::work() -> WorkResult
         }
 
         RELEASE_ASSERT(!m_plan->vm()->heap.worldIsStopped());
-        m_worklist.m_readyPlans.append(WTF::move(m_plan));
+        m_worklist.m_readyPlans.append(m_plan.releaseNonNull());
         m_worklist.m_planCompiledOrCancelled.notifyAll();
     }
 

--- a/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
@@ -329,7 +329,7 @@ void CalleeGroup::updateCallsitesToCallUs(const AbstractLocker& locker, CodeLoca
     // threads and not wasm ones. So the OMGOSREntryCallee could die between the time we collect the callsites and when
     // we actually repatch its callsites.
     // FIXME: These inline capacities were picked semi-randomly. We should figure out if there's a better number.
-    Vector<RefPtr<OMGOSREntryCallee>, 4> keepAliveOSREntryCallees;
+    Vector<Ref<OMGOSREntryCallee>, 4> keepAliveOSREntryCallees;
     Vector<Callsite, 16> callsites;
 
     auto functionSpaceIndex = toSpaceIndex(functionIndex);
@@ -372,7 +372,7 @@ void CalleeGroup::updateCallsitesToCallUs(const AbstractLocker& locker, CodeLoca
         if (auto iter = m_osrEntryCallees.find(callerIndex); iter != m_osrEntryCallees.end()) {
             if (RefPtr callee = iter->value.get()) {
                 collectCallsites(callee.get());
-                keepAliveOSREntryCallees.append(WTF::move(callee));
+                keepAliveOSREntryCallees.append(callee.releaseNonNull());
             } else
                 m_osrEntryCallees.remove(iter);
         }


### PR DESCRIPTION
#### ca8fccf37445855ac5896b534d53cf87203de7b4
<pre>
Replace RefPtr with Ref in Vector in JSC, take 2
<a href="https://bugs.webkit.org/show_bug.cgi?id=305271">https://bugs.webkit.org/show_bug.cgi?id=305271</a>

Reviewed by Keith Miller.

305422@main resulted in a ASan crash so now we use Vector&apos;s
removeAllMatching in JITWorklist to circumvent the issue.

Thanks to Claude AI for the suggestion.

Canonical link: <a href="https://commits.webkit.org/305779@main">https://commits.webkit.org/305779@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c044eb2c042bc655f30c0d418152cce9b0b383e3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139347 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11723 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/849 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147474 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92414 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1d05fd70-df0d-4c87-995b-d79c563da6e1) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12430 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11873 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106686 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77658 "7 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e0759fdf-4a2b-427c-bdde-7dcfe307101b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142294 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9440 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124813 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87548 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c5fdb1a9-51b8-403d-889d-a1947004cf47) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9002 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6736 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7771 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/131320 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118425 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/732 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150257 "Built successfully") | | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/164 "Found 1 new JSC stress test failure: stress/re-enter-resolve-rope-string.js.no-ftl (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11407 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/750 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115082 "Found 1 new test failure: scrollbars/corner-resizer-window-inactive.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11420 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9679 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115390 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9629 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121179 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66391 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21501 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11450 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/698 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/170618 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11184 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75116 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44400 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11387 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11237 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->