### PR TITLE
[WPE][cross-toolchain-helper]: libhyphen is required by default on WPE after 305816@main

### DIFF
--- a/Tools/yocto/meta-openembedded_and_meta-webkit.patch
+++ b/Tools/yocto/meta-openembedded_and_meta-webkit.patch
@@ -772,7 +772,7 @@ index 4133ad7..2234c9b 100644
      systemd-analyze \
      unifdef \
 diff --git a/sources/meta-webkit/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb b/sources/meta-webkit/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
-index 2b9b30f..d2c5fa6 100644
+index 2b9b30f..6d9c070 100644
 --- a/sources/meta-webkit/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
 +++ b/sources/meta-webkit/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
 @@ -132,6 +132,8 @@ RDEPENDS:packagegroup-wpewebkit-depends-core = "\
@@ -784,3 +784,35 @@ index 2b9b30f..d2c5fa6 100644
      zlib \
      libpng \
      libsoup \
+@@ -152,6 +154,7 @@ RDEPENDS:packagegroup-wpewebkit-depends-core = "\
+     wayland-protocols \
+     openjpeg \
+     libbacktrace \
++    hyphen \
+ "
+ 
+ RDEPENDS:packagegroup-wpewebkit-depends-core:append:libc-glibc = "\
+diff --git a/sources/meta-webkit/recipes-graphics/hyphen/hyphen_2.8.8.bb b/sources/meta-webkit/recipes-graphics/hyphen/hyphen_2.8.8.bb
+new file mode 100644
+index 0000000..75b3187
+--- /dev/null
++++ b/sources/meta-webkit/recipes-graphics/hyphen/hyphen_2.8.8.bb
+@@ -0,0 +1,18 @@
++SUMMARY = "A text hyphenation library"
++HOMEPAGE = "http://hunspell.sourceforge.net/"
++LICENSE = "LGPL-2.1-only | GPL-2.0-only | MPL-1.1"
++LIC_FILES_CHKSUM = " \
++    file://COPYING;md5=d45e3467790c1cae990cc9ca3293bc97 \
++    file://COPYING.LGPL;md5=d8045f3b8f929c1cb29a1e3fd737b499 \
++    file://COPYING.MPL;md5=bfe1f75d606912a4111c90743d6c7325 \
++"
++
++SRC_URI = "${SOURCEFORGE_MIRROR}/project/hunspell/Hyphen/2.8/${BPN}-${PV}.tar.gz"
++SRC_URI[md5sum] = "5ade6ae2a99bc1e9e57031ca88d36dad"
++SRC_URI[sha256sum] = "304636d4eccd81a14b6914d07b84c79ebb815288c76fe027b9ebff6ff24d5705"
++
++inherit autotools pkgconfig
++
++RDEPENDS:${PN} = "perl"
++
++BBCLASSEXTEND = "native"


### PR DESCRIPTION
#### bfc4c6e3d42a85595a54d302361908b6a712747a
<pre>
[WPE][cross-toolchain-helper]: libhyphen is required by default on WPE after 305816@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=305841">https://bugs.webkit.org/show_bug.cgi?id=305841</a>

Unreviewed build fix.

After 305816@main libhyphen is required by the default WPE build.
However this dependency was not available on the Yocto environment
used by the RPi4 perf bots.

This patch adds the recipe for libhyphen and builds the dependency
into the default image that cross-toolchain-helper generates.

The changes are integrated here as a local patch that has been
forwarded in another PR to the meta-webkit layer repo for review.
Refs: <a href="https://github.com/Igalia/meta-webkit/pull/582">https://github.com/Igalia/meta-webkit/pull/582</a>

* Tools/yocto/meta-openembedded_and_meta-webkit.patch:

Canonical link: <a href="https://commits.webkit.org/305887@main">https://commits.webkit.org/305887@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/493216890c361743aca16b0e1c37bcb74e428db1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/139722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12099 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1227 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147860 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141595 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/12807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/12250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/106988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/142669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/12807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/125134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87857 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/12807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8149 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/12807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/1131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150642 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11783 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/1186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/115393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/11797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/12250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115708 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/121613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66788 "Build is in progress. Recent messages:") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21551 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11827 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/1095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/11567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/11763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/11614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->