### PR TITLE
Drop LegacyNativeDictionaryRequiredInterfaceNullability from MouseEventInit

### DIFF
--- a/Source/WebCore/dom/EventInit.idl
+++ b/Source/WebCore/dom/EventInit.idl
@@ -23,9 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary EventInit {
+dictionary EventInit {
     boolean bubbles = false;
     boolean cancelable = false;
     boolean composed = false;

--- a/Source/WebCore/dom/EventModifierInit.idl
+++ b/Source/WebCore/dom/EventModifierInit.idl
@@ -24,9 +24,7 @@
  *
  */
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary EventModifierInit : UIEventInit {
+dictionary EventModifierInit : UIEventInit {
     boolean ctrlKey = false;
     boolean shiftKey = false;
     boolean altKey = false;

--- a/Source/WebCore/dom/MouseEventInit.h
+++ b/Source/WebCore/dom/MouseEventInit.h
@@ -25,17 +25,21 @@
 
 #pragma once
 
+#include <WebCore/EventModifierInit.h>
 #include <WebCore/EventTargetInlines.h>
-#include <WebCore/MouseRelatedEvent.h>
 
 namespace WebCore {
 
-struct MouseEventInit : MouseRelatedEventInit {
+struct MouseEventInit : EventModifierInit {
+    double screenX { 0 };
+    double screenY { 0 };
     double clientX { 0 };
     double clientY { 0 };
     int16_t button { 0 };
     unsigned short buttons { 0 };
     RefPtr<EventTarget> relatedTarget;
+    double movementX { 0 };
+    double movementY { 0 };
 };
 
 }

--- a/Source/WebCore/dom/MouseEventInit.idl
+++ b/Source/WebCore/dom/MouseEventInit.idl
@@ -24,18 +24,17 @@
  */
 
 // https://w3c.github.io/uievents/#idl-mouseeventinit
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary MouseEventInit : EventModifierInit {
+dictionary MouseEventInit : EventModifierInit {
     unrestricted double screenX = 0;
     unrestricted double screenY = 0;
     unrestricted double clientX = 0;
     unrestricted double clientY = 0;
 
-    double movementX = 0;
-    double movementY = 0;
-
     short button = 0;
     unsigned short buttons = 0;
     EventTarget? relatedTarget = null;
+
+    // FIXME: non-standard.
+    double movementX = 0;
+    double movementY = 0;
 };

--- a/Source/WebCore/dom/MouseRelatedEvent.cpp
+++ b/Source/WebCore/dom/MouseRelatedEvent.cpp
@@ -28,6 +28,7 @@
 #include "LocalDOMWindow.h"
 #include "LocalFrame.h"
 #include "LocalFrameView.h"
+#include "MouseEventInit.h"
 #include "RenderBoxModelObjectInlines.h"
 #include "RenderLayer.h"
 #include "RenderLayerInlines.h"
@@ -68,7 +69,7 @@ MouseRelatedEvent::MouseRelatedEvent(enum EventInterfaceType eventInterface, con
 {
 }
 
-MouseRelatedEvent::MouseRelatedEvent(enum EventInterfaceType eventInterface, const AtomString& eventType, const MouseRelatedEventInit& initializer, IsTrusted isTrusted)
+MouseRelatedEvent::MouseRelatedEvent(enum EventInterfaceType eventInterface, const AtomString& eventType, const MouseEventInit& initializer, IsTrusted isTrusted)
     : UIEventWithKeyState(eventInterface, eventType, initializer, isTrusted)
         , m_movementX(initializer.movementX)
         , m_movementY(initializer.movementY)

--- a/Source/WebCore/dom/MouseRelatedEvent.h
+++ b/Source/WebCore/dom/MouseRelatedEvent.h
@@ -30,12 +30,7 @@ namespace WebCore {
 
 class LocalFrameView;
 
-struct MouseRelatedEventInit : public EventModifierInit {
-    double screenX { 0 };
-    double screenY { 0 };
-    double movementX { 0 };
-    double movementY { 0 };
-};
+struct MouseEventInit;
 
 // Internal only: Helper class for what's common between mouse and wheel events.
 class MouseRelatedEvent : public UIEventWithKeyState {
@@ -87,7 +82,7 @@ protected:
         const DoublePoint& screenLocation, const DoublePoint& windowLocation, double movementX, double movementY, OptionSet<Modifier> modifiers,
         IsSimulated = IsSimulated::No, IsTrusted = IsTrusted::Yes);
     MouseRelatedEvent(enum EventInterfaceType, const AtomString& type, IsCancelable, MonotonicTime, RefPtr<WindowProxy>&&, const DoublePoint& globalLocation, OptionSet<Modifier>);
-    MouseRelatedEvent(enum EventInterfaceType, const AtomString& type, const MouseRelatedEventInit&, IsTrusted = IsTrusted::No);
+    MouseRelatedEvent(enum EventInterfaceType, const AtomString& type, const MouseEventInit&, IsTrusted = IsTrusted::No);
     MouseRelatedEvent(enum EventInterfaceType, const AtomString& type, const EventModifierInit&, IsTrusted = IsTrusted::No);
 
     void initCoordinates();

--- a/Source/WebCore/dom/TouchEvent.h
+++ b/Source/WebCore/dom/TouchEvent.h
@@ -50,7 +50,7 @@ public:
         return adoptRef(*new TouchEvent);
     }
 
-    struct Init : MouseRelatedEventInit {
+    struct Init : EventModifierInit {
         RefPtr<TouchList> touches;
         RefPtr<TouchList> targetTouches;
         RefPtr<TouchList> changedTouches;

--- a/Source/WebCore/dom/TouchEvent.idl
+++ b/Source/WebCore/dom/TouchEvent.idl
@@ -43,9 +43,7 @@
     readonly attribute boolean metaKey;
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary TouchEventInit : UIEventInit {
+dictionary TouchEventInit : EventModifierInit {
     TouchList? touches = null;
     TouchList? targetTouches = null;
     TouchList? changedTouches = null;

--- a/Source/WebCore/dom/UIEventInit.idl
+++ b/Source/WebCore/dom/UIEventInit.idl
@@ -23,9 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary UIEventInit : EventInit {
+dictionary UIEventInit : EventInit {
     WindowProxy? view = null;
     long detail = 0;
 };


### PR DESCRIPTION
#### 8951bfc9a967e7feb2611f162fa341989afc930f
<pre>
Drop LegacyNativeDictionaryRequiredInterfaceNullability from MouseEventInit
<a href="https://bugs.webkit.org/show_bug.cgi?id=305757">https://bugs.webkit.org/show_bug.cgi?id=305757</a>
<a href="https://rdar.apple.com/168436995">rdar://168436995</a>

Reviewed by Sam Weinig.

As part of this we get rid of MouseRelatedEventInit as that is not a
standalone dictionary in the specification and we don&apos;t need it.

Also correct non-Cocoa TouchEvent to use EventModifierInit while here.

Canonical link: <a href="https://commits.webkit.org/305829@main">https://commits.webkit.org/305829@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80e50faa703fa574e2043ed4ad681092db7dca28

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139517 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11893 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1019 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147645 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92585 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c42f2ea3-49e6-4e8f-aeff-333c84f26f89) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141390 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12601 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12043 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106817 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/77773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/237a015f-7000-478f-851b-f00297ab0ec1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142464 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9649 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124964 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87681 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e7b23af2-03b5-41ae-a33e-8a36139cb930) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9276 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6883 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7943 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118571 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/952 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150428 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11577 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/968 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115220 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11591 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9897 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115531 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10083 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121398 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66583 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21523 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11622 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11357 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75300 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11557 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11408 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->