### PR TITLE
[WPEPlatform] Provide a way to notify of changes in buffers used to render a WPEView contents

### DIFF
--- a/Source/WebKit/UIProcess/glib/AcceleratedBackingStore.messages.in
+++ b/Source/WebKit/UIProcess/glib/AcceleratedBackingStore.messages.in
@@ -35,4 +35,8 @@ messages -> AcceleratedBackingStore {
 
     DidDestroyBuffer(uint64_t id)
     Frame(uint64_t id, Vector<WebCore::IntRect, 1> damage, UnixFileDescriptor syncFD)
+
+#if ENABLE(WPE_PLATFORM)
+    DidChangeBufferConfiguration(uint32_t bufferCount);
+#endif
 }

--- a/Source/WebKit/UIProcess/wpe/AcceleratedBackingStore.h
+++ b/Source/WebKit/UIProcess/wpe/AcceleratedBackingStore.h
@@ -89,6 +89,7 @@ private:
 #if OS(ANDROID)
     void didCreateAndroidBuffer(uint64_t id, RefPtr<AHardwareBuffer>&&);
 #endif
+    void didChangeBufferConfiguration(uint32_t bufferCount);
     void didDestroyBuffer(uint64_t id);
     void frame(uint64_t bufferID, Rects&&, WTF::UnixFileDescriptor&&);
     void frameDone();
@@ -96,6 +97,8 @@ private:
     void bufferRendered();
     void bufferReleased(WPEBuffer*);
     void toplevelChanged();
+
+    void notifyBufferConfigurationIfNeeded();
 
     WeakPtr<WebPageProxy> m_webPage;
     GRefPtr<WPEView> m_wpeView;
@@ -107,6 +110,7 @@ private:
     Rects m_pendingDamageRects;
     HashMap<uint64_t, GRefPtr<WPEBuffer>> m_buffers;
     HashMap<WPEBuffer*, uint64_t> m_bufferIDs;
+    std::optional<unsigned> m_targetBufferCount;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WPEPlatform/wpe/WPEView.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEView.h
@@ -52,6 +52,9 @@ struct _WPEViewClass
 {
     GObjectClass parent_class;
 
+    void               (* buffers_changed)       (WPEView            *view,
+                                                  WPEBuffer         **buffers,
+                                                  guint               n_buffers);
     gboolean           (* render_buffer)         (WPEView            *view,
                                                   WPEBuffer          *buffer,
                                                   const WPERectangle *damage_rects,
@@ -122,6 +125,9 @@ WPE_API void                  wpe_view_set_cursor_from_bytes        (WPEView    
                                                                      guint               hotspot_y);
 WPE_API WPEToplevelState      wpe_view_get_toplevel_state           (WPEView            *view);
 WPE_API WPEScreen            *wpe_view_get_screen                   (WPEView            *view);
+WPE_API void                  wpe_view_buffers_changed              (WPEView            *view,
+                                                                     WPEBuffer         **buffers,
+                                                                     guint               n_buffers);
 WPE_API gboolean              wpe_view_render_buffer                (WPEView            *view,
                                                                      WPEBuffer          *buffer,
                                                                      const WPERectangle *damage_rects,

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
@@ -354,6 +354,8 @@ private:
 #endif
 
     private:
+        // FIXME: Allow configuring the initial buffer count, e.g. for triple buffering.
+        static constexpr unsigned s_initialBuffers = 2;
         static constexpr unsigned s_maximumBuffers = 4;
 
         std::unique_ptr<RenderTarget> createTarget() const;


### PR DESCRIPTION
#### b195011055b14ddb0ced1b8765bf521f26616fa2
<pre>
[WPEPlatform] Provide a way to notify of changes in buffers used to render a WPEView contents
<a href="https://bugs.webkit.org/show_bug.cgi?id=305877">https://bugs.webkit.org/show_bug.cgi?id=305877</a>

Reviewed by Carlos Garcia Campos.

Add a new WPEView.buffers_changed virtual function (and a corresponding
signal) that gets invoked when the graphics buffers used to render the
contents of the view have changed. This may be used by platform
implementation to e.g. perform setup in advance, before rendered
contents are provided in those buffers.

While at it, always create at least two buffers initially, because in
most situations one buffer will be used for rendering while the other
is being displayed. This way the initial configuration can be always
reported as having two buffers, instead of invoking the virtual function
twice in quick succession right after the view is created.

* Source/WebKit/UIProcess/glib/AcceleratedBackingStore.messages.in:
* Source/WebKit/UIProcess/wpe/AcceleratedBackingStore.cpp:
(WebKit::AcceleratedBackingStore::didChangeBufferConfiguration):
(WebKit::AcceleratedBackingStore::notifyBufferConfigurationIfNeeded):
(WebKit::AcceleratedBackingStore::didCreateDMABufBuffer):
(WebKit::AcceleratedBackingStore::didCreateSHMBuffer):
(WebKit::AcceleratedBackingStore::didCreateAndroidBuffer):
(WebKit::AcceleratedBackingStore::didDestroyBuffer):
* Source/WebKit/UIProcess/wpe/AcceleratedBackingStore.h:
* Source/WebKit/WPEPlatform/wpe/WPEView.cpp:
(wpe_view_class_init):
(wpe_view_buffers_changed):
* Source/WebKit/WPEPlatform/wpe/WPEView.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp:
(WebKit::AcceleratedSurface::SwapChain::nextTarget):
(WebKit::AcceleratedSurface::SwapChain::reset):
(WebKit::AcceleratedSurface::SwapChain::releaseUnusedBuffers):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h:

Canonical link: <a href="https://commits.webkit.org/306008@main">https://commits.webkit.org/306008@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15fdca7f19516c86a93c60ca0cf68f092458cb9a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139874 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12255 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1385 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148016 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92943 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12965 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12407 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107105 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77955 "2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142824 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9983 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125267 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87984 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9636 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7150 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8306 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118856 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150800 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11940 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1335 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115519 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11952 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10228 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115834 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29473 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10618 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121747 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66945 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11982 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1222 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11722 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75669 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11918 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11770 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->