### PR TITLE
[GST][MSE] Make sure to extend only the very first sample when DTS = 0 and PTS > 0

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -482,7 +482,7 @@ void AppendPipeline::handleEndOfAppend()
     sourceBufferPrivate().didReceiveAllPendingSamples();
 }
 
-void AppendPipeline::appsinkNewSample(const Track& track, GRefPtr<GstSample>&& sample)
+void AppendPipeline::appsinkNewSample(Track& track, GRefPtr<GstSample>&& sample)
 {
     ASSERT(isMainThread());
 
@@ -525,9 +525,11 @@ void AppendPipeline::appsinkNewSample(const Track& track, GRefPtr<GstSample>&& s
     // results for applications, we extend the duration of this first sample to the left so that it starts at zero.
     if (mediaSample->decodeTime() == MediaTime::zeroTime() && mediaSample->presentationTime() > MediaTime::zeroTime()
         && mediaSample->presentationTime() <= MediaTime(1, 10)
-        && mediaSample->isSync()) {
+        && mediaSample->isSync()
+        && !track.hasExtendedFirstSample) {
         GST_DEBUG_OBJECT(pipeline(), "Extending first sample to make it start at PTS=0");
         mediaSample->extendToTheBeginning();
+        track.hasExtendedFirstSample = true;
     }
 
     if (track.streamType == StreamType::Text) {
@@ -741,6 +743,10 @@ void AppendPipeline::resetParserState()
     // All processing related to the previous append has been aborted and the pipeline is idle.
     // We can listen again to new requests coming from the streaming thread.
     m_taskQueue.finishAborting();
+
+    // Reset the flag for extending the first sample, as we're starting fresh with new data.
+    for (std::unique_ptr<Track>& track : m_tracks)
+        track->hasExtendedFirstSample = false;
 
 #if (!(LOG_DISABLED || defined(GST_DISABLE_GST_DEBUG)))
     {

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.h
@@ -76,6 +76,7 @@ private:
             , streamType(streamType)
             , caps(caps)
             , presentationSize(presentationSize)
+            , hasExtendedFirstSample(false)
         { }
 
         TrackID trackId;
@@ -83,6 +84,7 @@ private:
         GRefPtr<GstCaps> caps;
         GRefPtr<GstCaps> finalCaps;
         FloatSize presentationSize;
+        bool hasExtendedFirstSample;
 
         // Needed by some formats. To simplify the code, parser/encoder can be a GstIdentity when not needed.
         GRefPtr<GstElement> parser;
@@ -121,7 +123,7 @@ private:
     static std::tuple<GRefPtr<GstCaps>, StreamType, FloatSize> parseDemuxerSrcPadCaps(GstCaps*);
     Ref<WebCore::TrackPrivateBase> makeWebKitTrack(Track& appendPipelineTrack, int trackIndex, TrackID);
     void appsinkCapsChanged(Track&);
-    void appsinkNewSample(const Track&, GRefPtr<GstSample>&&);
+    void appsinkNewSample(Track&, GRefPtr<GstSample>&&);
     void handleEndOfAppend();
     void didReceiveInitializationSegment();
 


### PR DESCRIPTION
#### 251600bd35269686018c08ecb9c522a991aabcc9
<pre>
[GST][MSE] Make sure to extend only the very first sample when DTS = 0 and PTS &gt; 0
<a href="https://bugs.webkit.org/show_bug.cgi?id=305858">https://bugs.webkit.org/show_bug.cgi?id=305858</a>

Reviewed by NOBODY (OOPS!).

In the absence of an edit list, ensure that WebKit’s AppendPipeline
extends only a single sample.

This fixes the handling of invalid streams with multiple DTS = 0
samples. Modifying PTS values for all of them results in unexpected
behavior, playback issues, PTS reordering, etc.

The problem was spotted in a video web application that uses TS -&gt; MSE
transmuxing.

See: <a href="https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1601">https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1601</a>

Original author: Andrzej Surdej &lt;101130014+asurdej-comcast@users.noreply.github.com&gt;

* Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp:
(WebCore::AppendPipeline::appsinkNewSample): Only extend first sample if no other sample has ever been extended before, or since the last parser reset. Set the hasExtendedFirstSample flag for the track on first extension.
(WebCore::AppendPipeline::resetParserState): Reset the hasExtendedFirstSample for all tracks.
* Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.h:
(WebCore::AppendPipeline::Track::Track): Add hasExtendedFirstSample flag.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/251600bd35269686018c08ecb9c522a991aabcc9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139743 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12120 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1248 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147882 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92820 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141616 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12828 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12271 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107001 "Found 1 new test failure: imported/w3c/web-platform-tests/media-source/mediasource-config-change-mp4-v-framerate.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77895 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142690 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9869 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125149 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87873 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9533 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7042 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8170 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118751 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1145 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150663 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11804 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1201 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115409 "Found 1 new test failure: imported/w3c/web-platform-tests/media-source/mediasource-config-change-mp4-v-framerate.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11818 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10105 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115726 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10489 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121636 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66822 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11848 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1109 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11588 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75526 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11784 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11635 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->