### PR TITLE
[JSC][WASM][Debugger] Fix instance registration race and use InstanceAnchor for lifecycle management

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmModule.cpp
+++ b/Source/JavaScriptCore/wasm/WasmModule.cpp
@@ -140,6 +140,22 @@ void Module::copyInitialCalleeGroupToAllMemoryModes(MemoryMode initialMode)
 }
 
 
+Ref<Wasm::InstanceAnchor> Module::createAnchor(JSWebAssemblyInstance* instance)
+{
+    // Create the anchor but do NOT add to m_anchors yet.
+    // This allows Memory::registerInstance() to access the anchor without
+    // exposing the incomplete instance to concurrent threads.
+    return Wasm::InstanceAnchor::create(*this, instance);
+}
+
+void Module::publishAnchor(Wasm::InstanceAnchor& anchor)
+{
+    // Expose the anchor to concurrent threads by adding to m_anchors.
+    // This should only be called after the instance is fully initialized.
+    WTF::storeStoreFence();
+    m_anchors.add(anchor);
+}
+
 Ref<Wasm::InstanceAnchor> Module::registerAnchor(JSWebAssemblyInstance* instance)
 {
     auto anchor = Wasm::InstanceAnchor::create(*this, instance);

--- a/Source/JavaScriptCore/wasm/WasmModule.h
+++ b/Source/JavaScriptCore/wasm/WasmModule.h
@@ -89,6 +89,8 @@ public:
 
     IPIntCallees& ipintCallees() const { return m_ipintCallees.get(); }
 
+    Ref<Wasm::InstanceAnchor> createAnchor(JSWebAssemblyInstance*);
+    void publishAnchor(Wasm::InstanceAnchor&);
     Ref<Wasm::InstanceAnchor> registerAnchor(JSWebAssemblyInstance*);
 
     std::unique_ptr<MergedProfile> createMergedProfile(const IPIntCallee&);

--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.cpp
@@ -533,14 +533,6 @@ void DebugServer::trackInstance(JSWebAssemblyInstance* instance)
     }
 }
 
-void DebugServer::untrackInstance(JSWebAssemblyInstance* instance)
-{
-    if (!m_moduleManager)
-        return;
-    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Untracking WebAssembly instance: ", RawPointer(instance));
-    m_moduleManager->unregisterInstance(instance);
-}
-
 void DebugServer::trackModule(Module& module)
 {
     if (!m_moduleManager)

--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.h
@@ -111,7 +111,6 @@ public:
 #endif
 
     void trackInstance(JSWebAssemblyInstance*);
-    void untrackInstance(JSWebAssemblyInstance*);
     void trackModule(Module&);
     void untrackModule(Module&);
 

--- a/Source/JavaScriptCore/wasm/debugger/WasmModuleManager.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmModuleManager.cpp
@@ -30,15 +30,14 @@
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
-#include "DeferGC.h"
 #include "JSWebAssemblyInstance.h"
 #include "JSWebAssemblyModule.h"
 #include "VM.h"
+#include "WasmDebugServerUtilities.h"
 #include "WasmFormat.h"
+#include "WasmInstanceAnchor.h"
 #include "WasmModule.h"
 #include "WasmModuleInformation.h"
-#include "WeakGCMap.h"
-#include "WeakGCMapInlines.h"
 #include <wtf/DataLog.h>
 #include <wtf/HashMap.h>
 #include <wtf/HexNumber.h>
@@ -52,7 +51,6 @@ namespace JSC {
 namespace Wasm {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ModuleManager);
-
 
 uint32_t ModuleManager::registerModule(Module& module)
 {
@@ -77,18 +75,16 @@ uint32_t ModuleManager::registerInstance(JSWebAssemblyInstance* jsInstance)
 {
     Locker locker { m_lock };
     uint32_t instanceId = m_nextInstanceId++;
-    m_instanceIdToInstance.set(instanceId, jsInstance);
+
+    // Store the instance's anchor which provides thread-safe access and automatic cleanup
+    RefPtr<InstanceAnchor> anchor = jsInstance->anchor();
+    RELEASE_ASSERT(anchor, "Instance must have an anchor");
+
+    amortizedCleanupIfNeeded();
+    m_instanceIdToInstance.set(instanceId, ThreadSafeWeakPtr { *anchor });
+
     jsInstance->setDebugId(instanceId);
     dataLogLnIf(Options::verboseWasmDebugger(), "[ModuleManager][registerInstance] - registered instance with ID: ", instanceId, " for module ID: ", jsInstance->module().debugId());
-    return instanceId;
-}
-
-uint32_t ModuleManager::unregisterInstance(JSWebAssemblyInstance* jsInstance)
-{
-    Locker locker { m_lock };
-    uint32_t instanceId = jsInstance->debugId();
-    m_instanceIdToInstance.remove(instanceId);
-    dataLogLnIf(Options::verboseWasmDebugger(), "[ModuleManager][unregisterInstance] - unregistered instance with ID: ", instanceId, " for module ID: ", jsInstance->module().debugId());
     return instanceId;
 }
 
@@ -103,15 +99,40 @@ Module* ModuleManager::module(uint32_t moduleId) const
     return itr->value;
 }
 
-JSWebAssemblyInstance* ModuleManager::jsInstance(uint32_t instanceId) const
+JSWebAssemblyInstance* ModuleManager::jsInstance(uint32_t instanceId)
 {
     Locker locker { m_lock };
-    auto* result = m_instanceIdToInstance.get(instanceId);
-    if (!result) {
+    amortizedCleanupIfNeeded();
+
+    auto it = m_instanceIdToInstance.find(instanceId);
+    if (it == m_instanceIdToInstance.end()) {
         dataLogLnIf(Options::verboseWasmDebugger(), "[ModuleManager][jsInstance] - instance not found for ID: ", instanceId);
         return nullptr;
     }
-    return result;
+
+    // This function is called from the debugger thread (WasmDebugServer) to access JSWebAssemblyInstance
+    // objects during LLDB packet processing. Using InstanceAnchor provides thread-safe access and automatic
+    // cleanup when instances are destroyed.
+    //
+    // Safety guarantees:
+    // 1. InstanceAnchor::tearDown() is called in JSWebAssemblyInstance destructor, nulling out the pointer
+    // 2. VMs are stopped during debugger access per GDB remote protocol, preventing GC and ensuring stability
+    // 3. The anchor's lock protects concurrent access to the instance pointer
+    RefPtr<InstanceAnchor> anchor = it->value.get();
+    if (!anchor) {
+        dataLogLnIf(Options::verboseWasmDebugger(), "[ModuleManager][jsInstance] - anchor is dead for ID: ", instanceId);
+        return nullptr;
+    }
+
+    Locker anchorLocker { anchor->m_lock };
+    JSWebAssemblyInstance* instance = anchor->instance();
+    if (!instance) {
+        dataLogLnIf(Options::verboseWasmDebugger(), "[ModuleManager][jsInstance] - instance is null for ID: ", instanceId);
+        return nullptr;
+    }
+
+    RELEASE_ASSERT(instance->vm().debugState()->isStopped(), "Instance exists but VM is not stopped");
+    return instance;
 }
 
 static String generateModuleName(VirtualAddress address, const RefPtr<Module>&)
@@ -162,6 +183,22 @@ uint32_t ModuleManager::nextInstanceId() const
 {
     Locker locker { m_lock };
     return m_nextInstanceId;
+}
+
+void ModuleManager::amortizedCleanupIfNeeded()
+{
+    if (++m_operationCountSinceLastCleanup > m_maxOperationCountWithoutCleanup) {
+        m_instanceIdToInstance.removeIf([](auto& entry) {
+            return !entry.value.get(); // Remove entries with dead anchors
+        });
+        cleanupHappened();
+    }
+}
+
+void ModuleManager::cleanupHappened()
+{
+    m_operationCountSinceLastCleanup = 0;
+    m_maxOperationCountWithoutCleanup = std::min(std::numeric_limits<unsigned>::max() / 2, static_cast<unsigned>(m_instanceIdToInstance.size())) * 2;
 }
 
 }

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
@@ -155,12 +155,6 @@ void JSWebAssemblyInstance::finishCreation(VM& vm)
     }
 
     m_vm->traps().registerMirror(m_stackMirror);
-
-    // Now, JSWebAssemblyInstance is fully initialized. Expose it to the concurrent compiler.
-    m_anchor = m_module->registerAnchor(this);
-
-    if (Options::enableWasmDebugger()) [[unlikely]]
-        Wasm::DebugServer::singleton().trackInstance(this);
 }
 
 JSWebAssemblyInstance::~JSWebAssemblyInstance()
