### PR TITLE
Address memory unsafe cast warnings in WebGPUDowncastConvertToBackingContext.cpp

### DIFF
--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUAdapterImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUAdapterImpl.h
@@ -58,6 +58,7 @@ private:
     AdapterImpl& operator=(AdapterImpl&&) = delete;
 
     WGPUAdapter backing() const { return m_backing.get(); }
+    bool isAdapterImpl() const final { return true; }
     bool xrCompatible() final;
 
     void requestDevice(const DeviceDescriptor&, CompletionHandler<void(RefPtr<Device>&&)>&&) final;
@@ -67,5 +68,9 @@ private:
 };
 
 } // namespace WebCore::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WebGPU::AdapterImpl)
+    static bool isType(const WebCore::WebGPU::Adapter& adapter) { return adapter.isAdapterImpl(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // HAVE(WEBGPU_IMPLEMENTATION)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUBindGroupImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUBindGroupImpl.h
@@ -58,6 +58,7 @@ private:
     BindGroupImpl& operator=(BindGroupImpl&&) = delete;
 
     WGPUBindGroup backing() const { return m_backing.get(); }
+    bool isBindGroupImpl() const final { return true; }
 
     void setLabelInternal(const String&) final;
     bool updateExternalTextures(ExternalTexture&) final;
@@ -67,5 +68,9 @@ private:
 };
 
 } // namespace WebCore::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WebGPU::BindGroupImpl)
+    static bool isType(const WebCore::WebGPU::BindGroup& bindGroup) { return bindGroup.isBindGroupImpl(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // HAVE(WEBGPU_IMPLEMENTATION)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUBindGroupLayoutImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUBindGroupLayoutImpl.h
@@ -57,6 +57,7 @@ private:
     BindGroupLayoutImpl& operator=(BindGroupLayoutImpl&&) = delete;
 
     WGPUBindGroupLayout backing() const { return m_backing.get(); }
+    bool isBindGroupLayoutImpl() const final { return true; }
 
     void setLabelInternal(const String&) final;
 
@@ -65,5 +66,9 @@ private:
 };
 
 } // namespace WebCore::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WebGPU::BindGroupLayoutImpl)
+    static bool isType(const WebCore::WebGPU::BindGroupLayout& bindGroupLayout) { return bindGroupLayout.isBindGroupLayoutImpl(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // HAVE(WEBGPU_IMPLEMENTATION)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUBufferImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUBufferImpl.h
@@ -58,6 +58,7 @@ private:
     BufferImpl& operator=(BufferImpl&&) = delete;
 
     WGPUBuffer backing() const { return m_backing.get(); }
+    bool isBufferImpl() const final { return true; }
 
     void mapAsync(MapModeFlags, Size64 offset, std::optional<Size64> sizeForMap, CompletionHandler<void(bool)>&&) final;
     void getMappedRange(Size64 offset, std::optional<Size64>, NOESCAPE const Function<void(std::span<uint8_t>)>&) final;
@@ -74,5 +75,9 @@ private:
 };
 
 } // namespace WebCore::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WebGPU::BufferImpl)
+    static bool isType(const WebCore::WebGPU::Buffer& buffer) { return buffer.isBufferImpl(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // HAVE(WEBGPU_IMPLEMENTATION)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandBufferImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandBufferImpl.h
@@ -57,6 +57,7 @@ private:
     CommandBufferImpl& operator=(CommandBufferImpl&&) = delete;
 
     WGPUCommandBuffer backing() const { return m_backing.get(); }
+    bool isCommandBufferImpl() const final { return true; }
 
     void setLabelInternal(const String&) final;
 
@@ -65,5 +66,9 @@ private:
 };
 
 } // namespace WebCore::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WebGPU::CommandBufferImpl)
+    static bool isType(const WebCore::WebGPU::CommandBuffer& commandBuffer) { return commandBuffer.isCommandBufferImpl(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // HAVE(WEBGPU_IMPLEMENTATION)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandEncoderImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandEncoderImpl.h
@@ -57,6 +57,7 @@ private:
     CommandEncoderImpl& operator=(CommandEncoderImpl&&) = delete;
 
     WGPUCommandEncoder backing() const { return m_backing.get(); }
+    bool isCommandEncoderImpl() const final { return true; }
 
     RefPtr<RenderPassEncoder> beginRenderPass(const RenderPassDescriptor&) final;
     RefPtr<ComputePassEncoder> beginComputePass(const std::optional<ComputePassDescriptor>&) final;
@@ -110,5 +111,9 @@ private:
 };
 
 } // namespace WebCore::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WebGPU::CommandEncoderImpl)
+    static bool isType(const WebCore::WebGPU::CommandEncoder& commandEncoder) { return commandEncoder.isCommandEncoderImpl(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // HAVE(WEBGPU_IMPLEMENTATION)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.h
@@ -89,6 +89,8 @@ private:
     CompositorIntegrationImpl& operator=(const CompositorIntegrationImpl&) = delete;
     CompositorIntegrationImpl& operator=(CompositorIntegrationImpl&&) = delete;
 
+    bool isCompositorIntegrationImpl() const final { return true; }
+
     void prepareForDisplay(uint32_t frameIndex, CompletionHandler<void()>&&) override;
     void updateContentsHeadroom(float) override;
 
@@ -107,5 +109,9 @@ private:
 };
 
 } // namespace WebCore::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WebGPU::CompositorIntegrationImpl)
