### PR TITLE
[Linux] Continuously parse `/proc/self/statm` in a background thread

### DIFF
--- a/Source/WTF/wtf/PlatformGTK.cmake
+++ b/Source/WTF/wtf/PlatformGTK.cmake
@@ -62,6 +62,7 @@ if (CMAKE_SYSTEM_NAME MATCHES "Linux")
     list(APPEND WTF_SOURCES
         linux/CurrentProcessMemoryStatus.cpp
         linux/MemoryFootprintLinux.cpp
+        linux/MemoryStatusMonitor.cpp
         linux/RealTimeThreads.cpp
 
         unix/MemoryPressureHandlerUnix.cpp

--- a/Source/WTF/wtf/PlatformJSCOnly.cmake
+++ b/Source/WTF/wtf/PlatformJSCOnly.cmake
@@ -93,6 +93,7 @@ elseif (CMAKE_SYSTEM_NAME MATCHES "Linux")
     list(APPEND WTF_SOURCES
         linux/CurrentProcessMemoryStatus.cpp
         linux/MemoryFootprintLinux.cpp
+        linux/MemoryStatusMonitor.cpp
         linux/RealTimeThreads.cpp
 
         unix/MemoryPressureHandlerUnix.cpp

--- a/Source/WTF/wtf/PlatformWPE.cmake
+++ b/Source/WTF/wtf/PlatformWPE.cmake
@@ -20,6 +20,7 @@ list(APPEND WTF_SOURCES
 
     linux/CurrentProcessMemoryStatus.cpp
     linux/MemoryFootprintLinux.cpp
+    linux/MemoryStatusMonitor.cpp
     linux/RealTimeThreads.cpp
 
     posix/CPUTimePOSIX.cpp

--- a/Source/WTF/wtf/haiku/CurrentProcessMemoryStatus.cpp
+++ b/Source/WTF/wtf/haiku/CurrentProcessMemoryStatus.cpp
@@ -31,7 +31,7 @@
 
 namespace WTF {
 
-void currentProcessMemoryStatus(ProcessMemoryStatus& memoryStatus)
+void currentProcessMemoryStatus(ProcessMemoryStatus& memoryStatus, MemoryStatusForceUpdate)
 {
     memoryStatus.size = 0;
     memoryStatus.resident = 0;

--- a/Source/WTF/wtf/linux/CurrentProcessMemoryStatus.cpp
+++ b/Source/WTF/wtf/linux/CurrentProcessMemoryStatus.cpp
@@ -26,43 +26,16 @@
 #include "config.h"
 #include <wtf/linux/CurrentProcessMemoryStatus.h>
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <unistd.h>
-#include <wtf/PageBlock.h>
+#include <wtf/linux/MemoryStatusMonitor.h>
 
 namespace WTF {
 
-IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
-void currentProcessMemoryStatus(ProcessMemoryStatus& memoryStatus)
+void currentProcessMemoryStatus(ProcessMemoryStatus& memoryStatus, MemoryStatusForceUpdate forceUpdate)
 {
-    FILE* file = fopen("/proc/self/statm", "r");
-    if (!file)
-        return;
-
-    char buffer[128];
-    char* line = fgets(buffer, 128, file);
-    fclose(file);
-    if (!line)
-        return;
-
-    size_t pageSize = WTF::pageSize();
-    char* end = nullptr;
-    unsigned long long intValue = strtoull(line, &end, 10);
-    memoryStatus.size = intValue * pageSize;
-    intValue = strtoull(end, &end, 10);
-    memoryStatus.resident = intValue * pageSize;
-    intValue = strtoull(end, &end, 10);
-    memoryStatus.shared = intValue * pageSize;
-    intValue = strtoull(end, &end, 10);
-    memoryStatus.text = intValue * pageSize;
-    intValue = strtoull(end, &end, 10);
-    memoryStatus.lib = intValue * pageSize;
-    intValue = strtoull(end, &end, 10);
-    memoryStatus.data = intValue * pageSize;
-    intValue = strtoull(end, &end, 10);
-    memoryStatus.dt = intValue * pageSize;
+    auto& monitor = MemoryStatusMonitor::singleton();
+    if (forceUpdate == MemoryStatusForceUpdate::Yes)
+        monitor.updateMemoryStatus();
+    memoryStatus = monitor.memoryStatus();
 }
-IGNORE_CLANG_WARNINGS_END
 
 } // namespace WTF

--- a/Source/WTF/wtf/linux/CurrentProcessMemoryStatus.h
+++ b/Source/WTF/wtf/linux/CurrentProcessMemoryStatus.h
@@ -29,8 +29,10 @@
 
 namespace WTF {
 
-WTF_EXPORT_PRIVATE void currentProcessMemoryStatus(ProcessMemoryStatus&);
+enum class MemoryStatusForceUpdate : bool { No, Yes };
+WTF_EXPORT_PRIVATE void currentProcessMemoryStatus(ProcessMemoryStatus&, MemoryStatusForceUpdate = MemoryStatusForceUpdate::No);
 
 } // namespace WTF
 
+using WTF::MemoryStatusForceUpdate;
 using WTF::currentProcessMemoryStatus;

--- a/Source/WTF/wtf/linux/MemoryFootprintLinux.cpp
+++ b/Source/WTF/wtf/linux/MemoryFootprintLinux.cpp
@@ -26,26 +26,14 @@
 #include "config.h"
 #include <wtf/MemoryFootprint.h>
 
-#include <stdio.h>
-#include <wtf/MonotonicTime.h>
-#include <wtf/StdLibExtras.h>
 #include <wtf/linux/CurrentProcessMemoryStatus.h>
-#include <wtf/text/StringView.h>
 
 namespace WTF {
 
-static const Seconds s_memoryFootprintUpdateInterval = 1_s;
-
 size_t memoryFootprint()
 {
-    static ProcessMemoryStatus memoryStatus;
-    static MonotonicTime previousUpdateTime = { };
-    Seconds elapsed = MonotonicTime::now() - previousUpdateTime;
-    if (elapsed >= s_memoryFootprintUpdateInterval) {
-        currentProcessMemoryStatus(memoryStatus);
-        previousUpdateTime = MonotonicTime::now();
-    }
-
+    ProcessMemoryStatus memoryStatus;
+    currentProcessMemoryStatus(memoryStatus);
     return memoryStatus.resident;
 }
 

--- a/Source/WTF/wtf/linux/MemoryStatusMonitor.cpp
+++ b/Source/WTF/wtf/linux/MemoryStatusMonitor.cpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "MemoryStatusMonitor.h"
+
+#include <fcntl.h>
+#include <unistd.h>
+#include <wtf/PageBlock.h>
+#include <wtf/Threading.h>
+#include <wtf/text/StringToIntegerConversion.h>
+#include <wtf/text/StringView.h>
+
+namespace WTF {
+
+static const Seconds s_maxUpdateInterval { 10_s };
+
+MemoryStatusMonitor& MemoryStatusMonitor::singleton()
+{
+    static NeverDestroyed<MemoryStatusMonitor> memoryStatusMonitor;
+    return memoryStatusMonitor;
+}
+
+MemoryStatusMonitor::MemoryStatusMonitor()
+{
+    m_statmFd = UnixFileDescriptor { open("/proc/self/statm", O_RDONLY | O_CLOEXEC), UnixFileDescriptor::Adopt };
+    if (!m_statmFd)
+        return;
+
+    Thread::create("MemoryStatusMonitor"_s, [this] {
+        while (true) {
+            MonotonicTime nextUpdateTime;
+            {
+                Locker locker { m_lock };
+                nextUpdateTime = m_lastUpdateTime + s_maxUpdateInterval;
+            }
+
+            if (nextUpdateTime <= MonotonicTime::now()) {
+                updateMemoryStatus();
+                sleep(s_maxUpdateInterval);
+                continue;
+            }
+
+            sleep(nextUpdateTime - MonotonicTime::now());
+        }
+    })->detach();
+}
+
+void MemoryStatusMonitor::updateMemoryStatus()
+{
+    std::array<char, 256> buffer;
+
+    ssize_t numBytes = pread(m_statmFd.value(), buffer.data(), buffer.size() - 1, 0);
+    if (numBytes <= 0)
+        return;
+
+    buffer[numBytes] = '\0';
+
+    auto view = StringView::fromLatin1(buffer.data());
+
+    auto size = parseNextColumn(view);
+    if (!size)
+        return;
+
+    auto resident = parseNextColumn(view);
+    if (!resident)
+        return;
+
+    auto shared = parseNextColumn(view);
+    if (!shared)
+        return;
+
+    auto text = parseNextColumn(view);
+    if (!text)
+        return;
+
+    auto lib = parseNextColumn(view);
+    if (!lib)
+        return;
+
+    auto data = parseNextColumn(view);
+    if (!data)
+        return;
+
+    auto dt = parseNextColumn(view);
+    if (!dt)
+        return;
+
+    size_t pageSize = WTF::pageSize();
+
+    Locker locker { m_lock };
+    m_memoryStatus = {
+        .size = *size * pageSize,
+        .resident = *resident * pageSize,
+        .shared = *shared * pageSize,
+        .text = *text * pageSize,
+        .lib = *lib * pageSize,
+        .data = *data * pageSize,
+        .dt = *dt * pageSize
+    };
+    m_lastUpdateTime = MonotonicTime::now();
+}
+
+std::optional<size_t> MemoryStatusMonitor::parseNextColumn(StringView& view)
+{
+    size_t whitspaceIndex = view.find(' ');
+    if (whitspaceIndex == notFound)
+        return std::nullopt;
+    view = view.substring(0, whitspaceIndex + 1);
+    return parseIntegerAllowingTrailingJunk<size_t>(view);
+}
+
+} // namespace WTF

--- a/Source/WTF/wtf/linux/MemoryStatusMonitor.h
+++ b/Source/WTF/wtf/linux/MemoryStatusMonitor.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Lock.h>
+#include <wtf/MonotonicTime.h>
+#include <wtf/NeverDestroyed.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/ProcessMemoryStatus.h>
+#include <wtf/unix/UnixFileDescriptor.h>
+
+namespace WTF {
+
+class MemoryStatusMonitor {
+    WTF_MAKE_NONCOPYABLE(MemoryStatusMonitor);
+    friend NeverDestroyed<MemoryStatusMonitor>;
+public:
+    static MemoryStatusMonitor& singleton();
+
+    void updateMemoryStatus();
+
+    ProcessMemoryStatus memoryStatus() const
+    {
+        Locker locker { m_lock };
+        return m_memoryStatus;
+    }
+
+    ~MemoryStatusMonitor() = default;
+
+private:
+    MemoryStatusMonitor();
+
+    std::optional<size_t> parseNextColumn(StringView&);
+
+    WTF::UnixFileDescriptor m_statmFd;
+
+    mutable Lock m_lock;
+    ProcessMemoryStatus m_memoryStatus WTF_GUARDED_BY_LOCK(m_lock);
+    MonotonicTime m_lastUpdateTime WTF_GUARDED_BY_LOCK(m_lock);
+};
+
+} // namespace WTF

--- a/Source/WTF/wtf/unix/MemoryPressureHandlerUnix.cpp
+++ b/Source/WTF/wtf/unix/MemoryPressureHandlerUnix.cpp
@@ -115,7 +115,7 @@ static size_t processMemoryUsage()
 {
 #if OS(LINUX) || OS(HAIKU)
     ProcessMemoryStatus memoryStatus;
-    currentProcessMemoryStatus(memoryStatus);
+    currentProcessMemoryStatus(memoryStatus, MemoryStatusForceUpdate::Yes);
     return (memoryStatus.resident - memoryStatus.shared);
 #elif OS(FREEBSD)
     static size_t pageSize = sysconf(_SC_PAGE_SIZE);

--- a/Source/WebCore/page/linux/ResourceUsageThreadLinux.cpp
+++ b/Source/WebCore/page/linux/ResourceUsageThreadLinux.cpp
@@ -313,7 +313,7 @@ void ResourceUsageThread::platformCollectCPUData(JSC::VM*, ResourceUsageData& da
 void ResourceUsageThread::platformCollectMemoryData(JSC::VM* vm, ResourceUsageData& data)
 {
     ProcessMemoryStatus memoryStatus;
-    currentProcessMemoryStatus(memoryStatus);
+    currentProcessMemoryStatus(memoryStatus, MemoryStatusForceUpdate::Yes);
     data.totalDirtySize = memoryStatus.resident - memoryStatus.shared;
 
     size_t currentGCHeapCapacity = vm->heap.blockBytesAllocated();


### PR DESCRIPTION
#### c86710699efd7a8e3f82b260582423c4427300b5
<pre>
[Linux] Continuously parse `/proc/self/statm` in a background thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=305833">https://bugs.webkit.org/show_bug.cgi?id=305833</a>

Reviewed by NOBODY (OOPS!).

Introduce a `MemoryStatusMonitor` singleton that polls
`/proc/self/statm` in a background thread at 10 second intervals,
allowing `currentProcessMemoryStatus()` to return
cached values instead of reading the file on every call. This improves
performance when memory stats are frequently queried by
`ResourceUsageThread`.

It&apos;s also possible to force an immediate update of memory status by
calling `updateMemoryStatus()` before retrieving the cached values.
This method is thread-safe and can be called from any thread.

The monitor uses a cached file descriptor with `pread()` to avoid
`fopen()`/`fclose()` overhead on each poll. Memory status is protected
by a `Lock` for thread-safe access from any thread.

* Source/WTF/wtf/PlatformGTK.cmake:
* Source/WTF/wtf/PlatformJSCOnly.cmake:
* Source/WTF/wtf/PlatformWPE.cmake:
* Source/WTF/wtf/haiku/CurrentProcessMemoryStatus.cpp:
(WTF::currentProcessMemoryStatus):
* Source/WTF/wtf/linux/CurrentProcessMemoryStatus.cpp:
(WTF::currentProcessMemoryStatus):
* Source/WTF/wtf/linux/CurrentProcessMemoryStatus.h:
* Source/WTF/wtf/linux/MemoryFootprintLinux.cpp:
(WTF::memoryFootprint):
* Source/WTF/wtf/linux/MemoryStatusMonitor.cpp: Added.
(WTF::MemoryStatusMonitor::singleton):
(WTF::MemoryStatusMonitor::MemoryStatusMonitor):
(WTF::MemoryStatusMonitor::updateMemoryStatus):
(WTF::MemoryStatusMonitor::parseNextColumn):
* Source/WTF/wtf/linux/MemoryStatusMonitor.h: Added.
(WTF::MemoryStatusMonitor::memoryStatus const):
* Source/WTF/wtf/unix/MemoryPressureHandlerUnix.cpp:
(WTF::processMemoryUsage):
* Source/WebCore/page/linux/ResourceUsageThreadLinux.cpp:
(WebCore::ResourceUsageThread::platformCollectMemoryData):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c86710699efd7a8e3f82b260582423c4427300b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140078 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12459 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1589 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148226 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93155 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141951 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13169 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12611 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107234 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78033 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143028 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10128 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125423 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88126 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9773 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7305 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8510 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/132052 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119007 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1434 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151014 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/875 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12144 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1498 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115665 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12157 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10396 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115990 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10834 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121910 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67155 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12187 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1382 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/171350 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11928 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75884 "Built successfully") | [⏳ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12122 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11974 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->