### PR TITLE
AX: When the `id` attribute changes for an element that is the target of an aria-owns, the AX children of the aria-owns element are not updated

### DIFF
--- a/LayoutTests/accessibility/aria-owns-id-change-expected.txt
+++ b/LayoutTests/accessibility/aria-owns-id-change-expected.txt
@@ -1,0 +1,34 @@
+This test ensures aria-owns relationships update when a target element's id changes.
+
+Initial state - owner should have 2 children (Item 1 + owned button), other-owner should have 1 child:
+PASS: owner.childrenCount === 2
+PASS: owner.childAtIndex(1).role.toLowerCase().includes('button') === true
+PASS: otherOwner.childrenCount === 1
+
+Changing the owned element's id from 'owned' to 'not-owned':
+document.getElementById('owned').id = 'not-owned'
+
+Owner should now only have 1 child (Item 1):
+PASS: owner.childrenCount === 1
+
+Changing the element's id back to 'owned':
+document.getElementById('not-owned').id = 'owned'
+
+Owner should now have 2 children again:
+PASS: owner.childrenCount === 2
+PASS: owner.childAtIndex(1).role.toLowerCase().includes('button') === true
+
+Testing ownership transfer - changing id to match other-owner's aria-owns:
+document.getElementById('owned').id = 'different-id'
+
+Owner should have 1 child, other-owner should have 2 children:
+PASS: owner.childrenCount === 1
+PASS: otherOwner.childrenCount === 2
+PASS: otherOwner.childAtIndex(1).role.toLowerCase().includes('button') === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Item 1
+Item 2
+Owned button

--- a/LayoutTests/accessibility/aria-owns-id-change.html
+++ b/LayoutTests/accessibility/aria-owns-id-change.html
@@ -1,0 +1,60 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<div tabindex="0" role="group" aria-owns="owned" id="owner">
+    <div>Item 1</div>
+</div>
+
+<div tabindex="0" role="group" aria-owns="different-id" id="other-owner">
+    <div>Item 2</div>
+</div>
+
+<div role="button" id="owned">Owned button</div>
+
+<script>
+var output = "This test ensures aria-owns relationships update when a target element's id changes.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var owner, otherOwner;
+    setTimeout(async () => {
+        owner = accessibilityController.accessibleElementById("owner");
+        otherOwner = accessibilityController.accessibleElementById("other-owner");
+
+        output += "Initial state - owner should have 2 children (Item 1 + owned button), other-owner should have 1 child:\n";
+        output += expect("owner.childrenCount", "2");
+        output += expect("owner.childAtIndex(1).role.toLowerCase().includes('button')", "true");
+        output += expect("otherOwner.childrenCount", "1");
+
+        output += "\nChanging the owned element's id from 'owned' to 'not-owned':\n";
+        output += evalAndReturn("document.getElementById('owned').id = 'not-owned'");
+        output += "\nOwner should now only have 1 child (Item 1):\n";
+        output += await expectAsync("owner.childrenCount", "1");
+
+        output += "\nChanging the element's id back to 'owned':\n";
+        output += evalAndReturn("document.getElementById('not-owned').id = 'owned'");
+        output += "\nOwner should now have 2 children again:\n";
+        output += await expectAsync("owner.childrenCount", "2");
+
+        output += expect("owner.childAtIndex(1).role.toLowerCase().includes('button')", "true");
+
+        output += "\nTesting ownership transfer - changing id to match other-owner's aria-owns:\n";
+        output += evalAndReturn("document.getElementById('owned').id = 'different-id'");
+        output += "\nOwner should have 1 child, other-owner should have 2 children:\n";
+        output += await expectAsync("owner.childrenCount", "1");
+        output += await expectAsync("otherOwner.childrenCount", "2");
+        output += expect("otherOwner.childAtIndex(1).role.toLowerCase().includes('button')", "true");
+
+        debug(output);
+        finishJSTest();
+    });
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -826,6 +826,7 @@ jquery/traversing.html [ Pass Slow ]
 # Static text elements aren't exposed in the accessibility tree on ATSPI, which these tests rely on.
 # https://bugs.webkit.org/show_bug.cgi?id=282117
 # https://github.com/WebKit/WebKit/blob/e666928e70449224996d14a5868c902134facf30/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp#L1395#L1397
+accessibility/aria-owns-id-change.html [ Skip ]
 accessibility/opacity-0-bounding-box.html [ Skip ]
 accessibility/clip-path-bounding-box.html [ Skip ]
 accessibility/first-letter-single-character.html [ Skip ]


### PR DESCRIPTION
#### 2b5fb0a03893d854f5f4c3b0085122ab4e7525a9
<pre>
AX: When the `id` attribute changes for an element that is the target of an aria-owns, the AX children of the aria-owns element are not updated
<a href="https://bugs.webkit.org/show_bug.cgi?id=255018">https://bugs.webkit.org/show_bug.cgi?id=255018</a>
<a href="https://rdar.apple.com/107644248">rdar://107644248</a>

Reviewed by Joshua Hoffman.

When an element&apos;s id attribute changes, any aria-owns relationships
targeting that element may also change. Previously, the accessibility
tree was not being properly updated in this case, leaving owners with
stale children.

Now when an element&apos;s id changes, we find any current owner(s) via the
existing relations map (before it&apos;s rebuilt) and notify them via childrenChanged().

The relations map is already marked dirty via relationsNeedUpdate(true)
which is called after handleAttributeChange. When relations are rebuilt,
addRelation handles notifying new owners. This fix ensures old owners
(whose target has gone away) are also notified.

* LayoutTests/accessibility/aria-owns-id-change-expected.txt: Added.
* LayoutTests/accessibility/aria-owns-id-change.html: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::handleAttributeChange):

Canonical link: <a href="https://commits.webkit.org/305890@main">https://commits.webkit.org/305890@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90ad7ce6c7224b17ee86c6101c369d054ad460f5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139693 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12069 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1197 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147830 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92761 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141566 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12778 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12220 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106970 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77872 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142640 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9834 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125115 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87834 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9492 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7015 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8120 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118721 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1113 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150612 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11754 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1165 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115373 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11767 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10070 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115684 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29391 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10449 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121592 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66759 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11798 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1075 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11538 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75476 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11733 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11585 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->