### PR TITLE
Address more unsafe cast warnings in Source/WebCore/rendering

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -17,11 +17,8 @@ html/InputType.cpp
 [ iOS ] platform/ios/wak/WAKWindow.mm
 rendering/BidiRun.cpp
 rendering/BidiRun.h
-rendering/RenderMultiColumnSet.h
 rendering/cocoa/RenderThemeCocoa.mm
-rendering/svg/RenderSVGResourcePattern.cpp
 rendering/svg/SVGRenderTreeAsText.cpp
-rendering/svg/SVGTextQuery.cpp
 svg/properties/SVGAnimatedDecoratedProperty.h
 svg/properties/SVGAnimatedPrimitiveProperty.h
 svg/properties/SVGAnimatedPropertyAccessorImpl.h

--- a/Source/WebCore/rendering/RenderMultiColumnSet.h
+++ b/Source/WebCore/rendering/RenderMultiColumnSet.h
@@ -50,7 +50,7 @@ public:
     virtual ~RenderMultiColumnSet();
 
     RenderBlockFlow* multiColumnBlockFlow() const { return downcast<RenderBlockFlow>(parent()); }
-    RenderMultiColumnFlow* multiColumnFlow() const { return static_cast<RenderMultiColumnFlow*>(fragmentedFlow()); }
+    RenderMultiColumnFlow* multiColumnFlow() const { return downcast<RenderMultiColumnFlow>(fragmentedFlow()); }
 
     RenderMultiColumnSet* nextSiblingMultiColumnSet() const;
     RenderMultiColumnSet* previousSiblingMultiColumnSet() const;

--- a/Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp
@@ -177,7 +177,7 @@ bool RenderSVGResourcePattern::buildTileImageTransform(const RenderElement& rend
 
 RefPtr<ImageBuffer> RenderSVGResourcePattern::createTileImage(GraphicsContext& context, const PatternAttributes& attributes, const FloatSize& size, const FloatSize& scale, const AffineTransform& tileImageTransform) const
 {
-    CheckedPtr patternRenderer = static_cast<RenderSVGResourcePattern*>(attributes.patternContentElement()->renderer());
+    CheckedPtr patternRenderer = downcast<RenderSVGResourcePattern>(attributes.patternContentElement()->renderer());
     ASSERT(patternRenderer);
     ASSERT(patternRenderer->hasLayer());
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.h
@@ -106,4 +106,5 @@ private:
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::LegacyRenderSVGResourceClipper)
 static bool isType(const WebCore::RenderObject& renderer) { return renderer.isLegacyRenderSVGResourceClipper(); }
 static bool isType(const WebCore::LegacyRenderSVGResource& resource) { return resource.resourceType() == WebCore::ClipperResourceType; }
+static bool isType(const WebCore::LegacyRenderSVGResourceContainer& resource) { return resource.resourceType() == WebCore::ClipperResourceType; }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.h
@@ -104,4 +104,7 @@ Renderer* getRenderSVGResourceById(TreeScope& treeScope, const AtomString& id)
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(LegacyRenderSVGResourceContainer, isLegacyRenderSVGResourceContainer())
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::LegacyRenderSVGResourceContainer)
+    static bool isType(const WebCore::RenderObject& renderer) { return renderer.isLegacyRenderSVGResourceContainer(); }
+    static bool isType(const WebCore::LegacyRenderSVGResource& resource) { return resource.resourceType() != WebCore::SolidColorResourceType; }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.h
@@ -97,4 +97,5 @@ WTF::TextStream& operator<<(WTF::TextStream&, FilterData::FilterDataState);
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::LegacyRenderSVGResourceFilter)
     static bool isType(const WebCore::RenderObject& renderer) { return renderer.isLegacyRenderSVGResourceFilter(); }
     static bool isType(const WebCore::LegacyRenderSVGResource& resource) { return resource.resourceType() == WebCore::FilterResourceType; }
+    static bool isType(const WebCore::LegacyRenderSVGResourceContainer& resource) { return resource.resourceType() == WebCore::FilterResourceType; }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceLinearGradient.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceLinearGradient.h
@@ -57,4 +57,7 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_LEGACY_RENDER_SVG_RESOURCE(LegacyRenderSVGResourceLinearGradient, LinearGradientResourceType)
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::LegacyRenderSVGResourceLinearGradient)
+    static bool isType(const WebCore::LegacyRenderSVGResource& resource) { return resource.resourceType() == WebCore::LinearGradientResourceType; }
+    static bool isType(const WebCore::LegacyRenderSVGResourceContainer& resource) { return resource.resourceType() == WebCore::LinearGradientResourceType; }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarker.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarker.h
@@ -83,4 +83,5 @@ private:
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::LegacyRenderSVGResourceMarker)
 static bool isType(const WebCore::RenderObject& renderer) { return renderer.isLegacyRenderSVGResourceMarker(); }
 static bool isType(const WebCore::LegacyRenderSVGResource& resource) { return resource.resourceType() == WebCore::MarkerResourceType; }
