### PR TITLE
BitmapImageSource unconditionally starts animations even if they should be disallowed (fast/images/page-wide-animation-toggle.html is timing out after 302278@main).

### DIFF
--- a/LayoutTests/fast/images/mac/play-all-pause-all-animations-context-menu-items.html
+++ b/LayoutTests/fast/images/mac/play-all-pause-all-animations-context-menu-items.html
@@ -33,10 +33,10 @@ window.addEventListener("load", () => {
     shouldBecomeEqual("internals.isImageAnimating(img)", "false", () => {
       debug("Playing all animations via the context menu item.");
       eventSender.contextClick().find(item => item.title === "Play All Animations").click();
-      internals.settings.setAllowAnimationControlsOverride(false);
 
       shouldBecomeEqual("internals.isImageAnimating(img)", "true", () => {
         internals.settings.setImageAnimationControlEnabled(false);
+        internals.settings.setAllowAnimationControlsOverride(false);
         internals.clearMemoryCache();
         finishJSTest();
       });

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8364,8 +8364,8 @@ imported/w3c/web-platform-tests/css/CSS2/box-display/display-012.xht [ ImageOnly
 imported/w3c/web-platform-tests/css/CSS2/box-display/display-013.xht [ ImageOnlyFailure ]
 
 # webkit.org/b/301655 Internals animation toggle causes the Image global preference to change, unpausing animations in tests
-fast/images/page-wide-animation-toggle.html [ Pass Timeout ]
-fast/images/individual-animation-toggle.html [ Pass Timeout ]
+fast/images/page-wide-animation-toggle.html [ Pass ]
+fast/images/individual-animation-toggle.html [ Pass ]
 
 webkit.org/b/301175 editing/selection/ios/become-first-responder-after-relinquishing-focus.html [ Pass Timeout ]
 

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2523,8 +2523,7 @@ webkit.org/b/302364 http/tests/site-isolation/window-open-with-name-cross-site.h
 
 webkit.org/b/301013 http/tests/workers/service/registerServiceWorkerClient-after-network-process-crash.html [ Pass Failure ]
 
-# webkit.org/b/301655 Internals animation toggle causes the Image global preference to change, unpausing animations in tests
-fast/images/page-wide-animation-toggle.html [ Pass Timeout ]
-fast/images/individual-animation-toggle.html [ Pass Timeout ]
+fast/images/page-wide-animation-toggle.html [ Pass ]
+fast/images/individual-animation-toggle.html [ Pass ]
 
 webkit.org/b/304523 inspector/unit-tests/iterableweakset.html [ Pass Failure ]

--- a/Source/WebCore/testing/InternalSettings.cpp
+++ b/Source/WebCore/testing/InternalSettings.cpp
@@ -345,6 +345,7 @@ ExceptionOr<void> InternalSettings::setAllowAnimationControlsOverride(bool allow
     if (!m_page)
         return Exception { ExceptionCode::InvalidAccessError };
     settings().setAllowAnimationControlsOverride(allowAnimationControls);
+    Image::setSystemAllowsAnimationControls(allowAnimationControls);
     return { };
 }
 

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1209,7 +1209,7 @@ void Internals::setImageAnimationEnabled(bool enabled)
             return;
 
         // We need to set this here to mimic the behavior of the AX preference changing
-        Image::setSystemAllowsAnimationControls(!enabled);
+        Image::setSystemAllowsAnimationControls(enabled);
         page->setImageAnimationEnabled(enabled);
     }
 }


### PR DESCRIPTION
#### f9480ef63794dbfbe42bd2bdda45d9cdbe416f26
<pre>
BitmapImageSource unconditionally starts animations even if they should be disallowed (fast/images/page-wide-animation-toggle.html is timing out after <a href="https://commits.webkit.org/302278@main">302278@main</a>).
<a href="https://bugs.webkit.org/show_bug.cgi?id=301655">https://bugs.webkit.org/show_bug.cgi?id=301655</a>
<a href="https://rdar.apple.com/163668078">rdar://163668078</a>

Reviewed by NOBODY (OOPS!).

The tests that were checking if animations were disabled were racing
with the animation frames themselves and won more often than not before <a href="https://commits.webkit.org/302278@main">302278@main</a>.
The way this worked was after the frames of a gif had finished a loop of the animation,
the image would report that it was not animating. When the shouldBecomeEqual check&apos;s
timer would fire, we would see the animation was not running and call the test a pass.
In fact, it was about to start animating again on the next rendering update.
This is because the logic that would check if animation was allowed or not would see that
Image::systemAllowsAnimationControls (which is supposed to match the system AX setting for reduced motion)
would be false and so we&apos;d early exit. This effectively means that the tests were never
really testing the code they intended to. After <a href="https://commits.webkit.org/302278@main">302278@main</a>, which aligned DOM timers to 4ms
intervals once reaching max nesting level, we would much more rarely execute the test harness
code in that time between when the animation had finished a loop and when the next loop was scheduled.
This led to the tests being flaky after that change.

This patch causes us to more effectively mock out that system level AX setting so we will run the
animation allowance check.

Covered by existing tests.

* LayoutTests/fast/images/mac/play-all-pause-all-animations-context-menu-items.html:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/testing/InternalSettings.cpp:
(WebCore::InternalSettings::setAllowAnimationControlsOverride):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::setImageAnimationEnabled):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f9480ef63794dbfbe42bd2bdda45d9cdbe416f26

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139765 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12142 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1270 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147904 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92835 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141638 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12850 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12293 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107021 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77904 "2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142712 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9886 "2 flakes") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125165 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87894 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9552 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7055 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; 1 api test failed or timed out; 1 api test failed or timed out; Running compile-webkit-without-change") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8192 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118787 "Found 3 new API test failures: TestWebKitAPI.ActionSheetTests.PlayPauseAnimationInsideLink, TestWebKitAPI.ActionSheetTests.PlayPauseAnimationCoveredByLink, TestWebKitAPI.WebKit.IsAnyAnimationAllowedToPlayBehaviorWithIndividualAnimationControl (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1165 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150685 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11826 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1223 "9 flakes 1 failures") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115425 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11840 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10122 "1 flakes") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115743 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10519 "Passed tests") | [⏳ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/macOS-Release-WK2-Stress-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66837 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11870 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1143 "Found 1 new test failure: fast/images/pagewide-play-pause-offscreen-animations.html (failure)") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11610 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75548 "Built successfully") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11806 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11657 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->