### PR TITLE
Blur and Focus events should only be dispatched if the window is both active and focused.

### DIFF
--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -541,7 +541,7 @@ void FocusController::setFocused(bool focused)
     protect(m_page)->setActivityState(focused ? m_activityState | ActivityState::IsFocused : m_activityState - ActivityState::IsFocused);
 }
 
-void FocusController::setFocusedInternal(bool focused)
+void FocusController::setFocusedInternal()
 {
     if (!isFocused()) {
         if (RefPtr focusedOrMainFrame = this->focusedOrMainFrame())
@@ -552,10 +552,8 @@ void FocusController::setFocusedInternal(bool focused)
         setFocusedFrame(protect(m_page->mainFrame()).ptr());
 
     RefPtr focusedFrame = localFocusedFrame();
-    if (focusedFrame && focusedFrame->view()) {
-        protect(focusedFrame->selection())->setFocused(focused);
-        dispatchEventsOnWindowAndFocusedElement(protect(focusedFrame->document()).get(), focused);
-    }
+    if (focusedFrame && focusedFrame->view())
+        protect(focusedFrame->selection())->setFocused(isFocused());
 }
 
 FocusableElementSearchResult FocusController::findFocusableElementStartingWithLocalFrame(FocusDirection direction, const FocusEventData& focusEventData, LocalFrame& frame, ShouldFocusElement shouldFocusElement)
@@ -1237,16 +1235,24 @@ bool FocusController::setFocusedElement(Element* element, Frame* newFocusedFrame
 
 void FocusController::setActivityState(OptionSet<ActivityState> activityState)
 {
+    static constexpr OptionSet activeAndFocused { ActivityState::IsFocused, ActivityState::WindowIsActive };
+    bool wasActiveAndFocused = m_activityState.containsAll(activeAndFocused);
     auto changed = m_activityState ^ activityState;
     m_activityState = activityState;
+    bool isActiveAndFocused = m_activityState.containsAll(activeAndFocused);
+    bool shouldDispatchEvent = wasActiveAndFocused != isActiveAndFocused;
 
     if (changed & ActivityState::IsFocused)
-        setFocusedInternal(activityState.contains(ActivityState::IsFocused));
+        setFocusedInternal();
     if (changed & ActivityState::WindowIsActive) {
-        setActiveInternal(activityState.contains(ActivityState::WindowIsActive));
+        setActiveInternal();
         if (changed & ActivityState::IsVisible)
             setIsVisibleAndActiveInternal(activityState.contains(ActivityState::WindowIsActive));
     }
+
+    RefPtr focusedFrame = localFocusedFrame();
+    if (focusedFrame && shouldDispatchEvent)
+        dispatchEventsOnWindowAndFocusedElement(protect(focusedFrame->document()), isActiveAndFocused);
 }
 
 void FocusController::setActive(bool active)
@@ -1254,7 +1260,7 @@ void FocusController::setActive(bool active)
     protect(m_page)->setActivityState(active ? m_activityState | ActivityState::WindowIsActive : m_activityState - ActivityState::WindowIsActive);
 }
 
-void FocusController::setActiveInternal(bool active)
+void FocusController::setActiveInternal()
 {
     RefPtr localMainFrame = m_page->localMainFrame();
     if (!localMainFrame)
@@ -1268,10 +1274,6 @@ void FocusController::setActiveInternal(bool active)
 
     if (RefPtr focusedOrMainFrame = this->focusedOrMainFrame())
         focusedOrMainFrame->selection().pageActivationChanged();
-
-    RefPtr focusedFrame = localFocusedFrame();
-    if (focusedFrame && isFocused())
-        dispatchEventsOnWindowAndFocusedElement(protect(focusedFrame->document()).get(), active);
 }
 
 static void contentAreaDidShowOrHide(ScrollableArea* scrollableArea, bool didShow)

--- a/Source/WebCore/page/FocusController.h
+++ b/Source/WebCore/page/FocusController.h
@@ -91,8 +91,8 @@ public:
     WEBCORE_EXPORT FocusableElementSearchResult findFocusableElementContinuingFromFrame(FocusDirection, WebCore::FrameIdentifier, const FocusEventData&, LocalFrame&, ShouldFocusElement);
 
 private:
-    void setActiveInternal(bool);
-    void setFocusedInternal(bool);
+    void setActiveInternal();
+    void setFocusedInternal();
     void setIsVisibleAndActiveInternal(bool);
 
     enum class InitialFocus : bool { No, Yes };

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FocusWebView.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FocusWebView.mm
@@ -399,18 +399,53 @@ TEST(FocusWebView, NoFocusEventsForBackgroundWindow)
 #endif
     [webView waitForNextPresentationUpdate];
 
-#if PLATFORM(MAC)
-    // FIXME: rdar://168467484 (Blur and Focus events should only be dispatched if the window is both active and focused.)
-    // Expected count is 1, not 2. On Mac, input.focus() flips IsFocused before the window is active (via
-    // Widget::setFocus → MakeFirstResponder), causing an extra dispatch. iOS's Widget::setFocus is a no-op.
-    // This extra focus event on Mac will be correctly suppressed with rdar://168467484.
-    int expectedFocusEventCount = 2;
-#else
-    int expectedFocusEventCount = 1;
-#endif
-
     NSNumber *focusEventCount = [webView objectByEvaluatingJavaScript:@"getFocusEventCount()"];
-    EXPECT_EQ([focusEventCount intValue], expectedFocusEventCount);
+    EXPECT_EQ([focusEventCount intValue], 1);
+}
+
+TEST(FocusWebView, SingleBlurEventWhenNoLongerActiveAndFocused)
+{
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration]);
+
+    NSString *html = @"<!DOCTYPE html>"
+        "<html>"
+        "<body>"
+        "<input id='input' type='text'>"
+        "<script>"
+        "let blurEventCount = 0;"
+        "input.addEventListener('blur', () => {"
+        "    blurEventCount++;"
+        "});"
+        "function getBlurEventCount() { return blurEventCount; }"
+        "</script>"
+        "</body>"
+        "</html>";
+    [webView synchronouslyLoadHTMLString:html];
+
+    [[webView window] makeKeyWindow];
+#if PLATFORM(IOS_FAMILY)
+    [webView becomeFirstResponder];
+#else
+    [[webView window] makeFirstResponder:webView];
+#endif
+    [webView objectByEvaluatingJavaScript:@"input.focus()"];
+
+#if PLATFORM(IOS_FAMILY)
+    [webView resignFirstResponder];
+#else
+    [[webView window] makeFirstResponder:nil];
+#endif
+    [webView waitForNextPresentationUpdate];
+
+    NSNumber *blurEventCount = [webView objectByEvaluatingJavaScript:@"getBlurEventCount()"];
+    EXPECT_EQ([blurEventCount intValue], 1);
+
+    [[webView window] resignKeyWindow];
+    [webView waitForNextPresentationUpdate];
+
+    blurEventCount = [webView objectByEvaluatingJavaScript:@"getBlurEventCount()"];
+    EXPECT_EQ([blurEventCount intValue], 1);
 }
 
 


