### PR TITLE
AX: accessibility/first-letter-single-character.html can pass even when it shouldn't due to imprecise string comparison

### DIFF
--- a/LayoutTests/accessibility/first-letter-single-character-expected.txt
+++ b/LayoutTests/accessibility/first-letter-single-character-expected.txt
@@ -3,12 +3,12 @@ This test verifies that first-letter pseudo-element text is exposed in the acces
 Test case 1: Single character (entire text is first-letter)
 PASS: singleCharContainer.childrenCount === 1
 PASS: singleCharText.role.toLowerCase().includes('text') === true
-PASS: singleCharText.stringValue.includes('H') === true
+PASS: Static text value was "H"
 
 Test case 2: Multiple characters (first-letter plus remaining text)
 PASS: multiCharContainer.childrenCount === 1
 PASS: multiCharText.role.toLowerCase().includes('text') === true
-PASS: multiCharText.stringValue.includes('Hi') === true
+PASS: Static text value was "Hi"
 
 PASS successfullyParsed is true
 

--- a/LayoutTests/accessibility/first-letter-single-character.html
+++ b/LayoutTests/accessibility/first-letter-single-character.html
@@ -21,7 +21,7 @@ if (window.accessibilityController) {
     output += expect("singleCharContainer.childrenCount", "1");
     var singleCharText = singleCharContainer.childAtIndex(0);
     output += expect("singleCharText.role.toLowerCase().includes('text')", "true");
-    output += expect("singleCharText.stringValue.includes('H')", "true");
+    output += expectStaticTextValue(singleCharText, "H");
 
     output += "\nTest case 2: Multiple characters (first-letter plus remaining text)\n";
     var multiCharContainer = accessibilityController.accessibleElementById("multi-char");
@@ -29,7 +29,7 @@ if (window.accessibilityController) {
     var multiCharText = multiCharContainer.childAtIndex(0);
     output += expect("multiCharText.role.toLowerCase().includes('text')", "true");
     // Should expose "Hi" - the "h" is capitalized by text-transform
-    output += expect("multiCharText.stringValue.includes('Hi')", "true");
+    output += expectStaticTextValue(multiCharText, "Hi");
 
     debug(output);
 }

--- a/LayoutTests/resources/accessibility-helper.js
+++ b/LayoutTests/resources/accessibility-helper.js
@@ -79,6 +79,38 @@ function platformStaticTextValue(axElement) {
     return accessibilityController.platformName === "ios" ? axElement.description : axElement.stringValue;
 }
 
+function stripAXPrefix(string) {
+    return string.replace(/^AX[A-Za-z]+:\s*/, "");
+}
+
+function expectStaticTextValue(axElement, expectedValue) {
+    if (!axElement)
+        return "";
+
+    if (!axElement.role.toLowerCase().includes("statictext"))
+        return `FAIL: platformStaticTextValue called on a non-text object (role was ${axElement.role}).\n`;
+
+    function pass(expected) {
+        return `PASS: Static text value was "${expected}"\n`;
+    }
+    function fail(expected, actual) {
+        return `FAIL: Static text value was not "${expected}" — was ${stripAXPrefix(actual)}`;
+    }
+
+    var textValue;
+    if (accessibilityController.platformName === "ios") {
+        textValue = axElement.description;
+        if (textValue === `AXLabel: ${expectedValue}`)
+            return pass(expectedValue);
+        return fail(expectedValue, textValue)
+    }
+
+    textValue = axElement.stringValue;
+    if (textValue === `AXValue: ${expectedValue}`)
+        return pass(expectedValue);
+    return fail(expectedValue, textValue)
+}
+
 // Dumps the accessibility tree hierarchy for the given accessibilityObject into
 // an element with id="tree", e.g., <pre id="tree"></pre>. In addition, it
 // returns a two element array with the first element [0] being false if the


### PR DESCRIPTION
#### 4778d9552c65b14cc556b04fd9582a7dda2f7045
<pre>
AX: accessibility/first-letter-single-character.html can pass even when it shouldn&apos;t due to imprecise string comparison
<a href="https://bugs.webkit.org/show_bug.cgi?id=305871">https://bugs.webkit.org/show_bug.cgi?id=305871</a>
<a href="https://rdar.apple.com/168533599">rdar://168533599</a>

Reviewed by Joshua Hoffman.

Make the string comparisons in this test more precise so we don&apos;t allow incorrect implementations to pass.

* LayoutTests/accessibility/first-letter-single-character-expected.txt:
* LayoutTests/accessibility/first-letter-single-character.html:
* LayoutTests/resources/accessibility-helper.js:

Canonical link: <a href="https://commits.webkit.org/305940@main">https://commits.webkit.org/305940@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ac86b1ae9723b2729b3ce7917eefb234e7dd7a4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139775 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12152 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1280 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147914 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92845 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a3a7914f-8e20-4f66-9858-3199e793cf11) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12860 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12303 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107036 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77910 "1 flakes 2 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/63dc1e29-53e3-423f-8367-859165a76507) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142722 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9896 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125169 "Found 1 new API test failure: TestWebKitAPI.WKDownload.DownloadRequestFailure (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87903 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9570 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7064 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8202 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118775 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1169 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150695 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11836 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1227 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115434 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11854 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10154 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115752 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29429 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10547 "Passed tests") | [⏳ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/macOS-Release-WK2-Stress-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66847 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11880 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1131 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11623 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11820 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11667 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->