### PR TITLE
[CSS] Fix @scope crossing UA shadow root

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-ua-shadow-host-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-ua-shadow-host-expected.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<title>CSS Reftest Reference</title>
+<style>
+div {
+  background-color: green;
+  height: 100px;
+  width: 100px;
+}
+</style>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-ua-shadow-host.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-ua-shadow-host.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<title>@scope works with elements that have UA shadow roots</title>
+<link rel="help" href="https://drafts.csswg.org/css-cascade-6/#scoped-styles">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<style>
+input {
+  appearance: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  background-color: red;
+}
+@scope (.test) {
+  input {
+    width: 100px;
+    height: 100px;
+    background-color: green;
+  }
+}
+</style>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div class="test">
+  <input>
+</div>

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -675,7 +675,7 @@ std::pair<bool, std::optional<Vector<ElementRuleCollector::ScopingRootWithDistan
             bool shadowHostCrossed = false;
             while (ancestor && !shadowHostCrossed) {
                 auto subContext = context;
-                if (ancestor->shadowRoot()) {
+                if (auto* shadowRoot = ancestor->shadowRoot(); shadowRoot && shadowRoot->mode() != ShadowRootMode::UserAgent) {
                     subContext.styleScopeOrdinal = Style::ScopeOrdinal::Shadow;
                     shadowHostCrossed = true;
                 }


### PR DESCRIPTION
#### a6e8f5201887064522834f7967184ab363b3fc02
<pre>
[CSS] Fix @scope crossing UA shadow root
<a href="https://bugs.webkit.org/show_bug.cgi?id=305369">https://bugs.webkit.org/show_bug.cgi?id=305369</a>
<a href="https://rdar.apple.com/168101378">rdar://168101378</a>

Reviewed by Anne van Kesteren.

Test: imported/w3c/web-platform-tests/css/css-cascade/scope-ua-shadow-host.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-ua-shadow-host-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-ua-shadow-host.html: Added.
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::scopeRulesMatch):

Canonical link: <a href="https://commits.webkit.org/306129@main">https://commits.webkit.org/306129@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/617fc70dda45187ff56ca456eb556f8ea71b71b3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140140 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12521 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1650 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148292 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93216 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142012 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13232 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12674 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107290 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78060 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143089 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10190 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125479 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88181 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2d1596d7-8293-455b-993f-aba00a4a51c4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9837 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7363 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8573 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119062 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1486 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151077 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12207 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1555 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115718 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12220 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10458 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116043 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29554 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/11024 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121961 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67216 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12249 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1438 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11991 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75946 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12185 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12035 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->