### PR TITLE
[iOS] GPU process is exiting early when ASAN is enabled

### DIFF
--- a/Source/WebKit/Shared/Sandbox/iOS/gpu-defines.sb
+++ b/Source/WebKit/Shared/Sandbox/iOS/gpu-defines.sb
@@ -410,12 +410,11 @@
         vm_remap_external))
 
 (define (syscall-mig-allowed)
-#if ASAN_ENABLED
-    (kernel-mig-routine
-        mach_vm_region_recurse
-        task_set_exc_guard_behavior)
-#endif
      (kernel-mig-routine
+#if ASAN_ENABLED
+        mach_vm_region_recurse
+        task_set_exc_guard_behavior
+#endif
         _mach_make_memory_entry
         clock_get_time
         host_get_clock_service


### PR DESCRIPTION
#### d456e93c47e74bee118818704c888fa6a3b13164
<pre>
[iOS] GPU process is exiting early when ASAN is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=305804">https://bugs.webkit.org/show_bug.cgi?id=305804</a>
<a href="https://rdar.apple.com/168470556">rdar://168470556</a>

Reviewed by Sihui Liu.

GPU process is exiting early when ASAN is enabled on iOS due to a syscall issue in the sandbox.

* Source/WebKit/Shared/Sandbox/iOS/gpu-defines.sb:

Canonical link: <a href="https://commits.webkit.org/305880@main">https://commits.webkit.org/305880@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e356856cb99c47e4c6e084aa1b61055bc51615b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139605 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/11981 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1109 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147737 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92673 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/20cacf4e-9386-4fe8-b1df-3d2493289dce) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12689 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12131 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106893 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77825 "1 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f8b199b9-2c17-4306-99a7-07a5cea28531) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142552 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9737 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125042 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87756 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/944c9717-fcf4-4bd4-8c75-aea0d0ed3689) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9375 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6951 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8031 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118646 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150519 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11665 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1069 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115296 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11679 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/9982 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115607 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10248 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121495 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66671 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21548 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11710 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/984 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11446 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75388 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11645 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11496 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->