### PR TITLE
WebServiceWorkerFetchTaskClient::doCancel can create a potential deadlock

### DIFF
--- a/Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.cpp
@@ -258,10 +258,13 @@ void WebServiceWorkerFetchTaskClient::didNotHandleInternal()
 
 void WebServiceWorkerFetchTaskClient::doCancel()
 {
-    Locker lock(m_connectionLock);
-
     ASSERT(!isMainRunLoop());
-    m_connection = nullptr;
+
+    {
+        Locker lock(m_connectionLock);
+        m_connection = nullptr;
+    }
+
     if (m_cancelledCallback)
         m_cancelledCallback();
 }


### PR DESCRIPTION
#### 4b0afef4a5e01030bd108306d3f737698d4c04bb
<pre>
WebServiceWorkerFetchTaskClient::doCancel can create a potential deadlock
<a href="https://rdar.apple.com/168446830">rdar://168446830</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=305769">https://bugs.webkit.org/show_bug.cgi?id=305769</a>

Reviewed by Chris Dumez.

WebServiceWorkerFetchTaskClient::doCancel is called when we try to cancel a fetch intercepted by a service worker.
This in turns will cancel the fetch readablestream body synchronously via the client setCancelledCallback callback in ServiceWorkerFetch::processResponse.
Cancelling the stream will call the client consumeBodyReceivedByChunk callback set in ServiceWorkerFetch::processResponse.
The consumeBodyReceivedByChunk callback can then call WebServiceWorkerFetchTaskClient::didFinish or didFail.

All of this will happen synchronously.
In that case, as WebServiceWorkerFetchTaskClient::doCancel holds a lock for its m_connection, WebServiceWorkerFetchTaskClient::didFinish may be blocked since it also tries to take the same lock.

We update the code in WebServiceWorkerFetchTaskClient::doCancel to only take the connection lock for the time to set m_connection.
The lock is no longer held while executing the cancelled callback.
This should prevent this potential deadlock.

Canonical link: <a href="https://commits.webkit.org/305835@main">https://commits.webkit.org/305835@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/254ec8dc9d342b69677a1f6857b8a2b8da708481

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139516 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11892 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1018 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147644 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92584 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dad887c2-1018-4738-b3be-92f4d86fc3ce) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12600 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12042 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106813 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77772 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b610adf6-6155-4fc1-9bab-952cd796c82c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142463 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9643 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124961 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87677 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c47ab17c-5714-4cc3-999d-bae6e557b8d9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9269 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6881 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7942 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118566 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150427 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11576 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/965 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115217 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11590 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9895 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115528 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29356 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10089 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121395 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66582 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11621 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/905 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11356 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75299 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11556 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11407 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->