### PR TITLE
[Safer CPP] Address some unretained data members warnings

### DIFF
--- a/Source/JavaScriptCore/API/JSContext.mm
+++ b/Source/JavaScriptCore/API/JSContext.mm
@@ -210,7 +210,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 {
     auto& thread = Thread::currentSingleton();
     CallbackData *entry = (CallbackData *)thread.m_apiData;
-    return entry ? entry->context : nil;
+    return entry ? entry->context.get() : nil;
 }
 
 + (JSValue *)currentThis

--- a/Source/JavaScriptCore/API/JSContextInternal.h
+++ b/Source/JavaScriptCore/API/JSContextInternal.h
@@ -31,7 +31,7 @@
 
 struct CallbackData {
     CallbackData* next;
-    JSContext *context;
+    RetainPtr<JSContext> context;
     RetainPtr<JSValue> preservedException;
     JSValueRef calleeValue;
     JSValueRef thisValue;

--- a/Source/JavaScriptCore/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
@@ -1,4 +1,3 @@
-API/JSContextInternal.h
+[ iOS ] API/JSValue.h
 API/JSValue.mm
 API/tests/Regress141275.mm
-[ iOS ] API/JSValue.h

--- a/Source/WTF/wtf/Assertions.h
+++ b/Source/WTF/wtf/Assertions.h
@@ -177,7 +177,7 @@ typedef struct {
     const char* name;
     WTFLogLevel level;
 #if !RELEASE_LOG_DISABLED && USE(OS_LOG)
-    __unsafe_unretained os_log_t osLogChannel;
+    SUPPRESS_UNRETAINED_MEMBER __unsafe_unretained os_log_t osLogChannel;
 #endif
 } WTFLogChannel;
 

--- a/Source/WebCore/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
@@ -1,7 +1,4 @@
-[ Mac ] accessibility/cocoa/AXCoreObjectCocoa.mm
 bridge/objc/WebScriptObject.h
-platform/ios/WebAVPlayerController.h
-platform/ios/WebAVPlayerController.mm
 [ iOS ] platform/cocoa/WebAVPlayerLayer.h
 [ iOS ] platform/graphics/ios/DisplayRefreshMonitorIOS.mm
 [ iOS ] platform/ios/DeviceMotionClientIOS.h

--- a/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
@@ -512,9 +512,9 @@ PlatformRoleMap createPlatformRoleMap()
 {
     struct RoleEntry {
         AccessibilityRole value;
-        NSString *string;
+        RetainPtr<NSString> string;
     };
-    static const auto roles = std::to_array<RoleEntry>({
+    static const NeverDestroyed roles = std::to_array<RoleEntry>({
         { AccessibilityRole::Unknown, NSAccessibilityUnknownRole },
         { AccessibilityRole::Button, NSAccessibilityButtonRole },
         { AccessibilityRole::RadioButton, NSAccessibilityRadioButtonRole },
@@ -647,8 +647,8 @@ PlatformRoleMap createPlatformRoleMap()
         { AccessibilityRole::FrameHost, NSAccessibilityGroupRole },
     });
     PlatformRoleMap roleMap;
-    for (auto& role : roles)
-        roleMap.add(static_cast<unsigned>(role.value), role.string);
+    for (auto& role : roles.get())
+        roleMap.add(static_cast<unsigned>(role.value), role.string.get());
     return roleMap;
 }
 

--- a/Source/WebCore/platform/ios/WebAVPlayerController.mm
+++ b/Source/WebCore/platform/ios/WebAVPlayerController.mm
@@ -197,8 +197,8 @@ Class webAVPlayerControllerClassSingleton()
     BOOL _pictureInPictureInterrupted;
     BOOL _muted;
     NSTimeInterval _seekToTime;
-    WebAVMediaSelectionOption *_currentAudioMediaSelectionOption;
-    WebAVMediaSelectionOption *_currentLegibleMediaSelectionOption;
+    RetainPtr<WebAVMediaSelectionOption> _currentAudioMediaSelectionOption;
+    RetainPtr<WebAVMediaSelectionOption> _currentLegibleMediaSelectionOption;
     RetainPtr<AVPlayer> _player;
 }
 
@@ -243,8 +243,6 @@ Class webAVPlayerControllerClassSingleton()
     [_timing release];
     [_audioMediaSelectionOptions release];
     [_legibleMediaSelectionOptions release];
-    [_currentAudioMediaSelectionOption release];
-    [_currentLegibleMediaSelectionOption release];
     [_externalPlaybackAirPlayDeviceLocalizedName release];
     [_minTiming release];
     [_maxTiming release];
@@ -694,7 +692,7 @@ Class webAVPlayerControllerClassSingleton()
 
 - (WebAVMediaSelectionOption *)currentAudioMediaSelectionOption
 {
-    return _currentAudioMediaSelectionOption;
+    return _currentAudioMediaSelectionOption.get();
 }
 
 - (void)setCurrentAudioMediaSelectionOption:(WebAVMediaSelectionOption *)option
@@ -702,8 +700,7 @@ Class webAVPlayerControllerClassSingleton()
     if (option == _currentAudioMediaSelectionOption)
         return;
 
-    [_currentAudioMediaSelectionOption release];
-    _currentAudioMediaSelectionOption = [option retain];
+    _currentAudioMediaSelectionOption = option;
 
     if (!self.delegate)
         return;
@@ -721,7 +718,7 @@ Class webAVPlayerControllerClassSingleton()
 
 - (WebAVMediaSelectionOption *)currentLegibleMediaSelectionOption
 {
-    return _currentLegibleMediaSelectionOption;
+    return _currentLegibleMediaSelectionOption.get();
 }
 
 - (void)setCurrentLegibleMediaSelectionOption:(WebAVMediaSelectionOption *)option
@@ -729,8 +726,7 @@ Class webAVPlayerControllerClassSingleton()
     if (option == _currentLegibleMediaSelectionOption)
         return;
 
-    [_currentLegibleMediaSelectionOption release];
-    _currentLegibleMediaSelectionOption = [option retain];
+    _currentLegibleMediaSelectionOption = option;
 
     if (!self.delegate)
         return;
@@ -1142,6 +1138,7 @@ Class webAVPlayerControllerClassSingleton()
 
 @implementation WebAVMediaSelectionOption {
     RetainPtr<NSString> _localizedDisplayName;
+    RetainPtr<AVMediaType> _mediaType;
 }
 
 - (instancetype)initWithMediaType:(AVMediaType)mediaType displayName:(NSString *)displayName
@@ -1159,7 +1156,7 @@ Class webAVPlayerControllerClassSingleton()
 - (id)copyWithZone:(NSZone *)zone
 {
     RetainPtr displayName = adoptNS([_localizedDisplayName copyWithZone:zone]);
-    SUPPRESS_RETAINPTR_CTOR_ADOPT return [[WebAVMediaSelectionOption allocWithZone:zone] initWithMediaType:_mediaType displayName:displayName.get()];
+    SUPPRESS_RETAINPTR_CTOR_ADOPT return [[WebAVMediaSelectionOption allocWithZone:zone] initWithMediaType:_mediaType.get() displayName:displayName.get()];
 }
 
 - (NSString *)displayName
@@ -1170,6 +1167,11 @@ Class webAVPlayerControllerClassSingleton()
 - (NSString *)localizedDisplayName
 {
     return _localizedDisplayName.get();
+}
+
+- (AVMediaType)mediaType
+{
+    return _mediaType.get();
 }
 
 - (NSArray<NSNumber *> *)mediaSubTypes


### PR DESCRIPTION
#### 8dd3944f12c16a49acea73e3d2441e9330280742
<pre>
[Safer CPP] Address some unretained data members warnings
<a href="https://bugs.webkit.org/show_bug.cgi?id=305738">https://bugs.webkit.org/show_bug.cgi?id=305738</a>

Reviewed by Darin Adler.

* Source/JavaScriptCore/API/JSContext.mm:
(+[JSContext currentContext]):
* Source/JavaScriptCore/API/JSContextInternal.h:
* Source/JavaScriptCore/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations:
* Source/WTF/wtf/Assertions.h:
* Source/WebCore/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations:
* Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm:
(WebCore::Accessibility::createPlatformRoleMap):
* Source/WebCore/platform/ios/WebAVPlayerController.mm:
(-[WebAVPlayerController dealloc]):
(-[WebAVPlayerController currentAudioMediaSelectionOption]):
(-[WebAVPlayerController setCurrentAudioMediaSelectionOption:]):
(-[WebAVPlayerController currentLegibleMediaSelectionOption]):
(-[WebAVPlayerController setCurrentLegibleMediaSelectionOption:]):
(-[WebAVMediaSelectionOption copyWithZone:]):
(-[WebAVMediaSelectionOption mediaType]):

Canonical link: <a href="https://commits.webkit.org/305797@main">https://commits.webkit.org/305797@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e310729f6daa333339537eb316932d824b9d3c1e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139434 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11810 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/936 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147561 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92502 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f2e85176-bb84-4172-a71a-5166b4aba325) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141307 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12517 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11960 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106751 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77723 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cfb0a081-17a1-4119-8811-118f0715931b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142381 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9564 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124891 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87613 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c3f817b8-b509-4211-b24a-a5ec5e385492) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9174 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6814 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7858 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/131407 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118500 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/862 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150344 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/229 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11494 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/878 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115150 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11508 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9809 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115462 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29331 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9916 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121308 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66500 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11537 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/820 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/170705 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11272 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75204 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44425 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11474 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11324 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->