### PR TITLE
Add C++17 [[nodiscard]] to WTF::Expected

### DIFF
--- a/Source/WTF/wtf/Expected.h
+++ b/Source/WTF/wtf/Expected.h
@@ -275,7 +275,7 @@ struct voidbase {
 } // namespace __expected_detail
 
 template<class T, class E>
-class expected : private __expected_detail::base<T, E> {
+class [[nodiscard]] expected : private __expected_detail::base<T, E> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(expected);
     typedef __expected_detail::base<T, E> base;
 
@@ -343,7 +343,7 @@ public:
 };
 
 template<class E>
-class expected<void, E> : private __expected_detail::voidbase<E> {
+class [[nodiscard]] expected<void, E> : private __expected_detail::voidbase<E> {
     typedef __expected_detail::voidbase<E> base;
 
 public:


### PR DESCRIPTION
#### af5087de6b80f815cdbfa0eeaf1bbb57a8127233
<pre>
Add C++17 [[nodiscard]] to WTF::Expected
<a href="https://bugs.webkit.org/show_bug.cgi?id=305706">https://bugs.webkit.org/show_bug.cgi?id=305706</a>
<a href="https://rdar.apple.com/168368301">rdar://168368301</a>

Reviewed by NOBODY (OOPS!).

This is a follow-up to <a href="https://commits.webkit.org/304354@main">304354@main</a>. This restores [[nodiscard]] behavior
in WebGPU/WGSL/TypeCheck.cpp.

* Source/WTF/wtf/Expected.h:
(std::experimental::fundamentals_v3::expected): Added [[nodiscard]] attribute.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af5087de6b80f815cdbfa0eeaf1bbb57a8127233

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139350 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11726 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/852 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147477 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92417 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12433 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11876 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106688 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77660 "5 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142297 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9444 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124815 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87550 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9008 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6739 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7774 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/131323 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118427 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/736 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150260 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/144 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11410 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/754 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115084 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11423 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9684 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115392 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9639 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121183 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66394 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11453 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/702 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/170621 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11187 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75119 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44401 "Found 1 new JSC binary failure: testb3, Found 8 new JSC stress test failures: wasm.yaml/wasm/stress/wasm-js-string-builtins-signature-validation.js.default-wasm, wasm.yaml/wasm/stress/wasm-js-string-builtins-signature-validation.js.wasm-bbq, wasm.yaml/wasm/stress/wasm-js-string-builtins-signature-validation.js.wasm-bbq-no-consts, wasm.yaml/wasm/stress/wasm-js-string-builtins-signature-validation.js.wasm-collect-continuously, wasm.yaml/wasm/stress/wasm-js-string-builtins-signature-validation.js.wasm-eager, wasm.yaml/wasm/stress/wasm-js-string-builtins-signature-validation.js.wasm-eager-jettison, wasm.yaml/wasm/stress/wasm-js-string-builtins-signature-validation.js.wasm-no-cjit, wasm.yaml/wasm/stress/wasm-js-string-builtins-signature-validation.js.wasm-slow-memory (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11390 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11240 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->