### PR TITLE
[visionOS] WebAVPlayerController leaks when playing a video in Safari one window and entering tab overview in another window

### DIFF
--- a/Source/WebCore/platform/ios/WebAVPlayerController.h
+++ b/Source/WebCore/platform/ios/WebAVPlayerController.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -144,8 +144,10 @@ class PlaybackSessionInterfaceIOS;
 
 @end
 
-Class webAVPlayerControllerClassSingleton();
+namespace WebCore {
 RetainPtr<WebAVPlayerController> createWebAVPlayerController();
+WEBCORE_EXPORT Class webAVPlayerControllerClassSingleton();
+}
 
 NS_ASSUME_NONNULL_END
 

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -53,6 +53,8 @@ ios/IOSMouseEventTestHarness.mm @nonARC
 
 Tests/WTF/cocoa/URLExtras.mm @nonARC
 
+Tests/WebCore/cocoa/WebAVPlayerControllerLeakTests.mm @nonARC
+
 Tests/WebKitCocoa/AVFoundationPreference.mm @nonARC
 Tests/WebKitCocoa/AdaptiveImageGlyph.mm @nonARC
 Tests/WebKitCocoa/AdditionalReadAccessAllowedURLs.mm @nonARC

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -3805,6 +3805,7 @@
 		A1798B862243446B000764BD /* apple-pay-availability.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "apple-pay-availability.html"; sourceTree = "<group>"; };
 		A1798B8822435D2E000764BD /* apple-pay-availability-in-iframe.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "apple-pay-availability-in-iframe.html"; sourceTree = "<group>"; };
 		A17991861E1C994E00A505ED /* SharedBuffer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = SharedBuffer.mm; sourceTree = "<group>"; };
+		6869316B2E69A1B000121550 /* WebAVPlayerControllerLeakTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebAVPlayerControllerLeakTests.mm; sourceTree = "<group>"; };
 		A17991891E1CA24100A505ED /* SharedBufferTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SharedBufferTest.cpp; sourceTree = "<group>"; };
 		A179918A1E1CA24100A505ED /* SharedBufferTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SharedBufferTest.h; sourceTree = "<group>"; };
 		A17A5A3422A887EC0065C5F0 /* AppKitTestSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppKitTestSPI.h; sourceTree = "<group>"; };
@@ -6982,6 +6983,7 @@
 				7BA3936B271EDFCA0015911C /* TestGraphicsContextGLCocoa.mm */,
 				74DEF21D2A946FD700E034A3 /* TestUTIRegistry.cpp */,
 				7498C3CF2A94435F009A387E /* TestUTIUtilities.cpp */,
