### PR TITLE
[WebDriver][BiDi] Fix browsingContext.reload invalid parameter handling

### DIFF
--- a/Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.cpp
@@ -319,15 +319,29 @@ void BidiBrowsingContextAgent::navigate(const BrowsingContext& browsingContext, 
     });
 }
 
-void BidiBrowsingContextAgent::reload(const BrowsingContext& browsingContext, std::optional<bool>&& optionalIgnoreCache, std::optional<ReadinessState>&& optionalReadinessState, CommandCallbackOf<String, Inspector::Protocol::BidiBrowsingContext::NavigationID>&& callback)
+void BidiBrowsingContextAgent::reload(const BrowsingContext& browsingContext, std::optional<bool>&& optionalIgnoreCache, const String& wait, CommandCallbackOf<String, Inspector::Protocol::BidiBrowsingContext::NavigationID>&& callback)
 {
     RefPtr session = m_session.get();
     ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
 
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(browsingContext.isEmpty(), FrameNotFound);
+
+    auto pageAndFrameHandles = session->extractBrowsingContextHandles(browsingContext);
+    ASYNC_FAIL_IF_UNEXPECTED_RESULT(pageAndFrameHandles);
+    auto& [pageHandle, frameHandle] = pageAndFrameHandles.value();
+
+    std::optional<ReadinessState> readinessState;
+    if (!wait.isNull()) {
+        readinessState = Inspector::Protocol::WebDriverBidiHelpers::parseEnumValueFromString<ReadinessState>(wait);
+        ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!readinessState, InvalidParameter);
+    }
+
+    UNUSED_PARAM(frameHandle);
+
     // FIXME: implement `ignoreCache` option.
 
