### PR TITLE
([Site Isolation] Web Inspector: support cross-origin iframes in the Worker domain)

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/worker/worker-in-cross-origin-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/worker/worker-in-cross-origin-iframe-expected.txt
@@ -1,0 +1,21 @@
+Test that workers spawned in cross-origin iframes are properly surfaced through the frame target's Worker domain under site isolation.
+
+
+== Running test suite: SiteIsolation.Worker.CrossOriginIFrame
+-- Running test case: SiteIsolation.Worker.CrossOrigin.Setup
+PASS: Frame target should be created.
+PASS: Parent target should have Frame type.
+PASS: Parent frame target should have the Worker domain.
+PASS: Worker target should be created.
+PASS: Worker target should have Worker type.
+PASS: Worker's parent target should be the frame target.
+Worker target name: CrossOriginWorker
+
+-- Running test case: SiteIsolation.Worker.CrossOrigin.EvaluateInWorker
+PASS: Evaluation should not throw.
+Resulting passphrase value: worker-in-cross-origin-iframe
+
+-- Running test case: SiteIsolation.Worker.CrossOrigin.RemoveIframe
+PASS: Worker target should be removed.
+PASS: Frame target should be removed.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/worker/worker-in-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/worker/worker-in-cross-origin-iframe.html
@@ -1,0 +1,107 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script>
+    let iframe;
+
+    function addCrossOriginIFrame() {
+        let crossOriginHost = location.hostname === "localhost" ? "127.0.0.1" : "localhost";
+        iframe = document.createElement("iframe");
+        iframe.src = `http://${crossOriginHost}:8000/site-isolation/inspector/worker/resources/iframe-with-worker.html`;
+        document.body.appendChild(iframe);
+    }
+
+    function removeCrossOriginIFrame() {
+        iframe.remove();
+    }
+
+    function test() {
+        let suite = InspectorTest.createAsyncSuite("SiteIsolation.Worker.CrossOriginIFrame");
+
+        let parentFrameTarget;
+        let workerTarget;
+
+        suite.addTestCase({
+            name: "SiteIsolation.Worker.CrossOrigin.Setup",
+            description: "Adding a cross-origin iframe with a worker should create both frame and worker targets.",
+            async test() {
+                // When a cross-origin iframe loads under site isolation, the target
+                // lifecycle is: a non-provisional FrameTarget is created, then a
+                // provisional FrameTarget is created, then the non-provisional one is
+                // destroyed and the provisional one commits. The worker connects to
+                // whichever FrameTarget is current at the time Worker.enable() runs.
+                //
+                // Rather than trying to match a specific FrameTarget from the events
+                // array (which can see multiple Frame targets due to the provisional
+                // swap), use the worker's parentTarget as the source of truth.
+                let workerAddedPromise = new Promise((resolve) => {
+                    WI.targetManager.addEventListener(WI.TargetManager.Event.TargetAdded, (event) => {
+                        if (event.data.target.type === WI.TargetType.Worker)
+                            resolve(event.data.target);
+                    });
+                });
+
+                InspectorTest.evaluateInPage("addCrossOriginIFrame()");
+
+                workerTarget = await workerAddedPromise;
+                parentFrameTarget = workerTarget.parentTarget;
+
+                InspectorTest.expectNotNull(parentFrameTarget, "Frame target should be created.");
+                InspectorTest.expectEqual(parentFrameTarget.type, WI.TargetType.Frame, "Parent target should have Frame type.");
+                InspectorTest.expectThat(parentFrameTarget.hasDomain("Worker"), "Parent frame target should have the Worker domain.");
+
+                InspectorTest.expectNotNull(workerTarget, "Worker target should be created.");
+                InspectorTest.expectEqual(workerTarget.type, WI.TargetType.Worker, "Worker target should have Worker type.");
+                InspectorTest.expectEqual(workerTarget.parentTarget, parentFrameTarget, "Worker's parent target should be the frame target.");
+                InspectorTest.log(`Worker target name: ${workerTarget.displayName}`);
+            }
+        });
+
+        suite.addTestCase({
+            name: "SiteIsolation.Worker.CrossOrigin.EvaluateInWorker",
+            description: "Should be able to evaluate JavaScript in the worker spawned by the cross-origin iframe.",
+            async test() {
+                InspectorTest.assert(workerTarget, "Worker target should exist from setup.");
+
+                let response = await workerTarget.RuntimeAgent.evaluate.invoke({
+                    expression: "passphrase",
+                    objectGroup: "test",
+                    returnByValue: true,
+                });
+                InspectorTest.expectThat(!response.wasThrown, "Evaluation should not throw.");
+                InspectorTest.log("Resulting passphrase value: " + response.result.value);
+            }
+        });
+
+        suite.addTestCase({
+            name: "SiteIsolation.Worker.CrossOrigin.RemoveIframe",
+            description: "Removing the cross-origin iframe should clean up both worker and frame targets.",
+            async test() {
+                let removedTargets = [];
+                let allRemovedPromise = new Promise((resolve) => {
+                    WI.targetManager.addEventListener(WI.TargetManager.Event.TargetRemoved, (event) => {
+                        removedTargets.push(event.data.target);
+                        if (removedTargets.length >= 2)
+                            resolve();
+                    });
+                });
+
+                InspectorTest.evaluateInPage("removeCrossOriginIFrame()");
+
+                await allRemovedPromise;
+
+                let removedWorker = removedTargets.find((t) => t.type === WI.TargetType.Worker);
+                let removedFrame = removedTargets.find((t) => t.type === WI.TargetType.Frame);
+
+                InspectorTest.expectNotNull(removedWorker, "Worker target should be removed.");
+                InspectorTest.expectNotNull(removedFrame, "Frame target should be removed.");
+            }
+        });
+
+        suite.runTestCasesAndFinish();
+    }
+</script>
+
+<body onload="runTest()">
+    <p>Test that workers spawned in cross-origin iframes are properly surfaced through the frame target's Worker domain
+        under site isolation.</p>
+</body>

