### PR TITLE
Batch most RemoteGraphicsContext messages

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.messages.in
@@ -66,46 +66,46 @@ messages -> RemoteGraphicsContext Stream {
     SetLineDash(FixedVector<double> dashArray, float dashOffset) StreamBatched
     SetLineJoin(enum:uint8_t WebCore::LineJoin lineJoin) StreamBatched
     SetMiterLimit(float limit) StreamBatched
-    Clip(WebCore::FloatRect rect)
-    ClipRoundedRect(WebCore::FloatRoundedRect rect)
-    ClipOut(WebCore::FloatRect rect)
-    ClipOutRoundedRect(WebCore::FloatRoundedRect rect)
-    ClipToImageBuffer(WebCore::RenderingResourceIdentifier renderingResourceIdentifier, WebCore::FloatRect destinationRect)
-    ClipOutToPath(WebCore::Path path)
-    ClipPath(WebCore::Path path, enum:bool WebCore::WindRule windRule)
-    ResetClip()
-    DrawGlyphs(WebCore::RenderingResourceIdentifier fontIdentifier, IPC::ArrayReferenceTuple<WebCore::GlyphBufferGlyph, WebCore::FloatSize> glyphsAdvances, WebCore::FloatPoint localAnchor, enum:uint8_t WebCore::FontSmoothingMode smoothingMode)
-    DrawDisplayList(WebKit::RemoteDisplayListIdentifier identifier)
-    DrawFilteredImageBuffer(std::optional<WebCore::RenderingResourceIdentifier> sourceImageIdentifier, WebCore::FloatRect sourceImageRect, Ref<WebCore::Filter> filter)
-    DrawImageBuffer(WebCore::RenderingResourceIdentifier imageBufferIdentifier, WebCore::FloatRect destinationRect, WebCore::FloatRect srcRect, struct WebCore::ImagePaintingOptions options)
-    DrawNativeImage(WebCore::RenderingResourceIdentifier imageIdentifier, WebCore::FloatRect destRect, WebCore::FloatRect srcRect, struct WebCore::ImagePaintingOptions options)
-    DrawSystemImage(Ref<WebCore::SystemImage> systemImage, WebCore::FloatRect destinationRect)
-    DrawPatternNativeImage(WebCore::RenderingResourceIdentifier imageIdentifier, WebCore::FloatRect destRect, WebCore::FloatRect tileRect, WebCore::AffineTransform transform, WebCore::FloatPoint phase, WebCore::FloatSize spacing, struct WebCore::ImagePaintingOptions options)
-    DrawPatternImageBuffer(WebCore::RenderingResourceIdentifier imageIdentifier, WebCore::FloatRect destRect, WebCore::FloatRect tileRect, WebCore::AffineTransform transform, WebCore::FloatPoint phase, WebCore::FloatSize spacing, struct WebCore::ImagePaintingOptions options)
-    BeginTransparencyLayer(float opacity)
-    BeginTransparencyLayerWithCompositeMode(struct WebCore::CompositeMode compositeMode)
-    EndTransparencyLayer()
-    DrawRect(WebCore::FloatRect rect, float borderThickness)
-    DrawLine(WebCore::FloatPoint point1, WebCore::FloatPoint point2)
-    DrawLinesForText(WebCore::FloatPoint point, float thickness, std::span<const WebCore::FloatSegment> lineSegments, bool printing, bool doubleLines, enum:uint8_t WebCore::StrokeStyle strokeStyle)
-    DrawDotsForDocumentMarker(WebCore::FloatRect rect, struct WebCore::DocumentMarkerLineStyle style)
-    DrawEllipse(WebCore::FloatRect rect)
-    DrawPath(WebCore::Path path)
-    DrawFocusRingPath(WebCore::Path path, float outlineWidth, WebCore::Color color)
-    DrawFocusRingRects(Vector<WebCore::FloatRect> rects, float outlineOffset, float outlineWidth, WebCore::Color color)
-    FillRect(WebCore::FloatRect rect, enum:bool WebCore::RequiresClipToRect requiresClipToRect)
-    FillRectWithColor(WebCore::FloatRect rect, WebCore::Color color)
-    FillRectWithGradient(WebCore::FloatRect rect, Ref<WebCore::Gradient> gradient)
-    FillRectWithGradientAndSpaceTransform(WebCore::FloatRect rect, Ref<WebCore::Gradient> gradient, WebCore::AffineTransform transform, enum:bool WebCore::RequiresClipToRect requiresClipToRect)
-    FillCompositedRect(WebCore::FloatRect rect, WebCore::Color color, enum:uint8_t WebCore::CompositeOperator op, enum:uint8_t WebCore::BlendMode blendMode)
-    FillRoundedRect(WebCore::FloatRoundedRect rect, WebCore::Color color, enum:uint8_t WebCore::BlendMode blendMode)
-    FillRectWithRoundedHole(WebCore::FloatRect rect, WebCore::FloatRoundedRect roundedHoleRect, WebCore::Color color)
+    Clip(WebCore::FloatRect rect) StreamBatched
+    ClipRoundedRect(WebCore::FloatRoundedRect rect) StreamBatched
+    ClipOut(WebCore::FloatRect rect) StreamBatched
+    ClipOutRoundedRect(WebCore::FloatRoundedRect rect) StreamBatched
+    ClipToImageBuffer(WebCore::RenderingResourceIdentifier renderingResourceIdentifier, WebCore::FloatRect destinationRect) StreamBatched
+    ClipOutToPath(WebCore::Path path) StreamBatched
+    ClipPath(WebCore::Path path, enum:bool WebCore::WindRule windRule) StreamBatched
+    ResetClip() StreamBatched
+    DrawGlyphs(WebCore::RenderingResourceIdentifier fontIdentifier, IPC::ArrayReferenceTuple<WebCore::GlyphBufferGlyph, WebCore::FloatSize> glyphsAdvances, WebCore::FloatPoint localAnchor, enum:uint8_t WebCore::FontSmoothingMode smoothingMode) StreamBatched
+    DrawDisplayList(WebKit::RemoteDisplayListIdentifier identifier) StreamBatched
+    DrawFilteredImageBuffer(std::optional<WebCore::RenderingResourceIdentifier> sourceImageIdentifier, WebCore::FloatRect sourceImageRect, Ref<WebCore::Filter> filter) StreamBatched
+    DrawImageBuffer(WebCore::RenderingResourceIdentifier imageBufferIdentifier, WebCore::FloatRect destinationRect, WebCore::FloatRect srcRect, struct WebCore::ImagePaintingOptions options) StreamBatched
+    DrawNativeImage(WebCore::RenderingResourceIdentifier imageIdentifier, WebCore::FloatRect destRect, WebCore::FloatRect srcRect, struct WebCore::ImagePaintingOptions options) StreamBatched
+    DrawSystemImage(Ref<WebCore::SystemImage> systemImage, WebCore::FloatRect destinationRect) StreamBatched
+    DrawPatternNativeImage(WebCore::RenderingResourceIdentifier imageIdentifier, WebCore::FloatRect destRect, WebCore::FloatRect tileRect, WebCore::AffineTransform transform, WebCore::FloatPoint phase, WebCore::FloatSize spacing, struct WebCore::ImagePaintingOptions options) StreamBatched
+    DrawPatternImageBuffer(WebCore::RenderingResourceIdentifier imageIdentifier, WebCore::FloatRect destRect, WebCore::FloatRect tileRect, WebCore::AffineTransform transform, WebCore::FloatPoint phase, WebCore::FloatSize spacing, struct WebCore::ImagePaintingOptions options) StreamBatched
+    BeginTransparencyLayer(float opacity) StreamBatched
+    BeginTransparencyLayerWithCompositeMode(struct WebCore::CompositeMode compositeMode) StreamBatched
+    EndTransparencyLayer() StreamBatched
+    DrawRect(WebCore::FloatRect rect, float borderThickness) StreamBatched
+    DrawLine(WebCore::FloatPoint point1, WebCore::FloatPoint point2) StreamBatched
+    DrawLinesForText(WebCore::FloatPoint point, float thickness, std::span<const WebCore::FloatSegment> lineSegments, bool printing, bool doubleLines, enum:uint8_t WebCore::StrokeStyle strokeStyle) StreamBatched
+    DrawDotsForDocumentMarker(WebCore::FloatRect rect, struct WebCore::DocumentMarkerLineStyle style) StreamBatched
+    DrawEllipse(WebCore::FloatRect rect) StreamBatched
+    DrawPath(WebCore::Path path) StreamBatched
+    DrawFocusRingPath(WebCore::Path path, float outlineWidth, WebCore::Color color) StreamBatched
+    DrawFocusRingRects(Vector<WebCore::FloatRect> rects, float outlineOffset, float outlineWidth, WebCore::Color color) StreamBatched
+    FillRect(WebCore::FloatRect rect, enum:bool WebCore::RequiresClipToRect requiresClipToRect) StreamBatched
+    FillRectWithColor(WebCore::FloatRect rect, WebCore::Color color) StreamBatched
+    FillRectWithGradient(WebCore::FloatRect rect, Ref<WebCore::Gradient> gradient) StreamBatched
+    FillRectWithGradientAndSpaceTransform(WebCore::FloatRect rect, Ref<WebCore::Gradient> gradient, WebCore::AffineTransform transform, enum:bool WebCore::RequiresClipToRect requiresClipToRect) StreamBatched
+    FillCompositedRect(WebCore::FloatRect rect, WebCore::Color color, enum:uint8_t WebCore::CompositeOperator op, enum:uint8_t WebCore::BlendMode blendMode) StreamBatched
+    FillRoundedRect(WebCore::FloatRoundedRect rect, WebCore::Color color, enum:uint8_t WebCore::BlendMode blendMode) StreamBatched
+    FillRectWithRoundedHole(WebCore::FloatRect rect, WebCore::FloatRoundedRect roundedHoleRect, WebCore::Color color) StreamBatched
 #if ENABLE(INLINE_PATH_DATA)
-    FillLine(struct WebCore::PathDataLine line)
-    FillArc(struct WebCore::PathArc arc)
-    FillClosedArc(struct WebCore::PathClosedArc closedArc)
-    FillQuadCurve(struct WebCore::PathDataQuadCurve curve)
-    FillBezierCurve(struct WebCore::PathDataBezierCurve curve)
+    FillLine(struct WebCore::PathDataLine line) StreamBatched
+    FillArc(struct WebCore::PathArc arc) StreamBatched
+    FillClosedArc(struct WebCore::PathClosedArc closedArc) StreamBatched
+    FillQuadCurve(struct WebCore::PathDataQuadCurve curve) StreamBatched
+    FillBezierCurve(struct WebCore::PathDataBezierCurve curve) StreamBatched
 #endif
     FillPathSegment(WebCore::PathSegment segment) StreamBatched
     FillPath(WebCore::Path path)
@@ -122,17 +122,17 @@ messages -> RemoteGraphicsContext Stream {
     StrokePathSegment(WebCore::PathSegment segment) StreamBatched
     StrokePath(WebCore::Path path) StreamBatched
     StrokeEllipse(WebCore::FloatRect rect) StreamBatched
-    ClearRect(WebCore::FloatRect rect)
-    DrawControlPart(Ref<WebCore::ControlPart> part, WebCore::FloatRoundedRect borderRect, float deviceScaleFactor, WebCore::ControlStyle style)
+    ClearRect(WebCore::FloatRect rect) StreamBatched
+    DrawControlPart(Ref<WebCore::ControlPart> part, WebCore::FloatRoundedRect borderRect, float deviceScaleFactor, WebCore::ControlStyle style) StreamBatched
 #if USE(CG)
-    ApplyStrokePattern()
-    ApplyFillPattern()
+    ApplyStrokePattern() StreamBatched
+    ApplyFillPattern() StreamBatched
 #endif
-    ApplyDeviceScaleFactor(float scaleFactor)
+    ApplyDeviceScaleFactor(float scaleFactor) StreamBatched
 
     BeginPage(WebCore::FloatRect pageRect)
     EndPage()
-    SetURLForRect(URL link, WebCore::FloatRect destRect)
+    SetURLForRect(URL link, WebCore::FloatRect destRect) StreamBatched
 
 #if PLATFORM(COCOA) && ENABLE(VIDEO)
     DrawVideoFrame(struct WebKit::SharedVideoFrame frame, WebCore::FloatRect rect, struct WebCore::ImageOrientation orientation, bool shouldDiscardAlpha) NotStreamEncodable


### PR DESCRIPTION
#### 93c7005425b83ed769ceb9fece30117f084cd0e5
<pre>
Batch most RemoteGraphicsContext messages
<a href="https://bugs.webkit.org/show_bug.cgi?id=305852">https://bugs.webkit.org/show_bug.cgi?id=305852</a>
<a href="https://rdar.apple.com/168514038">rdar://168514038</a>

Reviewed by Kimmo Kinnunen.

Adds StreamBatched to most messages in RemoteGraphicsContext, reducing
IPC overhead. This progresses both SP3 and MM (see radar).

* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.messages.in:

Canonical link: <a href="https://commits.webkit.org/306224@main">https://commits.webkit.org/306224@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8882d6becb3cba96c745930fa26e48201821fdb3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139730 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12107 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1235 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147868 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/93822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12815 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12258 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/106994 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77888 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142677 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9860 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125143 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87865 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9523 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7036 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8157 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118743 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150650 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11791 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1194 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115407 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11805 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10097 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115718 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29636 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10476 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121631 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66796 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11835 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1103 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11575 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75513 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11771 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11622 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->