+				6869316B2E69A1B000121550 /* WebAVPlayerControllerLeakTests.mm */,
 				CD89D0381C4EDB2A00040A04 /* WebCoreNSURLSession.mm */,
 				44D3F8382BE1A6BE00BE0218 /* XMLParsing.mm */,
 			);

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/WebAVPlayerControllerLeakTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/WebAVPlayerControllerLeakTests.mm
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if PLATFORM(IOS_FAMILY) && HAVE(AVKIT)
+
+#import <WebCore/WebAVPlayerController.h>
+#import <objc/runtime.h>
+#import <wtf/RetainPtr.h>
+
+namespace TestWebKitAPI {
+
+// Test that the normal WebAVPlayerControllerForwarder class properly releases its ivar.
+TEST(WebAVPlayerControllerLeak, NormalForwarderClassReleasesIvar)
+{
+    __weak id weakController = nil;
+
+    @autoreleasepool {
+        // Get the normal WebAVPlayerControllerForwarder class (not the dynamic subclass)
+        Class forwarderClass = objc_getClass("WebAVPlayerControllerForwarder");
+        ASSERT_NE(forwarderClass, nullptr);
+
+        // Create an instance of the normal forwarder class
+        id forwarder = [[forwarderClass alloc] init];
+        ASSERT_NE(forwarder, nil);
+
+        // Get the _playerController via the getter
+        id playerController = [forwarder performSelector:@selector(playerController)];
+        ASSERT_NE(playerController, nil);
+
+        // Store a weak reference to track if it gets deallocated
+        weakController = playerController;
+        EXPECT_NE(weakController, nil);
+
+        // Release the forwarder - this should release the _playerController too
+        [forwarder release];
+    }
+
+    // The weak reference should be nil because the _playerController was properly released
+    EXPECT_EQ(weakController, nil);
+}
+
+// Test that the dynamically-created WebAVPlayerControllerForwarder_AVKitCompatible class
+// properly releases its ivar.
+TEST(WebAVPlayerControllerLeak, DynamicForwarderClassReleasesIvar)
+{
+    __weak id weakController = nil;
+
+    @autoreleasepool {
+        // Get the dynamically-created class
+        Class dynamicClass = WebCore::webAVPlayerControllerClassSingleton();
+        ASSERT_NE(dynamicClass, nullptr);
+
+        // Verify it's the dynamic class, not the normal one
+        EXPECT_STREQ(class_getName(dynamicClass), "WebAVPlayerControllerForwarder_AVKitCompatible");
+
+        // Create an instance of the dynamic class
+        id forwarder = [[dynamicClass alloc] init];
+        ASSERT_NE(forwarder, nil);
+
+        // Get the _playerController via the getter
+        id playerController = [forwarder performSelector:@selector(playerController)];
+
+        // The playerController should be set by -init
+        ASSERT_NE(playerController, nil);
+
+        // Store a weak reference to track if it gets deallocated
+        weakController = playerController;
+        EXPECT_NE(weakController, nil);
+
+        // Release the forwarder - this should release the _playerController too
+        [forwarder release];
+    }
+
+    // The weak reference should be nil because the _playerController was properly released.
+    EXPECT_EQ(weakController, nil);
+}
+
+} // namespace TestWebKitAPI
+
+#endif // PLATFORM(IOS_FAMILY) && HAVE(AVKIT)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurity.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurity.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,7 +29,9 @@
 #import "PlatformUtilities.h"
 #import "TestCocoa.h"
 #import "TestNavigationDelegate.h"
+#import "TestUIDelegate.h"
 #import "TestWKWebView.h"
+#import <WebKit/WKFrameInfoPrivate.h>
 #import <WebKit/WKProcessPoolPrivate.h>
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/WKWebViewPrivateForTesting.h>

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
@@ -32,6 +32,7 @@
 #import "Utilities.h"
 #import <WebKit/WKNavigationDelegatePrivate.h>
 #import <WebKit/WKPreferencesPrivate.h>
+#import <WebKit/WKProcessPoolPrivate.h>
 #import <WebKit/WKWebView.h>
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/_WKFeature.h>

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteWebArchive.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteWebArchive.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,6 +34,7 @@
 #import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKPreferencesRefPrivate.h>
 #import <WebKit/WKWebViewConfigurationPrivate.h>
+#import <WebKit/WKWebViewPrivate.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/text/WTFString.h>
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ScreenTime.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ScreenTime.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,6 +32,7 @@
 #import "InstanceMethodSwizzler.h"
 #import "PlatformUtilities.h"
 #import "Test.h"
+#import "TestCocoa.h"
 #import "TestNavigationDelegate.h"
 #import "TestWKWebView.h"
 #import "Utilities.h"

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2025-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,6 +25,7 @@
 
 #import "config.h"
 
+#import "HTTPServer.h"
 #import "InstanceMethodSwizzler.h"
 #import "PlatformUtilities.h"
 #import "SafeBrowsingSPI.h"
@@ -39,6 +40,7 @@
 #import <WebKit/_WKTextExtraction.h>
 #import <wtf/SoftLinking.h>
 #import <wtf/WorkQueue.h>
+#import <wtf/text/MakeString.h>
 
 SOFT_LINK_PRIVATE_FRAMEWORK(SafariSafeBrowsing);
 SOFT_LINK_CLASS(SafariSafeBrowsing, SSBLookupContext);


### PR DESCRIPTION
#### 30ae065f0e43e2a0f52667ffc1520bb74cec19c7
<pre>
[visionOS] WebAVPlayerController leaks when playing a video in Safari one window and entering tab overview in another window
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=305752">https://bugs.webkit.org/show_bug.cgi?id=305752</a>&gt;
&lt;<a href="https://rdar.apple.com/121550335">rdar://121550335</a>&gt;

Reviewed by Geoffrey Garen.

Tests: Tools/TestWebKitAPI/Tests/WebCore/cocoa/WebAVPlayerControllerLeakTests.mm

Fix the following bugs:

