### PR TITLE
Workaround Cookie observer issues with Enhanced Security heuristics

### DIFF
--- a/Source/WebCore/platform/network/cocoa/CookieStorageObserver.h
+++ b/Source/WebCore/platform/network/cocoa/CookieStorageObserver.h
@@ -55,6 +55,8 @@ public:
 
     void cookiesDidChange();
 
+    void registerInternalsForNotifications(bool isReregistering);
+
 private:
     RetainPtr<NSHTTPCookieStorage> m_cookieStorage;
     bool m_hasRegisteredInternalsForNotifications { false };


### PR DESCRIPTION
#### 40c01e0830ae322be1fae407faf577d5e5fb57fb
<pre>
Workaround Cookie observer issues with Enhanced Security heuristics
<a href="https://bugs.webkit.org/show_bug.cgi?id=305331">https://bugs.webkit.org/show_bug.cgi?id=305331</a>
<a href="https://rdar.apple.com/167988684">rdar://167988684</a>

Reviewed by Matthew Finkel.

A bug exists in CFNetwork which can cause our notification registration
for cookie changes to be unregistered. This occurs when a
NSHTTPCookieStorage object is destroyed, particularly when a
non-persistent website data store is used.

When the Enhanced Security heuristics flag is enabled, we perform a
hasCookies call to check for cookies more regularly, which surfaces this
bug more frequently. This change applies a temporary workaround that
re-registers for cookie notifications, if required, after a call to
hasCookies.

A new test is also added that ensures this behaviour is tested for.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm

* Source/WebCore/platform/network/cocoa/CookieStorageObserver.h:
* Source/WebCore/platform/network/cocoa/CookieStorageObserver.mm:
(WebCore::CookieStorageObserver::startObserving):
(WebCore::CookieStorageObserver::registerInternalsForNotifications):
* Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm:
(WebCore::NetworkStorageSession::hasCookies const):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm:
(-[EnhancedSecurityCookieObserver cookiesDidChangeInCookieStore:]):
(TEST(EnhancedSecurityPolicies, NonPersistentDataStoreCookieNotification)):

Canonical link: <a href="https://commits.webkit.org/305930@main">https://commits.webkit.org/305930@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d571bc49d1600276c8b548a22132de977dfee821

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139659 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12035 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1163 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147794 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92727 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6a7b88af-e21c-4a15-8907-032f42046bec) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141532 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12744 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12185 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107032 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77852 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cc5bc3fb-b081-4e33-a97e-5129ddedbaa1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142606 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9801 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125082 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87803 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b31f176a-ebe6-40e4-9ac4-ee824ed6b440) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9449 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6989 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8086 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118695 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1080 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150576 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11720 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1123 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115344 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11733 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10035 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115654 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29423 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10375 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121549 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/66725 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11764 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1033 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11503 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75442 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11699 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11551 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->