### PR TITLE
WGSL compilation: cannot use override value in constant expression

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/value_constructor-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/value_constructor-expected.txt
@@ -353,24 +353,7 @@ PASS :matrix_elementwise:type1="abstract-float";type2="bool"
 PASS :array_zero_value:case="i32"
 PASS :array_zero_value:case="f32"
 PASS :array_zero_value:case="u32"
-FAIL :array_zero_value:case="valid_array" assert_unreached:
-  - VALIDATION FAILED: Unexpected compilationInfo 'error' message.
-    8:58: error: cannot use override value in constant expression
-
-    ---- shader ----
-    override o : i32 = 1;
-        struct valid_S {
-          x : u32
-        }
-        struct invalid_S {
-          x : array<u32>
-        }
-        const x : array<array<u32, 2>, 2> = array<array<u32, 2>, 2>();
-      at (elided: below max severity)
-  - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
-    8:57: cannot use override value in constant expression
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
+PASS :array_zero_value:case="valid_array"
 PASS :array_zero_value:case="invalid_rta"
 PASS :array_zero_value:case="invalid_override_array"
 PASS :array_zero_value:case="valid_struct"
@@ -379,24 +362,7 @@ PASS :array_zero_value:case="invalid_atomic"
 PASS :array_value:case="i32"
 PASS :array_value:case="f32"
 PASS :array_value:case="u32"
-FAIL :array_value:case="valid_array" assert_unreached:
-  - VALIDATION FAILED: Unexpected compilationInfo 'error' message.
-    8:58: error: cannot use override value in constant expression
-
-    ---- shader ----
-    override o : i32 = 1;
-        struct valid_S {
-          x : u32
-        }
-        struct invalid_S {
-          x : array<u32>
-        }
-        const x : array<array<u32, 2>, 2> = array<array<u32, 2>, 2>(array(0,1), array(2,3));
-      at (elided: below max severity)
-  - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
-    8:57: cannot use override value in constant expression
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
+PASS :array_value:case="valid_array"
 PASS :array_value:case="invalid_rta"
 PASS :array_value:case="invalid_override_array"
 PASS :array_value:case="valid_struct"

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -1889,7 +1889,7 @@ Result<void> TypeChecker::visit(AST::ArrayTypeExpression& array)
 
     Types::Array::Size size;
     if (array.maybeElementCount()) {
-        UNWRAP(elementCountType, infer(*array.maybeElementCount(), Evaluation::Override));
+        UNWRAP(elementCountType, infer(*array.maybeElementCount(), std::min(m_evaluation, Evaluation::Override)));
         if (!unify(m_types.i32Type(), elementCountType) && !unify(m_types.u32Type(), elementCountType)) [[unlikely]]
             TYPE_ERROR(array.span(), "array count must be an i32 or u32 value, found '"_s, *elementCountType, '\'');
 

--- a/Tools/TestWebKitAPI/Tests/WGSL/TypeCheckingTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WGSL/TypeCheckingTests.mm
@@ -280,6 +280,9 @@ TEST(WGSLTypeCheckingTests, Constants)
 
     // Test invalid explicit u32 conversion
     expectTypeError(fn("let x = u32(37359285590000);"_s), "value 37359285590000 cannot be represented as 'u32'"_s);
+
+    // Test nested arrays
+    expectNoError(fn("const c = array<array<u32, 1>, 1>(array<u32, 1>(0));"_s));
 }
 
 TEST(WGSLTypeCheckingTests, Continue)


### PR DESCRIPTION
#### 4f07563c85a8ae5a4cfd527576e4284aed7bb2f8
<pre>
WGSL compilation: cannot use override value in constant expression
<a href="https://bugs.webkit.org/show_bug.cgi?id=302750">https://bugs.webkit.org/show_bug.cgi?id=302750</a>
<a href="https://rdar.apple.com/165093959">rdar://165093959</a>

Reviewed by Mike Wyrzykowski.

Array type expressions were always inferring the count as an override expression,
but they should be treated as constant if we&apos;re already in a constant context.

Test: Tools/TestWebKitAPI/Tests/WGSL/TypeCheckingTests.mm
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
* Tools/TestWebKitAPI/Tests/WGSL/TypeCheckingTests.mm:
(TestWGSLAPI::TEST(WGSLTypeCheckingTests, Constants)):

Canonical link: <a href="https://commits.webkit.org/306020@main">https://commits.webkit.org/306020@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed8dc5cfe24581ef70ae6efc6b8950e24642beea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140103 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12484 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1614 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148252 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/93180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141976 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13196 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12637 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107255 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/93180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143053 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10152 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125446 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88147 "Failed to checkout and rebase branch from PR 56885") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9800 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7332 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8535 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119025 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1454 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151040 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12170 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1522 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115685 "Failed to checkout and rebase branch from PR 56885") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12184 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10426 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116010 "Failed to checkout and rebase branch from PR 56885") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29479 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10936 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121929 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/67180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12212 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1405 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11954 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75910 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12149 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11999 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->