### PR TITLE
[WPE] Update dependency lists to include Qt6 development packages

### DIFF
--- a/Tools/wpe/dependencies/apt
+++ b/Tools/wpe/dependencies/apt
@@ -14,9 +14,7 @@ PACKAGES+=(
     libicu-dev
     libxml2-dev
     pkg-config
-    qtbase5-dev
-    qtbase5-private-dev
-    qtdeclarative5-dev
+    qt6-declarative-private-dev
     unifdef
     wayland-protocols
     zlib1g-dev

--- a/Tools/wpe/dependencies/dnf
+++ b/Tools/wpe/dependencies/dnf
@@ -7,7 +7,6 @@ PACKAGES+=(
     # These are dependencies necessary for building WebKitWPE.
     libicu-devel
     libxml2-devel
-    qt6-qtbase-devel
     qt6-qtdeclarative-devel
     zlib-devel
 

--- a/Tools/wpe/dependencies/pacman
+++ b/Tools/wpe/dependencies/pacman
@@ -7,6 +7,7 @@ PACKAGES+=(
     gnutls
     icu
     libxml2
+    qt6-declarative
     ru
     unifdef
     zlib


### PR DESCRIPTION
#### 405c81e89df3aba54153c0ed2c3aa660c2d2908f
<pre>
[WPE] Update dependency lists to include Qt6 development packages
<a href="https://bugs.webkit.org/show_bug.cgi?id=305823">https://bugs.webkit.org/show_bug.cgi?id=305823</a>

Reviewed by Carlos Alberto Lopez Perez.

Ensure that scripts that install dependencies using package managers
will install the needed Qt6 packages.

* Tools/wpe/dependencies/apt: List only qt6-declarative-private-dev,
other needed packages will be pulled as dependencies.
* Tools/wpe/dependencies/dnf: Remove qt6-qtbase-devel from the list,
as it will be pullked anyway as a dependency of qt6-qtdeclarative-devel.
* Tools/wpe/dependencies/pacman: Add qt6-declarative, other needed
packages will be pulled as dependencies.

Canonical link: <a href="https://commits.webkit.org/305876@main">https://commits.webkit.org/305876@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ca26f9eefd3ed312928918b7e5f291d033daa14

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/139653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12029 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1157 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147788 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92721 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141526 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12738 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12179 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106936 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77848 "1 flakes 1 failures") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/142600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9790 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125081 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87798 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9438 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/6985 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8080 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118686 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1079 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150570 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11714 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1121 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115339 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11727 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10029 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115649 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10356 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121548 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66719 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21547 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11758 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1032 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11497 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11693 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11545 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->