+    static bool isType(const WebCore::WebGPU::CompositorIntegration& compositorIntegration) { return compositorIntegration.isCompositorIntegrationImpl(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // HAVE(WEBGPU_IMPLEMENTATION)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUComputePassEncoderImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUComputePassEncoderImpl.h
@@ -57,6 +57,7 @@ private:
     ComputePassEncoderImpl& operator=(ComputePassEncoderImpl&&) = delete;
 
     WGPUComputePassEncoder backing() const { return m_backing.get(); }
+    bool isComputePassEncoderImpl() const final { return true; }
 
     void setPipeline(const ComputePipeline&) final;
     void dispatch(Size32 workgroupCountX, Size32 workgroupCountY, Size32 workgroupCountZ) final;
@@ -83,5 +84,9 @@ private:
 };
 
 } // namespace WebCore::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WebGPU::ComputePassEncoderImpl)
+    static bool isType(const WebCore::WebGPU::ComputePassEncoder& encoder) { return encoder.isComputePassEncoderImpl(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // HAVE(WEBGPU_IMPLEMENTATION)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUComputePipelineImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUComputePipelineImpl.h
@@ -59,6 +59,7 @@ private:
     ComputePipelineImpl& operator=(ComputePipelineImpl&&) = delete;
 
     WGPUComputePipeline backing() const { return m_backing.get(); }
+    bool isComputePipelineImpl() const final { return true; }
 
     Ref<BindGroupLayout> getBindGroupLayout(uint32_t index) final;
 
@@ -69,5 +70,9 @@ private:
 };
 
 } // namespace WebCore::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WebGPU::ComputePipelineImpl)
+    static bool isType(const WebCore::WebGPU::ComputePipeline& pipeline) { return pipeline.isComputePipelineImpl(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // HAVE(WEBGPU_IMPLEMENTATION)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.h
@@ -62,6 +62,7 @@ private:
     DeviceImpl& operator=(DeviceImpl&&) = delete;
 
     WGPUDevice backing() const { return m_backing.get(); }
+    bool isDeviceImpl() const final { return true; }
 
     Ref<Queue> queue() final;
 
@@ -109,5 +110,9 @@ private:
 };
 
 } // namespace WebCore::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WebGPU::DeviceImpl)
