### PR TITLE
[ews] Add unit-tests for Trigger step

### DIFF
--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -10151,5 +10151,61 @@ class TestDisplaySaferCPPResults(BuildStepMixinAdditions, unittest.TestCase):
         self.assertEqual([LeaveComment(), SetBuildSummary()], next_steps)
 
 
+class TestTrigger(BuildStepMixinAdditions, unittest.TestCase):
+    def setUp(self):
+        self.longMessage = True
+        return self.setup_test_build_step()
+
+    def tearDown(self):
+        return self.tear_down_test_build_step()
+
+    def test_defaults(self):
+        step = Trigger(schedulerNames=['test-scheduler'])
+        props = step.propertiesToPassToTriggers()
+        self.assertIn('configuration', props)
+        self.assertIn('platform', props)
+        self.assertIn('fullPlatform', props)
+        self.assertIn('architecture', props)
+        self.assertIn('codebase', props)
+        self.assertIn('retry_count', props)
+        self.assertIn('os_version_builder', props)
+        self.assertIn('xcode_version_builder', props)
+        self.assertIn('ews_revision', props)
+        self.assertNotIn('github.number', props)
+        self.assertNotIn('github.head.sha', props)
+        self.assertNotIn('repository', props)
+        self.assertFalse(step.updateSourceStamp)
+        self.assertNotIn('triggers', props)
+
+    def test_pull_request_properties_included_when_enabled(self):
+        step = Trigger(schedulerNames=['test-scheduler'], pull_request=True)
+        props = step.propertiesToPassToTriggers(pull_request=True)
+        self.assertIn('github.base.ref', props)
+        self.assertIn('github.head.ref', props)
+        self.assertIn('github.head.sha', props)
+        self.assertIn('github.head.repo.full_name', props)
+        self.assertIn('github.number', props)
+        self.assertIn('github.title', props)
+        self.assertIn('repository', props)
+        self.assertIn('project', props)
+        self.assertIn('owners', props)
+        self.assertIn('classification', props)
+        self.assertIn('identifier', props)
+
+    def test_triggers_property_included_when_triggers_set(self):
+        step = Trigger(schedulerNames=['test-scheduler'], triggers=['trigger1', 'trigger2'])
+        props = step.propertiesToPassToTriggers()
+        self.assertIn('triggers', props)
+
+    def test_ews_revision_excluded_when_include_revision_false(self):
+        step = Trigger(schedulerNames=['test-scheduler'], include_revision=False)
+        props = step.propertiesToPassToTriggers()
+        self.assertNotIn('ews_revision', props)
+
+    def test_scheduler_names_set(self):
+        step = Trigger(schedulerNames=['scheduler1', 'scheduler2'])
+        self.assertEqual(step.schedulerNames, ['scheduler1', 'scheduler2'])
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
#### ce926a0c26ed2d6f77a18925ac5051112edeb5ba
<pre>
[ews] Add unit-tests for Trigger step
<a href="https://bugs.webkit.org/show_bug.cgi?id=305847">https://bugs.webkit.org/show_bug.cgi?id=305847</a>
<a href="https://rdar.apple.com/168509206">rdar://168509206</a>

Reviewed by Brianna Fan.

* Tools/CISupport/ews-build/steps_unittest.py:

Canonical link: <a href="https://commits.webkit.org/305892@main">https://commits.webkit.org/305892@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b267ebfd37a5dcff47c9391d6555391ba8a51c79

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139745 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12122 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1250 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147884 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/45c3b01b-b1d0-4957-ab9f-35b15ac0ac04) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141618 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/12830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/12273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/107002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/263d1570-9df4-4e77-aeed-2a2dba34b1dc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142692 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/12830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/125146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87874 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3cb9fd5b-865b-411f-93a8-8d490b367261) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/12830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8172 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/12830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1142 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150665 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11806 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/1198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/115410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/139170 "Passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/11820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/12273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115727 "Passed tests") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/121634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/66811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21552 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11850 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/1107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/11590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/11786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11637 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->