### PR TITLE
[WebDriver][BiDi] Fix browsingContext.traverseHistory validation

### DIFF
--- a/Source/WebKit/UIProcess/Automation/Automation.json
+++ b/Source/WebKit/UIProcess/Automation/Automation.json
@@ -71,6 +71,7 @@
                 "JavaScriptTimeout",
                 "WindowNotFound",
                 "FrameNotFound",
+                "NoSuchHistoryEntry",
                 "NodeNotFound",
                 "InvalidNodeIdentifier",
                 "InvalidElementState",

--- a/Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.cpp
@@ -157,11 +157,22 @@ Ref<Inspector::Protocol::BidiBrowsingContext::Info> BidiBrowsingContextAgent::ge
 {
     // https://w3c.github.io/webdriver-bidi/#get-the-navigable-info
 
+    // Use URL from UI process (updated synchronously) instead of web process frame tree data
+    // which may be stale after navigation.
+    String url;
+    if (RefPtr frame = WebFrameProxy::webFrame(tree.info.frameID)) {
+        if (frame->isMainFrame()) {
+            if (RefPtr page = frame->page())
+                url = page->currentURL();
+        } else
+            url = frame->url().string();
+    }
+
     // FIXME: Properly support different user contexts, which will likely map to different WebAutomationSessions.
     // https://bugs.webkit.org/show_bug.cgi?id=288104
     auto info = Inspector::Protocol::BidiBrowsingContext::Info::create()
         .setContext(getBrowsingContextID(tree.info.frameID))
-        .setUrl(tree.info.request.url().string())
+        .setUrl(url)
         .setClientWindow("placeholder_window"_s)
         .setUserContext("default"_s)
         .setChildrenIsNull()
@@ -342,12 +353,19 @@ void BidiBrowsingContextAgent::reload(const BrowsingContext& browsingContext, st
     });
 }
 
-void BidiBrowsingContextAgent::traverseHistory(const BrowsingContext& browsingContext, int delta, CommandCallback<void>&& callback)
+void BidiBrowsingContextAgent::traverseHistory(const BrowsingContext& browsingContext, double delta, CommandCallback<void>&& callback)
 {
+    // https://w3c.github.io/webdriver-bidi/#command-browsingContext-traverseHistory
     RefPtr session = m_session.get();
     ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
 
-    session->traverseHistoryInBrowsingContext(browsingContext, delta, WTF::move(callback));
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!JSC::isSafeInteger(delta), InvalidParameter);
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(browsingContext.startsWith("frame-"_s), InvalidParameter);
+
+    RefPtr webPageProxy = session->webPageProxyForHandle(browsingContext);
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!webPageProxy, FrameNotFound);
+
+    session->traverseHistoryInBrowsingContext(browsingContext, static_cast<int64_t>(delta), WTF::move(callback));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.h
+++ b/Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.h
@@ -58,7 +58,7 @@ public:
     void handleUserPrompt(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext&, std::optional<bool>&& optionalShouldAccept, const String& userText, Inspector::CommandCallback<void>&&) override;
     void navigate(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext&, const String& url, std::optional<Inspector::Protocol::BidiBrowsingContext::ReadinessState>&&, Inspector::CommandCallbackOf<String, Inspector::Protocol::BidiBrowsingContext::NavigationID>&&) override;
     void reload(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext&, std::optional<bool>&& optionalIgnoreCache, std::optional<Inspector::Protocol::BidiBrowsingContext::ReadinessState>&& optionalWait, Inspector::CommandCallbackOf<String, Inspector::Protocol::BidiBrowsingContext::NavigationID>&&) override;
-    void traverseHistory(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext&, int delta, Inspector::CommandCallback<void>&&) override;
+    void traverseHistory(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext&, double delta, Inspector::CommandCallback<void>&&) override;
 
 private:
     enum class IncludeParentID: bool { No, Yes };

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -52,6 +52,7 @@
 #include <WebCore/MIMETypeRegistry.h>
 #include <WebCore/PointerEventTypeNames.h>
 #include <algorithm>