+    static bool isType(const WebCore::WebGPU::Device& device) { return device.isDeviceImpl(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // HAVE(WEBGPU_IMPLEMENTATION)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDowncastConvertToBackingContext.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDowncastConvertToBackingContext.cpp
@@ -64,142 +64,142 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(DowncastConvertToBackingContext);
 
 WGPUAdapter DowncastConvertToBackingContext::convertToBacking(const Adapter& adapter)
 {
-    return static_cast<const AdapterImpl&>(adapter).backing();
+    return downcast<AdapterImpl>(adapter).backing();
 }
 
 WGPUBindGroup DowncastConvertToBackingContext::convertToBacking(const BindGroup& bindGroup)
 {
-    return static_cast<const BindGroupImpl&>(bindGroup).backing();
+    return downcast<BindGroupImpl>(bindGroup).backing();
 }
 
 WGPUBindGroupLayout DowncastConvertToBackingContext::convertToBacking(const BindGroupLayout& bindGroupLayout)
 {
-    return static_cast<const BindGroupLayoutImpl&>(bindGroupLayout).backing();
+    return downcast<BindGroupLayoutImpl>(bindGroupLayout).backing();
 }
 
 WGPUBuffer DowncastConvertToBackingContext::convertToBacking(const Buffer& buffer)
 {
-    return static_cast<const BufferImpl&>(buffer).backing();
+    return downcast<BufferImpl>(buffer).backing();
 }
 
 WGPUCommandBuffer DowncastConvertToBackingContext::convertToBacking(const CommandBuffer& commandBuffer)
 {
-    return static_cast<const CommandBufferImpl&>(commandBuffer).backing();
+    return downcast<CommandBufferImpl>(commandBuffer).backing();
 }
 
 WGPUCommandEncoder DowncastConvertToBackingContext::convertToBacking(const CommandEncoder& commandEncoder)
 {
-    return static_cast<const CommandEncoderImpl&>(commandEncoder).backing();
+    return downcast<CommandEncoderImpl>(commandEncoder).backing();
 }
 
 WGPUComputePassEncoder DowncastConvertToBackingContext::convertToBacking(const ComputePassEncoder& computePassEncoder)
 {
-    return static_cast<const ComputePassEncoderImpl&>(computePassEncoder).backing();
+    return downcast<ComputePassEncoderImpl>(computePassEncoder).backing();
 }
 
 WGPUComputePipeline DowncastConvertToBackingContext::convertToBacking(const ComputePipeline& computePipeline)
 {
-    return static_cast<const ComputePipelineImpl&>(computePipeline).backing();
+    return downcast<ComputePipelineImpl>(computePipeline).backing();
 }
 
 WGPUDevice DowncastConvertToBackingContext::convertToBacking(const Device& device)
 {
-    return static_cast<const DeviceImpl&>(device).backing();
+    return downcast<DeviceImpl>(device).backing();
 }
 
 WGPUExternalTexture DowncastConvertToBackingContext::convertToBacking(const ExternalTexture& externalTexture)
 {
-    return static_cast<const ExternalTextureImpl&>(externalTexture).backing();
+    return downcast<ExternalTextureImpl>(externalTexture).backing();
 }
 
 WGPUInstance DowncastConvertToBackingContext::convertToBacking(const GPU& gpu)
 {
-    return static_cast<const GPUImpl&>(gpu).backing();
+    return downcast<GPUImpl>(gpu).backing();
 }
 
 WGPUPipelineLayout DowncastConvertToBackingContext::convertToBacking(const PipelineLayout& pipelineLayout)
 {
-    return static_cast<const PipelineLayoutImpl&>(pipelineLayout).backing();
+    return downcast<PipelineLayoutImpl>(pipelineLayout).backing();
 }
 
 WGPUSurface DowncastConvertToBackingContext::convertToBacking(const PresentationContext& presentationContext)
 {
-    return static_cast<const PresentationContextImpl&>(presentationContext).backing();
+    return downcast<PresentationContextImpl>(presentationContext).backing();
 }
 
 WGPUQuerySet DowncastConvertToBackingContext::convertToBacking(const QuerySet& querySet)
 {
-    return static_cast<const QuerySetImpl&>(querySet).backing();
+    return downcast<QuerySetImpl>(querySet).backing();
 }
 
 WGPUQueue DowncastConvertToBackingContext::convertToBacking(const Queue& queue)
 {
-    return static_cast<const QueueImpl&>(queue).backing();
+    return downcast<QueueImpl>(queue).backing();
 }
 
 WGPURenderBundleEncoder DowncastConvertToBackingContext::convertToBacking(const RenderBundleEncoder& renderBundleEncoder)
 {
-    return static_cast<const RenderBundleEncoderImpl&>(renderBundleEncoder).backing();
+    return downcast<RenderBundleEncoderImpl>(renderBundleEncoder).backing();
 }
 
 WGPURenderBundle DowncastConvertToBackingContext::convertToBacking(const RenderBundle& renderBundle)
 {
-    return static_cast<const RenderBundleImpl&>(renderBundle).backing();
+    return downcast<RenderBundleImpl>(renderBundle).backing();
 }
 
 WGPURenderPassEncoder DowncastConvertToBackingContext::convertToBacking(const RenderPassEncoder& renderPassEncoder)
 {
-    return static_cast<const RenderPassEncoderImpl&>(renderPassEncoder).backing();
+    return downcast<RenderPassEncoderImpl>(renderPassEncoder).backing();
 }
 
 WGPURenderPipeline DowncastConvertToBackingContext::convertToBacking(const RenderPipeline& renderPipeline)
 {
-    return static_cast<const RenderPipelineImpl&>(renderPipeline).backing();
+    return downcast<RenderPipelineImpl>(renderPipeline).backing();
 }
 
 WGPUSampler DowncastConvertToBackingContext::convertToBacking(const Sampler& sampler)
 {
-    return static_cast<const SamplerImpl&>(sampler).backing();
+    return downcast<SamplerImpl>(sampler).backing();
 }
 
 WGPUShaderModule DowncastConvertToBackingContext::convertToBacking(const ShaderModule& shaderModule)
 {
-    return static_cast<const ShaderModuleImpl&>(shaderModule).backing();
+    return downcast<ShaderModuleImpl>(shaderModule).backing();
 }
 
 WGPUTexture DowncastConvertToBackingContext::convertToBacking(const Texture& texture)
 {
-    return static_cast<const TextureImpl&>(texture).backing();
+    return downcast<TextureImpl>(texture).backing();
 }
 
 WGPUTextureView DowncastConvertToBackingContext::convertToBacking(const TextureView& textureView)
 {
-    return static_cast<const TextureViewImpl&>(textureView).backing();
+    return downcast<TextureViewImpl>(textureView).backing();
 }
 
 CompositorIntegrationImpl& DowncastConvertToBackingContext::convertToBacking(CompositorIntegration& compositorIntegration)
 {
-    return static_cast<CompositorIntegrationImpl&>(compositorIntegration);
+    return downcast<CompositorIntegrationImpl>(compositorIntegration);
 }
 
 WGPUXRBinding DowncastConvertToBackingContext::convertToBacking(const XRBinding& xrBinding)
 {
-    return static_cast<const XRBindingImpl&>(xrBinding).backing();
+    return downcast<XRBindingImpl>(xrBinding).backing();
 }
 
 WGPUXRProjectionLayer DowncastConvertToBackingContext::convertToBacking(const XRProjectionLayer& layer)
 {
-    return static_cast<const XRProjectionLayerImpl&>(layer).backing();
+    return downcast<XRProjectionLayerImpl>(layer).backing();
 }
 
 WGPUXRSubImage DowncastConvertToBackingContext::convertToBacking(const XRSubImage& subImage)
 {
-    return static_cast<const XRSubImageImpl&>(subImage).backing();
+    return downcast<XRSubImageImpl>(subImage).backing();
 }
 
 WGPUXRView DowncastConvertToBackingContext::convertToBacking(const XRView& xrView)
 {
-    return static_cast<const XRViewImpl&>(xrView).backing();
+    return downcast<XRViewImpl>(xrView).backing();
 }
 
 } // namespace WebCore::WebGPU

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUExternalTextureImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUExternalTextureImpl.h
@@ -51,6 +51,7 @@ public:
     virtual ~ExternalTextureImpl();
 
     WGPUExternalTexture backing() const { return m_backing.get(); };
+    bool isExternalTextureImpl() const final { return true; }
 
 private:
     friend class DowncastConvertToBackingContext;
@@ -76,5 +77,9 @@ private:
 };
 
 } // namespace WebCore::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WebGPU::ExternalTextureImpl)
