### PR TITLE
Remove unneeded quirk for Google accounts log-in with second factors configured

### DIFF
--- a/Source/WebCore/Modules/credentialmanagement/BasicCredential.cpp
+++ b/Source/WebCore/Modules/credentialmanagement/BasicCredential.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "BasicCredential.h"
 
+#if ENABLE(WEB_AUTHN)
+
 #include "AuthenticatorCoordinator.h"
 #include "DocumentPage.h"
 #include "JSDOMPromiseDeferred.h"
@@ -57,14 +59,12 @@ String BasicCredential::type() const
 
 void BasicCredential::isConditionalMediationAvailable(Document& document, DOMPromiseDeferred<IDLBoolean>&& promise)
 {
-    if (RefPtr page = document.page()) {
-#if ENABLE(WEB_AUTHN)
+    if (RefPtr page = document.page())
         page->authenticatorCoordinator().isConditionalMediationAvailable(document, WTF::move(promise));
-#else
-        promise.resolve(false);
-#endif
-    } else
+    else
         promise.reject(Exception { ExceptionCode::InvalidStateError });
 }
 
 } // namespace WebCore
+
+#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/credentialmanagement/BasicCredential.h
+++ b/Source/WebCore/Modules/credentialmanagement/BasicCredential.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if ENABLE(WEB_AUTHN)
+
 #include <WebCore/Document.h>
 #include <WebCore/IDLTypes.h>
 #include <WebCore/JSDOMPromiseDeferredForward.h>
@@ -69,3 +71,5 @@ private:
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ToClassName) \
     static bool isType(const WebCore::BasicCredential& credential) { return credential.credentialType() == WebCore::Type; } \
 SPECIALIZE_TYPE_TRAITS_END()
+
+#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/credentialmanagement/BasicCredential.idl
+++ b/Source/WebCore/Modules/credentialmanagement/BasicCredential.idl
@@ -25,7 +25,8 @@
 
 [
     InterfaceName=Credential,
-    EnabledByQuirk=shouldExposeCredentialsContainer,
+    Conditional=WEB_AUTHN,
+    EnabledBySetting=WebAuthenticationEnabled,
     Exposed=Window,
     SecureContext
 ] interface BasicCredential {

--- a/Source/WebCore/Modules/credentialmanagement/CredentialCreationOptions.h
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialCreationOptions.h
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#if ENABLE(WEB_AUTHN)
+
 #include "AbortSignal.h"
 #include "MediationRequirement.h"
 #include "PublicKeyCredentialCreationOptions.h"
@@ -41,3 +43,5 @@ struct CredentialCreationOptions {
 };
 
 } // namespace WebCore
