### PR TITLE
Digital Credentials: improve c++ safeness

### DIFF
--- a/Source/WebKit/UIProcess/DigitalCredentials/WKDigitalCredentialsPicker.mm
+++ b/Source/WebKit/UIProcess/DigitalCredentials/WKDigitalCredentialsPicker.mm
@@ -308,10 +308,10 @@ static RetainPtr<NSArray<NSArray<WKIdentityDocumentPresentmentRequestAuthenticat
 
     for (auto&& validatedRequest : requestData.requests) {
 
-        RetainPtr<NSArray<WKIdentityDocumentPresentmentMobileDocumentPresentmentRequest *>> presentmentRequests = mapPresentmentRequests(validatedRequest.presentmentRequests);
-        RetainPtr<NSArray<NSArray<WKIdentityDocumentPresentmentRequestAuthenticationCertificate *> *>> authenticationCertificates = mapRequestAuthentications(validatedRequest.requestAuthentications);
+        RetainPtr presentmentRequests = mapPresentmentRequests(validatedRequest.presentmentRequests);
+        RetainPtr authenticationCertificates = mapRequestAuthentications(validatedRequest.requestAuthentications);
 
-        RetainPtr mobileDocumentRequest = [WebKit::allocWKIdentityDocumentPresentmentMobileDocumentRequestInstance() initWithPresentmentRequests:presentmentRequests.get() authenticationCertificates:authenticationCertificates.get()];
+        RetainPtr mobileDocumentRequest = adoptNS([WebKit::allocWKIdentityDocumentPresentmentMobileDocumentRequestInstance() initWithPresentmentRequests:presentmentRequests.get() authenticationCertificates:authenticationCertificates.get()]);
         [mobileDocumentRequests addObject:mobileDocumentRequest.get()];
     }
 

--- a/Source/WebKit/WebProcess/DigitalCredentials/DigitalCredentialsCoordinator.cpp
+++ b/Source/WebKit/WebProcess/DigitalCredentials/DigitalCredentialsCoordinator.cpp
@@ -98,8 +98,7 @@ void DigitalCredentialsCoordinator::dismissDigitalCredentialsPicker(CompletionHa
 void DigitalCredentialsCoordinator::provideRawDigitalCredentialRequests(CompletionHandler<void(Vector<WebCore::UnvalidatedDigitalCredentialRequest>&&)>&& completionHandler)
 {
     ASSERT(!m_rawRequests.isEmpty());
-    completionHandler(WTF::move(m_rawRequests));
-    m_rawRequests.clear();
+    completionHandler(std::exchange(m_rawRequests, { }));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/DigitalCredentials/DigitalCredentialsCoordinator.h
+++ b/Source/WebKit/WebProcess/DigitalCredentials/DigitalCredentialsCoordinator.h
@@ -53,7 +53,6 @@ class DigitalCredentialsCoordinator : public WebCore::CredentialRequestCoordinat
     WTF_MAKE_TZONE_ALLOCATED(DigitalCredentialsCoordinator);
 
 public:
-    explicit DigitalCredentialsCoordinator(WebPage&);
     ~DigitalCredentialsCoordinator();
 
     static Ref<DigitalCredentialsCoordinator> create(WebPage&);
@@ -66,6 +65,8 @@ public:
     void provideRawDigitalCredentialRequests(CompletionHandler<void(Vector<WebCore::UnvalidatedDigitalCredentialRequest>&&)>&&);
 
 private:
+    explicit DigitalCredentialsCoordinator(WebPage&);
+
     // IPC::MessageReceiver.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
 


### PR DESCRIPTION
#### fd556bc5bbf1f0bd480af1d4dd913c5d314c4633
<pre>
Digital Credentials: improve c++ safeness
<a href="https://rdar.apple.com/168427091">rdar://168427091</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=305750">https://bugs.webkit.org/show_bug.cgi?id=305750</a>

Reviewed by Anne van Kesteren.

Addresses some small c++ safeness issues in Digital Credentials code.

Relies on existing tests.

* Source/WebKit/UIProcess/DigitalCredentials/WKDigitalCredentialsPicker.mm:
(-[WKDigitalCredentialsPicker performRequest:]): missing adoptNS() wrapper.
* Source/WebKit/WebProcess/DigitalCredentials/DigitalCredentialsCoordinator.cpp: use std:exchange to clear m_rawRequests after passing it to the completion handler. Was moving it then clearing it, which could lead to use-after-move issues.
(WebKit::DigitalCredentialsCoordinator::provideRawDigitalCredentialRequests):
* Source/WebKit/WebProcess/DigitalCredentials/DigitalCredentialsCoordinator.h: made explicit constructor private.

Canonical link: <a href="https://commits.webkit.org/305822@main">https://commits.webkit.org/305822@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf9b3c619590095f01c52eb2b9b94dd05c8479af

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139479 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11855 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/981 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147606 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92547 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ec24e09d-ef17-4c7e-bd9a-f595a7f16d42) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12563 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12005 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106783 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77747 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6e3e7be5-168e-4660-95cc-4cfe53371a5e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142426 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9603 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124926 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87646 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/900ab06c-a0e2-47ef-a794-183abe58b714) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9220 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6848 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7905 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118532 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150389 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11539 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/922 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115185 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11553 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9854 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115497 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/9994 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121351 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66545 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21519 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11583 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/859 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11318 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75249 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11519 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11370 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->