### PR TITLE
Child table column has incorrect height when parent table height is not defined

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/nested-table-height-td-percent-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/nested-table-height-td-percent-expected.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Nested table with percentage heights as data element</title>
+<link rel="match" href="nested-table-height-100-percent-ref.html">
+<style>
+  html, body {
+    margin: 0;
+    height: 100%;
+  }
+  .full-height {
+    background: red;
+    height: 100%;
+  }
+</style>
+<table style="border: thin solid blue" width="100%">
+  <tbody>
+    <tr>
+      <td valign="top" height="100%"  style="padding: 3px;">
+        <div class="full-height" >&nbsp;</div>
+      </td>
+      <td valign="top" width="155" style="background: blue; color: white;">
+        some text here<br><br><br><br><br>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/nested-table-height-td-percent-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/nested-table-height-td-percent-ref.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Nested table with percentage heights as data element</title>
+<link rel="match" href="nested-table-height-100-percent-ref.html">
+<style>
+  html, body {
+    margin: 0;
+    height: 100%;
+  }
+  .full-height {
+    background: red;
+    height: 100%;
+  }
+</style>
+<table style="border: thin solid blue" width="100%">
+  <tbody>
+    <tr>
+      <td valign="top" height="100%"  style="padding: 3px;">
+        <div class="full-height" >&nbsp;</div>
+      </td>
+      <td valign="top" width="155" style="background: blue; color: white;">
+        some text here<br><br><br><br><br>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/nested-table-height-td-percent.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/nested-table-height-td-percent.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Nested table with percentage heights</title>
+<link rel="match" href="nested-table-height-100-percent-ref.html">
+<style>
+  html, body {
+    margin: 0;
+    height: 100%;
+  }
+</style>
+<table style="border: thin solid blue" width="100%">
+  <tbody>
+    <tr>
+      <td valign="top" height="100%">
+        <table width= "100%" height= "100%"">
+          <tbody>
+            <tr>
+              <td style="background: red; width: 115; height: 100%;">&nbsp;</td>
+            </tr>
+          </tbody>
+        </table>
+      </td>
+      <td valign="top" width="155" style="background: blue; color: white;">
+        some text here<br><br><br><br><br>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -644,6 +644,10 @@ void RenderTableSection::layoutRows()
                 cell->setNeedsLayout(MarkOnlyThis);
                 cell->setOverridingBorderBoxLogicalWidth(rowHeight);
             }
+
+            auto ancestorIsAuto = cell->containingBlock()->hasAutoHeightOrContainingBlockWithAutoHeight() && cell->style().logicalHeight().isPercent();
+            if (ancestorIsAuto)
+                cell->setOverridingBorderBoxLogicalHeight(rowHeight);
             cell->layoutIfNeeded();
 
             // FIXME: Make pagination work with vertical tables.


### PR DESCRIPTION
#### d9ad55b852b051ddc4d8216ca34e5c0eb52d090f
<pre>
Child table column has incorrect height when parent table height is not defined
<a href="https://bugs.webkit.org/show_bug.cgi?id=17562#attach_19388">https://bugs.webkit.org/show_bug.cgi?id=17562#attach_19388</a>

When the table height is not defined, the cell height in a row is determined by the largest cell height in that row. WebKit matches this behavior.

Cells containing nested tables that had not height defined, not match the tallest cell in the row in WebKit.

This occurs because the table height in this case is calculated from internal content only,
without considering the row’s largest cell height in case that it&apos;s a nested table included in td element

This change overrides the cell height when both child table and td heights are
undefined besides parent table height, ensuring cells with table correctly match the right row height.

Explanation of why this fixes the bug (OOPS!).

Tests: imported/w3c/web-platform-tests/css/css-tables/nested-table-height-td-percent-ref.html
       imported/w3c/web-platform-tests/css/css-tables/nested-table-height-td-percent.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/nested-table-height-td-percent-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/nested-table-height-td-percent-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/nested-table-height-td-percent.html: Added.
* Source/WebCore/rendering/RenderTableSection.cpp:
(WebCore::RenderTableSection::layoutRows):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9ad55b852b051ddc4d8216ca34e5c0eb52d090f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139595 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11971 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1099 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147727 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92663 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141468 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12679 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12121 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106883 "Found 1 new test failure: tables/mozilla_expected_failures/bugs/bug32205-4.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77818 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142542 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9725 "Found 1 new test failure: tables/mozilla_expected_failures/bugs/bug32205-4.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125029 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87746 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9361 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6940 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8021 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118636 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1027 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150509 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11655 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1052 "Found 1 new test failure: tables/mozilla_expected_failures/bugs/bug32205-4.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115286 "Found 1 new test failure: tables/mozilla_expected_failures/bugs/bug32205-4.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11669 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9970 "Found 1 new test failure: tables/mozilla_expected_failures/bugs/bug32205-4.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115597 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10231 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121480 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66661 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11700 "Built successfully") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11436 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75378 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11635 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11486 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->