### PR TITLE
[JSC] ValueRep reduction involving GetClosureVal, etc should preserve speculations

### DIFF
--- a/JSTests/stress/valuerep-reduction-dce-speculation-check.js
+++ b/JSTests/stress/valuerep-reduction-dce-speculation-check.js
@@ -1,0 +1,21 @@
+//@ runDefault("--useConcurrentJIT=0", "--jitPolicyScale=0")
+
+function fn(a1) {
+  try {
+    throw 1;
+  } catch {
+    +a1;
+    eval('1');
+  }
+}
+
+let num_to_primitive = 0;
+const obj = {};
+obj[Symbol.toPrimitive] = a => num_to_primitive++;
+
+fn(1.1);
+fn(1);
+fn(obj);
+
+if (num_to_primitive != 1)
+  throw Error("Did not call toPrimitive");

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -5113,6 +5113,7 @@ private:
             if (!m_graph.hasExitSite(node->origin.semantic, BadType)) {
                 if (!node->shouldSpeculateInt32() && node->shouldSpeculateNumber()) {
                     node->setResult(NodeResultDouble);
+                    node->mergeFlags(NodeMustGenerate); // Absorbs speculation check from the using edge
                     return true;
                 }
             }

--- a/Source/JavaScriptCore/dfg/DFGValueRepReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGValueRepReductionPhase.cpp
@@ -601,15 +601,20 @@ private:
             case MultiGetByOffset:
             case GetByOffset: {
                 candidate->setResult(NodeResultDouble);
+                candidate->mergeFlags(NodeMustGenerate); // Absorbs speculation check from the using edge
                 resultNode = candidate;
                 break;
             }
 
             case MultiGetByVal: {
-                if constexpr (useKind == Int52RepUse)
+                if constexpr (useKind == Int52RepUse) {
                     candidate->setResult(NodeResultInt52);
-                if constexpr (useKind == Int32Use)
+                    candidate->mergeFlags(NodeMustGenerate); // Absorbs speculation check from using edge
+                }
+                if constexpr (useKind == Int32Use) {
                     candidate->setResult(NodeResultInt32);
+                    candidate->mergeFlags(NodeMustGenerate); // Absorbs speculation check from using edge
+                }
                 resultNode = candidate;
                 break;
             }


### PR DESCRIPTION
#### 5bd8600b286caca627645bbce984fc69a70011eb
<pre>
[JSC] ValueRep reduction involving GetClosureVal, etc should preserve speculations
<a href="https://rdar.apple.com/157185744">rdar://157185744</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=305862">https://bugs.webkit.org/show_bug.cgi?id=305862</a>

Reviewed by Yusuke Suzuki.

ValueRep reduction phase can do transformations like:

SomeNode(Check:Number:GetClosureVal(result=JSValue) -&gt; SomeNode(DoubleRep:GetClosureVar(result=Double))

Effectively folding the speculation check along the edge into the
GetClosureVar node itself. Then, if SomeNode has no references, the
whole thing is eliminated by DCE. Had this transformation not occurred,
DCE would have left a Check node to preserve the speculation.

Since the GetClosure, etc are absorbing the speculation check, they
need to survive DCE so set the must generate flag.

Test: JSTests/stress/valuerep-reduction-dce-speculation-check.js
* JSTests/stress/valuerep-reduction-dce-speculation-check.js: Added.
(fn):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::attemptToMakeDoubleResultForGet):
* Source/JavaScriptCore/dfg/DFGValueRepReductionPhase.cpp:
(JSC::DFG::ValueRepReductionPhase::convertValueRepsToUnboxed):

Canonical link: <a href="https://commits.webkit.org/305916@main">https://commits.webkit.org/305916@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bba4b267f11cf93a7a7b159d2811a675e02d68b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139755 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12132 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1260 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147894 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92825 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12840 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12283 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107011 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/77898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142702 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9874 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125160 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87884 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9538 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7047 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8182 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/131728 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118755 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1159 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150675 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/551 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11816 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1216 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115416 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11830 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10112 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115733 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10501 "Passed tests") | [⏳ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/macOS-Release-WK2-Stress-Tests-EWS "Waiting to run tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/66827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21565 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11860 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1123 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/171027 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11600 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75587 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/44480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11796 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11647 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->