### PR TITLE
Remove LegacyNativeDictionaryRequiredInterfaceNullability for fetch, gamepad, and geolocation

### DIFF
--- a/Source/WebCore/Modules/fetch/FetchRequest.cpp
+++ b/Source/WebCore/Modules/fetch/FetchRequest.cpp
@@ -273,20 +273,8 @@ ExceptionOr<void> FetchRequest::initializeWith(FetchRequest& input, Init&& init)
         m_navigationPreloadIdentifier = input.m_navigationPreloadIdentifier;
     }
 
-    if (RefPtr executionContext = scriptExecutionContext()) {
-        if (RefPtr document = dynamicDowncast<Document>(*executionContext); document && document->settings().localNetworkAccessEnabled()) {
-            switch (init.targetAddressSpace) {
-            case IPAddressSpace::Public:
-                m_targetAddressSpace = IPAddressSpace::Public;
-                break;
-            case IPAddressSpace::Local:
-                m_targetAddressSpace = IPAddressSpace::Local;
-                break;
-            }
-
-            m_targetAddressSpace = updateTargetAddressSpaceIfNeeded(m_targetAddressSpace, m_request.url());
-        }
-    }
+    if (RefPtr document = dynamicDowncast<Document>(context); document && document->settings().localNetworkAccessEnabled())
+        m_targetAddressSpace = updateTargetAddressSpaceIfNeeded(*init.targetAddressSpace, m_request.url());
 
     auto setBodyResult = init.body ? setBody(WTF::move(*init.body)) : setBody(input);
     if (setBodyResult.hasException())

--- a/Source/WebCore/Modules/fetch/FetchRequest.h
+++ b/Source/WebCore/Modules/fetch/FetchRequest.h
@@ -114,7 +114,7 @@ private:
     const Ref<AbortSignal> m_signal;
     Markable<FetchIdentifier> m_navigationPreloadIdentifier;
     bool m_enableContentExtensionsCheck { true };
-    IPAddressSpace m_targetAddressSpace;
+    IPAddressSpace m_targetAddressSpace { IPAddressSpace::Public };
 };
 
 WebCoreOpaqueRoot root(FetchRequest*);

--- a/Source/WebCore/Modules/fetch/FetchRequestInit.h
+++ b/Source/WebCore/Modules/fetch/FetchRequestInit.h
@@ -51,8 +51,8 @@ struct FetchRequestInit {
     JSC::JSValue signal;
     std::optional<RequestPriority> priority;
     JSC::JSValue window;
-    IPAddressSpace targetAddressSpace { IPAddressSpace::Public };
-    bool hasMembers() const { return !method.isEmpty() || headers || body || !referrer.isEmpty() || referrerPolicy || mode || credentials || cache || redirect || !integrity.isEmpty() || keepalive || !window.isUndefined() || !signal.isUndefined() || targetAddressSpace != IPAddressSpace::Public; }
+    std::optional<IPAddressSpace> targetAddressSpace;
+    bool hasMembers() const { return !method.isEmpty() || headers || body || !referrer.isEmpty() || referrerPolicy || mode || credentials || cache || redirect || !integrity.isEmpty() || keepalive || !window.isUndefined() || !signal.isUndefined() || (targetAddressSpace && *targetAddressSpace != IPAddressSpace::Public); }
 };
 
 }

