### PR TITLE
Allow implicit conversion from RefPtr<T> to T*

### DIFF
--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -1038,7 +1038,7 @@ RegisterID* BracketAccessorNode::emitBytecode(BytecodeGenerator& generator, Regi
 
     bool subscriptIsNonIndexString = isNonIndexStringElement(*m_subscript);
     RefPtr<RegisterID> base = subscriptIsNonIndexString
-        ? generator.emitNode(m_base)
+        ? RefPtr { generator.emitNode(m_base) }
         : generator.emitNodeForLeftHandSide(m_base, m_subscriptHasAssignments, m_subscript->isPure(generator));
 
     if (m_base->isOptionalChainBase())

--- a/Source/JavaScriptCore/runtime/Identifier.h
+++ b/Source/JavaScriptCore/runtime/Identifier.h
@@ -232,7 +232,6 @@ JSValue identifierToSafePublicJSValue(VM&, const Identifier&);
 // crashes in code that somehow dangled a StringImpl.
 // https://bugs.webkit.org/show_bug.cgi?id=150137
 struct IdentifierRepHash : PtrHash<RefPtr<UniquedStringImpl>> {
-    static unsigned hash(const RefPtr<UniquedStringImpl>& key) { return key->existingSymbolAwareHash(); }
     static unsigned hash(const UniquedStringImpl* key) { return key->existingSymbolAwareHash(); }
     static constexpr bool hasHashInValue = true;
 };

--- a/Source/WTF/wtf/HashFunctions.h
+++ b/Source/WTF/wtf/HashFunctions.h
@@ -135,10 +135,10 @@ namespace WTF {
         static bool equal(std::add_const_t<UnderlyingType>* a, std::add_const_t<UnderlyingType>* b) { return a == b; }
         static constexpr bool safeToCompareToEmptyOrDeleted = true;
 
-        static unsigned hash(const T& key) { return hash(getPtr(key)); }
-        static bool equal(const T& a, const T& b) { return getPtr(a) == getPtr(b); }
-        static bool equal(std::add_const_t<UnderlyingType>* a, const T& b) { return a == getPtr(b); }
-        static bool equal(const T& a, std::add_const_t<UnderlyingType>* b) { return getPtr(a) == b; }
+        static unsigned hash(const T& key) requires(!std::is_convertible_v<const T&, std::add_const_t<UnderlyingType>*>) { return hash(getPtr(key)); }
+        static bool equal(const T& a, const T& b) requires(!std::is_convertible_v<const T&, std::add_const_t<UnderlyingType>*>) { return getPtr(a) == getPtr(b); }
+        static bool equal(std::add_const_t<UnderlyingType>* a, const T& b) requires(!std::is_convertible_v<const T&, std::add_const_t<UnderlyingType>*>) { return a == getPtr(b); }
+        static bool equal(const T& a, std::add_const_t<UnderlyingType>* b) requires(!std::is_convertible_v<const T&, std::add_const_t<UnderlyingType>*>) { return getPtr(a) == b; }
     };
 
     template<typename T> struct PtrHash : PtrHashBase<T, IsSmartPtr<T>::value> {

--- a/Source/WTF/wtf/HashTraits.h
+++ b/Source/WTF/wtf/HashTraits.h
@@ -225,7 +225,7 @@ template<typename P, typename Q, typename R> struct HashTraits<RefPtr<P, Q, R>> 
     static bool isEmptyValue(const RefPtr<P, Q, R>& value) { return !value; }
 
     using PeekType = P*;
-    static PeekType peek(const RefPtr<P, Q, R>& value) { return value.get(); }
+    static PeekType peek(const RefPtr<P, Q, R>& value) { return value; }
     static PeekType peek(P* value) { return value; }
 
     static void customDeleteBucket(RefPtr<P, Q, R>& value)

--- a/Source/WTF/wtf/RefPtr.h
+++ b/Source/WTF/wtf/RefPtr.h
@@ -67,6 +67,7 @@ public:
 
     T* get() const LIFETIME_BOUND { return PtrTraits::unwrap(m_ptr); }
     T* unsafeGet() const { return PtrTraits::unwrap(m_ptr); } // FIXME: Replace with get() then remove.
+    operator T*() const LIFETIME_BOUND { return PtrTraits::unwrap(m_ptr); }
 
     Ref<T> releaseNonNull() { ASSERT(m_ptr); Ref<T> tmp(adoptRef(*m_ptr)); m_ptr = nullptr; return tmp; }
 
@@ -76,11 +77,6 @@ public:
     ALWAYS_INLINE T* operator->() const LIFETIME_BOUND { return &**this; }
 
     bool operator!() const { return !m_ptr; }
-
-    // This conversion operator allows implicit conversion to bool but not to other integer types.
-    using UnspecifiedBoolType = void (RefPtr::*)() const;
-    operator UnspecifiedBoolType() const { return m_ptr ? &RefPtr::unspecifiedBoolTypeInstance : nullptr; }
-
     explicit operator bool() const { return !!m_ptr; }
     
     RefPtr& operator=(const RefPtr&);
@@ -97,8 +93,6 @@ public:
     [[nodiscard]] RefPtr copyRef() const & { return RefPtr(m_ptr); }
 
 private:
-    void unspecifiedBoolTypeInstance() const { }
-
     friend RefPtr adoptRef<T, PtrTraits, RefDerefTraits>(T*);
     template<typename X, typename Y, typename Z> friend class RefPtr;
 

--- a/Source/WTF/wtf/ThreadSafeWeakPtr.h
+++ b/Source/WTF/wtf/ThreadSafeWeakPtr.h
@@ -585,7 +585,7 @@ public:
         m_weak = nullptr;
         m_strong = WTF::move(strong);
         ASSERT(isStrong());
-        return m_strong.get();
+        return m_strong;
     }
 
     ThreadSafeWeakOrStrongPtr& operator=(const ThreadSafeWeakOrStrongPtr& other)

--- a/Source/WTF/wtf/text/SymbolRegistry.cpp
+++ b/Source/WTF/wtf/text/SymbolRegistry.cpp
@@ -61,7 +61,7 @@ Ref<RegisteredSymbolImpl> SymbolRegistry::symbolForKey(const String& rep)
 // When removing a registered symbol from the table, we know it's already the one in the table, so no need for a string equality check.
 struct SymbolRegistryTableRemovalHashTranslator {
     static unsigned hash(const RegisteredSymbolImpl* key) { return key->hash(); }
-    static bool equal(const RefPtr<StringImpl>& a, const RegisteredSymbolImpl* b) { return a.get() == b; }
+    static bool equal(const RefPtr<StringImpl>& a, const RegisteredSymbolImpl* b) { return a == b; }
 };
 
 void SymbolRegistry::remove(RegisteredSymbolImpl& uid)

--- a/Source/WebCore/accessibility/AXTableHelpers.cpp
+++ b/Source/WebCore/accessibility/AXTableHelpers.cpp
@@ -242,13 +242,13 @@ bool isDataTableWithTraversal(HTMLTableElement& tableElement, AXObjectCache& cac
                     if (topSectionIndicatesLayoutTable(tableSectionElement))
                         return false;
                 } else if (elementName == ElementName::HTML_tbody)
-                    firstBody = firstBody ? firstBody : tableSectionElement;
+                    firstBody = firstBody ? firstBody : RefPtr { tableSectionElement };
                 else {
                     ASSERT_WITH_MESSAGE(elementName == ElementName::HTML_tfoot, "table section elements should always have either thead, tbody, or tfoot tag");
-                    firstFoot = firstFoot ? firstFoot : tableSectionElement;
+                    firstFoot = firstFoot ? firstFoot : RefPtr { tableSectionElement };
                 }
             } else if (auto* tableRow = dynamicDowncast<HTMLTableRowElement>(currentElement.get())) {
-                firstRow = firstRow ? firstRow : tableRow;
+                firstRow = firstRow ? firstRow : RefPtr { tableRow };
 
                 rowCount += 1;
                 if (isDataTableBasedOnRowColumnCount())

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -1467,7 +1467,7 @@ AXTextMarker AXTextMarker::toTextRunMarker(std::optional<AXID> stopAtID) const
     // AXTextMarker { ID 3: StaticText, Offset 3 }
     // Because we had to walk over ID 2 which had length 3 text.
     size_t precedingOffset = 0;
-    RefPtr current = runs ? WTF::move(object) : findObjectWithRuns(*object, AXDirection::Next, stopAtID);
+    RefPtr current = runs ? WTF::move(object) : RefPtr { findObjectWithRuns(*object, AXDirection::Next, stopAtID) };
     while (current) {
         unsigned totalLength = current->textRuns()->totalLength();
         if (precedingOffset + totalLength >= offset())

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -1725,7 +1725,7 @@ AXTextMarker AXIsolatedTree::lastMarker()
 
     const auto& children = root->unignoredChildren();
     // Start the `findLast` traversal from the last child of the root to reduce the amount of traversal done.
-    RefPtr endObject = children.isEmpty() ? root : dynamicDowncast<AXIsolatedObject>(children[children.size() - 1].get());
+    RefPtr endObject = children.isEmpty() ? root : dynamicDowncast<AXIsolatedObject>(children[children.size() - 1]);
     return endObject ? AXTextMarker { *endObject, 0 }.findLast() : AXTextMarker();
 }
 #endif // ENABLE(AX_THREAD_TEXT_APIS)

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
@@ -568,7 +568,7 @@ NSRange makeNSRange(std::optional<SimpleRange> range)
         return NSMakeRange(NSNotFound, 0);
 
     RefPtr rootEditableElement = frame->selection().selection().rootEditableElement();
-    RefPtr scope = rootEditableElement ? rootEditableElement : document->documentElement();
+    RefPtr scope = rootEditableElement ? rootEditableElement : RefPtr { document->documentElement() };
     if (!scope)
         return NSMakeRange(NSNotFound, 0);
 
@@ -593,7 +593,7 @@ std::optional<SimpleRange> makeDOMRange(Document* document, NSRange range)
     // to use the root editable element of the selection start as the positional base.
     // That fits with AppKit's idea of an input context.
     RefPtr selectionRoot = document->frame()->selection().selection().rootEditableElement();
-    RefPtr scope = selectionRoot ? selectionRoot : document->documentElement();
+    RefPtr scope = selectionRoot ? selectionRoot : RefPtr { document->documentElement() };
     if (!scope)
         return std::nullopt;
 

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -315,7 +315,7 @@ void WebAnimation::setTimeline(RefPtr<AnimationTimeline>&& timeline)
     Ref protectedThis { *this };
     setTimelineInternal(WTF::move(timeline));
 
-    RefPtr documentTimeline = dynamicDowncast<DocumentTimeline>(m_timeline.get());
+    RefPtr documentTimeline = dynamicDowncast<DocumentTimeline>(m_timeline);
     setSuspended(documentTimeline && documentTimeline->animationsAreSuspended());
 
     // 9. Perform the steps corresponding to the first matching condition from the following, if any:
@@ -752,7 +752,7 @@ void WebAnimation::setEffectiveFrameRate(std::optional<FramesPerSecond> effectiv
         return;
 
     std::optional<FramesPerSecond> maximumFrameRate = std::nullopt;
-    if (RefPtr timeline = dynamicDowncast<DocumentTimeline>(m_timeline.get()))
+    if (RefPtr timeline = dynamicDowncast<DocumentTimeline>(m_timeline))
         maximumFrameRate = timeline->maximumFrameRate();
 
     std::optional<FramesPerSecond> adjustedEffectiveFrameRate;
@@ -857,7 +857,7 @@ void WebAnimation::cancel(Silently silently)
         //    scheduled event time is an unresolved time value.
         // Otherwise, queue a task to dispatch cancelEvent at animation. The task source for this task is the DOM manipulation task source.
         auto scheduledTime = [&]() -> std::optional<WebAnimationTime> {
-            if (RefPtr documentTimeline = dynamicDowncast<DocumentTimeline>(m_timeline.get())) {
+            if (RefPtr documentTimeline = dynamicDowncast<DocumentTimeline>(m_timeline)) {
                 if (auto currentTime = documentTimeline->currentTime())
                     return documentTimeline->convertTimelineTimeToOriginRelativeTime(*currentTime);
             }
@@ -899,7 +899,7 @@ void WebAnimation::enqueueAnimationEvent(Ref<AnimationEventBase>&& event)
     auto documentTimeline = [&]() -> DocumentTimeline* {
         if (auto* timeline = dynamicDowncast<DocumentTimeline>(m_timeline.get()))
             return timeline;
-        if (RefPtr scrollTimeline = dynamicDowncast<ScrollTimeline>(m_timeline.get())) {
+        if (RefPtr scrollTimeline = dynamicDowncast<ScrollTimeline>(m_timeline)) {
             if (RefPtr source = scrollTimeline->source())
                 return Ref { source->document() }->existingTimeline();
         }
@@ -1148,7 +1148,7 @@ void WebAnimation::finishNotificationSteps()
     //    effect end to an origin-relative time.
     //    Otherwise, queue a task to dispatch finishEvent at animation. The task source for this task is the DOM manipulation task source.
     auto scheduledTime = [&]() -> std::optional<WebAnimationTime> {
-        if (RefPtr documentTimeline = dynamicDowncast<DocumentTimeline>(m_timeline.get())) {
+        if (RefPtr documentTimeline = dynamicDowncast<DocumentTimeline>(m_timeline)) {
             if (auto animationEndTime = convertAnimationTimeToTimelineTime(effectEndTime()))
                 return documentTimeline->convertTimelineTimeToOriginRelativeTime(*animationEndTime);
         }

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -502,7 +502,7 @@ SelectorChecker::MatchResult SelectorChecker::matchRecursively(CheckingContext& 
     case CSSSelector::Relation::ShadowPartDescendant: {
         // Continue matching in the scope where this rule came from.
         RefPtr host = checkingContext.styleScopeOrdinal == Style::ScopeOrdinal::Element
-            ? context.element->shadowHost()
+            ? RefPtr { context.element->shadowHost() }
             : Style::hostForScopeOrdinal(*context.element, checkingContext.styleScopeOrdinal);
         if (!host)
             return MatchResult::fails(Match::SelectorFailsCompletely);

--- a/Source/WebCore/editing/FormatBlockCommand.cpp
+++ b/Source/WebCore/editing/FormatBlockCommand.cpp
@@ -67,7 +67,7 @@ void FormatBlockCommand::formatRange(const Position& start, const Position& end,
 {
     RefPtr nodeToSplitTo = enclosingBlockToSplitTreeTo(start.deprecatedNode());
     ASSERT(nodeToSplitTo);
-    RefPtr<Node> outerBlock = (start.deprecatedNode() == nodeToSplitTo) ? start.deprecatedNode() : splitTreeToNode(*start.deprecatedNode(), *nodeToSplitTo);
+    RefPtr<Node> outerBlock = (start.deprecatedNode() == nodeToSplitTo) ? RefPtr { start.deprecatedNode() } : splitTreeToNode(*start.deprecatedNode(), *nodeToSplitTo);
     if (!outerBlock)
         return;
 

--- a/Source/WebCore/editing/IndentOutdentCommand.cpp
+++ b/Source/WebCore/editing/IndentOutdentCommand.cpp
@@ -107,7 +107,7 @@ void IndentOutdentCommand::indentIntoBlockquote(const Position& start, const Pos
     if (!nodeToSplitTo)
         return;
 
-    RefPtr<Node> outerBlock = (start.containerNode() == nodeToSplitTo) ? start.containerNode() : splitTreeToNode(*start.containerNode(), *nodeToSplitTo);
+    RefPtr<Node> outerBlock = (start.containerNode() == nodeToSplitTo) ? RefPtr { start.containerNode() } : splitTreeToNode(*start.containerNode(), *nodeToSplitTo);
     if (!outerBlock)
         return;
 

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -1419,7 +1419,7 @@ void WebGLRenderingContextBase::uncacheDeletedBuffer(const AbstractLocker& locke
 void WebGLRenderingContextBase::setBoundVertexArrayObject(const AbstractLocker&, WebGLVertexArrayObjectBase* arrayObject)
 {
     ASSERT(m_defaultVertexArrayObject);
-    m_boundVertexArrayObject = arrayObject ? arrayObject : m_defaultVertexArrayObject;
+    m_boundVertexArrayObject = arrayObject ? RefPtr { arrayObject } : m_defaultVertexArrayObject;
 }
 
 #undef REMOVE_BUFFER_FROM_BINDING

--- a/Source/WebCore/html/parser/HTMLConstructionSite.cpp
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.cpp
@@ -829,7 +829,7 @@ std::tuple<RefPtr<HTMLElement>, RefPtr<JSCustomElementInterface>, RefPtr<CustomE
     Ref ownerDocument = treeScope->documentScope();
     bool insideTemplateElement = m_openElements.containsTemplateElement();
     RefPtr element = HTMLElementFactory::createKnownElement(token.tagName(), ownerDocument, insideTemplateElement ? nullptr : form(), true);
-    RefPtr<CustomElementRegistry> registry = m_openElements.stackDepth() > 1 ? registryForCurrentNode(currentNode(), treeScope) : m_registry;
+    RefPtr<CustomElementRegistry> registry = m_openElements.stackDepth() > 1 ? RefPtr { registryForCurrentNode(currentNode(), treeScope) } : m_registry;
     if (!element) [[unlikely]] {
         auto* elementInterface = registry ? registry->findInterface(token.name()) : nullptr;
         if (elementInterface) [[unlikely]] {

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -1750,7 +1750,7 @@ void DocumentLoader::clearArchiveResources()
 
 SharedBuffer* DocumentLoader::parsedArchiveData() const
 {
-    return m_parsedArchiveData.get();
+    return m_parsedArchiveData;
 }
 
 #endif // ENABLE(WEB_ARCHIVE) || ENABLE(MHTML)
@@ -2584,7 +2584,7 @@ void DocumentLoader::setPreviewConverter(RefPtr<PreviewConverter>&& previewConve
 
 PreviewConverter* DocumentLoader::previewConverter() const
 {
-    return m_previewConverter.get();
+    return m_previewConverter;
 }
 
 #endif

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -2222,8 +2222,8 @@ void FrameLoader::stopForUserCancel(bool deferCheckLoadComplete)
 DocumentLoader* FrameLoader::activeDocumentLoader() const
 {
     if (m_state == FrameState::Provisional)
-        return m_provisionalDocumentLoader.get();
-    return m_documentLoader.get();
+        return m_provisionalDocumentLoader;
+    return m_documentLoader;
 }
 
 RefPtr<DocumentLoader> FrameLoader::protectedActiveDocumentLoader() const
@@ -4647,7 +4647,7 @@ void FrameLoader::retryAfterFailedCacheOnlyMainResourceLoad()
     ASSERT(!m_loadingFromCachedPage);
     ASSERT(history().provisionalItem());
     ASSERT(history().provisionalItem()->formData());
-    ASSERT(history().provisionalItem() == m_requestedHistoryItem.get());
+    ASSERT(history().provisionalItem() == m_requestedHistoryItem);
 
     FrameLoadType loadType = m_loadType;
     RefPtr item = history().provisionalItem();
@@ -4791,7 +4791,7 @@ void FrameLoader::tellClientAboutPastMemoryCacheLoads()
 
 NetworkingContext* FrameLoader::networkingContext() const
 {
-    return m_networkingContext.get();
+    return m_networkingContext;
 }
 
 RefPtr<NetworkingContext> FrameLoader::protectedNetworkingContext() const

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -177,7 +177,7 @@ public:
     WEBCORE_EXPORT HitTestResult hitTestResultAtPoint(const LayoutPoint&, OptionSet<HitTestRequest::Type>) const;
 
     bool mousePressed() const { return m_mousePressed; }
-    Node* mousePressNode() const { return m_mousePressNode.get(); }
+    Node* mousePressNode() const { return m_mousePressNode; }
 
     WEBCORE_EXPORT ScrollableArea* focusedScrollableArea() const;
 

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -2986,7 +2986,7 @@ ExceptionOr<RefPtr<WindowProxy>> LocalDOMWindow::open(LocalDOMWindow& activeWind
         return newFrameOrException.releaseException();
 
     auto newFrame = newFrameOrException.releaseReturnValue();
-    return newFrame ? &newFrame->windowProxy() : RefPtr<WindowProxy> { nullptr };
+    return newFrame ? &newFrame->windowProxy() : nullptr;
 }
 
 void LocalDOMWindow::showModalDialog(const String& urlString, const String& dialogFeaturesString, LocalDOMWindow& activeWindow, LocalDOMWindow& firstWindow, NOESCAPE const Function<void(LocalDOMWindow&)>& prepareDialogFunction)

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -686,7 +686,7 @@ ScrollingCoordinator* Page::scrollingCoordinator()
         protectedScrollingCoordinator()->windowScreenDidChange(m_displayID, m_displayNominalFramesPerSecond);
     }
 
-    return m_scrollingCoordinator.get();
+    return m_scrollingCoordinator;
 }
 
 RefPtr<ScrollingCoordinator> Page::protectedScrollingCoordinator()

--- a/Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp
@@ -268,7 +268,7 @@ void ThreadedScrollingTree::scrollingTreeNodeDidScroll(ScrollingTreeScrollingNod
 
     auto deferrer = ScrollingTreeWheelEventTestMonitorCompletionDeferrer { *this, node.scrollingNodeID(), WheelEventTestMonitor::DeferReason::ScrollingThreadSyncNeeded };
     RunLoop::mainSingleton().dispatch([protectedThis = Ref { *this }, deferrer = WTF::move(deferrer)] {
-        if (RefPtr scrollingCoordinator = protectedThis->m_scrollingCoordinator.get())
+        if (RefPtr scrollingCoordinator = protectedThis->m_scrollingCoordinator)
             scrollingCoordinator->scrollingThreadAddedPendingUpdate();
     });
 }
@@ -291,7 +291,7 @@ void ThreadedScrollingTree::scrollingTreeNodeScrollUpdated(ScrollingTreeScrollin
     addPendingScrollUpdate(WTF::move(scrollUpdate));
 
     RunLoop::mainSingleton().dispatch([protectedThis = Ref { *this }] {
-        if (RefPtr scrollingCoordinator = protectedThis->m_scrollingCoordinator.get())
+        if (RefPtr scrollingCoordinator = protectedThis->m_scrollingCoordinator)
             scrollingCoordinator->scrollingThreadAddedPendingUpdate();
     });
 }

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -1895,7 +1895,8 @@ RefPtr<Element> elementForExtractedText(const LocalFrame& frame, ExtractedText&&
     if (!node)
         return { };
 
-    return dynamicDowncast<Element>(node) ?: node->parentElementInComposedTree();
+    RefPtr element = dynamicDowncast<Element>(node);
+    return element ? element : RefPtr { node->parentElementInComposedTree() };
 }
 
 std::optional<SimpleRange> rangeForExtractedText(const LocalFrame& frame, ExtractedText&& extractedText)

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -2963,7 +2963,7 @@ String RenderLayerCompositor::layerTreeAsText(OptionSet<LayerTreeAsTextOptions> 
     updateCompositingForLayerTreeAsTextDump();
 
     // Exclude any implicitly created layers that wrap the root contents layer, unless the caller explicitly requested the true root to be included.
-    RefPtr dumpRootLayer = (options & LayerTreeAsTextOptions::IncludeRootLayers) ? rootGraphicsLayer() : m_rootContentsLayer;
+    RefPtr dumpRootLayer = (options & LayerTreeAsTextOptions::IncludeRootLayers) ? RefPtr { rootGraphicsLayer() } : m_rootContentsLayer;
 
     if (!dumpRootLayer)
         return String();

--- a/Source/WebCore/svg/SVGAnimateElementBase.cpp
+++ b/Source/WebCore/svg/SVGAnimateElementBase.cpp
@@ -50,7 +50,7 @@ SVGAttributeAnimator* SVGAnimateElementBase::animator() const
     if (!m_animator)
         m_animator = protectedTargetElement()->createAnimator(attributeName(), animationMode(), calcMode(), isAccumulated(), isAdditive());
 
-    return m_animator.get();
+    return m_animator;
 }
 
 bool SVGAnimateElementBase::hasValidAttributeType() const

--- a/Source/WebCore/svg/SVGAnimateElementBase.h
+++ b/Source/WebCore/svg/SVGAnimateElementBase.h
@@ -44,7 +44,7 @@ protected:
 
 private:
     SVGAttributeAnimator* animator() const;
-    SVGAttributeAnimator* animatorIfExists() const { return m_animator.get(); }
+    SVGAttributeAnimator* animatorIfExists() const { return m_animator; }
 
     void setTargetElement(SVGElement*) override;
     void setAttributeName(const QualifiedName&) override;

--- a/Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.cpp
+++ b/Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.cpp
@@ -131,12 +131,12 @@ void SVGFilterPrimitiveStandardAttributes::markFilterEffectForRepaint()
         return;
 
     if (auto* filterPrimitiveRenderer = dynamicDowncast<RenderSVGResourceFilterPrimitive>(renderer.get())) {
-        filterPrimitiveRenderer->markFilterEffectForRepaint(m_effect.get());
+        filterPrimitiveRenderer->markFilterEffectForRepaint(m_effect);
         return;
     }
 
     if (auto* filterPrimitiveRenderer = dynamicDowncast<LegacyRenderSVGResourceFilterPrimitive>(renderer.get())) {
-        filterPrimitiveRenderer->markFilterEffectForRepaint(m_effect.get());
+        filterPrimitiveRenderer->markFilterEffectForRepaint(m_effect);
         return;
     }
 

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
@@ -635,7 +635,7 @@ void NavigationState::NavigationClient::decidePolicyForNavigationAction(WebPageP
             return;
         checker->didCallCompletionHandler();
 
-        RefPtr<API::WebsitePolicies> apiWebsitePolicies = preferences ?  preferences->_websitePolicies.get() : defaultWebsitePolicies;
+        RefPtr<API::WebsitePolicies> apiWebsitePolicies = preferences ?  RefPtr { preferences->_websitePolicies.get() } : defaultWebsitePolicies;
 
         if (apiWebsitePolicies) {
             if (apiWebsitePolicies->websiteDataStore() && subframeNavigation)

--- a/Source/WebKit/UIProcess/WebPermissionControllerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPermissionControllerProxy.cpp
@@ -67,7 +67,7 @@ void WebPermissionControllerProxy::deref() const
 
 void WebPermissionControllerProxy::query(const WebCore::ClientOrigin& clientOrigin, const WebCore::PermissionDescriptor& descriptor, std::optional<WebPageProxyIdentifier> identifier, WebCore::PermissionQuerySource source, CompletionHandler<void(std::optional<WebCore::PermissionState>)>&& completionHandler)
 {
-    auto webPageProxy = identifier ? m_process->webPage(identifier.value()) : mostReasonableWebPageProxy(clientOrigin.topOrigin, source);
+    auto webPageProxy = identifier ? RefPtr { m_process->webPage(identifier.value()) } : mostReasonableWebPageProxy(clientOrigin.topOrigin, source);
 
     if (!webPageProxy) {
         completionHandler(WebCore::PermissionState::Prompt);

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -329,7 +329,7 @@ void WebChromeClient::takeFocus(FocusDirection direction)
 
 void WebChromeClient::focusedElementChanged(Element* element, LocalFrame* frame, FocusOptions options, BroadcastFocusedElement broadcast)
 {
-    RefPtr coreFrame =  element ? element->document().protectedFrame() : frame;
+    RefPtr coreFrame =  element ? element->document().frame() : frame;
     RefPtr webFrame = coreFrame ? WebFrame::fromCoreFrame(*coreFrame) : nullptr;
     RefPtr page = m_page.get();
     if (page && broadcast == BroadcastFocusedElement::Yes)

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -5353,7 +5353,7 @@ void WebPage::updateLayoutViewportHeightExpansionTimerFired()
         auto& hitTestedNodes = hitTestResult.listBasedTestResult();
         HashSet<Ref<Element>> elementsOutsideOfAnyLargeViewportConstrainedContainers;
         for (auto& node : hitTestedNodes) {
-            RefPtr firstParentOrSelf = dynamicDowncast<Element>(node) ?: node->parentElementInComposedTree();
+            RefPtr firstParentOrSelf = dynamicDowncast<Element>(node.get()) ?: node->parentElementInComposedTree();
             Vector<Ref<Element>> ancestorsForHitTestedNode;
             for (RefPtr parent = firstParentOrSelf; parent; parent = parent->parentElementInComposedTree()) {
                 if (largeViewportConstrainedElements.contains(*parent))

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm
@@ -131,7 +131,7 @@ namespace ax = WebCore::Accessibility;
                 return [protectedSelf accessibilityPluginObject];
         }
 
-        RefPtr frame = protectedFrame ? protectedFrame : [protectedSelf focusedLocalFrame];
+        RefPtr frame = protectedFrame ? protectedFrame : RefPtr { [protectedSelf focusedLocalFrame] };
         if (RefPtr document = frame ? frame->document() : nullptr) {
             if (CheckedPtr cache = document->axObjectCache()) {
                 if (RefPtr root = cache->rootObjectForFrame(*frame))
@@ -143,7 +143,7 @@ namespace ax = WebCore::Accessibility;
             // It's possible we were given a null frame (this is explicitly expected when off the main-thread, since
             // we can't access the webpage off the main-thread to get a frame). Now that we are actually on the main-thread,
             // try again if necessary.
-            RefPtr frame = protectedFrame ? protectedFrame : [protectedSelf focusedLocalFrame];
+            RefPtr frame = protectedFrame ? protectedFrame : RefPtr { [protectedSelf focusedLocalFrame] };
 
             if (RefPtr root = frame ? cache->rootObjectForFrame(*frame) : nullptr)
                 return root->wrapper();


### PR DESCRIPTION
#### 3e93d47f3f5897abc26f8d2ca1731e5602439e47
<pre>
Allow implicit conversion from RefPtr&lt;T&gt; to T*
<a href="https://bugs.webkit.org/show_bug.cgi?id=305754">https://bugs.webkit.org/show_bug.cgi?id=305754</a>

Reviewed by Anne van Kesteren.

Allow implicit conversion from RefPtr&lt;T&gt; to T*. This is consistent with
what we do for RetainPtr and Ref. This also makes smart pointer adoption
a little easier.

* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::BracketAccessorNode::emitBytecode):
* Source/JavaScriptCore/runtime/Identifier.h:
* Source/WTF/wtf/HashFunctions.h:
* Source/WTF/wtf/HashTraits.h:
* Source/WTF/wtf/ParkingLot.cpp:
(WTF::ParkingLot::parkConditionallyImpl):
(WTF::ParkingLot::unparkCount):
(WTF::ParkingLot::forEachImpl):
* Source/WTF/wtf/RefPtr.h:
(WTF::RefPtr::operator! const):
(WTF::RefPtr::operator UnspecifiedBoolType const): Deleted.
(WTF::RefPtr::unspecifiedBoolTypeInstance const): Deleted.
* Source/WTF/wtf/ThreadSafeWeakPtr.h:
(WTF::ThreadSafeWeakOrStrongPtr::tryConvertToStrong):
* Source/WTF/wtf/text/SymbolRegistry.cpp:
(WTF::SymbolRegistryTableRemovalHashTranslator::equal):
* Source/WebCore/accessibility/AXTableHelpers.cpp:
(WebCore::AXTableHelpers::isDataTableWithTraversal):
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarker::toTextRunMarker const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::lastMarker):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm:
(makeNSRange):
(makeDOMRange):
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::setTimeline):
(WebCore::WebAnimation::setEffectiveFrameRate):
(WebCore::WebAnimation::cancel):
(WebCore::WebAnimation::enqueueAnimationEvent):
(WebCore::WebAnimation::finishNotificationSteps):
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::matchRecursively const):
* Source/WebCore/editing/FormatBlockCommand.cpp:
(WebCore::FormatBlockCommand::formatRange):
* Source/WebCore/editing/IndentOutdentCommand.cpp:
(WebCore::IndentOutdentCommand::indentIntoBlockquote):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::setBoundVertexArrayObject):
* Source/WebCore/html/parser/HTMLConstructionSite.cpp:
(WebCore::HTMLConstructionSite::createHTMLElementOrFindCustomElementInterface):
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::parsedArchiveData const):
(WebCore::DocumentLoader::previewConverter const):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::activeDocumentLoader const):
(WebCore::FrameLoader::retryAfterFailedCacheOnlyMainResourceLoad):
(WebCore::FrameLoader::networkingContext const):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::updateSelectionForMouseDrag):
(WebCore::EventHandler::scrollOverflow):
(WebCore::EventHandler::logicalScrollOverflow):
(WebCore::EventHandler::handleMouseReleaseEvent):
(WebCore::EventHandler::updateMouseEventTargetNode):
(WebCore::EventHandler::startKeyboardScrollAnimationOnEnclosingScrollableContainer):
(WebCore::EventHandler::handleTouchEvent):
* Source/WebCore/page/EventHandler.h:
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::open):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::scrollingCoordinator):
* Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp:
(WebCore::ThreadedScrollingTree::scrollingTreeNodeDidScroll):
(WebCore::ThreadedScrollingTree::scrollingTreeNodeScrollUpdated):
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::elementForExtractedText):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::layerTreeAsText):
* Source/WebCore/svg/SVGAnimateElementBase.cpp:
(WebCore::SVGAnimateElementBase::animator const):
* Source/WebCore/svg/SVGAnimateElementBase.h:
(WebCore::SVGAnimateElementBase::animatorIfExists const):
* Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.cpp:
(WebCore::SVGFilterPrimitiveStandardAttributes::markFilterEffectForRepaint):
* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::NavigationState::NavigationClient::decidePolicyForNavigationAction):
* Source/WebKit/UIProcess/WebPermissionControllerProxy.cpp:
(WebKit::WebPermissionControllerProxy::query):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::focusedElementChanged):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::updateLayoutViewportHeightExpansionTimerFired):
* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm:
(-[WKAccessibilityWebPageObjectBase accessibilityRootObjectWrapper:]):
* Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp:
(TestWebKitAPI::TEST(WTF_WeakPtr, Downcasting)):
(TestWebKitAPI::TEST(WTF_WeakPtr, DerivedConstructAndAssign)):
(TestWebKitAPI::TEST(WTF_WeakPtr, DerivedConstructAndAssignConst)):
(TestWebKitAPI::TEST(WTF_WeakPtr, MakeWeakPtrTakesRef)):
(TestWebKitAPI::TEST(WTF_WeakPtr, MakeWeakPtrTakesRefPtr)):
(TestWebKitAPI::makeWeakPtr): Deleted.

Canonical link: <a href="https://commits.webkit.org/305823@main">https://commits.webkit.org/305823@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d74a45fad8c314ea5de6401e94bb9b870b2a40b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139505 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11881 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1007 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147633 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f80a55be-2893-4b49-833c-36f40744afb6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141378 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12589 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12031 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/106807 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b27cbaf9-446b-4eef-aeba-efad248956a2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142452 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9636 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/124954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87671 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0b88d6f0-aca3-4827-ade1-1cbd0d7aac59) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9259 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/6873 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7931 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/131478 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118560 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/939 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150416 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/300 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11565 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/955 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/115209 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11579 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/9885 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115520 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29346 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/10066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/121386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/66571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11609 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/170777 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11345 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/75288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/44438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11545 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11396 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->