### PR TITLE
[GFC] Add initial implementation for automatic block sizes

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
@@ -255,6 +255,14 @@ BorderBoxPositions GridLayout::performBlockAxisSelfAlignment(const PlacedGridIte
         case ItemPosition::SelfStart:
         case ItemPosition::Start:
             return { };
+
+        // https://www.w3.org/TR/css-align-3/#align-grid
+        // Sizes as either stretch (typical non-replaced elements) or start (typical replaced
+        // elements); see Grid Item Sizing in [CSS-GRID-1]. The resulting box is then start-aligned.
+        //
+        // Stretching should be handled by GridLayout::layoutGridItems.
+        case ItemPosition::Normal:
+            return { };
         default:
             ASSERT_NOT_IMPLEMENTED_YET();
             return { };
@@ -407,12 +415,14 @@ std::pair<UsedInlineSizes, UsedBlockSizes> GridLayout::layoutGridItems(const Pla
     auto& integrationUtils = formattingContext.integrationUtils();
     for (auto& gridItem : placedGridItems) {
         auto& gridItemBoxGeometry = formattingContext.geometryForGridItem(gridItem.layoutBox());
+        CheckedRef formattingContextRootStyle = formattingContext.root().style();
 
-        auto columnsGap = GridLayoutUtils::computeGapValue(formattingContext.root().style().columnGap());
+        auto columnsGap = GridLayoutUtils::computeGapValue(formattingContextRootStyle->columnGap());
         auto usedInlineSizeForGridItem = GridLayoutUtils::usedInlineSizeForGridItem(gridItem, gridItemBoxGeometry.horizontalBorderAndPadding(), usedTrackSizes.columnSizes, columnsGap);
         usedInlineSizes.append(usedInlineSizeForGridItem);
 
-        auto usedBlockSizeForGridItem = GridLayoutUtils::usedBlockSizeForGridItem(gridItem) + gridItemBoxGeometry.verticalBorderAndPadding();
+        auto rowsGap = GridLayoutUtils::computeGapValue(formattingContextRootStyle->rowGap());
+        auto usedBlockSizeForGridItem = GridLayoutUtils::usedBlockSizeForGridItem(gridItem, gridItemBoxGeometry.verticalBorderAndPadding(), usedTrackSizes.rowSizes, rowsGap);
         usedBlockSizes.append(usedBlockSizeForGridItem);
 
         auto& layoutBox = gridItem.layoutBox();

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
@@ -39,7 +39,8 @@ LayoutUnit computeGapValue(const Style::GapGutter&);
 
 LayoutUnit usedInlineSizeForGridItem(const PlacedGridItem&, LayoutUnit borderAndPadding, const TrackSizes& usedColumnSizes,
     LayoutUnit columnsGap);
-LayoutUnit usedBlockSizeForGridItem(const PlacedGridItem&);
+LayoutUnit usedBlockSizeForGridItem(const PlacedGridItem&, LayoutUnit borderAndPadding, const TrackSizes& usedRowSizes,
+    LayoutUnit rowsGap);
 
 LayoutUnit computeGridLinePosition(size_t gridLineIndex, const TrackSizes&, LayoutUnit gap);
 


### PR DESCRIPTION
#### dea602a06b892ab6d942314ea1ddbaae4a91179e
<pre>
[GFC] Add initial implementation for automatic block sizes
<a href="https://bugs.webkit.org/show_bug.cgi?id=305870">https://bugs.webkit.org/show_bug.cgi?id=305870</a>
<a href="https://rdar.apple.com/165728545">rdar://165728545</a>

Reviewed by Brandon Stewart and Alan Baradlay.

In 303843@main, we added some logic to add initial support for computing
the automatic inline size of grid items. Here, we add the matching
behavior for the block size of similar types of grid items (non-replaced
ones that are stretching). The logic for this is exactly the same except
we are working with attributes in the opposite axis (height values,
align-self, etc.).

Since this is just the initial implementation of this logic, I ended up
writing the logic by modifying the inline axis one instead of trying to
abstract it into some helper function that is shared by both. This is
because we will need to build upon both versions, and while here we were
easily able to adopt ideas from one version to another, that may not be
the case in the future. Eventually, both will evolve to a point where we
can do this and share code, but in the beginning, we will just be verbose
to keep implementation straightforward.

* Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp:
(WebCore::Layout::GridLayout::performBlockAxisSelfAlignment):
If we are in the &quot;start,&quot; case we end up returning the same value as the
start alignment value. If we are in the &quot;stretch,&quot; case we still return
the same value, which is 0 so there is no alignment shift to, to allow
the stretching logic to get performed later.

(WebCore::Layout::GridLayout::layoutGridItems const):
* Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp:
(WebCore::Layout::GridLayoutUtils::usedBlockSizeForGridItem):
Same idea as usedInlineSizeForGridItem in that if we have an automatic
size, are non-replaced, and are stretching, then we will stretch into
the available space. We also need to start adding in the
borderAndPadding here, rather than outside the function where it was
previously occurring, since the stretching logic will need it.

Canonical link: <a href="https://commits.webkit.org/305980@main">https://commits.webkit.org/305980@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ea1a6ce8ce17af6687d7806259ceb1d268ec226

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139914 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12295 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1425 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148057 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/056b5a8c-676b-4b56-9cc2-e7cd196421c9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141787 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13005 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12447 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107136 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aa9fd528-f1d7-42e1-a531-6dbdf22a827d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142864 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10018 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125298 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88016 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9670 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7187 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8346 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118891 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1300 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150842 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11980 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1366 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115550 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11993 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10266 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115865 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29452 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10656 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121778 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66985 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12022 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1252 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11762 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75709 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11958 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11810 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->