+#include <limits>
 #include <wtf/CallbackAggregator.h>
 #include <wtf/FileSystem.h>
 #include <wtf/HashMap.h>
@@ -408,6 +409,11 @@ Expected<PageAndFrameHandle, AutomationCommandError> WebAutomationSession::extra
     return makeUnexpected(AUTOMATION_COMMAND_ERROR_WITH_NAME(FrameNotFound));
 }
 
+bool WebAutomationSession::isKnownFrameHandle(const String& handle) const
+{
+    return m_handleWebFrameMap.contains(handle);
+}
+
 // Platform-independent Commands.
 
 void WebAutomationSession::getNextContext(Vector<Ref<WebPageProxy>>&& pages, Ref<JSON::ArrayOf<Inspector::Protocol::Automation::BrowsingContext>> contexts, CommandCallback<Ref<JSON::ArrayOf<Inspector::Protocol::Automation::BrowsingContext>>>&& callback)
@@ -628,9 +634,11 @@ void WebAutomationSession::waitForNavigationToComplete(const Inspector::Protocol
     callback({ });
 }
 
-void WebAutomationSession::waitForNavigationToCompleteOnPage(WebPageProxy& page, Inspector::Protocol::Automation::PageLoadStrategy loadStrategy, Seconds timeout, Inspector::CommandCallback<void>&& callback)
+void WebAutomationSession::waitForNavigationToCompleteOnPage(WebPageProxy& page, Inspector::Protocol::Automation::PageLoadStrategy loadStrategy, Seconds timeout, Inspector::CommandCallback<void>&& callback, std::optional<WebCore::NavigationIdentifier> expectedNavigationID)
 {
     ASSERT(!m_loadTimer.isActive());
+    m_pendingNormalNavigationInBrowsingContextNavigationIDsPerPage.remove(page.identifier());
+    m_pendingEagerNavigationInBrowsingContextNavigationIDsPerPage.remove(page.identifier());
     Ref pageLoadState = page.pageLoadState();
 
     if (loadStrategy == Inspector::Protocol::Automation::PageLoadStrategy::None || (!pageLoadState->isLoading() && !pageLoadState->hasUncommittedLoad())) {
@@ -641,9 +649,13 @@ void WebAutomationSession::waitForNavigationToCompleteOnPage(WebPageProxy& page,
     m_loadTimer.startOneShot(timeout);
     switch (loadStrategy) {
     case Inspector::Protocol::Automation::PageLoadStrategy::Normal:
+        if (expectedNavigationID)
+            m_pendingNormalNavigationInBrowsingContextNavigationIDsPerPage.set(page.identifier(), *expectedNavigationID);
         m_pendingNormalNavigationInBrowsingContextCallbacksPerPage.set(page.identifier(), WTF::move(callback));
         break;
     case Inspector::Protocol::Automation::PageLoadStrategy::Eager:
+        if (expectedNavigationID)
+            m_pendingEagerNavigationInBrowsingContextNavigationIDsPerPage.set(page.identifier(), *expectedNavigationID);
         m_pendingEagerNavigationInBrowsingContextCallbacksPerPage.set(page.identifier(), WTF::move(callback));
         break;
     case Inspector::Protocol::Automation::PageLoadStrategy::None:
@@ -677,6 +689,8 @@ void WebAutomationSession::respondToPendingPageNavigationCallbacksWithTimeout(Ha
     for (auto id : copyToVector(map.keys())) {
         RefPtr page = WebProcessProxy::webPage(id);
         auto callback = map.take(id);
+        m_pendingNormalNavigationInBrowsingContextNavigationIDsPerPage.remove(id);
+        m_pendingEagerNavigationInBrowsingContextNavigationIDsPerPage.remove(id);
         if (page && m_client->isShowingJavaScriptDialogOnPage(*this, *page))
             callback({ });
         else
@@ -881,8 +895,8 @@ void WebAutomationSession::navigateBrowsingContext(const Inspector::Protocol::Au
     auto pageLoadStrategy = optionalPageLoadStrategy.value_or(defaultPageLoadStrategy);
     auto pageLoadTimeout = optionalPageLoadTimeout ? Seconds::fromMilliseconds(*optionalPageLoadTimeout) : defaultPageLoadTimeout;
 
-    page->loadRequest(URL { url });
-    waitForNavigationToCompleteOnPage(*page, pageLoadStrategy, pageLoadTimeout, WTF::move(callback));
+    RefPtr navigation = page->loadRequest(URL { url });
+    waitForNavigationToCompleteOnPage(*page, pageLoadStrategy, pageLoadTimeout, WTF::move(callback), navigation ? std::optional { navigation->navigationID() } : std::nullopt);
 }
 
 void WebAutomationSession::goBackInBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle& handle, std::optional<Inspector::Protocol::Automation::PageLoadStrategy>&& optionalPageLoadStrategy, std::optional<double>&& optionalPageLoadTimeout, CommandCallback<void>&& callback)
@@ -909,7 +923,7 @@ void WebAutomationSession::goForwardInBrowsingContext(const Inspector::Protocol:
     waitForNavigationToCompleteOnPage(*page, pageLoadStrategy, pageLoadTimeout, WTF::move(callback));
 }
 
-void WebAutomationSession::traverseHistoryInBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle& handle, int delta, CommandCallback<void>&& callback)
+void WebAutomationSession::traverseHistoryInBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle& handle, int64_t delta, CommandCallback<void>&& callback)
 {
     auto page = webPageProxyForHandle(handle);
     ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!page, WindowNotFound);
@@ -924,24 +938,24 @@ void WebAutomationSession::traverseHistoryInBrowsingContext(const Inspector::Pro
 
 #if ENABLE(BACK_FORWARD_LIST_SWIFT)
     WebBackForwardListWrapper& backForwardList = page->backForwardListWrapper();
-    unsigned backCount = backForwardList.backListCount();
-    unsigned forwardCount = backForwardList.forwardListCount();
+    int64_t backCount = static_cast<int64_t>(backForwardList.backListCount());
+    int64_t forwardCount = static_cast<int64_t>(backForwardList.forwardListCount());
 #else
     Ref backForwardList = page->backForwardListWrapper();
-    unsigned backCount = backForwardList->backListCount();
-    unsigned forwardCount = backForwardList->forwardListCount();
+    int64_t backCount = static_cast<int64_t>(backForwardList->backListCount());
+    int64_t forwardCount = static_cast<int64_t>(backForwardList->forwardListCount());
 #endif
-    int currentIndex = static_cast<int>(backCount);
-    int targetIndex = currentIndex + delta;
-    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(targetIndex < 0, InvalidParameter);
-    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(targetIndex >= static_cast<int>(backCount + forwardCount + 1), InvalidParameter);
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(delta < -backCount, NoSuchHistoryEntry);
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(delta > forwardCount, NoSuchHistoryEntry);
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(delta < std::numeric_limits<int>::min(), NoSuchHistoryEntry);
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(delta > std::numeric_limits<int>::max(), NoSuchHistoryEntry);
 
 #if ENABLE(BACK_FORWARD_LIST_SWIFT)
-    RefPtr targetItem = backForwardList.itemAtIndex(targetIndex);
+    RefPtr targetItem = backForwardList.itemAtIndex(static_cast<int>(delta));
 #else
-    RefPtr targetItem = backForwardList->itemAtIndex(targetIndex);
+    RefPtr targetItem = backForwardList->itemAtIndex(static_cast<int>(delta));
 #endif
-    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!targetItem, InternalError);
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!targetItem, NoSuchHistoryEntry);
 
     page->goToBackForwardItem(*targetItem);
     waitForNavigationToCompleteOnPage(*page, defaultPageLoadStrategy, defaultPageLoadTimeout, WTF::move(callback));
@@ -959,7 +973,7 @@ void WebAutomationSession::reloadBrowsingContext(const Inspector::Protocol::Auto
     waitForNavigationToCompleteOnPage(*page, pageLoadStrategy, pageLoadTimeout, WTF::move(callback));
 }
 
-void WebAutomationSession::navigationOccurredForFrame(const WebFrameProxy& frame)
+void WebAutomationSession::navigationOccurredForFrame(const WebFrameProxy& frame, std::optional<WebCore::NavigationIdentifier> navigationID)
 {
     if (frame.isMainFrame()) {
         // New page loaded, clear frame handles previously cached for frame's page.
@@ -975,9 +989,19 @@ void WebAutomationSession::navigationOccurredForFrame(const WebFrameProxy& frame
             return handlesToRemove.contains(iter.key);
         });
 
-        if (auto callback = m_pendingNormalNavigationInBrowsingContextCallbacksPerPage.take(frame.page()->identifier())) {
-            m_loadTimer.stop();
-            callback({ });
+        auto pageID = frame.page()->identifier();
+        if (m_pendingNormalNavigationInBrowsingContextCallbacksPerPage.contains(pageID)) {
+            bool shouldCompleteCallback = true;
+            if (auto expectedNavigationID = m_pendingNormalNavigationInBrowsingContextNavigationIDsPerPage.get(pageID))
+                shouldCompleteCallback = navigationID && *expectedNavigationID == *navigationID;
+
+            if (shouldCompleteCallback) {
+                if (auto callback = m_pendingNormalNavigationInBrowsingContextCallbacksPerPage.take(pageID)) {
+                    m_pendingNormalNavigationInBrowsingContextNavigationIDsPerPage.remove(pageID);
+                    m_loadTimer.stop();
+                    callback({ });
+                }
+            }
         }
         m_domainNotifier->browsingContextCleared(handleForWebPageProxy(*protect(frame.page())));
     } else {
@@ -1006,9 +1030,19 @@ void WebAutomationSession::documentLoadedForFrame(const WebFrameProxy& frame, st
 #endif
 
     if (frame.isMainFrame()) {
-        if (auto callback = m_pendingEagerNavigationInBrowsingContextCallbacksPerPage.take(frame.page()->identifier())) {
-            m_loadTimer.stop();
-            callback({ });
+        auto pageID = frame.page()->identifier();
+        if (m_pendingEagerNavigationInBrowsingContextCallbacksPerPage.contains(pageID)) {
+            bool shouldCompleteCallback = true;
+            if (auto expectedNavigationID = m_pendingEagerNavigationInBrowsingContextNavigationIDsPerPage.get(pageID))
+                shouldCompleteCallback = navigationID && *expectedNavigationID == *navigationID;
+
+            if (shouldCompleteCallback) {
+                if (auto callback = m_pendingEagerNavigationInBrowsingContextCallbacksPerPage.take(pageID)) {
+                    m_pendingEagerNavigationInBrowsingContextNavigationIDsPerPage.remove(pageID);
+                    m_loadTimer.stop();
+                    callback({ });
+                }
+            }
         }
 
 #if ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
@@ -40,6 +40,7 @@
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/NavigationIdentifier.h>
 #include <WebCore/ShareableBitmap.h>
+#include <cstdint>
 #include <wtf/CheckedPtr.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
@@ -162,7 +163,7 @@ public:
     WebProcessPool* NODELETE processPool() const;
     void setProcessPool(WebProcessPool*);
 
-    void navigationOccurredForFrame(const WebFrameProxy&);
+    void navigationOccurredForFrame(const WebFrameProxy&, std::optional<WebCore::NavigationIdentifier> = std::nullopt);
     void documentLoadedForFrame(const WebFrameProxy&, std::optional<WebCore::NavigationIdentifier>, WallTime timestamp);
     void loadCompletedForFrame(const WebFrameProxy&, std::optional<WebCore::NavigationIdentifier>, WallTime timestamp);
     void inspectorFrontendLoaded(const WebPageProxy&);
@@ -242,7 +243,7 @@ public:
     void navigateBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle&, const String& url, std::optional<Inspector::Protocol::Automation::PageLoadStrategy>&&, std::optional<double>&& pageLoadTimeout, Inspector::CommandCallback<void>&&) override;
     void goBackInBrowsingContext(const String&, std::optional<Inspector::Protocol::Automation::PageLoadStrategy>&&, std::optional<double>&& pageLoadTimeout, Inspector::CommandCallback<void>&&) override;
     void goForwardInBrowsingContext(const String&, std::optional<Inspector::Protocol::Automation::PageLoadStrategy>&&, std::optional<double>&& pageLoadTimeout, Inspector::CommandCallback<void>&&) override;
-    void traverseHistoryInBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle&, int delta, Inspector::CommandCallback<void>&&);
+    void traverseHistoryInBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle&, int64_t delta, Inspector::CommandCallback<void>&&);
     void reloadBrowsingContext(const String&, std::optional<Inspector::Protocol::Automation::PageLoadStrategy>&&, std::optional<double>&& pageLoadTimeout, Inspector::CommandCallback<void>&&) override;
     void waitForNavigationToComplete(const Inspector::Protocol::Automation::BrowsingContextHandle&, const Inspector::Protocol::Automation::FrameHandle&, std::optional<Inspector::Protocol::Automation::PageLoadStrategy>&&, std::optional<double>&& pageLoadTimeout, Inspector::CommandCallback<void>&&) override;
     void evaluateJavaScriptFunction(const Inspector::Protocol::Automation::BrowsingContextHandle&, const Inspector::Protocol::Automation::FrameHandle&, const String& function, Ref<JSON::Array>&& arguments, std::optional<bool>&& expectsImplicitCallbackArgument, std::optional<bool>&& forceUserGesture, std::optional<double>&& callbackTimeout, Inspector::CommandCallback<String>&&) override;
@@ -316,6 +317,7 @@ public:
     String handleForWebPageProxy(const WebPageProxy&);
 
     Expected<PageAndFrameHandle, AutomationCommandError> extractBrowsingContextHandles(const String&);
+    bool isKnownFrameHandle(const String&) const;
 
 private:
     Ref<Inspector::Protocol::Automation::BrowsingContext> buildBrowsingContextForPage(WebPageProxy&, WebCore::FloatRect windowFrame);
@@ -323,7 +325,7 @@ private:
 
     std::optional<WebCore::FrameIdentifier> webFrameIDForHandle(const String&, bool& frameNotFound);
 
-    void waitForNavigationToCompleteOnPage(WebPageProxy&, Inspector::Protocol::Automation::PageLoadStrategy, Seconds, Inspector::CommandCallback<void>&&);
+    void waitForNavigationToCompleteOnPage(WebPageProxy&, Inspector::Protocol::Automation::PageLoadStrategy, Seconds, Inspector::CommandCallback<void>&&, std::optional<WebCore::NavigationIdentifier> = std::nullopt);
     void waitForNavigationToCompleteOnFrame(WebFrameProxy&, Inspector::Protocol::Automation::PageLoadStrategy, Seconds, Inspector::CommandCallback<void>&&);
     void respondToPendingPageNavigationCallbacksWithTimeout(HashMap<WebPageProxyIdentifier, Inspector::CommandCallback<void>>&);
     void respondToPendingFrameNavigationCallbacksWithTimeout(HashMap<WebCore::FrameIdentifier, Inspector::CommandCallback<void>>&);
@@ -404,6 +406,8 @@ private:
 
     HashMap<WebPageProxyIdentifier, Inspector::CommandCallback<void>> m_pendingNormalNavigationInBrowsingContextCallbacksPerPage;
     HashMap<WebPageProxyIdentifier, Inspector::CommandCallback<void>> m_pendingEagerNavigationInBrowsingContextCallbacksPerPage;
+    HashMap<WebPageProxyIdentifier, WebCore::NavigationIdentifier> m_pendingNormalNavigationInBrowsingContextNavigationIDsPerPage;
+    HashMap<WebPageProxyIdentifier, WebCore::NavigationIdentifier> m_pendingEagerNavigationInBrowsingContextNavigationIDsPerPage;
     HashMap<WebCore::FrameIdentifier, Inspector::CommandCallback<void>> m_pendingNormalNavigationInBrowsingContextCallbacksPerFrame;
     HashMap<WebCore::FrameIdentifier, Inspector::CommandCallback<void>> m_pendingEagerNavigationInBrowsingContextCallbacksPerFrame;
     HashMap<WebPageProxyIdentifier, Inspector::CommandCallback<void>> m_pendingInspectorCallbacksPerPage;

--- a/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp
@@ -118,6 +118,8 @@ static String toBidiErrorCode(int errorCode, const String& inspectorInternalMsg)
         return "no such browsing context"_s;
     case Inspector::Protocol::Automation::ErrorMessage::FrameNotFound:
         return "no such frame"_s;
+    case Inspector::Protocol::Automation::ErrorMessage::NoSuchHistoryEntry:
+        return "no such history entry"_s;
     case Inspector::Protocol::Automation::ErrorMessage::NodeNotFound:
         return "stale element reference"_s;
     case Inspector::Protocol::Automation::ErrorMessage::InvalidNodeIdentifier:

--- a/Source/WebKit/UIProcess/Automation/protocol/BidiBrowsingContext.json
+++ b/Source/WebKit/UIProcess/Automation/protocol/BidiBrowsingContext.json
@@ -170,7 +170,7 @@
             "wpt": "https://github.com/web-platform-tests/wpt/tree/master/webdriver/tests/bidi/browsing_context/traverse_history",
             "parameters": [
                 { "name": "context", "$ref": "BidiBrowsingContext.BrowsingContext", "description": "The identifier of the browsing context to traverse history." },
-                { "name": "delta", "type": "integer", "description": "The number of steps to traverse in history. Positive values go forward, negative values go backward, and a value of zero will succeed with no action." }
+                { "name": "delta", "type": "number", "description": "The number of steps to traverse in history. Positive values go forward, negative values go backward, and a value of zero will succeed with no action." }
             ],
             "async": true
         }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -7505,7 +7505,7 @@ void WebPageProxy::didFailProvisionalLoadForFrameShared(Ref<WebProcessProxy>&& p
 
     if (m_controlledByAutomation && willInternallyHandleFailure == WillInternallyHandleFailure::No) {
         if (RefPtr automationSession = process->processPool().automationSession())
-            automationSession->navigationOccurredForFrame(frame);
+            automationSession->navigationOccurredForFrame(frame, navigationID);
     }
 
     // FIXME: We should message check that navigationID is not zero here, but it's currently zero for some navigations through the back/forward cache.
@@ -8005,7 +8005,7 @@ void WebPageProxy::didFinishLoadForFrame(IPC::Connection& connection, FrameIdent
             protectedPageLoadState->didFinishLoad(transaction);
 
         if (RefPtr automationSession = activeAutomationSession()) {
-            automationSession->navigationOccurredForFrame(*frame);
+            automationSession->navigationOccurredForFrame(*frame, navigationID);
             automationSession->loadCompletedForFrame(*frame, navigationID, WallTime::now());
         }
 
@@ -8079,7 +8079,7 @@ void WebPageProxy::didFailLoadForFrame(IPC::Connection& connection, FrameIdentif
 
     if (m_controlledByAutomation) {
         if (RefPtr automationSession = m_configuration->processPool().automationSession())
-            automationSession->navigationOccurredForFrame(*frame);
+            automationSession->navigationOccurredForFrame(*frame, navigationID);
     }
 
     frame->didFailLoad();
@@ -8141,7 +8141,7 @@ void WebPageProxy::didSameDocumentNavigationForFrame(IPC::Connection& connection
 
     if (m_controlledByAutomation) {
         if (RefPtr automationSession = m_configuration->processPool().automationSession())
-            automationSession->navigationOccurredForFrame(*frame);
+            automationSession->navigationOccurredForFrame(*frame, navigationID);
     }
 
     protectedPageLoadState->clearPendingAPIRequest(transaction);
@@ -8192,7 +8192,7 @@ void WebPageProxy::didSameDocumentNavigationForFrameViaJS(IPC::Connection& conne
 
     if (m_controlledByAutomation) {
         if (RefPtr automationSession = m_configuration->processPool().automationSession())
-            automationSession->navigationOccurredForFrame(*frame);
+            automationSession->navigationOccurredForFrame(*frame, navigation ? std::optional { navigation->navigationID() } : std::nullopt);
     }
 
     protectedPageLoadState->clearPendingAPIRequest(transaction);

--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -2808,23 +2808,6 @@
     "imported/w3c/webdriver/tests/bidi/browsing_context/traverse_history/delta.py": {
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288334"}}
     },
-    "imported/w3c/webdriver/tests/bidi/browsing_context/traverse_history/invalid.py": {
-        "expected": { "all": { "status": ["PASS"], "bug": "webkit.org/b/288334"}},
-        "subtests" : {
-            "test_params_context_invalid_value": {
-                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288334"}}
-            },
-            "test_delta_invalid_value[-2]": {
-                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288334"}}
-            },
-            "test_delta_invalid_value[1]": {
-                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288334"}}
-            },
-            "test_iframe": {
-                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288334"}}
-            }
-        }
-    },
     "imported/w3c/webdriver/tests/bidi/browsing_context/user_prompt_closed/beforeunload.py": {
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288343"}}
     },


### PR DESCRIPTION
#### d370cc78d5b17a388c27def8aacd41eff3f21946

overview detailed doc: https://docs.google.com/document/d/1zEtJZbfMoAnMidjQXk7AW040uzqEzlp2oisuD4aborg/edit?usp=sharing

<pre>
[WebDriver][BiDi] Fix browsingContext.traverseHistory validation
  <a href="https://bugs.webkit.org/show_bug.cgi?id=288334">https://bugs.webkit.org/show_bug.cgi?id=288334</a>

  Reviewed by NOBODY (OOPS!).

  The traverseHistory command was not properly validating the delta parameter
  or rejecting iframe contexts. This change adds validation to ensure delta is
  a JavaScript safe integer and rejects child browsing contexts (iframes).
  Also fixes URL reporting in getNavigableInfo to use UI process URL which is
  updated synchronously after navigation, instead of potentially stale frame
  tree data.

  * Source/WebKit/UIProcess/Automation/Automation.json:
  Add NoSuchHistoryEntry error code for invalid history navigation.
  * Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.cpp:
  (WebKit::BidiBrowsingContextAgent::getNavigableInfo):
  (WebKit::BidiBrowsingContextAgent::traverseHistory):
  * Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.h:
  * Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
  (WebKit::WebAutomationSession::isKnownFrameHandle const):
  (WebKit::WebAutomationSession::waitForNavigationToCompleteOnPage):
  (WebKit::WebAutomationSession::respondToPendingPageNavigationCallbacksWithTimeout):
  (WebKit::WebAutomationSession::navigateBrowsingContext):
  (WebKit::WebAutomationSession::traverseHistoryInBrowsingContext):
  (WebKit::WebAutomationSession::navigationOccurredForFrame):
  (WebKit::WebAutomationSession::documentLoadedForFrame):
  * Source/WebKit/UIProcess/Automation/WebAutomationSession.h:
  * Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp:
  (WebKit::toBidiErrorCode):
  * Source/WebKit/UIProcess/Automation/protocol/BidiBrowsingContext.json:
  * Source/WebKit/UIProcess/WebPageProxy.cpp:
  (WebKit::WebPageProxy::didFailProvisionalLoadForFrameShared):
  (WebKit::WebPageProxy::didFinishLoadForFrame):
  (WebKit::WebPageProxy::didFailLoadForFrame):
  (WebKit::WebPageProxy::didSameDocumentNavigationForFrame):
  (WebKit::WebPageProxy::didSameDocumentNavigationForFrameViaJS):
  * WebDriverTests/TestExpectations.json:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d70406de2d096dbf58001078746546f84e9604af

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146506 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19179 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12690 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155170 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99907 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19640 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19083 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112854 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80619 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149469 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15107 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131630 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93620 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14366 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12133 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2614 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123938 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157494 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/646 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10927 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120848 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18983 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15933 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121089 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18996 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131248 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/74785 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16733 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8157 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18603 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82353 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18332 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18488 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18390 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->