--- a/Source/WebCore/Modules/fetch/FetchRequestInit.idl
+++ b/Source/WebCore/Modules/fetch/FetchRequestInit.idl
@@ -27,9 +27,7 @@ typedef (sequence<sequence<ByteString>> or record<ByteString, ByteString>) Heade
 
 typedef (Blob or BufferSource or DOMFormData or URLSearchParams or ReadableStream or USVString) BodyInit;
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary FetchRequestInit {
+dictionary FetchRequestInit {
     ByteString method;
     HeadersInit headers;
     BodyInit? body;

--- a/Source/WebCore/Modules/fetch/FetchResponse.idl
+++ b/Source/WebCore/Modules/fetch/FetchResponse.idl
@@ -31,9 +31,7 @@ typedef (sequence<sequence<ByteString>> or record<ByteString, ByteString>) Heade
 
 enum FetchResponseType { "basic", "cors", "default", "error", "opaque", "opaqueredirect" };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary FetchResponseInit {
+dictionary FetchResponseInit {
     unsigned short status = 200;
     [AtomString] ByteString statusText = "";
     HeadersInit headers;

--- a/Source/WebCore/Modules/gamepad/GamepadEvent.cpp
+++ b/Source/WebCore/Modules/gamepad/GamepadEvent.cpp
@@ -33,15 +33,15 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(GamepadEvent);
 
-GamepadEvent::GamepadEvent(const AtomString& eventType, Gamepad& gamepad)
+GamepadEvent::GamepadEvent(const AtomString& eventType, Ref<Gamepad>&& gamepad)
     : Event(EventInterfaceType::GamepadEvent, eventType, CanBubble::No, IsCancelable::No)
-    , m_gamepad(&gamepad)
+    , m_gamepad(WTF::move(gamepad))
 {
 }
 
-GamepadEvent::GamepadEvent(const AtomString& eventType, const Init& initializer, IsTrusted isTrusted)
+GamepadEvent::GamepadEvent(const AtomString& eventType, Init&& initializer, IsTrusted isTrusted)
     : Event(EventInterfaceType::GamepadEvent, eventType, initializer, isTrusted)
-    , m_gamepad(initializer.gamepad)
+    , m_gamepad(WTF::move(initializer.gamepad))
 {
 }
 

--- a/Source/WebCore/Modules/gamepad/GamepadEvent.h
+++ b/Source/WebCore/Modules/gamepad/GamepadEvent.h
@@ -36,27 +36,27 @@ namespace WebCore {
 class GamepadEvent final : public Event {
     WTF_MAKE_TZONE_ALLOCATED(GamepadEvent);
 public:
-    static Ref<GamepadEvent> create(const AtomString& eventType, Gamepad& gamepad)
+    static Ref<GamepadEvent> create(const AtomString& eventType, Ref<Gamepad>&& gamepad)
     {
-        return adoptRef(*new GamepadEvent(eventType, gamepad));
+        return adoptRef(*new GamepadEvent(eventType, WTF::move(gamepad)));
     }
 
     struct Init : EventInit {
         RefPtr<Gamepad> gamepad;
     };
 
-    static Ref<GamepadEvent> create(const AtomString& eventType, const Init& initializer, IsTrusted isTrusted = IsTrusted::No)
+    static Ref<GamepadEvent> create(const AtomString& eventType, Init&& initializer, IsTrusted isTrusted = IsTrusted::No)
     {
-        return adoptRef(*new GamepadEvent(eventType, initializer, isTrusted));
+        return adoptRef(*new GamepadEvent(eventType, WTF::move(initializer), isTrusted));
     }
 
-    Gamepad* gamepad() const { return m_gamepad.get(); }
+    Gamepad* gamepad() const { return m_gamepad; }
 
 private:
-    explicit GamepadEvent(const AtomString& eventType, Gamepad&);
-    GamepadEvent(const AtomString& eventType, const Init&, IsTrusted);
+    explicit GamepadEvent(const AtomString& eventType, Ref<Gamepad>&&);
+    GamepadEvent(const AtomString& eventType, Init&&, IsTrusted);
 
-    RefPtr<Gamepad> m_gamepad;
+    const RefPtr<Gamepad> m_gamepad;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/gamepad/GamepadEvent.idl
+++ b/Source/WebCore/Modules/gamepad/GamepadEvent.idl
@@ -33,10 +33,7 @@
     readonly attribute Gamepad? gamepad;
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary GamepadEventInit : EventInit {
-    // The specification says this member should be required and non-nullable.
-    // However, this does not match the behavior of Chrome or Firefox.
+dictionary GamepadEventInit : EventInit {
+    // This should probably be nullable: https://github.com/w3c/gamepad/pull/217.
     Gamepad? gamepad = null;
 };

--- a/Source/WebCore/Modules/gamepad/GamepadManager.cpp
+++ b/Source/WebCore/Modules/gamepad/GamepadManager.cpp
@@ -135,7 +135,7 @@ void GamepadManager::platformGamepadDisconnected(PlatformGamepad& platformGamepa
         navigatorGamepad.gamepadDisconnected(platformGamepad);
         notifiedNavigators.add(navigator.get());
 
-        window->dispatchEvent(GamepadEvent::create(eventNames().gamepaddisconnectedEvent, gamepad.get()), window->protectedDocument().get());
+        window->dispatchEvent(GamepadEvent::create(eventNames().gamepaddisconnectedEvent, WTF::move(gamepad)), window->protectedDocument().get());
     }
 
     // Notify all the Navigators that haven't already been notified.
@@ -187,7 +187,7 @@ void GamepadManager::makeGamepadVisible(PlatformGamepad& platformGamepad, WeakHa
 
         LOG(Gamepad, "(%u) GamepadManager::makeGamepadVisible - Dispatching gamepadconnected event for gamepad '%s'", (unsigned)getpid(), platformGamepad.id().utf8().data());
         UserGestureIndicator gestureIndicator(IsProcessingUserGesture::Yes, document.get());
-        window->dispatchEvent(GamepadEvent::create(eventNames().gamepadconnectedEvent, gamepad.get()), window->protectedDocument().get());
+        window->dispatchEvent(GamepadEvent::create(eventNames().gamepadconnectedEvent, WTF::move(gamepad)), window->protectedDocument().get());
     }
 }
 

--- a/Source/WebCore/Modules/geolocation/PositionOptions.idl
+++ b/Source/WebCore/Modules/geolocation/PositionOptions.idl
@@ -24,9 +24,7 @@
  */
 
 // https://w3c.github.io/geolocation-api/#position_options_interface
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary PositionOptions {
+dictionary PositionOptions {
     boolean enableHighAccuracy = false;
     [Clamp] unsigned long timeout = 0xFFFFFFFF;
     [Clamp] unsigned long maximumAge = 0;


### PR DESCRIPTION
#### 322a72bb8e35291e30b949dce15259a291a13e3d
<pre>
Remove LegacyNativeDictionaryRequiredInterfaceNullability for fetch, gamepad, and geolocation
<a href="https://bugs.webkit.org/show_bug.cgi?id=305783">https://bugs.webkit.org/show_bug.cgi?id=305783</a>

Reviewed by Sam Weinig.

Also cleanup the code for targetAddressSpace in Fetch and align
GamepadEvent code more with other events.

Canonical link: <a href="https://commits.webkit.org/305855@main">https://commits.webkit.org/305855@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7b1a8d3c7b0e467037ae53195bc3b1ce230f71f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139632 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12008 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1136 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147766 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1f83a8d1-8e9b-4b6d-8cca-6bffa513ee80) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141505 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12716 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/12158 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/106919 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a59e60a1-9e28-4853-bf1f-d6186117eb6e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142579 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9770 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125061 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87781 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aa15492f-cad2-4cdf-a25c-08da9e174800) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9413 "Passed tests") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8058 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118672 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1059 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150548 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11693 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1094 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/115322 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11706 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/12158 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115633 "Passed tests") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/10313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121521 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/66698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21537 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11737 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/1006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11475 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75415 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/11672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11523 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->