### PR TITLE
Resync `css/css-position/sticky` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -6477,6 +6477,7 @@
         "web-platform-tests/css/css-position/sticky/position-sticky-table-td-bottom-ref.html",
         "web-platform-tests/css/css-position/sticky/position-sticky-table-td-left-ref.html",
         "web-platform-tests/css/css-position/sticky/position-sticky-table-td-right-ref.html",
+        "web-platform-tests/css/css-position/sticky/position-sticky-table-td-subpixel-zoom-ref.html",
         "web-platform-tests/css/css-position/sticky/position-sticky-table-td-top-ref.html",
         "web-platform-tests/css/css-position/sticky/position-sticky-table-tfoot-bottom-ref.html",
         "web-platform-tests/css/css-position/sticky/position-sticky-table-th-bottom-ref.html",

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-bottom-004-expected.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-bottom-004-expected.xht
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
+  <style type="text/css"><![CDATA[
+  div
+  {
+  background-color: green;
+  height: 100px;
+  width: 100px;
+  }
+  ]]></style>
+ </head>
+ <body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div></div>
+ </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-bottom-004.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-bottom-004.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<title>CSS Position Test: sticky element with bottom offset</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-position/#stickypos-insets">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="
+  The static position of #sticky is outside (below) of its containing block.
+  Sticky positioning doesn't force it to move up into the containing block.
+">
+
+<style>
+#scroll-container {
+  overflow: hidden;
+  width: 100px;
+  height: 100px;
+  background: red;
+}
+#sticky {
+  position: sticky;
+  bottom: 0;
+  height: 100px;
+  background: green;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div id="scroll-container">
+  <div style="height: 100px; margin-top: -100px">
+    <div style="height: 100px"></div>
+    <div id="sticky"></div>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-bottom-005-expected.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-bottom-005-expected.xht
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
+  <style type="text/css"><![CDATA[
+  div
+  {
+  background-color: green;
+  height: 100px;
+  width: 100px;
+  }
+  ]]></style>
+ </head>
+ <body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div></div>
+ </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-bottom-005.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-bottom-005.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<title>CSS Position Test: sticky element with bottom offset</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-position/#stickypos-insets">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="
+  The static position of #sticky is outside (above) of its containing block.
+  Sticky positioning doesn't force it to move down into the containing block.
+">
+
+<style>
+#scroll-container {
+  overflow: hidden;
+  width: 100px;
+  height: 100px;
+  background: red;
+}
+#sticky {
+  position: sticky;
+  bottom: 0;
+  height: 100px;
+  background: green;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div id="scroll-container">
+  <div style="padding-top: 200px">
+    <div style="margin-top: -200px"></div>
+    <div id="sticky"></div>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-bottom-006-expected.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-bottom-006-expected.xht
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
+  <style type="text/css"><![CDATA[
+  div
+  {
+  background-color: green;
+  height: 100px;
+  width: 100px;
+  }
+  ]]></style>
+ </head>
+ <body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div></div>
+ </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-bottom-006.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-bottom-006.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<title>CSS Position Test: sticky element with bottom offset</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-position/#stickypos-insets">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="
+  The static position of #sticky is outside (above) of its nearest scrollport.
+  Sticky positioning doesn't force it to move down into the scrollport.
+">
+
+<style>
+#scroll-container {
+  overflow: hidden;
+  width: 100px;
+  height: 100px;
+  background: green;
+}
+#sticky {
+  position: sticky;
+  bottom: 0;
+  height: 100px;
+  background: red;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div id="scroll-container">
+  <div style="margin-top: -100px"></div>
+  <div id="sticky"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-bottom-007-expected.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-bottom-007-expected.xht
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
+  <style type="text/css"><![CDATA[
+  div
+  {
+  background-color: green;
+  height: 100px;
+  width: 100px;
+  }
+  ]]></style>
+ </head>
+ <body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div></div>
+ </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-bottom-007.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-bottom-007.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<title>CSS Position Test: sticky element with bottom offset</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-position/#stickypos-insets">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="
+  When the scroll container is scrolled to the top, then #sticky is visible.
+  If we scroll 100px down, then #sticky should update its sticky offsets
+  to still be visible.
+">
+
+<style>
+#scroll-container {
+  overflow: hidden;
+  width: 100px;
+  height: 100px;
+  background: red;
+}
+#sticky {
+  position: sticky;
+  bottom: 0;
+  height: 100px;
+  background: green;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div id="scroll-container">
+  <div style="height: 500px"></div>
+  <div id="sticky"></div>
+</div>
+
+<script>
+scroller.scrollTop = 100;
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-fractional-offset-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-fractional-offset-expected.html
@@ -4,8 +4,15 @@
     width: 100px;
     height: 100px;
     overflow-y: scroll;
