### PR TITLE
AX: Popovers should enforce a minimum role

### DIFF
--- a/LayoutTests/accessibility/popover-minimum-role-expected.txt
+++ b/LayoutTests/accessibility/popover-minimum-role-expected.txt
@@ -1,0 +1,19 @@
+This test ensures popover elements have a minimum role of group per HTML AAM.
+
+A div with popover attribute should have computed role 'group' (minimum role per HTML AAM):
+PASS: popoverDiv.computedRoleString === 'group'
+
+An explicit role='generic' popover should keep 'generic' (explicit role takes precedence):
+PASS: explicitGenericPopover.computedRoleString === 'generic'
+
+A display:contents popover should also have computed role 'group':
+PASS: displayContentsPopover.computedRoleString === 'group'
+
+Dynamic test - adding popover attribute should change role to group:
+PASS: !dynamicPopover || dynamicPopover.computedRoleString !== 'group' === true
+PASS: dynamicPopover.computedRoleString === 'group'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Popover contentExplicit generic popoverDisplay contents popoverDynamic popover

--- a/LayoutTests/accessibility/popover-minimum-role.html
+++ b/LayoutTests/accessibility/popover-minimum-role.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="popover-div" popover="manual">Popover content</div>
+<div id="explicit-generic-popover" role="generic" popover="manual">Explicit generic popover</div>
+<div id="display-contents-popover" popover="manual" style="display:contents">Display contents popover</div>
+
+<script>
+var output = "This test ensures popover elements have a minimum role of group per HTML AAM.\n\n";
+var popoverDiv;
+var explicitGenericPopover;
+var displayContentsPopover;
+var dynamicPopover;
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    document.getElementById("popover-div").showPopover();
+    document.getElementById("explicit-generic-popover").showPopover();
+    document.getElementById("display-contents-popover").showPopover();
+
+    setTimeout(async function() {
+        popoverDiv = accessibilityController.accessibleElementById("popover-div");
+        explicitGenericPopover = accessibilityController.accessibleElementById("explicit-generic-popover");
+        displayContentsPopover = accessibilityController.accessibleElementById("display-contents-popover");
+
+        output += "A div with popover attribute should have computed role 'group' (minimum role per HTML AAM):\n";
+        output += expect("popoverDiv.computedRoleString", "'group'");
+
+        output += "\nAn explicit role='generic' popover should keep 'generic' (explicit role takes precedence):\n";
+        output += expect("explicitGenericPopover.computedRoleString", "'generic'");
+
+        output += "\nA display:contents popover should also have computed role 'group':\n";
+        output += expect("displayContentsPopover.computedRoleString", "'group'");
+
+        output += "\nDynamic test - adding popover attribute should change role to group:\n";
+        var newDiv = document.createElement("div");
+        newDiv.id = "dynamic-popover";
+        newDiv.textContent = "Dynamic popover";
+        document.body.appendChild(newDiv);
+
+        // Verify the div doesn't have a computed role before adding the popover attribute.
+        dynamicPopover = accessibilityController.accessibleElementById("dynamic-popover");
+        output += expect("!dynamicPopover || dynamicPopover.computedRoleString !== 'group'", "true");
+
+        newDiv.setAttribute("popover", "manual");
+        newDiv.showPopover();
+
+        await waitFor(() => {
+            dynamicPopover = accessibilityController.accessibleElementById("dynamic-popover");
+            return dynamicPopover && dynamicPopover.computedRoleString === "group";
+        });
+        output += expect("dynamicPopover.computedRoleString", "'group'");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -3174,7 +3174,11 @@ void AXObjectCache::handleAttributeChange(Element* element, const QualifiedName&
         postNotification(element, AXNotification::CommandForChanged);
     else if (attrName == popovertargetAttr)
         postNotification(element, AXNotification::PopoverTargetChanged);
-    else if (attrName == scopeAttr)
+    else if (attrName == popoverAttr) {
+        // The popover attribute affects role computation (generic -> group).
+        if (RefPtr axObject = get(*element))
+            axObject->updateRole();
+    } else if (attrName == scopeAttr)
         postNotification(element, AXNotification::CellScopeChanged);
     else if (attrName == datetimeAttr)
         postNotification(element, AXNotification::DatetimeChanged);

--- a/Source/WebCore/accessibility/AXUtilities.cpp
+++ b/Source/WebCore/accessibility/AXUtilities.cpp
@@ -32,6 +32,7 @@
 #include "CSSValueList.h"
 #include "DocumentView.h"
 #include "ElementInlines.h"
+#include "HTMLElement.h"
 #include "HTMLImageElement.h"
 #include "HTMLMapElement.h"
 #include "HTMLMediaElement.h"
@@ -506,6 +507,12 @@ RefPtr<Node> lastNode(const FixedVector<AXID>& axIDs, AXObjectCache& cache)
         }
     }
     return nullptr;
+}
+
+bool isPopoverElement(const Node* node)
+{
+    RefPtr element = dynamicDowncast<HTMLElement>(node);
+    return element && element->hasAttributeWithoutSynchronization(popoverAttr);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AXUtilities.h
+++ b/Source/WebCore/accessibility/AXUtilities.h
@@ -66,6 +66,10 @@ bool hasAccNameAttribute(Element&);
 
 bool isNodeFocused(Node&);
 
+// Returns true if the node is an HTML element with the popover attribute.
+// https://www.w3.org/TR/html-aam-1.0/#att-popover
+bool isPopoverElement(const Node*);
+
 bool needsLayoutOrStyleRecalc(const Document&);
 
 bool isRenderHidden(const RenderStyle*);

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -476,6 +476,10 @@ AccessibilityRole AccessibilityNodeObject::determineAccessibilityRole()
             return parentTable->hasGridRole() ? AccessibilityRole::GridCell : AccessibilityRole::Cell;
     }
 
