### PR TITLE
[JSC] Add WasmStruct related B3 Values

### DIFF
--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -2077,6 +2077,10 @@
 		E392E6F824D25FA600B20767 /* B3BottomTupleValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E392E6F624D25FA600B20767 /* B3BottomTupleValue.cpp */; };
 		E392E6F924D25FA900B20767 /* B3BottomTupleValue.h in Headers */ = {isa = PBXBuildFile; fileRef = E392E6F724D25FA600B20767 /* B3BottomTupleValue.h */; };
 		E393ADD81FE702D00022D681 /* WeakMapImplInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E393ADD71FE702CC0022D681 /* WeakMapImplInlines.h */; };
+		E3952C182F1DDF5700F5BEE8 /* B3WasmStructGetValue.h in Headers */ = {isa = PBXBuildFile; fileRef = E3952C122F1DDF5700F5BEE8 /* B3WasmStructGetValue.h */; };
+		E3952C192F1DDF5700F5BEE8 /* B3WasmStructNewValue.h in Headers */ = {isa = PBXBuildFile; fileRef = E3952C142F1DDF5700F5BEE8 /* B3WasmStructNewValue.h */; };
+		E3952C1A2F1DDF5700F5BEE8 /* B3WasmStructFieldValue.h in Headers */ = {isa = PBXBuildFile; fileRef = E3952C102F1DDF5700F5BEE8 /* B3WasmStructFieldValue.h */; };
+		E3952C1B2F1DDF5700F5BEE8 /* B3WasmStructSetValue.h in Headers */ = {isa = PBXBuildFile; fileRef = E3952C162F1DDF5700F5BEE8 /* B3WasmStructSetValue.h */; };
 		E399AEC32559457F00B78485 /* IntlDateTimeFormat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A1587D671B4DC14100D69849 /* IntlDateTimeFormat.cpp */; };
 		E39BF39922A2288B00BD183E /* SymbolTableInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E39BF39822A2288B00BD183E /* SymbolTableInlines.h */; };
 		E39D45F51D39005600B3B377 /* InterpreterInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E39D9D841D39000600667282 /* InterpreterInlines.h */; };
@@ -5941,6 +5945,14 @@
 		E392E6F624D25FA600B20767 /* B3BottomTupleValue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = B3BottomTupleValue.cpp; path = b3/B3BottomTupleValue.cpp; sourceTree = "<group>"; };
 		E392E6F724D25FA600B20767 /* B3BottomTupleValue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = B3BottomTupleValue.h; path = b3/B3BottomTupleValue.h; sourceTree = "<group>"; };
 		E393ADD71FE702CC0022D681 /* WeakMapImplInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WeakMapImplInlines.h; sourceTree = "<group>"; };
+		E3952C102F1DDF5700F5BEE8 /* B3WasmStructFieldValue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = B3WasmStructFieldValue.h; path = b3/B3WasmStructFieldValue.h; sourceTree = "<group>"; };
+		E3952C112F1DDF5700F5BEE8 /* B3WasmStructFieldValue.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = B3WasmStructFieldValue.cpp; path = b3/B3WasmStructFieldValue.cpp; sourceTree = "<group>"; };
+		E3952C122F1DDF5700F5BEE8 /* B3WasmStructGetValue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = B3WasmStructGetValue.h; path = b3/B3WasmStructGetValue.h; sourceTree = "<group>"; };
+		E3952C132F1DDF5700F5BEE8 /* B3WasmStructGetValue.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = B3WasmStructGetValue.cpp; path = b3/B3WasmStructGetValue.cpp; sourceTree = "<group>"; };
+		E3952C142F1DDF5700F5BEE8 /* B3WasmStructNewValue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = B3WasmStructNewValue.h; path = b3/B3WasmStructNewValue.h; sourceTree = "<group>"; };
+		E3952C152F1DDF5700F5BEE8 /* B3WasmStructNewValue.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = B3WasmStructNewValue.cpp; path = b3/B3WasmStructNewValue.cpp; sourceTree = "<group>"; };
+		E3952C162F1DDF5700F5BEE8 /* B3WasmStructSetValue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = B3WasmStructSetValue.h; path = b3/B3WasmStructSetValue.h; sourceTree = "<group>"; };
+		E3952C172F1DDF5700F5BEE8 /* B3WasmStructSetValue.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = B3WasmStructSetValue.cpp; path = b3/B3WasmStructSetValue.cpp; sourceTree = "<group>"; };
 		E3963CEC1B73F75000EB4CE5 /* NodesAnalyzeModule.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NodesAnalyzeModule.cpp; sourceTree = "<group>"; };
 		E39BF39822A2288B00BD183E /* SymbolTableInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SymbolTableInlines.h; sourceTree = "<group>"; };
 		E39D8B2C23021E1E00265852 /* WasmOperations.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WasmOperations.cpp; sourceTree = "<group>"; };
@@ -6919,6 +6931,14 @@
 				53D444DB1DAF08AB00B92784 /* B3WasmAddressValue.h */,
 				5341FC6F1DAC33E500E7E4D7 /* B3WasmBoundsCheckValue.cpp */,
 				5341FC711DAC343C00E7E4D7 /* B3WasmBoundsCheckValue.h */,
