### PR TITLE
[ApplePay] Unrecognized payment networks need not always throw exceptions

### DIFF
--- a/LayoutTests/http/tests/ssl/applepay/ApplePaySession-expected.txt
+++ b/LayoutTests/http/tests/ssl/applepay/ApplePaySession-expected.txt
@@ -1,3 +1,6 @@
+CONSOLE MESSAGE: 'invalidNetwork' is not a valid payment network.
+CONSOLE MESSAGE: 'invalidNetwork' is not a valid payment network.
+CONSOLE MESSAGE: 'carteBancaire' is not a valid payment network.
 Test basic creation of an ApplePaySession object.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
@@ -77,13 +80,13 @@ SETUP: request = validRequest(); request.supportedNetworks = [];
 PASS new ApplePaySession(2, request) threw exception TypeError: At least one supported network must be provided..
 
 SETUP: request = validRequest(); request.supportedNetworks = ['invalidNetwork'];
-PASS new ApplePaySession(2, request) threw exception TypeError: "invalidNetwork" is not a valid payment network..
+PASS new ApplePaySession(2, request) threw exception TypeError: At least one supported network must be provided..
 
 SETUP: request = validRequest(); request.supportedNetworks = ['invalidNetwork', 'visa'];
-PASS new ApplePaySession(2, request) threw exception TypeError: "invalidNetwork" is not a valid payment network..
+PASS new ApplePaySession(2, request) did not throw exception.
 
 SETUP: request = validRequest(); request.supportedNetworks = ['carteBancaire'];
-PASS new ApplePaySession(2, request) threw exception TypeError: "carteBancaire" is not a valid payment network..
+PASS new ApplePaySession(2, request) threw exception TypeError: At least one supported network must be provided..
 
 SETUP: request = validRequest(); request.supportedNetworks = ['visa', 'visa'];
 PASS new ApplePaySession(2, request) did not throw exception.

--- a/LayoutTests/http/tests/ssl/applepay/ApplePaySession.html
+++ b/LayoutTests/http/tests/ssl/applepay/ApplePaySession.html
@@ -79,7 +79,7 @@ function go() {
     logAndShouldThrow("request = validRequest(); request.supportedNetworks = 7;", "new ApplePaySession(2, request)")
     logAndShouldThrow("request = validRequest(); request.supportedNetworks = [];", "new ApplePaySession(2, request)")
     logAndShouldThrow("request = validRequest(); request.supportedNetworks = ['invalidNetwork'];", "new ApplePaySession(2, request)")
-    logAndShouldThrow("request = validRequest(); request.supportedNetworks = ['invalidNetwork', 'visa'];", "new ApplePaySession(2, request)")
+    logAndShouldNotThrow("request = validRequest(); request.supportedNetworks = ['invalidNetwork', 'visa'];", "new ApplePaySession(2, request)")
     logAndShouldThrow("request = validRequest(); request.supportedNetworks = ['carteBancaire'];", "new ApplePaySession(2, request)")
     // FIXME: Should duplicate supportedNetworks be allowed?
     logAndShouldNotThrow("request = validRequest(); request.supportedNetworks = ['visa', 'visa'];", "new ApplePaySession(2, request)")

--- a/LayoutTests/http/tests/ssl/applepay/PaymentRequest.https-expected.txt
+++ b/LayoutTests/http/tests/ssl/applepay/PaymentRequest.https-expected.txt
@@ -1,3 +1,5 @@
+CONSOLE MESSAGE: 'invalidNetwork' is not a valid payment network.
+CONSOLE MESSAGE: 'invalidNetwork' is not a valid payment network.
 Test basic creation of a PaymentRequest object with an Apple Pay payment method.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
@@ -59,10 +61,10 @@ SETUP: paymentMethod = validPaymentMethod(); paymentMethod.data.supportedNetwork
 PASS new PaymentRequest([paymentMethod], validPaymentDetails()) threw exception TypeError: At least one supported network must be provided..
 
 SETUP: paymentMethod = validPaymentMethod(); paymentMethod.data.supportedNetworks = ['invalidNetwork'];
-PASS new PaymentRequest([paymentMethod], validPaymentDetails()) threw exception TypeError: "invalidNetwork" is not a valid payment network..
+PASS new PaymentRequest([paymentMethod], validPaymentDetails()) threw exception TypeError: At least one supported network must be provided..
 
 SETUP: paymentMethod = validPaymentMethod(); paymentMethod.data.supportedNetworks = ['invalidNetwork', 'visa'];
-PASS new PaymentRequest([paymentMethod], validPaymentDetails()) threw exception TypeError: "invalidNetwork" is not a valid payment network..
+PASS new PaymentRequest([paymentMethod], validPaymentDetails()) did not throw exception.
 
 
 Testing ApplePayRequest.merchantCapabilities

--- a/LayoutTests/http/tests/ssl/applepay/PaymentRequest.https.html
+++ b/LayoutTests/http/tests/ssl/applepay/PaymentRequest.https.html
@@ -41,6 +41,15 @@ function logAndShouldThrow(setup, test) {
     });
 }
 
