### PR TITLE
Incorrect alpha interpolation for SVG radial gradients

### DIFF
--- a/Source/WebCore/platform/graphics/cg/GradientRendererCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GradientRendererCG.cpp
@@ -68,6 +68,12 @@ GradientRendererCG::Strategy GradientRendererCG::pickStrategy(ColorInterpolation
             if (anyComponentIsNone(stops))
                 return makeShading(colorInterpolationMethod, stops);
 
+            // CoreGraphics' kCGGradientInterpolatesPremultiplied flag doesn't work correctly for unpremultiplied alpha.
+            // Use the Shading strategy which does manual interpolation and correctly handles unpremultiplied alpha.
+            // See https://bugs.webkit.org/show_bug.cgi?id=305452
+            if (colorInterpolationMethod.alphaPremultiplication == AlphaPremultiplication::Unpremultiplied)
+                return makeShading(colorInterpolationMethod, stops);
+
             return makeGradient(colorInterpolationMethod, stops, destinationColorSpace);
         },
         [&] (const auto&) -> Strategy {
@@ -122,10 +128,18 @@ GradientRendererCG::Strategy GradientRendererCG::makeGradient(ColorInterpolation
         return options;
     };
 
+    auto gradientInterpolatesUnpremultipliedOptionsDictionary = [] () -> CFDictionaryRef {
+        static CFTypeRef keys[] = { kCGGradientInterpolatesPremultiplied };
+        static CFTypeRef values[] = { kCFBooleanFalse };
+        static CFDictionaryRef options = CFDictionaryCreate(kCFAllocatorDefault, keys, values, std::size(keys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+
+        return options;
+    };
+
    auto gradientOptionsDictionary = [&] (auto colorInterpolationMethod) -> CFDictionaryRef {
         switch (colorInterpolationMethod.alphaPremultiplication) {
         case AlphaPremultiplication::Unpremultiplied:
-            return nullptr;
+            return gradientInterpolatesUnpremultipliedOptionsDictionary();
         case AlphaPremultiplication::Premultiplied:
             return gradientInterpolatesPremultipliedOptionsDictionary();
         }


### PR DESCRIPTION
#### a4a76d4381b367ee4d66b0f61d6042dcf1075ddb
<pre>
Incorrect alpha interpolation for SVG radial gradients
<a href="https://bugs.webkit.org/show_bug.cgi?id=305452">https://bugs.webkit.org/show_bug.cgi?id=305452</a>
<a href="https://rdar.apple.com/168145344">rdar://168145344</a>

Reviewed by NOBODY (OOPS!).

SVG gradients were rendering with incorrect alpha interpolation,
causing color components to be lost when interpolating between opaque
and transparent colors.

SVG gradients now correctly use straight alpha (unpremultiplied)
interpolation as required by the SVG specification, matching the
behavior of Chrome and Firefox.

When creating a CGGradient with kCGGradientInterpolatesPremultiplied
set to kCFBooleanFalse, the gradient still uses premultiplied alpha
interpolation instead of straight alpha.

So this patch is forcing it locally. Probably not the best. I will open
a radar on CoreGraphics. But in the meantime, this fixes the bug
for Canva team, by giving the correct rendering.

Also if there is no WPT progression, then tests are missing and I need
to add them.

* Source/WebCore/platform/graphics/cg/GradientRendererCG.cpp:
(WebCore::GradientRendererCG::pickStrategy const):
(WebCore::GradientRendererCG::makeGradient const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4a76d4381b367ee4d66b0f61d6042dcf1075ddb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139678 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12054 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1182 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147813 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92746 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/81c6a2b2-fe87-49e7-8332-b261b70eb039) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141551 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12763 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12204 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106956 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77863 "1 flakes 7 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/02d72fbe-a560-42d6-a0ea-4690dd07d50a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142625 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9821 "Found 10 new test failures: fast/forms/auto-fill-button/input-strong-password-viewable-baseline-alignment.html fast/forms/auto-fill-button/input-strong-password-viewable-taller-button-height.html imported/mozilla/svg/linearGradient-basic-03.svg svg/gradients/spreadMethod.svg svg/gradients/spreadMethodDiagonal.svg svg/gradients/spreadMethodDiagonal2.svg svg/gradients/spreadMethodDuplicateStop.svg svg/gradients/spreadMethodReversed.svg svg/gradients/stopAlpha.svg svg/stroke/non-scaling-stroke-gradient-text.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125103 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87820 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2cca186b-df2e-4e81-848f-915c94f8ffb5) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9474 "Found 1 new test failure: imported/w3c/web-platform-tests/svg/pservers/reftests/radialgradient-basic-002.svg (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7004 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8105 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118711 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1101 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150595 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11739 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1149 "Found 11 new test failures: fast/forms/auto-fill-button/input-strong-password-viewable-baseline-alignment.html fast/forms/auto-fill-button/input-strong-password-viewable-taller-button-height.html imported/mozilla/svg/linearGradient-basic-03.svg imported/w3c/web-platform-tests/svg/pservers/reftests/radialgradient-basic-002.svg svg/gradients/spreadMethod.svg svg/gradients/spreadMethodDiagonal.svg svg/gradients/spreadMethodDiagonal2.svg svg/gradients/spreadMethodDuplicateStop.svg svg/gradients/spreadMethodReversed.svg svg/gradients/stopAlpha.svg ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115360 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11752 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10054 "Found 11 new test failures: fast/forms/auto-fill-button/input-strong-password-viewable-baseline-alignment.html fast/forms/auto-fill-button/input-strong-password-viewable-taller-button-height.html imported/mozilla/svg/linearGradient-basic-03.svg imported/w3c/web-platform-tests/svg/pservers/reftests/radialgradient-basic-002.svg svg/gradients/spreadMethod.svg svg/gradients/spreadMethodDiagonal.svg svg/gradients/spreadMethodDiagonal2.svg svg/gradients/spreadMethodDuplicateStop.svg svg/gradients/spreadMethodReversed.svg svg/gradients/stopAlpha.svg ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115671 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10416 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121576 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66744 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11783 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1058 "Found 11 new test failures: fast/forms/auto-fill-button/input-strong-password-viewable-baseline-alignment.html fast/forms/auto-fill-button/input-strong-password-viewable-taller-button-height.html imported/mozilla/svg/linearGradient-basic-03.svg imported/w3c/web-platform-tests/svg/pservers/reftests/radialgradient-basic-002.svg svg/gradients/spreadMethod.svg svg/gradients/spreadMethodDiagonal.svg svg/gradients/spreadMethodDiagonal2.svg svg/gradients/spreadMethodDuplicateStop.svg svg/gradients/spreadMethodReversed.svg svg/gradients/stopAlpha.svg ... (failure)") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11523 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75461 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11718 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11570 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->