+static bool isType(const WebCore::LegacyRenderSVGResourceContainer& resource) { return resource.resourceType() == WebCore::MarkerResourceType; }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.h
@@ -73,4 +73,7 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_LEGACY_RENDER_SVG_RESOURCE(LegacyRenderSVGResourceMasker, MaskerResourceType)
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::LegacyRenderSVGResourceMasker)
+    static bool isType(const WebCore::LegacyRenderSVGResource& resource) { return resource.resourceType() == WebCore::MaskerResourceType; }
+    static bool isType(const WebCore::LegacyRenderSVGResourceContainer& resource) { return resource.resourceType() == WebCore::MaskerResourceType; }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.h
@@ -78,4 +78,7 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_LEGACY_RENDER_SVG_RESOURCE(LegacyRenderSVGResourcePattern, PatternResourceType)
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::LegacyRenderSVGResourcePattern)
+    static bool isType(const WebCore::LegacyRenderSVGResource& resource) { return resource.resourceType() == WebCore::PatternResourceType; }
+    static bool isType(const WebCore::LegacyRenderSVGResourceContainer& resource) { return resource.resourceType() == WebCore::PatternResourceType; }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceRadialGradient.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceRadialGradient.h
@@ -59,4 +59,7 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_LEGACY_RENDER_SVG_RESOURCE(LegacyRenderSVGResourceRadialGradient, RadialGradientResourceType)
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::LegacyRenderSVGResourceRadialGradient)
+    static bool isType(const WebCore::LegacyRenderSVGResource& resource) { return resource.resourceType() == WebCore::RadialGradientResourceType; }
+    static bool isType(const WebCore::LegacyRenderSVGResourceContainer& resource) { return resource.resourceType() == WebCore::RadialGradientResourceType; }
+SPECIALIZE_TYPE_TRAITS_END()


### PR DESCRIPTION
#### 59868a4d261a430b92314701e3f5de61588c2666
<pre>
Address more unsafe cast warnings in Source/WebCore/rendering
<a href="https://bugs.webkit.org/show_bug.cgi?id=305815">https://bugs.webkit.org/show_bug.cgi?id=305815</a>

Reviewed by Anne van Kesteren.

* Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WebCore/rendering/RenderMultiColumnSet.h:
* Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp:
(WebCore::RenderSVGResourcePattern::createTileImage const):
* Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp:
(WebCore::writeSVGPaintingResource):
(WebCore::writeChildren):
(WebCore::writeSVGResourceContainer):
(WebCore::writeResources):
* Source/WebCore/rendering/svg/SVGTextQuery.cpp:
(WebCore::SVGTextQuery::Data::Data):
(WebCore::SVGTextQuery::numberOfCharacters const):
(WebCore::TextLengthData::TextLengthData):
(WebCore::SVGTextQuery::textLengthCallback const):
(WebCore::SubStringLengthData::SubStringLengthData):
(WebCore::SVGTextQuery::subStringLengthCallback const):
(WebCore::StartPositionOfCharacterData::StartPositionOfCharacterData):
(WebCore::SVGTextQuery::startPositionOfCharacterCallback const):
(WebCore::EndPositionOfCharacterData::EndPositionOfCharacterData):
(WebCore::SVGTextQuery::endPositionOfCharacterCallback const):
(WebCore::RotationOfCharacterData::RotationOfCharacterData):
(WebCore::SVGTextQuery::rotationOfCharacterCallback const):
(WebCore::ExtentOfCharacterData::ExtentOfCharacterData):
(WebCore::SVGTextQuery::extentOfCharacterCallback const):
(WebCore::CharacterNumberAtPositionData::CharacterNumberAtPositionData):
(WebCore::SVGTextQuery::characterNumberAtPositionCallback const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.h:
(isType):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.h:
(isType):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.h:
(isType):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceLinearGradient.h:
(isType):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarker.h:
(isType):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.h:
(isType):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.h:
(isType):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceRadialGradient.h:
(isType):

Canonical link: <a href="https://commits.webkit.org/305874@main">https://commits.webkit.org/305874@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2388a7a9686fe3b5d101eb0c079dfa1bf17d199

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/139652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12028 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1156 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147787 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92720 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9bc8a210-cd87-4bb1-bbe1-0cd2080b2779) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141525 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12737 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12178 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106935 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/77851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/29c0f54d-fbc8-49bf-8f60-6a1925b48e77) 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/142599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9787 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125079 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87797 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/afce8ab1-ee00-4070-a12c-c42bdc9f8ec0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9435 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6984 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8079 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118684 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1077 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150569 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11713 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1119 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115338 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11726 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10028 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 9 flakes") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115648 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29379 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10354 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121546 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66718 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11757 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1030 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11496 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75435 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11692 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11544 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->