### PR TITLE
AX: aria-labelledby uses referenced checkbox value instead of name

### DIFF
--- a/LayoutTests/accessibility/aria-labelledby-on-checkbox-expected.txt
+++ b/LayoutTests/accessibility/aria-labelledby-on-checkbox-expected.txt
@@ -1,0 +1,11 @@
+This test verifies that when a button has aria-labelledby referencing a checkbox or radio, the button gets the checkbox/radio accessible name (from its label), not its value attribute.
+
+PASS: platformValueForW3CName(buttonReferencingCheckbox) === 'Checkbox Label Text'
+PASS: platformValueForW3CName(buttonReferencingCheckboxAriaLabel) === 'Checkbox ARIA Label'
+PASS: platformValueForW3CName(buttonReferencingRadio) === 'Radio Label Text'
+PASS: platformValueForW3CName(buttonReferencingCheckbox) === 'Updated Checkbox Label'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Toggle   Toggle  Label for checkbox with aria-label  Toggle  Radio Label Text Updated Checkbox Label

--- a/LayoutTests/accessibility/aria-labelledby-on-checkbox.html
+++ b/LayoutTests/accessibility/aria-labelledby-on-checkbox.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<button id="button-referencing-checkbox" aria-labelledby="checkbox-with-label">Toggle</button>
+<input type="checkbox" id="checkbox-with-label" value="checkbox-value">
+<label for="checkbox-with-label">Checkbox Label Text</label>
+
+<button id="button-referencing-checkbox-arialabel" aria-labelledby="checkbox-with-arialabel">Toggle</button>
+<input type="checkbox" id="checkbox-with-arialabel" value="checkbox-value" aria-label="Checkbox ARIA Label">
+<label for="checkbox-with-arialabel">Label for checkbox with aria-label</label>
+
+<button id="button-referencing-radio" aria-labelledby="radio-with-label">Toggle</button>
+<input type="radio" id="radio-with-label" name="radios" value="radio-value">
+<label for="radio-with-label">Radio Label Text</label>
+
+<script>
+var output = "This test verifies that when a button has aria-labelledby referencing a checkbox or radio, the button gets the checkbox/radio accessible name (from its label), not its value attribute.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var buttonReferencingCheckbox = accessibilityController.accessibleElementById("button-referencing-checkbox");
+    output += expect("platformValueForW3CName(buttonReferencingCheckbox)", "'Checkbox Label Text'");
+
+    var buttonReferencingCheckboxAriaLabel = accessibilityController.accessibleElementById("button-referencing-checkbox-arialabel");
+    output += expect("platformValueForW3CName(buttonReferencingCheckboxAriaLabel)", "'Checkbox ARIA Label'");
+
+    var buttonReferencingRadio = accessibilityController.accessibleElementById("button-referencing-radio");
+    output += expect("platformValueForW3CName(buttonReferencingRadio)", "'Radio Label Text'");
+
+    var newLabel = document.createElement("label");
+    newLabel.setAttribute("for", "checkbox-with-label");
+    newLabel.id = "new-label";
+    newLabel.textContent = "Updated Checkbox Label";
+    document.querySelector("label[for='checkbox-with-label']").remove();
+    document.body.appendChild(newLabel);
+
+    setTimeout(async function() {
+        output += await expectAsync("platformValueForW3CName(buttonReferencingCheckbox)", "'Updated Checkbox Label'");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### c4647c597529734f6e159485f035f2de45744351
<pre>
AX: aria-labelledby uses referenced checkbox value instead of name
<a href="https://bugs.webkit.org/show_bug.cgi?id=284774">https://bugs.webkit.org/show_bug.cgi?id=284774</a>
<a href="https://rdar.apple.com/141564913">rdar://141564913</a>

Reviewed by Chris Fleizach.

When computing accessible names for aria-labelledby references, checkboxes
and radio buttons incorrectly returned their value attribute instead of
their label text. Fix by looking up associated label elements for these
input types.

Test: accessibility/aria-labelledby-on-checkbox.html

* LayoutTests/accessibility/aria-labelledby-on-checkbox-expected.txt: Added.
* LayoutTests/accessibility/aria-labelledby-on-checkbox.html: Added.
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::accessibleNameForNode):

Canonical link: <a href="https://commits.webkit.org/305894@main">https://commits.webkit.org/305894@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/262dee16c74ced30fe8986fb79838e7ac18cf5b3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139453 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11829 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/955 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147580 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92521 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/81aaf6db-bd4b-4422-b22f-71f02c28ed95) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141326 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12537 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/11979 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106766 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77732 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7ff8e776-e96b-430a-aade-abe5aa46262f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142400 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9582 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/125129 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87629 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a77d7657-3534-4813-9d58-3c970704dac1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9194 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6828 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7878 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118514 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/878 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150363 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11513 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/894 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115166 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11527 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9827 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115479 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29394 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9949 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121323 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66519 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11557 "Built successfully") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11291 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75223 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11493 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11344 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->