### PR TITLE
REGRESSION(305691@main): PDF background should remain gray in pre-Liquid Glass macOS

### DIFF
--- a/LayoutTests/platform/mac-sequoia/pdf/fullscreen-expected.txt
+++ b/LayoutTests/platform/mac-sequoia/pdf/fullscreen-expected.txt
@@ -1,0 +1,16 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x524
+  RenderBlock {HTML} at (0,0) size 800x524
+    RenderBody {BODY} at (8,8) size 784x508
+layer at (8,8) size 788x504
+  RenderIFrame {IFRAME} at (0,0) size 788x504 [border: (2px inset #000000)]
+    layer at (0,0) size 784x504
+      RenderView at (0,0) size 784x500
+    layer at (0,0) size 784x500
+      RenderBlock {HTML} at (0,0) size 784x500
+        RenderBody {BODY} at (0,0) size 784x500 [bgcolor=#808080]
+    layer at (0,0) size 784x500
+      RenderEmbeddedObject {EMBED} at (0,0) size 784x500
+    layer at (0,0) size 784x500
+      RenderFlexibleBox {DIV} at (0,0) size 784x500

--- a/LayoutTests/platform/mac-sequoia/pdf/load-pdf-twice-in-sequence-expected.txt
+++ b/LayoutTests/platform/mac-sequoia/pdf/load-pdf-twice-in-sequence-expected.txt
@@ -1,0 +1,200 @@
+
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 2
+        (GraphicsLayer
+          (position 8.00 8.00)
+          (bounds 300.00 300.00)
+          (children 1
+            (GraphicsLayer
+              (anchor 0.00 0.00)
+              (bounds 300.00 300.00)
+              (backgroundColor #808080)
+              (children 2
+                (GraphicsLayer
+                  (anchor 0.00 0.00)
+                  (bounds 300.00 300.00)
+                  (children 1
+                    (GraphicsLayer
+                      (anchor 0.00 0.00)
+                      (children 2
+                        (GraphicsLayer
+                          (anchor 0.00 0.00)
+                          (transform [0.97 0.00 0.00 0.00] [0.00 0.97 0.00 0.00] [0.00 0.00 1.00 0.00] [11.00 7.00 0.00 1.00])
+                          (children 1
+                            (GraphicsLayer
+                              (position 34.55 38.86)
+                              (anchor 0.00 0.00)
+                              (bounds 215.91 215.91)
+                              (children 1
+                                (GraphicsLayer
+                                  (anchor 0.00 0.00)
+                                  (bounds 100.00 100.00)
+                                  (drawsContent 1)
+                                  (backgroundColor #FFFFFF)
+                                  (transform [2.16 0.00 0.00 0.00] [0.00 2.16 0.00 0.00] [0.00 0.00 1.00 0.00] [0.00 0.00 0.00 1.00])
+                                )
+                              )
+                            )
+                          )
+                        )
+                        (GraphicsLayer
+                          (anchor 0.00 0.00)
+                          (bounds 285.00 294.00)
+                          (drawsContent 1)
+                          (transform [0.97 0.00 0.00 0.00] [0.00 0.97 0.00 0.00] [0.00 0.00 1.00 0.00] [11.00 7.00 0.00 1.00])
+                        )
+                      )
+                    )
+                  )
+                )
+                (GraphicsLayer
+                  (anchor 0.00 0.00)
+                  (bounds 300.00 300.00)
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 8.00 8.00)
+          (bounds 300.00 300.00)
+        )
+      )
+    )
+  )
+)
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 1046.00 1388.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 1046.00 1388.00)
+      (contentsOpaque 1)
+      (children 4
+        (GraphicsLayer
+          (position 8.00 8.00)
+          (bounds 300.00 300.00)
+          (children 1
+            (GraphicsLayer
+              (anchor 0.00 0.00)
+              (bounds 300.00 300.00)
+              (backgroundColor #808080)
+              (children 2
+                (GraphicsLayer
+                  (anchor 0.00 0.00)
+                  (bounds 300.00 300.00)
+                  (children 1
+                    (GraphicsLayer
+                      (anchor 0.00 0.00)
+                      (children 2
+                        (GraphicsLayer
+                          (anchor 0.00 0.00)
+                          (transform [0.97 0.00 0.00 0.00] [0.00 0.97 0.00 0.00] [0.00 0.00 1.00 0.00] [11.00 7.00 0.00 1.00])
+                          (children 1
+                            (GraphicsLayer
+                              (position 34.55 38.86)
+                              (anchor 0.00 0.00)
+                              (bounds 215.91 215.91)
+                              (children 1
+                                (GraphicsLayer
+                                  (anchor 0.00 0.00)
+                                  (bounds 100.00 100.00)
+                                  (drawsContent 1)
+                                  (backgroundColor #FFFFFF)
+                                  (transform [2.16 0.00 0.00 0.00] [0.00 2.16 0.00 0.00] [0.00 0.00 1.00 0.00] [0.00 0.00 0.00 1.00])
+                                )
+                              )
+                            )
+                          )
+                        )
+                        (GraphicsLayer
+                          (anchor 0.00 0.00)
+                          (bounds 285.00 294.00)
+                          (drawsContent 1)
+                          (transform [0.97 0.00 0.00 0.00] [0.00 0.97 0.00 0.00] [0.00 0.00 1.00 0.00] [11.00 7.00 0.00 1.00])
+                        )
+                      )
+                    )
+                  )
+                )
+                (GraphicsLayer
+                  (anchor 0.00 0.00)
+                  (bounds 300.00 300.00)
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 312.00 8.00)
+          (bounds 300.00 300.00)
+          (children 1
+            (GraphicsLayer
+              (anchor 0.00 0.00)
+              (bounds 300.00 300.00)
+              (backgroundColor #808080)
+              (children 2
+                (GraphicsLayer
+                  (anchor 0.00 0.00)
+                  (bounds 300.00 300.00)
+                  (children 1
+                    (GraphicsLayer
+                      (anchor 0.00 0.00)
+                      (children 2
+                        (GraphicsLayer
+                          (anchor 0.00 0.00)
+                          (transform [0.97 0.00 0.00 0.00] [0.00 0.97 0.00 0.00] [0.00 0.00 1.00 0.00] [11.00 7.00 0.00 1.00])
+                          (children 1
+                            (GraphicsLayer
+                              (position 34.55 38.86)
+                              (anchor 0.00 0.00)
+                              (bounds 215.91 215.91)
+                              (children 1
+                                (GraphicsLayer
+                                  (anchor 0.00 0.00)
+                                  (bounds 100.00 100.00)
+                                  (drawsContent 1)
+                                  (backgroundColor #FFFFFF)
+                                  (transform [2.16 0.00 0.00 0.00] [0.00 2.16 0.00 0.00] [0.00 0.00 1.00 0.00] [0.00 0.00 0.00 1.00])
+                                )
+                              )
+                            )
+                          )
+                        )
+                        (GraphicsLayer
+                          (anchor 0.00 0.00)
+                          (bounds 285.00 294.00)
+                          (drawsContent 1)
+                          (transform [0.97 0.00 0.00 0.00] [0.00 0.97 0.00 0.00] [0.00 0.00 1.00 0.00] [11.00 7.00 0.00 1.00])
+                        )
+                      )
+                    )
+                  )
+                )
+                (GraphicsLayer
+                  (anchor 0.00 0.00)
+                  (bounds 300.00 300.00)
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 8.00 8.00)
+          (bounds 300.00 300.00)
+        )
+        (GraphicsLayer
+          (position 312.00 8.00)
+          (bounds 300.00 300.00)
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/platform/mac-sequoia/pdf/pdf-in-embed-expected.txt
+++ b/LayoutTests/platform/mac-sequoia/pdf/pdf-in-embed-expected.txt
@@ -1,0 +1,72 @@
+
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 2
+        (GraphicsLayer
+          (position 8.00 8.00)
+          (bounds 300.00 300.00)
+          (children 1
+            (GraphicsLayer
+              (anchor 0.00 0.00)
+              (bounds 300.00 300.00)
+              (backgroundColor #808080)
+              (children 2
+                (GraphicsLayer
+                  (anchor 0.00 0.00)
+                  (bounds 300.00 300.00)
+                  (children 1
+                    (GraphicsLayer
+                      (anchor 0.00 0.00)
+                      (children 2
+                        (GraphicsLayer
+                          (anchor 0.00 0.00)
+                          (transform [0.97 0.00 0.00 0.00] [0.00 0.97 0.00 0.00] [0.00 0.00 1.00 0.00] [11.00 7.00 0.00 1.00])
+                          (children 1
+                            (GraphicsLayer
+                              (position 34.55 38.86)
+                              (anchor 0.00 0.00)
+                              (bounds 215.91 215.91)
+                              (children 1
+                                (GraphicsLayer
+                                  (anchor 0.00 0.00)
+                                  (bounds 100.00 100.00)
+                                  (drawsContent 1)
+                                  (backgroundColor #FFFFFF)
+                                  (transform [2.16 0.00 0.00 0.00] [0.00 2.16 0.00 0.00] [0.00 0.00 1.00 0.00] [0.00 0.00 0.00 1.00])
+                                )
+                              )
+                            )
+                          )
+                        )
+                        (GraphicsLayer
+                          (anchor 0.00 0.00)
+                          (bounds 285.00 294.00)
+                          (drawsContent 1)
+                          (transform [0.97 0.00 0.00 0.00] [0.00 0.97 0.00 0.00] [0.00 0.00 1.00 0.00] [11.00 7.00 0.00 1.00])
+                        )
+                      )
+                    )
+                  )
+                )
+                (GraphicsLayer
+                  (anchor 0.00 0.00)
+                  (bounds 300.00 300.00)
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 8.00 8.00)
+          (bounds 300.00 300.00)
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/platform/mac-sequoia/pdf/pdf-in-styled-embed-expected.txt
+++ b/LayoutTests/platform/mac-sequoia/pdf/pdf-in-styled-embed-expected.txt
@@ -1,0 +1,75 @@
+
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 788.00 805.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 788.00 805.00)
+      (contentsOpaque 1)
+      (children 2
+        (GraphicsLayer
+          (offsetFromRenderer width=-28 height=-28)
+          (position 180.00 180.00)
+          (bounds 436.00 436.00)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (position 68.00 68.00)
+              (anchor 0.00 0.00)
+              (bounds 300.00 300.00)
+              (backgroundColor #808080)
+              (children 2
+                (GraphicsLayer
+                  (anchor 0.00 0.00)
+                  (bounds 300.00 300.00)
+                  (children 1
+                    (GraphicsLayer
+                      (anchor 0.00 0.00)
+                      (children 2
+                        (GraphicsLayer
+                          (anchor 0.00 0.00)
+                          (transform [0.97 0.00 0.00 0.00] [0.00 0.97 0.00 0.00] [0.00 0.00 1.00 0.00] [11.00 7.00 0.00 1.00])
+                          (children 1
+                            (GraphicsLayer
+                              (position 34.55 38.86)
+                              (anchor 0.00 0.00)
+                              (bounds 215.91 215.91)
+                              (children 1
+                                (GraphicsLayer
+                                  (anchor 0.00 0.00)
+                                  (bounds 100.00 100.00)
+                                  (drawsContent 1)
+                                  (backgroundColor #FFFFFF)
+                                  (transform [2.16 0.00 0.00 0.00] [0.00 2.16 0.00 0.00] [0.00 0.00 1.00 0.00] [0.00 0.00 0.00 1.00])
+                                )
+                              )
+                            )
+                          )
+                        )
+                        (GraphicsLayer
+                          (anchor 0.00 0.00)
+                          (bounds 285.00 294.00)
+                          (drawsContent 1)
+                          (transform [0.97 0.00 0.00 0.00] [0.00 0.97 0.00 0.00] [0.00 0.00 1.00 0.00] [11.00 7.00 0.00 1.00])
+                        )
+                      )
+                    )
+                  )
+                )
+                (GraphicsLayer
+                  (anchor 0.00 0.00)
+                  (bounds 300.00 300.00)
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 248.00 248.00)
+          (bounds 300.00 300.00)
+        )
+      )
+    )
+  )
+)
+

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -1633,7 +1633,13 @@ String PDFPluginBase::annotationStyle() const
 
 Color PDFPluginBase::pluginBackgroundColor()
 {
-    static NeverDestroyed color = roundAndClampToSRGBALossy(RetainPtr { [CocoaColor whiteColor].CGColor }.get());
+    static NeverDestroyed color = roundAndClampToSRGBALossy(RetainPtr {
+#if HAVE(LIQUID_GLASS)
+        [CocoaColor whiteColor].CGColor
+#else
+        [CocoaColor grayColor].CGColor
+#endif
+    }.get());
     return color.get();
 }
 


### PR DESCRIPTION
#### 3aa7942d9f603d5b6efe7ddb9f5bb6e6dc3c85db
<pre>
REGRESSION(305691@main): PDF background should remain gray in pre-Liquid Glass macOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=305700">https://bugs.webkit.org/show_bug.cgi?id=305700</a>
<a href="https://rdar.apple.com/168362073">rdar://168362073</a>

Reviewed by Alexey Proskuryakov.

The gray to white background color change in 305691@main only makes
sense in Liquid Glass environments, which is a subset of all (supported)
macOS configurations. In this patch, we limit the behavior change to
platforms where HAVE_LIQUID_GLASS is true. Critically, this restores
behavior on macOS Sequoia-and-older.

No new tests, but we check in non-Liquid Glass test expectations as
well.

* LayoutTests/platform/mac-sequoia/pdf/fullscreen-expected.txt: Added.
* LayoutTests/platform/mac-sequoia/pdf/load-pdf-twice-in-sequence-expected.txt: Added.
* LayoutTests/platform/mac-sequoia/pdf/pdf-in-embed-expected.txt: Added.
* LayoutTests/platform/mac-sequoia/pdf/pdf-in-styled-embed-expected.txt: Added.
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::pluginBackgroundColor):

Canonical link: <a href="https://commits.webkit.org/305813@main">https://commits.webkit.org/305813@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f15d556fd0082559ce86bd9587b32c72b665f00

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139380 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11756 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/882 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147507 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92448 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/92047817-881b-4b2c-ba01-95d8592762d9) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12463 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11906 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106712 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77683 "4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/be685fa7-6a94-4ba5-9c0b-135abd81b7cf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142327 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9493 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124843 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87574 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3c1ef215-2c71-48e2-8318-6ced900e3f9a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9079 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6767 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7804 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118454 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/788 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150290 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11440 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/804 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115109 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11453 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9735 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115420 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9748 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121233 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66434 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21514 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11483 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/751 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11218 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75150 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11420 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11270 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->