### PR TITLE
[JSC] Use `hasSpecialProperties` bit for cheking `constructor` properties

### DIFF
--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -1587,7 +1587,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncConcat, (JSGlobalObject* globalObject, Ca
     if (!callFrame->argumentCount()) {
         if (isJSArray(thisValue)) [[likely]] {
             auto* array = jsCast<JSArray*>(thisValue);
-            if (arrayMissingIsConcatSpreadable(vm, array) && arraySpeciesWatchpointIsValid(vm, array)) [[likely]] {
+            if (arrayMissingIsConcatSpreadable(vm, array) && arraySpeciesWatchpointIsValid(array)) [[likely]] {
                 JSArray* result = tryCloneArrayFromFast<ArrayFillMode::Empty>(globalObject, array);
                 RETURN_IF_EXCEPTION(scope, { });
                 if (result) [[likely]]
@@ -1598,7 +1598,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncConcat, (JSGlobalObject* globalObject, Ca
         JSValue argumentValue = callFrame->uncheckedArgument(0);
         if (isJSArray(thisValue)) [[likely]] {
             auto* firstArray = jsCast<JSArray*>(thisValue);
-            if (arrayMissingIsConcatSpreadable(vm, firstArray) && arraySpeciesWatchpointIsValid(vm, firstArray)) [[likely]] {
+            if (arrayMissingIsConcatSpreadable(vm, firstArray) && arraySpeciesWatchpointIsValid(firstArray)) [[likely]] {
                 // This code assumes that neither array has set Symbol.isConcatSpreadable. If the first array
                 // has indexed accessors then one of those accessors might change the value of Symbol.isConcatSpreadable
                 // on the second argument.
@@ -2194,7 +2194,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncFlat, (JSGlobalObject* globalObject, Call
         }
     }
 
-    if (isJSArray(thisObject) && arraySpeciesWatchpointIsValid(vm, thisObject)) [[likely]] {
+    if (isJSArray(thisObject) && arraySpeciesWatchpointIsValid(thisObject)) [[likely]] {
         JSArray* thisArray = jsCast<JSArray*>(thisObject);
         auto fastResult = thisArray->fastFlat(globalObject, depthNum, length);
         RETURN_IF_EXCEPTION(scope, { });

--- a/Source/JavaScriptCore/runtime/ArrayPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/ArrayPrototypeInlines.h
@@ -47,7 +47,7 @@ enum class SpeciesConstructResult : uint8_t {
     CreatedObject
 };
 
-ALWAYS_INLINE bool arraySpeciesWatchpointIsValid(VM& vm, JSObject* thisObject)
+ALWAYS_INLINE bool arraySpeciesWatchpointIsValid(JSObject* thisObject)
 {
     JSGlobalObject* globalObject = thisObject->globalObject();
     ArrayPrototype* arrayPrototype = globalObject->arrayPrototype();
@@ -59,10 +59,7 @@ ALWAYS_INLINE bool arraySpeciesWatchpointIsValid(VM& vm, JSObject* thisObject)
     if (globalObject->arraySpeciesWatchpointSet().state() != IsWatched)
         return false;
 
-    if (!thisObject->hasCustomProperties())
-        return true;
-
-    return thisObject->getDirectOffset(vm, vm.propertyNames->constructor) == invalidOffset;
+    return !thisObject->structure()->hasSpecialProperties();
 }
 
 ALWAYS_INLINE bool arrayMissingIsConcatSpreadable(VM& vm, JSObject* thisObject)
@@ -101,7 +98,7 @@ ALWAYS_INLINE std::pair<SpeciesConstructResult, JSObject*> speciesConstructArray
     if (thisIsArray) [[likely]] {
         // Fast path in the normal case where the user has not set an own constructor and the Array.prototype.constructor is normal.
         // We need prototype check for subclasses of Array, which are Array objects but have a different prototype by default.
-        bool isValid = arraySpeciesWatchpointIsValid(vm, thisObject);
+        bool isValid = arraySpeciesWatchpointIsValid(thisObject);
         RETURN_IF_EXCEPTION(scope, exceptionResult);
         if (isValid) [[likely]]
             return std::pair { SpeciesConstructResult::FastPath, nullptr };

--- a/Source/JavaScriptCore/runtime/JSMicrotask.cpp
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.cpp
@@ -796,7 +796,7 @@ void runInternalMicrotask(JSGlobalObject* globalObject, InternalMicrotask task, 
         auto* promise = jsCast<JSPromise*>(arguments[0]);
         auto* promiseToResolve = jsCast<JSPromise*>(arguments[1]);
 
-        if (!promiseSpeciesWatchpointIsValid(vm, promise)) [[unlikely]]
+        if (!promiseSpeciesWatchpointIsValid(promise)) [[unlikely]]
             RELEASE_AND_RETURN(scope, promiseResolveThenableJobFastSlow(globalObject, promise, promiseToResolve));
 
         scope.release();
@@ -809,7 +809,7 @@ void runInternalMicrotask(JSGlobalObject* globalObject, InternalMicrotask task, 
         JSValue context = arguments[1];
         auto task = static_cast<InternalMicrotask>(payload);
 
-        if (!promiseSpeciesWatchpointIsValid(vm, promise)) [[unlikely]]
+        if (!promiseSpeciesWatchpointIsValid(promise)) [[unlikely]]
             RELEASE_AND_RETURN(scope, promiseResolveThenableJobWithInternalMicrotaskFastSlow(globalObject, promise, task, context));
 
         switch (promise->status()) {

--- a/Source/JavaScriptCore/runtime/JSPromise.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromise.cpp
@@ -591,7 +591,7 @@ void JSPromise::resolveWithInternalMicrotaskForAsyncAwait(JSGlobalObject* global
 
     if (resolution.inherits<JSPromise>()) {
         auto* promise = jsCast<JSPromise*>(resolution);
-        if (promiseSpeciesWatchpointIsValid(vm, promise)) [[likely]]
+        if (promiseSpeciesWatchpointIsValid(promise)) [[likely]]
             return promise->performPromiseThenWithInternalMicrotask(vm, globalObject, task, jsUndefined(), context);
 
         JSValue constructor;
@@ -701,7 +701,7 @@ JSObject* promiseSpeciesConstructor(JSGlobalObject* globalObject, JSObject* this
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     if (auto* promise = jsDynamicCast<JSPromise*>(thisObject)) [[likely]] {
-        if (promiseSpeciesWatchpointIsValid(vm, promise)) [[likely]]
+        if (promiseSpeciesWatchpointIsValid(promise)) [[likely]]
             return globalObject->promiseConstructor();
     }
 
@@ -749,7 +749,7 @@ JSObject* JSPromise::then(JSGlobalObject* globalObject, JSValue onFulfilled, JSV
 
     JSObject* resultPromise;
     JSValue resultPromiseCapability;
-    if (promiseSpeciesWatchpointIsValid(vm, this)) [[likely]] {
+    if (promiseSpeciesWatchpointIsValid(this)) [[likely]] {
         if (inherits<JSInternalPromise>())
             resultPromise = JSInternalPromise::create(vm, globalObject->internalPromiseStructure());
         else
@@ -778,7 +778,7 @@ JSObject* JSPromise::promiseResolve(JSGlobalObject* globalObject, JSObject* cons
 
     if (argument.inherits<JSPromise>()) {
         auto* promise = jsCast<JSPromise*>(argument);
-        if (promiseSpeciesWatchpointIsValid(vm, promise)) [[likely]]
+        if (promiseSpeciesWatchpointIsValid(promise)) [[likely]]
             return promise;
 
         auto property = promise->get(globalObject, vm.propertyNames->constructor);

--- a/Source/JavaScriptCore/runtime/JSPromisePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromisePrototype.cpp
@@ -91,7 +91,7 @@ void JSPromisePrototype::addOwnInternalSlots(VM& vm, JSGlobalObject* globalObjec
     putDirectWithoutTransition(vm, vm.propertyNames->builtinNames().thenPrivateName(), globalObject->promiseProtoThenFunction(), PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
 }
 
-bool promiseSpeciesWatchpointIsValid(VM& vm, JSPromise* thisObject)
+bool promiseSpeciesWatchpointIsValid(JSPromise* thisObject)
 {
     auto* structure = thisObject->structure();
     JSGlobalObject* globalObject = structure->globalObject();
@@ -112,10 +112,7 @@ bool promiseSpeciesWatchpointIsValid(VM& vm, JSPromise* thisObject)
     if (promisePrototype != structure->storedPrototype(thisObject))
         return false;
 
-    if (!thisObject->hasCustomProperties())
-        return true;
-
-    return thisObject->getDirectOffset(vm, vm.propertyNames->constructor) == invalidOffset;
+    return !structure->hasSpecialProperties();
 }
 
 JSC_DEFINE_HOST_FUNCTION(promiseProtoFuncThen, (JSGlobalObject* globalObject, CallFrame* callFrame))
@@ -268,7 +265,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseProtoFuncFinally, (JSGlobalObject* globalObject,
     }
 
     auto* promise = jsDynamicCast<JSPromise*>(thisValue);
-    if (promise && promise->isThenFastAndNonObservable() && promiseSpeciesWatchpointIsValid(vm, promise)) [[likely]] {
+    if (promise && promise->isThenFastAndNonObservable() && promiseSpeciesWatchpointIsValid(promise)) [[likely]] {
         JSPromise* resultPromise = JSPromise::create(vm, globalObject->promiseStructure());
         auto* context = JSPromiseCombinatorsGlobalContext::create(vm, resultPromise, onFinally, jsUndefined());
         promise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::PromiseFinallyReactionJob, resultPromise, context);

--- a/Source/JavaScriptCore/runtime/JSPromisePrototype.h
+++ b/Source/JavaScriptCore/runtime/JSPromisePrototype.h
@@ -57,7 +57,7 @@ private:
     void addOwnInternalSlots(VM&, JSGlobalObject*);
 };
 
-bool promiseSpeciesWatchpointIsValid(VM&, JSPromise*);
+bool promiseSpeciesWatchpointIsValid(JSPromise*);
 JSC_DECLARE_HOST_FUNCTION(promiseProtoFuncThen);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/StructureInlines.h
+++ b/Source/JavaScriptCore/runtime/StructureInlines.h
@@ -525,7 +525,7 @@ inline PropertyOffset Structure::add(VM& vm, PropertyName propertyName, unsigned
     }
     if (propertyName == vm.propertyNames->underscoreProto)
         setHasUnderscoreProtoPropertyExcludingOriginalProto(true);
-    else if (propertyName == vm.propertyNames->then || propertyName == vm.propertyNames->iteratorSymbol)
+    else if (propertyName == vm.propertyNames->then || propertyName == vm.propertyNames->iteratorSymbol || propertyName == vm.propertyNames->constructor)
         setHasSpecialProperties(true);
 
     auto rep = propertyName.uid();
@@ -685,7 +685,7 @@ ALWAYS_INLINE auto Structure::addOrReplacePropertyWithoutTransition(VM& vm, Prop
     }
     if (propertyName == vm.propertyNames->underscoreProto)
         setHasUnderscoreProtoPropertyExcludingOriginalProto(true);
-    else if (propertyName == vm.propertyNames->then || propertyName == vm.propertyNames->iteratorSymbol)
+    else if (propertyName == vm.propertyNames->then || propertyName == vm.propertyNames->iteratorSymbol || propertyName == vm.propertyNames->constructor)
         setHasSpecialProperties(true);
 
     PropertyOffset newOffset = table->nextOffset(m_inlineCapacity);


### PR DESCRIPTION
#### bbf8d344a5bb20d7b13bc2cd7c4fa1c16ce17c01
<pre>
[JSC] Use `hasSpecialProperties` bit for cheking `constructor` properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=305801">https://bugs.webkit.org/show_bug.cgi?id=305801</a>

Reviewed by Yusuke Suzuki.

This patch changes to use `hasSpecialProperties` bit for cheking `constructor` properties.

* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/ArrayPrototypeInlines.h:
(JSC::arraySpeciesWatchpointIsValid):
* Source/JavaScriptCore/runtime/JSMicrotask.cpp:
(JSC::runInternalMicrotask):
* Source/JavaScriptCore/runtime/JSPromise.cpp:
(JSC::JSPromise::resolveWithInternalMicrotaskForAsyncAwait):
(JSC::promiseSpeciesConstructor):
(JSC::JSPromise::then):
(JSC::JSPromise::promiseResolve):
* Source/JavaScriptCore/runtime/JSPromisePrototype.cpp:
(JSC::promiseSpeciesWatchpointIsValid):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSPromisePrototype.h:
* Source/JavaScriptCore/runtime/StructureInlines.h:
(JSC::Structure::add):
(JSC::Structure::addOrReplacePropertyWithoutTransition):

Canonical link: <a href="https://commits.webkit.org/305848@main">https://commits.webkit.org/305848@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/920d14d898633fba86cbd78f98b7f75ea88c35b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139600 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11976 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1104 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147732 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92668 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12684 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12126 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106896 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/77822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142547 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9739 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125034 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87758 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9377 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6946 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8026 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/131573 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118648 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1032 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150514 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/396 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11660 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1060 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115298 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11674 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9977 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115609 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29365 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10252 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121487 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66666 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11705 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/976 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/170872 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11441 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75383 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/44455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11640 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11491 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->