### PR TITLE
Add support for the "color-interpolation" attribute for SVG gradients

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7660,7 +7660,6 @@ imported/w3c/web-platform-tests/svg/painting/color-interpolation-001.svg [ Pass 
 imported/w3c/web-platform-tests/svg/pservers/scripted/pattern-transform-clear.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/pservers/reftests/fill-fallback-none-1.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/pservers/reftests/fill-fallback-currentcolor-1.svg [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/svg/pservers/reftests/gradient-color-interpolation.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/pservers/reftests/gradient-transform-03.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/pservers/reftests/meshgradient-basic-001.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/pservers/reftests/meshgradient-basic-002.svg [ ImageOnlyFailure ]

--- a/Source/WebCore/rendering/svg/RenderSVGResourceGradient.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceGradient.cpp
@@ -64,6 +64,20 @@ GradientSpreadMethod RenderSVGResourceGradient::platformSpreadMethodFromSVGType(
     return GradientSpreadMethod::Pad;
 }
 
+ColorInterpolationMethod RenderSVGResourceGradient::gradientColorInterpolationMethod() const
+{
+    switch (style().colorInterpolation()) {
+    case ColorInterpolation::Auto:
+    case ColorInterpolation::SRGB:
+        return { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied };
+    case ColorInterpolation::LinearRGB:
+        return { ColorInterpolationMethod::SRGBLinear { }, AlphaPremultiplication::Unpremultiplied };
+    }
+
+    ASSERT_NOT_REACHED();
+    return { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied };
+}
+
 bool RenderSVGResourceGradient::buildGradientIfNeeded(const RenderLayerModelObject& targetRenderer, const RenderStyle& style, AffineTransform& userspaceTransform)
 {
     if (!m_gradient) {

--- a/Source/WebCore/rendering/svg/RenderSVGResourceGradient.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceGradient.h
@@ -52,6 +52,7 @@ protected:
     bool buildGradientIfNeeded(const RenderLayerModelObject&, const RenderStyle&, AffineTransform& userspaceTransform);
     GradientColorStops stopsByApplyingColorFilter(const GradientColorStops&, const RenderStyle&) const;
     GradientSpreadMethod platformSpreadMethodFromSVGType(SVGSpreadMethodType) const;
+    ColorInterpolationMethod gradientColorInterpolationMethod() const;
 
     RefPtr<Gradient> m_gradient;
 };

--- a/Source/WebCore/rendering/svg/RenderSVGResourceLinearGradient.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceLinearGradient.cpp
@@ -62,7 +62,7 @@ RefPtr<Gradient> RenderSVGResourceLinearGradient::createGradient(const RenderSty
 
     return Gradient::create(
         Gradient::LinearData { startPoint, endPoint },
-        { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied },
+        gradientColorInterpolationMethod(),
         platformSpreadMethodFromSVGType(m_attributes->spreadMethod()),
         stopsByApplyingColorFilter(m_attributes->stops(), style),
         false);

--- a/Source/WebCore/rendering/svg/RenderSVGResourceRadialGradient.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceRadialGradient.cpp
@@ -66,7 +66,7 @@ RefPtr<Gradient> RenderSVGResourceRadialGradient::createGradient(const RenderSty
 
     return Gradient::create(
         Gradient::RadialData { focalPoint, centerPoint, focalRadius, radius, 1 },
-        { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied },
+        gradientColorInterpolationMethod(),
         platformSpreadMethodFromSVGType(m_attributes->spreadMethod()),
         stopsByApplyingColorFilter(m_attributes->stops(), style),
         false);

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.cpp
@@ -378,4 +378,18 @@ GradientSpreadMethod LegacyRenderSVGResourceGradient::platformSpreadMethodFromSV
     return GradientSpreadMethod::Pad;
 }
 
+ColorInterpolationMethod LegacyRenderSVGResourceGradient::gradientColorInterpolationMethod() const
+{
+    switch (style().colorInterpolation()) {
+    case ColorInterpolation::Auto:
+    case ColorInterpolation::SRGB:
+        return { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied };
+    case ColorInterpolation::LinearRGB:
+        return { ColorInterpolationMethod::SRGBLinear { }, AlphaPremultiplication::Unpremultiplied };
+    }
+
+    ASSERT_NOT_REACHED();
+    return { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied };
+}
+
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.h
@@ -87,6 +87,7 @@ protected:
 
     static GradientColorStops stopsByApplyingColorFilter(const GradientColorStops&, const RenderStyle&);
     static GradientSpreadMethod platformSpreadMethodFromSVGType(SVGSpreadMethodType);
+    ColorInterpolationMethod gradientColorInterpolationMethod() const;
 
 private:
     void element() const = delete;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceLinearGradient.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceLinearGradient.cpp
@@ -55,7 +55,7 @@ Ref<Gradient> LegacyRenderSVGResourceLinearGradient::buildGradient(const RenderS
 {
     return Gradient::create(
         Gradient::LinearData { startPoint(m_attributes), endPoint(m_attributes) },
-        { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied },
+        gradientColorInterpolationMethod(),
         platformSpreadMethodFromSVGType(m_attributes.spreadMethod()),
         stopsByApplyingColorFilter(m_attributes.stops(), style),
         false);

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceRadialGradient.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceRadialGradient.cpp
@@ -66,7 +66,7 @@ Ref<Gradient> LegacyRenderSVGResourceRadialGradient::buildGradient(const RenderS
 {
     return Gradient::create(
         Gradient::RadialData { focalPoint(m_attributes), centerPoint(m_attributes), focalRadius(m_attributes), radius(m_attributes), 1 },
-        { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied },
+        gradientColorInterpolationMethod(),
         platformSpreadMethodFromSVGType(m_attributes.spreadMethod()),
         stopsByApplyingColorFilter(m_attributes.stops(), style),
         false);


### PR DESCRIPTION
#### 3bc2a037ac2b991d868f91b91d594e2a963d01c6
<pre>
Add support for the &quot;color-interpolation&quot; attribute for SVG gradients
<a href="https://bugs.webkit.org/show_bug.cgi?id=234783">https://bugs.webkit.org/show_bug.cgi?id=234783</a>
<a href="https://rdar.apple.com/87294645">rdar://87294645</a>

Reviewed by Simon Fraser.

SVG gradients now properly respect the color-interpolation attribute
as specified in the SVG specification. Previously, all gradients were
hardcoded to interpolate colors in sRGB space, regardless of the
color-interpolation attribute value.

It fixes both:
  * New Layer-Based SVG Renderer (LBSE)
  * Legacy SVG Renderer

with color-interpolation=&quot;sRGB&quot; or color-interpolation=&quot;auto&quot;
gradients interpolate in sRGB space
(using ColorInterpolationMethod::SRGB, the default)

with color-interpolation=&quot;linearRGB&quot;
gradients interpolate in linear RGB space
(using ColorInterpolationMethod::SRGBLinear)

* LayoutTests/TestExpectations:
  This fix enables the following WPT test to pass:
  - imported/w3c/web-platform-tests/svg/pservers/reftests/gradient-color-interpolation.svg

* Source/WebCore/rendering/svg/RenderSVGResourceGradient.cpp:
(WebCore::RenderSVGResourceGradient::gradientColorInterpolationMethod const):
* Source/WebCore/rendering/svg/RenderSVGResourceGradient.h:
* Source/WebCore/rendering/svg/RenderSVGResourceLinearGradient.cpp:
(WebCore::RenderSVGResourceLinearGradient::createGradient):
* Source/WebCore/rendering/svg/RenderSVGResourceRadialGradient.cpp:
(WebCore::RenderSVGResourceRadialGradient::createGradient):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.cpp:
(WebCore::LegacyRenderSVGResourceGradient::gradientColorInterpolationMethod const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceLinearGradient.cpp:
(WebCore::LegacyRenderSVGResourceLinearGradient::buildGradient const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceRadialGradient.cpp:
(WebCore::LegacyRenderSVGResourceRadialGradient::buildGradient const):

Canonical link: <a href="https://commits.webkit.org/305921@main">https://commits.webkit.org/305921@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f90a7b6cd5df5cab46c9988560a3894424c907c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139831 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12212 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1342 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147973 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c0ba127e-3a29-4527-97f3-6d1f258d82fd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141704 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12922 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12364 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107071 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a2e33ff2-6c6f-480c-a958-14bc58d062aa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142781 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9947 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125222 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87945 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2523f779-c1bd-45eb-a6d1-7ae058e163f9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9604 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7111 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8263 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118821 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1223 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150757 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11897 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1290 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115485 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11909 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10188 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115800 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10576 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121702 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/66902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21567 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11939 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1181 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11678 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75626 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11875 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11727 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->