-    background: lightgreen;
+    /**
+     * The scroll container background color can affect whether we use light
+     * or dark scrollbars. Use the same color as the test to ensure they match
+     **/
+    background: red;
     display: inline-block;
+  }
+  .container div {
+    background: lightgreen;
   }
 </style>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-fractional-offset-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-fractional-offset-ref.html
@@ -4,8 +4,15 @@
     width: 100px;
     height: 100px;
     overflow-y: scroll;
-    background: lightgreen;
+    /**
+     * The scroll container background color can affect whether we use light
+     * or dark scrollbars. Use the same color as the test to ensure they match
+     **/
+    background: red;
     display: inline-block;
+  }
+  .container div {
+    background: lightgreen;
   }
 </style>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-horizontal-rtl-overconstrained-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-horizontal-rtl-overconstrained-expected.txt
@@ -1,0 +1,6 @@
+
+PASS start of scroll container
+FAIL right before the in-flow position of the sticky box assert_equals: expected 80 but got 180
+FAIL right after the in-flow position the sticky box assert_equals: expected 120 but got 220
+PASS end of scroll container
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-horizontal-rtl-overconstrained.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-horizontal-rtl-overconstrained.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<title>position:overconstrained sticky elements with rtl direction</title>
+<link rel="help" href="https://www.w3.org/TR/css-position-3/#sticky-pos" />
+<meta name="assert" content="This test checks that the left is adjusted when the sticky element is overconstrained and the direction of the containing block is rtl" />
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+
+.scroller {
+  width: 100px;
+  height: 100px;
+  overflow: auto;
+  position: relative;
+}
+.container {
+  display: flex;
+  position: relative;
+  width: 600px;
+  direction: rtl;
+}
+.padding {
+  width: 200px;
+  height: 100px;
+  flex: none;
+}
+.sticky {
+  position: sticky;
+  background: green;
+  left: 0;
+  right: 0;
+  width: 200px;
+  height: 100px;
+  flex: none;
+  direction: ltr;
+}
+</style>
+
+<body>
+  <div class="scroller">
+    <div class="container">
+      <div class="padding"></div>
+      <div class="sticky"></div>
+      <div class="padding"></div>
+    </div>
+  </div>
+</body>
+
+<script>
+test(() => {
+  const scroller = document.querySelector('.scroller');
+  const element = document.querySelector('.sticky');
+  scroller.scrollLeft = 0;
+  assert_equals(element.offsetLeft, 0);
+}, 'start of scroll container');
+
+test(() => {
+    const scroller = document.querySelector('.scroller');
+    const element = document.querySelector('.sticky');
+    scroller.scrollLeft = 180;
+    assert_equals(element.offsetLeft, 80);
+}, 'right before the in-flow position of the sticky box');
+
+test(() => {
+    const scroller = document.querySelector('.scroller');
+    const element = document.querySelector('.sticky');
+    scroller.scrollLeft = 220;
+    assert_equals(element.offsetLeft, 120);
+}, 'right after the in-flow position the sticky box');
+
+test(() => {
+  const scroller = document.querySelector('.scroller');
+  const element = document.querySelector('.sticky');
+  scroller.scrollLeft = 500;
+  assert_equals(element.offsetLeft, 400);
+}, 'end of scroll container');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-in-fixed-container.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-in-fixed-container.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<meta name="fuzzy" content="1;0-50">
 <link rel="match" href="position-sticky-in-fixed-container-ref.html">
 <link rel="help" href="https://drafts.csswg.org/css-position-3/#sticky-pos">
 <link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1854010">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-left-and-right-overconstrained-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-left-and-right-overconstrained-expected.txt
