### PR TITLE
[Tools][WPE] generate-bundle: add some fixes for running it inside the SDK

### DIFF
--- a/Tools/Scripts/generate-bundle
+++ b/Tools/Scripts/generate-bundle
@@ -465,7 +465,15 @@ class BundleCreator(object):
 
     def _get_gstreamer_modules(self):
         gstreamer_plugins_dir = self._get_pkg_config_var('gstreamer-1.0', 'pluginsdir')
-        return self._list_files_directory(gstreamer_plugins_dir, filter_suffix='.so')
+        gstreamer_plugin_list = self._list_files_directory(gstreamer_plugins_dir, filter_suffix='.so')
+        # Discard the Gstreamer plugins that are not needed and that increase the final bundle
+        # size significantly (either because their own size or because they pull extra libraries)
+        gst_plugin_ignore_list = [ '1394', 'a52dec', 'aasink', 'aja', 'amrnb', 'amrwbdec', 'cacasink', 'cdparanoia', 'dc1394', 'de265', 'directfb', 'dv',
+                                   'dvdlpcmdec', 'flite', 'fluidsynthmidi', 'ges', 'gtk', 'gtkwayland', 'lc3', 'ldac', 'libvisual', 'modplug', 'msdk', 'musepack',
+                                   'neonhttpsrc', 'nvcodec', 'openaptx', 'opencv', 'openmpt', 'openni2', 'python', 'qml6', 'qmlgl', 'qroverlay', 'rtspclientsink',
+                                   'sbc', 'shout2', 'spandsp', 'taglib', 'uvch264', 'voaacenc', 'voamrwbenc', 'waylandsink', 'wildmidi', 'zbar', 'zxing',
+                                   'codec2json', 'camerabin', 'ximagesrc', 'openexr', 'nle', 'ladspa', 'openal']
+        return [p for p in gstreamer_plugin_list if os.path.basename(p).removeprefix('libgst').removesuffix('.so') not in gst_plugin_ignore_list]
 
     def _get_gstreamer_plugin_scanner(self):
         def plugin_scanner_found(plugin_scanner_path):
@@ -490,7 +498,13 @@ class BundleCreator(object):
         libc_library_names = [ 'libanl', 'libBrokenLocale', 'libc', 'libcrypt', 'libdl', 'libgcc_s', 'libm',
                                'libmvec', 'libnsl', 'libpthread', 'libresolv', 'librt', 'libthread_db', 'libutil']
         libc_libraries = []
-        lib_dir = self._get_pkg_config_var('dri', 'libdir')
+        # libc does not have pkg-config support, use gcc to find the dir for the libraries
+        retcode, stdout, stderr = self._run_cmd_and_get_output(['gcc', '-print-file-name=libc.so.6'])
+        if retcode != 0:
+            raise RuntimeError('The gcc command returned status %d' % retcode)
+        lib_dir = os.path.dirname(os.path.realpath(stdout.strip()))
+        if not os.path.isdir(lib_dir):
+            raise RuntimeError('The value returned by gcc is not a directory: %s' % lib_dir)
         for entry in os.listdir(lib_dir):
             if any(entry.startswith(l+'.so.') for l in libc_library_names) or (entry.startswith('libnss_') and '.so.' in entry):
                 libc_libraries.append(os.path.join(lib_dir, entry))
@@ -874,7 +888,7 @@ class BundleCreator(object):
                 os.makedirs(icons_target_dir)
                 gtk_icon_basedir = '/run/host/share/icons' if flatpakutils.is_sandboxed() else '/usr/share/icons'
                 gtk_target_icon_dir = os.path.join(icons_target_dir, 'hicolor')
-                for gtk_icon_theme in ['Adwaita', 'hicolor']:
+                for gtk_icon_theme in ['Adwaita', 'hicolor', 'gnome']:
                     gtk_source_icon_dir = os.path.join(gtk_icon_basedir, gtk_icon_theme)
                     if not os.path.isdir(gtk_source_icon_dir):
                         raise NotImplementedError('Can not find the GTK icon theme at path "%s" in this system' % gtk_source_icon_dir)

--- a/Tools/Scripts/webkitpy/binary_bundling/tests/webdriver/run-webdriver-tests-bundle-docker.sh
+++ b/Tools/Scripts/webkitpy/binary_bundling/tests/webdriver/run-webdriver-tests-bundle-docker.sh
@@ -27,6 +27,9 @@ FBUNDLE="$(readlink -f ${2})"
 MYDIR="$(dirname $(readlink -f ${0}))"
 
 TESTINITSCRIPT="install_deps_docker_start_test.sh"
