### PR TITLE
Address some unsafe cast warnings in Source/WebCore/svg

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -36,7 +36,6 @@ rendering/cocoa/RenderThemeCocoa.mm
 rendering/svg/RenderSVGResourcePattern.cpp
 rendering/svg/SVGRenderTreeAsText.cpp
 rendering/svg/SVGTextQuery.cpp
-svg/SVGPathSegListSource.cpp
 svg/properties/SVGAnimatedDecoratedProperty.h
 svg/properties/SVGAnimatedPrimitiveProperty.h
 svg/properties/SVGAnimatedPropertyAccessorImpl.h

--- a/Source/WebCore/svg/SVGPathSegImpl.h
+++ b/Source/WebCore/svg/SVGPathSegImpl.h
@@ -81,41 +81,41 @@ private:
     Ref<SVGPathSeg> clone() const final { return SVGPathSegValue::cloneInternal<SVGPathSegLinetoVerticalRel>(); }
 };
 
-class SVGPathSegMovetoAbs final : public SVGPathSegSingleCoordinate {
+class SVGPathSegMovetoAbs final : public SVGPathSegMoveto {
 public:
     static constexpr auto create = SVGPathSegValue::create<SVGPathSegMovetoAbs>;
 private:
-    using SVGPathSegSingleCoordinate::SVGPathSegSingleCoordinate;
+    using SVGPathSegMoveto::SVGPathSegMoveto;
     SVGPathSegType pathSegType() const final { return SVGPathSegType::MoveToAbs; }
     String pathSegTypeAsLetter() const final { return "M"_s; }
     Ref<SVGPathSeg> clone() const final { return SVGPathSegValue::cloneInternal<SVGPathSegMovetoAbs>(); }
 };
 
-class SVGPathSegMovetoRel final : public SVGPathSegSingleCoordinate {
+class SVGPathSegMovetoRel final : public SVGPathSegMoveto {
 public:
     static constexpr auto create = SVGPathSegValue::create<SVGPathSegMovetoRel>;
 private:
-    using SVGPathSegSingleCoordinate::SVGPathSegSingleCoordinate;
+    using SVGPathSegMoveto::SVGPathSegMoveto;
     SVGPathSegType pathSegType() const final { return SVGPathSegType::MoveToRel; }
     String pathSegTypeAsLetter() const final { return "m"_s; }
     Ref<SVGPathSeg> clone() const final { return SVGPathSegValue::cloneInternal<SVGPathSegMovetoRel>(); }
 };
 
-class SVGPathSegLinetoAbs final : public SVGPathSegSingleCoordinate {
+class SVGPathSegLinetoAbs final : public SVGPathSegLineto {
 public:
     static constexpr auto create = SVGPathSegValue::create<SVGPathSegLinetoAbs>;
 private:
-    using SVGPathSegSingleCoordinate::SVGPathSegSingleCoordinate;
+    using SVGPathSegLineto::SVGPathSegLineto;
     SVGPathSegType pathSegType() const final { return SVGPathSegType::LineToAbs; }
     String pathSegTypeAsLetter() const final { return "L"_s; }
     Ref<SVGPathSeg> clone() const final { return SVGPathSegValue::cloneInternal<SVGPathSegLinetoAbs>(); }
 };
 
-class SVGPathSegLinetoRel final : public SVGPathSegSingleCoordinate {
+class SVGPathSegLinetoRel final : public SVGPathSegLineto {
 public:
     static constexpr auto create = SVGPathSegValue::create<SVGPathSegLinetoRel>;
 private:
-    using SVGPathSegSingleCoordinate::SVGPathSegSingleCoordinate;
+    using SVGPathSegLineto::SVGPathSegLineto;
     SVGPathSegType pathSegType() const final { return SVGPathSegType::LineToRel; }
     String pathSegTypeAsLetter() const final { return "l"_s; }
     Ref<SVGPathSeg> clone() const final { return SVGPathSegValue::cloneInternal<SVGPathSegLinetoRel>(); }
@@ -181,21 +181,21 @@ private:
     Ref<SVGPathSeg> clone() const final { return SVGPathSegValue::cloneInternal<SVGPathSegArcRel>(); }
 };
 
-class SVGPathSegCurvetoQuadraticSmoothAbs final : public SVGPathSegSingleCoordinate {
+class SVGPathSegCurvetoQuadraticSmoothAbs final : public SVGPathSegCurvetoQuadraticSmooth {
 public:
     static constexpr auto create = SVGPathSegValue::create<SVGPathSegCurvetoQuadraticSmoothAbs>;
 private:
-    using SVGPathSegSingleCoordinate::SVGPathSegSingleCoordinate;
+    using SVGPathSegCurvetoQuadraticSmooth::SVGPathSegCurvetoQuadraticSmooth;
     SVGPathSegType pathSegType() const final { return SVGPathSegType::CurveToQuadraticSmoothAbs; }
     String pathSegTypeAsLetter() const final { return "T"_s; }
     Ref<SVGPathSeg> clone() const final { return SVGPathSegValue::cloneInternal<SVGPathSegCurvetoQuadraticSmoothAbs>(); }
 };
 
-class SVGPathSegCurvetoQuadraticSmoothRel final : public SVGPathSegSingleCoordinate {
+class SVGPathSegCurvetoQuadraticSmoothRel final : public SVGPathSegCurvetoQuadraticSmooth {
 public:
     static constexpr auto create = SVGPathSegValue::create<SVGPathSegCurvetoQuadraticSmoothRel>;
 private:
-    using SVGPathSegSingleCoordinate::SVGPathSegSingleCoordinate;
+    using SVGPathSegCurvetoQuadraticSmooth::SVGPathSegCurvetoQuadraticSmooth;
     SVGPathSegType pathSegType() const final { return SVGPathSegType::CurveToQuadraticSmoothRel; }
     String pathSegTypeAsLetter() const final { return "t"_s; }
     Ref<SVGPathSeg> clone() const final { return SVGPathSegValue::cloneInternal<SVGPathSegCurvetoQuadraticSmoothRel>(); }

--- a/Source/WebCore/svg/SVGPathSegListSource.cpp
+++ b/Source/WebCore/svg/SVGPathSegListSource.cpp
@@ -56,8 +56,7 @@ std::optional<SVGPathSegType> SVGPathSegListSource::parseSVGSegmentType()
 std::optional<SVGPathSource::MoveToSegment> SVGPathSegListSource::parseMoveToSegment(FloatPoint)
 {
     ASSERT(m_segment);
-    ASSERT(m_segment->pathSegType() == SVGPathSegType::MoveToAbs || m_segment->pathSegType() == SVGPathSegType::MoveToRel);
-    RefPtr moveTo = static_cast<SVGPathSegSingleCoordinate*>(m_segment.get());
+    RefPtr moveTo = downcast<SVGPathSegMoveto>(m_segment.get());
 
     MoveToSegment segment;
     segment.targetPoint = FloatPoint(moveTo->x(), moveTo->y());
@@ -67,9 +66,8 @@ std::optional<SVGPathSource::MoveToSegment> SVGPathSegListSource::parseMoveToSeg
 std::optional<SVGPathSource::LineToSegment> SVGPathSegListSource::parseLineToSegment(FloatPoint)
 {
     ASSERT(m_segment);
-    ASSERT(m_segment->pathSegType() == SVGPathSegType::LineToAbs || m_segment->pathSegType() == SVGPathSegType::LineToRel);
-    RefPtr lineTo = static_cast<SVGPathSegSingleCoordinate*>(m_segment.get());
-    
+    RefPtr lineTo = downcast<SVGPathSegLineto>(m_segment.get());
+
     LineToSegment segment;
     segment.targetPoint = FloatPoint(lineTo->x(), lineTo->y());
     return segment;
@@ -78,8 +76,7 @@ std::optional<SVGPathSource::LineToSegment> SVGPathSegListSource::parseLineToSeg
 std::optional<SVGPathSource::LineToHorizontalSegment> SVGPathSegListSource::parseLineToHorizontalSegment(FloatPoint)
 {
     ASSERT(m_segment);
-    ASSERT(m_segment->pathSegType() == SVGPathSegType::LineToHorizontalAbs || m_segment->pathSegType() == SVGPathSegType::LineToHorizontalRel);
-    RefPtr horizontal = static_cast<SVGPathSegLinetoHorizontal*>(m_segment.get());
+    RefPtr horizontal = downcast<SVGPathSegLinetoHorizontal>(m_segment.get());
     
     LineToHorizontalSegment segment;
     segment.x = horizontal->x();
@@ -89,8 +86,7 @@ std::optional<SVGPathSource::LineToHorizontalSegment> SVGPathSegListSource::pars
 std::optional<SVGPathSource::LineToVerticalSegment> SVGPathSegListSource::parseLineToVerticalSegment(FloatPoint)
 {
     ASSERT(m_segment);
-    ASSERT(m_segment->pathSegType() == SVGPathSegType::LineToVerticalAbs || m_segment->pathSegType() == SVGPathSegType::LineToVerticalRel);
-    RefPtr vertical = static_cast<SVGPathSegLinetoVertical*>(m_segment.get());
+    RefPtr vertical = downcast<SVGPathSegLinetoVertical>(m_segment.get());
     
     LineToVerticalSegment segment;
     segment.y = vertical->y();
@@ -100,9 +96,8 @@ std::optional<SVGPathSource::LineToVerticalSegment> SVGPathSegListSource::parseL
 std::optional<SVGPathSource::CurveToCubicSegment> SVGPathSegListSource::parseCurveToCubicSegment(FloatPoint)
 {
     ASSERT(m_segment);
-    ASSERT(m_segment->pathSegType() == SVGPathSegType::CurveToCubicAbs || m_segment->pathSegType() == SVGPathSegType::CurveToCubicRel);
-    RefPtr cubic = static_cast<SVGPathSegCurvetoCubic*>(m_segment.get());
-    
+    RefPtr cubic = downcast<SVGPathSegCurvetoCubic>(m_segment.get());
+
     CurveToCubicSegment segment;
     segment.point1 = FloatPoint(cubic->x1(), cubic->y1());
     segment.point2 = FloatPoint(cubic->x2(), cubic->y2());
@@ -113,9 +108,8 @@ std::optional<SVGPathSource::CurveToCubicSegment> SVGPathSegListSource::parseCur
 std::optional<SVGPathSource::CurveToCubicSmoothSegment> SVGPathSegListSource::parseCurveToCubicSmoothSegment(FloatPoint)
 {
     ASSERT(m_segment);
-    ASSERT(m_segment->pathSegType() == SVGPathSegType::CurveToCubicSmoothAbs || m_segment->pathSegType() == SVGPathSegType::CurveToCubicSmoothRel);
-    RefPtr cubicSmooth = static_cast<SVGPathSegCurvetoCubicSmooth*>(m_segment.get());
-    
+    RefPtr cubicSmooth = downcast<SVGPathSegCurvetoCubicSmooth>(m_segment.get());
+
     CurveToCubicSmoothSegment segment;
     segment.point2 = FloatPoint(cubicSmooth->x2(), cubicSmooth->y2());
     segment.targetPoint = FloatPoint(cubicSmooth->x(), cubicSmooth->y());
@@ -125,9 +119,8 @@ std::optional<SVGPathSource::CurveToCubicSmoothSegment> SVGPathSegListSource::pa
 std::optional<SVGPathSource::CurveToQuadraticSegment> SVGPathSegListSource::parseCurveToQuadraticSegment(FloatPoint)
 {
     ASSERT(m_segment);
-    ASSERT(m_segment->pathSegType() == SVGPathSegType::CurveToQuadraticAbs || m_segment->pathSegType() == SVGPathSegType::CurveToQuadraticRel);
-    RefPtr quadratic = static_cast<SVGPathSegCurvetoQuadratic*>(m_segment.get());
-    
+    RefPtr quadratic = downcast<SVGPathSegCurvetoQuadratic>(m_segment.get());
+
     CurveToQuadraticSegment segment;
     segment.point1 = FloatPoint(quadratic->x1(), quadratic->y1());
     segment.targetPoint = FloatPoint(quadratic->x(), quadratic->y());
@@ -137,9 +130,8 @@ std::optional<SVGPathSource::CurveToQuadraticSegment> SVGPathSegListSource::pars
 std::optional<SVGPathSource::CurveToQuadraticSmoothSegment> SVGPathSegListSource::parseCurveToQuadraticSmoothSegment(FloatPoint)
 {
     ASSERT(m_segment);
-    ASSERT(m_segment->pathSegType() == SVGPathSegType::CurveToQuadraticSmoothAbs || m_segment->pathSegType() == SVGPathSegType::CurveToQuadraticSmoothRel);
-    RefPtr quadraticSmooth = static_cast<SVGPathSegSingleCoordinate*>(m_segment.get());
-    
+    RefPtr quadraticSmooth = downcast<SVGPathSegCurvetoQuadraticSmooth>(m_segment.get());
+
     CurveToQuadraticSmoothSegment segment;
     segment.targetPoint = FloatPoint(quadraticSmooth->x(), quadraticSmooth->y());
     return segment;
@@ -148,9 +140,8 @@ std::optional<SVGPathSource::CurveToQuadraticSmoothSegment> SVGPathSegListSource
 std::optional<SVGPathSource::ArcToSegment> SVGPathSegListSource::parseArcToSegment(FloatPoint)
 {
     ASSERT(m_segment);
-    ASSERT(m_segment->pathSegType() == SVGPathSegType::ArcAbs || m_segment->pathSegType() == SVGPathSegType::ArcRel);
-    RefPtr arcTo = static_cast<SVGPathSegArc*>(m_segment.get());
-    
+    RefPtr arcTo = downcast<SVGPathSegArc>(m_segment.get());
+
     ArcToSegment segment;
     segment.rx = arcTo->r1();
     segment.ry = arcTo->r2();

--- a/Source/WebCore/svg/SVGPathSegValue.h
+++ b/Source/WebCore/svg/SVGPathSegValue.h
@@ -101,6 +101,21 @@ private:
     using SVGPathSegValue::SVGPathSegValue;
 };
 
+class SVGPathSegMoveto : public SVGPathSegSingleCoordinate {
+protected:
+    using SVGPathSegSingleCoordinate::SVGPathSegSingleCoordinate;
+};
+
+class SVGPathSegLineto : public SVGPathSegSingleCoordinate {
+protected:
+    using SVGPathSegSingleCoordinate::SVGPathSegSingleCoordinate;
+};
+
+class SVGPathSegCurvetoQuadraticSmooth : public SVGPathSegSingleCoordinate {
+protected:
+    using SVGPathSegSingleCoordinate::SVGPathSegSingleCoordinate;
+};
+
 class SVGPathSegCurvetoQuadratic : public SVGPathSegValue<float, float, float, float> {
 public:
     float x() const { return argument<0>(); }
@@ -189,3 +204,75 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SVGPathSegLinetoHorizontal)
+static bool isType(const WebCore::SVGPathSeg& object)
+{
+    auto type = object.pathSegType();
+    return type == WebCore::SVGPathSegType::LineToHorizontalAbs || type == WebCore::SVGPathSegType::LineToHorizontalRel;
+}
+SPECIALIZE_TYPE_TRAITS_END()
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SVGPathSegLinetoVertical)
+static bool isType(const WebCore::SVGPathSeg& object)
+{
+    auto type = object.pathSegType();
+    return type == WebCore::SVGPathSegType::LineToVerticalAbs || type == WebCore::SVGPathSegType::LineToVerticalRel;
+}
+SPECIALIZE_TYPE_TRAITS_END()
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SVGPathSegMoveto)
+static bool isType(const WebCore::SVGPathSeg& object)
+{
+    auto type = object.pathSegType();
+    return type == WebCore::SVGPathSegType::MoveToAbs || type == WebCore::SVGPathSegType::MoveToRel;
+}
+SPECIALIZE_TYPE_TRAITS_END()
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SVGPathSegLineto)
+static bool isType(const WebCore::SVGPathSeg& object)
+{
+    auto type = object.pathSegType();
+    return type == WebCore::SVGPathSegType::LineToAbs || type == WebCore::SVGPathSegType::LineToRel;
+}
+SPECIALIZE_TYPE_TRAITS_END()
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SVGPathSegCurvetoQuadraticSmooth)
+static bool isType(const WebCore::SVGPathSeg& object)
+{
+    auto type = object.pathSegType();
+    return type == WebCore::SVGPathSegType::CurveToQuadraticSmoothAbs || type == WebCore::SVGPathSegType::CurveToQuadraticSmoothRel;
+}
+SPECIALIZE_TYPE_TRAITS_END()
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SVGPathSegCurvetoQuadratic)
+static bool isType(const WebCore::SVGPathSeg& object)
+{
+    auto type = object.pathSegType();
+    return type == WebCore::SVGPathSegType::CurveToQuadraticAbs || type == WebCore::SVGPathSegType::CurveToQuadraticRel;
+}
+SPECIALIZE_TYPE_TRAITS_END()
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SVGPathSegCurvetoCubicSmooth)
+static bool isType(const WebCore::SVGPathSeg& object)
+{
+    auto type = object.pathSegType();
+    return type == WebCore::SVGPathSegType::CurveToCubicSmoothAbs || type == WebCore::SVGPathSegType::CurveToCubicSmoothRel;
+}
+SPECIALIZE_TYPE_TRAITS_END()
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SVGPathSegCurvetoCubic)
+static bool isType(const WebCore::SVGPathSeg& object)
+{
+    auto type = object.pathSegType();
+    return type == WebCore::SVGPathSegType::CurveToCubicAbs || type == WebCore::SVGPathSegType::CurveToCubicRel;
+}
+SPECIALIZE_TYPE_TRAITS_END()
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SVGPathSegArc)
+static bool isType(const WebCore::SVGPathSeg& object)
+{
+    auto type = object.pathSegType();
+    return type == WebCore::SVGPathSegType::ArcAbs || type == WebCore::SVGPathSegType::ArcRel;
+}
+SPECIALIZE_TYPE_TRAITS_END()


### PR DESCRIPTION
#### 8123c8a002e5d154d0781ce560e90742ad7d78d5
<pre>
Address some unsafe cast warnings in Source/WebCore/svg
<a href="https://bugs.webkit.org/show_bug.cgi?id=305805">https://bugs.webkit.org/show_bug.cgi?id=305805</a>

Reviewed by Anne van Kesteren.

* Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WebCore/svg/SVGPathSegImpl.h:
* Source/WebCore/svg/SVGPathSegListSource.cpp:
(WebCore::SVGPathSegListSource::parseMoveToSegment):
(WebCore::SVGPathSegListSource::parseLineToSegment):
(WebCore::SVGPathSegListSource::parseLineToHorizontalSegment):
(WebCore::SVGPathSegListSource::parseLineToVerticalSegment):
(WebCore::SVGPathSegListSource::parseCurveToCubicSegment):
(WebCore::SVGPathSegListSource::parseCurveToCubicSmoothSegment):
(WebCore::SVGPathSegListSource::parseCurveToQuadraticSegment):
(WebCore::SVGPathSegListSource::parseCurveToQuadraticSmoothSegment):
(WebCore::SVGPathSegListSource::parseArcToSegment):
* Source/WebCore/svg/SVGPathSegValue.h:
(isType):

Canonical link: <a href="https://commits.webkit.org/305857@main">https://commits.webkit.org/305857@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bfc3789f585de7c686592d933826caa775a3c52f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139637 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12013 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1141 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147771 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b5fd5b7d-1a35-4269-af73-807ef76c5f03) 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/141684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12721 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12163 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106924 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142584 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9772 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125065 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87786 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1852899e-6120-49c4-b7b0-9c086d5242ee) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9415 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/6972 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8063 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118673 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1063 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150553 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11698 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1099 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/115327 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11711 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10012 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115638 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29369 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/10324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121525 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/66703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11742 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1010 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11480 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75420 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/11677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11528 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->