### PR TITLE
Remove LegacyNativeDictionaryRequiredInterfaceNullability from IDL dictionaries (Part 1)

### DIFF
--- a/Source/WebCore/Modules/ShapeDetection/DetectedBarcode.h
+++ b/Source/WebCore/Modules/ShapeDetection/DetectedBarcode.h
@@ -38,7 +38,6 @@ namespace WebCore {
 struct DetectedBarcode {
     ShapeDetection::DetectedBarcode convertToBacking() const
     {
-        ASSERT(boundingBox);
         return {
             {
                 static_cast<float>(boundingBox->x()),
@@ -54,7 +53,7 @@ struct DetectedBarcode {
         };
     }
 
-    RefPtr<DOMRectReadOnly> boundingBox;
+    Ref<DOMRectReadOnly> boundingBox;
     String rawValue;
     BarcodeFormat format { BarcodeFormat::Unknown };
     Vector<Point2D> cornerPoints;

--- a/Source/WebCore/Modules/ShapeDetection/DetectedBarcode.idl
+++ b/Source/WebCore/Modules/ShapeDetection/DetectedBarcode.idl
@@ -28,7 +28,6 @@
 [
     EnabledBySetting=ShapeDetection,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary DetectedBarcode {
     required DOMRectReadOnly boundingBox;
     required DOMString rawValue;

--- a/Source/WebCore/Modules/ShapeDetection/DetectedFace.h
+++ b/Source/WebCore/Modules/ShapeDetection/DetectedFace.h
@@ -39,7 +39,6 @@ struct Landmark;
 struct DetectedFace {
     ShapeDetection::DetectedFace convertToBacking() const
     {
-        ASSERT(boundingBox);
         return {
             {
                 static_cast<float>(boundingBox->x()),
@@ -53,7 +52,7 @@ struct DetectedFace {
         };
     }
 
-    RefPtr<DOMRectReadOnly> boundingBox;
+    Ref<DOMRectReadOnly> boundingBox;
     std::optional<Vector<Landmark>> landmarks;
 };
 

--- a/Source/WebCore/Modules/ShapeDetection/DetectedFace.idl
+++ b/Source/WebCore/Modules/ShapeDetection/DetectedFace.idl
@@ -28,7 +28,6 @@
 [
     EnabledBySetting=ShapeDetection,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary DetectedFace {
     required DOMRectReadOnly boundingBox;
     required FrozenArray<Landmark>? landmarks;

--- a/Source/WebCore/Modules/ShapeDetection/DetectedText.h
+++ b/Source/WebCore/Modules/ShapeDetection/DetectedText.h
@@ -39,7 +39,6 @@ struct Point2D;
 struct DetectedText {
     ShapeDetection::DetectedText convertToBacking() const
     {
-        ASSERT(boundingBox);
         return {
             {
                 static_cast<float>(boundingBox->x()),
@@ -54,7 +53,7 @@ struct DetectedText {
         };
     }
 
-    RefPtr<DOMRectReadOnly> boundingBox;
+    Ref<DOMRectReadOnly> boundingBox;
     String rawValue;
     Vector<Point2D> cornerPoints;
 };

--- a/Source/WebCore/Modules/ShapeDetection/DetectedText.idl
+++ b/Source/WebCore/Modules/ShapeDetection/DetectedText.idl
@@ -28,7 +28,6 @@
 [
     EnabledBySetting=ShapeDetection,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary DetectedText {
     required DOMRectReadOnly boundingBox;
     required DOMString rawValue;

--- a/Source/WebCore/Modules/ShapeDetection/Landmark.idl
+++ b/Source/WebCore/Modules/ShapeDetection/Landmark.idl
@@ -28,7 +28,6 @@
 [
     EnabledBySetting=ShapeDetection,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary Landmark {
     required FrozenArray<Point2D> locations;
     LandmarkType type;

--- a/Source/WebCore/Modules/ShapeDetection/Point2D.idl
+++ b/Source/WebCore/Modules/ShapeDetection/Point2D.idl
@@ -27,7 +27,6 @@
 
 [
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary Point2D {
     double x = 0.0;
     double y = 0.0;

--- a/Source/WebCore/Modules/applepay-ams-ui/ApplePayAMSUIRequest.idl
+++ b/Source/WebCore/Modules/applepay-ams-ui/ApplePayAMSUIRequest.idl
@@ -25,7 +25,6 @@
 
 [
     Conditional=APPLE_PAY_AMS_UI&PAYMENT_REQUEST,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ApplePayAMSUIRequest {
     required JSON engagementRequest;
 };

--- a/Source/WebCore/Modules/applepay/ApplePayAutomaticReloadPaymentRequest.idl
+++ b/Source/WebCore/Modules/applepay/ApplePayAutomaticReloadPaymentRequest.idl
@@ -28,7 +28,6 @@
     ExportMacro=WEBCORE_EXPORT,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ApplePayAutomaticReloadPaymentRequest {
     required DOMString paymentDescription;
     required ApplePayLineItem automaticReloadBilling; // must be `paymentTiming: "automaticReload"`

--- a/Source/WebCore/Modules/applepay/ApplePayCouponCodeDetails.idl
+++ b/Source/WebCore/Modules/applepay/ApplePayCouponCodeDetails.idl
@@ -27,7 +27,6 @@
     Conditional=APPLE_PAY_COUPON_CODE,
     ExportMacro=WEBCORE_EXPORT,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ApplePayCouponCodeDetails {
     DOMString couponCode;
 };

--- a/Source/WebCore/Modules/applepay/ApplePayDateComponents.idl
+++ b/Source/WebCore/Modules/applepay/ApplePayDateComponents.idl
@@ -28,7 +28,6 @@
     ExportMacro=WEBCORE_EXPORT,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ApplePayDateComponents {
     unsigned long years;
     unsigned long months;

--- a/Source/WebCore/Modules/applepay/ApplePayDateComponentsRange.idl
+++ b/Source/WebCore/Modules/applepay/ApplePayDateComponentsRange.idl
@@ -28,7 +28,6 @@
     ExportMacro=WEBCORE_EXPORT,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ApplePayDateComponentsRange {
     required ApplePayDateComponents startDateComponents;
     required ApplePayDateComponents endDateComponents;

--- a/Source/WebCore/Modules/applepay/ApplePayDeferredPaymentRequest.idl
+++ b/Source/WebCore/Modules/applepay/ApplePayDeferredPaymentRequest.idl
@@ -28,7 +28,6 @@
     ExportMacro=WEBCORE_EXPORT,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ApplePayDeferredPaymentRequest {
     DOMString billingAgreement;
     required ApplePayLineItem deferredBilling; // must be `paymentTiming: "deferred"

--- a/Source/WebCore/Modules/applepay/ApplePayDisbursementRequest.idl
+++ b/Source/WebCore/Modules/applepay/ApplePayDisbursementRequest.idl
@@ -28,7 +28,6 @@
     ExportMacro=WEBCORE_EXPORT,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ApplePayDisbursementRequest {
     sequence<ApplePayContactField> requiredRecipientContactFields;
 };

--- a/Source/WebCore/Modules/applepay/ApplePayInstallmentItem.idl
+++ b/Source/WebCore/Modules/applepay/ApplePayInstallmentItem.idl
@@ -27,7 +27,6 @@
     Conditional=APPLE_PAY_INSTALLMENTS,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ApplePayInstallmentItem {
     ApplePayInstallmentItemType type = "generic";
     DOMString amount;

--- a/Source/WebCore/Modules/applepay/ApplePayLineItem.idl
+++ b/Source/WebCore/Modules/applepay/ApplePayLineItem.idl
@@ -42,7 +42,6 @@
     ExportMacro=WEBCORE_EXPORT,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ApplePayLineItem {
     ApplePayLineItemType type = "final";
     DOMString label;

--- a/Source/WebCore/Modules/applepay/ApplePayPayment.idl
+++ b/Source/WebCore/Modules/applepay/ApplePayPayment.idl
@@ -26,7 +26,6 @@
 [
     Conditional=APPLE_PAY,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ApplePayPayment {
     required ApplePayPaymentToken token;
     ApplePayPaymentContact billingContact;
@@ -37,7 +36,6 @@
 [
     Conditional=APPLE_PAY,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ApplePayPaymentToken {
     required ApplePayPaymentMethod paymentMethod;
     DOMString transactionIdentifier;

--- a/Source/WebCore/Modules/applepay/ApplePayPaymentMethod.idl
+++ b/Source/WebCore/Modules/applepay/ApplePayPaymentMethod.idl
@@ -28,7 +28,6 @@
     ExportMacro=WEBCORE_EXPORT,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ApplePayPaymentMethod {
     DOMString displayName;
     DOMString network;

--- a/Source/WebCore/Modules/applepay/ApplePayPaymentOrderDetails.idl
+++ b/Source/WebCore/Modules/applepay/ApplePayPaymentOrderDetails.idl
@@ -25,7 +25,6 @@
 
 [
     Conditional=APPLE_PAY_PAYMENT_ORDER_DETAILS,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ApplePayPaymentOrderDetails {
     required DOMString orderTypeIdentifier;
     required DOMString orderIdentifier;

--- a/Source/WebCore/Modules/applepay/ApplePayPaymentPass.idl
+++ b/Source/WebCore/Modules/applepay/ApplePayPaymentPass.idl
@@ -37,7 +37,6 @@
     Conditional=APPLE_PAY,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ApplePayPaymentPass {
     required DOMString primaryAccountIdentifier;
     required DOMString primaryAccountNumberSuffix;

--- a/Source/WebCore/Modules/applepay/ApplePayPaymentTokenContext.idl
+++ b/Source/WebCore/Modules/applepay/ApplePayPaymentTokenContext.idl
@@ -28,7 +28,6 @@
     ExportMacro=WEBCORE_EXPORT,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ApplePayPaymentTokenContext {
     required DOMString merchantIdentifier;
     required DOMString externalIdentifier;

--- a/Source/WebCore/Modules/applepay/ApplePayRecurringPaymentRequest.idl
+++ b/Source/WebCore/Modules/applepay/ApplePayRecurringPaymentRequest.idl
@@ -28,7 +28,6 @@
     ExportMacro=WEBCORE_EXPORT,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ApplePayRecurringPaymentRequest {
     required DOMString paymentDescription;
     required ApplePayLineItem regularBilling; // must be `paymentTiming: "recurring"

--- a/Source/WebCore/Modules/applepay/ApplePaySessionError.idl
+++ b/Source/WebCore/Modules/applepay/ApplePaySessionError.idl
@@ -26,7 +26,6 @@
 [
     Conditional=APPLE_PAY,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ApplePaySessionError {
     DOMString code; // FIXME: use an enum instead
     record<DOMString, DOMString> info;

--- a/Source/WebCore/Modules/applepay/ApplePayShippingMethod.idl
+++ b/Source/WebCore/Modules/applepay/ApplePayShippingMethod.idl
@@ -28,7 +28,6 @@
     ExportMacro=WEBCORE_EXPORT,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ApplePayShippingMethod {
     required DOMString label;
     required DOMString detail;

--- a/Source/WebCore/Modules/applepay/paymentrequest/ApplePayPaymentCompleteDetails.idl
+++ b/Source/WebCore/Modules/applepay/paymentrequest/ApplePayPaymentCompleteDetails.idl
@@ -25,7 +25,6 @@
 
 [
     Conditional=APPLE_PAY&PAYMENT_REQUEST,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ApplePayPaymentCompleteDetails {
     [Conditional=APPLE_PAY_PAYMENT_ORDER_DETAILS] ApplePayPaymentOrderDetails orderDetails;
 };

--- a/Source/WebCore/Modules/async-clipboard/ClipboardItem.idl
+++ b/Source/WebCore/Modules/async-clipboard/ClipboardItem.idl
@@ -30,9 +30,7 @@ typedef Promise<ClipboardItemDataType> ClipboardItemData;
 
 enum PresentationStyle { "unspecified", "inline", "attachment" };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary ClipboardItemOptions {
+dictionary ClipboardItemOptions {
     PresentationStyle presentationStyle = "unspecified";
 };
 

--- a/Source/WebCore/Modules/cache/CacheQueryOptions.idl
+++ b/Source/WebCore/Modules/cache/CacheQueryOptions.idl
@@ -23,9 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary CacheQueryOptions {
+dictionary CacheQueryOptions {
     boolean ignoreSearch = false;
     boolean ignoreMethod = false;
     boolean ignoreVary = false;

--- a/Source/WebCore/Modules/cache/MultiCacheQueryOptions.idl
+++ b/Source/WebCore/Modules/cache/MultiCacheQueryOptions.idl
@@ -23,8 +23,6 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary MultiCacheQueryOptions : CacheQueryOptions{
+dictionary MultiCacheQueryOptions : CacheQueryOptions {
     DOMString cacheName;
 };

--- a/Source/WebCore/Modules/contact-picker/ContactInfo.idl
+++ b/Source/WebCore/Modules/contact-picker/ContactInfo.idl
@@ -27,7 +27,6 @@
 
 [
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ContactInfo {
     sequence<USVString> name;
     sequence<USVString> email;

--- a/Source/WebCore/Modules/contact-picker/ContactsSelectOptions.idl
+++ b/Source/WebCore/Modules/contact-picker/ContactsSelectOptions.idl
@@ -25,8 +25,6 @@
 
 // https://wicg.github.io/contact-api/
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary ContactsSelectOptions {
+dictionary ContactsSelectOptions {
     boolean multiple = false;
 };

--- a/Source/WebCore/Modules/cookie-consent/RequestCookieConsentOptions.idl
+++ b/Source/WebCore/Modules/cookie-consent/RequestCookieConsentOptions.idl
@@ -23,8 +23,6 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary RequestCookieConsentOptions {
+dictionary RequestCookieConsentOptions {
     VoidCallback? moreInfo;
 };

--- a/Source/WebCore/Modules/cookie-store/CookieInit.idl
+++ b/Source/WebCore/Modules/cookie-store/CookieInit.idl
@@ -27,9 +27,7 @@
 
 typedef double DOMHighResTimeStamp;
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary CookieInit {
+dictionary CookieInit {
     required USVString name;
     required USVString value;
     DOMHighResTimeStamp? expires = null;

--- a/Source/WebCore/Modules/cookie-store/CookieStoreDeleteOptions.idl
+++ b/Source/WebCore/Modules/cookie-store/CookieStoreDeleteOptions.idl
@@ -25,9 +25,7 @@
 
 // https://wicg.github.io/cookie-store/#dictdef-cookiestoredeleteoptions
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary CookieStoreDeleteOptions {
+dictionary CookieStoreDeleteOptions {
     required USVString name;
     USVString? domain = null;
     USVString path = "/";

--- a/Source/WebCore/Modules/cookie-store/CookieStoreGetOptions.idl
+++ b/Source/WebCore/Modules/cookie-store/CookieStoreGetOptions.idl
@@ -28,7 +28,6 @@
 [
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary CookieStoreGetOptions {
     USVString name;
     USVString url;

--- a/Source/WebCore/Modules/credentialmanagement/CredentialCreationOptions.idl
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialCreationOptions.idl
@@ -26,7 +26,6 @@
 
 [
     Conditional=WEB_AUTHN,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary CredentialCreationOptions {
     CredentialMediationRequirement mediation = "optional";
     AbortSignal signal;

--- a/Source/WebCore/Modules/credentialmanagement/CredentialRequestOptions.h
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialRequestOptions.h
@@ -42,7 +42,9 @@ struct CredentialRequestOptions {
     MediationRequirement mediation;
     RefPtr<AbortSignal> signal;
     std::optional<PublicKeyCredentialRequestOptions> publicKey;
+#if ENABLE(WEB_AUTHN)
     std::optional<DigitalCredentialRequestOptions> digital;
+#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/credentialmanagement/CredentialRequestOptions.idl
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialRequestOptions.idl
@@ -26,7 +26,6 @@
 
 [
     Conditional=WEB_AUTHN,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary CredentialRequestOptions {
     CredentialMediationRequirement mediation = "optional";
     AbortSignal signal;

--- a/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp
@@ -124,6 +124,7 @@ bool CredentialsContainer::performCommonChecks(const Options& options, Credentia
     }
 
     if constexpr (std::is_same_v<Options, CredentialRequestOptions>) {
+#if ENABLE(WEB_AUTHN)
         if (!options.publicKey && !options.digital) {
             promise.reject(Exception { ExceptionCode::NotSupportedError, "Missing request type."_s });
             return false;
@@ -133,6 +134,12 @@ bool CredentialsContainer::performCommonChecks(const Options& options, Credentia
             promise.reject(Exception { ExceptionCode::NotSupportedError, "Only one request type is supported at a time."_s });
             return false;
         }
+#else
+        if (!options.publicKey) {
+            promise.reject(Exception { ExceptionCode::NotSupportedError, "Missing request type."_s });
+            return false;
+        }
+#endif
     }
 
     ASSERT(document->isSecureContext());

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySystemMediaCapability.idl
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySystemMediaCapability.idl
@@ -30,7 +30,6 @@
     Conditional=ENCRYPTED_MEDIA,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary MediaKeySystemMediaCapability {
     DOMString contentType = "";
     DOMString robustness = "";

--- a/Source/WebCore/Modules/entriesapi/FileSystemDirectoryEntry.idl
+++ b/Source/WebCore/Modules/entriesapi/FileSystemDirectoryEntry.idl
@@ -40,9 +40,7 @@
         optional ErrorCallback? errorCallback);
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary FileSystemFlags {
+dictionary FileSystemFlags {
     boolean create = false;
     boolean exclusive = false;
 };

--- a/Source/WebCore/Modules/fetch/FetchBody.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBody.cpp
@@ -382,7 +382,7 @@ FetchBody FetchBody::createProxy(JSDOMGlobalObject& globalObject)
         return proxy;
 
     Ref identityTransform = identityTransformOrException.releaseReturnValue();
-    auto proxyStreamOrException = Ref { *m_readableStream }->pipeThrough(globalObject, { &identityTransform->readable(), &identityTransform->writable() }, { });
+    auto proxyStreamOrException = Ref { *m_readableStream }->pipeThrough(globalObject, { identityTransform->readable(), identityTransform->writable() }, { });
     ASSERT(!proxyStreamOrException.hasException());
     if (proxyStreamOrException.hasException())
         return proxy;

--- a/Source/WebCore/Modules/filesystem/FileSystemDirectoryHandle.idl
+++ b/Source/WebCore/Modules/filesystem/FileSystemDirectoryHandle.idl
@@ -23,21 +23,15 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary FileSystemGetFileOptions {
+dictionary FileSystemGetFileOptions {
     boolean create = false;
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary FileSystemGetDirectoryOptions {
+dictionary FileSystemGetDirectoryOptions {
     boolean create = false;
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary FileSystemRemoveOptions {
+dictionary FileSystemRemoveOptions {
     boolean recursive = false;
 };
 

--- a/Source/WebCore/Modules/filesystem/FileSystemFileHandle.idl
+++ b/Source/WebCore/Modules/filesystem/FileSystemFileHandle.idl
@@ -27,7 +27,6 @@
 
 [
     EnabledBySetting=AccessHandleEnabled&FileSystemWritableStreamEnabled,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary FileSystemCreateWritableOptions {
     boolean keepExistingData = false;
 };

--- a/Source/WebCore/Modules/filesystem/FileSystemSyncAccessHandle.idl
+++ b/Source/WebCore/Modules/filesystem/FileSystemSyncAccessHandle.idl
@@ -37,8 +37,6 @@
     unsigned long long write([AllowShared] (ArrayBufferView or ArrayBuffer) buffer, optional FilesystemReadWriteOptions options = {});
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary FilesystemReadWriteOptions {
+dictionary FilesystemReadWriteOptions {
     [EnforceRange] unsigned long long at;
 };

--- a/Source/WebCore/Modules/gamepad/GamepadEffectParameters.idl
+++ b/Source/WebCore/Modules/gamepad/GamepadEffectParameters.idl
@@ -26,7 +26,6 @@
 [
     Conditional=GAMEPAD,
     EnabledBySetting=GamepadVibrationActuatorEnabled,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary GamepadEffectParameters {
     double duration = 0.0;
     double startDelay = 0.0;

--- a/Source/WebCore/Modules/identity/DigitalCredentialGetRequest.idl
+++ b/Source/WebCore/Modules/identity/DigitalCredentialGetRequest.idl
@@ -23,9 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary DigitalCredentialGetRequest {
+dictionary DigitalCredentialGetRequest {
     required DOMString protocol;
     required object data;
 };

--- a/Source/WebCore/Modules/identity/DigitalCredentialRequestOptions.idl
+++ b/Source/WebCore/Modules/identity/DigitalCredentialRequestOptions.idl
@@ -23,8 +23,6 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary DigitalCredentialRequestOptions {
+dictionary DigitalCredentialRequestOptions {
     required sequence<DigitalCredentialGetRequest> requests;
 };

--- a/Source/WebCore/Modules/identity/protocols/ISO18013/MobileDocumentRequest.idl
+++ b/Source/WebCore/Modules/identity/protocols/ISO18013/MobileDocumentRequest.idl
@@ -23,9 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary MobileDocumentRequest {
+dictionary MobileDocumentRequest {
     required DOMString deviceRequest;
     required DOMString encryptionInfo;
 };

--- a/Source/WebCore/Modules/indexeddb/IDBDatabase.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabase.idl
@@ -47,15 +47,11 @@
     attribute EventHandler onversionchange;
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary IDBObjectStoreParameters {
+dictionary IDBObjectStoreParameters {
     (DOMString or sequence<DOMString>)? keyPath = null;
     boolean autoIncrement = false;
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary IDBTransactionOptions {
+dictionary IDBTransactionOptions {
     IDBTransactionDurability durability = "default";
 };

--- a/Source/WebCore/Modules/indexeddb/IDBObjectStore.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBObjectStore.idl
@@ -68,9 +68,7 @@ typedef (DOMString or sequence<DOMString>) IDBKeyPath;
     undefined deleteIndex(DOMString name);
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary IDBIndexParameters {
+dictionary IDBIndexParameters {
     boolean unique = false;
     boolean multiEntry = false;
 };

--- a/Source/WebCore/Modules/mediacapabilities/AudioConfiguration.idl
+++ b/Source/WebCore/Modules/mediacapabilities/AudioConfiguration.idl
@@ -27,7 +27,6 @@
     EnabledBySetting=MediaCapabilitiesEnabled,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary AudioConfiguration {
   required DOMString contentType;
   DOMString channels;

--- a/Source/WebCore/Modules/mediacapabilities/MediaCapabilitiesDecodingInfo.idl
+++ b/Source/WebCore/Modules/mediacapabilities/MediaCapabilitiesDecodingInfo.idl
@@ -26,7 +26,6 @@
 [
     EnabledBySetting=MediaCapabilitiesEnabled,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary MediaCapabilitiesDecodingInfo : MediaCapabilitiesInfo {
     [EnabledBySetting=MediaCapabilitiesExtensionsEnabled] required MediaDecodingConfiguration configuration;
 };

--- a/Source/WebCore/Modules/mediacapabilities/MediaCapabilitiesEncodingInfo.idl
+++ b/Source/WebCore/Modules/mediacapabilities/MediaCapabilitiesEncodingInfo.idl
@@ -26,7 +26,6 @@
 [
     EnabledBySetting=MediaCapabilitiesEnabled,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary MediaCapabilitiesEncodingInfo : MediaCapabilitiesInfo {
     [EnabledBySetting=MediaCapabilitiesExtensionsEnabled] required MediaEncodingConfiguration configuration;
 };

--- a/Source/WebCore/Modules/mediacapabilities/MediaCapabilitiesInfo.idl
+++ b/Source/WebCore/Modules/mediacapabilities/MediaCapabilitiesInfo.idl
@@ -26,7 +26,6 @@
 [
     EnabledBySetting=MediaCapabilitiesEnabled,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary MediaCapabilitiesInfo {
   required boolean supported;
   required boolean smooth;

--- a/Source/WebCore/Modules/mediarecorder/MediaRecorder.idl
+++ b/Source/WebCore/Modules/mediarecorder/MediaRecorder.idl
@@ -54,9 +54,7 @@ enum RecordingState { "inactive", "recording", "paused" };
     [CallWith=CurrentDocument] static boolean isTypeSupported(DOMString type);
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary MediaRecorderOptions {
+dictionary MediaRecorderOptions {
     DOMString mimeType;
     unsigned long audioBitsPerSecond;
     unsigned long videoBitsPerSecond;

--- a/Source/WebCore/Modules/mediasession/MediaImage.idl
+++ b/Source/WebCore/Modules/mediasession/MediaImage.idl
@@ -27,7 +27,6 @@
     Conditional=MEDIA_SESSION,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary MediaImage {
     required USVString src;
     DOMString sizes = "";

--- a/Source/WebCore/Modules/mediasession/MediaMetadataInit.idl
+++ b/Source/WebCore/Modules/mediasession/MediaMetadataInit.idl
@@ -25,7 +25,6 @@
 
 [
     Conditional=MEDIA_SESSION,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary MediaMetadataInit {
     DOMString title = "";
     DOMString artist = "";

--- a/Source/WebCore/Modules/mediasession/MediaPositionState.idl
+++ b/Source/WebCore/Modules/mediasession/MediaPositionState.idl
@@ -27,7 +27,6 @@
     Conditional=MEDIA_SESSION,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary MediaPositionState {
     required double duration;
     double playbackRate = 1;

--- a/Source/WebCore/Modules/mediasession/MediaSessionActionDetails.idl
+++ b/Source/WebCore/Modules/mediasession/MediaSessionActionDetails.idl
@@ -23,18 +23,21 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/mediasession/#dictdef-mediasessionactiondetails
 [
     Conditional=MEDIA_SESSION,
     ExportMacro=WEBCORE_EXPORT,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary MediaSessionActionDetails {
     required MediaSessionAction action;
-    double? seekOffset;
-    double? seekTime;
-    boolean? fastSeek;
-    boolean? isActivating;
+    double seekOffset;
+    double seekTime;
+    boolean fastSeek;
+    boolean isActivating;
 
-    [Conditional=MEDIA_SESSION_PLAYLIST, EnabledBySetting=MediaSessionPlaylistEnabled] DOMString? trackIdentifier;
+    // FIXME: Add support for `enterPictureInPictureReason`.
+    // MediaSessionEnterPictureInPictureReason enterPictureInPictureReason;
+
+    [Conditional=MEDIA_SESSION_PLAYLIST, EnabledBySetting=MediaSessionPlaylistEnabled] DOMString trackIdentifier;
 };

--- a/Source/WebCore/Modules/mediasource/MediaSourceInit.idl
+++ b/Source/WebCore/Modules/mediasource/MediaSourceInit.idl
@@ -25,7 +25,6 @@
 
 [
     Conditional=MEDIA_SOURCE,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary MediaSourceInit {
     boolean detachable = false;
 };

--- a/Source/WebCore/Modules/mediastream/DoubleRange.idl
+++ b/Source/WebCore/Modules/mediastream/DoubleRange.idl
@@ -25,7 +25,6 @@
 [
     Conditional=MEDIA_STREAM,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary DoubleRange {
     double max;
     double min;

--- a/Source/WebCore/Modules/mediastream/LongRange.idl
+++ b/Source/WebCore/Modules/mediastream/LongRange.idl
@@ -25,7 +25,6 @@
 [
     Conditional=MEDIA_STREAM,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary LongRange {
     long max;
     long min;

--- a/Source/WebCore/Modules/mediastream/MediaDevices.idl
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.idl
@@ -46,7 +46,6 @@ typedef (MediaDeviceInfo or InputDeviceInfo) DeviceInfo;
 
 [
     Conditional=MEDIA_STREAM,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary DisplayMediaStreamConstraints {
     (boolean or MediaTrackConstraints) video = true;
     (boolean or MediaTrackConstraints) audio = false;
@@ -54,7 +53,6 @@ typedef (MediaDeviceInfo or InputDeviceInfo) DeviceInfo;
 
 [
     Conditional=MEDIA_STREAM,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary MediaStreamConstraints {
     (boolean or MediaTrackConstraints) video = false;
     (boolean or MediaTrackConstraints) audio = false;

--- a/Source/WebCore/Modules/mediastream/MediaSettingsRange.idl
+++ b/Source/WebCore/Modules/mediastream/MediaSettingsRange.idl
@@ -27,7 +27,6 @@
 [
     Conditional=MEDIA_STREAM,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary MediaSettingsRange {
     double max;
     double min;

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
@@ -122,9 +122,9 @@ public:
         std::optional<int> sampleRate;
         std::optional<int> sampleSize;
         std::optional<bool> echoCancellation;
-        String displaySurface;
         String deviceId;
         String groupId;
+        String displaySurface;
 
         String whiteBalanceMode;
         std::optional<double> zoom;

--- a/Source/WebCore/Modules/mediastream/PhotoCapabilities.idl
+++ b/Source/WebCore/Modules/mediastream/PhotoCapabilities.idl
@@ -27,7 +27,6 @@
 [
     Conditional=MEDIA_STREAM,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary PhotoCapabilities {
     RedEyeReduction         redEyeReduction;
     MediaSettingsRange      imageHeight;

--- a/Source/WebCore/Modules/mediastream/PhotoSettings.idl
+++ b/Source/WebCore/Modules/mediastream/PhotoSettings.idl
@@ -28,7 +28,6 @@
     Conditional=MEDIA_STREAM,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary PhotoSettings {
     FillLightMode   fillLightMode;
     double          imageHeight;

--- a/Source/WebCore/Modules/permissions/PermissionDescriptor.idl
+++ b/Source/WebCore/Modules/permissions/PermissionDescriptor.idl
@@ -27,7 +27,6 @@
 
 [
     EnabledBySetting=PermissionsAPIEnabled,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary PermissionDescriptor {
     required PermissionName name;
 };

--- a/Source/WebCore/Modules/push-api/PushSubscriptionJSON.idl
+++ b/Source/WebCore/Modules/push-api/PushSubscriptionJSON.idl
@@ -27,7 +27,6 @@
 
 [
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary PushSubscriptionJSON {
     USVString endpoint;
     EpochTimeStamp? expirationTime;

--- a/Source/WebCore/Modules/push-api/PushSubscriptionOptionsInit.idl
+++ b/Source/WebCore/Modules/push-api/PushSubscriptionOptionsInit.idl
@@ -25,9 +25,7 @@
 
 // https://www.w3.org/TR/push-api/#pushsubscriptionoptionsinit-dictionary
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary PushSubscriptionOptionsInit {
+dictionary PushSubscriptionOptionsInit {
     boolean userVisibleOnly = false;
     (BufferSource or DOMString)? applicationServerKey = null;
 };

--- a/Source/WebCore/Modules/reporting/ReportingObserver.idl
+++ b/Source/WebCore/Modules/reporting/ReportingObserver.idl
@@ -38,9 +38,7 @@ typedef sequence<Report> ReportList;
     ReportList takeRecords();
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary ReportingObserverOptions {
+dictionary ReportingObserverOptions {
     sequence<[AtomString] DOMString>? types;
     boolean buffered = false;
 };

--- a/Source/WebCore/Modules/storage/StorageManager.idl
+++ b/Source/WebCore/Modules/storage/StorageManager.idl
@@ -37,7 +37,6 @@
 
 [
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary StorageEstimate {
     unsigned long long usage;
     unsigned long long quota;

--- a/Source/WebCore/Modules/streams/ByteLengthQueuingStrategy.idl
+++ b/Source/WebCore/Modules/streams/ByteLengthQueuingStrategy.idl
@@ -28,10 +28,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary QueuingStrategyInit {
-  required unrestricted double highWaterMark;
+dictionary QueuingStrategyInit {
+    required unrestricted double highWaterMark;
 };
 
 [

--- a/Source/WebCore/Modules/streams/QueuingStrategy.idl
+++ b/Source/WebCore/Modules/streams/QueuingStrategy.idl
@@ -25,7 +25,6 @@
 
 [
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary QueuingStrategy {
     unrestricted double highWaterMark;
     QueuingStrategySize size;

--- a/Source/WebCore/Modules/streams/ReadableStream.h
+++ b/Source/WebCore/Modules/streams/ReadableStream.h
@@ -64,8 +64,8 @@ public:
         std::optional<ReaderMode> mode;
     };
     struct WritablePair {
-        RefPtr<ReadableStream> readable;
-        RefPtr<WritableStream> writable;
+        Ref<ReadableStream> readable;
+        Ref<WritableStream> writable;
     };
     struct IteratorOptions {
         bool preventCancel { false };
@@ -171,7 +171,7 @@ public:
         bool m_preventCancel { false };
     };
 
-    ExceptionOr<Ref<Iterator>> createIterator(ScriptExecutionContext*, IteratorOptions&&);
+    ExceptionOr<Ref<Iterator>> createIterator(ScriptExecutionContext*, std::optional<IteratorOptions>&&);
 
 protected:
     static ExceptionOr<Ref<ReadableStream>> createFromJSValues(JSC::JSGlobalObject&, JSC::JSValue, JSC::JSValue);

--- a/Source/WebCore/Modules/streams/ReadableStream.idl
+++ b/Source/WebCore/Modules/streams/ReadableStream.idl
@@ -30,22 +30,16 @@
 
 enum ReadableStreamReaderMode { "byob" };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary ReadableStreamGetReaderOptions {
+dictionary ReadableStreamGetReaderOptions {
     ReadableStreamReaderMode mode;
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary ReadableWritablePair {
+dictionary ReadableWritablePair {
     required ReadableStream readable;
     required WritableStream writable;
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary ReadableStreamIteratorOptions {
+dictionary ReadableStreamIteratorOptions {
     boolean preventCancel = false;
 };
 

--- a/Source/WebCore/Modules/streams/StreamPipeOptions.idl
+++ b/Source/WebCore/Modules/streams/StreamPipeOptions.idl
@@ -23,9 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary StreamPipeOptions {
+dictionary StreamPipeOptions {
   boolean preventClose = false;
   boolean preventAbort = false;
   boolean preventCancel = false;

--- a/Source/WebCore/Modules/streams/UnderlyingSource.idl
+++ b/Source/WebCore/Modules/streams/UnderlyingSource.idl
@@ -25,7 +25,6 @@
 
 [
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary UnderlyingSource {
     UnderlyingSourceStartCallback start;
     UnderlyingSourcePullCallback pull;

--- a/Source/WebCore/bindings/js/JSDOMConvertOptional.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertOptional.h
@@ -38,16 +38,14 @@ struct OptionalConversionType;
 template<typename IDL>
 struct OptionalConversionType {
     using Type = typename IDLOptional<IDL>::ConversionResultType;
+    static constexpr Type nullValue() { return IDL::nullValue(); }
 };
 
 template<>
 struct OptionalConversionType<IDLObject> {
+    // FIXME: Switch all nullable IDLObjects to using std::optional<JSC::Strong<JSC::JSObject>> and remove this.
     using Type = std::optional<JSC::Strong<JSC::JSObject>>;
-};
-
-template<typename T>
-struct OptionalConversionType<IDLDictionary<T>> {
-    using Type = std::conditional_t<std::is_default_constructible_v<T>, T, std::optional<T>>;
+    static constexpr Type nullValue() { return std::nullopt; }
 };
 
 }
@@ -60,46 +58,47 @@ struct OptionalConversionType<IDLDictionary<T>> {
 // is needed in those cases.
 
 template<typename IDL> struct Converter<IDLOptional<IDL>> : DefaultConverter<IDLOptional<IDL>> {
-    using ReturnType = typename Detail::OptionalConversionType<IDL>::Type;
+    using OptionalConversionType = typename Detail::OptionalConversionType<IDL>;
+    using ReturnType = typename OptionalConversionType::Type;
     using Result = ConversionResult<IDLOptional<IDL>>;
 
     static Result convert(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value)
     {
         if (value.isUndefined())
-            return ReturnType { };
+            return { OptionalConversionType::nullValue() };
         return WebCore::convert<IDL>(lexicalGlobalObject, value);
     }
     static Result convert(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value, JSC::JSObject& thisObject)
     {
         if (value.isUndefined())
-            return ReturnType { };
+            return { OptionalConversionType::nullValue() };
         return WebCore::convert<IDL>(lexicalGlobalObject, value, thisObject);
     }
     static Result convert(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value, JSDOMGlobalObject& globalObject)
     {
         if (value.isUndefined())
-            return ReturnType { };
+            return { OptionalConversionType::nullValue() };
         return WebCore::convert<IDL>(lexicalGlobalObject, value, globalObject);
     }
     template<ExceptionThrowerFunctor ExceptionThrower = DefaultExceptionThrower>
     static Result convert(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value, ExceptionThrower&& exceptionThrower)
     {
         if (value.isUndefined())
-            return ReturnType { };
+            return { OptionalConversionType::nullValue() };
         return WebCore::convert<IDL>(lexicalGlobalObject, value, std::forward<ExceptionThrower>(exceptionThrower));
     }
     template<ExceptionThrowerFunctor ExceptionThrower = DefaultExceptionThrower>
     static Result convert(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value, JSC::JSObject& thisObject, ExceptionThrower&& exceptionThrower)
     {
         if (value.isUndefined())
-            return ReturnType { };
+            return { OptionalConversionType::nullValue() };
         return WebCore::convert<IDL>(lexicalGlobalObject, value, thisObject, std::forward<ExceptionThrower>(exceptionThrower));
     }
     template<ExceptionThrowerFunctor ExceptionThrower = DefaultExceptionThrower>
     static Result convert(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value, JSDOMGlobalObject& globalObject, ExceptionThrower&& exceptionThrower)
     {
         if (value.isUndefined())
-            return ReturnType { };
+            return { OptionalConversionType::nullValue() };
         return WebCore::convert<IDL>(lexicalGlobalObject, value, globalObject, std::forward<ExceptionThrower>(exceptionThrower));
     }
 };


### PR DESCRIPTION
#### b389bf8338f292cf1ac00d9e9ef317e31901d875
<pre>
Remove LegacyNativeDictionaryRequiredInterfaceNullability from IDL dictionaries (Part 1)
<a href="https://bugs.webkit.org/show_bug.cgi?id=305782">https://bugs.webkit.org/show_bug.cgi?id=305782</a>

Reviewed by Anne van Kesteren.

First batch of removing relatively trivial uses of LegacyNativeDictionaryRequiredInterfaceNullability.

* Source/WebCore/Modules/ShapeDetection/DetectedBarcode.h:
* Source/WebCore/Modules/ShapeDetection/DetectedBarcode.idl:
* Source/WebCore/Modules/ShapeDetection/DetectedFace.h:
* Source/WebCore/Modules/ShapeDetection/DetectedFace.idl:
* Source/WebCore/Modules/ShapeDetection/DetectedText.h:
* Source/WebCore/Modules/ShapeDetection/DetectedText.idl:
* Source/WebCore/Modules/ShapeDetection/Landmark.idl:
* Source/WebCore/Modules/ShapeDetection/Point2D.idl:
* Source/WebCore/Modules/applepay-ams-ui/ApplePayAMSUIRequest.idl:
* Source/WebCore/Modules/applepay/ApplePayAutomaticReloadPaymentRequest.idl:
* Source/WebCore/Modules/applepay/ApplePayCouponCodeDetails.idl:
* Source/WebCore/Modules/applepay/ApplePayDateComponents.idl:
* Source/WebCore/Modules/applepay/ApplePayDateComponentsRange.idl:
* Source/WebCore/Modules/applepay/ApplePayDeferredPaymentRequest.idl:
* Source/WebCore/Modules/applepay/ApplePayDisbursementRequest.idl:
* Source/WebCore/Modules/applepay/ApplePayInstallmentItem.idl:
* Source/WebCore/Modules/applepay/ApplePayLineItem.idl:
* Source/WebCore/Modules/applepay/ApplePayPayment.idl:
* Source/WebCore/Modules/applepay/ApplePayPaymentMethod.idl:
* Source/WebCore/Modules/applepay/ApplePayPaymentOrderDetails.idl:
* Source/WebCore/Modules/applepay/ApplePayPaymentPass.idl:
* Source/WebCore/Modules/applepay/ApplePayPaymentTokenContext.idl:
* Source/WebCore/Modules/applepay/ApplePayRecurringPaymentRequest.idl:
* Source/WebCore/Modules/applepay/ApplePaySessionError.idl:
* Source/WebCore/Modules/applepay/ApplePayShippingMethod.idl:
* Source/WebCore/Modules/applepay/paymentrequest/ApplePayPaymentCompleteDetails.idl:
* Source/WebCore/Modules/async-clipboard/ClipboardItem.idl:
* Source/WebCore/Modules/cache/CacheQueryOptions.idl:
* Source/WebCore/Modules/cache/MultiCacheQueryOptions.idl:
* Source/WebCore/Modules/contact-picker/ContactInfo.idl:
* Source/WebCore/Modules/contact-picker/ContactsSelectOptions.idl:
* Source/WebCore/Modules/cookie-consent/RequestCookieConsentOptions.idl:
* Source/WebCore/Modules/cookie-store/CookieInit.idl:
* Source/WebCore/Modules/cookie-store/CookieStoreDeleteOptions.idl:
* Source/WebCore/Modules/cookie-store/CookieStoreGetOptions.idl:
* Source/WebCore/Modules/credentialmanagement/CredentialCreationOptions.idl:
* Source/WebCore/Modules/credentialmanagement/CredentialRequestOptions.h:
* Source/WebCore/Modules/credentialmanagement/CredentialRequestOptions.idl:
* Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp:
* Source/WebCore/Modules/encryptedmedia/MediaKeySystemMediaCapability.idl:
* Source/WebCore/Modules/entriesapi/FileSystemDirectoryEntry.idl:
* Source/WebCore/Modules/fetch/FetchBody.cpp:
* Source/WebCore/Modules/fetch/FetchResponse.idl:
* Source/WebCore/Modules/filesystem/FileSystemDirectoryHandle.idl:
* Source/WebCore/Modules/filesystem/FileSystemFileHandle.idl:
* Source/WebCore/Modules/filesystem/FileSystemSyncAccessHandle.idl:
* Source/WebCore/Modules/gamepad/GamepadEffectParameters.idl:
* Source/WebCore/Modules/geolocation/PositionOptions.idl:
* Source/WebCore/Modules/identity/DigitalCredentialGetRequest.idl:
* Source/WebCore/Modules/identity/DigitalCredentialRequestOptions.idl:
* Source/WebCore/Modules/identity/protocols/ISO18013/MobileDocumentRequest.idl:
* Source/WebCore/Modules/indexeddb/IDBDatabase.idl:
* Source/WebCore/Modules/indexeddb/IDBObjectStore.idl:
* Source/WebCore/Modules/mediacapabilities/AudioConfiguration.idl:
* Source/WebCore/Modules/mediacapabilities/MediaCapabilitiesDecodingInfo.idl:
* Source/WebCore/Modules/mediacapabilities/MediaCapabilitiesEncodingInfo.idl:
* Source/WebCore/Modules/mediacapabilities/MediaCapabilitiesInfo.idl:
* Source/WebCore/Modules/mediarecorder/MediaRecorder.idl:
* Source/WebCore/Modules/mediasession/MediaImage.idl:
* Source/WebCore/Modules/mediasession/MediaMetadataInit.idl:
* Source/WebCore/Modules/mediasession/MediaPositionState.idl:
* Source/WebCore/Modules/mediasession/MediaSessionActionDetails.idl:
* Source/WebCore/Modules/mediasource/MediaSourceInit.idl:
* Source/WebCore/Modules/mediastream/DoubleRange.idl:
* Source/WebCore/Modules/mediastream/LongRange.idl:
* Source/WebCore/Modules/mediastream/MediaDevices.idl:
* Source/WebCore/Modules/mediastream/MediaSettingsRange.idl:
* Source/WebCore/Modules/mediastream/MediaStreamTrack.h:
* Source/WebCore/Modules/mediastream/PhotoCapabilities.idl:
* Source/WebCore/Modules/mediastream/PhotoSettings.idl:
* Source/WebCore/Modules/permissions/PermissionDescriptor.idl:
* Source/WebCore/Modules/push-api/PushSubscriptionJSON.idl:
* Source/WebCore/Modules/push-api/PushSubscriptionOptionsInit.idl:
* Source/WebCore/Modules/reporting/ReportingObserver.idl:
* Source/WebCore/Modules/storage/StorageManager.idl:
* Source/WebCore/Modules/streams/ByteLengthQueuingStrategy.idl:
* Source/WebCore/Modules/streams/QueuingStrategy.idl:
* Source/WebCore/Modules/streams/ReadableStream.cpp:
* Source/WebCore/Modules/streams/ReadableStream.h:
* Source/WebCore/Modules/streams/ReadableStream.idl:
* Source/WebCore/Modules/streams/StreamPipeOptions.idl:
* Source/WebCore/Modules/streams/UnderlyingSource.idl:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/JSDOMConvertOptional.h:

Canonical link: <a href="https://commits.webkit.org/305982@main">https://commits.webkit.org/305982@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7201b985250fb7efb519aa61c1da64c5ba7ec65

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139893 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12274 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1404 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148035 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92963 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141766 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12984 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12426 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107119 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/77964 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142843 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10004 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125285 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87999 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9657 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7170 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8325 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118877 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1287 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150819 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11959 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1353 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115531 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11972 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10249 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115846 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29453 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10641 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121765 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66964 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12001 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1240 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11741 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75688 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11937 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11789 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->