### PR TITLE
AX: ::first-letter text not exposed in the accessibility tree if no other text accompanies it

### DIFF
--- a/LayoutTests/accessibility/first-letter-single-character-expected.txt
+++ b/LayoutTests/accessibility/first-letter-single-character-expected.txt
@@ -1,0 +1,17 @@
+This test verifies that first-letter pseudo-element text is exposed in the accessibility tree.
+
+Test case 1: Single character (entire text is first-letter)
+PASS: singleCharContainer.childrenCount === 1
+PASS: singleCharText.role.toLowerCase().includes('text') === true
+PASS: singleCharText.stringValue.includes('H') === true
+
+Test case 2: Multiple characters (first-letter plus remaining text)
+PASS: multiCharContainer.childrenCount === 1
+PASS: multiCharText.role.toLowerCase().includes('text') === true
+PASS: multiCharText.stringValue.includes('Hi') === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+H
+Hi

--- a/LayoutTests/accessibility/first-letter-single-character.html
+++ b/LayoutTests/accessibility/first-letter-single-character.html
@@ -1,0 +1,38 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+<style>
+div::first-letter { text-transform: capitalize; }
+</style>
+</head>
+<body>
+
+<div id="single-char" role="group">h</div>
+<div id="multi-char" role="group">hi</div>
+
+<script>
+var output = "This test verifies that first-letter pseudo-element text is exposed in the accessibility tree.\n\n";
+
+if (window.accessibilityController) {
+    output += "Test case 1: Single character (entire text is first-letter)\n";
+    var singleCharContainer = accessibilityController.accessibleElementById("single-char");
+    output += expect("singleCharContainer.childrenCount", "1");
+    var singleCharText = singleCharContainer.childAtIndex(0);
+    output += expect("singleCharText.role.toLowerCase().includes('text')", "true");
+    output += expect("singleCharText.stringValue.includes('H')", "true");
+
+    output += "\nTest case 2: Multiple characters (first-letter plus remaining text)\n";
+    var multiCharContainer = accessibilityController.accessibleElementById("multi-char");
+    output += expect("multiCharContainer.childrenCount", "1");
+    var multiCharText = multiCharContainer.childAtIndex(0);
+    output += expect("multiCharText.role.toLowerCase().includes('text')", "true");
+    // Should expose "Hi" - the "h" is capitalized by text-transform
+    output += expect("multiCharText.stringValue.includes('Hi')", "true");
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -823,11 +823,12 @@ jquery/traversing.html [ Pass Slow ]
 # Accessibility-related bugs
 #////////////////////////////////////////////////////////////////////////////////////////
 
-# Static text elements aren't exposed in the accessibility tree on ATSPI, which this test relies on.
+# Static text elements aren't exposed in the accessibility tree on ATSPI, which these tests rely on.
 # https://bugs.webkit.org/show_bug.cgi?id=282117
 # https://github.com/WebKit/WebKit/blob/e666928e70449224996d14a5868c902134facf30/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp#L1395#L1397
 accessibility/opacity-0-bounding-box.html [ Skip ]
 accessibility/clip-path-bounding-box.html [ Skip ]
+accessibility/first-letter-single-character.html [ Skip ]
 
 accessibility/dynamic-expanded-text.html [ Failure ]
 

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -1268,13 +1268,17 @@ bool AccessibilityRenderObject::computeIsIgnored() const
         if (!renderText->hasRenderedText()) {
             // Layout must be clean to make the right decision here (because hasRenderedText() can return false solely because layout is dirty).
             AX_ASSERT(!renderText->needsLayout() || !renderText->text().length());
+            // If this is a RenderTextFragment with an associated first-letter, the entire text may have been
+            // consumed by the first-letter pseudo-element. In this case, don't ignore the text node, as its
+            // text content can still be retrieved from the associated DOM Text node.
+            if (auto* renderTextFragment = dynamicDowncast<RenderTextFragment>(renderText.get())) {
+                if (renderTextFragment->firstLetter())
+                    return false;
+            }
             return true;
         }
 
         if (renderText->text().containsOnly<isASCIIWhitespace>())
-            return true;
-
-        if (renderText->parent()->isFirstLetter())
             return true;
 
         // The alt attribute may be set on a text fragment through CSS, which should be honored.


### PR DESCRIPTION
#### 5d93330177973782771b8f4e44c1503ce464773c
<pre>
AX: ::first-letter text not exposed in the accessibility tree if no other text accompanies it
<a href="https://bugs.webkit.org/show_bug.cgi?id=305787">https://bugs.webkit.org/show_bug.cgi?id=305787</a>
<a href="https://rdar.apple.com/168458291">rdar://168458291</a>

Reviewed by Joshua Hoffman.

When a ::first-letter pseudo-element consumes all text in an element
(e.g., &lt;div&gt;h&lt;/div&gt; with div::first-letter styling), the text node&apos;s
renderer becomes an empty RenderTextFragment. The hasRenderedText()
check in computeIsIgnored() returns false for this empty fragment,
causing the text to be incorrectly ignored in the accessibility tree.

Fix this by checking if an empty RenderTextFragment has an associated
first-letter container. If so, don&apos;t ignore it because its text content
can still be retrieved from the associated DOM Text node.

* LayoutTests/accessibility/first-letter-single-character-expected.txt: Added.
* LayoutTests/accessibility/first-letter-single-character.html: Added.
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::computeIsIgnored const):

Canonical link: <a href="https://commits.webkit.org/305884@main">https://commits.webkit.org/305884@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8eed4b542c6718c2c7b454dfdcdaf3b33929cec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139580 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11956 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1084 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147712 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92648 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/88f5bf93-27a0-410b-8ab1-32edeb361abe) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141453 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12664 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12106 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106870 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77812 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/64ddc589-2696-4643-8122-cdbfc88f3db0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142527 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125010 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87733 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d4505c91-6fc7-4015-a146-b0fe4539e099) 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6931 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8006 "Built successfully") | | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1008 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150494 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11640 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1028 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115272 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11654 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9959 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115583 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29386 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10213 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121456 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66646 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11685 "Built successfully") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11421 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75363 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11620 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11471 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->