+				E3952C112F1DDF5700F5BEE8 /* B3WasmStructFieldValue.cpp */,
+				E3952C102F1DDF5700F5BEE8 /* B3WasmStructFieldValue.h */,
+				E3952C132F1DDF5700F5BEE8 /* B3WasmStructGetValue.cpp */,
+				E3952C122F1DDF5700F5BEE8 /* B3WasmStructGetValue.h */,
+				E3952C152F1DDF5700F5BEE8 /* B3WasmStructNewValue.cpp */,
+				E3952C142F1DDF5700F5BEE8 /* B3WasmStructNewValue.h */,
+				E3952C172F1DDF5700F5BEE8 /* B3WasmStructSetValue.cpp */,
+				E3952C162F1DDF5700F5BEE8 /* B3WasmStructSetValue.h */,
 				0F2C63AD1E60AE3C00C13839 /* B3Width.cpp */,
 				0F2C63AE1E60AE3D00C13839 /* B3Width.h */,
 				5C3A77BB22F24890003827FF /* testb3.h */,
@@ -10889,6 +10909,10 @@
 				0F2BBD9A1C5FF3F50023EF23 /* B3VariableValue.h in Headers */,
 				53D444DC1DAF08AB00B92784 /* B3WasmAddressValue.h in Headers */,
 				5341FC721DAC343C00E7E4D7 /* B3WasmBoundsCheckValue.h in Headers */,