--- a/LayoutTests/inspector/worker/resources/cross-origin-worker.js
+++ b/LayoutTests/inspector/worker/resources/cross-origin-worker.js
@@ -1,0 +1,5 @@
+var passphrase = "worker-in-cross-origin-iframe";
+
+self.addEventListener("message", (event) => {
+    self.postMessage(passphrase);
+});

--- a/LayoutTests/inspector/worker/resources/iframe-with-worker.html
+++ b/LayoutTests/inspector/worker/resources/iframe-with-worker.html
@@ -1,0 +1,4 @@
+<script>
+var worker = new Worker("cross-origin-worker.js", {name: "CrossOriginWorker"});
+worker.postMessage("ping");
+</script>

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -255,6 +255,7 @@ http/tests/site-isolation/inspector/debugger/pause-in-cross-origin-iframe.html [
 http/tests/site-isolation/inspector/debugger/scriptParsed-frame-target.html [ Pass ]
 http/tests/site-isolation/inspector/debugger/setBreakpoint-cross-origin-iframe.html [ Pass ]
 http/tests/site-isolation/inspector/page/override-setting-cross-origin-iframe.html [ Pass Failure ]
+http/tests/site-isolation/inspector/worker/worker-in-cross-origin-iframe.html [ Pass ]
 http/tests/ssl/applepay/page-cache-active-apple-pay-session.html [ Failure ]
 http/tests/ssl/applepay/page-cache-inactive-apple-pay-session.html [ Failure ]
 http/tests/ssl/media-stream/get-user-media-secure-connection.html [ Failure ]

--- a/Source/JavaScriptCore/inspector/protocol/Worker.json
+++ b/Source/JavaScriptCore/inspector/protocol/Worker.json
@@ -1,7 +1,7 @@
 {
     "domain": "Worker",
     "debuggableTypes": ["web-page"],
-    "targetTypes": ["page", "worker"],
+    "targetTypes": ["frame", "page", "worker"],
     "commands": [
         {
             "name": "enable",

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1918,6 +1918,7 @@ inspector/agents/WebDebuggerAgent.cpp
 inspector/agents/WebHeapAgent.cpp
 inspector/agents/frame/FrameConsoleAgent.cpp
 inspector/agents/frame/FrameDebuggerAgent.cpp
+inspector/agents/frame/FrameWorkerAgent.cpp
 inspector/agents/page/PageAuditAgent.cpp
 inspector/agents/page/PageCanvasAgent.cpp
 inspector/agents/page/PageConsoleAgent.cpp

--- a/Source/WebCore/inspector/FrameInspectorController.cpp
+++ b/Source/WebCore/inspector/FrameInspectorController.cpp
@@ -37,6 +37,7 @@
 #include "FrameDebuggerAgent.h"
 #include "FrameInlines.h"
 #include "FrameRuntimeAgent.h"
+#include "FrameWorkerAgent.h"
 #include "InspectorInstrumentation.h"
 #include "InspectorWebAgentBase.h"
 #include "InstrumentingAgents.h"
@@ -160,6 +161,8 @@ void FrameInspectorController::createLazyAgents()
     m_agents.append(makeUniqueRef<FrameDebuggerAgent>(context));
 
     createRuntimeAgent();
+
+    m_agents.append(makeUniqueRef<FrameWorkerAgent>(context));
 }
 
 void FrameInspectorController::connectFrontend(Inspector::FrontendChannel& frontendChannel, bool isAutomaticInspection, bool immediatelyPause)

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -36,6 +36,7 @@
 #include "ComputedEffectTiming.h"
 #include "ContextDestructionObserverInlines.h"
 #include "DOMWrapperWorld.h"
+#include "Document.h"
 #include "DocumentLoader.h"
 #include "Event.h"
 #include "EventTargetInlines.h"
@@ -1383,8 +1384,11 @@ InstrumentingAgents& InspectorInstrumentation::instrumentingAgents(Page& page)
 InstrumentingAgents* InspectorInstrumentation::instrumentingAgents(ScriptExecutionContext& context)
 {
     // Using RefPtr makes us hit the m_inRemovedLastRefFunction assert.
-    if (WeakPtr document = dynamicDowncast<Document>(context))
+    if (WeakPtr document = dynamicDowncast<Document>(context)) {
+        if (auto* frame = document->frame())
+            return &instrumentingAgents(*frame);
         return instrumentingAgents(document->page());
+    }
     if (auto* workerOrWorkletGlobal = dynamicDowncast<WorkerOrWorkletGlobalScope>(context))
         return &instrumentingAgents(*workerOrWorkletGlobal);
     return nullptr;

--- a/Source/WebCore/inspector/agents/frame/FrameWorkerAgent.cpp
+++ b/Source/WebCore/inspector/agents/frame/FrameWorkerAgent.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "FrameWorkerAgent.h"
+
+#include "Document.h"
+#include "InstrumentingAgents.h"
+#include "LocalFrame.h"
+#include "Page.h"
+#include "WorkerInspectorProxy.h"
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FrameWorkerAgent);
+
+FrameWorkerAgent::FrameWorkerAgent(FrameAgentContext& context)
+    : InspectorWorkerAgent(context)
+    , m_inspectedFrame(context.inspectedFrame)
+{
+}
+
+FrameWorkerAgent::~FrameWorkerAgent() = default;
+
+void FrameWorkerAgent::didCreateFrontendAndBackend()
+{
+    Ref { m_instrumentingAgents.get() }->setPersistentWorkerAgent(this);
+}
+
+void FrameWorkerAgent::willDestroyFrontendAndBackend(DisconnectReason reason)
+{
+    Ref { m_instrumentingAgents.get() }->setPersistentWorkerAgent(nullptr);
+
+    InspectorWorkerAgent::willDestroyFrontendAndBackend(reason);
+}
+
+void FrameWorkerAgent::connectToAllWorkerInspectorProxies()
+{
+    RefPtr frame = m_inspectedFrame.get();
+    if (!frame)
+        return;
+
+    RefPtr page = frame->page();
+    if (!page || !page->identifier())
+        return;
+
+    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=312381 SI WorkerInspectorProxy should support proxiesForFrame()
+    for (Ref proxy : WorkerInspectorProxy::proxiesForPage(*page->identifier())) {
+        RefPtr context = proxy->scriptExecutionContext();
+        if (!context)
+            continue;
+
+        RefPtr document = dynamicDowncast<Document>(context.get());
+        if (!document || document->frame() != frame.get())
+            continue;
+
+        connectToWorkerInspectorProxy(proxy);
+    }
+}
+
+} // namespace WebCore

--- a/Source/WebCore/inspector/agents/frame/FrameWorkerAgent.h
+++ b/Source/WebCore/inspector/agents/frame/FrameWorkerAgent.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "InspectorWorkerAgent.h"
+#include <wtf/TZoneMalloc.h>
+
+namespace WebCore {
+
+class LocalFrame;
+
+class FrameWorkerAgent final : public InspectorWorkerAgent {
+    WTF_MAKE_NONCOPYABLE(FrameWorkerAgent);
+    WTF_MAKE_TZONE_ALLOCATED(FrameWorkerAgent);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FrameWorkerAgent);
+public:
+    FrameWorkerAgent(FrameAgentContext&);
+    ~FrameWorkerAgent();
+
+    // InspectorAgentBase
+    void didCreateFrontendAndBackend() override;
+    void willDestroyFrontendAndBackend(Inspector::DisconnectReason) override;
+
+private:
+    void connectToAllWorkerInspectorProxies() override;
+
+    WeakRef<LocalFrame> m_inspectedFrame;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/inspector/agents/page/PageWorkerAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageWorkerAgent.cpp
@@ -26,8 +26,8 @@
 #include "config.h"
 #include "PageWorkerAgent.h"
 
-#include "Document.h"
 #include "Page.h"
+#include "Settings.h"
 #include "WorkerInspectorProxy.h"
 
 namespace WebCore {
@@ -46,6 +46,12 @@ PageWorkerAgent::~PageWorkerAgent() = default;
 
 void PageWorkerAgent::connectToAllWorkerInspectorProxies()
 {
+    // Under site isolation, every frame (including the main frame) has its own
+    // FrameInspectorController with a FrameWorkerAgent that handles workers for
+    // that frame. PageWorkerAgent does not need to connect to any workers.
+    if (m_page->settings().siteIsolationEnabled())
+        return;
+
     for (Ref proxy : WorkerInspectorProxy::proxiesForPage(*m_page->identifier()))
         connectToWorkerInspectorProxy(proxy);
 }

--- a/Source/WebInspectorUI/UserInterface/Controllers/TargetManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/TargetManager.js
@@ -159,6 +159,14 @@ WI.TargetManager = class TargetManager extends WI.Object
         if (!target)
             return;
 
+        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=312386 SI Move cleanup of children workers to backend
+        if (target.type === WI.TargetType.Frame) {
+            for (let workerTarget of this.workerTargets) {
+                if (workerTarget.parentTarget === target)
+                    WI.workerManager.workerTerminated(workerTarget.identifier);
+            }
+        }
+
         this._checkAndHandlePageTargetTermination(target);
         this.removeTarget(target);
     }


### PR DESCRIPTION
#### 047f3dc902f24c8e1cb0cc9e67afbe22d7e314f6
<pre>
([Site Isolation] Web Inspector: support cross-origin iframes in the Worker domain)
<a href="https://bugs.webkit.org/show_bug.cgi?id=308488">https://bugs.webkit.org/show_bug.cgi?id=308488</a>
<a href="https://rdar.apple.com/143596746">rdar://143596746</a>

Reviewed by Qianlang Chen.

Introducing FrameWorkerAgent to enable worker discovery and inspection in
cross-origin iframes under site isolation. When the iframe spawns a worker,
InspectorInstrumentation resolves the page-level InstrumentingAgents which
has no connected PageWorkerAgent in that process.

FrameWorkerAgent registers in the shared persistentWorkerAgent slot on the
frame&apos;s InstrumentingAgents at frontend connect time, matching the existing
PageWorkerAgent lifecycle. This works because page and frame WorkerAgents
never coexist on the same InstrumentingAgents instance, and FrameWorkerAgent
inherits from InspectorWorkerAgent. The PageChannel threading model is
inherited from InspectorWorkerAgent — no changes needed.

Under site isolation, PageWorkerAgent early-returns in
connectToAllWorkerInspectorProxies since every frame (including main) has
its own FrameWorkerAgent. FrameWorkerAgent filters
WorkerInspectorProxy::proxiesForPage to only connect workers whose
scriptExecutionContext Document belongs to the inspected frame. This
prevents double-connection when multiple same-site frames share a WebProcess.

instrumentingAgents(ScriptExecutionContext&amp;) now prefers the frame&apos;s
InstrumentingAgents when a document has an associated frame. Since the
frame&apos;s agents fall back to the page&apos;s agents for unset slots, the existing
workerStarted, workerTerminated, and shouldWaitForDebuggerOnStart Impl
functions work without any routing changes

Adding &quot;frame&quot; to Worker.json targetTypes is sufficient for the frontend —
WorkerManager.initializeTarget already gates on hasDomain(&quot;Worker&quot;), which
now returns true for FrameTargets.

TargetManager.targetDestroyed cleans up child WorkerTargets when a
FrameTarget is destroyed, since Worker.workerTerminated messages from the
backend get dropped due to a race in willDestroyFrame.

Tests: http/tests/site-isolation/inspector/worker/worker-in-cross-origin-iframe.html
       http/tests/site-isolation/inspector/worker/worker-resources/iframe-with-worker.html

* LayoutTests/http/tests/site-isolation/inspector/worker/worker-in-cross-origin-iframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/worker/worker-in-cross-origin-iframe.html: Added.
* LayoutTests/inspector/worker/resources/cross-origin-worker.js: Added.
* LayoutTests/inspector/worker/resources/iframe-with-worker.html: Added.
* LayoutTests/platform/mac-site-isolation/TestExpectations:
* Source/JavaScriptCore/inspector/protocol/Worker.json:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/inspector/FrameInspectorController.cpp:
(WebCore::FrameInspectorController::createLazyAgents):
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::instrumentingAgents):
* Source/WebCore/inspector/agents/frame/FrameWorkerAgent.cpp: Copied from Source/WebCore/inspector/agents/page/PageWorkerAgent.cpp.
(WebCore::FrameWorkerAgent::FrameWorkerAgent):
(WebCore::FrameWorkerAgent::didCreateFrontendAndBackend):
(WebCore::FrameWorkerAgent::willDestroyFrontendAndBackend):
(WebCore::FrameWorkerAgent::connectToAllWorkerInspectorProxies):
* Source/WebCore/inspector/agents/frame/FrameWorkerAgent.h: Copied from Source/WebCore/inspector/agents/page/PageWorkerAgent.cpp.
* Source/WebCore/inspector/agents/page/PageWorkerAgent.cpp:
(WebCore::PageWorkerAgent::connectToAllWorkerInspectorProxies):
* Source/WebInspectorUI/UserInterface/Controllers/TargetManager.js:
(WI.TargetManager.prototype.targetDestroyed):

Canonical link: <a href="https://commits.webkit.org/311312@main">https://commits.webkit.org/311312@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc22ee63574feb732a3a7bd2cf802ef39a6d03b6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156612 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29947 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23131 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165435 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158483 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30084 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29951 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121302 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159570 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23539 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140643 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101970 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13207 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/148662 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/132274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18472 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167918 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/17447 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/12038 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20089 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129417 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29550 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24854 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129527 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35083 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29473 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140266 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87274 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24353 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17069 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/188573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29181 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93145 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/188573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28706 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28936 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28831 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->