+    // Per HTML AAM, elements with the popover attribute have a minimum role of group.
+    if (roleFromNode == AccessibilityRole::Generic && isPopoverElement(node()))
+        return AccessibilityRole::Group;
+
     return roleFromNode;
 }
 

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -2541,6 +2541,10 @@ AccessibilityRole AccessibilityRenderObject::determineAccessibilityRole()
             return parentTable->hasGridRole() ? AccessibilityRole::GridCell : AccessibilityRole::Cell;
     }
 
+    // Per HTML AAM, elements with the popover attribute have a minimum role of group.
+    if (roleFromNode == AccessibilityRole::Generic && isPopoverElement(node.get()))
+        return AccessibilityRole::Group;
+
     if (roleFromNode != AccessibilityRole::Unknown)
         return roleFromNode;
 


### PR DESCRIPTION
#### ca84c2ccb9282f699c1f780322d23c2355c1602c
<pre>
AX: Popovers should enforce a minimum role
<a href="https://bugs.webkit.org/show_bug.cgi?id=284230">https://bugs.webkit.org/show_bug.cgi?id=284230</a>
<a href="https://rdar.apple.com/141096771">rdar://141096771</a>

Reviewed by NOBODY (OOPS!).

Per https://www.w3.org/TR/html-aam-1.0/#att-popover, elements with the popover attribute should have a minimum role of group (which is semantically stronger than generic).

* LayoutTests/accessibility/popover-minimum-role-expected.txt: Added.
* LayoutTests/accessibility/popover-minimum-role.html: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::handleAttributeChange):
* Source/WebCore/accessibility/AXUtilities.cpp:
(WebCore::isPopoverElement):
* Source/WebCore/accessibility/AXUtilities.h:
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::determineAccessibilityRole):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::determineAccessibilityRole):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee42db8a7062ba96dc66fbaa4406f2866489a457

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139446 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11822 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/948 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147573 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92514 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/67a85384-4e2e-4cec-9536-3a24965249b1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141319 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12530 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11972 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106760 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77730 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b04ed40c-5246-4137-8443-03d6d791e162) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142393 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9574 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124896 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87623 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fc69e439-3213-4bf2-ae84-e8e8b053f047) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9186 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/popovers/popover-minimum-role.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6822 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7871 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118508 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/869 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150356 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11506 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/885 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/popovers/popover-minimum-role.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115160 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/popovers/popover-minimum-role.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11520 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9820 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/popovers/popover-minimum-role.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115473 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9940 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121315 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66512 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11550 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/827 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/popovers/popover-minimum-role.html (failure)") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11284 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75216 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11486 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11336 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->