### PR TITLE
Include Platform before conditions

### DIFF
--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -831,6 +831,7 @@ def generate_messages_header(receiver):
     result.append('\n')
 
     if receiver.condition:
+        result.append('#include <wtf/Platform.h>\n')
         result.append('#if %s\n\n' % receiver.condition)
 
     result += forward_declarations_and_headers(receiver)

--- a/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessages.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
 #if (ENABLE(WEBKIT2) && (NESTED_MASTER_CONDITION || MASTER_OR && MASTER_AND))
 
 #include "ArgumentCoders.h"

--- a/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessages.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
 #if (ENABLE(WEBKIT2) && (NESTED_MASTER_CONDITION || MASTER_OR && MASTER_AND))
 
 #include "ArgumentCoders.h"


### PR DESCRIPTION
#### 6b8dbb2ce6e9f090a59f95403e6e01a86b8f9fe1
<pre>
Include Platform before conditions
<a href="https://bugs.webkit.org/show_bug.cgi?id=305845">https://bugs.webkit.org/show_bug.cgi?id=305845</a>
<a href="https://rdar.apple.com/168507070">rdar://168507070</a>

Reviewed by Richard Robinson.

Include the header required for the ENABLE() macro on the next line.
Although WebKit builds include these headers ambiently through
an -include directive, that doesn&apos;t help when these generated headers
are built as a standalone clang module where they need to be
hermetic and include everything that they use. This is also
causing issues on Linux as reported in

<a href="https://bugs.webkit.org/show_bug.cgi?id=305785">https://bugs.webkit.org/show_bug.cgi?id=305785</a>
Canonical link: <a href="https://commits.webkit.org/306342@main">https://commits.webkit.org/306342@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a3de259c6fb5973440d29442f835c501763c2cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139841 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12222 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1352 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147983 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92910 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/983d19c3-8f54-4aa0-9b34-d9e4b1623a83) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12932 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12374 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107079 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77942 "1 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/942149e6-00b8-4ea0-9d4b-ba95c1ac9eca) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142791 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9957 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125237 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87956 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ed99f1c4-b6bd-403b-930e-f5cc8d7c37c7) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/139186 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9611 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7122 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8273 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118830 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150767 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11907 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1305 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115492 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11919 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10200 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115806 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29712 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10588 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121717 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66912 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11949 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1192 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11689 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75636 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11885 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11737 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->