### PR TITLE
Remove CSSShapeFunctionEnabled preference

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1455,20 +1455,6 @@ CSSSelectorJITCompilerEnabled:
     WebCore:
       default: true
 
-CSSShapeFunctionEnabled:
-  type: bool
-  status: stable
-  category: css
-  humanReadableName: "CSS shape() function"
-  humanReadableDescription: "Enable the CSS shape() function"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
-
 CSSTextAutospaceEnabled:
   type: bool
   status: stable

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -100,7 +100,6 @@ CSSParserContext::CSSParserContext(const Settings& settings)
     , gridLanesEnabled { settings.gridLanesEnabled() }
     , cssAppearanceBaseEnabled { settings.cssAppearanceBaseEnabled() }
     , cssPaintingAPIEnabled { settings.cssPaintingAPIEnabled() }
-    , cssShapeFunctionEnabled { settings.cssShapeFunctionEnabled() }
     , cssTextDecorationLineErrorValues { settings.cssTextDecorationLineErrorValues() }
     , cssBackgroundClipBorderAreaEnabled { settings.cssBackgroundClipBorderAreaEnabled() }
     , cssWordBreakAutoPhraseEnabled { settings.cssWordBreakAutoPhraseEnabled() }
@@ -142,34 +141,31 @@ void add(Hasher& hasher, const CSSParserContext& context)
         | context.gridLanesEnabled                          << 6
         | context.cssAppearanceBaseEnabled                  << 7
         | context.cssPaintingAPIEnabled                     << 8
-        | context.cssShapeFunctionEnabled                   << 9
-        | context.cssBackgroundClipBorderAreaEnabled        << 10
-        | context.cssWordBreakAutoPhraseEnabled             << 11
-        | context.popoverAttributeEnabled                   << 12
-        | context.sidewaysWritingModesEnabled               << 13
-        | context.cssTextWrapPrettyEnabled                  << 14
-        | context.thumbAndTrackPseudoElementsEnabled        << 15
+        | context.cssBackgroundClipBorderAreaEnabled        << 9
+        | context.cssWordBreakAutoPhraseEnabled             << 10
+        | context.popoverAttributeEnabled                   << 11
+        | context.sidewaysWritingModesEnabled               << 12
+        | context.cssTextWrapPrettyEnabled                  << 13
+        | context.thumbAndTrackPseudoElementsEnabled        << 14
 #if ENABLE(SERVICE_CONTROLS)
-        | context.imageControlsEnabled                      << 16
+        | context.imageControlsEnabled                      << 15
 #endif
-        | context.colorLayersEnabled                        << 17
-        | context.contrastColorEnabled                      << 18
-        | context.targetTextPseudoElementEnabled            << 19
-        | context.cssProgressFunctionEnabled                << 20
-        | context.cssRandomFunctionEnabled                  << 21
-        | context.cssTreeCountingFunctionsEnabled           << 22
-        | context.cssURLModifiersEnabled                    << 23
-        | context.cssURLIntegrityModifierEnabled            << 24
-        | context.cssAxisRelativePositionKeywordsEnabled    << 25
-        | context.cssDynamicRangeLimitMixEnabled            << 26
-        | context.cssConstrainedDynamicRangeLimitEnabled    << 27
-        | context.cssTextDecorationLineErrorValues          << 28
-        | context.cssTextTransformMathAutoEnabled           << 29
-        | context.cssInternalAutoBaseParsingEnabled         << 30
-        | context.cssTextTransformMathAutoEnabled           << 31;
+        | context.colorLayersEnabled                        << 16
+        | context.contrastColorEnabled                      << 17
+        | context.targetTextPseudoElementEnabled            << 18
+        | context.cssProgressFunctionEnabled                << 19
+        | context.cssRandomFunctionEnabled                  << 20
+        | context.cssTreeCountingFunctionsEnabled           << 21
+        | context.cssURLModifiersEnabled                    << 22
+        | context.cssURLIntegrityModifierEnabled            << 23
+        | context.cssAxisRelativePositionKeywordsEnabled    << 24
+        | context.cssDynamicRangeLimitMixEnabled            << 25
+        | context.cssConstrainedDynamicRangeLimitEnabled    << 26
+        | context.cssTextDecorationLineErrorValues          << 27
+        | context.cssTextTransformMathAutoEnabled           << 28
+        | context.cssInternalAutoBaseParsingEnabled         << 29
+        | context.cssMathDepthEnabled                       << 30;
     add(hasher, context.baseURL, context.charset, context.propertySettings, context.mode, bits);
-    uint32_t bits2 =  context.cssMathDepthEnabled           << 0;
-    add(hasher, context.baseURL, context.charset, context.propertySettings, context.mode, bits, bits2);
 }
 
 void CSSParserContext::setUASheetMode()

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -64,7 +64,6 @@ struct CSSParserContext {
     bool gridLanesEnabled : 1 { false };
     bool cssAppearanceBaseEnabled : 1 { false };
     bool cssPaintingAPIEnabled : 1 { false };
-    bool cssShapeFunctionEnabled : 1 { false };
     bool cssTextDecorationLineErrorValues : 1 { false };
     bool cssBackgroundClipBorderAreaEnabled : 1 { false };
     bool cssWordBreakAutoPhraseEnabled : 1 { false };

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Shapes.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Shapes.cpp
@@ -798,9 +798,6 @@ static std::optional<CSS::Shape> consumeBasicShapeShapeFunctionParameters(CSSPar
     // shape() = shape( <'fill-rule'>? from <coordinate-pair>, <shape-command># )
     // https://drafts.csswg.org/css-shapes-2/#shape-function
 
-    if (!state.context.cssShapeFunctionEnabled)
-        return { };
-
     auto fillRule = consumeFillRule(args);
 
     if (!consumeIdent<CSSValueFrom>(args))


### PR DESCRIPTION
#### a4b5bbe6c2b4f5845c4fd9c2c7565e382d64e85d
<pre>
Remove CSSShapeFunctionEnabled preference
<a href="https://bugs.webkit.org/show_bug.cgi?id=305778">https://bugs.webkit.org/show_bug.cgi?id=305778</a>

Reviewed by Tim Nguyen.

It&apos;s been stable for a year.

Also remove the duplicate entry of cssTextTransformMathAutoEnabled in
CSSParserContext. Taking up 2 precious bits!

Canonical link: <a href="https://commits.webkit.org/305833@main">https://commits.webkit.org/305833@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f23da9034b0e243e98e82b6e6a0ee87cc49f42e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139538 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11914 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1041 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147668 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92606 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/71e6c877-692b-4486-98b1-5a9b1f229630) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141411 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12622 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12064 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106834 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/77789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d7e4881e-8bf8-476b-8b9d-32048ea1789b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142485 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9668 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124979 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87698 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/151ff85d-4a0a-460c-aa1c-defd5df75c48) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9298 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6902 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7964 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/131511 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118586 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/972 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150449 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/334 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11598 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/988 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115235 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11612 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9922 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115546 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10148 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121417 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66604 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21526 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11643 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/170810 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11378 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75321 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/44446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11578 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11429 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->