### PR TITLE
Initialize CacheModel based on whether app is a web browser

### DIFF
--- a/Source/WebKit/UIProcess/LegacyGlobalSettings.cpp
+++ b/Source/WebKit/UIProcess/LegacyGlobalSettings.cpp
@@ -30,11 +30,20 @@
 #include <wtf/NeverDestroyed.h>
 #include <wtf/TZoneMallocInlines.h>
 
+#if PLATFORM(COCOA)
+#include "DefaultWebBrowserChecks.h"
+#endif
+
 namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(LegacyGlobalSettings);
 
-LegacyGlobalSettings::LegacyGlobalSettings() = default;
+LegacyGlobalSettings::LegacyGlobalSettings()
+#if PLATFORM(COCOA)
+    : m_cacheModel { isFullWebBrowserOrRunningTest() ? CacheModel::PrimaryWebBrowser : CacheModel::DocumentBrowser }
+#endif
+{
+}
 
 LegacyGlobalSettings& LegacyGlobalSettings::singleton()
 {


### PR DESCRIPTION
#### 8539dbad57196cae82907b9eededdfb7b66fadd9
<pre>
Initialize CacheModel based on whether app is a web browser
<a href="https://bugs.webkit.org/show_bug.cgi?id=305790">https://bugs.webkit.org/show_bug.cgi?id=305790</a>
<a href="https://rdar.apple.com/168463192">rdar://168463192</a>

Reviewed by Per Arne Vollan.

CacheModel is currently initialized to PrimaryWebBrowser by default. This means that we end up doing
things like enabling the web process cache for trivial use cases in iOS apps that just use a
WKWebView to display a small ad or other element.

To fix this, initialize CacheModel to DocumentBrowser by default, and only set it to
PrimaryWebBrowser if the UIProcess is actually a browser.

* Source/WebKit/UIProcess/LegacyGlobalSettings.cpp:
(WebKit::LegacyGlobalSettings::LegacyGlobalSettings):

Canonical link: <a href="https://commits.webkit.org/306035@main">https://commits.webkit.org/306035@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a1dac0bae8401775a4fccd2ad9687c622b757e3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139572 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11948 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1075 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147704 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92640 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4dc546f5-00d9-429b-a5f4-fc5017933adc) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12656 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12098 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106862 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77806 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/af47a323-95f4-4cce-8194-00855ebbb2ce) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142519 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9699 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125004 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87725 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/81ad6452-f6d0-4843-a179-e31360247f60) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9336 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6925 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/7998 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118615 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150486 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11632 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1021 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115266 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11646 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9952 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115577 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29486 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10212 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121449 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66638 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11677 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/952 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11413 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75355 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11612 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11463 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->