+[[ -n "${DISPLAY}" ]] && DOCKER_DISPLAY_BIND+="-v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=${DISPLAY} "
+[[ -n "${XAUTHORITY}" ]] && DOCKER_DISPLAY_BIND+="-v ${XAUTHORITY}:${XAUTHORITY} -e XAUTHORITY=${XAUTHORITY} "
+[[ -n "${WAYLAND_DISPLAY}" ]] && DOCKER_DISPLAY_BIND+="-v ${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY}:/tmp/${WAYLAND_DISPLAY} -e XDG_RUNTIME_DIR=/tmp -e WAYLAND_DISPLAY=${WAYLAND_DISPLAY} "
 
 set -eux
 
@@ -58,10 +61,7 @@ for DISTRO in ${DISTROS_TO_TEST[@]}; do
     docker run --init --rm \
                 -v "${MYDIR}:/testdata:ro" \
                 -v "${FBUNDLE}:/testbundle.tar.xz:ro" \
-                -v "/tmp/.X11-unix:/tmp/.X11-unix" \
-                -v "${XAUTHORITY}:${XAUTHORITY}" \
-                -e "XAUTHORITY=${XAUTHORITY}" \
-                -e "DISPLAY=${DISPLAY}" \
+                ${DOCKER_DISPLAY_BIND} \
                 -h "${HOSTNAME}" \
                 "${DISTRO}" \
                 "/testdata/${TESTINITSCRIPT}" "${PORT}"

--- a/Tools/gtk/dependencies/apt
+++ b/Tools/gtk/dependencies/apt
@@ -44,6 +44,11 @@ PACKAGES+=(
     $(aptIfExists python-psutil)
     $(aptIfExists python-yaml)
 
+    # Icon themes needed by the MiniBrowser (generate-bundle needs this as well)
+    adwaita-icon-theme
+    gnome-icon-theme
+    hicolor-icon-theme
+
     # These are dependencies necessary for building the jhbuild.
     icon-naming-utils
     libcups2-dev

--- a/Tools/gtk/dependencies/dnf
+++ b/Tools/gtk/dependencies/dnf
@@ -38,6 +38,11 @@ PACKAGES+=(
     weston-devel
     xorg-x11-server-Xvfb
 
+    # Icon themes needed by the MiniBrowser (generate-bundle needs this as well)
+    adwaita-icon-theme
+    gnome-icon-theme
+    hicolor-icon-theme
+
     # These are dependencies necessary for building the jhbuild.
     bison
     cups-devel

--- a/Tools/gtk/dependencies/pacman
+++ b/Tools/gtk/dependencies/pacman
@@ -52,6 +52,10 @@ PACKAGES+=(
     weston
     xorg-server-xvfb
 
+    # Icon themes needed by the MiniBrowser (generate-bundle needs this as well)
+    adwaita-icon-theme
+    hicolor-icon-theme
+
     # These are dependencies necessary for building the jhbuild.
     # Note: Could not find libegl-mesa.
     bigreqsproto


### PR DESCRIPTION
#### 7bfd86f9a0d43079773c4389f7907cd931964b80
<pre>
[Tools][WPE] generate-bundle: add some fixes for running it inside the SDK
<a href="https://bugs.webkit.org/show_bug.cgi?id=305768">https://bugs.webkit.org/show_bug.cgi?id=305768</a>

Reviewed by Adrian Perez de Castro.

This adds a few fixes and improvements to for running generate-bundle on the
new SDK like removing some unneded gstreamer plugins that bloats the tarball,
as well as fixing finding the base libdir for libc, ensuring that all the
needed icons are copied into the bundle and allowing to run the test suite
from a Wayland environment.

* Tools/Scripts/generate-bundle:
(BundleCreator._get_gstreamer_modules):
(BundleCreator._get_libc_libraries):
(BundleCreator._create_bundle):
* Tools/Scripts/webkitpy/binary_bundling/tests/webdriver/run-webdriver-tests-bundle-docker.sh:
* Tools/gtk/dependencies/apt:
* Tools/gtk/dependencies/dnf:
* Tools/gtk/dependencies/pacman:

Canonical link: <a href="https://commits.webkit.org/306045@main">https://commits.webkit.org/306045@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b75f61b07d2d62b2171d173ebb4318009d1c7a67

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139519 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11895 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1021 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147647 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92587 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141392 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12603 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12045 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106816 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77774 "6 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142466 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9646 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124963 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87680 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/139548 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9271 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6884 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7945 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118568 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/951 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150430 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11579 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/967 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115219 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11593 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9898 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115530 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10081 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121397 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66585 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21636 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11624 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/907 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11359 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11559 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11410 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->