### PR TITLE
[WebDriver BiDi] Fix browsingContext.activate error handling and navigation ID tracking

### DIFF
--- a/Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.cpp
@@ -70,11 +70,19 @@ void BidiBrowsingContextAgent::activate(const BrowsingContext& browsingContext, 
     RefPtr session = m_session.get();
     ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
 
-    RefPtr webPageProxy = session->webPageProxyForHandle(browsingContext);
-    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!webPageProxy, WindowNotFound);
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(browsingContext.isEmpty(), FrameNotFound);
 
-    // FIXME: detect non-top level browsing contexts, returning `invalid argument`.
-    session->switchToBrowsingContext(browsingContext, emptyString(), [callback = WTF::move(callback)](CommandResult<void>&& result) {
+    auto browsingContextHandles = session->extractBrowsingContextHandles(browsingContext);
+    ASYNC_FAIL_IF_UNEXPECTED_RESULT(browsingContextHandles);
+
+    auto [topLevelHandle, frameHandle] = browsingContextHandles.value();
+    if (!frameHandle.isEmpty())
+        ASYNC_FAIL_WITH_PREDEFINED_ERROR(InvalidParameter);
+
+    RefPtr webPageProxy = session->webPageProxyForHandle(topLevelHandle);
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!webPageProxy, FrameNotFound);
+
+    session->switchToBrowsingContext(topLevelHandle, emptyString(), [callback = WTF::move(callback)](CommandResult<void>&& result) {
         if (!result) {
             callback(makeUnexpected(result.error()));
             return;

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -630,6 +630,11 @@ void WebAutomationSession::waitForNavigationToComplete(const Inspector::Protocol
 
 void WebAutomationSession::waitForNavigationToCompleteOnPage(WebPageProxy& page, Inspector::Protocol::Automation::PageLoadStrategy loadStrategy, Seconds timeout, Inspector::CommandCallback<void>&& callback)
 {
+    waitForNavigationToCompleteOnPage(page, loadStrategy, timeout, std::nullopt, WTF::move(callback));
+}
+
+void WebAutomationSession::waitForNavigationToCompleteOnPage(WebPageProxy& page, Inspector::Protocol::Automation::PageLoadStrategy loadStrategy, Seconds timeout, std::optional<WebCore::NavigationIdentifier> expectedNavigationID, Inspector::CommandCallback<void>&& callback)
+{
     ASSERT(!m_loadTimer.isActive());
     Ref pageLoadState = page.pageLoadState();
 
@@ -641,10 +646,10 @@ void WebAutomationSession::waitForNavigationToCompleteOnPage(WebPageProxy& page,
     m_loadTimer.startOneShot(timeout);
     switch (loadStrategy) {
     case Inspector::Protocol::Automation::PageLoadStrategy::Normal:
-        m_pendingNormalNavigationInBrowsingContextCallbacksPerPage.set(page.identifier(), WTF::move(callback));
+        m_pendingNormalNavigationInBrowsingContextCallbacksPerPage.set(page.identifier(), PendingNavigationCallback { expectedNavigationID, WTF::move(callback) });
         break;
     case Inspector::Protocol::Automation::PageLoadStrategy::Eager:
-        m_pendingEagerNavigationInBrowsingContextCallbacksPerPage.set(page.identifier(), WTF::move(callback));
+        m_pendingEagerNavigationInBrowsingContextCallbacksPerPage.set(page.identifier(), PendingNavigationCallback { expectedNavigationID, WTF::move(callback) });
         break;
     case Inspector::Protocol::Automation::PageLoadStrategy::None:
         ASSERT_NOT_REACHED();
@@ -662,21 +667,22 @@ void WebAutomationSession::waitForNavigationToCompleteOnFrame(WebFrameProxy& fra
     m_loadTimer.startOneShot(timeout);
     switch (loadStrategy) {
     case Inspector::Protocol::Automation::PageLoadStrategy::Normal:
-        m_pendingNormalNavigationInBrowsingContextCallbacksPerFrame.set(frame.frameID(), WTF::move(callback));
+        m_pendingNormalNavigationInBrowsingContextCallbacksPerFrame.set(frame.frameID(), PendingNavigationCallback { std::nullopt, WTF::move(callback) });
         break;
     case Inspector::Protocol::Automation::PageLoadStrategy::Eager:
-        m_pendingEagerNavigationInBrowsingContextCallbacksPerFrame.set(frame.frameID(), WTF::move(callback));
+        m_pendingEagerNavigationInBrowsingContextCallbacksPerFrame.set(frame.frameID(), PendingNavigationCallback { std::nullopt, WTF::move(callback) });
         break;
     case Inspector::Protocol::Automation::PageLoadStrategy::None:
         ASSERT_NOT_REACHED();
     }
 }
 
-void WebAutomationSession::respondToPendingPageNavigationCallbacksWithTimeout(HashMap<WebPageProxyIdentifier, Inspector::CommandCallback<void>>& map)
+void WebAutomationSession::respondToPendingPageNavigationCallbacksWithTimeout(HashMap<WebPageProxyIdentifier, PendingNavigationCallback>& map)
 {
     for (auto id : copyToVector(map.keys())) {
         RefPtr page = WebProcessProxy::webPage(id);
-        auto callback = map.take(id);
+        auto pendingCallback = map.take(id);
+        auto callback = WTF::move(pendingCallback.callback);
         if (page && m_client->isShowingJavaScriptDialogOnPage(*this, *page))
             callback({ });
         else
@@ -691,12 +697,13 @@ static WebPageProxy* findPageForFrameID(const WebProcessPool& processPool, Frame
     return nullptr;
 }
 
-void WebAutomationSession::respondToPendingFrameNavigationCallbacksWithTimeout(HashMap<FrameIdentifier, Inspector::CommandCallback<void>>& map)
+void WebAutomationSession::respondToPendingFrameNavigationCallbacksWithTimeout(HashMap<FrameIdentifier, PendingNavigationCallback>& map)
 {
     Ref processPool = *m_processPool;
     for (auto id : copyToVector(map.keys())) {
         RefPtr page = findPageForFrameID(processPool, id);
-        auto callback = map.take(id);
+        auto pendingCallback = map.take(id);
+        auto callback = WTF::move(pendingCallback.callback);
         if (page && m_client->isShowingJavaScriptDialogOnPage(*this, *page))
             callback({ });
         else
@@ -881,8 +888,12 @@ void WebAutomationSession::navigateBrowsingContext(const Inspector::Protocol::Au
     auto pageLoadStrategy = optionalPageLoadStrategy.value_or(defaultPageLoadStrategy);
     auto pageLoadTimeout = optionalPageLoadTimeout ? Seconds::fromMilliseconds(*optionalPageLoadTimeout) : defaultPageLoadTimeout;
 
-    page->loadRequest(URL { url });
-    waitForNavigationToCompleteOnPage(*page, pageLoadStrategy, pageLoadTimeout, WTF::move(callback));
+    RefPtr navigation = page->loadRequest(ResourceRequest { URL { url } });
+    std::optional<WebCore::NavigationIdentifier> navigationID;
+    if (navigation)
+        navigationID = navigation->navigationID();
+
+    waitForNavigationToCompleteOnPage(*page, pageLoadStrategy, pageLoadTimeout, navigationID, WTF::move(callback));
 }
 
 void WebAutomationSession::goBackInBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle& handle, std::optional<Inspector::Protocol::Automation::PageLoadStrategy>&& optionalPageLoadStrategy, std::optional<double>&& optionalPageLoadTimeout, CommandCallback<void>&& callback)
@@ -959,7 +970,14 @@ void WebAutomationSession::reloadBrowsingContext(const Inspector::Protocol::Auto
     waitForNavigationToCompleteOnPage(*page, pageLoadStrategy, pageLoadTimeout, WTF::move(callback));
 }
 
-void WebAutomationSession::navigationOccurredForFrame(const WebFrameProxy& frame)
+static bool navigationIDMatchesPendingCallback(std::optional<WebCore::NavigationIdentifier> pendingNavigationID, std::optional<WebCore::NavigationIdentifier> navigationID)
+{
+    if (!pendingNavigationID)
+        return true;
+    return navigationID && *pendingNavigationID == *navigationID;
+}
+
+void WebAutomationSession::navigationOccurredForFrame(const WebFrameProxy& frame, std::optional<WebCore::NavigationIdentifier> navigationID)
 {
     if (frame.isMainFrame()) {
         // New page loaded, clear frame handles previously cached for frame's page.
@@ -975,15 +993,25 @@ void WebAutomationSession::navigationOccurredForFrame(const WebFrameProxy& frame
             return handlesToRemove.contains(iter.key);
         });
 
-        if (auto callback = m_pendingNormalNavigationInBrowsingContextCallbacksPerPage.take(frame.page()->identifier())) {
-            m_loadTimer.stop();
-            callback({ });
+        auto pageIdentifier = frame.page()->identifier();
+        if (auto iterator = m_pendingNormalNavigationInBrowsingContextCallbacksPerPage.find(pageIdentifier); iterator != m_pendingNormalNavigationInBrowsingContextCallbacksPerPage.end()) {
+            if (navigationIDMatchesPendingCallback(iterator->value.expectedNavigationID, navigationID)) {
+                auto pendingCallback = m_pendingNormalNavigationInBrowsingContextCallbacksPerPage.take(pageIdentifier);
+                auto callback = WTF::move(pendingCallback.callback);
+                m_loadTimer.stop();
+                callback({ });
+            }
         }
         m_domainNotifier->browsingContextCleared(handleForWebPageProxy(*protect(frame.page())));
     } else {
-        if (auto callback = m_pendingNormalNavigationInBrowsingContextCallbacksPerFrame.take(frame.frameID())) {
-            m_loadTimer.stop();
-            callback({ });
+        auto frameIdentifier = frame.frameID();
+        if (auto iterator = m_pendingNormalNavigationInBrowsingContextCallbacksPerFrame.find(frameIdentifier); iterator != m_pendingNormalNavigationInBrowsingContextCallbacksPerFrame.end()) {
+            if (navigationIDMatchesPendingCallback(iterator->value.expectedNavigationID, navigationID)) {
+                auto pendingCallback = m_pendingNormalNavigationInBrowsingContextCallbacksPerFrame.take(frameIdentifier);
+                auto callback = WTF::move(pendingCallback.callback);
+                m_loadTimer.stop();
+                callback({ });
+            }
         }
     }
 }
@@ -1006,18 +1034,28 @@ void WebAutomationSession::documentLoadedForFrame(const WebFrameProxy& frame, st
 #endif
 
     if (frame.isMainFrame()) {
-        if (auto callback = m_pendingEagerNavigationInBrowsingContextCallbacksPerPage.take(frame.page()->identifier())) {
-            m_loadTimer.stop();
-            callback({ });
+        auto pageIdentifier = frame.page()->identifier();
+        if (auto iterator = m_pendingEagerNavigationInBrowsingContextCallbacksPerPage.find(pageIdentifier); iterator != m_pendingEagerNavigationInBrowsingContextCallbacksPerPage.end()) {
+            if (navigationIDMatchesPendingCallback(iterator->value.expectedNavigationID, navigationID)) {
+                auto pendingCallback = m_pendingEagerNavigationInBrowsingContextCallbacksPerPage.take(pageIdentifier);
+                auto callback = WTF::move(pendingCallback.callback);
+                m_loadTimer.stop();
+                callback({ });
+            }
         }
 
 #if ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)
         resetMouseState();
 #endif
     } else {
-        if (auto callback = m_pendingEagerNavigationInBrowsingContextCallbacksPerFrame.take(frame.frameID())) {
-            m_loadTimer.stop();
-            callback({ });
+        auto frameIdentifier = frame.frameID();
+        if (auto iterator = m_pendingEagerNavigationInBrowsingContextCallbacksPerFrame.find(frameIdentifier); iterator != m_pendingEagerNavigationInBrowsingContextCallbacksPerFrame.end()) {
+            if (navigationIDMatchesPendingCallback(iterator->value.expectedNavigationID, navigationID)) {
+                auto pendingCallback = m_pendingEagerNavigationInBrowsingContextCallbacksPerFrame.take(frameIdentifier);
+                auto callback = WTF::move(pendingCallback.callback);
+                m_loadTimer.stop();
+                callback({ });
+            }
         }
     }
 }

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
@@ -162,7 +162,7 @@ public:
     WebProcessPool* NODELETE processPool() const;
     void setProcessPool(WebProcessPool*);
 
-    void navigationOccurredForFrame(const WebFrameProxy&);
+    void navigationOccurredForFrame(const WebFrameProxy&, std::optional<WebCore::NavigationIdentifier>);
     void documentLoadedForFrame(const WebFrameProxy&, std::optional<WebCore::NavigationIdentifier>, WallTime timestamp);
     void loadCompletedForFrame(const WebFrameProxy&, std::optional<WebCore::NavigationIdentifier>, WallTime timestamp);
     void inspectorFrontendLoaded(const WebPageProxy&);
@@ -318,15 +318,21 @@ public:
     Expected<PageAndFrameHandle, AutomationCommandError> extractBrowsingContextHandles(const String&);
 
 private:
+    struct PendingNavigationCallback {
+        std::optional<WebCore::NavigationIdentifier> expectedNavigationID;
+        Inspector::CommandCallback<void> callback;
+    };
+
     Ref<Inspector::Protocol::Automation::BrowsingContext> buildBrowsingContextForPage(WebPageProxy&, WebCore::FloatRect windowFrame);
     void getNextContext(Vector<Ref<WebPageProxy>>&&, Ref<JSON::ArrayOf<Inspector::Protocol::Automation::BrowsingContext>>, Inspector::CommandCallback<Ref<JSON::ArrayOf<Inspector::Protocol::Automation::BrowsingContext>>>&&);
 
     std::optional<WebCore::FrameIdentifier> webFrameIDForHandle(const String&, bool& frameNotFound);
 
     void waitForNavigationToCompleteOnPage(WebPageProxy&, Inspector::Protocol::Automation::PageLoadStrategy, Seconds, Inspector::CommandCallback<void>&&);
+    void waitForNavigationToCompleteOnPage(WebPageProxy&, Inspector::Protocol::Automation::PageLoadStrategy, Seconds, std::optional<WebCore::NavigationIdentifier>, Inspector::CommandCallback<void>&&);
     void waitForNavigationToCompleteOnFrame(WebFrameProxy&, Inspector::Protocol::Automation::PageLoadStrategy, Seconds, Inspector::CommandCallback<void>&&);
-    void respondToPendingPageNavigationCallbacksWithTimeout(HashMap<WebPageProxyIdentifier, Inspector::CommandCallback<void>>&);
-    void respondToPendingFrameNavigationCallbacksWithTimeout(HashMap<WebCore::FrameIdentifier, Inspector::CommandCallback<void>>&);
+    void respondToPendingPageNavigationCallbacksWithTimeout(HashMap<WebPageProxyIdentifier, PendingNavigationCallback>&);
+    void respondToPendingFrameNavigationCallbacksWithTimeout(HashMap<WebCore::FrameIdentifier, PendingNavigationCallback>&);
     void loadTimerFired();
 
     void exitFullscreenWindowForPage(WebPageProxy&, WTF::CompletionHandler<void()>&&);
@@ -402,10 +408,10 @@ private:
     HashMap<WebCore::FrameIdentifier, String> m_webFrameHandleMap;
     HashMap<String, WebCore::FrameIdentifier> m_handleWebFrameMap;
 
-    HashMap<WebPageProxyIdentifier, Inspector::CommandCallback<void>> m_pendingNormalNavigationInBrowsingContextCallbacksPerPage;
-    HashMap<WebPageProxyIdentifier, Inspector::CommandCallback<void>> m_pendingEagerNavigationInBrowsingContextCallbacksPerPage;
-    HashMap<WebCore::FrameIdentifier, Inspector::CommandCallback<void>> m_pendingNormalNavigationInBrowsingContextCallbacksPerFrame;
-    HashMap<WebCore::FrameIdentifier, Inspector::CommandCallback<void>> m_pendingEagerNavigationInBrowsingContextCallbacksPerFrame;
+    HashMap<WebPageProxyIdentifier, PendingNavigationCallback> m_pendingNormalNavigationInBrowsingContextCallbacksPerPage;
+    HashMap<WebPageProxyIdentifier, PendingNavigationCallback> m_pendingEagerNavigationInBrowsingContextCallbacksPerPage;
+    HashMap<WebCore::FrameIdentifier, PendingNavigationCallback> m_pendingNormalNavigationInBrowsingContextCallbacksPerFrame;
+    HashMap<WebCore::FrameIdentifier, PendingNavigationCallback> m_pendingEagerNavigationInBrowsingContextCallbacksPerFrame;
     HashMap<WebPageProxyIdentifier, Inspector::CommandCallback<void>> m_pendingInspectorCallbacksPerPage;
 #if ENABLE(WEBDRIVER_KEYBOARD_INTERACTIONS)
     HashMap<WebPageProxyIdentifier, Inspector::CommandCallback<void>> m_pendingKeyboardEventsFlushedCallbacksPerPage;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -7505,7 +7505,7 @@ void WebPageProxy::didFailProvisionalLoadForFrameShared(Ref<WebProcessProxy>&& p
 
     if (m_controlledByAutomation && willInternallyHandleFailure == WillInternallyHandleFailure::No) {
         if (RefPtr automationSession = process->processPool().automationSession())
-            automationSession->navigationOccurredForFrame(frame);
+            automationSession->navigationOccurredForFrame(frame, navigationID);
     }
 
     // FIXME: We should message check that navigationID is not zero here, but it's currently zero for some navigations through the back/forward cache.
@@ -8005,7 +8005,7 @@ void WebPageProxy::didFinishLoadForFrame(IPC::Connection& connection, FrameIdent
             protectedPageLoadState->didFinishLoad(transaction);
 
         if (RefPtr automationSession = activeAutomationSession()) {
-            automationSession->navigationOccurredForFrame(*frame);
+            automationSession->navigationOccurredForFrame(*frame, navigationID);
             automationSession->loadCompletedForFrame(*frame, navigationID, WallTime::now());
         }
 
@@ -8079,7 +8079,7 @@ void WebPageProxy::didFailLoadForFrame(IPC::Connection& connection, FrameIdentif
 
     if (m_controlledByAutomation) {
         if (RefPtr automationSession = m_configuration->processPool().automationSession())
-            automationSession->navigationOccurredForFrame(*frame);
+            automationSession->navigationOccurredForFrame(*frame, navigationID);
     }
 
     frame->didFailLoad();
@@ -8141,7 +8141,7 @@ void WebPageProxy::didSameDocumentNavigationForFrame(IPC::Connection& connection
 
     if (m_controlledByAutomation) {
         if (RefPtr automationSession = m_configuration->processPool().automationSession())
-            automationSession->navigationOccurredForFrame(*frame);
+            automationSession->navigationOccurredForFrame(*frame, navigationID);
     }
 
     protectedPageLoadState->clearPendingAPIRequest(transaction);
@@ -8192,7 +8192,7 @@ void WebPageProxy::didSameDocumentNavigationForFrameViaJS(IPC::Connection& conne
 
     if (m_controlledByAutomation) {
         if (RefPtr automationSession = m_configuration->processPool().automationSession())
-            automationSession->navigationOccurredForFrame(*frame);
+            automationSession->navigationOccurredForFrame(*frame, navigation ? std::optional(navigation->navigationID()) : std::nullopt);
     }
 
     protectedPageLoadState->clearPendingAPIRequest(transaction);

--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -2128,19 +2128,6 @@
     "imported/w3c/webdriver/tests/bidi/browsing_context/activate/activate.py": {
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288324"}}
     },
-    "imported/w3c/webdriver/tests/bidi/browsing_context/activate/invalid.py": {
-        "subtests": {
-            "test_params_context_invalid_value[]": {
-                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288324"}}
-            },
-            "test_params_context_invalid_value[somestring]": {
-                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288324"}}
-            },
-            "test_params_context_iframe": {
-                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288324"}}
-            }
-        }
-    },
     "imported/w3c/webdriver/tests/bidi/browsing_context/capture_screenshot/capture_screenshot.py": {
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288325"}}
     },


### PR DESCRIPTION
#### ac659ef6463a7fec731ee6f21906c6ce3954f9ee

overview detailed doc: https://docs.google.com/document/d/1SMLsiAghaiL88ckZ72A5pYsf5Ghvi4ATarLEvkPhC2Q/edit?usp=sharing

<pre>
[WebDriver BiDi] Fix browsingContext.activate error handling and navigation ID tracking
  <a href="https://bugs.webkit.org/show_bug.cgi?id=288324">https://bugs.webkit.org/show_bug.cgi?id=288324</a>

  Reviewed by NOBODY (OOPS!).

  The browsingContext.activate command was not properly validating context types
  per the WebDriver BiDi specification. Empty or invalid context IDs should return
  &quot;no such frame&quot;, and child browsing contexts (iframes) should return &quot;invalid argument&quot;
  since activate only works on top-level traversables.

  Additionally, navigation completion callbacks could fire for the wrong navigation
  when multiple navigations occurred in quick succession. This change tracks the
  expected navigation ID and only completes the callback when the matching navigation
  finishes.

  * Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.cpp:
  (WebKit::BidiBrowsingContextAgent::activate): Validate context is non-empty and
  is a top-level browsing context before activating. Use extractBrowsingContextHandles
  to distinguish between top-level and frame contexts.

  * Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
  (WebKit::WebAutomationSession::waitForNavigationToCompleteOnPage): Added overload
  accepting optional NavigationIdentifier to track expected navigation.
  (WebKit::WebAutomationSession::waitForNavigationToCompleteOnFrame): Store navigation
  callback with nullopt navigation ID.
  (WebKit::WebAutomationSession::respondToPendingPageNavigationCallbacksWithTimeout):
  Updated to use PendingNavigationCallback struct.
  (WebKit::WebAutomationSession::respondToPendingFrameNavigationCallbacksWithTimeout):
  Updated to use PendingNavigationCallback struct.
  (WebKit::WebAutomationSession::navigateBrowsingContext): Capture navigation ID from
  loadRequest and pass to waitForNavigationToCompleteOnPage.
  (WebKit::navigationIDMatchesPendingCallback): Added helper to match navigation IDs.
  (WebKit::WebAutomationSession::navigationOccurredForFrame): Only complete callback
  when navigation ID matches the expected one.
  (WebKit::WebAutomationSession::documentLoadedForFrame): Only complete callback
  when navigation ID matches the expected one.

  * Source/WebKit/UIProcess/Automation/WebAutomationSession.h:
  (WebKit::WebAutomationSession::PendingNavigationCallback): Added struct to hold
  expected navigation ID alongside callback.

  * Source/WebKit/UIProcess/WebPageProxy.cpp:
  (WebKit::WebPageProxy::didFailProvisionalLoadForFrameShared): Pass navigation ID.
  (WebKit::WebPageProxy::didFinishLoadForFrame): Pass navigation ID.
  (WebKit::WebPageProxy::didFailLoadForFrame): Pass navigation ID.
  (WebKit::WebPageProxy::didSameDocumentNavigationForFrame): Pass navigation ID.
  (WebKit::WebPageProxy::didSameDocumentNavigationForFrameViaJS): Pass navigation ID.

  * WebDriverTests/TestExpectations.json: Remove expectations for tests that now pass.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f5f864d0b77c7e77c07af45b827263ff5a502fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146508 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19181 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12692 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155172 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99908 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19642 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19085 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112824 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80620 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149471 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15110 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131637 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93622 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14369 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12134 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2616 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123941 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157496 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/648 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10934 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120920 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18985 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15935 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121090 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18997 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131255 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/74787 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16734 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8164 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18605 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82354 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18334 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18489 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18392 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->