### PR TITLE
Add infrastructure for the ::picker pseudo-element

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3493,6 +3493,20 @@ HTMLEnhancedSelectParsingEnabled:
      WebCore:
        default: true
 
+HTMLEnhancedSelectPseudoElementsEnabled:
+   type: bool
+   status: unstable
+   category: css
+   humanReadableName: "Enhanced HTML select element pseudo-elements"
+   humanReadableDescription: "Enable enhanced HTML select element pseudo-elements"
+   defaultValue:
+     WebKitLegacy:
+       default: false
+     WebKit:
+       default: false
+     WebCore:
+       default: false
+
 HTMLEnhancedSelectSelectedContentEnabled:
    type: bool
    status: unstable

--- a/Source/WebCore/css/CSSPseudoSelectors.json
+++ b/Source/WebCore/css/CSSPseudoSelectors.json
@@ -541,6 +541,10 @@
         "part": {
             "argument": "required"
         },
+        "picker": {
+            "argument": "required",
+            "settings-flag": "htmlEnhancedSelectPseudoElementsEnabled"
+        },
         "placeholder": {
             "aliases": [
                 "-webkit-input-placeholder"

--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -333,6 +333,7 @@ std::optional<PseudoElementType> CSSSelector::stylePseudoElementTypeFor(PseudoEl
 #endif
     case PseudoElement::Slotted:
     case PseudoElement::Part:
+    case PseudoElement::Picker:
     case PseudoElement::UserAgentPart:
     case PseudoElement::UserAgentPartLegacyAlias:
     case PseudoElement::WebKitUnknown:
@@ -962,6 +963,7 @@ bool complexSelectorMatchesElementBackedPseudoElement(const CSSSelector& complex
         switch (pseudoElement) {
         case CSSSelector::PseudoElement::Slotted:
         case CSSSelector::PseudoElement::Part:
+        case CSSSelector::PseudoElement::Picker:
         case CSSSelector::PseudoElement::UserAgentPart:
         case CSSSelector::PseudoElement::UserAgentPartLegacyAlias:
             return true;
@@ -1005,6 +1007,7 @@ bool isElementBackedPseudoElement(CSSSelector::PseudoElement pseudoElement)
 {
     switch (pseudoElement) {
     case CSSSelector::PseudoElement::Part:
+    case CSSSelector::PseudoElement::Picker:
     case CSSSelector::PseudoElement::Slotted:
     case CSSSelector::PseudoElement::UserAgentPart:
     case CSSSelector::PseudoElement::UserAgentPartLegacyAlias:

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -352,6 +352,20 @@ SelectorChecker::MatchResult SelectorChecker::matchRecursively(CheckingContext& 
                 return MatchResult::fails(Match::SelectorFailsLocally);
             break;
         }
+        case CSSSelector::PseudoElement::Picker: {
+            auto* root = context.element->containingShadowRoot();
+            if (!root || root->mode() != ShadowRootMode::UserAgent)
+                return MatchResult::fails(Match::SelectorFailsLocally);
+
+            auto* argumentList = context.selector->argumentList();
+            ASSERT(argumentList && !argumentList->isEmpty());
+
+            auto part = makeString("picker("_s, argumentList->at(0), ')');
+            if (context.element->userAgentPart() != part)
+                return MatchResult::fails(Match::SelectorFailsLocally);
+
+            break;
+        }
         case CSSSelector::PseudoElement::WebKitUnknown:
             return MatchResult::fails(Match::SelectorFailsLocally);
         default: {

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -111,6 +111,7 @@ CSSParserContext::CSSParserContext(const Settings& settings)
 #endif
     , colorLayersEnabled { settings.cssColorLayersEnabled() }
     , targetTextPseudoElementEnabled { settings.targetTextPseudoElementEnabled() }
+    , htmlEnhancedSelectPseudoElementsEnabled { settings.htmlEnhancedSelectPseudoElementsEnabled() }
     , cssProgressFunctionEnabled { settings.cssProgressFunctionEnabled() }
     , cssRandomFunctionEnabled { settings.cssRandomFunctionEnabled() }
     , cssTreeCountingFunctionsEnabled { settings.cssTreeCountingFunctionsEnabled() }
@@ -161,7 +162,8 @@ void add(Hasher& hasher, const CSSParserContext& context)
         context.cssTextDecorationLineErrorValues,
         context.cssTextTransformMathAutoEnabled,
         context.cssInternalAutoBaseParsingEnabled,
-        context.cssMathDepthEnabled
+        context.cssMathDepthEnabled,
+        context.htmlEnhancedSelectPseudoElementsEnabled
     );
     add(hasher, context.baseURL, context.charset, context.propertySettings, context.mode, bits);
 }

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -75,6 +75,7 @@ struct CSSParserContext {
 #endif
     bool colorLayersEnabled : 1 { false };
     bool targetTextPseudoElementEnabled : 1 { false };
+    bool htmlEnhancedSelectPseudoElementsEnabled : 1 { false };
     bool cssProgressFunctionEnabled : 1 { false };
     bool cssRandomFunctionEnabled : 1 { false };
     bool cssTreeCountingFunctionsEnabled : 1 { false };

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -504,6 +504,8 @@ static bool isPseudoClassValidAfterPseudoElement(CSSSelector::PseudoClass pseudo
     switch (compoundPseudoElement) {
     case CSSSelector::PseudoElement::Part:
         return !isTreeStructuralPseudoClass(pseudoClass);
+    case CSSSelector::PseudoElement::Picker:
+        return !isTreeStructuralPseudoClass(pseudoClass);
     case CSSSelector::PseudoElement::Slotted:
         return false;
     case CSSSelector::PseudoElement::WebKitResizer:
@@ -961,6 +963,19 @@ std::unique_ptr<MutableCSSSelector> CSSSelectorParser::consumePseudo(CSSParserTo
             if (ident.type() != IdentToken || !block.atEnd())
                 return nullptr;
             selector->setArgumentList({ { ident.value().toAtomString() } });
+            return selector;
+        }
+
+        case CSSSelector::PseudoElement::Picker: {
+            auto& ident = block.consumeIncludingWhitespace();
+            if (ident.type() != IdentToken || !block.atEnd())
+                return nullptr;
+
+            auto argument = ident.value().toAtomString();
+            if (argument != "select"_s)
+                return nullptr;
+
+            selector->setArgumentList({ { argument } });
             return selector;
         }
 

--- a/Source/WebCore/css/parser/CSSSelectorParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParserContext.cpp
@@ -39,6 +39,7 @@ CSSSelectorParserContext::CSSSelectorParserContext(const CSSParserContext& conte
     , imageControlsEnabled(context.imageControlsEnabled)
 #endif
     , popoverAttributeEnabled(context.popoverAttributeEnabled)
+    , htmlEnhancedSelectPseudoElementsEnabled(context.htmlEnhancedSelectPseudoElementsEnabled)
     , targetTextPseudoElementEnabled(context.targetTextPseudoElementEnabled)
     , thumbAndTrackPseudoElementsEnabled(context.thumbAndTrackPseudoElementsEnabled)
     , viewTransitionsEnabled(context.propertySettings.viewTransitionsEnabled)
@@ -52,6 +53,7 @@ CSSSelectorParserContext::CSSSelectorParserContext(const Document& document)
     , imageControlsEnabled(document.settings().imageControlsEnabled())
 #endif
     , popoverAttributeEnabled(document.settings().popoverAttributeEnabled())
+    , htmlEnhancedSelectPseudoElementsEnabled(document.settings().htmlEnhancedSelectPseudoElementsEnabled())
     , targetTextPseudoElementEnabled(document.settings().targetTextPseudoElementEnabled())
     , thumbAndTrackPseudoElementsEnabled(document.settings().thumbAndTrackPseudoElementsEnabled())
     , viewTransitionsEnabled(document.settings().viewTransitionsEnabled())
@@ -66,6 +68,7 @@ void add(Hasher& hasher, const CSSSelectorParserContext& context)
         context.imageControlsEnabled,
 #endif
         context.popoverAttributeEnabled,
+        context.htmlEnhancedSelectPseudoElementsEnabled,
         context.targetTextPseudoElementEnabled,
         context.thumbAndTrackPseudoElementsEnabled,
         context.viewTransitionsEnabled,

--- a/Source/WebCore/css/parser/CSSSelectorParserContext.h
+++ b/Source/WebCore/css/parser/CSSSelectorParserContext.h
@@ -40,6 +40,7 @@ struct CSSSelectorParserContext {
     bool imageControlsEnabled : 1 { false };
 #endif
     bool popoverAttributeEnabled : 1 { false };
+    bool htmlEnhancedSelectPseudoElementsEnabled : 1 { false };
     bool targetTextPseudoElementEnabled : 1 { false };
     bool thumbAndTrackPseudoElementsEnabled : 1 { false };
     bool viewTransitionsEnabled : 1 { false };

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -1517,6 +1517,7 @@ static FunctionType constructFragmentsInternal(const CSSSelector& rootSelector, 
 #endif
             case CSSSelector::PseudoElement::Highlight:
             case CSSSelector::PseudoElement::Part:
+            case CSSSelector::PseudoElement::Picker:
             case CSSSelector::PseudoElement::Slotted:
             case CSSSelector::PseudoElement::ViewTransitionGroup:
             case CSSSelector::PseudoElement::ViewTransitionImagePair:


### PR DESCRIPTION
#### 28550cbe51f253e5f87b52075dd4cb21d60be51b
<pre>
Add infrastructure for the ::picker pseudo-element
<a href="https://bugs.webkit.org/show_bug.cgi?id=305775">https://bugs.webkit.org/show_bug.cgi?id=305775</a>

Reviewed by Tim Nguyen.

As user agent parts do not support arguments, we implement this as a
proper pseudo-element. But we reuse userAgentPart() for matching
purposes as that is rather convenient.

This is all behind an HTMLEnhancedSelectPseudoElementsEnabled
preference that is not enabled for testing yet.

Canonical link: <a href="https://commits.webkit.org/305885@main">https://commits.webkit.org/305885@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb3cf7d58c1cd6929bd42d9bee587305531bc684

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/139688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12064 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1192 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147825 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9b8b4fd9-5b35-4627-b1df-287a83e663f9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141561 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12773 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12215 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/106972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aab30e76-6f38-4365-9a23-cb813a57683c) 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/142635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/9836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/125112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87836 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/82e20259-f1cc-4918-b638-401ef03a7c45) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/9493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7012 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8115 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/131661 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/118722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/1110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150606 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/484 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11749 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/1161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/115375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11762 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/10066 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115686 "Passed tests") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/10445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/121588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/66754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21550 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11793 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/1070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/170960 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11533 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75471 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/44466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11728 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11580 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->