+
+#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/credentialmanagement/CredentialCreationOptions.idl
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialCreationOptions.idl
@@ -25,6 +25,7 @@
  */
 
 [
+    Conditional=WEB_AUTHN,
     LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary CredentialCreationOptions {
     CredentialMediationRequirement mediation = "optional";

--- a/Source/WebCore/Modules/credentialmanagement/CredentialMediationRequirement.idl
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialMediationRequirement.idl
@@ -24,6 +24,7 @@
  */
 
 [
+    Conditional=WEB_AUTHN,
     ImplementedAs=MediationRequirement
 ] enum CredentialMediationRequirement {
     "silent",

--- a/Source/WebCore/Modules/credentialmanagement/CredentialRequestOptions.h
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialRequestOptions.h
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#if ENABLE(WEB_AUTHN)
+
 #include <WebCore/DigitalCredentialRequestOptions.h>
 #include <WebCore/MediationRequirement.h>
 #include <WebCore/PublicKeyCredentialRequestOptions.h>
@@ -44,3 +46,5 @@ struct CredentialRequestOptions {
 };
 
 } // namespace WebCore
+
+#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/credentialmanagement/CredentialRequestOptions.idl
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialRequestOptions.idl
@@ -25,11 +25,12 @@
  */
 
 [
+    Conditional=WEB_AUTHN,
     LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary CredentialRequestOptions {
     CredentialMediationRequirement mediation = "optional";
     AbortSignal signal;
     PublicKeyCredentialRequestOptions publicKey;
     // https://wicg.github.io/digital-identities/#extensions-to-credentialrequestoptions-dictionary
-    [Conditional=WEB_AUTHN, EnabledBySetting=DigitalCredentialsEnabled] DigitalCredentialRequestOptions digital;
+    [EnabledBySetting=DigitalCredentialsEnabled] DigitalCredentialRequestOptions digital;
 };

--- a/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp
@@ -27,6 +27,8 @@
 #include "config.h"
 #include "CredentialsContainer.h"
 
+#if ENABLE(WEB_AUTHN)
+
 #include "CredentialCreationOptions.h"
 #include "CredentialRequestCoordinator.h"
 #include "CredentialRequestOptions.h"
@@ -53,7 +55,6 @@ void CredentialsContainer::get(CredentialRequestOptions&& options, CredentialPro
         return;
     }
 
-#if ENABLE(WEB_AUTHN)
     if (options.digital) {
 #if HAVE(DIGITAL_CREDENTIALS_UI)
         DigitalCredential::discoverFromExternalSource(*document(), WTF::move(promise), WTF::move(options));
@@ -63,9 +64,6 @@ void CredentialsContainer::get(CredentialRequestOptions&& options, CredentialPro
         return;
     }
     document()->page()->authenticatorCoordinator().discoverFromExternalSource(*document(), WTF::move(options), WTF::move(promise));
-#else
-    promise.resolve(nullptr);
-#endif
 }
 
 void CredentialsContainer::store(const BasicCredential&, CredentialPromise&& promise)
@@ -84,12 +82,10 @@ void CredentialsContainer::isCreate(CredentialCreationOptions&& options, Credent
         return;
     }
 
-#if ENABLE(WEB_AUTHN)
     if (options.publicKey) {
         document()->page()->authenticatorCoordinator().create(*document(), WTF::move(options), WTF::move(options.signal), WTF::move(promise));
         return;
     }
-#endif
 
     promise.resolve(nullptr);
 }
@@ -144,3 +140,5 @@ bool CredentialsContainer::performCommonChecks(const Options& options, Credentia
 }
 
 } // namespace WebCore
+
+#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.h
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.h
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#if ENABLE(WEB_AUTHN)
+
 #include <WebCore/BasicCredential.h>
 #include <wtf/RefCounted.h>
 #include <wtf/WeakPtr.h>
@@ -68,3 +70,5 @@ protected:
 };
 
 } // namespace WebCore
+
+#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.idl
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.idl
@@ -25,7 +25,8 @@
  */
 
 [
-    EnabledByQuirk=shouldExposeCredentialsContainer,
+    Conditional=WEB_AUTHN,
+    EnabledBySetting=WebAuthenticationEnabled,
     Exposed=Window,
     SecureContext,
     SkipVTableValidation,

--- a/Source/WebCore/Modules/credentialmanagement/MediationRequirement.h
+++ b/Source/WebCore/Modules/credentialmanagement/MediationRequirement.h
@@ -25,8 +25,12 @@
 
 #pragma once
 
+#if ENABLE(WEB_AUTHN)
+
 namespace WebCore {
 
 enum class MediationRequirement : uint8_t { Silent, Optional, Required, Conditional };
 
 } // namespace WebCore
+
+#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/credentialmanagement/Navigator+Credentials.idl
+++ b/Source/WebCore/Modules/credentialmanagement/Navigator+Credentials.idl
@@ -26,7 +26,8 @@
 
 // https://w3c.github.io/webappsec-credential-management/#framework-credential-management
 [
-    EnabledByQuirk=shouldExposeCredentialsContainer,
+    Conditional=WEB_AUTHN,
+    EnabledBySetting=WebAuthenticationEnabled,
     ImplementedBy=NavigatorCredentials
 ] partial interface Navigator {
     // FIXME: `credentials` should not be nullable.

--- a/Source/WebCore/Modules/credentialmanagement/NavigatorCredentials.cpp
+++ b/Source/WebCore/Modules/credentialmanagement/NavigatorCredentials.cpp
@@ -27,6 +27,8 @@
 #include "config.h"
 #include "NavigatorCredentials.h"
 
+#if ENABLE(WEB_AUTHN)
+
 #include "Document.h"
 #include "LocalFrameInlines.h"
 #include "Navigator.h"
@@ -67,3 +69,5 @@ NavigatorCredentials* NavigatorCredentials::from(Navigator* navigator)
 }
 
 } // namespace WebCore