+    static bool isType(const WebCore::WebGPU::ExternalTexture& texture) { return texture.isExternalTextureImpl(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // HAVE(WEBGPU_IMPLEMENTATION)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUImpl.h
@@ -105,6 +105,7 @@ private:
     GPUImpl& operator=(GPUImpl&&) = delete;
 
     WGPUInstance backing() const { return m_backing.get(); }
+    bool isGPUImpl() const final { return true; }
 
     void requestAdapter(const RequestAdapterOptions&, CompletionHandler<void(RefPtr<Adapter>&&)>&&) final;
     RefPtr<DDModel::DDMesh> createModelBacking(unsigned width, unsigned height, const DDModel::DDImageAsset& diffuseTexture, const DDModel::DDImageAsset& specularTexture, CompletionHandler<void(Vector<MachSendRight>&&)>&&) final;
@@ -146,5 +147,9 @@ private:
 };
 
 } // namespace WebCore::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WebGPU::GPUImpl)
+    static bool isType(const WebCore::WebGPU::GPU& gpu) { return gpu.isGPUImpl(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // HAVE(WEBGPU_IMPLEMENTATION)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUPipelineLayoutImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUPipelineLayoutImpl.h
@@ -57,6 +57,7 @@ private:
     PipelineLayoutImpl& operator=(PipelineLayoutImpl&&) = delete;
 
     WGPUPipelineLayout backing() const { return m_backing.get(); }
+    bool isPipelineLayoutImpl() const final { return true; }
 
     void setLabelInternal(const String&) final;
 
@@ -65,5 +66,9 @@ private:
 };
 
 } // namespace WebCore::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WebGPU::PipelineLayoutImpl)
+    static bool isType(const WebCore::WebGPU::PipelineLayout& layout) { return layout.isPipelineLayoutImpl(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // HAVE(WEBGPU_IMPLEMENTATION)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUPresentationContextImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUPresentationContextImpl.h
@@ -55,6 +55,7 @@ public:
     void present(uint32_t frameIndex, bool = false);
 
     WGPUSurface backing() const { return m_backing.get(); }
+    bool isPresentationContextImpl() const final { return true; }
     RefPtr<WebCore::NativeImage> getMetalTextureAsNativeImage(uint32_t bufferIndex, bool& isIOSurfaceSupportedFormat) final;
 
 private:
@@ -83,5 +84,9 @@ private:
 };
 
 } // namespace WebCore::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WebGPU::PresentationContextImpl)
+    static bool isType(const WebCore::WebGPU::PresentationContext& context) { return context.isPresentationContextImpl(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // HAVE(WEBGPU_IMPLEMENTATION)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUQuerySetImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUQuerySetImpl.h
@@ -57,6 +57,7 @@ private:
     QuerySetImpl& operator=(QuerySetImpl&&) = delete;
 
     WGPUQuerySet backing() const { return m_backing.get(); }
+    bool isQuerySetImpl() const final { return true; }
 
     void destroy() final;
 
@@ -67,5 +68,9 @@ private:
 };
 
 } // namespace WebCore::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WebGPU::QuerySetImpl)
+    static bool isType(const WebCore::WebGPU::QuerySet& querySet) { return querySet.isQuerySetImpl(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // HAVE(WEBGPU_IMPLEMENTATION)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.h
@@ -58,6 +58,7 @@ private:
     QueueImpl& operator=(QueueImpl&&) = delete;
 
     WGPUQueue backing() const { return m_backing.get(); }
+    bool isQueueImpl() const final { return true; }
 
     void submit(Vector<Ref<WebGPU::CommandBuffer>>&&) final;
 
@@ -102,5 +103,9 @@ private:
 };
 
 } // namespace WebCore::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WebGPU::QueueImpl)
+    static bool isType(const WebCore::WebGPU::Queue& queue) { return queue.isQueueImpl(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // HAVE(WEBGPU_IMPLEMENTATION)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderBundleEncoderImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderBundleEncoderImpl.h
@@ -57,6 +57,7 @@ private:
     RenderBundleEncoderImpl& operator=(RenderBundleEncoderImpl&&) = delete;
 
     WGPURenderBundleEncoder backing() const { return m_backing.get(); }
+    bool isRenderBundleEncoderImpl() const final { return true; }
 
     void setPipeline(const RenderPipeline&) final;
 
@@ -94,5 +95,9 @@ private:
 };
 
 } // namespace WebCore::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WebGPU::RenderBundleEncoderImpl)
+    static bool isType(const WebCore::WebGPU::RenderBundleEncoder& encoder) { return encoder.isRenderBundleEncoderImpl(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // HAVE(WEBGPU_IMPLEMENTATION)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderBundleImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderBundleImpl.h
@@ -57,6 +57,7 @@ private:
     RenderBundleImpl& operator=(RenderBundleImpl&&) = delete;
 
     WGPURenderBundle backing() const { return m_backing.get(); }
+    bool isRenderBundleImpl() const final { return true; }
 
     void setLabelInternal(const String&) final;
 
@@ -65,5 +66,9 @@ private:
 };
 
 } // namespace WebCore::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WebGPU::RenderBundleImpl)
+    static bool isType(const WebCore::WebGPU::RenderBundle& bundle) { return bundle.isRenderBundleImpl(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // HAVE(WEBGPU_IMPLEMENTATION)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderPassEncoderImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderPassEncoderImpl.h
@@ -57,6 +57,7 @@ private:
     RenderPassEncoderImpl& operator=(RenderPassEncoderImpl&&) = delete;
 
     WGPURenderPassEncoder backing() const { return m_backing.get(); }
+    bool isRenderPassEncoderImpl() const final { return true; }
 
     void setPipeline(const RenderPipeline&) final;
 
@@ -108,5 +109,9 @@ private:
 };
 
 } // namespace WebCore::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WebGPU::RenderPassEncoderImpl)
