### PR TITLE
Address some unsafe cast warnings in Source/WebCore/layout

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -10,8 +10,6 @@ domjit/DOMJITHelpers.h
 domjit/JSDocumentDOMJIT.cpp
 domjit/JSNodeDOMJIT.cpp
 html/InputType.cpp
-layout/layouttree/LayoutIterator.h
-layout/layouttree/LayoutTreeBuilder.cpp
 loader/cache/CachedResourceClientWalker.h
 [ iOS ] platform/cocoa/WebAVPlayerLayerView.mm
 [ iOS ] platform/ios/VideoPresentationInterfaceAVKitLegacy.mm

--- a/Source/WebCore/html/HTMLTableColElement.h
+++ b/Source/WebCore/html/HTMLTableColElement.h
@@ -51,4 +51,13 @@ private:
     unsigned m_span;
 };
 
-} //namespace
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::HTMLTableColElement)
+    static bool isType(const WebCore::HTMLElement& element) { return element.hasTagName(WebCore::HTMLNames::colTag) || element.hasTagName(WebCore::HTMLNames::colgroupTag); }
+    static bool isType(const WebCore::Node& node)
+    {
+        auto* htmlElement = dynamicDowncast<WebCore::HTMLElement>(node);
+        return htmlElement && isType(*htmlElement);
+    }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/layout/layouttree/LayoutIterator.h
+++ b/Source/WebCore/layout/layouttree/LayoutIterator.h
@@ -52,10 +52,6 @@ private:
     const T* m_current;
 };
 
