### PR TITLE
Address unsafe cast warnings in Source/WebCore/Modules

### DIFF
--- a/Source/WebCore/Modules/Model/Implementation/DDMeshImpl.h
+++ b/Source/WebCore/Modules/Model/Implementation/DDMeshImpl.h
@@ -70,6 +70,8 @@ private:
     DDMeshImpl& operator=(const DDMeshImpl&) = delete;
     DDMeshImpl& operator=(DDMeshImpl&&) = delete;
 
+    bool isDDMeshImpl() const final { return true; }
+
     void setLabelInternal(const String&) final;
     void update(const DDUpdateMeshDescriptor&) final;
     void updateTexture(const DDUpdateTextureDescriptor&) final;
@@ -90,5 +92,9 @@ private:
 };
 
 }
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::DDModel::DDMeshImpl)
+    static bool isType(const WebCore::DDModel::DDMesh& mesh) { return mesh.isDDMeshImpl(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // HAVE(WEBGPU_IMPLEMENTATION)

--- a/Source/WebCore/Modules/Model/Implementation/ModelDowncastConvertToBackingContext.cpp
+++ b/Source/WebCore/Modules/Model/Implementation/ModelDowncastConvertToBackingContext.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(DowncastConvertToBackingContext);
 
 WGPUDDMesh DowncastConvertToBackingContext::convertToBacking(const DDMesh& mesh)
 {
-    return static_cast<const DDMeshImpl&>(mesh).backing();
+    return downcast<DDMeshImpl>(mesh).backing();
 }
 
 }

--- a/Source/WebCore/Modules/Model/InternalAPI/DDMesh.h
+++ b/Source/WebCore/Modules/Model/InternalAPI/DDMesh.h
@@ -68,6 +68,7 @@ public:
     virtual void updateTexture(const DDUpdateTextureDescriptor&) = 0;
     virtual void updateMaterial(const DDUpdateMaterialDescriptor&) = 0;
     virtual bool isRemoteDDMeshProxy() const { return false; }
+    virtual bool isDDMeshImpl() const { return false; }
     virtual void setEntityTransform(const DDFloat4x4&) = 0;
     virtual std::optional<DDFloat4x4> entityTransform() const = 0;
     virtual bool supportsTransform(const WebCore::TransformationMatrix&) const { return false; }

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUBindGroupImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUBindGroupImpl.cpp
@@ -52,7 +52,7 @@ void BindGroupImpl::setLabelInternal(const String& label)
 
 bool BindGroupImpl::updateExternalTextures(ExternalTexture& externalTexture)
 {
-    return wgpuBindGroupUpdateExternalTextures(m_backing.get(), static_cast<const ExternalTextureImpl&>(externalTexture).backing());
+    return wgpuBindGroupUpdateExternalTextures(m_backing.get(), downcast<ExternalTextureImpl>(externalTexture).backing());
 }
 
 } // namespace WebCore::WebGPU

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUXRBindingImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUXRBindingImpl.cpp
@@ -64,7 +64,7 @@ RefPtr<XRSubImage> XRBindingImpl::getSubImage(XRProjectionLayer&, WebCore::WebXR
 
 RefPtr<XRSubImage> XRBindingImpl::getViewSubImage(XRProjectionLayer& projectionLayer)
 {
-    auto& projectionLayerImpl = static_cast<XRProjectionLayerImpl&>(projectionLayer);
+    auto& projectionLayerImpl = downcast<XRProjectionLayerImpl>(projectionLayer);
     return XRSubImageImpl::create(adoptWebGPU(wgpuBindingGetViewSubImage(m_backing.get(), projectionLayerImpl.backing())), Ref { m_convertToBackingContext });
 }
 

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.cpp
@@ -108,7 +108,8 @@ Ref<RealtimeMediaSource> LibWebRTCRtpReceiverBackend::createSource(Document& doc
     case webrtc::MediaType::UNSUPPORTED:
         break;
     case webrtc::MediaType::AUDIO: {
-        webrtc::scoped_refptr<webrtc::AudioTrackInterface> audioTrack { static_cast<webrtc::AudioTrackInterface*>(rtcTrack.get()) };
+        // This is a cast from a webrtc type, not much we can do to make it safe.
+        SUPPRESS_MEMORY_UNSAFE_CAST webrtc::scoped_refptr<webrtc::AudioTrackInterface> audioTrack { static_cast<webrtc::AudioTrackInterface*>(rtcTrack.get()) };
         Ref source = RealtimeIncomingAudioSource::create(toRef(WTF::move(audioTrack)), fromStdString(rtcTrack->id()));
         if (document.page()) {
             auto& webRTCProvider = downcast<LibWebRTCProvider>(document.page()->webRTCProvider());
@@ -117,7 +118,8 @@ Ref<RealtimeMediaSource> LibWebRTCRtpReceiverBackend::createSource(Document& doc
         return source;
     }
     case webrtc::MediaType::VIDEO: {
-        webrtc::scoped_refptr<webrtc::VideoTrackInterface> videoTrack { static_cast<webrtc::VideoTrackInterface*>(rtcTrack.get()) };
+        // This is a cast from a webrtc type, not much we can do to make it safe.
+        SUPPRESS_MEMORY_UNSAFE_CAST webrtc::scoped_refptr<webrtc::VideoTrackInterface> videoTrack { static_cast<webrtc::VideoTrackInterface*>(rtcTrack.get()) };
         Ref source = RealtimeIncomingVideoSource::create(toRef(WTF::move(videoTrack)), fromStdString(rtcTrack->id()));
         if (document.settings().webRTCMediaPipelineAdditionalLoggingEnabled())
             source->enableFrameRatedMonitoring();

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCStatsCollector.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCStatsCollector.cpp
@@ -668,7 +668,8 @@ RTCStatsReport::VideoSourceStats::VideoSourceStats(const webrtc::RTCVideoSourceS
 template <typename T, typename PreciseType>
 void addToStatsMap(DOMMapAdapter& report, const webrtc::RTCStats& rtcStats)
 {
-    T stats { static_cast<const PreciseType&>(rtcStats) };
+    // This is a cast from a webrtc type, not much we can do to make it safe.
+    SUPPRESS_MEMORY_UNSAFE_CAST T stats { static_cast<const PreciseType&>(rtcStats) };
     String statsId = stats.id;
     report.set<IDLDOMString, IDLDictionary<T>>(WTF::move(statsId), WTF::move(stats));
 }

--- a/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -1,8 +1,3 @@
-Modules/Model/Implementation/ModelDowncastConvertToBackingContext.cpp
-Modules/WebGPU/Implementation/WebGPUBindGroupImpl.cpp
-Modules/WebGPU/Implementation/WebGPUXRBindingImpl.cpp
-Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.cpp
-Modules/mediastream/libwebrtc/LibWebRTCStatsCollector.cpp
 bindings/js/DOMGCOutputConstraint.cpp
 bindings/js/JSDOMAsyncIterator.h
 bindings/js/JSDOMConvertWebGL.cpp


### PR DESCRIPTION
#### 9249f978b803ccb85fe18c81e15b4fa7ad030183
<pre>
Address unsafe cast warnings in Source/WebCore/Modules
<a href="https://bugs.webkit.org/show_bug.cgi?id=305797">https://bugs.webkit.org/show_bug.cgi?id=305797</a>

Reviewed by Mike Wyrzykowski and Darin Adler.

* Source/WebCore/Modules/Model/Implementation/DDMeshImpl.h:
(isType):
* Source/WebCore/Modules/Model/Implementation/ModelDowncastConvertToBackingContext.cpp:
(WebCore::DDModel::DowncastConvertToBackingContext::convertToBacking):
* Source/WebCore/Modules/Model/InternalAPI/DDMesh.h:
(WebCore::DDModel::DDMesh::isDDMeshImpl const):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUBindGroupImpl.cpp:
(WebCore::WebGPU::BindGroupImpl::updateExternalTextures):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUXRBindingImpl.cpp:
(WebCore::WebGPU::XRBindingImpl::getViewSubImage):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.cpp:
(WebCore::LibWebRTCRtpReceiverBackend::createSource):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCStatsCollector.cpp:
(WebCore::addToStatsMap):
* Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/305846@main">https://commits.webkit.org/305846@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c12ef5755791894f00634740adabfa7f2a2d52b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139602 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11978 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1106 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147734 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92670 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/473e1563-c64d-443f-84fc-38f6f0de5b0a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141475 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12686 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12128 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106889 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/77824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e3361841-9e9b-4911-a319-8dde147ee755) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142549 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9734 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125038 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87752 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/44977586-ea28-42a7-abb8-dc802fd4c506) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9371 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6949 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8028 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118643 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1036 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150516 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11662 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1064 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115292 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11676 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9979 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115603 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29363 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10246 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121491 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66668 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11707 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/979 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11443 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75385 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11642 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11493 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->