+    static bool isType(const WebCore::WebGPU::RenderPassEncoder& encoder) { return encoder.isRenderPassEncoderImpl(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // HAVE(WEBGPU_IMPLEMENTATION)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderPipelineImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderPipelineImpl.h
@@ -59,6 +59,7 @@ private:
     RenderPipelineImpl& operator=(RenderPipelineImpl&&) = delete;
 
     WGPURenderPipeline backing() const { return m_backing.get(); }
+    bool isRenderPipelineImpl() const final { return true; }
 
     Ref<BindGroupLayout> getBindGroupLayout(uint32_t index) final;
 
@@ -69,5 +70,9 @@ private:
 };
 
 } // namespace WebCore::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WebGPU::RenderPipelineImpl)
+    static bool isType(const WebCore::WebGPU::RenderPipeline& pipeline) { return pipeline.isRenderPipelineImpl(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // HAVE(WEBGPU_IMPLEMENTATION)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUSamplerImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUSamplerImpl.h
@@ -57,6 +57,7 @@ private:
     SamplerImpl& operator=(SamplerImpl&&) = delete;
 
     WGPUSampler backing() const { return m_backing.get(); }
+    bool isSamplerImpl() const final { return true; }
 
     void setLabelInternal(const String&) final;
 
@@ -65,5 +66,9 @@ private:
 };
 
 } // namespace WebCore::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WebGPU::SamplerImpl)
+    static bool isType(const WebCore::WebGPU::Sampler& sampler) { return sampler.isSamplerImpl(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // HAVE(WEBGPU_IMPLEMENTATION)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUShaderModuleImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUShaderModuleImpl.h
@@ -57,6 +57,7 @@ private:
     ShaderModuleImpl& operator=(ShaderModuleImpl&&) = delete;
 
     WGPUShaderModule backing() const { return m_backing.get(); }
+    bool isShaderModuleImpl() const final { return true; }
 
     void compilationInfo(CompletionHandler<void(Ref<CompilationInfo>&&)>&&) final;
 
@@ -67,5 +68,9 @@ private:
 };
 
 } // namespace WebCore::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WebGPU::ShaderModuleImpl)
+    static bool isType(const WebCore::WebGPU::ShaderModule& module) { return module.isShaderModuleImpl(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // HAVE(WEBGPU_IMPLEMENTATION)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUTextureImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUTextureImpl.h
@@ -60,6 +60,7 @@ private:
     TextureImpl& operator=(TextureImpl&&) = delete;
 
     WGPUTexture backing() const { return m_backing.get(); }
+    bool isTextureImpl() const final { return true; }
 
     RefPtr<TextureView> createView(const std::optional<TextureViewDescriptor>&) final;
 
@@ -76,5 +77,9 @@ private:
 };
 
 } // namespace WebCore::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WebGPU::TextureImpl)
+    static bool isType(const WebCore::WebGPU::Texture& texture) { return texture.isTextureImpl(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // HAVE(WEBGPU_IMPLEMENTATION)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUTextureViewImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUTextureViewImpl.h
@@ -57,6 +57,7 @@ private:
     TextureViewImpl& operator=(TextureViewImpl&&) = delete;
 
     WGPUTextureView backing() const { return m_backing.get(); }
+    bool isTextureViewImpl() const final { return true; }
 
     void setLabelInternal(const String&) final;
 
@@ -65,5 +66,9 @@ private:
 };
 
 } // namespace WebCore::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WebGPU::TextureViewImpl)
+    static bool isType(const WebCore::WebGPU::TextureView& textureView) { return textureView.isTextureViewImpl(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // HAVE(WEBGPU_IMPLEMENTATION)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUXRBindingImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUXRBindingImpl.h
@@ -68,6 +68,7 @@ private:
     XRBindingImpl& operator=(XRBindingImpl&&) = delete;
 
     WGPUXRBinding backing() const { return m_backing.get(); }
+    bool isXRBindingImpl() const final { return true; }
 
     RefPtr<XRProjectionLayer> createProjectionLayer(const XRProjectionLayerInit&) final;
     RefPtr<XRSubImage> getSubImage(XRProjectionLayer&, WebCore::WebXRFrame&, std::optional<XREye>/* = "none"*/) final;
@@ -79,5 +80,9 @@ private:
 };
 
 } // namespace WebCore::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WebGPU::XRBindingImpl)
+    static bool isType(const WebCore::WebGPU::XRBinding& xrBinding) { return xrBinding.isXRBindingImpl(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // HAVE(WEBGPU_IMPLEMENTATION)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUXRProjectionLayerImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUXRProjectionLayerImpl.h
@@ -50,6 +50,7 @@ public:
 
     virtual ~XRProjectionLayerImpl();
     WGPUXRProjectionLayer backing() const { return m_backing.get(); }
+    bool isXRProjectionLayerImpl() const final { return true; }
 
 private:
     friend class DowncastConvertToBackingContext;
@@ -85,5 +86,9 @@ private:
 };
 
 } // namespace WebCore::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WebGPU::XRProjectionLayerImpl)
+    static bool isType(const WebCore::WebGPU::XRProjectionLayer& xrProjectionLayer) { return xrProjectionLayer.isXRProjectionLayerImpl(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // HAVE(WEBGPU_IMPLEMENTATION)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUXRSubImageImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUXRSubImageImpl.h
@@ -60,11 +60,16 @@ private:
     RefPtr<Texture> motionVectorTexture() final;
 
     WGPUXRSubImage backing() const { return m_backing.get(); }
+    bool isXRSubImageImpl() const final { return true; }
 
     WebGPUPtr<WGPUXRSubImage> m_backing;
     const Ref<ConvertToBackingContext> m_convertToBackingContext;
 };
 
 } // namespace WebCore::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WebGPU::XRSubImageImpl)