@@ -181,9 +175,6 @@ JSWebAssemblyInstance::~JSWebAssemblyInstance()
         m_anchor->tearDown();
         m_anchor = nullptr;
     }
-
-    if (Options::enableWasmDebugger()) [[unlikely]]
-        Wasm::DebugServer::singleton().untrackInstance(this);
 }
 
 void JSWebAssemblyInstance::destroy(JSCell* cell)
@@ -335,6 +326,11 @@ JSWebAssemblyInstance* JSWebAssemblyInstance::tryCreate(VM& vm, Structure* insta
     jsInstance->finishCreation(vm);
     RETURN_IF_EXCEPTION(throwScope, nullptr);
 
+    // Create the anchor (but don't publish it yet) so that Memory::registerInstance()
+    // can access it during memory setup without exposing the incomplete instance to
+    // concurrent threads.
+    jsInstance->m_anchor = jsInstance->m_module->createAnchor(jsInstance);
+
     if (creationMode == CreationMode::FromJS) {
         // If the list of module.imports is not empty and Type(importObject) is not Object, a TypeError is thrown.
         if (moduleInformation.imports.size() && !importObject)
@@ -384,7 +380,15 @@ JSWebAssemblyInstance* JSWebAssemblyInstance::tryCreate(VM& vm, Structure* insta
         jsInstance->setDummyMemory(vm, jsMemory);
         RETURN_IF_EXCEPTION(throwScope, nullptr);
     }
-    
+
+    // Now that the instance is fully initialized, publish the anchor to expose it to
+    // concurrent threads (concurrent compiler, etc.).
+    jsInstance->m_module->publishAnchor(*jsInstance->m_anchor);
+
+    // Register with debugger after instance and anchor are fully initialized.
+    if (Options::enableWasmDebugger()) [[unlikely]]
+        Wasm::DebugServer::singleton().trackInstance(jsInstance);
+
     return jsInstance;
 }
 


### PR DESCRIPTION
#### 0eca865c7788439ca14b152ed8617e477ae76207
<pre>
[JSC][WASM][Debugger] Fix instance registration race and use InstanceAnchor for lifecycle management
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0eca865c7788439ca14b152ed8617e477ae76207

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139420 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11796 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/922 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147547 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92488 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ae795def-63c2-46cf-9612-6ac454994a8a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12503 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11946 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77716 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/09b46ffd-2d26-4af4-a959-c2e20fd5a78e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142367 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9547 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124880 "Passed tests") | [⏳ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/API-Tests-WPE-EWS "Waiting to run tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ab132b1d-fea3-48af-a1f1-06669fafd2f9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9154 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6802 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7844 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/131393 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118486 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/847 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150330 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/215 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11480 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/863 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11493 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9793 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9872 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121293 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66486 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11523 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/809 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/170691 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11258 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75190 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44420 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11460 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11310 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->