+function logAndShouldNotThrow(setup, test) {
+    return activateThen(() => {
+        debug("SETUP: " + setup)
+        eval(setup);
+        shouldNotThrow(test);
+        debug("");
+    });
+}
+
 function logAndShouldReject(setup, test) {
     return activateThen(() => {
         debug("SETUP: " + setup)
@@ -81,7 +90,7 @@ async function go() {
     await logAndShouldThrow("paymentMethod = validPaymentMethod(); paymentMethod.data.supportedNetworks = 7;", "new PaymentRequest([paymentMethod], validPaymentDetails())")
     await logAndShouldThrow("paymentMethod = validPaymentMethod(); paymentMethod.data.supportedNetworks = [];", "new PaymentRequest([paymentMethod], validPaymentDetails())")
     await logAndShouldThrow("paymentMethod = validPaymentMethod(); paymentMethod.data.supportedNetworks = ['invalidNetwork'];", "new PaymentRequest([paymentMethod], validPaymentDetails())")
-    await logAndShouldThrow("paymentMethod = validPaymentMethod(); paymentMethod.data.supportedNetworks = ['invalidNetwork', 'visa'];", "new PaymentRequest([paymentMethod], validPaymentDetails())")
+    await logAndShouldNotThrow("paymentMethod = validPaymentMethod(); paymentMethod.data.supportedNetworks = ['invalidNetwork', 'visa'];", "new PaymentRequest([paymentMethod], validPaymentDetails())")
     debug("")
 
     debug("Testing ApplePayRequest.merchantCapabilities")

--- a/Source/WebCore/Modules/applepay/ApplePaySessionPaymentRequest.h
+++ b/Source/WebCore/Modules/applepay/ApplePaySessionPaymentRequest.h
@@ -89,7 +89,7 @@ public:
     void setShippingContact(const PaymentContact& shippingContact) { m_shippingContact = shippingContact; }
 
     const Vector<String>& supportedNetworks() const { return m_supportedNetworks; }
-    void setSupportedNetworks(const Vector<String>& supportedNetworks) { m_supportedNetworks = supportedNetworks; }
+    void setSupportedNetworks(Vector<String>&& supportedNetworks) { m_supportedNetworks = WTF::move(supportedNetworks); }
 
     struct MerchantCapabilities {
         bool supports3DS { false };


### PR DESCRIPTION
#### 130b88c82e3c20a8f592763b085e7d4a08b1b79e
<pre>
[ApplePay] Unrecognized payment networks need not always throw exceptions
<a href="https://bugs.webkit.org/show_bug.cgi?id=305793">https://bugs.webkit.org/show_bug.cgi?id=305793</a>
<a href="https://rdar.apple.com/163015780">rdar://163015780</a>

Reviewed by Wenson Hsieh.

Apple Pay on the web flows can handle unrecognized payment networks more
gracefully. Currently, if the ApplePayPaymentRequest.supportedNetworks
array contains an unknown value, a TypeError is thrown and no payment
sheet is presented.

Historically, developers could key off of the Apple Pay API version
number to evaluate whether a given network would be recognized in the
current device. However, there is no longer a tight cadence between new
network support, OS version changes, and Apple Pay API version changes.
The current recommend technique is for developers to test the networks
and filter out unrecognised values, however this technique is cumbersome,
and requires developers to write lots of boilerplate code.

In this patch, we migrate this filtering approach in to WebKit,
abstracting away this need from page authors. Concretely, we no longer
immediately throw a TypeError when we encounter a network value that is
not recognized by the platform. Instead, we now produce console warnings
in these situations and pare down the provided supportedNetworks array
to only recognized values. We only throw an exception if this array is
empty.

Gracefully handling these unrecognized networks yields the following
benefits:

- Simpler merchant integrations: developers need not write convoluted
  boilerplate evluation code to create a payment request.
- Smoother Apple Pay user experience: reduces the frequency with which
  payment sheets are unexpectedly not presented.
- Simpler documentation: this takes page authors one step closer to not
  requiring use of the Apple Pay API version number, and we can now drop
  this from the supportedNetworks array documentation, c.f.
  <a href="https://developer.apple.com/documentation/applepayontheweb/applepaypaymentrequest/supportednetworks.">https://developer.apple.com/documentation/applepayontheweb/applepaypaymentrequest/supportednetworks.</a>

No new tests, however, some existing tests have been rebaselined
because of the behavior change with exceptions thrown.

* LayoutTests/http/tests/ssl/applepay/ApplePaySession-expected.txt:
* LayoutTests/http/tests/ssl/applepay/ApplePaySession.html:
* LayoutTests/http/tests/ssl/applepay/PaymentRequest.https-expected.txt:
* LayoutTests/http/tests/ssl/applepay/PaymentRequest.https.html:
* Source/WebCore/Modules/applepay/ApplePayRequestBase.cpp:
(WebCore::convertAndValidate):
* Source/WebCore/Modules/applepay/ApplePaySessionPaymentRequest.h:
(WebCore::ApplePaySessionPaymentRequest::setSupportedNetworks):
  Drive-by fix: The only caller now moves a vector of strings, so teach
  move semantics to this setter.

Canonical link: <a href="https://commits.webkit.org/305895@main">https://commits.webkit.org/305895@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2429b9e02b20ad846311ec49b5618a594329aa7a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139703 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12079 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1207 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147841 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92771 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2724f2aa-4851-44f1-b16c-6e9b211d8cb6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141576 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12788 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12230 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106975 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/77876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8b7e1ee7-9c33-4fe5-b655-d7ef6cdaff06) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142650 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9837 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125122 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87841 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5703e0ce-2af9-4190-983b-d78fd38fdaae) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9495 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7020 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8130 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118723 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1120 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150622 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11764 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1173 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115381 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11777 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10076 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115694 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10451 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121600 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66769 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21553 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11808 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/1084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11548 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75486 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11743 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11595 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->