1. Fix leak of WebAVPlayerController object by adding
   -[WebAVPlayerControllerForwarder dealloc] method that clears the
   _playerController instance variable.  When using RetainPtr&lt;&gt; as an
   ivar, the ObjC runtime does not auto-generate -.cxx_construct or
   -.cxx_destruct methods, which caused the leak.
2. Fix addition of the _playerController instance variable to dynamic
   WebAVPlayerControllerForwarder_AVKitCompatible class by calling
   class_addIvar() before objc_registerClassPair().
3. Simplify WebAVPlayerControllerForwarder by replacing RetainPtr with a
   direct instance variable for _playerController, implementing
   getter/setter methods for _playerController that work for both the
   original and dynamic classes by computing the ivar location at
   runtime, then using a getter/setter in all other instance methods
   instead of direct instance variable access.  Using direct instance
   variable access would read from/write to the wrong location in the
   WebAVPlayerControllerForwarder_AVKitCompatible object since
   _playerController was in a different location.  This removes the need
   for custom methods in the dynamic class.

* Source/WebCore/platform/ios/WebAVPlayerController.h:
(WebCore::createWebAVPlayerController):
(WebCore::webAVPlayerControllerClassSingleton):
- Move into WebCore namespace.
- Export webAVPlayerControllerClassSingleton() for testing.
* Source/WebCore/platform/ios/WebAVPlayerController.mm:
(-[WebAVPlayerControllerForwarder playerController]):
(-[WebAVPlayerControllerForwarder setPlayerController:]):
- Add @property definition to document playerController instance
  variable with getter and setter.
- Change _playerController ivar from RetainPtr&lt;&gt; to raw pointer for
  simplicity and avoid pointer math in getter and setter.
- Implement getter and setter so that they work for both
  WebAVPlayerControllerForwarder and the dynamically constructed class.
(-[WebAVPlayerControllerForwarder init]):
- Update to use setter instead of direct ivar access.
(-[WebAVPlayerControllerForwarder dealloc]): Add.
- Use setter to clear _playerController ivar.
(-[WebAVPlayerControllerForwarder respondsToSelector:]):
- Update to use getter.
(-[WebAVPlayerControllerForwarder forwardingTargetForSelector:]):
- Update to use getter.
(-[WebAVPlayerControllerForwarder _forwardingTargetForKeyPath:]):
- Update to use getter.
- Use RetainPtr&lt;&gt; for local variables and optimize with autorelease()
  and WTF::move().
(createWebAVPlayerControllerForwarderClassSingleton):
- Call class_addIvar() before objc_registerClassPair() to make sure
  _playerController ivar is created properly.
- Ignore &quot;.&quot; methods when overriding AVPlayerController methods.
(WebCore::createWebAVPlayerController):
(WebCore::webAVPlayerControllerClassSingleton):
- Move into WebCore namespace.

* Tools/TestWebKitAPI/SourcesCocoa.txt:
- Add Tests/WebCore/cocoa/WebAVPlayerControllerLeakTests.mm.
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
- Add Tests/WebCore/cocoa/WebAVPlayerControllerLeakTests.mm.
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/WebAVPlayerControllerLeakTests.mm: Add.
(TestWebKitAPI::TEST(WebAVPlayerControllerLeak, NormalForwarderClassReleasesIvar)): Add.
(TestWebKitAPI::TEST(WebAVPlayerControllerLeak, DynamicForwarderClassReleasesIvar)): Add.
- Add tests to verify correct instance object behavior.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurity.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/PasteWebArchive.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ScreenTime.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm:
- Add missing headers after UnifiedSources reshuffle.

Canonical link: <a href="https://commits.webkit.org/306145@main">https://commits.webkit.org/306145@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1af943dace9d695df8e1c30736f7dea09c41bef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140458 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12840 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1971 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148787 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/93545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b73e7b18-30df-423a-8291-c9cc8a50769c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142331 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13552 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12994 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107680 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/93545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d7767468-19e0-4be7-b02f-110b3722535b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143409 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10435 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125733 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88580 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d8003248-b646-41f8-9843-1d09e4ea016a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10051 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7610 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8891 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119290 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1752 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151412 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12528 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1825 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115983 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12543 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10747 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116321 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/11579 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122236 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67551 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21678 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12570 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/1706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12310 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76270 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12508 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12354 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->