### PR TITLE
Remove CSSBackgroundClipBorderAreaEnabled preference

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1074,20 +1074,6 @@ CSSAxisRelativePositionKeywordsEnabled:
     WebCore:
       default: true
 
-CSSBackgroundClipBorderAreaEnabled:
-  type: bool
-  status: stable
-  category: css
-  humanReadableName: "CSS background-clip: border-area"
-  humanReadableDescription: "Enable the border-area value for background-clip"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
-
 CSSColorLayersEnabled:
   type: bool
   category: css

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -2245,15 +2245,8 @@
                 "border-box",
                 "padding-box",
                 "content-box",
-                {
-                    "value": "border-area",
-                    "settings-flag": "cssBackgroundClipBorderAreaEnabled",
-                    "url": "https://drafts.csswg.org/css-backgrounds-4/#background-clip"
-                },
-                {
-                    "value": "text",
-                    "url": "https://drafts.csswg.org/css-backgrounds-4/#background-clip"
-                },
+                "border-area",
+                "text",
                 {
                     "value": "-webkit-text",
                     "status": "non-standard"
@@ -2271,7 +2264,7 @@
             },
             "specification": {
                 "category": "css-backgrounds",
-                "url": "https://drafts.csswg.org/css-backgrounds/#propdef-background-clip"
+                "url": "https://www.w3.org/TR/css-backgrounds-4/#background-clip"
             }
         },
         "background-color": {
@@ -14440,13 +14433,13 @@
             }
         },
         "<single-background-clip>": {
-            "grammar": "<box> | border-area@(settings-flag=cssBackgroundClipBorderAreaEnabled) | text | -webkit-text",
+            "grammar": "<box> | border-area | text | -webkit-text",
             "exported": true,
             "specification": {
                 "category": "css-backgrounds",
-                "url": "https://www.w3.org/TR/css-backgrounds-3/#background-clip"
+                "url": "https://www.w3.org/TR/css-backgrounds-4/#background-clip"
             },
-            "comment": "Out of spec. 'background-clip' is currently defined to '<box>#'."
+            "comment": "-webkit-text is non-standard."
         },
         "<single-background-origin>": {
             "grammar": "<box>",

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -101,7 +101,6 @@ CSSParserContext::CSSParserContext(const Settings& settings)
     , cssAppearanceBaseEnabled { settings.cssAppearanceBaseEnabled() }
     , cssPaintingAPIEnabled { settings.cssPaintingAPIEnabled() }
     , cssTextDecorationLineErrorValues { settings.cssTextDecorationLineErrorValues() }
-    , cssBackgroundClipBorderAreaEnabled { settings.cssBackgroundClipBorderAreaEnabled() }
     , cssWordBreakAutoPhraseEnabled { settings.cssWordBreakAutoPhraseEnabled() }
     , popoverAttributeEnabled { settings.popoverAttributeEnabled() }
     , sidewaysWritingModesEnabled { settings.sidewaysWritingModesEnabled() }
@@ -140,29 +139,28 @@ void add(Hasher& hasher, const CSSParserContext& context)
         | context.gridLanesEnabled                          << 6
         | context.cssAppearanceBaseEnabled                  << 7
         | context.cssPaintingAPIEnabled                     << 8
-        | context.cssBackgroundClipBorderAreaEnabled        << 9
-        | context.cssWordBreakAutoPhraseEnabled             << 10
-        | context.popoverAttributeEnabled                   << 11
-        | context.sidewaysWritingModesEnabled               << 12
-        | context.cssTextWrapPrettyEnabled                  << 13
-        | context.thumbAndTrackPseudoElementsEnabled        << 14
+        | context.cssWordBreakAutoPhraseEnabled             << 9
+        | context.popoverAttributeEnabled                   << 10
+        | context.sidewaysWritingModesEnabled               << 11
+        | context.cssTextWrapPrettyEnabled                  << 12
+        | context.thumbAndTrackPseudoElementsEnabled        << 13
 #if ENABLE(SERVICE_CONTROLS)
-        | context.imageControlsEnabled                      << 15
+        | context.imageControlsEnabled                      << 14
 #endif
-        | context.colorLayersEnabled                        << 16
-        | context.targetTextPseudoElementEnabled            << 17
-        | context.cssProgressFunctionEnabled                << 18
-        | context.cssRandomFunctionEnabled                  << 19
-        | context.cssTreeCountingFunctionsEnabled           << 20
-        | context.cssURLModifiersEnabled                    << 21
-        | context.cssURLIntegrityModifierEnabled            << 22
-        | context.cssAxisRelativePositionKeywordsEnabled    << 23
-        | context.cssDynamicRangeLimitMixEnabled            << 24
-        | context.cssConstrainedDynamicRangeLimitEnabled    << 25
-        | context.cssTextDecorationLineErrorValues          << 26
-        | context.cssTextTransformMathAutoEnabled           << 27
-        | context.cssInternalAutoBaseParsingEnabled         << 28
-        | context.cssMathDepthEnabled                       << 29;
+        | context.colorLayersEnabled                        << 15
+        | context.targetTextPseudoElementEnabled            << 16
+        | context.cssProgressFunctionEnabled                << 17
+        | context.cssRandomFunctionEnabled                  << 18
+        | context.cssTreeCountingFunctionsEnabled           << 19
+        | context.cssURLModifiersEnabled                    << 20
+        | context.cssURLIntegrityModifierEnabled            << 21
+        | context.cssAxisRelativePositionKeywordsEnabled    << 22
+        | context.cssDynamicRangeLimitMixEnabled            << 23
+        | context.cssConstrainedDynamicRangeLimitEnabled    << 24
+        | context.cssTextDecorationLineErrorValues          << 25
+        | context.cssTextTransformMathAutoEnabled           << 26
+        | context.cssInternalAutoBaseParsingEnabled         << 27
+        | context.cssMathDepthEnabled                       << 28;
     add(hasher, context.baseURL, context.charset, context.propertySettings, context.mode, bits);
 }
 

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -65,7 +65,6 @@ struct CSSParserContext {
     bool cssAppearanceBaseEnabled : 1 { false };
     bool cssPaintingAPIEnabled : 1 { false };
     bool cssTextDecorationLineErrorValues : 1 { false };
-    bool cssBackgroundClipBorderAreaEnabled : 1 { false };
     bool cssWordBreakAutoPhraseEnabled : 1 { false };
     bool popoverAttributeEnabled : 1 { false };
     bool sidewaysWritingModesEnabled : 1 { false };

--- a/Source/WebCore/css/parser/CSSPropertyParserCustom.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserCustom.h
@@ -1078,7 +1078,7 @@ inline bool PropertyParserCustom::consumeBackgroundShorthand(CSSParserTokenRange
         switch (property) {
         // background-*
         case CSSPropertyBackgroundClip:
-            return CSSPropertyParsing::consumeSingleBackgroundClip(range, state);
+            return CSSPropertyParsing::consumeSingleBackgroundClip(range);
         case CSSPropertyBackgroundBlendMode:
             return CSSPropertyParsing::consumeSingleBackgroundBlendMode(range);
         case CSSPropertyBackgroundAttachment:


### PR DESCRIPTION
#### 2ad17190313ea889160f61b93c72df0a718d38d4
<pre>
Remove CSSBackgroundClipBorderAreaEnabled preference
<a href="https://bugs.webkit.org/show_bug.cgi?id=305816">https://bugs.webkit.org/show_bug.cgi?id=305816</a>

Reviewed by Tim Nguyen.

It&apos;s been stable for well over a year. Also update some of the
documentation in the JSON file.

Canonical link: <a href="https://commits.webkit.org/305873@main">https://commits.webkit.org/305873@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a7c25d3c0c064694f7e1353359bf759c426ab6b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/139648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12024 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1152 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147783 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92716 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b405ef53-09c2-41d9-9e93-586eb538af59) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141521 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12733 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12174 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106932 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77844 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6f80e8bf-8cb7-4862-b3f8-7497afdd4d9a) 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/142595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9792 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125074 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87794 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cea75cfe-bace-4196-927a-6b1d50091fa9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9441 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6980 "Passed tests") | [  ~~🛠 wpe-cairo-libwebrtc~~](https://ews-build.webkit.org/#/builders/166/builds/8226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/131621 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118688 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1072 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150565 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/444 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11709 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1113 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115335 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11722 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10023 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115645 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10360 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121540 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66714 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21545 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11753 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1023 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/170920 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11492 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75431 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/44462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11688 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11540 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->