### PR TITLE
Use the outermost SVG as base when computing offsetX/Y for SVG elements

### DIFF
--- a/LayoutTests/fast/events/offsetX-offsetY-svg-expected.txt
+++ b/LayoutTests/fast/events/offsetX-offsetY-svg-expected.txt
@@ -1,0 +1,3 @@
+
+PASS MouseEvent.offsetX/offsetY for an SVG element is always relative to the outermost <svg> CSS layout box
+

--- a/LayoutTests/fast/events/offsetX-offsetY-svg.html
+++ b/LayoutTests/fast/events/offsetX-offsetY-svg.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<title>MouseEvent.offsetX/offsetY for an SVG element is always relative to the outermost &lt;svg> CSS layout box</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<style>
+svg {
+    border: 10px solid blue;
+    border-width: 20px 40px 30px 10px;
+}
+</style>
+<svg width="400" height="400" viewBox="0 0 400000 400000">
+  <rect x="40000" y="60000" width="80000" height="80000" fill="blue"/>
+  <rect x="160000" y="180000" width="80000" height="80000" fill="blue" stroke="lightblue" stroke-width="10000"/>
+</svg>
+<script>
+function check_offset(test, element, clientX, clientY, expectedOffsetX, expectedOffsetY) {
+    element.onclick = test.step_func(function(event) {
+        assert_equals(event.offsetX, expectedOffsetX, 'offsetX');
+        assert_equals(event.offsetY, expectedOffsetY, 'offsetY');
+    });
+    var mouseEvent = new MouseEvent('click', { clientX: clientX, clientY: clientY });
+    element.dispatchEvent(mouseEvent);
+}
+
+test(function(t) {
+    var rects = document.querySelectorAll('rect');
+    var svgBoundingRect = document.querySelector('svg').getBoundingClientRect();
+    var offsetBase = { x: svgBoundingRect.left + 10, y: svgBoundingRect.top + 20 };
+    check_offset(t, rects[0], offsetBase.x + 80, offsetBase.y + 100, 80, 100);
+    check_offset(t, rects[1], offsetBase.x + 200, offsetBase.y + 220, 200, 220);
+});
+</script>


### PR DESCRIPTION
#### 5aa5773d26d4855f5b912a8aaab9d6fcaed6587f
<pre>
Use the outermost SVG as base when computing offsetX/Y for SVG elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=305484">https://bugs.webkit.org/show_bug.cgi?id=305484</a>
<a href="https://rdar.apple.com/168548585">rdar://168548585</a>

Reviewed by Abrar Rahman Protyasha.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/162fbdaa3d5778e2f02a47c1595400d328df4b22">https://chromium.googlesource.com/chromium/src.git/+/162fbdaa3d5778e2f02a47c1595400d328df4b22</a>

This patch fixes an issues where were not using closest ancestor CSS
layout box for SVG elements and now after fix, we use it and it is
always the outermost SVG root (RenderSVGRoot).

Test: fast/events/offsetX-offsetY-svg.html

* LayoutTests/fast/events/offsetX-offsetY-svg-expected.txt: Added.
* LayoutTests/fast/events/offsetX-offsetY-svg.html: Added.
* Source/WebCore/dom/MouseRelatedEvent.cpp:
(WebCore::MouseRelatedEvent::computeRelativePosition):

Canonical link: <a href="https://commits.webkit.org/305993@main">https://commits.webkit.org/305993@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbf6e157dc15e255b928ef7386c4a235b791d311

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139986 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12367 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1497 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148129 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/93056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2dcaae78-95b5-4f82-abc0-eb11b33d99e8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141859 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13077 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12519 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107176 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/93056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/75c001b3-5447-4609-bb9d-3f145cb1957b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142936 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10092 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125362 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88055 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/65de5d78-96f1-412b-b3ef-3d769938db11) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/9743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7245 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8418 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118965 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1366 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150917 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12052 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1431 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115597 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12065 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10326 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115913 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29458 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10723 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121843 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/67057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12094 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1317 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11835 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75781 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12030 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11882 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->