+				E3952C1A2F1DDF5700F5BEE8 /* B3WasmStructFieldValue.h in Headers */,
+				E3952C182F1DDF5700F5BEE8 /* B3WasmStructGetValue.h in Headers */,
+				E3952C192F1DDF5700F5BEE8 /* B3WasmStructNewValue.h in Headers */,
+				E3952C1B2F1DDF5700F5BEE8 /* B3WasmStructSetValue.h in Headers */,
 				0F2C63B21E60AE4700C13839 /* B3Width.h in Headers */,
 				52DD000826E039B90054E408 /* BaselineJITCode.h in Headers */,
 				723998F7265DBCDB0057867F /* BaselineJITPlan.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -195,6 +195,10 @@ b3/B3VariableLiveness.cpp
 b3/B3VariableValue.cpp
 b3/B3WasmAddressValue.cpp
 b3/B3WasmBoundsCheckValue.cpp
+b3/B3WasmStructFieldValue.cpp
+b3/B3WasmStructGetValue.cpp
+b3/B3WasmStructNewValue.cpp
+b3/B3WasmStructSetValue.cpp
 b3/B3Width.cpp
 
 builtins/BuiltinExecutables.cpp

--- a/Source/JavaScriptCore/b3/B3AbstractHeapRepository.cpp
+++ b/Source/JavaScriptCore/b3/B3AbstractHeapRepository.cpp
@@ -158,6 +158,16 @@ void AbstractHeapRepository::decorateFencedAccess(const AbstractHeap* heap, Valu
     m_heapForFencedAccess.append(HeapForValue(heap, value));
 }
 
+void AbstractHeapRepository::decorateWasmStructGet(const AbstractHeap* heap, Value* value)
+{
+    m_heapForWasmStructGet.append(HeapForValue(heap, value));
+}
+
+void AbstractHeapRepository::decorateWasmStructSet(const AbstractHeap* heap, Value* value)
+{
+    m_heapForWasmStructSet.append(HeapForValue(heap, value));
+}
+
 void AbstractHeapRepository::computeRangesAndDecorateInstructions()
 {
     root.compute();
@@ -195,6 +205,14 @@ void AbstractHeapRepository::computeRangesAndDecorateInstructions()
         entry.value->as<FenceValue>()->write = rangeFor(entry.heap);
     for (HeapForValue entry : m_heapForFencedAccess)
         entry.value->as<MemoryValue>()->setFenceRange(rangeFor(entry.heap));
+    for (HeapForValue entry : m_heapForWasmStructGet) {
+        auto* wasmStructGet = entry.value->as<WasmStructGetValue>();
+        wasmStructGet->setRange(rangeFor(entry.heap));
+    }
+    for (HeapForValue entry : m_heapForWasmStructSet) {
+        auto* wasmStructSet = entry.value->as<WasmStructSetValue>();
+        wasmStructSet->setRange(rangeFor(entry.heap));
+    }
 }
 
 } // namespace JSC::B3

--- a/Source/JavaScriptCore/b3/B3AbstractHeapRepository.h
+++ b/Source/JavaScriptCore/b3/B3AbstractHeapRepository.h
@@ -347,6 +347,8 @@ public:
     void decorateFenceRead(const AbstractHeap*, Value*);
     void decorateFenceWrite(const AbstractHeap*, Value*);
     void decorateFencedAccess(const AbstractHeap*, Value*);
+    void decorateWasmStructGet(const AbstractHeap*, Value*);
+    void decorateWasmStructSet(const AbstractHeap*, Value*);
 
     void computeRangesAndDecorateInstructions();
 
@@ -375,6 +377,8 @@ private:
     Vector<HeapForValue> m_heapForFenceRead;
     Vector<HeapForValue> m_heapForFenceWrite;
     Vector<HeapForValue> m_heapForFencedAccess;
+    Vector<HeapForValue> m_heapForWasmStructGet;
+    Vector<HeapForValue> m_heapForWasmStructSet;
 };
 
 } // namespace JSC::B3

--- a/Source/JavaScriptCore/b3/B3Kind.h
+++ b/Source/JavaScriptCore/b3/B3Kind.h
@@ -132,6 +132,8 @@ public:
         case AtomicXchgSub:
         case AtomicXchgXor:
         case AtomicXchg:
+        case WasmStructGet:
+        case WasmStructSet:
             return true;
         default:
             return false;

--- a/Source/JavaScriptCore/b3/B3Opcode.h
+++ b/Source/JavaScriptCore/b3/B3Opcode.h
@@ -362,6 +362,10 @@ enum Opcode : uint8_t {
     // to be able to perform such optimizations.
     WasmBoundsCheck,
 
+    WasmStructGet,
+    WasmStructSet,
+    WasmStructNew,
+
     // SIMD instructions
     VectorExtractLane,
     VectorReplaceLane,

--- a/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
+++ b/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
@@ -43,6 +43,8 @@
 #include "B3UpsilonValue.h"
 #include "B3ValueKeyInlines.h"
 #include "B3ValueInlines.h"
+#include "B3WasmStructGetValue.h"
+#include "B3WasmStructSetValue.h"
 #include "SIMDShuffle.h"
 #include <wtf/HashMap.h>
 #include <wtf/MathExtras.h>
@@ -3427,6 +3429,32 @@ private:
             }
             default:
                 break;
+            }
+            break;
+        }
+
+        case WasmStructGet: {
+            if (m_value->traps()) {
+                if (m_value->child(0)->opcode() == WasmStructNew) {
+                    WasmStructGetValue* structGet = m_value->as<WasmStructGetValue>();
+                    Value* newValue = m_insertionSet.insert<WasmStructGetValue>(m_index, WasmStructGet, m_value->origin(), m_value->type(), structGet->child(0), structGet->rtt(), structGet->structType(), structGet->fieldIndex(), structGet->fieldHeapKey(), structGet->mutability());
+                    newValue->as<WasmStructFieldValue>()->setRange(structGet->range());
+                    m_value->replaceWithIdentity(newValue);
+                    m_changed = true;
+                }
+            }
+            break;
+        }
+
+        case WasmStructSet: {
+            if (m_value->traps()) {
+                if (m_value->child(0)->opcode() == WasmStructNew) {
+                    WasmStructSetValue* structSet = m_value->as<WasmStructSetValue>();
+                    Value* newValue = m_insertionSet.insert<WasmStructSetValue>(m_index, WasmStructSet, m_value->origin(), structSet->child(0), structSet->child(1), structSet->rtt(), structSet->structType(), structSet->fieldIndex(), structSet->fieldHeapKey());
+                    newValue->as<WasmStructFieldValue>()->setRange(structSet->range());
+                    m_value->replaceWithIdentity(newValue);
+                    m_changed = true;
+                }
             }
             break;
         }

--- a/Source/JavaScriptCore/b3/B3Validate.cpp
+++ b/Source/JavaScriptCore/b3/B3Validate.cpp
@@ -829,6 +829,20 @@ public:
                 }
                 VALIDATE(m_procedure.code().wasmBoundsCheckGenerator(), ("At ", *value));
                 break;
+            case WasmStructGet:
+                VALIDATE(value->numChildren() == 1, ("At ", *value));
+                VALIDATE(value->child(0)->type() == Int64, ("At ", *value)); // struct pointer
+                break;
+            case WasmStructSet:
+                VALIDATE(value->numChildren() == 2, ("At ", *value));
+                VALIDATE(value->child(0)->type() == Int64, ("At ", *value)); // struct pointer
+                VALIDATE(value->type() == Void, ("At ", *value));
+                break;
+            case WasmStructNew:
+                VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));
+                VALIDATE(value->numChildren() == 2, ("At ", *value));
+                VALIDATE(value->type() == Int64, ("At ", *value)); // returns struct pointer
+                break;
             case Upsilon:
                 VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));
                 VALIDATE(value->numChildren() == 1, ("At ", *value));

--- a/Source/JavaScriptCore/b3/B3Value.cpp
+++ b/Source/JavaScriptCore/b3/B3Value.cpp
@@ -42,6 +42,9 @@
 #include "B3ValueInlines.h"
 #include "B3ValueKeyInlines.h"
 #include "B3WasmBoundsCheckValue.h"
+#include "B3WasmStructGetValue.h"
+#include "B3WasmStructNewValue.h"
+#include "B3WasmStructSetValue.h"
 #include <wtf/CommaPrinter.h>
 #include <wtf/ListDump.h>
 #include <wtf/StackTrace.h>
@@ -876,6 +879,24 @@ Effects Value::effects() const
         result.exitsSideways = true;
         result.reads = HeapRange::top();
         break;
+    case WasmStructGet: {
+        const auto* derived = as<WasmStructGetValue>();
+        result.reads = derived->range();
+        result.controlDependent = true;
+        result.readsMutability = derived->mutability();
+        break;
+    }
+    case WasmStructSet: {
+        const auto* derived = as<WasmStructSetValue>();
+        result.writes = derived->range();
+        result.controlDependent = true;
+        break;
+    }
+    case WasmStructNew:
+        result.reads = HeapRange::top();
+        result.writes = HeapRange::top();
+        result.exitsSideways = true;
+        break;
     case Upsilon:
     case Set:
         result.writesLocalState = true;
@@ -1093,6 +1114,9 @@ ValueKey Value::key() const
     case AtomicXchg:
     case WasmAddress:
     case WasmBoundsCheck:
+    case WasmStructGet:
+    case WasmStructSet:
+    case WasmStructNew:
     case MemoryCopy:
     case MemoryFill:
     case Fence:

--- a/Source/JavaScriptCore/b3/B3Value.h
+++ b/Source/JavaScriptCore/b3/B3Value.h
@@ -452,6 +452,7 @@ protected:
         case Set:
         case WasmAddress:
         case WasmBoundsCheck:
+        case WasmStructGet:
         case VectorExtractLane:
         case VectorSplat:
         case VectorNot:
@@ -516,6 +517,8 @@ protected:
         case Store8:
         case Store16:
         case Store:
+        case WasmStructSet:
+        case WasmStructNew:
         case VectorReplaceLane:
         case VectorEqual:
         case VectorNotEqual:

--- a/Source/JavaScriptCore/b3/B3ValueInlines.h
+++ b/Source/JavaScriptCore/b3/B3ValueInlines.h
@@ -52,6 +52,9 @@
 #include "B3VariableValue.h"
 #include "B3WasmAddressValue.h"
 #include "B3WasmBoundsCheckValue.h"
+#include "B3WasmStructGetValue.h"
+#include "B3WasmStructNewValue.h"
+#include "B3WasmStructSetValue.h"
 #include <wtf/GraphNodeWorklist.h>
 
 namespace JSC { namespace B3 {
@@ -166,6 +169,12 @@ namespace JSC { namespace B3 {
         return MACRO(WasmAddressValue); \
     case WasmBoundsCheck: \
         return MACRO(WasmBoundsCheckValue); \
+    case WasmStructGet: \
+        return MACRO(WasmStructGetValue); \
+    case WasmStructSet: \
+        return MACRO(WasmStructSetValue); \
+    case WasmStructNew: \
+        return MACRO(WasmStructNewValue); \
     case AtomicXchgAdd: \
     case AtomicXchgAnd: \
     case AtomicXchgOr: \

--- a/Source/JavaScriptCore/b3/B3ValueKey.cpp
+++ b/Source/JavaScriptCore/b3/B3ValueKey.cpp
@@ -232,6 +232,9 @@ Value* ValueKey::materialize(Procedure& proc, Origin origin) const
     case AtomicXchg:
     case WasmAddress:
     case WasmBoundsCheck:
+    case WasmStructGet:
+    case WasmStructSet:
+    case WasmStructNew:
     case MemoryCopy:
     case MemoryFill:
     case Fence:

--- a/Source/JavaScriptCore/b3/B3WasmStructFieldValue.cpp
+++ b/Source/JavaScriptCore/b3/B3WasmStructFieldValue.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -20,50 +20,19 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include "config.h"
+#include "B3WasmStructFieldValue.h"
 
 #if ENABLE(B3_JIT)
 
-#include "B3Value.h"
+namespace JSC::B3 {
 
-namespace JSC { namespace B3 {
+WasmStructFieldValue::~WasmStructFieldValue() = default;
 
-namespace Air {
-
-class StackSlot;
-
-} // namespace Air
-
-
-class JS_EXPORT_PRIVATE SlotBaseValue final : public Value {
-public:
-    static bool accepts(Kind kind) { return kind == SlotBase; }
-
-    ~SlotBaseValue() final;
-
-    Air::StackSlot* slot() const { return m_slot; }
-
-    B3_SPECIALIZE_VALUE_FOR_NO_CHILDREN
-
-private:
-    friend class Procedure;
-    friend class Value;
-
-    void dumpMeta(CommaPrinter&, PrintStream&) const final;
-
-    static Opcode opcodeFromConstructor(Origin, Air::StackSlot*) { return SlotBase; }
-    SlotBaseValue(Origin origin, Air::StackSlot* slot)
-        : Value(CheckedOpcode, SlotBase, pointerType(), Zero, origin)
-        , m_slot(slot)
-    {
-    }
-
-    SUPPRESS_FORWARD_DECL_MEMBER Air::StackSlot* m_slot;
-};
-
-} } // namespace JSC::B3
+} // namespace JSC::B3
 
 #endif // ENABLE(B3_JIT)
+

--- a/Source/JavaScriptCore/b3/B3WasmStructFieldValue.h
+++ b/Source/JavaScriptCore/b3/B3WasmStructFieldValue.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(B3_JIT)
+
+#include "B3Effects.h"
+#include "B3HeapRange.h"
+#include "B3Value.h"
+#include "WasmTypeDefinition.h"
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
+namespace JSC::B3 {
+
+class WasmStructFieldValue : public Value {
+public:
+    static bool accepts(Kind kind) { return kind.opcode() == WasmStructGet || kind.opcode() == WasmStructSet; }
+
+    ~WasmStructFieldValue() override;
+
+    Ref<const Wasm::RTT> rtt() const { return m_rtt; }
+    const Wasm::StructType* structType() const { return m_structType; }
+    Wasm::StructFieldCount fieldIndex() const { return m_fieldIndex; }
+    uint64_t fieldHeapKey() const { return m_fieldHeapKey; }
+
+    const HeapRange& range() const { return m_range; }
+    void setRange(HeapRange range) { m_range = range; }
+    Mutability mutability() const { return m_mutability; }
+
+protected:
+    template<typename... Arguments>
+    WasmStructFieldValue(CheckedOpcodeTag tag, Kind kind, Type type, NumChildren numChildren, Origin origin, Ref<const Wasm::RTT> rtt, const Wasm::StructType* structType, Wasm::StructFieldCount fieldIndex, uint64_t fieldHeapKey, Mutability mutability, Arguments... arguments)
+        : Value(tag, kind, type, numChildren, origin, arguments...)
+        , m_rtt(WTF::move(rtt))
+        , m_structType(structType)
+        , m_fieldIndex(fieldIndex)
+        , m_fieldHeapKey(fieldHeapKey)
+        , m_mutability(mutability)
+    {
+    }
+
+    Ref<const Wasm::RTT> m_rtt;
+    SUPPRESS_UNCOUNTED_MEMBER const Wasm::StructType* m_structType;
+    Wasm::StructFieldCount m_fieldIndex;
+    uint64_t m_fieldHeapKey;
+    HeapRange m_range { HeapRange::top() };
+    Mutability m_mutability;
+};
+
+} // namespace JSC::B3
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
+#endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/B3WasmStructGetValue.cpp
+++ b/Source/JavaScriptCore/b3/B3WasmStructGetValue.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -20,50 +20,30 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include "config.h"
+#include "B3WasmStructGetValue.h"
 
 #if ENABLE(B3_JIT)
 
-#include "B3Value.h"
+#include "B3ValueInlines.h"
 
-namespace JSC { namespace B3 {
+namespace JSC::B3 {
 
-namespace Air {
+WasmStructGetValue::~WasmStructGetValue() = default;
 
-class StackSlot;
+WasmStructGetValue::WasmStructGetValue(Kind kind, Origin origin, Type resultType, Value* structPtr, Ref<const Wasm::RTT> rtt, const Wasm::StructType* structType, Wasm::StructFieldCount fieldIndex, uint64_t fieldHeapKey, Mutability mutability)
+    : WasmStructFieldValue(CheckedOpcode, kind, resultType, One, origin, WTF::move(rtt), structType, fieldIndex, fieldHeapKey, mutability, structPtr)
+{
+}
 
-} // namespace Air
+void WasmStructGetValue::dumpMeta(CommaPrinter& comma, PrintStream& out) const
+{
+    out.print(comma, "fieldIndex = ", m_fieldIndex);
+}
 
-
-class JS_EXPORT_PRIVATE SlotBaseValue final : public Value {
-public:
-    static bool accepts(Kind kind) { return kind == SlotBase; }
-
-    ~SlotBaseValue() final;
-
-    Air::StackSlot* slot() const { return m_slot; }
-
-    B3_SPECIALIZE_VALUE_FOR_NO_CHILDREN
-
-private:
-    friend class Procedure;
-    friend class Value;
-
-    void dumpMeta(CommaPrinter&, PrintStream&) const final;
-
-    static Opcode opcodeFromConstructor(Origin, Air::StackSlot*) { return SlotBase; }
-    SlotBaseValue(Origin origin, Air::StackSlot* slot)
-        : Value(CheckedOpcode, SlotBase, pointerType(), Zero, origin)
-        , m_slot(slot)
-    {
-    }
-
-    SUPPRESS_FORWARD_DECL_MEMBER Air::StackSlot* m_slot;
-};
-
-} } // namespace JSC::B3
+} // namespace JSC::B3
 
 #endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/B3WasmStructGetValue.h
+++ b/Source/JavaScriptCore/b3/B3WasmStructGetValue.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -20,50 +20,40 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #pragma once
 
 #if ENABLE(B3_JIT)
 
-#include "B3Value.h"
+#include "B3WasmStructFieldValue.h"
 
-namespace JSC { namespace B3 {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
-namespace Air {
+namespace JSC::B3 {
 
-class StackSlot;
-
-} // namespace Air
-
-
-class JS_EXPORT_PRIVATE SlotBaseValue final : public Value {
+class WasmStructGetValue final : public WasmStructFieldValue {
 public:
-    static bool accepts(Kind kind) { return kind == SlotBase; }
+    static bool accepts(Kind kind) { return kind.opcode() == WasmStructGet; }
 
-    ~SlotBaseValue() final;
+    ~WasmStructGetValue() final;
 
-    Air::StackSlot* slot() const { return m_slot; }
-
-    B3_SPECIALIZE_VALUE_FOR_NO_CHILDREN
+    B3_SPECIALIZE_VALUE_FOR_FIXED_CHILDREN(1)
+    B3_SPECIALIZE_VALUE_FOR_FINAL_SIZE_FIXED_CHILDREN
 
 private:
+    void dumpMeta(CommaPrinter&, PrintStream&) const final;
+
     friend class Procedure;
     friend class Value;
 
-    void dumpMeta(CommaPrinter&, PrintStream&) const final;
-
-    static Opcode opcodeFromConstructor(Origin, Air::StackSlot*) { return SlotBase; }
-    SlotBaseValue(Origin origin, Air::StackSlot* slot)
-        : Value(CheckedOpcode, SlotBase, pointerType(), Zero, origin)
-        , m_slot(slot)
-    {
-    }
-
-    SUPPRESS_FORWARD_DECL_MEMBER Air::StackSlot* m_slot;
+    static Opcode opcodeFromConstructor(Kind, Origin, Type, Value*, Ref<const Wasm::RTT>, const Wasm::StructType*, Wasm::StructFieldCount, uint64_t, Mutability) { return WasmStructGet; }
+    JS_EXPORT_PRIVATE WasmStructGetValue(Kind, Origin, Type resultType, Value* structPtr, Ref<const Wasm::RTT>, const Wasm::StructType*, Wasm::StructFieldCount fieldIndex, uint64_t fieldHeapKey, Mutability);
 };
 
-} } // namespace JSC::B3
+} // namespace JSC::B3
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/B3WasmStructNewValue.cpp
+++ b/Source/JavaScriptCore/b3/B3WasmStructNewValue.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -20,50 +20,25 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include "config.h"
+#include "B3WasmStructNewValue.h"
 
 #if ENABLE(B3_JIT)
 
-#include "B3Value.h"
+#include "B3ValueInlines.h"
 
-namespace JSC { namespace B3 {
+namespace JSC::B3 {
 
-namespace Air {
+WasmStructNewValue::~WasmStructNewValue() = default;
 
-class StackSlot;
+void WasmStructNewValue::dumpMeta(CommaPrinter& comma, PrintStream& out) const
+{
+    out.print(comma, "typeIndex = ", m_typeIndex, comma, "fieldCount = ", m_structType->fieldCount());
+}
 
-} // namespace Air
-
-
-class JS_EXPORT_PRIVATE SlotBaseValue final : public Value {
-public:
-    static bool accepts(Kind kind) { return kind == SlotBase; }
-
-    ~SlotBaseValue() final;
-
-    Air::StackSlot* slot() const { return m_slot; }
-
-    B3_SPECIALIZE_VALUE_FOR_NO_CHILDREN
-
-private:
-    friend class Procedure;
-    friend class Value;
-
-    void dumpMeta(CommaPrinter&, PrintStream&) const final;
-
-    static Opcode opcodeFromConstructor(Origin, Air::StackSlot*) { return SlotBase; }
-    SlotBaseValue(Origin origin, Air::StackSlot* slot)
-        : Value(CheckedOpcode, SlotBase, pointerType(), Zero, origin)
-        , m_slot(slot)
-    {
-    }
-
-    SUPPRESS_FORWARD_DECL_MEMBER Air::StackSlot* m_slot;
-};
-
-} } // namespace JSC::B3
+} // namespace JSC::B3
 
 #endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/B3WasmStructNewValue.h
+++ b/Source/JavaScriptCore/b3/B3WasmStructNewValue.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(B3_JIT)
+
+#include "B3Value.h"
+#include "WasmTypeDefinition.h"
+#include <wtf/StdLibExtras.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
+namespace JSC::B3 {
+
+class WasmStructNewValue final : public Value {
+public:
+    static bool accepts(Kind kind) { return kind.opcode() == WasmStructNew; }
+
+    ~WasmStructNewValue() final;
+
+    // Child 0 is the instance pointer (Int64)
+    // Child 1 is the structureID (Int32)
+    Value* instance() const { return child(0); }
+    Value* structureID() const { return child(1); }
+
+    Ref<const Wasm::RTT> rtt() const { return m_rtt; }
+    const Wasm::StructType* structType() const { return m_structType; }
+    uint32_t typeIndex() const { return m_typeIndex; }
+
+    // Offset from instance for allocator lookup (pre-computed from ModuleInformation)
+    int32_t allocatorsBaseOffset() const { return m_allocatorsBaseOffset; }
+
+    B3_SPECIALIZE_VALUE_FOR_FIXED_CHILDREN(2)
+    B3_SPECIALIZE_VALUE_FOR_FINAL_SIZE_FIXED_CHILDREN
+
+private:
+    void dumpMeta(CommaPrinter&, PrintStream&) const final;
+
+    friend class Procedure;
+    friend class Value;
+
+    template<typename... Arguments>
+    static Opcode opcodeFromConstructor(Arguments...) { return WasmStructNew; }
+
+    WasmStructNewValue(Origin origin, Type resultType, Ref<const Wasm::RTT> rtt, const Wasm::StructType* structType, uint32_t typeIndex, int32_t allocatorsBaseOffset, Value* instance, Value* structureID)
+        : Value(CheckedOpcode, WasmStructNew, resultType, Two, origin, instance, structureID)
+        , m_rtt(WTF::move(rtt))
+        , m_structType(structType)
+        , m_typeIndex(typeIndex)
+        , m_allocatorsBaseOffset(allocatorsBaseOffset)
+    {
+    }
+
+    Ref<const Wasm::RTT> m_rtt;
+    const Wasm::StructType* m_structType;
+    uint32_t m_typeIndex;
+    int32_t m_allocatorsBaseOffset;
+};
+
+} // namespace JSC::B3
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
+#endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/B3WasmStructSetValue.cpp
+++ b/Source/JavaScriptCore/b3/B3WasmStructSetValue.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -20,50 +20,30 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include "config.h"
+#include "B3WasmStructSetValue.h"
 
 #if ENABLE(B3_JIT)
 
-#include "B3Value.h"
+#include "B3ValueInlines.h"
 
-namespace JSC { namespace B3 {
+namespace JSC::B3 {
 
-namespace Air {
+WasmStructSetValue::~WasmStructSetValue() = default;
 
-class StackSlot;
+WasmStructSetValue::WasmStructSetValue(Kind kind, Origin origin, Value* structPtr, Value* value, Ref<const Wasm::RTT> rtt, const Wasm::StructType* structType, Wasm::StructFieldCount fieldIndex, uint64_t fieldHeapKey)
+    : WasmStructFieldValue(CheckedOpcode, kind, Void, Two, origin, WTF::move(rtt), structType, fieldIndex, fieldHeapKey, Mutability::Mutable, structPtr, value)
+{
+}
 
-} // namespace Air
+void WasmStructSetValue::dumpMeta(CommaPrinter& comma, PrintStream& out) const
+{
+    out.print(comma, "fieldIndex = ", m_fieldIndex);
+}
 
-
-class JS_EXPORT_PRIVATE SlotBaseValue final : public Value {
-public:
-    static bool accepts(Kind kind) { return kind == SlotBase; }
-
-    ~SlotBaseValue() final;
-
-    Air::StackSlot* slot() const { return m_slot; }
-
-    B3_SPECIALIZE_VALUE_FOR_NO_CHILDREN
-
-private:
-    friend class Procedure;
-    friend class Value;
-
-    void dumpMeta(CommaPrinter&, PrintStream&) const final;
-
-    static Opcode opcodeFromConstructor(Origin, Air::StackSlot*) { return SlotBase; }
-    SlotBaseValue(Origin origin, Air::StackSlot* slot)
-        : Value(CheckedOpcode, SlotBase, pointerType(), Zero, origin)
-        , m_slot(slot)
-    {
-    }
-
-    SUPPRESS_FORWARD_DECL_MEMBER Air::StackSlot* m_slot;
-};
-
-} } // namespace JSC::B3
+} // namespace JSC::B3
 
 #endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/B3WasmStructSetValue.h
+++ b/Source/JavaScriptCore/b3/B3WasmStructSetValue.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -20,50 +20,40 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #pragma once
 
 #if ENABLE(B3_JIT)
 
-#include "B3Value.h"
+#include "B3WasmStructFieldValue.h"
 
-namespace JSC { namespace B3 {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
-namespace Air {
+namespace JSC::B3 {
 
-class StackSlot;
-
-} // namespace Air
-
-
-class JS_EXPORT_PRIVATE SlotBaseValue final : public Value {
+class WasmStructSetValue final : public WasmStructFieldValue {
 public:
-    static bool accepts(Kind kind) { return kind == SlotBase; }
+    static bool accepts(Kind kind) { return kind.opcode() == WasmStructSet; }
 
-    ~SlotBaseValue() final;
+    ~WasmStructSetValue() final;
 
-    Air::StackSlot* slot() const { return m_slot; }
-
-    B3_SPECIALIZE_VALUE_FOR_NO_CHILDREN
+    B3_SPECIALIZE_VALUE_FOR_FIXED_CHILDREN(2)
+    B3_SPECIALIZE_VALUE_FOR_FINAL_SIZE_FIXED_CHILDREN
 
 private:
+    void dumpMeta(CommaPrinter&, PrintStream&) const final;
+
     friend class Procedure;
     friend class Value;
 
-    void dumpMeta(CommaPrinter&, PrintStream&) const final;
-
-    static Opcode opcodeFromConstructor(Origin, Air::StackSlot*) { return SlotBase; }
-    SlotBaseValue(Origin origin, Air::StackSlot* slot)
-        : Value(CheckedOpcode, SlotBase, pointerType(), Zero, origin)
-        , m_slot(slot)
-    {
-    }
-
-    SUPPRESS_FORWARD_DECL_MEMBER Air::StackSlot* m_slot;
+    static Opcode opcodeFromConstructor(Kind, Origin, Value*, Value*, Ref<const Wasm::RTT>, const Wasm::StructType*, Wasm::StructFieldCount, uint64_t) { return WasmStructSet; }
+    JS_EXPORT_PRIVATE WasmStructSetValue(Kind, Origin, Value* structPtr, Value*, Ref<const Wasm::RTT>, const Wasm::StructType*, Wasm::StructFieldCount fieldIndex, uint64_t fieldHeapKey);
 };
 
-} } // namespace JSC::B3
+} // namespace JSC::B3
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
@@ -862,17 +862,19 @@ public:
         return *this;
     }
 
-#if CPU(ADDRESS64)
     // Generate a key for each field, which can be usable for B3 TBAA.
-    ptrdiff_t fieldHeapKey(StructFieldCount fieldIndex) const
+    uint64_t fieldHeapKey(StructFieldCount fieldIndex) const
     {
+        uint64_t ptr = std::bit_cast<uintptr_t>(this);
+#if CPU(ADDRESS64)
         static_assert(maxStructFieldCount <= (1U << 20));
         constexpr uint32_t fieldIndexMask = (1 << 20) - 1;
-        uintptr_t ptr = std::bit_cast<uintptr_t>(this);
         uint32_t maskedFieldIndex = fieldIndex & fieldIndexMask; // mod 20-bits.
-        return static_cast<ptrdiff_t>(ptr | (maskedFieldIndex & 0b1111) | (static_cast<uintptr_t>(maskedFieldIndex >> 4) << 48));
-    }
+        return static_cast<uint64_t>(ptr | (maskedFieldIndex & 0b1111) | (static_cast<uint64_t>(maskedFieldIndex >> 4) << 48));
+#else
+        return static_cast<uint64_t>(ptr | (static_cast<uint64_t>(fieldIndex) << 32));
 #endif
+    }
 
     bool isSubRTT(const RTT& other) const;
     bool isStrictSubRTT(const RTT& other) const;


### PR DESCRIPTION
#### 4a278cefb952b2a2d9c29d752a5a5aeb05243576
<pre>
[JSC] Add WasmStruct related B3 Values
<a href="https://bugs.webkit.org/show_bug.cgi?id=305735">https://bugs.webkit.org/show_bug.cgi?id=305735</a>
<a href="https://rdar.apple.com/168415672">rdar://168415672</a>

Reviewed by Yijia Huang.

This patch introduces high-level wasm struct B3 values: WasmStructNew,
WasmStructNew, WasmStructSet. This saves high-level semantics through B3
optimization pipeline, and we can apply data flow analysis onto Wasm GC
related operations. We lower them to the original B3 values in
B3LowerMacros phase, so after that phase, nothing changes.

Critically important thing is keeping WasmStructGet / WasmStructSet CSE
active. Previously it was achieved by memory decoration. But now we
achieve it by handling these wasm struct values in
B3EliminateCommonSubexpressions as the same way to what MemoryValue is
doing.

This is the first step torward optimizing Wasm GC in B3 significantly.
Our plans are,

1. Adding WasmRefCast / WasmRefTest values next. And then data flow
   analysis can filter wasm GC types and potentially remove many of
   these type test operations. This is effective if the source program
   is having many of them because of generics, and B3 successfully
   inlined these functions.
2. Adding scalar replacement with escape analysis. Now WasmStructNew,
   WasmStructGet, and WasmStructSet (and other type cast / test operations)
   semantics are kept in B3. We can easily construct escape analysis for
   them and we can perform scalar replacement (and this eliminates allocations).
3. We are working on B3 sparse conditional constant propagation right now.
   That lattice can start including the current flow-sensitive Wasm Ref
   types. And we can further remove many unnecessary type test
   operations. Basically saying we will do DFG CheckStructure-like things in B3
   for wasm GC types.

* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/b3/B3AbstractHeapRepository.cpp:
(JSC::B3::AbstractHeapRepository::decorateWasmStructGet):
(JSC::B3::AbstractHeapRepository::decorateWasmStructSet):
(JSC::B3::AbstractHeapRepository::computeRangesAndDecorateInstructions):
* Source/JavaScriptCore/b3/B3AbstractHeapRepository.h:
* Source/JavaScriptCore/b3/B3EliminateCommonSubexpressions.cpp:
* Source/JavaScriptCore/b3/B3Kind.h:
(JSC::B3::Kind::hasTraps const):
* Source/JavaScriptCore/b3/B3LowerMacros.cpp:
* Source/JavaScriptCore/b3/B3Opcode.h:
* Source/JavaScriptCore/b3/B3ReduceStrength.cpp:
* Source/JavaScriptCore/b3/B3SlotBaseValue.h:
* Source/JavaScriptCore/b3/B3Validate.cpp:
* Source/JavaScriptCore/b3/B3Value.cpp:
(JSC::B3::Value::effects const):
(JSC::B3::Value::key const):
* Source/JavaScriptCore/b3/B3Value.h:
* Source/JavaScriptCore/b3/B3ValueInlines.h:
* Source/JavaScriptCore/b3/B3ValueKey.cpp:
(JSC::B3::ValueKey::materialize const):
* Source/JavaScriptCore/b3/B3WasmStructFieldValue.cpp: Copied from Source/JavaScriptCore/b3/B3SlotBaseValue.h.
* Source/JavaScriptCore/b3/B3WasmStructFieldValue.h: Added.
(JSC::B3::WasmStructFieldValue::accepts):
(JSC::B3::WasmStructFieldValue::rtt const):
(JSC::B3::WasmStructFieldValue::structType const):
(JSC::B3::WasmStructFieldValue::fieldIndex const):
(JSC::B3::WasmStructFieldValue::fieldHeapKey const):
(JSC::B3::WasmStructFieldValue::range const):
(JSC::B3::WasmStructFieldValue::setRange):
(JSC::B3::WasmStructFieldValue::mutability const):
(JSC::B3::WasmStructFieldValue::WasmStructFieldValue):
* Source/JavaScriptCore/b3/B3WasmStructGetValue.cpp: Copied from Source/JavaScriptCore/b3/B3SlotBaseValue.h.
(JSC::B3::WasmStructGetValue::WasmStructGetValue):
(JSC::B3::WasmStructGetValue::dumpMeta const):
* Source/JavaScriptCore/b3/B3WasmStructGetValue.h: Copied from Source/JavaScriptCore/b3/B3SlotBaseValue.h.
* Source/JavaScriptCore/b3/B3WasmStructNewValue.cpp: Copied from Source/JavaScriptCore/b3/B3SlotBaseValue.h.
(JSC::B3::WasmStructNewValue::dumpMeta const):
* Source/JavaScriptCore/b3/B3WasmStructNewValue.h: Added.
* Source/JavaScriptCore/b3/B3WasmStructSetValue.cpp: Copied from Source/JavaScriptCore/b3/B3SlotBaseValue.h.
(JSC::B3::WasmStructSetValue::WasmStructSetValue):
(JSC::B3::WasmStructSetValue::dumpMeta const):
* Source/JavaScriptCore/b3/B3WasmStructSetValue.h: Copied from Source/JavaScriptCore/b3/B3SlotBaseValue.h.
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::emitStructSet):
(JSC::Wasm::OMGIRGenerator::addStructNew):
(JSC::Wasm::OMGIRGenerator::addStructNewDefault):
(JSC::Wasm::OMGIRGenerator::addStructGet):
(JSC::Wasm::OMGIRGenerator::addStructSet):
(JSC::Wasm::OMGIRGenerator::allocatorForWasmGCHeapCellSize):
(JSC::Wasm::OMGIRGenerator::allocateWasmGCStructUninitialized): Deleted.
* Source/JavaScriptCore/wasm/WasmTypeDefinition.h:

Canonical link: <a href="https://commits.webkit.org/305925@main">https://commits.webkit.org/305925@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/732af8b2dd4c3f47b7ed8ed14e4075e86f5e2665

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139830 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12211 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1341 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147972 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ab8ed92f-728b-49b3-bcc1-c549f2ac8c5a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12921 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12363 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107072 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b353010b-c5ad-470b-918f-7b3abad3202d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142780 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9949 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125225 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87946 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ee1c3a16-e07b-4644-9620-2272f3ed8fa5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9605 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7112 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8262 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/131804 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118822 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1226 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150756 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/626 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11896 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1293 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115484 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11908 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10189 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115799 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10579 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121705 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/66901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21569 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11938 "Built successfully") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/171102 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11677 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75625 "Found 3 new failures in b3/B3WasmStructNewValue.h, b3/B3ReduceStrength.cpp") | [⏳ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11874 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11726 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->