### PR TITLE
Stop using deprecated std::aligned_storage in ThreadSpecific.h

### DIFF
--- a/Source/WTF/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -1,1 +1,0 @@
-wtf/ThreadSpecific.h

--- a/Source/WTF/wtf/ThreadSpecific.h
+++ b/Source/WTF/wtf/ThreadSpecific.h
@@ -100,11 +100,11 @@ private:
             owner->setInTLS(nullptr);
         }
 
-        PointerType storagePointer() const { return const_cast<PointerType>(reinterpret_cast<const T*>(&m_storage)); }
+        SUPPRESS_MEMORY_UNSAFE_CAST PointerType storagePointer() const { return const_cast<PointerType>(reinterpret_cast<const T*>(&m_storage)); }
 
-        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        typename std::aligned_storage<sizeof(T), std::alignment_of<T>::value>::type m_storage;
-        ALLOW_DEPRECATED_DECLARATIONS_END
+        union alignas(T) {
+            std::byte bytes[sizeof(T)];
+        } m_storage;
         ThreadSpecific<T, canBeGCThread>* owner;
     };
 


### PR DESCRIPTION
#### 4ecbc23ba669e8efa9fa16a71a7793c9648df39d
<pre>
Stop using deprecated std::aligned_storage in ThreadSpecific.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=305741">https://bugs.webkit.org/show_bug.cgi?id=305741</a>

Reviewed by Darin Adler.

* Source/WTF/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WTF/wtf/ThreadSpecific.h:
(WTF::ThreadSpecific::Data::storagePointer const):
(WTF::ThreadSpecific::Data::alignas):

Canonical link: <a href="https://commits.webkit.org/305796@main">https://commits.webkit.org/305796@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/266f9c6a96c313157826fe87ffdc2d4fc92755c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139431 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11807 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/933 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147558 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92499 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e3f83016-aa36-4b18-94d8-ffd7efebfe9f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12514 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11957 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106749 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77720 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1c1c90cf-ae48-4752-a5e0-4f00f604ea3e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142378 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9563 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124888 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87611 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/40645e1b-9112-49ca-bb6e-d2996b276924) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9171 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6812 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7855 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/131404 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118499 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/858 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150341 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/226 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11491 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/874 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11504 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9806 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115460 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29330 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9903 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121303 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66497 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11534 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/816 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/170702 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11269 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75201 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44423 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11471 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11321 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->