### PR DESCRIPTION
#### 742452b1b1a52e39dc1fcf865685ee47e4db15c8
<pre>
Blur and Focus events should only be dispatched if the window is both active and focused.
<a href="https://bugs.webkit.org/show_bug.cgi?id=305846">https://bugs.webkit.org/show_bug.cgi?id=305846</a>
<a href="https://rdar.apple.com/168467484">rdar://168467484</a>

Reviewed by Abrar Rahman Protyasha.

If a window comes into focus, the focus controller may dispatch excess events currently. We should only dispatch
events when a window either becomes both focused &amp; active or when a window transition out of being both focused
and active.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FocusWebView.mm

* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusController::setFocusedInternal):
(WebCore::FocusController::setActivityState):
(WebCore::FocusController::setActiveInternal):
* Source/WebCore/page/FocusController.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FocusWebView.mm:
(TestWebKitAPI::NoFocusEventsForBackgroundWindow)):
(TestWebKitAPI::SingleBlurEventWhenNoLongerActiveAndFocused)):

Canonical link: <a href="https://commits.webkit.org/316735@main">https://commits.webkit.org/316735@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/289acd3bea8650556ac72ece1d0d9b3e18d98e5a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173202 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47134 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40635 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182775 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130758 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5d37dad0-c93a-40cb-83a7-433743bc9c6f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175067 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48427 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46816 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134676 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e87b9681-e6a6-432e-844b-a67caea9f7b7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176160 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38085 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155291 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115147 "Found 1 new API test failure: WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a8f97f24-aba3-4ae9-8414-f0735deb2f7e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36730 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35077 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31260 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147154 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34790 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185197 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38019 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39279 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143519 "Found 1 new test failure: compositing/color-matching/image-color-matching.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46802 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143390 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38705 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47481 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112562 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26314 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38347 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119230 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45987 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9734 "Passed tests") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45389 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45620 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45446 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->