### PR TITLE
Address some unsafe cast warnings in Source/WebCore/rendering

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -31,8 +31,6 @@ loader/cache/CachedResourceClientWalker.h
 [ iOS ] platform/ios/wak/WAKWindow.mm
 rendering/BidiRun.cpp
 rendering/BidiRun.h
-rendering/RenderAncestorIterator.h
-rendering/RenderIterator.h
 rendering/RenderMultiColumnSet.h
 rendering/cocoa/RenderThemeCocoa.mm
 rendering/svg/RenderSVGResourcePattern.cpp

--- a/Source/WebCore/rendering/RenderAncestorIterator.h
+++ b/Source/WebCore/rendering/RenderAncestorIterator.h
@@ -185,16 +185,16 @@ inline RenderAncestorConstIteratorAdapter<T> ancestorsOfType(const RenderObject&
 template <typename T>
 inline RenderAncestorIteratorAdapter<T> lineageOfType(RenderObject& first)
 {
-    if (isRendererOfType<T>(first))
-        return RenderAncestorIteratorAdapter<T>(static_cast<T*>(&first));
+    if (auto* casted = dynamicDowncast<T>(first))
+        return RenderAncestorIteratorAdapter<T>(casted);
     return ancestorsOfType<T>(first);
 }
 
 template <typename T>
 inline RenderAncestorConstIteratorAdapter<T> lineageOfType(const RenderObject& first)
 {
-    if (isRendererOfType<T>(first))
-        return RenderAncestorConstIteratorAdapter<T>(static_cast<const T*>(&first));
+    if (auto* casted = dynamicDowncast<T>(first))
+        return RenderAncestorConstIteratorAdapter<T>(casted);
     return ancestorsOfType<T>(first);
 }
 


### PR DESCRIPTION
#### 4e2b3cb0dd7dd93c3e2ef9b3d1a55e7d307fad04
<pre>
Address some unsafe cast warnings in Source/WebCore/rendering
<a href="https://bugs.webkit.org/show_bug.cgi?id=305802">https://bugs.webkit.org/show_bug.cgi?id=305802</a>

Reviewed by Alan Baradlay.

* Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WebCore/rendering/RenderAncestorIterator.h:
(WebCore::lineageOfType):
* Source/WebCore/rendering/RenderIterator.h:
(WebCore::RenderTraversal::firstChild):
(WebCore::RenderTraversal::lastChild):
(WebCore::RenderTraversal::nextSibling):
(WebCore::RenderTraversal::previousSibling):
(WebCore::RenderTraversal::findAncestorOfType):
(WebCore::RenderTraversal::firstWithin):
(WebCore::RenderTraversal::next):
(WebCore::RenderPostOrderTraversal::firstWithin):
(WebCore::RenderPostOrderTraversal::next):
(WebCore::isRendererOfType): Deleted.

Canonical link: <a href="https://commits.webkit.org/305849@main">https://commits.webkit.org/305849@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21e072c71b07c54a6307fc00295a8a4d5fd7a78a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139621 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11997 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1125 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147754 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/78a2a1e6-59cb-4f43-8f72-9e97181eb339) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141494 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12705 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12147 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/106909 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4e21f833-430c-4e86-8a4c-285829d05688) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142568 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/9757 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125051 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87771 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/890a8f87-863e-45e4-aeed-4359d8086292) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9398 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6963 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8047 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118662 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1049 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150535 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11682 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1082 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/115309 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11695 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9997 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115620 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/29362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10284 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121508 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/66687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21533 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11726 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11464 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75404 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11661 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11512 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->