### PR TITLE
Use C++23 std::ranges::contains in WTF

### DIFF
--- a/Source/WTF/wtf/Deque.h
+++ b/Source/WTF/wtf/Deque.h
@@ -34,6 +34,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <ranges>
 #include <wtf/Vector.h>
 
 namespace WTF {
@@ -462,8 +463,7 @@ template<typename T, size_t inlineCapacity>
 template<typename U>
 bool Deque<T, inlineCapacity>::contains(const U& searchValue) const
 {
-    auto endIterator = end();
-    return std::find(begin(), endIterator, searchValue) != endIterator;
+    return std::ranges::contains(*this, searchValue);
 }
 
 template<typename T, size_t inlineCapacity>

--- a/Source/WTF/wtf/SortedArrayMap.h
+++ b/Source/WTF/wtf/SortedArrayMap.h
@@ -221,7 +221,7 @@ template<typename ElementType, std::size_t N> template<typename KeyArgument> inl
     if (!parsedKey)
         return false;
     if constexpr (N < binarySearchThreshold)
-        return std::find(m_array.begin(), m_array.end(), *parsedKey) != m_array.end();
+        return std::ranges::contains(m_array, *parsedKey);
     auto iterator = std::lower_bound(m_array.begin(), m_array.end(), *parsedKey);
     return iterator != m_array.end() && *iterator == *parsedKey;
 }


### PR DESCRIPTION
#### 1757a47000e25f2c3c166495d52ce1984bde885d
<pre>
Use C++23 std::ranges::contains in WTF
<a href="https://bugs.webkit.org/show_bug.cgi?id=305730">https://bugs.webkit.org/show_bug.cgi?id=305730</a>
<a href="https://rdar.apple.com/168410559">rdar://168410559</a>

Reviewed by NOBODY (OOPS!).

* Source/WTF/wtf/Deque.h:
(WTF::inlineCapacity&gt;::contains const):
* Source/WTF/wtf/SortedArrayMap.h:
(WTF::N&gt;::contains const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1757a47000e25f2c3c166495d52ce1984bde885d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139397 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11773 "Hash 1757a470 for PR 56792 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/899 "Hash 1757a470 for PR 56792 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147524 "Hash 1757a470 for PR 56792 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92465 "Hash 1757a470 for PR 56792 does not build (failure)") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12480 "Hash 1757a470 for PR 56792 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11923 "Hash 1757a470 for PR 56792 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/147524 "Hash 1757a470 for PR 56792 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/92465 "Hash 1757a470 for PR 56792 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142344 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/12480 "Hash 1757a470 for PR 56792 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/899 "Hash 1757a470 for PR 56792 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/147524 "Hash 1757a470 for PR 56792 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/12480 "Hash 1757a470 for PR 56792 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/168/builds/899 "Hash 1757a470 for PR 56792 does not build (failure)") | [❌ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7821 "Hash 1757a470 for PR 56792 does not build (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/131370 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/12480 "Hash 1757a470 for PR 56792 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/899 "Hash 1757a470 for PR 56792 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150307 "Hash 1757a470 for PR 56792 does not build (failure)") | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/192 "Hash 1757a470 for PR 56792 does not build (failure)") | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11457 "Hash 1757a470 for PR 56792 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/899 "Hash 1757a470 for PR 56792 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/150307 "Hash 1757a470 for PR 56792 does not build (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11470 "Hash 1757a470 for PR 56792 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/11923 "Hash 1757a470 for PR 56792 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/150307 "Hash 1757a470 for PR 56792 does not build (failure)") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/899 "Hash 1757a470 for PR 56792 does not build (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66459 "Hash 1757a470 for PR 56792 does not build (failure)") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11500 "Hash 1757a470 for PR 56792 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/899 "Hash 1757a470 for PR 56792 does not build (failure)") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/170668 "Hash 1757a470 for PR 56792 does not build (failure)") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11235 "Hash 1757a470 for PR 56792 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75167 "Failed to build and analyze WebKit") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/170668 "Hash 1757a470 for PR 56792 does not build (failure)") | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11437 "Hash 1757a470 for PR 56792 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11287 "Hash 1757a470 for PR 56792 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->