### PR TITLE
[WPE] Further cleanup after removal of the Qt5 embedding API

### DIFF
--- a/Tools/Scripts/run-qt-wpe-minibrowser
+++ b/Tools/Scripts/run-qt-wpe-minibrowser
@@ -41,9 +41,6 @@ my $configuration = passedConfiguration();
 my $productDir = productDir();
 
 if ($configuration) {
-    $libPathQt5 = File::Spec->catfile(sourceDir(), "WebKitBuild", "$configuration", "lib", "qt5", "qml");
-    $ENV{"QML2_IMPORT_PATH"} = "$libPathQt5" if (-d "$libPathQt5");
-
     $libPathQt6 = File::Spec->catfile(sourceDir(), "WebKitBuild", "$configuration", "lib", "qt6", "qml");
     $ENV{"QML_IMPORT_PATH"} = "$libPathQt6" if (-d "$libPathQt6");
 }
@@ -52,13 +49,9 @@ if ($configuration) {
 checkBuild();
 
 if ($productDir) {
-    my $qt5qmlsubdir = "lib/qt5/qml";
-    $libPathQt5 = "$productDir/$qt5qmlsubdir" if (-d "$productDir/$qt5qmlsubdir");
-
     my $qt6qmlsubdir = "lib/qt6/qml";
     $libPathQt6 = "$productDir/$qt6qmlsubdir" if (-d "$productDir/$qt6qmlsubdir");
 }
-$ENV{"QML2_IMPORT_PATH"} = "$libPathQt5" if $libPathQt5;
 $ENV{"QML_IMPORT_PATH"} = "$libPathQt6" if $libPathQt6;
 
 $launcherPath = catdir($productDir, "bin", "qt-wpe-mini-browser");

--- a/Tools/Scripts/webkitpy/style/checker.py
+++ b/Tools/Scripts/webkitpy/style/checker.py
@@ -152,13 +152,7 @@ _PATH_RULES_SPECIFIER = [
      ["-readability/naming"]),
 
     ([
-        # The WPEQtViewBackend class needs to enforce a certain include order to the gbm.h/epoxy constraints.
-        os.path.join('Source', 'WebKit', 'UIProcess', 'API', 'wpe', 'qt5', 'WPEQtViewBackend.h')],
-     ["-build/include_order"]),
-
-    ([
         # The WPEQtViewLoadRequest class uses Qt naming conventions (d_ptr).
-        os.path.join('Source', 'WebKit', 'UIProcess', 'API', 'wpe', 'qt5', 'WPEQtViewLoadRequest.h'),
         os.path.join('Source', 'WebKit', 'UIProcess', 'API', 'wpe', 'qt6', 'WPEQtViewLoadRequest.h'),
 
         # The WPEQtView class uses Qt naming conventions (d_ptr).
@@ -169,7 +163,6 @@ _PATH_RULES_SPECIFIER = [
         # The WPEQtView class can't rely on the readability/parameter_name rule,
         # because omitting parameter names for QML signals leads to runtime
         # errors.
-        os.path.join('Source', 'WebKit', 'UIProcess', 'API', 'wpe', 'qt5', 'WPEQtView.h'),
         os.path.join('Source', 'WebKit', 'UIProcess', 'API', 'wpe', 'qt6', 'WPEQtView.h')],
      ["-readability/parameter_name", "-readability/naming/acronym"]),
 
@@ -195,9 +188,7 @@ _PATH_RULES_SPECIFIER = [
     ([
         # The WPE QT wrapper lib is not part of Webkit and therefore don't need to statically
         # link the WTF framework. Instead it uses the standard alloc mechanism.
-        os.path.join('Source', 'WebKit', 'UIProcess', 'API', 'wpe', 'qt5'),
         os.path.join('Source', 'WebKit', 'UIProcess', 'API', 'wpe', 'qt6'),
-        os.path.join('Tools', 'MiniBrowser', 'wpe', 'qt5', 'main.cpp'),
         os.path.join('Tools', 'MiniBrowser', 'wpe', 'qt6', 'main.cpp')],
      ["-runtime/wtf_make_unique", "-readability/naming/underscores", "-readability/naming/acronym"]),
 

--- a/Tools/TestWebKitAPI/Tests/WPEQt/WPEQtTest.h
+++ b/Tools/TestWebKitAPI/Tests/WPEQt/WPEQtTest.h
@@ -22,13 +22,8 @@
 #include <QtCore/qglobal.h>
 
 // WPEQt has to be included before the remaining Qt headers, because of epoxy.
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
 #include <wpe/qt6/WPEQtView.h>
 #include <wpe/qt6/WPEQtViewLoadRequest.h>
-#else
-#include <wpe/qt5/WPEQtView.h>
-#include <wpe/qt5/WPEQtViewLoadRequest.h>
-#endif
 
 #include <QEventLoop>
 #include <QQmlApplicationEngine>

--- a/Tools/glib/api_test_runner.py
+++ b/Tools/glib/api_test_runner.py
@@ -210,7 +210,7 @@ class TestRunner(object):
     def _run_test_qt(self, test_program):
         env = self._test_env
         env['XDG_SESSION_TYPE'] = 'wayland'
-        env['QML2_IMPORT_PATH'] = common.library_build_path(self._port, 'qt5', 'qml')
+        env['QML_IMPORT_PATH'] = common.library_build_path(self._port, 'qt6', 'qml')
 
         name = os.path.basename(test_program)
         if not hasattr(subprocess, 'TimeoutExpired'):

--- a/Tools/wpe/dependencies/dnf
+++ b/Tools/wpe/dependencies/dnf
@@ -7,8 +7,8 @@ PACKAGES+=(
     # These are dependencies necessary for building WebKitWPE.
     libicu-devel
     libxml2-devel
-    qt5-qtbase-devel
-    qt5-qtdeclarative-devel
+    qt6-qtbase-devel
+    qt6-qtdeclarative-devel
     zlib-devel
 
     # These are dependencies necessary for running tests.


### PR DESCRIPTION
#### 4b75ae7073f0c334e39853571a1719132ea1b8c5
<pre>
[WPE] Further cleanup after removal of the Qt5 embedding API
<a href="https://bugs.webkit.org/show_bug.cgi?id=305602">https://bugs.webkit.org/show_bug.cgi?id=305602</a>

Reviewed by Patrick Griffis.

Remove more remaining references to the Qt5 WPE binding; or replace with
Qt6 equivalents where appropriate. This is a follow-up to 305824@main.

* Tools/Scripts/run-qt-wpe-minibrowser: Remove path calculations and
setting environment variables for Qt5, leaving only the Qt6 ones.
* Tools/Scripts/webkitpy/style/checker.py: Remove references to Qt5 paths.
* Tools/TestWebKitAPI/Tests/WPEQt/WPEQtTest.h: Remove version check on
QT_VERSION, and use only Qt6 headers.
* Tools/glib/api_test_runner.py:
(TestRunner._run_test_qt): Replace setting of the QML2_IMPORT_PATH
environment variable with QML_IMPORT_PATH as used with Qt6, using the
corresponding Qt6 path.
* Tools/wpe/dependencies/dnf: Replace Qt5 packages with Qt6 ones.

Canonical link: <a href="https://commits.webkit.org/305862@main">https://commits.webkit.org/305862@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0de43323379dde8365c4445c2bf5b4408a260ec5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139568 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11944 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1071 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147700 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92636 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141441 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12652 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12094 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106857 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77804 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142515 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9696 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87721 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/138914 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9331 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6921 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7994 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118611 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/998 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150482 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11628 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1016 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115261 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11642 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9947 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115572 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10194 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121445 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66634 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21538 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11673 "Built successfully") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11409 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11608 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11459 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->