-// Similar to WTF::is<>() but without the static_assert() making sure the check is necessary.
-template <typename T, typename U>
-inline bool isLayoutBoxOfType(const U& layoutBox) { return TypeCastTraits<const T, const U>::isOfType(layoutBox); }
-
 namespace LayoutBoxTraversal {
 
 template <typename U>
@@ -116,46 +112,66 @@ namespace Traversal {
 template <typename T, typename U>
 inline const T* firstChild(U& current)
 {
-    auto* object = LayoutBoxTraversal::firstChild(current);
-    while (object && !isLayoutBoxOfType<T>(*object))
-        object = object->nextSibling();
-    return static_cast<const T*>(object);
+    if constexpr(std::same_as<T, Box>)
+        return LayoutBoxTraversal::firstChild(current);
+    else {
+        auto* object = LayoutBoxTraversal::firstChild(current);
+        while (object && !is<T>(*object))
+            object = object->nextSibling();
+        return uncheckedDowncast<T>(object);
+    }
 }
 
 template <typename T>
 inline const T* nextSibling(const T& current)
 {
-    auto* object = current.nextSibling();
-    while (object && !isLayoutBoxOfType<T>(*object))
-        object = object->nextSibling();
-    return static_cast<const T*>(object);
+    if constexpr(std::same_as<T, Box>)
+        return current.nextSibling();
+    else {
+        auto* object = current.nextSibling();
+        while (object && !is<T>(*object))
+            object = object->nextSibling();
+        return uncheckedDowncast<T>(object);
+    }
 }
 
 template <typename T, typename U>
 inline const T* firstWithin(const U& stayWithin)
 {
-    auto* descendant = LayoutBoxTraversal::firstChild(stayWithin);
-    while (descendant && !isLayoutBoxOfType<T>(*descendant))
-        descendant = LayoutBoxTraversal::next(*descendant, stayWithin);
-    return static_cast<const T*>(descendant);
+    if constexpr(std::same_as<T, Box>)
+        return LayoutBoxTraversal::firstChild(stayWithin);
+    else {
+        auto* descendant = LayoutBoxTraversal::firstChild(stayWithin);
+        while (descendant && !is<T>(*descendant))
+            descendant = LayoutBoxTraversal::next(*descendant, stayWithin);
+        return uncheckedDowncast<T>(descendant);
+    }
 }
 
 template <typename T, typename U>
 inline const T* next(const U& current, const ElementBox& stayWithin)
 {
-    auto* descendant = LayoutBoxTraversal::next(current, stayWithin);
-    while (descendant && !isLayoutBoxOfType<T>(*descendant))
-        descendant = LayoutBoxTraversal::next(*descendant, stayWithin);
-    return static_cast<const T*>(descendant);
+    if constexpr(std::same_as<T, Box>)
+        return LayoutBoxTraversal::next(current, stayWithin);
+    else {
+        auto* descendant = LayoutBoxTraversal::next(current, stayWithin);
+        while (descendant && !is<T>(*descendant))
+            descendant = LayoutBoxTraversal::next(*descendant, stayWithin);
+        return uncheckedDowncast<T>(descendant);
+    }
 }
 
 template <typename T, typename U>
 inline const T* nextSkippingChildren(const U& current, const ElementBox& stayWithin)
 {
-    auto* descendant = LayoutBoxTraversal::nextSkippingChildren(current, stayWithin);
-    while (descendant && !isLayoutBoxOfType<T>(*descendant))
-        descendant = LayoutBoxTraversal::nextSkippingChildren(*descendant, stayWithin);
-    return static_cast<const T*>(descendant);
+    if constexpr(std::same_as<T, Box>)
+        return LayoutBoxTraversal::nextSkippingChildren(current, stayWithin);
+    else {
+        auto* descendant = LayoutBoxTraversal::nextSkippingChildren(current, stayWithin);
+        while (descendant && !is<T>(*descendant))
+            descendant = LayoutBoxTraversal::nextSkippingChildren(*descendant, stayWithin);
+        return uncheckedDowncast<T>(descendant);
+    }
 }
 
 }

--- a/Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp
@@ -251,7 +251,7 @@ std::unique_ptr<Box> TreeBuilder::createLayoutBox(const ElementBox& parentContai
                 childLayoutBox = createContainer(elementAttributes(renderer), WTF::move(clonedStyle));
             } else if (displayType == DisplayType::TableColumn) {
                 childLayoutBox = createContainer(elementAttributes(renderer), WTF::move(clonedStyle));
-                auto& tableColElement = static_cast<HTMLTableColElement&>(*renderer.element());
+                auto& tableColElement = downcast<HTMLTableColElement>(*renderer.element());
                 auto columnWidth = tableColElement.width();
                 if (!columnWidth.isEmpty())
                     childLayoutBox->setColumnWidth(parseHTMLInteger(columnWidth).value_or(0));


### PR DESCRIPTION
#### 1d511d6cf0ce2f0ee360695270e341bf0f86b81d
<pre>
Address some unsafe cast warnings in Source/WebCore/layout
<a href="https://bugs.webkit.org/show_bug.cgi?id=305810">https://bugs.webkit.org/show_bug.cgi?id=305810</a>

Reviewed by Anne van Kesteren.

* Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WebCore/html/HTMLTableColElement.h:
(isType):
* Source/WebCore/layout/layouttree/LayoutIterator.h:
(WebCore::Layout::Traversal::firstChild):
(WebCore::Layout::Traversal::nextSibling):
(WebCore::Layout::Traversal::firstWithin):
(WebCore::Layout::Traversal::next):
(WebCore::Layout::Traversal::nextSkippingChildren):
(WebCore::Layout::isLayoutBoxOfType): Deleted.
* Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp:
(WebCore::Layout::TreeBuilder::createLayoutBox):

Canonical link: <a href="https://commits.webkit.org/305861@main">https://commits.webkit.org/305861@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50eaa6fad59cb1f5abc20eecc1d91a4dd020cf10

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139626 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12002 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1130 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147759 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b3df7610-57cf-46b5-8143-6d0232b23276) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141499 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12710 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12152 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106911 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f15a0135-7e98-4d23-bcb7-c9b58bf0daf3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142573 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9766 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125058 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87773 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8213086b-9b61-4004-86aa-edba07ce8e97) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9408 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6967 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8052 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118669 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1056 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150541 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11687 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1089 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115313 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11700 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10003 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115624 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29373 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10294 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121516 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66692 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11731 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1001 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11469 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75409 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11666 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11517 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->