### PR TITLE
Add WTF::packBools to make CSSParserContext changes less error prone

### DIFF
--- a/Source/WTF/wtf/Hasher.h
+++ b/Source/WTF/wtf/Hasher.h
@@ -36,6 +36,17 @@ namespace WTF {
 template<typename... Types> uint32_t computeHash(const Types&...);
 template<typename T, typename... OtherTypes> uint32_t computeHash(std::initializer_list<T>, std::initializer_list<OtherTypes>...);
 
+template<typename... Bools>
+constexpr auto packBools(Bools... bools)
+{
+    static_assert(sizeof...(bools) <= 64, "Cannot pack more than 64 bools!");
+    using ResultType = std::conditional_t<sizeof...(bools) <= 32, uint32_t, uint64_t>;
+    ResultType result = 0;
+    ResultType bit = 1;
+    ((result |= bools ? bit : 0, bit <<= 1), ...);
+    return result;
+}
+
 class Hasher {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(Hasher);
 public:

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -128,39 +128,41 @@ CSSParserContext::CSSParserContext(const Settings& settings)
 
 void add(Hasher& hasher, const CSSParserContext& context)
 {
-    uint32_t bits = context.isHTMLDocument                  << 0
-        | context.hasDocumentSecurityOrigin                 << 1
-        | static_cast<bool>(context.loadedFromOpaqueSource) << 2
-        | context.useSystemAppearance                       << 3
-        | context.springTimingFunctionEnabled               << 4
+    auto bits = WTF::packBools(
+        context.isHTMLDocument,
+        context.hasDocumentSecurityOrigin,
+        static_cast<bool>(context.loadedFromOpaqueSource),
+        context.useSystemAppearance,
+        context.springTimingFunctionEnabled,
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
-        | context.cssTransformStyleSeparatedEnabled         << 5
+        context.cssTransformStyleSeparatedEnabled,
 #endif
-        | context.gridLanesEnabled                          << 6
-        | context.cssAppearanceBaseEnabled                  << 7
-        | context.cssPaintingAPIEnabled                     << 8
-        | context.cssWordBreakAutoPhraseEnabled             << 9
-        | context.popoverAttributeEnabled                   << 10
-        | context.sidewaysWritingModesEnabled               << 11
-        | context.cssTextWrapPrettyEnabled                  << 12
-        | context.thumbAndTrackPseudoElementsEnabled        << 13
+        context.gridLanesEnabled,
+        context.cssAppearanceBaseEnabled,
+        context.cssPaintingAPIEnabled,
+        context.cssWordBreakAutoPhraseEnabled,
+        context.popoverAttributeEnabled,
+        context.sidewaysWritingModesEnabled,
+        context.cssTextWrapPrettyEnabled,
+        context.thumbAndTrackPseudoElementsEnabled,
 #if ENABLE(SERVICE_CONTROLS)
-        | context.imageControlsEnabled                      << 14
+        context.imageControlsEnabled,
 #endif
-        | context.colorLayersEnabled                        << 15
-        | context.targetTextPseudoElementEnabled            << 16
-        | context.cssProgressFunctionEnabled                << 17
-        | context.cssRandomFunctionEnabled                  << 18
-        | context.cssTreeCountingFunctionsEnabled           << 19
-        | context.cssURLModifiersEnabled                    << 20
-        | context.cssURLIntegrityModifierEnabled            << 21
-        | context.cssAxisRelativePositionKeywordsEnabled    << 22
-        | context.cssDynamicRangeLimitMixEnabled            << 23
-        | context.cssConstrainedDynamicRangeLimitEnabled    << 24
-        | context.cssTextDecorationLineErrorValues          << 25
-        | context.cssTextTransformMathAutoEnabled           << 26
-        | context.cssInternalAutoBaseParsingEnabled         << 27
-        | context.cssMathDepthEnabled                       << 28;
+        context.colorLayersEnabled,
+        context.targetTextPseudoElementEnabled,
+        context.cssProgressFunctionEnabled,
+        context.cssRandomFunctionEnabled,
+        context.cssTreeCountingFunctionsEnabled,
+        context.cssURLModifiersEnabled,
+        context.cssURLIntegrityModifierEnabled,
+        context.cssAxisRelativePositionKeywordsEnabled,
+        context.cssDynamicRangeLimitMixEnabled,
+        context.cssConstrainedDynamicRangeLimitEnabled,
+        context.cssTextDecorationLineErrorValues,
+        context.cssTextTransformMathAutoEnabled,
+        context.cssInternalAutoBaseParsingEnabled,
+        context.cssMathDepthEnabled
+    );
     add(hasher, context.baseURL, context.charset, context.propertySettings, context.mode, bits);
 }
 

--- a/Source/WebCore/css/parser/CSSSelectorParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParserContext.cpp
@@ -61,8 +61,7 @@ CSSSelectorParserContext::CSSSelectorParserContext(const Document& document)
 
 void add(Hasher& hasher, const CSSSelectorParserContext& context)
 {
-    add(hasher,
-        context.mode,
+    auto bits = WTF::packBools(
 #if ENABLE(SERVICE_CONTROLS)
         context.imageControlsEnabled,
 #endif
@@ -72,6 +71,7 @@ void add(Hasher& hasher, const CSSSelectorParserContext& context)
         context.viewTransitionsEnabled,
         context.webkitMediaTextTrackDisplayQuirkEnabled
     );
+    add(hasher, context.mode, bits);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/scripts/process-css-properties.py
+++ b/Source/WebCore/css/scripts/process-css-properties.py
@@ -3826,17 +3826,17 @@ class GenerateCSSPropertyNames:
         to.newline()
 
     def _generate_css_property_settings_hasher(self, *, to):
-        first, *middle, last = (f'{"(uint64_t) " if i >= 32 else ""}settings.{flag} << {i}' for (i, flag) in enumerate(self.properties_and_descriptors.settings_flags))
+        first, *middle, last = [f"settings.{flag}" for flag in self.properties_and_descriptors.settings_flags]
 
         to.write(f"void add(Hasher& hasher, const CSSPropertySettings& settings)")
         to.write(f"{{")
         with to.indent():
-            to.write(f"uint64_t bits = {first}")
+            to.write(f"add(hasher, WTF::packBools(")
             with to.indent():
-                to.write_lines((f"| {expression}" for expression in middle))
-                to.write(f"| {last};")
-
-            to.write(f"add(hasher, bits);")
+                to.write(f"{first},")
+                to.write_lines((f"{expression}," for expression in middle))
+                to.write(f"{last}")
+            to.write(f"));")
         to.write(f"}}")
         to.newline()
 

--- a/Source/WebCore/css/scripts/test/TestCSSPropertiesResults/CSSPropertyNames.gperf
+++ b/Source/WebCore/css/scripts/test/TestCSSPropertiesResults/CSSPropertyNames.gperf
@@ -856,10 +856,11 @@ bool operator==(const CSSPropertySettings& a, const CSSPropertySettings& b)
 
 void add(Hasher& hasher, const CSSPropertySettings& settings)
 {
-    uint64_t bits = settings.cssDescriptorEnabled << 0
-        | settings.cssSettingsOneEnabled << 1
-        | settings.cssSettingsShorthandEnabled << 2;
-    add(hasher, bits);
+    add(hasher, WTF::packBools(
+        settings.cssDescriptorEnabled,
+        settings.cssSettingsOneEnabled,
+        settings.cssSettingsShorthandEnabled
+    ));
 }
 
 


### PR DESCRIPTION
#### f9a36f88eef2cbd9b78807db48b78bc01422c353
<pre>
Add WTF::packBools to make CSSParserContext changes less error prone
<a href="https://bugs.webkit.org/show_bug.cgi?id=305829">https://bugs.webkit.org/show_bug.cgi?id=305829</a>
<a href="https://rdar.apple.com/151812337">rdar://151812337</a>

Reviewed by Antti Koivisto.

This will make adding and removing preferences much less cumbersome and
should have equivalent performance. It should be a slight improvement
even for CSSSelectorParserContext but probably not measurably so.

Canonical link: <a href="https://commits.webkit.org/305881@main">https://commits.webkit.org/305881@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c459bca859be5d055bc84af05f5f86e79277817c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/139674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12050 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1178 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147809 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92742 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141547 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12759 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12200 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106954 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/77861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/305e0a8d-81b4-47db-a682-c7e31f3fee97) 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/142621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9817 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125101 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87818 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9469 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/7001 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8101 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/131647 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118708 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1099 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150591 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/470 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11735 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1146 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115357 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11748 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10050 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115668 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10414 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121573 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66740 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21549 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11779 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1055 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/170946 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11518 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75457 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/44464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11714 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11566 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->