-    auto pageLoadStrategy = pageLoadStrategyFromReadinessState(optionalReadinessState.value_or(defaultReadinessState));
-    session->reloadBrowsingContext(browsingContext, pageLoadStrategy, defaultPageLoadTimeout.milliseconds(), [session = WTF::move(session), browsingContext, callback = WTF::move(callback)](CommandResult<void>&& result) {
+    auto pageLoadStrategy = pageLoadStrategyFromReadinessState(readinessState.value_or(defaultReadinessState));
+    session->reloadBrowsingContext(pageHandle, pageLoadStrategy, defaultPageLoadTimeout.milliseconds(), [session = WTF::move(session), pageHandle = String(pageHandle), callback = WTF::move(callback)](CommandResult<void>&& result) {
         if (!result) {
             callback(makeUnexpected(result.error()));
             return;
@@ -335,7 +349,7 @@ void BidiBrowsingContextAgent::reload(const BrowsingContext& browsingContext, st
 
         ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
 
-        RefPtr webPageProxy = session->webPageProxyForHandle(browsingContext);
+        RefPtr webPageProxy = session->webPageProxyForHandle(pageHandle);
         ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!webPageProxy, WindowNotFound);
 
         // FIXME: keep track of navigation IDs that we hand out.

--- a/Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.h
+++ b/Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.h
@@ -57,7 +57,7 @@ public:
     void getTree(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext& optionalRoot, std::optional<double>&& optionalMaxDepth, Inspector::CommandCallback<Ref<JSON::ArrayOf<Inspector::Protocol::BidiBrowsingContext::Info>>>&&) override;
     void handleUserPrompt(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext&, std::optional<bool>&& optionalShouldAccept, const String& userText, Inspector::CommandCallback<void>&&) override;
     void navigate(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext&, const String& url, std::optional<Inspector::Protocol::BidiBrowsingContext::ReadinessState>&&, Inspector::CommandCallbackOf<String, Inspector::Protocol::BidiBrowsingContext::NavigationID>&&) override;
-    void reload(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext&, std::optional<bool>&& optionalIgnoreCache, std::optional<Inspector::Protocol::BidiBrowsingContext::ReadinessState>&& optionalWait, Inspector::CommandCallbackOf<String, Inspector::Protocol::BidiBrowsingContext::NavigationID>&&) override;
+    void reload(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext&, std::optional<bool>&& optionalIgnoreCache, const String& wait, Inspector::CommandCallbackOf<String, Inspector::Protocol::BidiBrowsingContext::NavigationID>&&) override;
     void traverseHistory(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext&, int delta, Inspector::CommandCallback<void>&&) override;
 
 private:

--- a/Source/WebKit/UIProcess/Automation/protocol/BidiBrowsingContext.json
+++ b/Source/WebKit/UIProcess/Automation/protocol/BidiBrowsingContext.json
@@ -156,7 +156,7 @@
             "parameters": [
                 { "name": "context", "$ref": "BidiBrowsingContext.BrowsingContext", "description": "The identifier of the browsing context to reload." },
                 { "name": "ignoreCache", "type": "boolean", "optional": true },
-                { "name": "wait", "$ref": "BidiBrowsingContext.ReadinessState", "optional": true }
+                { "name": "wait", "type": "string", "optional": true, "description": "The readiness state at which the command will return. Expected values are \"none\", \"interactive\", or \"complete\". Parsed manually so omitted and invalid values (for example empty string) can be distinguished for BiDi error handling." }
             ],
             "returns": [
                 { "name": "url", "type": "string", "description": "The URL the browsing context navigated to." },

--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -2680,22 +2680,6 @@
     "imported/w3c/webdriver/tests/bidi/browsing_context/reload/frame.py": {
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288332"}}
     },
-    "imported/w3c/webdriver/tests/bidi/browsing_context/reload/invalid.py": {
-        "subtests": {
-            "test_params_context_invalid_value[]": {
-                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288332"}}
-            },
-            "test_params_context_invalid_value[somestring]": {
-                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288332"}}
-            },
-            "test_params_wait_invalid_value[]": {
-                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288332"}}
-            },
-            "test_params_wait_invalid_value[somestring]": {
-                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288332"}}
-            }
-        }
-    },
     "imported/w3c/webdriver/tests/bidi/browsing_context/reload/reload.py": {
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/reload/wait.py": {


### PR DESCRIPTION
#### ce9679323d73d0894f0d0b6a1a66f86f5629202c

Overview detailed doc: https://docs.google.com/document/d/1sHs6VqFNOeMWH-BW-F0lTuXg7SzNQMwFls39MMVPees/edit?usp=sharing

<pre>
[WebDriver][BiDi] Fix browsingContext.reload invalid parameter handling
https://bugs.webkit.org/show_bug.cgi?id=288332

Reviewed by NOBODY (OOPS!).

Fix browsingContext.reload parameter validation to align with WebDriver BiDi.

Ensure empty or invalid context IDs fail with no such frame, and invalid
`wait` values fail with invalid argument. Keep `wait` declared as a string for
reload so omitted values can be distinguished from invalid provided values
(e.g. empty string), then parse with the generated BiDi enum helper.

Also resolve the browsing context via extractBrowsingContextHandles and use the
resolved top-level page handle for reload and result URL lookup.

Tests: imported/w3c/webdriver/tests/bidi/browsing_context/reload/invalid.py

* Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.cpp:
(WebKit::BidiBrowsingContextAgent::reload):
Validate empty context, resolve page/frame handles, parse `wait` using
WebDriverBidiHelpers::parseEnumValueFromString, and reload using the resolved
page handle.
* Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.h:
Update reload signature to accept raw `wait` string.
* Source/WebKit/UIProcess/Automation/protocol/BidiBrowsingContext.json:
Keep reload `wait` as string and document expected values/rationale.
* WebDriverTests/TestExpectations.json:
Remove obsolete expectations for now-passing reload invalid-parameter tests.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbfe66f144538b2ab8776bf2e3331f6df0f7e53c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148030 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20715 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14311 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156711 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101443 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21173 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20620 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114116 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81371 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150990 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16351 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132942 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94882 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15493 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13297 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4150 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125098 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159046 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2180 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12342 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122148 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20514 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17233 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122361 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20522 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132649 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/76665 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17811 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9401 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20131 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83890 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19861 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20008 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19917 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->