### PR TITLE
[blocks-in-inline] wpt.fyi/runs paints too much

### DIFF
--- a/LayoutTests/fast/repaint/table-in-inline-repaint-expected.txt
+++ b/LayoutTests/fast/repaint/table-in-inline-repaint-expected.txt
@@ -1,0 +1,6 @@
+foo
+ (repaint rects
+  (rect 8 8 38 18)
+  (rect 8 8 784 18)
+)
+

--- a/LayoutTests/fast/repaint/table-in-inline-repaint.html
+++ b/LayoutTests/fast/repaint/table-in-inline-repaint.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<div>
+<span>
+    <div><div id=t style="margin-bottom:32px">initial</div></div>
+    <table style="width:100%"><td style="height:500px; background: blue"></td></table>
+</span>
+</div>
+<pre id=log></pre>
+<script>
+window.testRunner?.dumpAsText();
+window.internals?.startTrackingRepaints();
+
+t.offsetLeft;
+t.textContent = "foo";
+
+const rects = window.internals?.repaintRectsAsText();
+window.internals?.stopTrackingRepaints();
+
+log.textContent = rects;
+</script>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4785,6 +4785,7 @@ webkit.org/b/298433 [ Release ] imported/w3c/web-platform-tests/selection/caret/
 
 # Needs rebaseline.
 fast/text/glyph-display-lists [ Skip ]
+fast/repaint/table-in-inline-repaint.html [ Failure ]
 
 # Tests crashing in Debug
 webkit.org/b/299092 [ Debug ] accessibility/aria-flowto.html [ Skip ]

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -3962,6 +3962,9 @@ bool RenderBlockFlow::layoutSimpleBlockContentInInline(MarginInfo& marginInfo)
             // Do not interfere with margin collapsing.
             if (!blockRenderer->isInFlow() || !logicalHeight)
                 return false;
+            // FIXME: This should be some narrower test.
+            if (blockRenderer->isRenderTable())
+                return false;
             if (CheckedPtr renderBlock = dynamicDowncast<RenderBlock>(*blockRenderer))
                 return !renderBlock->containsFloats();
             return true;
@@ -4058,7 +4061,7 @@ RenderBlockFlow::InlineContentStatus RenderBlockFlow::markInlineContentDirtyForL
         auto& renderer = *walker.current();
         auto* box = dynamicDowncast<RenderBox>(renderer);
         hasInFlowBlockLevelElement = hasInFlowBlockLevelElement || (box && box->isBlockLevelBox() && box->isInFlow());
-        auto childNeedsLayout = relayoutChildren == RelayoutChildren::Yes || (box && box->hasRelativeDimensions());
+        auto childNeedsLayout = relayoutChildren == RelayoutChildren::Yes || (box && box->hasRelativeDimensions() && !box->isBlockLevelBox());
         auto childNeedsPreferredWidthComputation = relayoutChildren == RelayoutChildren::Yes && box && box->shouldInvalidatePreferredWidths();
         if (childNeedsLayout)
             renderer.setNeedsLayout(MarkOnlyThis);


### PR DESCRIPTION
#### b9b68de2b21d524a7a38049d6cab2cda55ed38bb
<pre>
[blocks-in-inline] wpt.fyi/runs paints too much
<a href="https://bugs.webkit.org/show_bug.cgi?id=305818">https://bugs.webkit.org/show_bug.cgi?id=305818</a>
<a href="https://rdar.apple.com/168483436">rdar://168483436</a>

Reviewed by Alan Baradlay.

With blocks-in-inline enabled we sometimes repaint more than before.

Test: fast/repaint/table-in-inline-repaint.html
* LayoutTests/fast/repaint/table-in-inline-repaint-expected.txt: Added.
* LayoutTests/fast/repaint/table-in-inline-repaint.html: Added.
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::layoutSimpleBlockContentInInline):

Disabllow tables from fast path as there is a bad interaction with their painting
that does not exist on normal path.

(WebCore::RenderBlockFlow::markInlineContentDirtyForLayout):

Don&apos;t mark block content with relative units as needing relayout. It is not needed for
block layout and dirty layout will force repaint.

Canonical link: <a href="https://commits.webkit.org/305878@main">https://commits.webkit.org/305878@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69c71bb61dffac956fe3d93f5b128cd99f309966

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/139658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12034 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1162 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147793 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92726 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/59ee4cb9-7327-40b9-bd46-00d89da339df) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141531 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12743 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12184 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106940 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/77853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eb9eac31-659f-400b-b115-10a214d90c3b) 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/142605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9796 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125084 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87802 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9d906228-ceb8-411a-a288-20136055d4c6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9446 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6988 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8085 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118691 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1082 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150575 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11719 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1125 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115343 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11732 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10033 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115653 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29381 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10369 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121552 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66724 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11763 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1036 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11502 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75441 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11698 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11550 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->