### PR TITLE
AX: WebKit does not compute a self-referential aria-labelledby correctly in SVG.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg-aam/name/comp_labelledby-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg-aam/name/comp_labelledby-expected.txt
@@ -23,10 +23,5 @@ PASS [aria-label][aria-labelledby] > circle
 PASS [aria-label][aria-labelledby] > rect
 PASS [aria-label][aria-labelledby] > polygon
 PASS [aria-label][aria-labelledby] > g
-FAIL [aria-labelledby="{[aria-label]} {[xlink:title]} {* > [title]}"] > g assert_equals: <a href="#" aria-labelledby="nolan gilliam kaufman villeneuve" data-expectedlabel="Nolan Gilliam Kaufman Villeneuve" xlink:title="group link label" data-testname="[aria-labelledby=&quot;{[aria-label]} {[xlink:title]} {* &gt; [title]}&quot;] &gt; g" class="ex">
-  <g fill="white" stroke="green" stroke-width="5">
-    <circle cx="40" cy="40" r="25"></circle>
-    <circle cx="60" cy="60" r="25"></circle>
-  </g>
-  </a> expected "Nolan Gilliam Kaufman Villeneuve" but got "Nolan Gilliam"
+PASS [aria-labelledby="{[aria-label]} {[xlink:title]} {* > [title]}"] > g
 

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -111,7 +111,10 @@
 #include "RenderTableCell.h"
 #include "RenderView.h"
 #include "RuleFeature.h"
+#include "SVGAElement.h"
 #include "SVGElement.h"
+#include "SVGElementTypeHelpers.h"
+#include "SVGTitleElement.h"
 #include "ShadowRoot.h"
 #include "StyleListStyleType.h"
 #include "StyleResolver.h"
@@ -121,6 +124,7 @@
 #include "TypedElementDescendantIteratorInlines.h"
 #include "UserGestureIndicator.h"
 #include "VisibleUnits.h"
+#include "XLinkNames.h"
 #include <numeric>
 #include <wtf/Scope.h>
 #include <wtf/SetForScope.h>
@@ -4174,6 +4178,12 @@ static String accessibleNameForNode(Node& node, Node* labelledbyNode)
     const AtomString& alt = element ? element->attributeWithoutSynchronization(altAttr) : nullAtom();
     if (!alt.isEmpty())
         return alt;
+
+    if (RefPtr svgElement = dynamicDowncast<SVGElement>(element)) {
+        // For SVG elements, check for SVG-specific labeling mechanisms per SVG-AAM spec.
+        if (String title = svgElement->title(); !title.isEmpty())
+            return title;
+    }
 
     // If the node can be turned into an AX object, we can use standard name computation rules.
     // If however, the node cannot (because there's no renderer e.g.) fallback to using the basic text underneath.


### PR DESCRIPTION
#### 0b1706ea5580e9617b324814f95a476ad2d31bf1
<pre>
AX: WebKit does not compute a self-referential aria-labelledby correctly in SVG.
<a href="https://bugs.webkit.org/show_bug.cgi?id=297239">https://bugs.webkit.org/show_bug.cgi?id=297239</a>
<a href="https://rdar.apple.com/158072617">rdar://158072617</a>

Reviewed by Joshua Hoffman.

We weren&apos;t checking for the SVG title element or attribute in accessibleNameForNode — this commit addresses that,
giving us one more passing WPT.

* LayoutTests/imported/w3c/web-platform-tests/svg-aam/name/comp_labelledby-expected.txt:
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::accessibleNameForNode):

Canonical link: <a href="https://commits.webkit.org/305896@main">https://commits.webkit.org/305896@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21c12361fc8011fd1f61fceb18d385996f46dedd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139696 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12072 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1200 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147833 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92764 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e1cf25c4-75df-48c3-a9cc-bfb30222b56b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141569 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12781 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12223 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106971 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77871 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/df6fa825-97b8-4a5e-b708-428ff7a7337b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142643 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9839 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125116 "Found 1 new API test failure: TestWebKitAPI.WKDownload.DownloadRequestFailure (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87835 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/36f127fe-affd-4c66-8ad2-e1820f8a76fc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9497 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7016 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8123 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118724 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1114 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150615 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11757 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1166 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115374 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11770 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10071 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115685 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29393 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10447 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121593 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66762 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11801 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1076 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11541 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75479 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11736 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11588 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->