### PR TITLE
`background-clip: text` does not work correctly when used on table cell

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-text-background-table-cell-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-text-background-table-cell-expected.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<head>
+<title>Test 'background-clip: text' on Table Cells</title>
+<style>
+.container {
+  position: relative;
+  top: 2px;
+  left: 1px;
+  margin: 0px;
+  height: 80px;
+}
+
+.gradient-text {
+  display: inline-block;
+  font-size: 40px;
+  font-family: sans-serif;
+  line-height: 40px;
+  background: linear-gradient(to bottom, red 0%, blue 100%);
+  background-size: 100% 40px;
+  background-clip: text;
+  color: transparent;
+  }
+</style>
+</head>
+<body>
+<div class="container">
+  <div class="gradient-text">Text</div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-text-background-table-cell-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-text-background-table-cell-ref.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<head>
+<title>Test 'background-clip: text' on Table Cells</title>
+<style>
+.container {
+  position: relative;
+  top: 2px;
+  margin: 0px;
+  height: 80px;
+}
+
+.gradient-text {
+  display: inline-block;
+  font-size: 40px;
+  font-family: sans-serif;
+  line-height: 40px;
+  background: linear-gradient(to bottom, red 0%, blue 100%);
+  background-size: 100% 40px;
+  background-clip: text;
+  color: transparent;
+  }
+</style>
+</head>
+<body>
+<div class="container">
+  <div class="gradient-text">Text</div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-text-background-table-cell.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-text-background-table-cell.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<head>
+<title>Test 'background-clip: text' on Table Cells</title>
+<link rel="match" href="clip-text-background-table-cell-ref.html">
+<meta name="fuzzy" content="maxDifference=0-6;totalPixels=0-728">
+<style>
+  table {
+    position: relative;
+    top: 1px;
+    margin: 0;
+    border-collapse: collapse;
+  }
+  tr {
+    padding: 0;
+    font-size: 40px;
+    line-height: 40px;
+    font-family: sans-serif;
+    vertical-align: top;
+    background: linear-gradient(red, blue);
+    background-clip: text;
+    color: transparent;
+  }
+</style>
+</head>
+<body>
+<table>
+  <thead>
+  <tr>
+    <td>Text</td>
+  </tr>
+  </thead>
+</table>
+</body>
+</html>
+

--- a/Source/WebCore/rendering/RenderTableCell.cpp
+++ b/Source/WebCore/rendering/RenderTableCell.cpp
@@ -1557,7 +1557,8 @@ void RenderTableCell::paintBackgroundsBehindCell(PaintInfo& paintInfo, LayoutPoi
         fillRect = LayoutRect { adjustedPaintOffset, size() };
     auto compositeOp = document().compositeOperatorForBackgroundColor(color, *this);
     BackgroundPainter painter { *this, paintInfo };
-    if (backgroundObject != this) {
+    auto hasBackgroundClipText = style.backgroundLayers().usedFirst().clip() == FillBox::Text;
+    if (backgroundObject != this && !hasBackgroundClipText) {
         painter.setOverrideClip(FillBox::BorderBox);
         painter.setOverrideOrigin(FillBox::BorderBox);
     }


### PR DESCRIPTION
#### 43fea4339cb5accd4672689841ea9dd0c852fe75
<pre>
`background-clip: text` does not work correctly when used on table cell
<a href="https://bugs.webkit.org/show_bug.cgi?id=285846">https://bugs.webkit.org/show_bug.cgi?id=285846</a>

Reviewed by Elika Etemad.

When `background-clip: text` is applied to a table cell, the background
was being painted for the entire cell instead of only the text.

This was caused by `RenderTableCell::paintBackgroundsBehindCell`
overriding the clip mode to `FillBox::BorderBox` regardless of the
specified `background-clip` as introduced by commit 7dcecb, so Background painter never execute the code path for `FillBox::Text`.

This patch set the clip mode to `FillBox::Text` when `background-clip: text` is present
so that the background painter applies the background only to the text.

* Source/WebCore/rendering/RenderTableCell.cpp:
(WebCore::RenderTableCell::paintBackgroundsBehindCell):
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-text-background-table-cell-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-text-background-table-cell-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-text-background-table-cell.html: Added.

Canonical link: <a href="https://commits.webkit.org/305987@main">https://commits.webkit.org/305987@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2806a0b50c22a9c76a3ff9ff49120651c8caf1c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140037 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/12418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1548 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/148181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/93111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141910 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/13128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12570 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/148181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/93111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142987 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/13128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/125395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/148181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/13128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/7281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8469 "Failed to checkout and rebase branch from PR 56774") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/13128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/1403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/150970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/12103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/1468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/150970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/12116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/10367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/150970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/121880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/67113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21614 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/12146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/1352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/11887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/75832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/12081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/11933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->