@@ -1,0 +1,6 @@
+
+PASS start of scroll container
+PASS right before the in-flow position of the sticky box
+PASS right after the in-flow position the sticky box
+PASS end of scroll container
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-left-and-right-overconstrained.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-left-and-right-overconstrained.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<title>position:sticky elements with width larger than the space available between left and right</title>
+<link rel="help" href="https://www.w3.org/TR/css-position-3/#sticky-pos" />
+<meta name="assert" content="This test checks that the end edge is adjusted when the sticky view rectangle width ends up smaller than the width of the sticky element border box" />
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+
+.scroller {
+  width: 100px;
+  height: 100px;
+  overflow: auto;
+  position: relative;
+  display: flex;
+}
+.padding {
+  width: 200px;
+  height: 100px;
+  flex: none;
+}
+.sticky {
+  position: sticky;
+  background: green;
+  left: 20px;
+  right: 0;
+  width: 200px;
+  height: 100px;
+  flex: none;
+}
+</style>
+
+<body>
+  <div class="scroller">
+    <div class="padding"></div>
+    <div class="sticky"></div>
+    <div class="padding"></div>
+  </div>
+</body>
+
+<script>
+test(() => {
+  const scroller = document.querySelector('.scroller');
+  const element = document.querySelector('.sticky');
+  scroller.scrollLeft = 0;
+  assert_equals(element.offsetLeft, 20);
+}, 'start of scroll container');
+
+test(() => {
+    const scroller = document.querySelector('.scroller');
+    const element = document.querySelector('.sticky');
+    scroller.scrollLeft = 160;
+    assert_equals(element.offsetLeft, 180);
+}, 'right before the in-flow position of the sticky box');
+
+test(() => {
+    const scroller = document.querySelector('.scroller');
+    const element = document.querySelector('.sticky');
+    scroller.scrollLeft = 220;
+    assert_equals(element.offsetLeft, 240);
+}, 'right after the in-flow position the sticky box');
+
+test(() => {
+  const scroller = document.querySelector('.scroller');
+  const element = document.querySelector('.sticky');
+  scroller.scrollLeft = 500;
+  assert_equals(element.offsetLeft, 400);
+}, 'end of scroll container');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-offset-print.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-offset-print.html
@@ -1,6 +1,11 @@
 <!DOCTYPE html>
 <link rel="help" href="https://bugs.chromium.org/p/chromium/issues/detail?id=1485969">
-<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<link rel="match" href="../../reference/ref-filled-green-100px-square-print-ref.html">
+<style>
+  :root {
+    print-color-adjust: exact;
+  }
+</style>
 <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
 <div id="scroller" style="position:relative; width:200px; height:100px; overflow:hidden;">
   <div style="position:absolute; width:1000px;">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-table-td-subpixel-zoom-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-table-td-subpixel-zoom-expected.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<!-- Passes if a black transparent rectangle is painted with 1px borders. -->
