### PR TITLE
Enable main resource blob cache

### DIFF
--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h
@@ -51,7 +51,7 @@ class Storage : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Storage, 
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(Storage);
 public:
     enum class Mode { Normal, AvoidRandomness };
-    static RefPtr<Storage> open(const String& cachePath, Mode, size_t capacity);
+    static RefPtr<Storage> open(const String& cachePath, Mode, size_t capacity, size_t mainResourceBlobMemoryCacheFileLimit);
 
     enum class ReadOperationIdentifierType { };
     using ReadOperationIdentifier = ObjectIdentifier<ReadOperationIdentifierType>;
@@ -142,7 +142,7 @@ public:
     void writeWithoutWaiting() { m_initialWriteDelay = 0_s; };
 
 private:
-    Storage(const String& directoryPath, Mode, Salt, size_t capacity);
+    Storage(const String& directoryPath, Mode, Salt, size_t capacity, size_t mainResourceBlobMemoryCacheFileLimit);
 
     String recordDirectoryPathForKey(const Key&) const;
     String recordPathForKey(const Key&) const;


### PR DESCRIPTION
#### 08681f04eaa2eab0e44c13c94a8df2e3e936f1e8
<pre>
Enable main resource blob cache
<a href="https://bugs.webkit.org/show_bug.cgi?id=305784">https://bugs.webkit.org/show_bug.cgi?id=305784</a>
<a href="https://rdar.apple.com/168456602">rdar://168456602</a>

Reviewed by Per Arne Vollan.

This enables the main resource blob memory cache added in 305234@main, which is a ~0.5% win on PLT6
and PLT7.

This is only enabled for web browser clients since the tradeoff of more used vnodes for slightly
higher PLT performance only seems worth it for browsers.

* Source/WebKit/NetworkProcess/cache/NetworkCache.cpp:
(WebKit::NetworkCache::Cache::open):
* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp:
(WebKit::NetworkCache::Storage::open):
(WebKit::NetworkCache::Storage::Storage):
* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h:

Canonical link: <a href="https://commits.webkit.org/305958@main">https://commits.webkit.org/305958@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e05b9bb83a133d7ec2a83a3945daddea8f9a50b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139556 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11932 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1059 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147688 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92624 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d346c656-d736-4283-a929-e6bfaa28348c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12640 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12082 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106847 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77800 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6eb61e1e-2acf-4255-9366-65592c3cc54b) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142503 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9688 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124993 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87711 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0ec977fe-c263-4dcd-a1d7-b43e6dc88fd3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9323 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6913 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7982 "Build is in progress. Recent messages:Printed configuration") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118605 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150469 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11616 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1006 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115250 "Passed tests") | | 
| | [💥 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11630 "An unexpected error occured. Recent messages:OS: Tahoe (26.2), Xcode: 26.2") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9937 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115561 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29442 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121435 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66622 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11661 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/941 "Passed tests") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11397 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75339 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11596 "Built successfully") | | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11447 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2") | | | | 
<!--EWS-Status-Bubble-End-->