+    static bool isType(const WebCore::WebGPU::XRSubImage& xrSubImage) { return xrSubImage.isXRSubImageImpl(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // HAVE(WEBGPU_IMPLEMENTATION)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUXRViewImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUXRViewImpl.h
@@ -68,11 +68,16 @@ private:
     XRViewImpl& operator=(XRViewImpl&&) = delete;
 
     WGPUXRView backing() const { return m_backing.get(); }
+    bool isXRViewImpl() const final { return true; }
 
     WebGPUPtr<WGPUXRView> m_backing;
     const Ref<ConvertToBackingContext> m_convertToBackingContext;
 };
 
 } // namespace WebCore::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WebGPU::XRViewImpl)
+    static bool isType(const WebCore::WebGPU::XRView& xrView) { return xrView.isXRViewImpl(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // HAVE(WEBGPU_IMPLEMENTATION)

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPU.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPU.h
@@ -119,6 +119,7 @@ public:
     virtual bool isValid(const XRView&) const = 0;
 
     virtual bool isRemoteGPUProxy() const { return false; }
+    virtual bool isGPUImpl() const { return false; }
 
 protected:
     GPU() = default;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUAdapter.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUAdapter.h
@@ -49,6 +49,7 @@ public:
     bool isFallbackAdapter() const { return m_isFallbackAdapter; }
     virtual bool xrCompatible() = 0;
     virtual bool isRemoteAdapterProxy() const { return false; }
+    virtual bool isAdapterImpl() const { return false; }
 
     virtual void requestDevice(const DeviceDescriptor&, CompletionHandler<void(RefPtr<Device>&&)>&&) = 0;
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBindGroup.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBindGroup.h
@@ -48,6 +48,7 @@ public:
     }
 
     virtual bool isRemoteBindGroupProxy() const { return false; }
+    virtual bool isBindGroupImpl() const { return false; }
 
 protected:
     BindGroup() = default;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBindGroupLayout.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBindGroupLayout.h
@@ -46,6 +46,7 @@ public:
     }
 
     virtual bool isRemoteBindGroupLayoutProxy() const { return false; }
+    virtual bool isBindGroupLayoutImpl() const { return false; }
 
 protected:
     BindGroupLayout() = default;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBuffer.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBuffer.h
@@ -58,6 +58,7 @@ public:
     virtual void copyFrom(std::span<const uint8_t>, size_t offset) = 0;
 
     virtual bool isRemoteBufferProxy() const { return false; }
+    virtual bool isBufferImpl() const { return false; }
 
 protected:
     Buffer() = default;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCommandBuffer.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCommandBuffer.h
@@ -45,6 +45,7 @@ public:
     }
 
     virtual bool isRemoteCommandBufferProxy() const { return false; }
+    virtual bool isCommandBufferImpl() const { return false; }
 
 protected:
     CommandBuffer() = default;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCommandEncoder.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCommandEncoder.h
@@ -103,6 +103,7 @@ public:
 
     virtual RefPtr<CommandBuffer> finish(const CommandBufferDescriptor&) = 0;
     virtual bool isRemoteCommandEncoderProxy() const { return false; }
+    virtual bool isCommandEncoderImpl() const { return false; }
 
 protected:
     CommandEncoder() = default;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCompositorIntegration.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCompositorIntegration.h
@@ -66,6 +66,7 @@ public:
     virtual void paintCompositedResultsToCanvas(WebCore::ImageBuffer&, uint32_t bufferIndex) = 0;
     virtual void updateContentsHeadroom(float) = 0;
     virtual bool isRemoteCompositorIntegrationProxy() const { return false; }
+    virtual bool isCompositorIntegrationImpl() const { return false; }
 
 protected:
     CompositorIntegration() = default;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUComputePassEncoder.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUComputePassEncoder.h
@@ -71,6 +71,7 @@ public:
     virtual void popDebugGroup() = 0;
     virtual void insertDebugMarker(String&& markerLabel) = 0;
     virtual bool isRemoteComputePassEncoderProxy() const { return false; }
+    virtual bool isComputePassEncoderImpl() const { return false; }
 
 protected:
     ComputePassEncoder() = default;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUComputePipeline.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUComputePipeline.h
@@ -50,6 +50,7 @@ public:
     // "A new GPUBindGroupLayout wrapper is returned each time"
     virtual Ref<BindGroupLayout> getBindGroupLayout(uint32_t index) = 0;
     virtual bool isRemoteComputePipelineProxy() const { return false; }
+    virtual bool isComputePipelineImpl() const { return false; }
 
 protected:
     ComputePipeline() = default;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUDevice.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUDevice.h
@@ -143,6 +143,7 @@ public:
     virtual void pauseAllErrorReporting(bool pause) = 0;
 
     virtual bool isRemoteDeviceProxy() const { return false; }
+    virtual bool isDeviceImpl() const { return false; }
     virtual Ref<BindGroupLayout> emptyBindGroupLayout() const = 0;
 
 protected:

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUExternalTexture.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUExternalTexture.h
@@ -54,6 +54,7 @@ public:
     virtual void updateExternalTexture(CVPixelBufferRef) = 0;
 #endif
     virtual bool isRemoteExternalTextureProxy() const { return false; }
+    virtual bool isExternalTextureImpl() const { return false; }
 
 protected:
     ExternalTexture() = default;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPipelineLayout.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPipelineLayout.h
@@ -45,6 +45,7 @@ public:
     }
 
     virtual bool isRemotePipelineLayoutProxy() const { return false; }
