### PR TITLE
AX: meter element has inconsistent labels between aria-label and title

### DIFF
--- a/LayoutTests/accessibility/mac/meter-gauge-value-description-expected.txt
+++ b/LayoutTests/accessibility/mac/meter-gauge-value-description-expected.txt
@@ -4,10 +4,10 @@ This tests the gauge value description for meter elements.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS meter1.valueDescription is 'AXValueDescription: '
-PASS meter2.valueDescription is 'AXValueDescription: suboptimal value'
-PASS meter3.valueDescription is 'AXValueDescription: optimal value'
-PASS meter4.valueDescription is 'AXValueDescription: critical value'
+PASS meter1.valueDescription is 'AXValueDescription: 1'
+PASS meter2.valueDescription is 'AXValueDescription: 5, suboptimal value'
+PASS meter3.valueDescription is 'AXValueDescription: 50, optimal value'
+PASS meter4.valueDescription is 'AXValueDescription: 90, critical value'
 PASS meter5.valueDescription is 'AXValueDescription: 50 hours, optimal value'
 PASS successfullyParsed is true
 

--- a/LayoutTests/accessibility/mac/meter-gauge-value-description.html
+++ b/LayoutTests/accessibility/mac/meter-gauge-value-description.html
@@ -19,20 +19,21 @@
 
     if (window.accessibilityController) {
 
-          // Test that we are not exposing the gauge value description if author 
+          // Test that we are not exposing the gauge value description if author
           // didn't specify low, high or optimum attribute.
+          // Value 83.5 gets clamped to 1 since the default max is 1.
           var meter1 = accessibilityController.accessibleElementById("meter");
-          shouldBe("meter1.valueDescription", "'AXValueDescription: '");
+          shouldBe("meter1.valueDescription", "'AXValueDescription: 1'");
 
           var meter2 = accessibilityController.accessibleElementById("meter2");
-          shouldBe("meter2.valueDescription", "'AXValueDescription: suboptimal value'");
-          
+          shouldBe("meter2.valueDescription", "'AXValueDescription: 5, suboptimal value'");
+
           var meter3 = accessibilityController.accessibleElementById("meter3");
-          shouldBe("meter3.valueDescription", "'AXValueDescription: optimal value'");
-          
+          shouldBe("meter3.valueDescription", "'AXValueDescription: 50, optimal value'");
+
           var meter4 = accessibilityController.accessibleElementById("meter4");
-          shouldBe("meter4.valueDescription", "'AXValueDescription: critical value'");
-          
+          shouldBe("meter4.valueDescription", "'AXValueDescription: 90, critical value'");
+
           // Test meter with inner text.
           var meter5 = accessibilityController.accessibleElementById("meter5");
           shouldBe("meter5.valueDescription", "'AXValueDescription: 50 hours, optimal value'");

--- a/LayoutTests/accessibility/mac/meter-title-attribute-expected.txt
+++ b/LayoutTests/accessibility/mac/meter-title-attribute-expected.txt
@@ -1,0 +1,26 @@
+This test ensures the title attribute on meter elements is exposed as part of the accessible description, not as help text.
+
+Meter with title attribute:
+	AXTitle:
+	AXDescription: Fuel level
+	AXHelp:
+PASS: meterWithTitle.description.includes('Fuel level') === true
+PASS: meterWithTitle.helpText.includes('Fuel level') === false
+
+Meter without title attribute:
+	AXTitle:
+	AXDescription:
+	AXHelp:
+PASS: meterWithoutTitle.description === 'AXDescription: '
+
+After dynamically adding title attribute:
+	AXTitle:
+	AXDescription: Battery level
+	AXHelp:
+PASS: meterWithoutTitle.description.includes('Battery level') === true
+PASS: meterWithoutTitle.helpText.includes('Battery level') === false
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/meter-title-attribute.html
+++ b/LayoutTests/accessibility/mac/meter-title-attribute.html
@@ -1,0 +1,49 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<meter id="meter-with-title" min="0" max="100" low="33" high="66" optimum="80" value="80" title="Fuel level" tabindex="0"></meter>
+<meter id="meter-without-title" min="0" max="100" value="50" tabindex="0"></meter>
+
+<script>
+var output = "This test ensures the title attribute on meter elements is exposed as part of the accessible description, not as help text.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var meterWithTitle = accessibilityController.accessibleElementById("meter-with-title");
+    output += "Meter with title attribute:\n";
+    output += platformTextAlternatives(meterWithTitle) + "\n";
+    output += expect("meterWithTitle.description.includes('Fuel level')", "true");
+    output += expect("meterWithTitle.helpText.includes('Fuel level')", "false");
+
+    var meterWithoutTitle = accessibilityController.accessibleElementById("meter-without-title");
+    output += "\nMeter without title attribute:\n";
+    output += platformTextAlternatives(meterWithoutTitle) + "\n";
+    output += expect("meterWithoutTitle.description", "'AXDescription: '");
+
+    // Test dynamic update: add a title to the meter without one.
+    document.getElementById("meter-without-title").setAttribute("title", "Battery level");
+
+    setTimeout(async function() {
+        await waitFor(() => {
+            meterWithoutTitle = accessibilityController.accessibleElementById("meter-without-title");
+            return meterWithoutTitle && meterWithoutTitle.description.includes("Battery level");
+        });
+
+        output += "\nAfter dynamically adding title attribute:\n";
+        output += platformTextAlternatives(meterWithoutTitle) + "\n";
+        output += expect("meterWithoutTitle.description.includes('Battery level')", "true");
+        output += expect("meterWithoutTitle.helpText.includes('Battery level')", "false");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/mac/accessibility/meter-element-expected.txt
+++ b/LayoutTests/platform/mac/accessibility/meter-element-expected.txt
@@ -23,7 +23,7 @@ Meter3
 AXRole: AXLevelIndicator
 AXTitle:
 AXDescription:
-AXValueDescription:
+AXValueDescription: 75
 AXValueSettable: false
 
 
@@ -46,7 +46,7 @@ AXValueSettable: false
 Meter6
 AXRole: AXLevelIndicator
 AXTitle:
-AXDescription:
+AXDescription: centimeters
 AXValueDescription: 12cm
 AXValueSettable: false
 
@@ -54,7 +54,7 @@ AXValueSettable: false
 Meter7
 AXRole: AXLevelIndicator
 AXTitle:
-AXDescription:
+AXDescription: centimeters
 AXValueDescription: 2cm
 AXValueSettable: false
 

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -3476,12 +3476,10 @@ void AccessibilityNodeObject::helpText(Vector<AccessibilityText>& textOrder) con
 
     // The title attribute should be used as help text unless it is already being used as descriptive text.
     // However, when the title attribute is the only text alternative provided, it may be exposed as the
-    // descriptive text. This is problematic in the case of meters because the HTML spec suggests authors
-    // can expose units through this attribute. Therefore, if the element is a meter, change its source
-    // type to AccessibilityTextSource::Help.
+    // descriptive text.
     const AtomString& title = getAttribute(titleAttr);
     if (!title.isEmpty()) {
-        if (!isMeter() && !roleIgnoresTitle())
+        if (!roleIgnoresTitle())
             textOrder.append(AccessibilityText(title, AccessibilityTextSource::TitleTag));
         else
             textOrder.append(AccessibilityText(title, AccessibilityTextSource::Help));

--- a/Source/WebCore/accessibility/AccessibilityProgressIndicator.cpp
+++ b/Source/WebCore/accessibility/AccessibilityProgressIndicator.cpp
@@ -84,6 +84,10 @@ String AccessibilityProgressIndicator::valueDescription() const
     if (description.isEmpty())
         description = meter->textContent();
 
+    // If no textual description is available, use the numeric value.
+    if (description.isEmpty())
+        description = String::number(meter->value());
+
     String gaugeRegionValue = gaugeRegionValueDescription();
     if (!gaugeRegionValue.isEmpty())
         description = description.isEmpty() ? gaugeRegionValue : makeString(description, ", "_s,  gaugeRegionValue);


### PR DESCRIPTION
#### a6c1ed442a54dbc364d5936d7e1d94de4ac4f156
<pre>
AX: meter element has inconsistent labels between aria-label and title
<a href="https://bugs.webkit.org/show_bug.cgi?id=273655">https://bugs.webkit.org/show_bug.cgi?id=273655</a>
<a href="https://rdar.apple.com/127460695">rdar://127460695</a>

Reviewed by Joshua Hoffman.

This commit includes two fixes for meter element accessibility:

1. The title attribute was incorrectly forced to AccessibilityTextSource::Help,
causing it to be exposed as AXHelp instead of AXDescription. No other browser
did this, and it resulted in suboptimal screenreader experience. Remove the special-case
isMeter() check so meters follow the same title handling as other elements.

2. The valueDescription only showed the gauge region (e.g., &quot;optimal value&quot;)
without the actual numeric value. Now when no textual description is available
(i.e. the text inside the meter element), we fall back to the numeric value,
producing output like &quot;80, optimal value&quot; instead of just &quot;optimal value&quot;.

* LayoutTests/accessibility/mac/meter-gauge-value-description-expected.txt:
* LayoutTests/accessibility/mac/meter-gauge-value-description.html:
* LayoutTests/accessibility/mac/meter-title-attribute-expected.txt: Added.
* LayoutTests/accessibility/mac/meter-title-attribute.html: Added.
* LayoutTests/platform/mac/accessibility/meter-element-expected.txt:
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::helpText const):
* Source/WebCore/accessibility/AccessibilityProgressIndicator.cpp:
(WebCore::AccessibilityProgressIndicator::valueDescription const):

Canonical link: <a href="https://commits.webkit.org/305883@main">https://commits.webkit.org/305883@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b642ec024f29ab64118b80d01f7f2f349310cd16

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139544 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11920 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1047 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147674 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92612 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4fc2134c-8b37-425d-8b8b-c27ba750eea2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141417 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12628 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12070 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106836 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77791 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2ccd2b1b-ab11-4431-ac3f-9559c20af0dc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142491 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9676 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124984 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87700 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3924b334-e1e3-4749-81ed-0e029f40a683) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9310 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/7076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7970 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118594 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/979 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150456 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11604 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/995 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115239 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11618 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9926 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115550 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29385 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10140 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121424 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66610 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11649 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/933 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11384 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75327 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11584 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11435 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->