+<html style="zoom: 1.5625; overflow:hidden;">
+  <style>
+    table {
+      border-spacing: 0; width:200px;}
+    td {
+      border: 1px solid black;
+      width: 100px;
+      height: 20px;
+    }
+    div::-webkit-scrollbar {
+      display: none;
+    }
+    div {
+      height:100px;
+      overflow:auto;
+    }
+  </style>
+
+  <div style="">
+    <table>
+      <tr>
+        <td style="";></td>
+      </tr>
+    </table>
+    <div style="height: 1000px;"></div>
+  </div>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-table-td-subpixel-zoom-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-table-td-subpixel-zoom-ref.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<!-- Passes if a black transparent rectangle is painted with 1px borders. -->
+<html style="zoom: 1.5625; overflow:hidden;">
+  <style>
+    table {
+      border-spacing: 0; width:200px;}
+    td {
+      border: 1px solid black;
+      width: 100px;
+      height: 20px;
+    }
+    div::-webkit-scrollbar {
+      display: none;
+    }
+    div {
+      height:100px;
+      overflow:auto;
+    }
+  </style>
+
+  <div style="">
+    <table>
+      <tr>
+        <td style="";></td>
+      </tr>
+    </table>
+    <div style="height: 1000px;"></div>
+  </div>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-table-td-subpixel-zoom.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-table-td-subpixel-zoom.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<!-- Passes if a black transparent rectangle is painted with 1px borders. -->
+<html style="zoom: 1.5625; overflow:hidden;">
+  <link rel="help" href="https://www.w3.org/TR/css-position-3/#sticky-pos" />
+  <meta name="assert" content="Position sticky pixel-snaps correctly under zoom" />
+  <link rel="match" href="position-sticky-table-td-subpixel-zoom-ref.html" />
+
+  <style>
+    table {
+      border-spacing: 0; width:200px;}
+    tr {
+      top: 0; position: sticky;
+    }
+    td {
+      border: 1px solid black;
+      width: 100px;
+      height: 20px;
+    }
+    div::-webkit-scrollbar {
+      display: none;
+    }
+    div {
+      height:100px;
+      overflow:auto;
+    }
+  </style>
+
+  <div style="">
+    <table>
+      <tr>
+        <td style="";></td>
+      </tr>
+    </table>
+    <div style="height: 1000px;"></div>
+  </div>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-top-and-bottom-overconstrained-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-top-and-bottom-overconstrained-expected.txt
@@ -1,0 +1,6 @@
+
+PASS start of scroll container
+PASS right before the in-flow position of the sticky box
+PASS right after the in-flow position the sticky box
+PASS end of scroll container
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-top-and-bottom-overconstrained.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-top-and-bottom-overconstrained.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<title>position:sticky elements with height larger than the space available between top and bottom</title>
+<link rel="help" href="https://www.w3.org/TR/css-position-3/#sticky-pos" />
+<meta name="assert" content="This test checks that the end edge is adjusted when the sticky view rectangle height ends up smaller than the height of the sticky element border box" />
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+
+.scroller {
+  height: 100px;
+  overflow: auto;
+  position: relative;
+}
+.padding {
+  height: 200px;
+}
+.sticky {
+  position: sticky;
+  background: green;
+  top: 20px;
+  bottom: 0;
+  height: 200px;
+}
+</style>
+
+<body>
+  <div class="scroller">
+    <div class="padding"></div>
+    <div class="sticky"></div>
+    <div class="padding"></div>
+  </div>
+</body>
+
+<script>
+test(() => {
+  const scroller = document.querySelector('.scroller');
+  const element = document.querySelector('.sticky');
+  scroller.scrollTop = 0;
+  assert_equals(element.offsetTop, 20);
+}, 'start of scroll container');
+
+test(() => {
+    const scroller = document.querySelector('.scroller');
+    const element = document.querySelector('.sticky');
+    scroller.scrollTop = 160;
+    assert_equals(element.offsetTop, 180);
+}, 'right before the in-flow position of the sticky box');
+
+test(() => {
+    const scroller = document.querySelector('.scroller');
+    const element = document.querySelector('.sticky');
+    scroller.scrollTop = 220;
+    assert_equals(element.offsetTop, 240);
+}, 'right after the in-flow position the sticky box');
+
+test(() => {
+  const scroller = document.querySelector('.scroller');
+  const element = document.querySelector('.sticky');
+  scroller.scrollTop = 500;
+  assert_equals(element.offsetTop, 400);
+}, 'end of scroll container');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/sticky-continuation-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/sticky-continuation-crash.html
@@ -1,0 +1,17 @@
+<script>
+document.addEventListener("DOMContentLoaded", () => {
+  a.appendChild(b)
+  b.style.cssFloat = "left"
+})
+</script>
+<style>
+:root {
+  column-width: 0px;
+}
+</style>
+<sub id="b">a</sub>
+<ul style="position: sticky">
+<input>
+<li>
+<section id="a">a</section>
+<font>a</font>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/w3c-import.log
@@ -19,6 +19,14 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-bottom-002.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-bottom-003-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-bottom-003.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-bottom-004-expected.xht
+/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-bottom-004.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-bottom-005-expected.xht
+/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-bottom-005.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-bottom-006-expected.xht
+/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-bottom-006.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-bottom-007-expected.xht
+/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-bottom-007.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-bottom.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-change-top-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-change-top-ref.html
@@ -72,6 +80,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-grid-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-grid-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-grid.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-horizontal-rtl-overconstrained.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-hyperlink-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-hyperlink-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-hyperlink.html
@@ -99,6 +108,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-left-005.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-left-006-expected.xht
 /LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-left-006.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-left-and-right-overconstrained.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-left.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-margins-002-expected.xht
 /LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-margins-002.html