+    virtual bool isPipelineLayoutImpl() const { return false; }
 
 protected:
     PipelineLayout() = default;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPresentationContext.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPresentationContext.h
@@ -56,6 +56,7 @@ public:
     virtual RefPtr<WebCore::NativeImage> getMetalTextureAsNativeImage(uint32_t bufferIndex, bool& isIOSurfaceSupportedFormat) = 0;
 
     virtual bool isRemotePresentationContextProxy() const { return false; }
+    virtual bool isPresentationContextImpl() const { return false; }
 
 protected:
     PresentationContext() = default;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUQuerySet.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUQuerySet.h
@@ -46,6 +46,7 @@ public:
 
     virtual void destroy() = 0;
     virtual bool isRemoteQuerySetProxy() const { return false; }
+    virtual bool isQuerySetImpl() const { return false; }
 
 protected:
     QuerySet() = default;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUQueue.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUQueue.h
@@ -100,6 +100,7 @@ public:
 
     virtual RefPtr<WebCore::NativeImage> getNativeImage(WebCore::VideoFrame&) = 0;
     virtual bool isRemoteQueueProxy() const { return false; }
+    virtual bool isQueueImpl() const { return false; }
 
 protected:
     Queue() = default;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderBundle.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderBundle.h
@@ -45,6 +45,7 @@ public:
     }
 
     virtual bool isRemoteRenderBundleProxy() const { return false; }
+    virtual bool isRenderBundleImpl() const { return false; }
 
 protected:
     RenderBundle() = default;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderBundleEncoder.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderBundleEncoder.h
@@ -84,6 +84,7 @@ public:
 
     virtual RefPtr<RenderBundle> finish(const RenderBundleDescriptor&) = 0;
     virtual bool isRemoteRenderBundleEncoderProxy() const { return false; }
+    virtual bool isRenderBundleEncoderImpl() const { return false; }
 
 protected:
     RenderBundleEncoder() = default;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassEncoder.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassEncoder.h
@@ -101,6 +101,7 @@ public:
     virtual void end() = 0;
 
     virtual bool isRemoteRenderPassEncoderProxy() const { return false; }
+    virtual bool isRenderPassEncoderImpl() const { return false; }
 
 protected:
     RenderPassEncoder() = default;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPipeline.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPipeline.h
@@ -50,6 +50,7 @@ public:
     // "A new GPUBindGroupLayout wrapper is returned each time"
     virtual Ref<BindGroupLayout> getBindGroupLayout(uint32_t index) = 0;
     virtual bool isRemoteRenderPipelineProxy() const { return false; }
+    virtual bool isRenderPipelineImpl() const { return false; }
 
 protected:
     RenderPipeline() = default;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUSampler.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUSampler.h
@@ -45,6 +45,7 @@ public:
     }
 
     virtual bool isRemoteSamplerProxy() const { return false; }
+    virtual bool isSamplerImpl() const { return false; }
 
 protected:
     Sampler() = default;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUShaderModule.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUShaderModule.h
@@ -50,6 +50,7 @@ public:
 
     virtual void compilationInfo(CompletionHandler<void(Ref<CompilationInfo>&&)>&&) = 0;
     virtual bool isRemoteShaderModuleProxy() const { return false; }
+    virtual bool isShaderModuleImpl() const { return false; }
 
 protected:
     ShaderModule() = default;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTexture.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTexture.h
@@ -54,6 +54,7 @@ public:
     virtual void undestroy() = 0;
 
     virtual bool isRemoteTextureProxy() const { return false; }
+    virtual bool isTextureImpl() const { return false; }
 
 protected:
     Texture() = default;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTextureView.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTextureView.h
@@ -45,6 +45,7 @@ public:
     }
 
     virtual bool isRemoteTextureViewProxy() const { return false; }
+    virtual bool isTextureViewImpl() const { return false; }
 
 protected:
     TextureView() = default;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUXRBinding.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUXRBinding.h
@@ -53,6 +53,7 @@ public:
     virtual RefPtr<XRSubImage> getViewSubImage(XRProjectionLayer&) = 0;
     virtual TextureFormat getPreferredColorFormat() = 0;
     virtual bool isRemoteXRBindingProxy() const { return false; }
+    virtual bool isXRBindingImpl() const { return false; }
 
 protected:
     XRBinding() = default;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUXRProjectionLayer.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUXRProjectionLayer.h
@@ -74,6 +74,7 @@ public:
     virtual void setDeltaPose(WebXRRigidTransform*) = 0;
 
     virtual bool isRemoteXRProjectionLayerProxy() const { return false; }
+    virtual bool isXRProjectionLayerImpl() const { return false; }
 
 protected:
     XRProjectionLayer() = default;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUXRSubImage.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUXRSubImage.h
@@ -42,6 +42,7 @@ public:
     virtual RefPtr<Texture> depthStencilTexture() = 0;
     virtual RefPtr<Texture> motionVectorTexture() = 0;
     virtual bool isRemoteXRSubImageProxy() const { return false; }
+    virtual bool isXRSubImageImpl() const { return false; }
 
 protected:
     XRSubImage() = default;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUXRView.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUXRView.h
@@ -39,6 +39,7 @@ public:
     virtual ~XRView() = default;
 
     virtual bool isRemoteXRViewProxy() const { return false; }
+    virtual bool isXRViewImpl() const { return false; }
 
 protected:
     XRView() = default;

--- a/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -1,6 +1,5 @@
 Modules/Model/Implementation/ModelDowncastConvertToBackingContext.cpp
 Modules/WebGPU/Implementation/WebGPUBindGroupImpl.cpp
