### PR TITLE
ServiceWorker performance resource timing need network load metrics to be complete to be JS observable

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/tentative/static-router/static-router-resource-timing.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/tentative/static-router/static-router-resource-timing.https-expected.txt
@@ -4,13 +4,13 @@ PASS Main resource load matched with the condition and resource timing
 PASS Main resource load not matched with the condition and resource timing
 FAIL Main resource load matched with the cache source and resource timing assert_equals: cache as source on main resource and cache hit expected 1 but got 0
 PASS Main resource fallback to the network when there is no cache entry and resource timing
-FAIL Subresource load matched the rule fetch-event source assert_equals: fetch-event as source on sub resource expected "fetch-event" but got ""
-FAIL Subresource load not matched with URLPattern condition assert_greater_than: no source type matched expected a number greater than 0 but got 0
+PASS Subresource load matched the rule fetch-event source
+PASS Subresource load not matched with URLPattern condition
 PASS Subresource load matched with URLPattern condition
-FAIL Subresource load matched with the cache source rule assert_equals: cache as source on subresource and cache hits expected "cache" but got ""
+PASS Subresource load matched with the cache source rule
 PASS Subresource load did not match with the cache and fallback to the network
 PASS Main resource load matched the rule with race-network-and-fetch-handler source, and the fetch handler response is faster than the server response
 PASS Main resource load matched the rule with race-network-and-fetch-handler source, and the server reseponse is faster than the fetch handler
-FAIL Subresource load matched the rule with race-network-and-fetch-handler source, and the fetch handler response is faster than the server response assert_equals: race as source on subresource and fetch wins expected "race-network-and-fetch-handler" but got ""
+PASS Subresource load matched the rule with race-network-and-fetch-handler source, and the fetch handler response is faster than the server response
 PASS Subresource load matched the rule with race-network-and-fetch-handler source, and the server reseponse is faster than the fetch handler
 

--- a/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
+++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
@@ -321,6 +321,7 @@ void WebResourceLoader::didFinishResourceLoad(NetworkLoadMetrics&& networkLoadMe
     }
 
     updateNetworkLoadMetrics(networkLoadMetrics);
+    networkLoadMetrics.markComplete();
 
 #if ENABLE(CONTENT_EXTENSIONS)
     if (networkLoadMetrics.responseBodyBytesReceived != std::numeric_limits<uint64_t>::max()) {


### PR DESCRIPTION
#### b9da27c9464921eb090a23994b3ae72577ad4297
<pre>
ServiceWorker performance resource timing need network load metrics to be complete to be JS observable
<a href="https://rdar.apple.com/168501148">rdar://168501148</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=305834">https://bugs.webkit.org/show_bug.cgi?id=305834</a>

Reviewed by Chris Dumez.

If network load metrics are not marked as complete, ResourceLoader is not creating the correct resource timing entry.
When doing a load from a service worker, the metrics may be empty, for instance in case of a synthetic response.
We explicitly mark network load metrics in WebResourceLoader::didFinishResourceLoad as complete to fix that issue.

Canonical link: <a href="https://commits.webkit.org/306073@main">https://commits.webkit.org/306073@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a655588c466fcd682f612d2c24734443a544c5b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140089 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12470 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1600 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148237 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93166 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13180 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12622 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107245 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78039 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143039 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10143 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125436 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88137 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9791 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7314 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8521 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119016 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1442 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151026 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12155 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1512 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115674 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12168 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10413 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115999 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29513 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10879 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121918 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67166 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12198 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1395 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11939 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75897 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12137 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11985 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->