### PR TITLE
Implement service worker resource timing API

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/tentative/static-router/static-router-resource-timing.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/tentative/static-router/static-router-resource-timing.https-expected.txt
@@ -1,16 +1,16 @@
 
-FAIL Main resource matched the rule with fetch-event source assert_equals: fetch-event as source on main resource expected (string) "fetch-event" but got (undefined) undefined
-FAIL Main resource load matched with the condition and resource timing assert_equals: network as source on main resource expected (string) "network" but got (undefined) undefined
-FAIL Main resource load not matched with the condition and resource timing assert_equals: no rule matched on main resource expected (string) "" but got (undefined) undefined
+PASS Main resource matched the rule with fetch-event source
+PASS Main resource load matched with the condition and resource timing
+PASS Main resource load not matched with the condition and resource timing
 FAIL Main resource load matched with the cache source and resource timing assert_equals: cache as source on main resource and cache hit expected 1 but got 0
-FAIL Main resource fallback to the network when there is no cache entry and resource timing assert_equals: cache as source on main resource and cache miss, fallback to network expected (string) "cache" but got (undefined) undefined
-FAIL Subresource load matched the rule fetch-event source assert_equals: fetch-event as source on sub resource expected (string) "fetch-event" but got (undefined) undefined
-FAIL Subresource load not matched with URLPattern condition assert_equals: no source type matched expected (string) "" but got (undefined) undefined
-FAIL Subresource load matched with URLPattern condition assert_equals: network as source on subresource expected (string) "network" but got (undefined) undefined
-FAIL Subresource load matched with the cache source rule assert_equals: cache as source on subresource and cache hits expected (string) "cache" but got (undefined) undefined
-FAIL Subresource load did not match with the cache and fallback to the network assert_equals: cache as source on subresource and cache misses expected (string) "cache" but got (undefined) undefined
-FAIL Main resource load matched the rule with race-network-and-fetch-handler source, and the fetch handler response is faster than the server response assert_equals: race as source on main resource, and fetch-event wins expected (string) "race-network-and-fetch-handler" but got (undefined) undefined
-FAIL Main resource load matched the rule with race-network-and-fetch-handler source, and the server reseponse is faster than the fetch handler assert_equals: race as source on main resource, and network wins expected (string) "race-network-and-fetch-handler" but got (undefined) undefined
-FAIL Subresource load matched the rule with race-network-and-fetch-handler source, and the fetch handler response is faster than the server response assert_equals: race as source on subresource and fetch wins expected (string) "race-network-and-fetch-handler" but got (undefined) undefined
-FAIL Subresource load matched the rule with race-network-and-fetch-handler source, and the server reseponse is faster than the fetch handler assert_equals: race as source on subresource and network wins expected (string) "race-network-and-fetch-handler" but got (undefined) undefined
+PASS Main resource fallback to the network when there is no cache entry and resource timing
+FAIL Subresource load matched the rule fetch-event source assert_equals: fetch-event as source on sub resource expected "fetch-event" but got ""
+FAIL Subresource load not matched with URLPattern condition assert_greater_than: no source type matched expected a number greater than 0 but got 0
+PASS Subresource load matched with URLPattern condition
+FAIL Subresource load matched with the cache source rule assert_equals: cache as source on subresource and cache hits expected "cache" but got ""
+PASS Subresource load did not match with the cache and fallback to the network
+PASS Main resource load matched the rule with race-network-and-fetch-handler source, and the fetch handler response is faster than the server response
+PASS Main resource load matched the rule with race-network-and-fetch-handler source, and the server reseponse is faster than the fetch handler
+FAIL Subresource load matched the rule with race-network-and-fetch-handler source, and the fetch handler response is faster than the server response assert_equals: race as source on subresource and fetch wins expected "race-network-and-fetch-handler" but got ""
+PASS Subresource load matched the rule with race-network-and-fetch-handler source, and the server reseponse is faster than the fetch handler
 

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/tentative/static-router/static-router-resource-timing.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/tentative/static-router/static-router-resource-timing.https.html
@@ -47,8 +47,12 @@ function test_resource_timing(options) {
   assert_equals(entryList.length, 1, description);
   const entry = entryList[0];
 
-  assert_equals(entry.workerMatchedSourceType, options.matched_source_type, description);
-  assert_equals(entry.workerFinalSourceType, options.final_source_type, description);
+  // FIXME: Remove workerMatchedSourceType and workerFinalSourceType when moved out of tentative.
+  const workerMatchedRouterSource = "workerMatchedRouterSource" in entry ? entry.workerMatchedRouterSource : entry.workerMatchedSourceType;
+  const workerFinalRouterSource = "workerFinalRouterSource" in entry ? entry.workerFinalRouterSource : entry.workerFinalSourceType;
+
+  assert_equals(workerMatchedRouterSource, options.matched_source_type, description);
+  assert_equals(workerFinalRouterSource, options.final_source_type, description);
 
   assert_greater_than(entry.workerRouterEvaluationStart, 0, description);
   switch (entry.matchedSouceType) {

--- a/Source/WebCore/page/PerformanceResourceTiming.cpp
+++ b/Source/WebCore/page/PerformanceResourceTiming.cpp
@@ -339,4 +339,34 @@ uint64_t PerformanceResourceTiming::decodedBodySize() const
     return decodedBodySize;
 }
 
+double PerformanceResourceTiming::workerRouterEvaluationStart() const
+{
+    // FIXME: Align time computation with other timestamps.
+    Seconds difference = m_resourceTiming.networkLoadMetrics().workerRouterEvaluationStart - m_timeOrigin;
+    if (difference.value() <= 0)
+        return 0.0;
+    auto reducedPrecision = Performance::reduceTimeResolution(difference).milliseconds();
+    return reducedPrecision ? reducedPrecision : 1;
+}
+
+double PerformanceResourceTiming::workerCacheLookupStart() const
+{
+    // FIXME: Align time computation with other timestamps.
+    Seconds difference = m_resourceTiming.networkLoadMetrics().workerCacheLookupStart - m_timeOrigin;
+    if (difference.value() <= 0)
+        return 0.0;
+    auto reducedPrecision = Performance::reduceTimeResolution(difference).milliseconds();
+    return reducedPrecision ? reducedPrecision : 1;
+}
+
+const String& PerformanceResourceTiming::workerMatchedRouterSource() const
+{
+    return m_resourceTiming.networkLoadMetrics().workerMatchedRouterSource;
+}
+
+const String& PerformanceResourceTiming::workerFinalRouterSource() const
+{
+    return m_resourceTiming.networkLoadMetrics().workerFinalRouterSource;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/page/PerformanceResourceTiming.h
+++ b/Source/WebCore/page/PerformanceResourceTiming.h
@@ -67,6 +67,10 @@ public:
     uint64_t transferSize() const;
     uint64_t encodedBodySize() const;
     uint64_t decodedBodySize() const;
+    double workerRouterEvaluationStart() const;
+    double workerCacheLookupStart() const;
+    const String& workerMatchedRouterSource() const;
+    const String& workerFinalRouterSource() const;
 
     const Vector<Ref<PerformanceServerTiming>>& serverTiming() const { return m_serverTiming; }
     ResourceTiming& resourceTiming() { return m_resourceTiming; }

--- a/Source/WebCore/page/PerformanceResourceTiming.idl
+++ b/Source/WebCore/page/PerformanceResourceTiming.idl
@@ -57,6 +57,11 @@ typedef double DOMHighResTimeStamp;
     readonly attribute unsigned long long encodedBodySize;
     readonly attribute unsigned long long decodedBodySize;
 
+    readonly attribute DOMHighResTimeStamp workerRouterEvaluationStart;
+    readonly attribute DOMHighResTimeStamp workerCacheLookupStart;
+    readonly attribute DOMString workerMatchedRouterSource;
+    readonly attribute DOMString workerFinalRouterSource;
+
     // https://w3c.github.io/resource-timing/#dfn-delivery-type
     readonly attribute DOMString deliveryType;
 

--- a/Source/WebCore/platform/network/NetworkLoadMetrics.h
+++ b/Source/WebCore/platform/network/NetworkLoadMetrics.h
@@ -95,6 +95,10 @@ public:
     MonotonicTime responseStart;
     MonotonicTime responseEnd;
     MonotonicTime workerStart;
+    MonotonicTime workerRouterEvaluationStart;
+    MonotonicTime workerCacheLookupStart;
+    String workerMatchedRouterSource;
+    String workerFinalRouterSource;
 
     // https://github.com/w3c/resource-timing/pull/408
     // Timing for interim (1xx) vs final (2xx/3xx/4xx/5xx) responses

--- a/Source/WebCore/workers/service/server/SWServerWorker.cpp
+++ b/Source/WebCore/workers/service/server/SWServerWorker.cpp
@@ -534,13 +534,18 @@ std::optional<ExceptionData> SWServerWorker::addRoutes(Vector<ServiceWorkerRoute
 }
 
 // https://w3c.github.io/ServiceWorker/#get-router-source
-RouterSource SWServerWorker::getRouterSource(const FetchOptions& options, const ResourceRequest& request) const
+std::optional<RouterSource> SWServerWorker::getRouterSource(const FetchOptions& options, const ResourceRequest& request) const
 {
     for (auto& route : m_routes) {
         if (matchRouterCondition(route.condition, options, request, isRunning()))
             return route.source;
     }
 
+    return { };
+}
+
+RouterSource SWServerWorker::defaultRouterSource() const
+{
     return m_shouldSkipHandleFetch ? RouterSourceEnum::Network : RouterSourceEnum::FetchEvent;
 }
 

--- a/Source/WebCore/workers/service/server/SWServerWorker.h
+++ b/Source/WebCore/workers/service/server/SWServerWorker.h
@@ -130,8 +130,10 @@ public:
     WEBCORE_EXPORT SWServerToContextConnection* contextConnection();
     String userAgent() const;
 
-    WEBCORE_EXPORT RouterSource getRouterSource(const FetchOptions&, const ResourceRequest&) const;
-    
+    bool hasRouterRules() const { return !m_routes.isEmpty(); }
+    WEBCORE_EXPORT std::optional<RouterSource> getRouterSource(const FetchOptions&, const ResourceRequest&) const;
+    WEBCORE_EXPORT RouterSource defaultRouterSource() const;
+
     WEBCORE_EXPORT SWServerRegistration* registration() const;
 
     void setHasTimedOutAnyFetchTasks() { m_hasTimedOutAnyFetchTasks = true; }

--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -526,6 +526,7 @@ set(WebKit_SERIALIZATION_IN_FILES
     Shared/ScriptTrackingPrivacyFilter.serialization.in
     Shared/ScrollingAccelerationCurve.serialization.in
     Shared/SerializedNode.serialization.in
+    Shared/ServiceWorkerTimingInfo.serialization.in
     Shared/SessionState.serialization.in
     Shared/SyntheticEditingCommandType.serialization.in
     Shared/TextFlags.serialization.in

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -374,6 +374,7 @@ $(PROJECT_DIR)/Shared/SandboxExtension.serialization.in
 $(PROJECT_DIR)/Shared/ScriptTrackingPrivacyFilter.serialization.in
 $(PROJECT_DIR)/Shared/ScrollingAccelerationCurve.serialization.in
 $(PROJECT_DIR)/Shared/SerializedNode.serialization.in
+$(PROJECT_DIR)/Shared/ServiceWorkerTimingInfo.serialization.in
 $(PROJECT_DIR)/Shared/SessionState.serialization.in
 $(PROJECT_DIR)/Shared/Shared/EditorState.serialization.in
 $(PROJECT_DIR)/Shared/SyntheticEditingCommandType.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -771,6 +771,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/ScriptTrackingPrivacyFilter.serialization.in \
 	Shared/ScrollingAccelerationCurve.serialization.in \
 	Shared/SerializedNode.serialization.in \
+	Shared/ServiceWorkerTimingInfo.serialization.in \
 	Shared/SessionState.serialization.in \
 	Shared/SyntheticEditingCommandType.serialization.in \
 	Shared/TextFlags.serialization.in \

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
@@ -33,6 +33,7 @@
 #include "NetworkResourceLoadIdentifier.h"
 #include "NetworkResourceLoadParameters.h"
 #include "PrivateRelayed.h"
+#include "ServiceWorkerTimingInfo.h"
 #include <WebCore/ContentFilterClient.h>
 #include <WebCore/ContentFilterUnblockHandler.h>
 #include <WebCore/ContentSecurityPolicyClient.h>
@@ -169,7 +170,11 @@ public:
     void serviceWorkerDidNotHandle(ServiceWorkerFetchTask*);
     void setServiceWorkerRegistration(WebCore::SWServerRegistration& serviceWorkerRegistration) { m_serviceWorkerRegistration = serviceWorkerRegistration; }
     void setWorkerStart(MonotonicTime);
-    MonotonicTime workerStart() const { return m_workerStart; }
+
+    void setWorkerRouterEvaluationStart(MonotonicTime);
+    void setWorkerCacheLookupStart(MonotonicTime);
+    void setWorkerMatchedRouterSource(WebCore::RouterSourceEnum);
+    void setWorkerFinalRouterSource(WebCore::RouterSourceEnum);
 
     std::optional<WebCore::ResourceError> doCrossOriginOpenerHandlingOfResponse(const WebCore::ResourceResponse&);
     void sendDidReceiveResponsePotentiallyInNewBrowsingContextGroup(const WebCore::ResourceResponse&, PrivateRelayed, bool needsContinueDidReceiveResponseMessage);
@@ -338,7 +343,8 @@ private:
     std::optional<NetworkActivityTracker> m_networkActivityTracker;
     RefPtr<ServiceWorkerFetchTask> m_serviceWorkerFetchTask;
     WeakPtr<WebCore::SWServerRegistration> m_serviceWorkerRegistration;
-    MonotonicTime m_workerStart;
+    std::optional<ServiceWorkerTimingInfo> m_serviceWorkerTimingInfo;
+
     NetworkResourceLoadIdentifier m_resourceLoadID;
     WebCore::ResourceResponse m_redirectResponse;
     URL m_firstResponseURL; // First URL in response's URL list (https://fetch.spec.whatwg.org/#concept-response-url-list).

--- a/Source/WebKit/Shared/ServiceWorkerTimingInfo.h
+++ b/Source/WebKit/Shared/ServiceWorkerTimingInfo.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/RouterSourceEnum.h>
+#include <wtf/MonotonicTime.h>
+
+namespace WebKit {
+
+struct ServiceWorkerTimingInfo {
+    MonotonicTime workerStart;
+    MonotonicTime workerRouterEvaluationStart;
+    MonotonicTime workerCacheLookupStart;
+    std::optional<WebCore::RouterSourceEnum> workerMatchedRouterSource;
+    std::optional<WebCore::RouterSourceEnum> workerFinalRouterSource;
+};
+
+} // namespace WebKit

--- a/Source/WebKit/Shared/ServiceWorkerTimingInfo.serialization.in
+++ b/Source/WebKit/Shared/ServiceWorkerTimingInfo.serialization.in
@@ -1,0 +1,29 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+struct WebKit::ServiceWorkerTimingInfo {
+    MonotonicTime workerStart;
+    MonotonicTime workerRouterEvaluationStart;
+    MonotonicTime workerCacheLookupStart;
+    std::optional<WebCore::RouterSourceEnum> workerMatchedRouterSource;
+    std::optional<WebCore::RouterSourceEnum> workerFinalRouterSource;
+}

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7488,6 +7488,11 @@ class WebCore::NetworkLoadMetrics {
     MonotonicTime responseStart;
     MonotonicTime responseEnd;
     MonotonicTime workerStart;
+    [NotSerialized] MonotonicTime workerRouterEvaluationStart;
+    [NotSerialized] MonotonicTime workerCacheLookupStart;
+    [NotSerialized] String workerMatchedRouterSource;
+    [NotSerialized] String workerFinalRouterSource;
+
     MonotonicTime firstInterimResponseStart;
 
     String protocol;

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -5447,6 +5447,8 @@
 		4105A0652D537C2B00EA2D19 /* FileSystemStorageManagerLock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FileSystemStorageManagerLock.h; sourceTree = "<group>"; };
 		410BA139257135F2002E2F8A /* NetworkRTCTCPSocketCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = NetworkRTCTCPSocketCocoa.mm; sourceTree = "<group>"; };
 		410BA13A257135F2002E2F8A /* NetworkRTCTCPSocketCocoa.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NetworkRTCTCPSocketCocoa.h; sourceTree = "<group>"; };
+		411051492F1E9A9D007558EA /* ServiceWorkerTimingInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ServiceWorkerTimingInfo.h; sourceTree = "<group>"; };
+		4110514A2F1E9A9D007558EA /* ServiceWorkerTimingInfo.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = ServiceWorkerTimingInfo.serialization.in; sourceTree = "<group>"; };
 		4111436320F677B10026F912 /* InjectUserScriptImmediately.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InjectUserScriptImmediately.h; sourceTree = "<group>"; };
 		411223B72602152B00B0A0B6 /* RTCDataChannelRemoteManager.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; name = RTCDataChannelRemoteManager.messages.in; path = Network/webrtc/RTCDataChannelRemoteManager.messages.in; sourceTree = "<group>"; };
 		411223BB26024E8000B0A0B6 /* RTCDataChannelRemoteManagerProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RTCDataChannelRemoteManagerProxy.h; sourceTree = "<group>"; };
@@ -10200,6 +10202,8 @@
 				460B87352AFD9F8200200D8C /* ScrollingAccelerationCurve.serialization.in */,
 				FAA54BCC2E3805FE00E3F012 /* SerializedNode.serialization.in */,
 				5C96003F28C02EAF00F2693B /* SerializedTypeInfo.h */,
+				411051492F1E9A9D007558EA /* ServiceWorkerTimingInfo.h */,
+				4110514A2F1E9A9D007558EA /* ServiceWorkerTimingInfo.serialization.in */,
 				1AFDE6571954A42B00C48FFA /* SessionState.cpp */,
 				1AFDE6581954A42B00C48FFA /* SessionState.h */,
 				5C03D5DD28F765F800D096AF /* SessionState.serialization.in */,

--- a/Source/WebKit/WebProcess/Network/WebResourceLoader.h
+++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.h
@@ -27,6 +27,7 @@
 
 #include "Connection.h"
 #include "MessageSender.h"
+#include "ServiceWorkerTimingInfo.h"
 #include "WebPageProxyIdentifier.h"
 #include "WebResourceInterceptController.h"
 #include <WebCore/FrameIdentifier.h>
@@ -95,7 +96,7 @@ private:
     void updateResultingClientIdentifier(WTF::UUID currentIdentifier, WTF::UUID newIdentifier);
 
     void didBlockAuthenticationChallenge();
-    void setWorkerStart(MonotonicTime value) { m_workerStart = value; }
+    void setServiceWorkerTimingInfo(ServiceWorkerTimingInfo&& info) { m_serviceWorkerTimingInfo = WTF::move(info); }
 
     void stopLoadingAfterXFrameOptionsOrContentSecurityPolicyDenied(const WebCore::ResourceResponse&);
 
@@ -110,6 +111,7 @@ private:
 #endif
 
     size_t calculateBytesTransferredOverNetworkDelta(size_t bytesTransferredOverNetwork);
+    void updateNetworkLoadMetrics(WebCore::NetworkLoadMetrics&);
 
     RefPtr<WebCore::ResourceLoader> m_coreLoader;
     const std::optional<TrackingParameters> m_trackingParameters;
@@ -124,7 +126,7 @@ private:
     Seconds timeSinceLoadStart() const { return MonotonicTime::now() - m_loadStart; }
 
     const MonotonicTime m_loadStart;
-    MonotonicTime m_workerStart;
+    std::optional<ServiceWorkerTimingInfo> m_serviceWorkerTimingInfo;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Network/WebResourceLoader.messages.in
+++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.messages.in
@@ -26,7 +26,7 @@
 ]
 messages -> WebResourceLoader {
     WillSendRequest(WebCore::ResourceRequest request, IPC::FormDataReference requestBody, WebCore::ResourceResponse redirectResponse) -> (WebCore::ResourceRequest newRequest, bool isAllowedToAskUserForCredentials)
-    SetWorkerStart(MonotonicTime value)
+    SetServiceWorkerTimingInfo(struct WebKit::ServiceWorkerTimingInfo info)
     DidSendData(uint64_t bytesSent, uint64_t totalBytesToBeSent)
     DidReceiveResponse(WebCore::ResourceResponse response, enum:bool WebKit::PrivateRelayed privateRelayed, bool needsContinueDidReceiveResponseMessage, std::optional<WebCore::NetworkLoadMetrics> optionalNetworkLoadMetrics)
     DidReceiveData(IPC::SharedBufferReference data, uint64_t bytesTransferredOverNetwork)


### PR DESCRIPTION
#### 14bbe4e4af393ea3abcf85e3e1fcf0f937701a40
<pre>
Implement service worker resource timing API
<a href="https://rdar.apple.com/168499249">rdar://168499249</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=305831">https://bugs.webkit.org/show_bug.cgi?id=305831</a>

Reviewed by Chris Dumez.

We add support for <a href="https://w3c.github.io/ServiceWorker/#service-worker-timing-info">https://w3c.github.io/ServiceWorker/#service-worker-timing-info</a> worker router evaluation start, worker cache lookup start, worker matched router source and worker final router source.
This is stored in NetworkResourceLoader and set by ServiceWorkerFetchTask and WebSWServerConnection.
We update SWServerWorker::getRouterSource to return null or a source, as per spec to be able to properly set worker router evaluation start.

From NetworkResourceLoader, we send this additional information to WebResourceLoader just before sending the actual response.
We add the necessary WebIDL API and stubs in PerformanceResourceTiming, as well as the plumbery in NetworkLoadMetrics.

For two new timestamp properties, we make sure that reducing the precision of the values will not make them back to 0.0, which is equivalent to not being set.
Instead, these values will be set to 1ms, the precision limit.
A follow-up patch will make these two timstamps consistent with other timestamps

Covered by rebased test.
We update this test to use the standardized names of the properties if available.

Canonical link: <a href="https://commits.webkit.org/306006@main">https://commits.webkit.org/306006@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/840d2be85fbe8635caa8a23d97a8a451652da679

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140069 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12450 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1580 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148215 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/93146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3caf3c68-790d-4744-9efe-9e812066da3f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141942 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13160 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12602 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107227 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/93146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f3bb2128-6001-4d30-b6fa-d6dc9dd16d1a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143019 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10120 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125414 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88118 "Found 1 new API test failure: WPE/TestWebKitWebXR:/webkit/WebKitWebXR/leave-immersive-mode (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/793e69d1-0bf4-4607-b4de-85af5e001108) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9766 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7298 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8501 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/118988 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1425 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151004 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12135 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1489 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115660 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12148 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10389 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115984 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29469 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10812 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121901 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/67145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12178 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1373 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11919 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/75864 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12113 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11965 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->