+
+#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/credentialmanagement/NavigatorCredentials.h
+++ b/Source/WebCore/Modules/credentialmanagement/NavigatorCredentials.h
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#if ENABLE(WEB_AUTHN)
+
 #include "CredentialsContainer.h"
 #include "Supplementable.h"
 #include <wtf/TZoneMalloc.h>
@@ -59,3 +61,5 @@ private:
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::NavigatorCredentials)
     static bool isType(const WebCore::SupplementBase& supplement) { return supplement.isNavigatorCredentials(); }
 SPECIALIZE_TYPE_TRAITS_END()
+
+#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptions.idl
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptions.idl
@@ -24,21 +24,21 @@
  */
 
 [
-    EnabledByQuirk=shouldExposeCredentialsContainer,
+    Conditional=WEB_AUTHN,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
     LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary PublicKeyCredentialCreationOptions {
-    [Conditional=WEB_AUTHN] required PublicKeyCredentialRpEntity rp;
-    [Conditional=WEB_AUTHN] required PublicKeyCredentialUserEntity user;
+    required PublicKeyCredentialRpEntity rp;
+    required PublicKeyCredentialUserEntity user;
 
-    [Conditional=WEB_AUTHN] required [OverrideIDLType=IDLBufferSource] BufferSource challenge;
-    [Conditional=WEB_AUTHN] required sequence<PublicKeyCredentialParameters> pubKeyCredParams;
+    required [OverrideIDLType=IDLBufferSource] BufferSource challenge;
+    required sequence<PublicKeyCredentialParameters> pubKeyCredParams;
 
-    [Conditional=WEB_AUTHN] unsigned long timeout;
-    [Conditional=WEB_AUTHN] sequence<PublicKeyCredentialDescriptor> excludeCredentials = [];
-    [Conditional=WEB_AUTHN] AuthenticatorSelectionCriteria authenticatorSelection;
-    [Conditional=WEB_AUTHN] AttestationConveyancePreference attestation = "none";
-    [Conditional=WEB_AUTHN] AuthenticationExtensionsClientInputs extensions;
+    unsigned long timeout;
+    sequence<PublicKeyCredentialDescriptor> excludeCredentials = [];
+    AuthenticatorSelectionCriteria authenticatorSelection;
+    AttestationConveyancePreference attestation = "none";
+    AuthenticationExtensionsClientInputs extensions;
 };
 

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptions.idl
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptions.idl
@@ -24,15 +24,15 @@
  */
 
 [
-    EnabledByQuirk=shouldExposeCredentialsContainer,
+    Conditional=WEB_AUTHN,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
     LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary PublicKeyCredentialRequestOptions {
-    [Conditional=WEB_AUTHN] required [OverrideIDLType=IDLBufferSource] BufferSource challenge;
-    [Conditional=WEB_AUTHN] unsigned long timeout;
-    [Conditional=WEB_AUTHN] DOMString rpId;
-    [Conditional=WEB_AUTHN] sequence<PublicKeyCredentialDescriptor> allowCredentials = [];
-    [Conditional=WEB_AUTHN] UserVerificationRequirement userVerification = "preferred";
-    [Conditional=WEB_AUTHN] AuthenticationExtensionsClientInputs extensions;
+    required [OverrideIDLType=IDLBufferSource] BufferSource challenge;
+    unsigned long timeout;
+    DOMString rpId;
+    sequence<PublicKeyCredentialDescriptor> allowCredentials = [];
+    UserVerificationRequirement userVerification = "preferred";
+    AuthenticationExtensionsClientInputs extensions;
 };

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -2343,15 +2343,6 @@ bool Quirks::shouldDisableDOMAudioSessionQuirk() const
     return m_quirksData.quirkIsEnabled(QuirksData::SiteSpecificQuirk::ShouldDisableDOMAudioSession);
 }
 
-bool Quirks::shouldExposeCredentialsContainerQuirk() const
-{
-#if ENABLE(WEB_AUTHN)
-    if (m_document && m_document->settings().webAuthenticationEnabled())
-        return true;
-#endif
-    return needsQuirks() && m_quirksData.isGoogleAccounts;
-}
-
 #if ENABLE(PICTURE_IN_PICTURE_API)
 bool Quirks::shouldReportVisibleDueToActivePictureInPictureContent() const
 {
@@ -2917,7 +2908,6 @@ static void handleGoogleQuirks(QuirksData& quirksData, const URL& quirksURL, con
     bool shouldEnableEnumerateDeviceQuirk = topDocumentHost == "meet.google.com"_s;
     quirksData.setQuirkState(QuirksData::SiteSpecificQuirk::ShouldEnableEnumerateDeviceQuirk, shouldEnableEnumerateDeviceQuirk);
 #endif
-    quirksData.isGoogleAccounts = topDocumentHost == "accounts.google.com"_s;
 }
 
 static void handleHBOMaxQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL&  /* documentURL */)

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -307,8 +307,6 @@ public:
 
     bool needsSuppressPostLayoutBoundaryEventsQuirk() const;
 
-    bool shouldExposeCredentialsContainerQuirk() const;
-
 #if ENABLE(PICTURE_IN_PICTURE_API)
     bool shouldReportVisibleDueToActivePictureInPictureContent() const;
 #endif

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -41,7 +41,6 @@ struct QuirksData {
     bool isGoogleDocs : 1 { false };
     bool isGoogleProperty : 1 { false };
     bool isGoogleMaps : 1 { false };
-    bool isGoogleAccounts : 1 { false };
     bool isNetflix : 1 { false };
     bool isOutlook : 1 { false };
     bool isSoundCloud : 1 { false };


### PR DESCRIPTION
#### cf6db19dedd5826d9734969cde22e3713ff56f2c
<pre>
Remove unneeded quirk for Google accounts log-in with second factors configured
<a href="https://bugs.webkit.org/show_bug.cgi?id=305830">https://bugs.webkit.org/show_bug.cgi?id=305830</a>

Reviewed by Carlos Garcia Campos.

The accounts.google.com site no longer hangs when trying to log-in to an
account that has second factors configured and WebAuthn is disabled (or
not built into WebKit). The quirk is no longer needed.

* Source/WebCore/Modules/credentialmanagement/BasicCredential.cpp:
(WebCore::BasicCredential::isConditionalMediationAvailable):
* Source/WebCore/Modules/credentialmanagement/BasicCredential.h:
* Source/WebCore/Modules/credentialmanagement/BasicCredential.idl:
* Source/WebCore/Modules/credentialmanagement/CredentialCreationOptions.h:
* Source/WebCore/Modules/credentialmanagement/CredentialCreationOptions.idl:
* Source/WebCore/Modules/credentialmanagement/CredentialMediationRequirement.idl:
* Source/WebCore/Modules/credentialmanagement/CredentialRequestOptions.h:
* Source/WebCore/Modules/credentialmanagement/CredentialRequestOptions.idl:
* Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp:
(WebCore::CredentialsContainer::get):
(WebCore::CredentialsContainer::isCreate):
* Source/WebCore/Modules/credentialmanagement/CredentialsContainer.h:
* Source/WebCore/Modules/credentialmanagement/CredentialsContainer.idl:
* Source/WebCore/Modules/credentialmanagement/MediationRequirement.h:
* Source/WebCore/Modules/credentialmanagement/Navigator+Credentials.idl:
* Source/WebCore/Modules/credentialmanagement/NavigatorCredentials.cpp:
* Source/WebCore/Modules/credentialmanagement/NavigatorCredentials.h:
* Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptions.idl:
* Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptions.idl:
* Source/WebCore/page/Quirks.cpp:
(WebCore::handleGoogleQuirks):
(WebCore::Quirks::shouldExposeCredentialsContainerQuirk const): Deleted.
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:

Canonical link: <a href="https://commits.webkit.org/305929@main">https://commits.webkit.org/305929@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d395ba464a0cb36a9c44f1565efb799774af98ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139673 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12049 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1177 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147808 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92741 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141546 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12758 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12199 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106953 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77860 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142620 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9815 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125100 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87816 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9467 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7000 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8100 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118706 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1098 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150590 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11734 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1145 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115356 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11747 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10049 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115667 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29422 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10405 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121572 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66739 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11778 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1054 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11517 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75456 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11713 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11565 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->