### PR TITLE
Add static checks that dictionary member order in the IDL matches the native dictionaries

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -263,6 +263,7 @@
 		BC05ACA62CEA70E500750CB1 /* VariantListOperations.h in Headers */ = {isa = PBXBuildFile; fileRef = BC05ACA52CEA70E500750CB1 /* VariantListOperations.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC2C0C212D2C54A900FCFBA0 /* FlatteningVariantAdaptor.h in Headers */ = {isa = PBXBuildFile; fileRef = BC2C0C202D2C54A900FCFBA0 /* FlatteningVariantAdaptor.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC5267672C2726D600E422DD /* MakeString.h in Headers */ = {isa = PBXBuildFile; fileRef = BC5267662C2726D600E422DD /* MakeString.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BCD8F92A2F1EDB8B00B42872 /* IsIncreasing.h in Headers */ = {isa = PBXBuildFile; fileRef = BCD8F9292F1EDB8B00B42872 /* IsIncreasing.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BCE0DFA72D1865B9003F0349 /* CompactVariant.h in Headers */ = {isa = PBXBuildFile; fileRef = BCE0DFA62D1865B9003F0349 /* CompactVariant.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BCE0DFA92D1865C4003F0349 /* CompactVariantOperations.h in Headers */ = {isa = PBXBuildFile; fileRef = BCE0DFA82D1865C4003F0349 /* CompactVariantOperations.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BCE0DFAB2D18670B003F0349 /* VariantExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = BCE0DFAA2D18670B003F0349 /* VariantExtras.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1682,6 +1683,7 @@
 		BC05ACA52CEA70E500750CB1 /* VariantListOperations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VariantListOperations.h; sourceTree = "<group>"; };
 		BC2C0C202D2C54A900FCFBA0 /* FlatteningVariantAdaptor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FlatteningVariantAdaptor.h; sourceTree = "<group>"; };
 		BC5267662C2726D600E422DD /* MakeString.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MakeString.h; sourceTree = "<group>"; };
+		BCD8F9292F1EDB8B00B42872 /* IsIncreasing.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IsIncreasing.h; sourceTree = "<group>"; };
 		BCE0DFA62D1865B9003F0349 /* CompactVariant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CompactVariant.h; sourceTree = "<group>"; };
 		BCE0DFA82D1865C4003F0349 /* CompactVariantOperations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CompactVariantOperations.h; sourceTree = "<group>"; };
 		BCE0DFAA2D18670B003F0349 /* VariantExtras.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VariantExtras.h; sourceTree = "<group>"; };
@@ -2493,6 +2495,7 @@
 				F6D67D3226F90142006E0349 /* Int128.h */,
 				33FD4811265CB38000ABE4F4 /* InterferenceGraph.h */,
 				A4F0F47C2E3056A3001BF35C /* IntervalSet.h */,
+				BCD8F9292F1EDB8B00B42872 /* IsIncreasing.h */,
 				5295B00427920C54006D746A /* IterationStatus.h */,
 				7CDD7FF9186D2A54007433CD /* IteratorRange.h */,
 				7A05093E1FB9DCC500B33FB8 /* JSONValues.cpp */,
@@ -3656,6 +3659,7 @@
 				1C08E3682985D8F300CAE594 /* IOReturnSPI.h in Headers */,
 				1C97FF7A297CD119006422AA /* IOSurfaceSPI.h in Headers */,
 				1C08E3692985D8F800CAE594 /* IOTypesSPI.h in Headers */,
+				BCD8F92A2F1EDB8B00B42872 /* IsIncreasing.h in Headers */,
 				DD3DC8B227A4BF8E007E5B61 /* IterationStatus.h in Headers */,
 				DD3DC86B27A4BF8E007E5B61 /* IteratorRange.h in Headers */,
 				DD3DC92D27A4BF8E007E5B61 /* JSONValues.h in Headers */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -143,6 +143,7 @@ set(WTF_PUBLIC_HEADERS
     Int128.h
     InterferenceGraph.h
     IntervalSet.h
+    IsIncreasing.h
     IterationStatus.h
     IteratorRange.h
     JSONValues.h

--- a/Source/WTF/wtf/IsIncreasing.h
+++ b/Source/WTF/wtf/IsIncreasing.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WTF {
+
+// `IsIncreasing` is a utility to check that a series of numbers are increasing.
+//
+// On example usage is for generated code to check the relative order of the members of a struct:
+//
+//   Given struct:
+//
+//     struct Foo {
+//         int a;
+//         int b;
+//         int c;
+//     };
+//
+//   You can statically assert:
+//
+//     static_assert(IsIncreasing<
+//           0
+//         , offsetof(Foo, a)
+//         , offsetof(Foo, b)
+//         , offsetof(Foo, c)
+//     >);
+
+template<size_t...>
+struct IsIncreasingChecker;
+
+template<size_t index>
+struct IsIncreasingChecker<index> {
+    static constexpr bool value = true;
+};
+
+template<size_t firstIndex, size_t secondIndex, size_t... remainingIndices>
+struct IsIncreasingChecker<firstIndex, secondIndex, remainingIndices...> {
+    static constexpr bool value = firstIndex > secondIndex ? false : IsIncreasingChecker<secondIndex, remainingIndices...>::value;
+};
+
+template<size_t... indices>
+constexpr bool IsIncreasing = IsIncreasingChecker<indices...>::value;
+
+} // namespace WTF
+
+using WTF::IsIncreasing;

--- a/Source/WebCore/bindings/scripts/test/JS/JSExposedToWorkerAndWindow.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSExposedToWorkerAndWindow.cpp
@@ -44,13 +44,25 @@
 #include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
+#include <type_traits>
 #include <wtf/GetPtr.h>
+#include <wtf/IsIncreasing.h>
 #include <wtf/PointerPreparations.h>
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
 using namespace JSC;
+
+IGNORE_WARNINGS_BEGIN("invalid-offsetof")
+
+static_assert(std::is_aggregate_v<ExposedToWorkerAndWindow::Dict>);
+static_assert(IsIncreasing<
+      0
+    , offsetof(ExposedToWorkerAndWindow::Dict, obj)
+>);
+
+IGNORE_WARNINGS_END
 
 template<> ConversionResult<IDLDictionary<ExposedToWorkerAndWindow::Dict>> convertDictionary<ExposedToWorkerAndWindow::Dict>(JSGlobalObject& lexicalGlobalObject, JSValue value)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp
@@ -48,6 +48,8 @@
 #include <JavaScriptCore/FunctionPrototype.h>
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSString.h>
+#include <type_traits>
+#include <wtf/IsIncreasing.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/SortedArrayMap.h>
 
@@ -92,6 +94,17 @@ template<> ASCIILiteral expectedEnumerationValues<TestCallbackInterface::Enum>()
 {
     return "\"value1\", \"value2\""_s;
 }
+
+IGNORE_WARNINGS_BEGIN("invalid-offsetof")
+
+static_assert(std::is_aggregate_v<TestCallbackInterface::Dictionary>);
+static_assert(IsIncreasing<
+      0
+    , offsetof(TestCallbackInterface::Dictionary, requiredMember)
+    , offsetof(TestCallbackInterface::Dictionary, optionalMember)
+>);
+
+IGNORE_WARNINGS_END
 
 template<> ConversionResult<IDLDictionary<TestCallbackInterface::Dictionary>> convertDictionary<TestCallbackInterface::Dictionary>(JSGlobalObject& lexicalGlobalObject, JSValue value)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDerivedDictionary.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDerivedDictionary.cpp
@@ -32,11 +32,23 @@
 #include "Settings.h"
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/ObjectConstructor.h>
+#include <type_traits>
+#include <wtf/IsIncreasing.h>
 
 
 
 namespace WebCore {
 using namespace JSC;
+
+IGNORE_WARNINGS_BEGIN("invalid-offsetof")
+
+static_assert(std::is_aggregate_v<TestDerivedDictionary>);
+static_assert(IsIncreasing<
+      0
+    , offsetof(TestDerivedDictionary, derivedBoolMember)
+>);
+
+IGNORE_WARNINGS_END
 
 template<> ConversionResult<IDLDictionary<TestDerivedDictionary>> convertDictionary<TestDerivedDictionary>(JSGlobalObject& lexicalGlobalObject, JSValue value)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDerivedDictionary2.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDerivedDictionary2.cpp
@@ -32,11 +32,23 @@
 #include "Settings.h"
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/ObjectConstructor.h>
+#include <type_traits>
+#include <wtf/IsIncreasing.h>
 
 
 
 namespace WebCore {
 using namespace JSC;
+
+IGNORE_WARNINGS_BEGIN("invalid-offsetof")
+
+static_assert(std::is_aggregate_v<TestDerivedDictionary2>);
+static_assert(IsIncreasing<
+      0
+    , offsetof(TestDerivedDictionary2, derivedBoolMember2)
+>);
+
+IGNORE_WARNINGS_END
 
 template<> ConversionResult<IDLDictionary<TestDerivedDictionary2>> convertDictionary<TestDerivedDictionary2>(JSGlobalObject& lexicalGlobalObject, JSValue value)
 {
@@ -127,6 +139,16 @@ JSC::JSObject* convertDictionaryToJS(JSC::JSGlobalObject& lexicalGlobalObject, J
     }
     return result;
 }
+
+IGNORE_WARNINGS_BEGIN("invalid-offsetof")
+
+static_assert(std::is_aggregate_v<TestDerivedDictionary2::Dictionary>);
+static_assert(IsIncreasing<
+      0
+    , offsetof(TestDerivedDictionary2::Dictionary, derivedBoolMember)
+>);
+
+IGNORE_WARNINGS_END
 
 template<> ConversionResult<IDLDictionary<TestDerivedDictionary2::Dictionary>> convertDictionary<TestDerivedDictionary2::Dictionary>(JSGlobalObject& lexicalGlobalObject, JSValue value)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDictionary.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDictionary.cpp
@@ -26,11 +26,24 @@
 #include "JSDOMConvertNumbers.h"
 #include "JSDOMConvertOptional.h"
 #include <JavaScriptCore/JSCInlines.h>
+#include <type_traits>
+#include <wtf/IsIncreasing.h>
 
 
 
 namespace WebCore {
 using namespace JSC;
+
+IGNORE_WARNINGS_BEGIN("invalid-offsetof")
+
+static_assert(std::is_aggregate_v<TestDictionary>);
+static_assert(IsIncreasing<
+      0
+    , offsetof(TestDictionary, member)
+    , offsetof(TestDictionary, guardedMember)
+>);
+
+IGNORE_WARNINGS_END
 
 template<> ConversionResult<IDLDictionary<TestDictionary>> convertDictionary<TestDictionary>(JSGlobalObject& lexicalGlobalObject, JSValue value)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDictionaryNoToNative.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDictionaryNoToNative.cpp
@@ -26,11 +26,23 @@
 #include "JSDOMGlobalObject.h"
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/ObjectConstructor.h>
+#include <type_traits>
+#include <wtf/IsIncreasing.h>
 
 
 
 namespace WebCore {
 using namespace JSC;
+
+IGNORE_WARNINGS_BEGIN("invalid-offsetof")
+
+static_assert(std::is_aggregate_v<TestDictionaryNoToNative>);
+static_assert(IsIncreasing<
+      0
+    , offsetof(TestDictionaryNoToNative, member)
+>);
+
+IGNORE_WARNINGS_END
 
 JSC::JSObject* convertDictionaryToJS(JSC::JSGlobalObject& lexicalGlobalObject, JSDOMGlobalObject& globalObject, const TestDictionaryNoToNative& dictionary)
 {
@@ -46,6 +58,16 @@ JSC::JSObject* convertDictionaryToJS(JSC::JSGlobalObject& lexicalGlobalObject, J
     }
     return result;
 }
+
+IGNORE_WARNINGS_BEGIN("invalid-offsetof")
+
+static_assert(std::is_aggregate_v<TestDictionaryNoToNative::GenerateKeyword>);
+static_assert(IsIncreasing<
+      0
+    , offsetof(TestDictionaryNoToNative::GenerateKeyword, member)
+>);
+
+IGNORE_WARNINGS_END
 
 template<> ConversionResult<IDLDictionary<TestDictionaryNoToNative::GenerateKeyword>> convertDictionary<TestDictionaryNoToNative::GenerateKeyword>(JSGlobalObject& lexicalGlobalObject, JSValue value)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDictionaryWithOnlyConditionalMembers.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDictionaryWithOnlyConditionalMembers.cpp
@@ -24,6 +24,8 @@
 #include "JSDOMGlobalObject.h"
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/ObjectConstructor.h>
+#include <type_traits>
+#include <wtf/IsIncreasing.h>
 
 #if ENABLE(TEST_CONDITIONAL)
 #include "JSDOMConvertOptional.h"
@@ -34,6 +36,18 @@
 
 namespace WebCore {
 using namespace JSC;
+
+IGNORE_WARNINGS_BEGIN("invalid-offsetof")
+
+static_assert(std::is_aggregate_v<TestDictionaryWithOnlyConditionalMembers>);
+static_assert(IsIncreasing<
+      0
+#if ENABLE(TEST_CONDITIONAL)
+    , offsetof(TestDictionaryWithOnlyConditionalMembers, conditionalMember)
+#endif
+>);
+
+IGNORE_WARNINGS_END
 
 template<> ConversionResult<IDLDictionary<TestDictionaryWithOnlyConditionalMembers>> convertDictionary<TestDictionaryWithOnlyConditionalMembers>(JSGlobalObject& lexicalGlobalObject, JSValue value)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestEmptyDictionary.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestEmptyDictionary.cpp
@@ -24,11 +24,22 @@
 #include "JSDOMGlobalObject.h"
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/ObjectConstructor.h>
+#include <type_traits>
+#include <wtf/IsIncreasing.h>
 
 
 
 namespace WebCore {
 using namespace JSC;
+
+IGNORE_WARNINGS_BEGIN("invalid-offsetof")
+
+static_assert(std::is_aggregate_v<TestEmptyDictionary>);
+static_assert(IsIncreasing<
+      0
+>);
+
+IGNORE_WARNINGS_END
 
 template<> ConversionResult<IDLDictionary<TestEmptyDictionary>> convertDictionary<TestEmptyDictionary>(JSGlobalObject& lexicalGlobalObject, JSValue value)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestEventConstructor.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestEventConstructor.cpp
@@ -42,13 +42,28 @@
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
+#include <type_traits>
 #include <wtf/GetPtr.h>
+#include <wtf/IsIncreasing.h>
 #include <wtf/PointerPreparations.h>
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
 using namespace JSC;
+
+IGNORE_WARNINGS_BEGIN("invalid-offsetof")
+
+static_assert(std::is_aggregate_v<TestEventConstructor::Init>);
+static_assert(IsIncreasing<
+      0
+    , offsetof(TestEventConstructor::Init, attr2)
+#if ENABLE(SPECIAL_EVENT)
+    , offsetof(TestEventConstructor::Init, attr3)
+#endif
+>);
+
+IGNORE_WARNINGS_END
 
 template<> ConversionResult<IDLDictionary<TestEventConstructor::Init>> convertDictionary<TestEventConstructor::Init>(JSGlobalObject& lexicalGlobalObject, JSValue value)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestInheritedDictionary.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestInheritedDictionary.cpp
@@ -32,11 +32,34 @@
 #include "Settings.h"
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/ObjectConstructor.h>
+#include <type_traits>
+#include <wtf/IsIncreasing.h>
 
 
 
 namespace WebCore {
 using namespace JSC;
+
+IGNORE_WARNINGS_BEGIN("invalid-offsetof")
+
+static_assert(std::is_aggregate_v<TestInheritedDictionary>);
+static_assert(IsIncreasing<
+      0
+    , offsetof(TestInheritedDictionary, boolMember)
+    , offsetof(TestInheritedDictionary, stringMember)
+    , offsetof(TestInheritedDictionary, callbackMember)
+    , offsetof(TestInheritedDictionary, partialRequiredLongMember)
+    , offsetof(TestInheritedDictionary, partialBooleanMember)
+    , offsetof(TestInheritedDictionary, partialStringMember)
+    , offsetof(TestInheritedDictionary, partialCallbackMember)
+    , offsetof(TestInheritedDictionary, partialUnsignedLongMemberWithImplementedAs)
+#if ENABLE(Conditional15)
+    , offsetof(TestInheritedDictionary, partialBooleanMemberWithConditional)
+#endif
+    , offsetof(TestInheritedDictionary, partialStringMemberWithEnabledBySetting)
+>);
+
+IGNORE_WARNINGS_END
 
 template<> ConversionResult<IDLDictionary<TestInheritedDictionary>> convertDictionary<TestInheritedDictionary>(JSGlobalObject& lexicalGlobalObject, JSValue value)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestInheritedDictionary2.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestInheritedDictionary2.cpp
@@ -29,11 +29,25 @@
 #include "JSVoidCallback.h"
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/ObjectConstructor.h>
+#include <type_traits>
+#include <wtf/IsIncreasing.h>
 
 
 
 namespace WebCore {
 using namespace JSC;
+
+IGNORE_WARNINGS_BEGIN("invalid-offsetof")
+
+static_assert(std::is_aggregate_v<TestInheritedDictionary2>);
+static_assert(IsIncreasing<
+      0
+    , offsetof(TestInheritedDictionary2, boolMember)
+    , offsetof(TestInheritedDictionary2, stringMember)
+    , offsetof(TestInheritedDictionary2, callbackMember)
+>);
+
+IGNORE_WARNINGS_END
 
 template<> ConversionResult<IDLDictionary<TestInheritedDictionary2>> convertDictionary<TestInheritedDictionary2>(JSGlobalObject& lexicalGlobalObject, JSValue value)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
@@ -104,7 +104,9 @@
 #include <JavaScriptCore/PropertyNameArray.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
+#include <type_traits>
 #include <wtf/GetPtr.h>
+#include <wtf/IsIncreasing.h>
 #include <wtf/PointerPreparations.h>
 #include <wtf/SortedArrayMap.h>
 #include <wtf/URL.h>
@@ -797,6 +799,62 @@ template<> ASCIILiteral expectedEnumerationValues<TestObj::EnumWithMissingValueD
 {
     return "\"value1\", \"value2\", \"value3\", \"\""_s;
 }
+
+IGNORE_WARNINGS_BEGIN("invalid-offsetof")
+
+static_assert(std::is_aggregate_v<TestObj::Dictionary>);
+static_assert(IsIncreasing<
+      0
+    , offsetof(TestObj::Dictionary, enumerationValueWithoutDefault)
+    , offsetof(TestObj::Dictionary, enumerationValueWithDefault)
+    , offsetof(TestObj::Dictionary, enumerationValueWithEmptyStringDefault)
+    , offsetof(TestObj::Dictionary, stringWithDefault)
+    , offsetof(TestObj::Dictionary, stringWithoutDefault)
+    , offsetof(TestObj::Dictionary, nullableStringWithDefault)
+    , offsetof(TestObj::Dictionary, stringTreatNullAsEmptyString)
+    , offsetof(TestObj::Dictionary, booleanWithDefault)
+    , offsetof(TestObj::Dictionary, booleanWithoutDefault)
+    , offsetof(TestObj::Dictionary, sequenceOfStrings)
+    , offsetof(TestObj::Dictionary, restrictedDouble)
+    , offsetof(TestObj::Dictionary, unrestrictedDouble)
+    , offsetof(TestObj::Dictionary, restrictedDoubleWithDefault)
+    , offsetof(TestObj::Dictionary, unrestrictedDoubleWithDefault)
+    , offsetof(TestObj::Dictionary, restrictedFloat)
+    , offsetof(TestObj::Dictionary, unrestrictedFloat)
+    , offsetof(TestObj::Dictionary, restrictedFloatWithDefault)
+    , offsetof(TestObj::Dictionary, unrestrictedFloatWithDefault)
+    , offsetof(TestObj::Dictionary, smallIntegerClamped)
+    , offsetof(TestObj::Dictionary, smallIntegerWithDefault)
+    , offsetof(TestObj::Dictionary, smallUnsignedIntegerEnforcedRange)
+    , offsetof(TestObj::Dictionary, smallUnsignedIntegerWithDefault)
+    , offsetof(TestObj::Dictionary, integer)
+    , offsetof(TestObj::Dictionary, integerWithDefault)
+    , offsetof(TestObj::Dictionary, unsignedInteger)
+    , offsetof(TestObj::Dictionary, unsignedIntegerWithDefault)
+    , offsetof(TestObj::Dictionary, largeInteger)
+    , offsetof(TestObj::Dictionary, largeIntegerWithDefault)
+    , offsetof(TestObj::Dictionary, unsignedLargeInteger)
+    , offsetof(TestObj::Dictionary, unsignedLargeIntegerWithDefault)
+    , offsetof(TestObj::Dictionary, nullableIntegerWithDefault)
+    , offsetof(TestObj::Dictionary, nullableNode)
+    , offsetof(TestObj::Dictionary, nullableEnum)
+    , offsetof(TestObj::Dictionary, anyValue)
+    , offsetof(TestObj::Dictionary, anyValueWithNullDefault)
+    , offsetof(TestObj::Dictionary, fooAlias)
+    , offsetof(TestObj::Dictionary, fooWithDefaultAlias)
+    , offsetof(TestObj::Dictionary, anyTypedefValue)
+    , offsetof(TestObj::Dictionary, dictionaryMember)
+    , offsetof(TestObj::Dictionary, dictionaryMemberWithDefault)
+    , offsetof(TestObj::Dictionary, unionMember)
+    , offsetof(TestObj::Dictionary, nullableUnionMember)
+    , offsetof(TestObj::Dictionary, undefinedUnionMember)
+    , offsetof(TestObj::Dictionary, bufferSourceValue)
+    , offsetof(TestObj::Dictionary, requiredBufferSourceValue)
+    , offsetof(TestObj::Dictionary, annotatedTypeInUnionMember)
+    , offsetof(TestObj::Dictionary, annotatedTypeInSequenceMember)
+>);
+
+IGNORE_WARNINGS_END
 
 template<> ConversionResult<IDLDictionary<TestObj::Dictionary>> convertDictionary<TestObj::Dictionary>(JSGlobalObject& lexicalGlobalObject, JSValue value)
 {
@@ -1530,6 +1588,19 @@ JSC::JSObject* convertDictionaryToJS(JSC::JSGlobalObject& lexicalGlobalObject, J
     return result;
 }
 
+IGNORE_WARNINGS_BEGIN("invalid-offsetof")
+
+static_assert(std::is_aggregate_v<TestObj::DictionaryThatShouldNotTolerateNull>);
+static_assert(IsIncreasing<
+      0
+    , offsetof(TestObj::DictionaryThatShouldNotTolerateNull, requiredEnumerationValue)
+    , offsetof(TestObj::DictionaryThatShouldNotTolerateNull, booleanWithoutDefault)
+    , offsetof(TestObj::DictionaryThatShouldNotTolerateNull, nonNullableNode)
+    , offsetof(TestObj::DictionaryThatShouldNotTolerateNull, requiredDictionaryMember)
+>);
+
+IGNORE_WARNINGS_END
+
 template<> ConversionResult<IDLDictionary<TestObj::DictionaryThatShouldNotTolerateNull>> convertDictionary<TestObj::DictionaryThatShouldNotTolerateNull>(JSGlobalObject& lexicalGlobalObject, JSValue value)
 {
     SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
@@ -1600,6 +1671,17 @@ template<> ConversionResult<IDLDictionary<TestObj::DictionaryThatShouldNotTolera
     };
 }
 
+IGNORE_WARNINGS_BEGIN("invalid-offsetof")
+
+static_assert(std::is_aggregate_v<TestObj::DictionaryThatShouldTolerateNull>);
+static_assert(IsIncreasing<
+      0
+    , offsetof(TestObj::DictionaryThatShouldTolerateNull, enumerationValue)
+    , offsetof(TestObj::DictionaryThatShouldTolerateNull, booleanWithoutDefault)
+>);
+
+IGNORE_WARNINGS_END
+
 template<> ConversionResult<IDLDictionary<TestObj::DictionaryThatShouldTolerateNull>> convertDictionary<TestObj::DictionaryThatShouldTolerateNull>(JSGlobalObject& lexicalGlobalObject, JSValue value)
 {
     SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
@@ -1635,6 +1717,17 @@ template<> ConversionResult<IDLDictionary<TestObj::DictionaryThatShouldTolerateN
         booleanWithoutDefaultConversionResult.releaseReturnValue(),
     };
 }
+
+IGNORE_WARNINGS_BEGIN("invalid-offsetof")
+
+static_assert(std::is_aggregate_v<AlternateDictionaryName>);
+static_assert(IsIncreasing<
+      0
+    , offsetof(AlternateDictionaryName, enumerationValue)
+    , offsetof(AlternateDictionaryName, booleanWithoutDefault)
+>);
+
+IGNORE_WARNINGS_END
 
 template<> ConversionResult<IDLDictionary<AlternateDictionaryName>> convertDictionary<AlternateDictionaryName>(JSGlobalObject& lexicalGlobalObject, JSValue value)
 {
@@ -1672,6 +1765,17 @@ template<> ConversionResult<IDLDictionary<AlternateDictionaryName>> convertDicti
     };
 }
 
+IGNORE_WARNINGS_BEGIN("invalid-offsetof")
+
+static_assert(std::is_aggregate_v<TestObj::ParentDictionary>);
+static_assert(IsIncreasing<
+      0
+    , offsetof(TestObj::ParentDictionary, parentMember2)
+    , offsetof(TestObj::ParentDictionary, parentMember1)
+>);
+
+IGNORE_WARNINGS_END
+
 template<> ConversionResult<IDLDictionary<TestObj::ParentDictionary>> convertDictionary<TestObj::ParentDictionary>(JSGlobalObject& lexicalGlobalObject, JSValue value)
 {
     SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
@@ -1707,6 +1811,17 @@ template<> ConversionResult<IDLDictionary<TestObj::ParentDictionary>> convertDic
         parentMember1ConversionResult.releaseReturnValue(),
     };
 }
+
+IGNORE_WARNINGS_BEGIN("invalid-offsetof")
+
+static_assert(std::is_aggregate_v<TestObj::ChildDictionary>);
+static_assert(IsIncreasing<
+      0
+    , offsetof(TestObj::ChildDictionary, childMember2)
+    , offsetof(TestObj::ChildDictionary, childMember1)
+>);
+
+IGNORE_WARNINGS_END
 
 template<> ConversionResult<IDLDictionary<TestObj::ChildDictionary>> convertDictionary<TestObj::ChildDictionary>(JSGlobalObject& lexicalGlobalObject, JSValue value)
 {
@@ -1768,7 +1883,112 @@ template<> ConversionResult<IDLDictionary<TestObj::ChildDictionary>> convertDict
     };
 }
 
+IGNORE_WARNINGS_BEGIN("invalid-offsetof")
+
+static_assert(std::is_aggregate_v<TestObj::GrandchildDictionary>);
+static_assert(IsIncreasing<
+      0
+    , offsetof(TestObj::GrandchildDictionary, grandchildMember2)
+    , offsetof(TestObj::GrandchildDictionary, grandchildMember1)
+>);
+
+IGNORE_WARNINGS_END
+
+template<> ConversionResult<IDLDictionary<TestObj::GrandchildDictionary>> convertDictionary<TestObj::GrandchildDictionary>(JSGlobalObject& lexicalGlobalObject, JSValue value)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    bool isNullOrUndefined = value.isUndefinedOrNull();
+    auto* object = isNullOrUndefined ? nullptr : value.getObject();
+    if (!isNullOrUndefined && !object) [[unlikely]] {
+        throwTypeError(&lexicalGlobalObject, throwScope);
+        return ConversionResultException { };
+    }
+    JSValue parentMember1Value;
+    if (isNullOrUndefined)
+        parentMember1Value = jsUndefined();
+    else {
+        parentMember1Value = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "parentMember1"_s));
+        RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
+    }
+    auto parentMember1ConversionResult = convert<IDLOptional<IDLBoolean>>(lexicalGlobalObject, parentMember1Value);
+    if (parentMember1ConversionResult.hasException(throwScope)) [[unlikely]]
+        return ConversionResultException { };
+    JSValue parentMember2Value;
+    if (isNullOrUndefined)
+        parentMember2Value = jsUndefined();
+    else {
+        parentMember2Value = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "parentMember2"_s));
+        RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
+    }
+    auto parentMember2ConversionResult = convert<IDLOptional<IDLBoolean>>(lexicalGlobalObject, parentMember2Value);
+    if (parentMember2ConversionResult.hasException(throwScope)) [[unlikely]]
+        return ConversionResultException { };
+    JSValue childMember1Value;
+    if (isNullOrUndefined)
+        childMember1Value = jsUndefined();
+    else {
+        childMember1Value = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "childMember1"_s));
+        RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
+    }
+    auto childMember1ConversionResult = convert<IDLOptional<IDLBoolean>>(lexicalGlobalObject, childMember1Value);
+    if (childMember1ConversionResult.hasException(throwScope)) [[unlikely]]
+        return ConversionResultException { };
+    JSValue childMember2Value;
+    if (isNullOrUndefined)
+        childMember2Value = jsUndefined();
+    else {
+        childMember2Value = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "childMember2"_s));
+        RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
+    }
+    auto childMember2ConversionResult = convert<IDLOptional<IDLBoolean>>(lexicalGlobalObject, childMember2Value);
+    if (childMember2ConversionResult.hasException(throwScope)) [[unlikely]]
+        return ConversionResultException { };
+    JSValue grandchildMember1Value;
+    if (isNullOrUndefined)
+        grandchildMember1Value = jsUndefined();
+    else {
+        grandchildMember1Value = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "grandchildMember1"_s));
+        RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
+    }
+    auto grandchildMember1ConversionResult = convert<IDLOptional<IDLBoolean>>(lexicalGlobalObject, grandchildMember1Value);
+    if (grandchildMember1ConversionResult.hasException(throwScope)) [[unlikely]]
+        return ConversionResultException { };
+    JSValue grandchildMember2Value;
+    if (isNullOrUndefined)
+        grandchildMember2Value = jsUndefined();
+    else {
+        grandchildMember2Value = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "grandchildMember2"_s));
+        RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
+    }
+    auto grandchildMember2ConversionResult = convert<IDLOptional<IDLBoolean>>(lexicalGlobalObject, grandchildMember2Value);
+    if (grandchildMember2ConversionResult.hasException(throwScope)) [[unlikely]]
+        return ConversionResultException { };
+    return TestObj::GrandchildDictionary {
+        TestObj::ChildDictionary {
+            TestObj::ParentDictionary {
+                parentMember2ConversionResult.releaseReturnValue(),
+                parentMember1ConversionResult.releaseReturnValue(),
+            },
+            childMember2ConversionResult.releaseReturnValue(),
+            childMember1ConversionResult.releaseReturnValue(),
+        },
+        grandchildMember2ConversionResult.releaseReturnValue(),
+        grandchildMember1ConversionResult.releaseReturnValue(),
+    };
+}
+
 #if ENABLE(Condition1)