@@ -175,6 +185,9 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-table-td-right-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-table-td-right-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-table-td-right.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-table-td-subpixel-zoom-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-table-td-subpixel-zoom-ref.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-table-td-subpixel-zoom.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-table-td-top-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-table-td-top-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-table-td-top.html
@@ -214,6 +227,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-top-006.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-top-and-bottom-003-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-top-and-bottom-003.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-top-and-bottom-overconstrained.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-top-and-bottom.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-top.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-transforms-translate.html
@@ -222,3 +236,4 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-writing-modes-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-writing-modes.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/sticky-after-input.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/sticky-continuation-crash.html


### PR DESCRIPTION
#### c3c145b62849eaeb33b57c79fbb01a5dc6eebc0f
<pre>
Resync `css/css-position/sticky` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=305849">https://bugs.webkit.org/show_bug.cgi?id=305849</a>
<a href="https://rdar.apple.com/168512817">rdar://168512817</a>

Reviewed by Tim Nguyen and Brandon Stewart.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/188c47200dc95d835a1a9db270250d10745301b0">https://github.com/web-platform-tests/wpt/commit/188c47200dc95d835a1a9db270250d10745301b0</a>

* LayoutTests/imported/w3c/resources/resource-files.json:
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-bottom-004-expected.xht: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-bottom-004.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-bottom-005-expected.xht: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-bottom-005.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-bottom-006-expected.xht: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-bottom-006.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-bottom-007-expected.xht: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-bottom-007.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-fractional-offset-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-fractional-offset-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-horizontal-rtl-overconstrained-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-horizontal-rtl-overconstrained.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-in-fixed-container.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-left-and-right-overconstrained-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-left-and-right-overconstrained.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-offset-print.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-table-td-subpixel-zoom-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-table-td-subpixel-zoom-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-table-td-subpixel-zoom.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-top-and-bottom-overconstrained-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-top-and-bottom-overconstrained.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/sticky-continuation-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/sticky/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/305915@main">https://commits.webkit.org/305915@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d535df9e8fb3ba20d94e9be51eeddad96e14da5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139726 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12103 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1231 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147864 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92794 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12811 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12254 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106991 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77884 "1 flakes 1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142673 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9858 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125138 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87861 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7f6f4e09-18f4-441a-b70b-1aa55068ee90) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9520 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7034 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8153 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118741 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1135 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150646 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11787 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1190 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115397 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11801 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/10156 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115713 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29409 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10474 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121623 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66792 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11831 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1099 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11571 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11767 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11618 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->