### PR TITLE
[JSC][WASM][Debugger] Fix instance registration race and use InstanceAnchor for lifecycle management

### DIFF
--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.cpp
@@ -533,14 +533,6 @@ void DebugServer::trackInstance(JSWebAssemblyInstance* instance)
     }
 }
 
-void DebugServer::untrackInstance(JSWebAssemblyInstance* instance)
-{
-    if (!m_moduleManager)
-        return;
-    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Untracking WebAssembly instance: ", RawPointer(instance));
-    m_moduleManager->unregisterInstance(instance);
-}
-
 void DebugServer::trackModule(Module& module)
 {
     if (!m_moduleManager)

--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.h
@@ -111,7 +111,6 @@ public:
 #endif
 
     void trackInstance(JSWebAssemblyInstance*);
-    void untrackInstance(JSWebAssemblyInstance*);
     void trackModule(Module&);
     void untrackModule(Module&);
 

--- a/Source/JavaScriptCore/wasm/debugger/WasmMemoryHandler.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmMemoryHandler.cpp
@@ -131,7 +131,7 @@ bool MemoryHandler::readMemoryData(VirtualAddress address, size_t length, String
     }
 
     void* memoryBase = jsInstance->cachedMemory();
-    size_t size = jsInstance->memory()->memory().size();
+    size_t size = jsInstance->cachedMemorySize();
     if (!memoryBase || offset + length > size) {
         dataLogLnIf(Options::verboseWasmDebugger(), "[MemoryHandler] - memory access out of bounds. Instance ID: ", instanceId, " offset: ", offset, " size: ", length, " memory size: ", size);
         return false;
@@ -188,7 +188,7 @@ void MemoryHandler::handleWasmMemoryRegionInfo(VirtualAddress address, uint32_t 
 {
     JSWebAssemblyInstance* instance = m_debugServer.m_moduleManager->jsInstance(instanceId);
     if (instance) {
-        size_t memorySize = instance->memory()->memory().size();
+        size_t memorySize = instance->cachedMemorySize();
         if (offset < memorySize) {
             // Address is within WASM memory - return the memory region
             uint32_t moduleId = instance->moduleInformation().debugInfo->id;

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
@@ -158,9 +158,6 @@ void JSWebAssemblyInstance::finishCreation(VM& vm)
 
     // Now, JSWebAssemblyInstance is fully initialized. Expose it to the concurrent compiler.
     m_anchor = m_module->registerAnchor(this);
-
-    if (Options::enableWasmDebugger()) [[unlikely]]
-        Wasm::DebugServer::singleton().trackInstance(this);
 }
 
 JSWebAssemblyInstance::~JSWebAssemblyInstance()
@@ -181,9 +178,6 @@ JSWebAssemblyInstance::~JSWebAssemblyInstance()
         m_anchor->tearDown();
         m_anchor = nullptr;
     }
-
-    if (Options::enableWasmDebugger()) [[unlikely]]
-        Wasm::DebugServer::singleton().untrackInstance(this);
 }
 
 void JSWebAssemblyInstance::destroy(JSCell* cell)
@@ -384,7 +378,12 @@ JSWebAssemblyInstance* JSWebAssemblyInstance::tryCreate(VM& vm, Structure* insta
         jsInstance->setDummyMemory(vm, jsMemory);
         RETURN_IF_EXCEPTION(throwScope, nullptr);
     }
-    
+
+
+    // Register with debugger after memory and anchor are fully initialized.
+    if (Options::enableWasmDebugger()) [[unlikely]]
+        Wasm::DebugServer::singleton().trackInstance(jsInstance);
+
     return jsInstance;
 }
 


### PR DESCRIPTION
#### 4211cd058e41ded60e6c7ca252d60371faf9a50f
<pre>
[JSC][WASM][Debugger] Fix instance registration race and use InstanceAnchor for lifecycle management
<a href="https://rdar.apple.com/168389785">rdar://168389785</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=305714">https://bugs.webkit.org/show_bug.cgi?id=305714</a>

Reviewed by Yusuke Suzuki.

Problem:
Debugger registration occurred in JSWebAssemblyInstance::finishCreation()
before memory setup, allowing ModuleManager::jsInstance() to return instances
without initialized memory.

Solution:
Move DebugServer::trackInstance() from finishCreation() to the end of
tryCreate(), after memory is initialized.

InstanceAnchor-based tracking:
- Changed ModuleManager to store ThreadSafeWeakPtr for thread-safe cross-thread access
- Automatic cleanup via InstanceAnchor::tearDown() in destructor
- Amortized cleanup removes dead entries (every 2 * map_size operations)
- VM-stopped assertion ensures no GC during debugger access

Tests: Existing WASM debugger tests cover this scenario.
Canonical link: <a href="https://commits.webkit.org/305830@main">https://commits.webkit.org/305830@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5d00f9d331a3df8ffc93360f6b25487f3bd23c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139459 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11835 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/961 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147586 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92527 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/90da3b4a-c3aa-4bbe-aafe-bd5d5343e384) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12543 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11985 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106771 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77737 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c2efb4c9-3a92-4dd8-83a2-76d4dbb3b0b7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142406 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9592 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124910 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87634 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0870d7c7-e56d-4392-ac48-08248b304b97) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9207 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6834 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7884 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/131432 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118522 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/887 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150369 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/254 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11519 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/903 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115170 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11533 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9835 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115482 "Found 1 new API test failure: WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/autoplay-policy (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29352 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9973 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121332 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66525 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11563 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/842 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/170730 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11298 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75229 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44433 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11499 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11350 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->