### PR TITLE
[GStreamer] Simplify quirks loading logic

### DIFF
--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkBcmNexus.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkBcmNexus.cpp
@@ -46,6 +46,13 @@ GStreamerQuirkBcmNexus::GStreamerQuirkBcmNexus()
     }
 }
 
+bool GStreamerQuirkBcmNexus::isPlatformSupported() const
+{
+    auto registry = gst_registry_get();
+    auto feature = adoptGRef(gst_registry_lookup_feature(registry, "brcmaudfilter"));
+    return feature;
+}
+
 std::optional<bool> GStreamerQuirkBcmNexus::isHardwareAccelerated(GstElementFactory* factory)
 {
     auto view = StringView::fromLatin1(GST_OBJECT_NAME(factory));

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkBcmNexus.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkBcmNexus.h
@@ -30,6 +30,7 @@ namespace WebCore {
 class GStreamerQuirkBcmNexus final : public GStreamerQuirkBroadcomBase {
 public:
     GStreamerQuirkBcmNexus();
+    bool isPlatformSupported() const final;
     const ASCIILiteral identifier() const final { return "BcmNexus"_s; }
 
     std::optional<bool> isHardwareAccelerated(GstElementFactory*) final;

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkOpenMAX.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkOpenMAX.cpp
@@ -35,6 +35,13 @@ GStreamerQuirkOpenMAX::GStreamerQuirkOpenMAX()
     GST_DEBUG_CATEGORY_INIT(webkit_openmax_quirks_debug, "webkitquirksopenmax", 0, "WebKit OpenMAX Quirks");
 }
 
+bool GStreamerQuirkOpenMAX::isPlatformSupported() const
+{
+    auto registry = gst_registry_get();
+    auto feature = adoptGRef(gst_registry_lookup_feature(registry, "omx"));
+    return feature;
+}
+
 bool GStreamerQuirkOpenMAX::processWebAudioSilentBuffer(GstBuffer* buffer) const
 {
     GST_TRACE("Force disabling GAP buffer flag");

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkOpenMAX.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkOpenMAX.h
@@ -30,6 +30,7 @@ class GStreamerQuirkOpenMAX final : public GStreamerQuirk {
 public:
     GStreamerQuirkOpenMAX();
     const ASCIILiteral identifier() const final { return "OpenMAX"_s; }
+    bool isPlatformSupported() const final;
     unsigned getAdditionalPlaybinFlags() const final { return getGstPlayFlag("text") | getGstPlayFlag("native-video"); }
 
     bool processWebAudioSilentBuffer(GstBuffer*) const final;

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirks.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirks.h
@@ -71,7 +71,7 @@ public:
     GStreamerQuirk() = default;
     virtual ~GStreamerQuirk() = default;
 
-    virtual bool isPlatformSupported() const { return true; }
+    virtual bool isPlatformSupported() const = 0;
     virtual GstElement* createAudioSink() { return nullptr; }
     virtual GstElement* createWebAudioSink() { return nullptr; }
     virtual void configureElement(GstElement*, const OptionSet<ElementRuntimeCharacteristics>&) { }


### PR DESCRIPTION
#### 1a54a65e353b9540d44a1c8ed435baec184186d9
<pre>
[GStreamer] Simplify quirks loading logic
<a href="https://bugs.webkit.org/show_bug.cgi?id=305761">https://bugs.webkit.org/show_bug.cgi?id=305761</a>

Reviewed by Xabier Rodriguez-Calvar.

This patch add support for automatic GStreamer quirks loading if the WEBKIT_GST_QUIRKS envrionment
variable has not been set. It is now mandatory to implement GStreamerQuirk::isPlatformSupported(),
only the OpenMAX and BcmNexus were missing an implementation.

* Source/WebCore/platform/gstreamer/GStreamerQuirkBcmNexus.cpp:
(WebCore::GStreamerQuirkBcmNexus::isPlatformSupported const):
* Source/WebCore/platform/gstreamer/GStreamerQuirkBcmNexus.h:
* Source/WebCore/platform/gstreamer/GStreamerQuirkOpenMAX.cpp:
(WebCore::GStreamerQuirkOpenMAX::isPlatformSupported const):
* Source/WebCore/platform/gstreamer/GStreamerQuirkOpenMAX.h:
* Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp:
(WebCore::GStreamerQuirksManager::GStreamerQuirksManager):
(WebCore::GStreamerQuirksManager::configureElement):
* Source/WebCore/platform/gstreamer/GStreamerQuirks.h:
(WebCore::GStreamerQuirk::isPlatformSupported const): Deleted.

Canonical link: <a href="https://commits.webkit.org/306067@main">https://commits.webkit.org/306067@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84e8ed61dbd633a038b355ef0a75c9a698c863ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140292 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12673 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1803 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148561 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/93370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142165 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13385 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12827 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/107496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/93370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143242 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10306 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/125590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88388 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/9930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/7470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8725 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119160 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/1603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151236 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12361 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/1670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/115839 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12373 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/10581 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116176 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29506 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/11237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/122076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/67374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12402 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/1536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12143 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76100 "Built successfully") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/12337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12187 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->