+
+IGNORE_WARNINGS_BEGIN("invalid-offsetof")
+
+static_assert(std::is_aggregate_v<TestObj::ConditionalDictionaryA>);
+static_assert(IsIncreasing<
+      0
+    , offsetof(TestObj::ConditionalDictionaryA, stringWithoutDefault)
+>);
+
+IGNORE_WARNINGS_END
 
 template<> ConversionResult<IDLDictionary<TestObj::ConditionalDictionaryA>> convertDictionary<TestObj::ConditionalDictionaryA>(JSGlobalObject& lexicalGlobalObject, JSValue value)
 {
@@ -1799,6 +2019,16 @@ template<> ConversionResult<IDLDictionary<TestObj::ConditionalDictionaryA>> conv
 
 #if ENABLE(Condition1) && ENABLE(Condition2)
 
+IGNORE_WARNINGS_BEGIN("invalid-offsetof")
+
+static_assert(std::is_aggregate_v<TestObj::ConditionalDictionaryB>);
+static_assert(IsIncreasing<
+      0
+    , offsetof(TestObj::ConditionalDictionaryB, stringWithoutDefault)
+>);
+
+IGNORE_WARNINGS_END
+
 template<> ConversionResult<IDLDictionary<TestObj::ConditionalDictionaryB>> convertDictionary<TestObj::ConditionalDictionaryB>(JSGlobalObject& lexicalGlobalObject, JSValue value)
 {
     SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
@@ -1828,6 +2058,16 @@ template<> ConversionResult<IDLDictionary<TestObj::ConditionalDictionaryB>> conv
 
 #if ENABLE(Condition1) || ENABLE(Condition2)
 
+IGNORE_WARNINGS_BEGIN("invalid-offsetof")
+
+static_assert(std::is_aggregate_v<TestObj::ConditionalDictionaryC>);
+static_assert(IsIncreasing<
+      0
+    , offsetof(TestObj::ConditionalDictionaryC, stringWithoutDefault)
+>);
+
+IGNORE_WARNINGS_END
+
 template<> ConversionResult<IDLDictionary<TestObj::ConditionalDictionaryC>> convertDictionary<TestObj::ConditionalDictionaryC>(JSGlobalObject& lexicalGlobalObject, JSValue value)
 {
     SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
@@ -1854,6 +2094,17 @@ template<> ConversionResult<IDLDictionary<TestObj::ConditionalDictionaryC>> conv
 }
 
 #endif
+
+IGNORE_WARNINGS_BEGIN("invalid-offsetof")
+
+static_assert(std::is_aggregate_v<TestObj::PromisePair>);
+static_assert(IsIncreasing<
+      0
+    , offsetof(TestObj::PromisePair, promise1)
+    , offsetof(TestObj::PromisePair, promise2)
+>);
+
+IGNORE_WARNINGS_END
 
 template<> ConversionResult<IDLDictionary<TestObj::PromisePair>> convertDictionary<TestObj::PromisePair>(JSGlobalObject& lexicalGlobalObject, JSValue value)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestObj.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestObj.h
@@ -259,6 +259,8 @@ template<> ConversionResult<IDLDictionary<TestObj::ParentDictionary>> convertDic
 
 template<> ConversionResult<IDLDictionary<TestObj::ChildDictionary>> convertDictionary<TestObj::ChildDictionary>(JSC::JSGlobalObject&, JSC::JSValue);
 
+template<> ConversionResult<IDLDictionary<TestObj::GrandchildDictionary>> convertDictionary<TestObj::GrandchildDictionary>(JSC::JSGlobalObject&, JSC::JSValue);
+
 #if ENABLE(Condition1)
 
 template<> ConversionResult<IDLDictionary<TestObj::ConditionalDictionaryA>> convertDictionary<TestObj::ConditionalDictionaryA>(JSC::JSGlobalObject&, JSC::JSValue);

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestPromiseRejectionEvent.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestPromiseRejectionEvent.cpp
@@ -46,13 +46,26 @@
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
+#include <type_traits>
 #include <wtf/GetPtr.h>
+#include <wtf/IsIncreasing.h>
 #include <wtf/PointerPreparations.h>
 #include <wtf/URL.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
 using namespace JSC;
+
+IGNORE_WARNINGS_BEGIN("invalid-offsetof")
+
+static_assert(std::is_aggregate_v<TestPromiseRejectionEvent::Init>);
+static_assert(IsIncreasing<
+      0
+    , offsetof(TestPromiseRejectionEvent::Init, promise)
+    , offsetof(TestPromiseRejectionEvent::Init, reason)
+>);
+
+IGNORE_WARNINGS_END
 
 template<> ConversionResult<IDLDictionary<TestPromiseRejectionEvent::Init>> convertDictionary<TestPromiseRejectionEvent::Init>(JSGlobalObject& lexicalGlobalObject, JSValue value)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneDictionary.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneDictionary.cpp
@@ -38,6 +38,8 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSString.h>
 #include <JavaScriptCore/ObjectConstructor.h>
+#include <type_traits>
+#include <wtf/IsIncreasing.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/SortedArrayMap.h>
 #include <wtf/Variant.h>
@@ -48,6 +50,46 @@ namespace WebCore {
 using namespace JSC;
 
 #if ENABLE(Condition1)
+
+IGNORE_WARNINGS_BEGIN("invalid-offsetof")
+
+static_assert(std::is_aggregate_v<DictionaryImplName>);
+static_assert(IsIncreasing<
+      0
+    , offsetof(DictionaryImplName, boolMember)
+    , offsetof(DictionaryImplName, stringMember)
+    , offsetof(DictionaryImplName, enumMember)
+    , offsetof(DictionaryImplName, permissiveEnumMember)
+    , offsetof(DictionaryImplName, callbackMember)
+    , offsetof(DictionaryImplName, unionMemberWithDefaultValue)
+    , offsetof(DictionaryImplName, nullableUnionWithNullDefaultValue)
+#if ENABLE(Conditional13) || ENABLE(Conditional14)
+    , offsetof(DictionaryImplName, partialRequiredLongMember)
+#endif
+#if ENABLE(Conditional13) || ENABLE(Conditional14)
+    , offsetof(DictionaryImplName, partialBooleanMember)
+#endif
+#if ENABLE(Conditional13) || ENABLE(Conditional14)
+    , offsetof(DictionaryImplName, partialStringMember)
+#endif
+#if ENABLE(Conditional13) || ENABLE(Conditional14)
+    , offsetof(DictionaryImplName, partialEnumMember)
+#endif
+#if ENABLE(Conditional13) || ENABLE(Conditional14)
+    , offsetof(DictionaryImplName, partialCallbackMember)
+#endif
+#if ENABLE(Conditional13) || ENABLE(Conditional14)
+    , offsetof(DictionaryImplName, partialUnsignedLongMemberWithImplementedAs)
+#endif
+#if ENABLE(Conditional13) || ENABLE(Conditional14)
+    , offsetof(DictionaryImplName, partialBooleanMemberWithIgnoredConditional)
+#endif
+#if ENABLE(Conditional13) || ENABLE(Conditional14)
+    , offsetof(DictionaryImplName, partialStringMemberWithEnabledBySetting)
+#endif
+>);
+
+IGNORE_WARNINGS_END
 
 template<> ConversionResult<IDLDictionary<DictionaryImplName>> convertDictionary<DictionaryImplName>(JSGlobalObject& lexicalGlobalObject, JSValue value)
 {

--- a/Source/WebCore/bindings/scripts/test/TestObj.idl
+++ b/Source/WebCore/bindings/scripts/test/TestObj.idl
@@ -603,6 +603,11 @@ dictionary ChildDictionary : ParentDictionary {
     boolean childMember1;
 };
 
+dictionary GrandchildDictionary : ChildDictionary {
+    boolean grandchildMember2;
+    boolean grandchildMember1;
+};
+
 [
     Conditional=Condition1
 ] dictionary TestConditionalDictionaryA {


### PR DESCRIPTION
#### 7d9305e7f16995e3b8837fb159d56f32c182fc6d
<pre>
Add static checks that dictionary member order in the IDL matches the native dictionaries
<a href="https://bugs.webkit.org/show_bug.cgi?id=305786">https://bugs.webkit.org/show_bug.cgi?id=305786</a>

Reviewed by Darin Adler.

Factors out the member ordering checks from the CoreIPC generator
into a new WTF file, IsIncreasing.h, renaming it from `MembersInCorrectOrder`
(since &quot;correct&quot; is a bit subjective, and it can work with any numbers).

Adds checks for IDL dictionaries that don&apos;t have the extended
attribute `LegacyNativeDictionaryRequiredInterfaceNullability`
that the native dictionary is an aggregate and that the relative
order of members matches the IDL definition. Compilers with
&quot;-Werror=missing-field-initializers&quot; will provide the final check,
ensuring that that all fields get initialized, proving that
relative order check was exhaustive.

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/IsIncreasing.h: Added.
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
* Source/WebCore/bindings/scripts/test/JS/JSExposedToWorkerAndWindow.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestDerivedDictionary.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestDerivedDictionary2.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestDictionary.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestDictionaryNoToNative.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestDictionaryWithOnlyConditionalMembers.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestEmptyDictionary.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestEventConstructor.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestInheritedDictionary.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestInheritedDictionary2.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestObj.h:
* Source/WebCore/bindings/scripts/test/JS/JSTestPromiseRejectionEvent.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneDictionary.cpp:
* Source/WebCore/bindings/scripts/test/TestObj.idl:
* Source/WebKit/Scripts/generate-serializers.py:

Canonical link: <a href="https://commits.webkit.org/305840@main">https://commits.webkit.org/305840@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed9736628ca7e9d05a001b5cfb503b66ffce69e1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139573 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11949 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1076 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147705 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92641 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141446 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12657 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12099 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106863 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/77809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142520 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9701 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125007 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87726 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/138919 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9338 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6926 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7999 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/131546 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118617 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1005 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150487 "Built successfully") | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/369 "Found 1 new JSC stress test failure: stress/re-enter-resolve-rope-string.js.no-ftl (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11633 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1024 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115267 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11647 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9953 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115578 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29359 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10197 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121453 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66639 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11678 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/170845 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11414 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75356 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/44449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11613 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11464 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->