-Modules/WebGPU/Implementation/WebGPUDowncastConvertToBackingContext.cpp
 Modules/WebGPU/Implementation/WebGPUXRBindingImpl.cpp
 Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.cpp
 Modules/mediastream/libwebrtc/LibWebRTCStatsCollector.cpp


### PR DESCRIPTION
#### a821dd9f500cf5627aa0a42b4a0cd114c0741938
<pre>
Address memory unsafe cast warnings in WebGPUDowncastConvertToBackingContext.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=305760">https://bugs.webkit.org/show_bug.cgi?id=305760</a>

Reviewed by Anne van Kesteren and Mike Wyrzykowski.

* Source/WebCore/Modules/WebGPU/Implementation/WebGPUAdapterImpl.h:
(isType):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUBindGroupImpl.h:
(isType):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUBindGroupLayoutImpl.h:
(isType):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUBufferImpl.h:
(isType):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandBufferImpl.h:
(isType):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandEncoderImpl.h:
(isType):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.h:
(isType):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUComputePassEncoderImpl.h:
(isType):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUComputePipelineImpl.h:
(isType):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.h:
(isType):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUDowncastConvertToBackingContext.cpp:
(WebCore::WebGPU::DowncastConvertToBackingContext::convertToBacking):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUExternalTextureImpl.h:
(isType):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUImpl.h:
(isType):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUPipelineLayoutImpl.h:
(isType):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUPresentationContextImpl.h:
(isType):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUQuerySetImpl.h:
(isType):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.h:
(isType):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderBundleEncoderImpl.h:
(isType):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderBundleImpl.h:
(isType):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderPassEncoderImpl.h:
(isType):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderPipelineImpl.h:
(isType):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUSamplerImpl.h:
(isType):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUShaderModuleImpl.h:
(isType):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUTextureImpl.h:
(isType):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUTextureViewImpl.h:
(isType):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUXRBindingImpl.h:
(isType):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUXRProjectionLayerImpl.h:
(isType):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUXRSubImageImpl.h:
(isType):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUXRViewImpl.h:
(isType):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPU.h:
(WebCore::WebGPU::GPU::isGPUImpl const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUAdapter.h:
(WebCore::WebGPU::Adapter::isAdapterImpl const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBindGroup.h:
(WebCore::WebGPU::BindGroup::isBindGroupImpl const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBindGroupLayout.h:
(WebCore::WebGPU::BindGroupLayout::isBindGroupLayoutImpl const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBuffer.h:
(WebCore::WebGPU::Buffer::isBufferImpl const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCommandBuffer.h:
(WebCore::WebGPU::CommandBuffer::isCommandBufferImpl const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCommandEncoder.h:
(WebCore::WebGPU::CommandEncoder::isCommandEncoderImpl const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCompositorIntegration.h:
(WebCore::WebGPU::CompositorIntegration::isCompositorIntegrationImpl const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUComputePassEncoder.h:
(WebCore::WebGPU::ComputePassEncoder::isComputePassEncoderImpl const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUComputePipeline.h:
(WebCore::WebGPU::ComputePipeline::isComputePipelineImpl const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUDevice.h:
(WebCore::WebGPU::Device::isDeviceImpl const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUExternalTexture.h:
(WebCore::WebGPU::ExternalTexture::isExternalTextureImpl const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPipelineLayout.h:
(WebCore::WebGPU::PipelineLayout::isPipelineLayoutImpl const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPresentationContext.h:
(WebCore::WebGPU::PresentationContext::isPresentationContextImpl const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUQuerySet.h:
(WebCore::WebGPU::QuerySet::isQuerySetImpl const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUQueue.h:
(WebCore::WebGPU::Queue::isQueueImpl const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderBundle.h:
(WebCore::WebGPU::RenderBundle::isRenderBundleImpl const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderBundleEncoder.h:
(WebCore::WebGPU::RenderBundleEncoder::isRenderBundleEncoderImpl const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassEncoder.h:
(WebCore::WebGPU::RenderPassEncoder::isRenderPassEncoderImpl const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPipeline.h:
(WebCore::WebGPU::RenderPipeline::isRenderPipelineImpl const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUSampler.h:
(WebCore::WebGPU::Sampler::isSamplerImpl const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUShaderModule.h:
(WebCore::WebGPU::ShaderModule::isShaderModuleImpl const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTexture.h:
(WebCore::WebGPU::Texture::isTextureImpl const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTextureView.h:
(WebCore::WebGPU::TextureView::isTextureViewImpl const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUXRBinding.h:
(WebCore::WebGPU::XRBinding::isXRBindingImpl const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUXRProjectionLayer.h:
(WebCore::WebGPU::XRProjectionLayer::isXRProjectionLayerImpl const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUXRSubImage.h:
(WebCore::WebGPU::XRSubImage::isXRSubImageImpl const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUXRView.h:
(WebCore::WebGPU::XRView::isXRViewImpl const):
* Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/305817@main">https://commits.webkit.org/305817@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/124673d5dbd9ac7989fd30b5a3a3a286be55b17b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139486 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11862 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/988 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147614 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92554 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5bfa27c0-79fa-44fc-ba0b-a080ffe28215) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141359 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12570 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12012 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106788 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/77751 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f5acfe64-d06d-4e4d-82fb-150badf12187) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142433 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9614 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124934 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87651 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9233 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6854 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7912 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118540 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/915 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150397 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11546 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/931 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115190 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11560 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9861 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115501 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29344 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10023 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121361 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66552 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11590 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/869 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11326 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75256 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11526 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11377 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->