### PR TITLE
AX: Elements with display: contents and content in a shadowroot do not have their content read when referenced by aria-labelledby

### DIFF
--- a/LayoutTests/accessibility/aria-labelledby-display-contents-shadow-root-expected.txt
+++ b/LayoutTests/accessibility/aria-labelledby-display-contents-shadow-root-expected.txt
@@ -1,0 +1,11 @@
+This test ensures aria-labelledby correctly references display:contents elements with shadow roots.
+
+PASS: testButton.role.toLowerCase().includes('button') === true
+PASS: platformValueForW3CName(testButton) === 'Shadow Label Text'
+PASS: platformValueForW3CName(testButton).includes('should NOT appear') === false
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Button Content
+

--- a/LayoutTests/accessibility/aria-labelledby-display-contents-shadow-root.html
+++ b/LayoutTests/accessibility/aria-labelledby-display-contents-shadow-root.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="label-element" style="display: contents;">
+  <template shadowrootmode="open">
+    <div>Shadow Label Text</div>
+  </template>
+</div>
+
+<button id="test-button" aria-labelledby="label-element">Button Content</button>
+
+<div id="unrelated-shadow-host">
+  <template shadowrootmode="open">
+    <div>This should NOT appear in button name</div>
+  </template>
+</div>
+
+<script>
+var output = "This test ensures aria-labelledby correctly references display:contents elements with shadow roots.\n\n";
+
+if (window.accessibilityController) {
+    var testButton = accessibilityController.accessibleElementById("test-button");
+    output += expect("testButton.role.toLowerCase().includes('button')", "true");
+    output += expect("platformValueForW3CName(testButton)", "'Shadow Label Text'");
+    output += expect("platformValueForW3CName(testButton).includes('should NOT appear')", "false");
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -4279,6 +4279,22 @@ static String accessibleNameForNode(Node& node, Node* labelledbyNode)
     if (!title.isEmpty())
         return title;
 
+    if (element && element->hasDisplayContents()) {
+        // For display:contents elements with shadow roots, the element doesn't have a renderer,
+        // so textUnderElement() won't find any children via the render tree. We need to explicitly
+        // traverse the shadow root content to compute the accessible name.
+        // https://bugs.webkit.org/show_bug.cgi?id=275222
+        if (RefPtr shadowRoot = shadowRootIgnoringUserAgentShadow(node)) {
+            StringBuilder builder;
+            for (RefPtr child = shadowRoot->firstChild(); child; child = child->nextSibling())
+                appendNameToStringBuilder(builder, accessibleNameForNode(*child));
+
+            String shadowText = builder.toString();
+            if (!shadowText.isEmpty())
+                return shadowText;
+        }
+    }
+
     return { };
 }
 


### PR DESCRIPTION
#### 2b263331d69ae6220d230cde4aa26ab460375b6e
<pre>
AX: Elements with display: contents and content in a shadowroot do not have their content read when referenced by aria-labelledby
<a href="https://bugs.webkit.org/show_bug.cgi?id=275222">https://bugs.webkit.org/show_bug.cgi?id=275222</a>
<a href="https://rdar.apple.com/129361833">rdar://129361833</a>

Reviewed by Joshua Hoffman.

When computing accessible names for elements referenced by aria-labelledby,
textUnderElement() relies on the render tree to find children. For display:contents
shadow hosts, there is no renderer, so shadow root content was never included.

The fix adds special handling in accessibleNameForNode() to explicitly traverse
shadow root content for display:contents elements.

* LayoutTests/accessibility/aria-labelledby-display-contents-shadow-root-expected.txt: Added.
* LayoutTests/accessibility/aria-labelledby-display-contents-shadow-root.html: Added.
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::accessibleNameForNode):

Canonical link: <a href="https://commits.webkit.org/305918@main">https://commits.webkit.org/305918@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3008307a465d55404e40879e6b8cfd0e5300d0bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139754 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12131 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1259 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147893 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92824 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5e0e95c6-a3a5-4be2-bfca-c1aea805ab8b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141627 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12839 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12282 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107010 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77897 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3495290d-9073-4c40-b8de-1591d1f26ed5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142701 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9871 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125156 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87883 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3eb62096-9414-4695-9826-106b9c797f92) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9536 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7045 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8181 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118753 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1154 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150674 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11815 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1211 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115415 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11829 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10108 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115732 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29413 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10500 "Passed tests") | [⏳ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/macOS-Release-WK2-Stress-Tests-EWS "Waiting to run tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/66826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11859 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1117 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11599 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75537 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11795 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11646 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->