### PR TITLE
Reduce use for .get() for smart pointers

### DIFF
--- a/Source/JavaScriptCore/inspector/InjectedScriptBase.h
+++ b/Source/JavaScriptCore/inspector/InjectedScriptBase.h
@@ -66,7 +66,7 @@ protected:
     InjectedScriptBase(const String& name);
     InjectedScriptBase(const String& name, JSC::JSGlobalObject*, JSC::JSObject*, InspectorEnvironment*);
 
-    InspectorEnvironment& inspectorEnvironment() const { return *m_environment.get(); }
+    InspectorEnvironment& inspectorEnvironment() const { return *m_environment; }
     CheckedRef<InspectorEnvironment> checkedInspectorEnvironment() const { return inspectorEnvironment(); }
 
     bool hasAccessToInspectedScriptState() const;

--- a/Source/JavaScriptCore/inspector/InjectedScriptManager.h
+++ b/Source/JavaScriptCore/inspector/InjectedScriptManager.h
@@ -59,7 +59,7 @@ public:
     JS_EXPORT_PRIVATE virtual void discardInjectedScripts();
 
     InjectedScriptHost& injectedScriptHost();
-    InspectorEnvironment& inspectorEnvironment() const { return *m_environment.get(); }
+    InspectorEnvironment& inspectorEnvironment() const { return *m_environment; }
     CheckedRef<InspectorEnvironment> checkedInspectorEnvironment() const { return inspectorEnvironment(); }
 
     JS_EXPORT_PRIVATE InjectedScript injectedScriptFor(JSC::JSGlobalObject*);

--- a/Source/WTF/wtf/Forward.h
+++ b/Source/WTF/wtf/Forward.h
@@ -159,6 +159,9 @@ template<typename, size_t = 0, typename = CrashOnOverflow, size_t = 16, typename
 template<typename, typename WeakPtrImpl = DefaultWeakPtrImpl, typename = RawPtrTraits<WeakPtrImpl>> class WeakPtr;
 template<typename, typename = DefaultWeakPtrImpl> class WeakRef;
 template<typename T> class InlineWeakPtr;
+template<typename T> struct NoTaggingTraits;
+template<typename T, typename = NoTaggingTraits<T>> class ThreadSafeWeakPtr;
+template<typename T, typename = NoTaggingTraits<T>> class ThreadSafeWeakRef;
 
 template <typename T>
 using SaSegmentedVector = SegmentedVector<T, 8, SequesteredArenaMalloc>;

--- a/Source/WTF/wtf/Ref.h
+++ b/Source/WTF/wtf/Ref.h
@@ -119,6 +119,18 @@ public:
     {
     }
 
+    template<typename X, typename Y>
+    Ref(const CheckedRef<X, Y>& other) requires std::is_convertible_v<X*, T*>
+        : m_ptr(&RefDerefTraits::ref(other.get()))
+    {
+    }
+
+    template<typename X, typename Y>
+    Ref(const ThreadSafeWeakRef<X, Y>& other) requires std::is_convertible_v<X*, T*>
+        : m_ptr(&RefDerefTraits::ref(other.get()))
+    {
+    }
+
     Ref& operator=(T&);
     Ref& operator=(Ref&&);
     template<typename X, typename Y, typename Z> Ref& operator=(Ref<X, Y, Z>&&);
@@ -183,6 +195,10 @@ private:
 // Template deduction guide.
 template<typename X, typename Y> Ref(const WeakRef<X, Y>&) -> Ref<X, RawPtrTraits<X>, DefaultRefDerefTraits<X>>;
 template<typename X, typename Y> Ref(WeakRef<X, Y>&) -> Ref<X, RawPtrTraits<X>, DefaultRefDerefTraits<X>>;
+template<typename X, typename Y> Ref(const CheckedRef<X, Y>&) -> Ref<X, RawPtrTraits<X>, DefaultRefDerefTraits<X>>;
+template<typename X, typename Y> Ref(CheckedRef<X, Y>&) -> Ref<X, RawPtrTraits<X>, DefaultRefDerefTraits<X>>;
+template<typename X, typename Y> Ref(const ThreadSafeWeakRef<X, Y>&) -> Ref<X, RawPtrTraits<X>, DefaultRefDerefTraits<X>>;
+template<typename X, typename Y> Ref(ThreadSafeWeakRef<X, Y>&) -> Ref<X, RawPtrTraits<X>, DefaultRefDerefTraits<X>>;
 
 template<typename T, typename _PtrTraits, typename RefDerefTraits> Ref<T, _PtrTraits, RefDerefTraits> adoptRef(T&);
 

--- a/Source/WTF/wtf/RefPtr.h
+++ b/Source/WTF/wtf/RefPtr.h
@@ -55,6 +55,8 @@ public:
     template<typename X, typename Y, typename Z> RefPtr(RefPtr<X, Y, Z>&& o) : m_ptr(o.leakRef()) { }
     template<typename X, typename Y> RefPtr(Ref<X, Y>&&);
     template<typename X, typename Y, typename Z> RefPtr(const WeakPtr<X, Y, Z>& o) requires std::is_convertible_v<X*, T*> : m_ptr(RefDerefTraits::refIfNotNull(o.get())) { }
+    template<typename X, typename Y> RefPtr(const CheckedPtr<X, Y>& o) requires std::is_convertible_v<X*, T*> : m_ptr(RefDerefTraits::refIfNotNull(o.get())) { }
+    template<typename X, typename Y> RefPtr(const ThreadSafeWeakPtr<X, Y>& o) requires std::is_convertible_v<X*, T*> : m_ptr(RefDerefTraits::refIfNotNull(o.get())) { }
 
     // Hash table deleted values, which are only constructed and never copied or destroyed.
     RefPtr(HashTableDeletedValueType) : m_ptr(PtrTraits::hashTableDeletedValue()) { }
@@ -112,6 +114,10 @@ private:
 template<typename X, typename Y> RefPtr(Ref<X, Y>&&) -> RefPtr<X, Y, DefaultRefDerefTraits<X>>;
 template<typename X, typename Y, typename Z> RefPtr(const WeakPtr<X, Y, Z>&) -> RefPtr<X, RawPtrTraits<X>, DefaultRefDerefTraits<X>>;
 template<typename X, typename Y, typename Z> RefPtr(WeakPtr<X, Y, Z>&) -> RefPtr<X, RawPtrTraits<X>, DefaultRefDerefTraits<X>>;
+template<typename X, typename Y> RefPtr(const CheckedPtr<X, Y>&) -> RefPtr<X, RawPtrTraits<X>, DefaultRefDerefTraits<X>>;
+template<typename X, typename Y> RefPtr(CheckedPtr<X, Y>&) -> RefPtr<X, RawPtrTraits<X>, DefaultRefDerefTraits<X>>;
+template<typename X, typename Y> RefPtr(const ThreadSafeWeakPtr<X, Y>&) -> RefPtr<X, RawPtrTraits<X>, DefaultRefDerefTraits<X>>;
+template<typename X, typename Y> RefPtr(ThreadSafeWeakPtr<X, Y>&) -> RefPtr<X, RawPtrTraits<X>, DefaultRefDerefTraits<X>>;
 
 template<typename T, typename U, typename V>
 template<typename X, typename Y>

--- a/Source/WTF/wtf/ThreadSafeWeakPtr.h
+++ b/Source/WTF/wtf/ThreadSafeWeakPtr.h
@@ -35,8 +35,8 @@
 
 namespace WTF {
 
-template<typename T, typename = NoTaggingTraits<T>> class ThreadSafeWeakPtr;
-template<typename T, typename = NoTaggingTraits<T>> class ThreadSafeWeakRef;
+template<typename T, typename> class ThreadSafeWeakPtr;
+template<typename T, typename> class ThreadSafeWeakRef;
 template<typename> class ThreadSafeWeakHashSet;
 template<typename, DestructionThread> class ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr;
 

--- a/Source/WebCore/Modules/cookie-store/CookieStore.cpp
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.cpp
@@ -88,7 +88,7 @@ private:
     void ensureOnMainThread(Function<void(ScriptExecutionContext&)>&&);
     void ensureOnContextThread(Function<void(CookieStore&)>&&);
 
-    RefPtr<CookieStore> protectedCookieStore() const { return m_cookieStore.get(); }
+    RefPtr<CookieStore> protectedCookieStore() const { return m_cookieStore; }
     WeakPtr<CookieStore, WeakPtrImplWithEventTargetData> m_cookieStore;
     Markable<ScriptExecutionContextIdentifier> m_contextIdentifier;
 };

--- a/Source/WebCore/Modules/mediastream/RTCIceTransport.h
+++ b/Source/WebCore/Modules/mediastream/RTCIceTransport.h
@@ -63,7 +63,7 @@ public:
     RTCIceGatheringState gatheringState() const { return m_gatheringState; }
 
     const RTCIceTransportBackend& backend() const { return m_backend.get(); }
-    RefPtr<RTCPeerConnection> connection() const { return m_connection.get(); }
+    RefPtr<RTCPeerConnection> connection() const { return m_connection; }
 
     struct CandidatePair {
         RefPtr<RTCIceCandidate> local;

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.h
@@ -80,7 +80,7 @@ private:
     friend class LibWebRTCMediaEndpoint;
     friend class LibWebRTCRtpSenderBackend;
     RTCPeerConnection& connection() { return m_peerConnection; }
-    Ref<RTCPeerConnection> protectedConnection() { return m_peerConnection.get(); }
+    Ref<RTCPeerConnection> protectedConnection() { return m_peerConnection; }
 
     void getStatsSucceeded(const DeferredPromise&, Ref<RTCStatsReport>&&);
 

--- a/Source/WebCore/Modules/webtransport/WebTransportReceiveStreamSource.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportReceiveStreamSource.h
@@ -46,7 +46,7 @@ public:
     void receiveBytes(std::span<const uint8_t>, bool, std::optional<WebCore::Exception>&&);
     void receiveError(JSDOMGlobalObject&, JSC::JSValue error);
     void setStream(ReadableStream& stream) { m_stream = stream; }
-    RefPtr<ReadableStream> stream() const { return m_stream.get(); };
+    RefPtr<ReadableStream> stream() const { return m_stream; };
 
 private:
     WebTransportReceiveStreamSource();

--- a/Source/WebCore/Modules/webxr/WebXRSession.h
+++ b/Source/WebCore/Modules/webxr/WebXRSession.h
@@ -83,7 +83,7 @@ public:
     XRVisibilityState visibilityState() const;
     const WebXRRenderState& renderState() const;
     const WebXRInputSourceArray& inputSources() const { return m_inputSources; }
-    RefPtr<PlatformXR::Device> device() const { return m_device.get(); }
+    RefPtr<PlatformXR::Device> device() const { return m_device; }
 
     const Vector<String> enabledFeatures() const;
 

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -509,12 +509,12 @@ Node* AXObjectCache::modalNode()
 
     // Check the cached current valid aria modal node first.
     // Usually when one dialog sets aria-modal=true, that dialog is the one we want.
-    if (isNodeVisible(m_currentModalElement.get()))
-        return m_currentModalElement.get();
+    if (isNodeVisible(m_currentModalElement))
+        return m_currentModalElement;
 
     // Recompute the valid aria modal node when m_currentModalElement is null or hidden.
     updateCurrentModalNode();
-    return m_currentModalElement.get();
+    return m_currentModalElement;
 }
 
 AccessibilityObject* AXObjectCache::focusedImageMapUIElement(HTMLAreaElement& areaElement)

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -641,7 +641,7 @@ public:
 
     AXComputedObjectAttributeCache* computedObjectAttributeCache() { return m_computedObjectAttributeCache.get(); }
 
-    Document* document() const { return m_document.get(); }
+    Document* document() const { return m_document; }
     RefPtr<Document> protectedDocument() const;
     FrameIdentifier frameID() const { return m_frameID; }
 

--- a/Source/WebCore/accessibility/AccessibilityScrollView.h
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.h
@@ -94,7 +94,7 @@ private:
     AccessibilityObject* parentObject() const final;
     RefPtr<AccessibilityObject> protectedHorizontalScrollbar() const { return m_horizontalScrollbar; }
     RefPtr<AccessibilityObject> protectedVerticalScrollbar() const { return m_verticalScrollbar; }
-    RefPtr<HTMLFrameOwnerElement> protectedFrameOwnerElement() const { return m_frameOwnerElement.get(); }
+    RefPtr<HTMLFrameOwnerElement> protectedFrameOwnerElement() const { return m_frameOwnerElement; }
 
     AccessibilityObject* firstChild() const final { return webAreaObject(); }
     AccessibilityScrollbar* addChildScrollbar(Scrollbar*);

--- a/Source/WebCore/bindings/js/ScriptController.cpp
+++ b/Source/WebCore/bindings/js/ScriptController.cpp
@@ -331,7 +331,7 @@ void ScriptController::initScriptForWindowProxy(JSWindowProxy& windowProxy)
 
 Ref<LocalFrame> ScriptController::protectedFrame() const
 {
-    return m_frame.get();
+    return m_frame;
 }
 
 static Identifier jsValueToModuleKey(JSGlobalObject* lexicalGlobalObject, JSValue value)

--- a/Source/WebCore/bindings/js/WindowProxy.cpp
+++ b/Source/WebCore/bindings/js/WindowProxy.cpp
@@ -76,7 +76,7 @@ WindowProxy::~WindowProxy()
 
 Frame* WindowProxy::frame() const
 {
-    return m_frame.get();
+    return m_frame;
 }
 
 void WindowProxy::detachFromFrame()

--- a/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.h
+++ b/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.h
@@ -39,12 +39,12 @@ public:
     static Ref<ComputedStylePropertyMapReadOnly> create(Element&);
 
     Type type() const final { return Type::Computed; }
-    Element* elementConcurrently() const { return m_element.get(); }
+    Element* elementConcurrently() const { return m_element; }
 
 private:
     explicit ComputedStylePropertyMapReadOnly(Element&);
 
-    RefPtr<Element> protectedElement() const { return m_element.get(); }
+    RefPtr<Element> protectedElement() const { return m_element; }
 
     RefPtr<CSSValue> propertyValue(CSSPropertyID) const final;
     String shorthandPropertySerialization(CSSPropertyID) const final;

--- a/Source/WebCore/dom/ContainerNode.h
+++ b/Source/WebCore/dom/ContainerNode.h
@@ -40,13 +40,13 @@ class ContainerNode : public Node {
 public:
     virtual ~ContainerNode();
 
-    Node* firstChild() const { return m_firstChild.get(); }
-    RefPtr<Node> protectedFirstChild() const { return m_firstChild.get(); }
+    Node* firstChild() const { return m_firstChild; }
+    RefPtr<Node> protectedFirstChild() const { return m_firstChild; }
     static constexpr ptrdiff_t firstChildMemoryOffset() { return OBJECT_OFFSETOF(ContainerNode, m_firstChild); }
-    Node* lastChild() const { return m_lastChild.get(); }
-    RefPtr<Node> protectedLastChild() const { return m_lastChild.get(); }
+    Node* lastChild() const { return m_lastChild; }
+    RefPtr<Node> protectedLastChild() const { return m_lastChild; }
     static constexpr ptrdiff_t lastChildMemoryOffset() { return OBJECT_OFFSETOF(ContainerNode, m_lastChild); }
-    bool hasChildNodes() const { return m_firstChild.get(); }
+    bool hasChildNodes() const { return m_firstChild; }
     bool hasOneChild() const { return m_firstChild && m_firstChild == m_lastChild; }
 
     bool directChildNeedsStyleRecalc() const { return hasStyleFlag(NodeStyleFlag::DirectChildNeedsStyleResolution); }

--- a/Source/WebCore/dom/DataTransferItemList.h
+++ b/Source/WebCore/dom/DataTransferItemList.h
@@ -57,7 +57,7 @@ public:
     // DataTransfer owns DataTransferItemList, and DataTransfer is kept alive as long as DataTransferItemList is alive.
     void ref() const final { m_dataTransfer->ref(); }
     void deref() const final { m_dataTransfer->deref(); }
-    DataTransfer& dataTransfer() { return m_dataTransfer.get(); }
+    DataTransfer& dataTransfer() { return m_dataTransfer; }
 
     // DOM API
     unsigned length() const;

--- a/Source/WebCore/dom/DatasetDOMStringMap.h
+++ b/Source/WebCore/dom/DatasetDOMStringMap.h
@@ -54,7 +54,7 @@ public:
     ExceptionOr<void> setNamedItem(const String& name, const AtomString& value);
     bool deleteNamedProperty(const String& name);
 
-    Element& element() { return m_element.get(); }
+    Element& element() { return m_element; }
     Ref<Element> protectedElement() const;
 
 private:

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -8179,7 +8179,7 @@ RefPtr<Document> Document::sameOriginTopLevelTraversable() const
     if (!m_frame)
         return nullptr;
 
-    RefPtr<Frame> topLevelAncestorFrame = m_frame.get();
+    RefPtr<Frame> topLevelAncestorFrame = m_frame;
     for (Frame* parent = topLevelAncestorFrame->tree().parent(); parent; parent = parent->tree().parent())
         topLevelAncestorFrame = parent;
 

--- a/Source/WebCore/dom/DocumentFullscreen.h
+++ b/Source/WebCore/dom/DocumentFullscreen.h
@@ -60,9 +60,9 @@ public:
     static void webkitCancelFullScreen(Document& document) { document.protectedFullscreen()->fullyExitFullscreen(); };
 
     // Helpers.
-    Document& document() { return m_document.get(); }
-    const Document& document() const { return m_document.get(); }
-    Ref<Document> protectedDocument() const { return m_document.get(); }
+    Document& document() { return m_document; }
+    const Document& document() const { return m_document; }
+    Ref<Document> protectedDocument() const { return m_document; }
     LocalFrame* frame() const;
     Element* documentElement() const { return document().documentElement(); }
     bool isSimpleFullscreenDocument() const;

--- a/Source/WebCore/dom/DocumentImmersive.h
+++ b/Source/WebCore/dom/DocumentImmersive.h
@@ -51,9 +51,9 @@ public:
     static void exitImmersive(Document&, Ref<DeferredPromise>&&);
 
     // Helpers.
-    Document& document() { return m_document.get(); }
-    const Document& document() const { return m_document.get(); }
-    Ref<Document> protectedDocument() const { return m_document.get(); }
+    Document& document() { return m_document; }
+    const Document& document() const { return m_document; }
+    Ref<Document> protectedDocument() const { return m_document; }
 
     HTMLModelElement* immersiveElement() const;
     RefPtr<HTMLModelElement> protectedImmersiveElement() const { return immersiveElement(); }

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -1195,7 +1195,7 @@ static std::optional<std::pair<SingleThreadWeakPtr<RenderElement>, LayoutRect>> 
         itemIndex = 0;
 
     auto itemLocalRect = renderListBox->itemBoundingBoxRect({ }, itemIndex);
-    return std::pair<SingleThreadWeakPtr<RenderElement>, LayoutRect> { renderListBox.releaseNonNull(), itemLocalRect };
+    return std::pair<SingleThreadWeakPtr<RenderElement>, LayoutRect> { renderListBox.get(), itemLocalRect };
 }
 
 void Element::scrollIntoView(std::optional<Variant<bool, ScrollIntoViewOptions>>&& arg)

--- a/Source/WebCore/dom/MutationObserverRegistration.h
+++ b/Source/WebCore/dom/MutationObserverRegistration.h
@@ -64,7 +64,7 @@ public:
 
     MutationObserver& observer() { return m_observer.get(); }
     Node& node() { return m_node; }
-    Ref<Node> protectedNode() { return m_node.get(); };
+    Ref<Node> protectedNode() { return m_node; };
     MutationRecordDeliveryOptions deliveryOptions() const { return m_options & MutationObserver::AllDeliveryFlags; }
     MutationObserverOptions mutationTypes() const { return m_options & MutationObserver::AllMutationTypes; }
 

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -172,8 +172,8 @@ public:
     Node* previousSibling() const { return m_previousSibling; }
     RefPtr<Node> protectedPreviousSibling() const { return m_previousSibling; }
     static constexpr ptrdiff_t previousSiblingMemoryOffset() { return OBJECT_OFFSETOF(Node, m_previousSibling); }
-    Node* nextSibling() const { return m_next.get(); }
-    RefPtr<Node> protectedNextSibling() const { return m_next.get(); }
+    Node* nextSibling() const { return m_next; }
+    RefPtr<Node> protectedNextSibling() const { return m_next; }
     static constexpr ptrdiff_t nextSiblingMemoryOffset() { return OBJECT_OFFSETOF(Node, m_next); }
     WEBCORE_EXPORT Ref<NodeList> childNodes();
     inline Node* firstChild() const;

--- a/Source/WebCore/dom/RadioButtonGroups.cpp
+++ b/Source/WebCore/dom/RadioButtonGroups.cpp
@@ -39,7 +39,7 @@ class RadioButtonGroup {
 public:
     bool isEmpty() const { return m_members.isEmptyIgnoringNullReferences(); }
     bool isRequired() const { return m_requiredCount; }
-    RefPtr<HTMLInputElement> checkedButton() const { return m_checkedButton.get(); }
+    RefPtr<HTMLInputElement> checkedButton() const { return m_checkedButton; }
     void add(HTMLInputElement&);
     void updateCheckedState(HTMLInputElement&);
     void requiredStateChanged(HTMLInputElement&);

--- a/Source/WebCore/dom/ScriptElement.h
+++ b/Source/WebCore/dom/ScriptElement.h
@@ -47,9 +47,9 @@ class ScriptElement {
 public:
     virtual ~ScriptElement() = default;
 
-    Element& element() { return m_element.get(); }
-    const Element& element() const { return m_element.get(); }
-    Ref<Element> protectedElement() const { return m_element.get(); }
+    Element& element() { return m_element; }
+    const Element& element() const { return m_element; }
+    Ref<Element> protectedElement() const { return m_element; }
 
     bool prepareScript(const TextPosition& scriptStartPosition = TextPosition());
 

--- a/Source/WebCore/dom/ShadowRoot.h
+++ b/Source/WebCore/dom/ShadowRoot.h
@@ -96,8 +96,8 @@ public:
     bool isDeclarativeShadowRoot() const { return m_isDeclarativeShadowRoot; }
     void setIsDeclarativeShadowRoot(bool flag) { m_isDeclarativeShadowRoot = flag; }
 
-    Element* host() const { return m_host.get(); }
-    RefPtr<Element> protectedHost() const { return m_host.get(); }
+    Element* host() const { return m_host; }
+    RefPtr<Element> protectedHost() const { return m_host; }
     void setHost(WeakPtr<Element, WeakPtrImplWithEventTargetData>&& host) { m_host = WTF::move(host); }
 
     bool hasScopedCustomElementRegistry() const { return m_hasScopedCustomElementRegistry; }

--- a/Source/WebCore/editing/Editor.h
+++ b/Source/WebCore/editing/Editor.h
@@ -212,8 +212,8 @@ public:
 
     CompositeEditCommand* lastEditCommand() { return m_lastEditCommand.get(); }
 
-    Document& document() const { return m_document.get(); }
-    Ref<Document> protectedDocument() const { return m_document.get(); }
+    Document& document() const { return m_document; }
+    Ref<Document> protectedDocument() const { return m_document; }
 
     WEBCORE_EXPORT void ref() const;
     WEBCORE_EXPORT void deref() const;

--- a/Source/WebCore/editing/WebContentReader.h
+++ b/Source/WebCore/editing/WebContentReader.h
@@ -44,8 +44,8 @@ public:
     {
     }
 
-    LocalFrame& frame() const { return m_frame.get(); }
-    Ref<LocalFrame> protectedFrame() const { return m_frame.get(); }
+    LocalFrame& frame() const { return m_frame; }
+    Ref<LocalFrame> protectedFrame() const { return m_frame; }
 
 protected:
     bool shouldSanitize() const;

--- a/Source/WebCore/history/BackForwardController.cpp
+++ b/Source/WebCore/history/BackForwardController.cpp
@@ -63,7 +63,7 @@ RefPtr<HistoryItem> BackForwardController::forwardItem(std::optional<FrameIdenti
 
 Ref<Page> BackForwardController::protectedPage() const
 {
-    return m_page.get();
+    return m_page;
 }
 
 bool BackForwardController::canGoBackOrForward(int distance) const

--- a/Source/WebCore/history/CachedPage.h
+++ b/Source/WebCore/history/CachedPage.h
@@ -49,7 +49,7 @@ public:
     WEBCORE_EXPORT void restore(Page&);
     void clear();
 
-    Page& page() const { return m_page.get(); }
+    Page& page() const { return m_page; }
     Ref<Page> protectedPage() const { return page(); }
     Document* document() const { return m_cachedMainFrame->document(); }
     DocumentLoader* documentLoader() const { return m_cachedMainFrame->documentLoader(); }

--- a/Source/WebCore/html/FormAssociatedElement.h
+++ b/Source/WebCore/html/FormAssociatedElement.h
@@ -39,8 +39,8 @@ public:
 
     virtual void formWillBeDestroyed() { m_form = nullptr; }
 
-    HTMLFormElement* form() const { return m_form.get(); }
-    RefPtr<HTMLFormElement> protectedForm() const { return m_form.get(); }
+    HTMLFormElement* form() const { return m_form; }
+    RefPtr<HTMLFormElement> protectedForm() const { return m_form; }
     virtual RefPtr<HTMLFormElement> formForBindings() const;
 
     void setForm(RefPtr<HTMLFormElement>&&);

--- a/Source/WebCore/html/InputType.h
+++ b/Source/WebCore/html/InputType.h
@@ -404,8 +404,8 @@ protected:
     {
     }
 
-    HTMLInputElement* element() const { return m_element.get(); }
-    RefPtr<HTMLInputElement> protectedElement() const { return m_element.get(); }
+    HTMLInputElement* element() const { return m_element; }
+    RefPtr<HTMLInputElement> protectedElement() const { return m_element; }
     Chrome* chrome() const;
     Decimal parseToNumberOrNaN(const String&) const;
 

--- a/Source/WebCore/html/parser/HTMLConstructionSite.h
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.h
@@ -204,7 +204,7 @@ public:
     static bool isFormattingTag(TagName);
 
 private:
-    Document& document() const { return m_document.get(); }
+    Document& document() const { return m_document; }
 
     // In the common case, this queue will have only one task because most
     // tokens produce only one DOM mutation.

--- a/Source/WebCore/inspector/InspectorCanvas.h
+++ b/Source/WebCore/inspector/InspectorCanvas.h
@@ -63,8 +63,8 @@ public:
 
     const String& identifier() const { return m_identifier; }
 
-    const CanvasRenderingContext& canvasContext() const { return m_context.get(); }
-    CanvasRenderingContext& canvasContext() { return m_context.get(); }
+    const CanvasRenderingContext& canvasContext() const { return m_context; }
+    CanvasRenderingContext& canvasContext() { return m_context; }
     HTMLCanvasElement* canvasElement() const;
 
     ScriptExecutionContext* scriptExecutionContext() const;

--- a/Source/WebCore/inspector/InspectorShaderProgram.h
+++ b/Source/WebCore/inspector/InspectorShaderProgram.h
@@ -39,8 +39,8 @@ public:
     static Ref<InspectorShaderProgram> create(WebGLProgram&, InspectorCanvas&);
 
     const String& identifier() const { return m_identifier; }
-    InspectorCanvas& canvas() const { return m_canvas.get(); }
-    WebGLProgram& program() const { return m_program.get(); }
+    InspectorCanvas& canvas() const { return m_canvas; }
+    WebGLProgram& program() const { return m_program; }
 
     String requestShaderSource(Inspector::Protocol::Canvas::ShaderType);
     bool updateShader(Inspector::Protocol::Canvas::ShaderType, const String& source);

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -3091,7 +3091,7 @@ RefPtr<Node> InspectorDOMAgent::nodeForPath(const String& path)
     if (!m_document)
         return nullptr;
 
-    RefPtr<Node> node = m_document.get();
+    RefPtr<Node> node = m_document;
     auto pathTokens = StringView(path).split(',');
     auto it = pathTokens.begin();
     if (it == pathTokens.end())

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -416,7 +416,7 @@ LocalFrame& FrameLoader::frame() const
 
 Ref<LocalFrame> FrameLoader::protectedFrame() const
 {
-    return m_frame.get();
+    return m_frame;
 }
 
 void FrameLoader::init()
@@ -707,7 +707,7 @@ void FrameLoader::clear(RefPtr<Document>&& newDocument, bool clearWindowProperti
     bool neededClear = m_needsClear;
     m_needsClear = false;
 
-    Ref<LocalFrame> frame = m_frame.get();
+    Ref frame = m_frame;
 
     RefPtr document = frame->document();
     if (neededClear)
@@ -897,7 +897,7 @@ void FrameLoader::finishedParsing()
 {
     LOG(Loading, "WebCoreLoading frame %" PRIu64 ": Finished parsing", m_frame->frameID().toUInt64());
 
-    Ref<LocalFrame> frame = m_frame.get();
+    Ref frame = m_frame;
 
     frame->injectUserScripts(UserScriptInjectionTime::DocumentEnd);
 
@@ -965,7 +965,7 @@ void FrameLoader::checkCompleted()
     if (m_isComplete)
         return;
 
-    Ref<LocalFrame> frame = m_frame.get();
+    Ref frame = m_frame;
     Ref<Document> document = *frame->document();
 
     // FIXME: It would be better if resource loads were kicked off after render tree update (or didn't complete synchronously).

--- a/Source/WebCore/loader/FrameNetworkingContext.h
+++ b/Source/WebCore/loader/FrameNetworkingContext.h
@@ -48,8 +48,8 @@ protected:
     {
     }
 
-    LocalFrame* frame() const { return m_frame.get(); }
-    RefPtr<LocalFrame> protectedFrame() const { return m_frame.get(); }
+    LocalFrame* frame() const { return m_frame; }
+    RefPtr<LocalFrame> protectedFrame() const { return m_frame; }
 
 private:
     bool isValid() const override { return !!m_frame; }

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -138,7 +138,7 @@ void HistoryController::saveScrollPositionAndViewStateToItem(HistoryItem* item)
 
 Ref<LocalFrame> HistoryController::protectedFrame() const
 {
-    return m_frame.get();
+    return m_frame;
 }
 
 /*

--- a/Source/WebCore/loader/ImageLoader.h
+++ b/Source/WebCore/loader/ImageLoader.h
@@ -68,9 +68,9 @@ public:
 
     void elementDidMoveToNewDocument(Document&);
 
-    Element& element() { return m_element.get(); }
-    const Element& element() const { return m_element.get(); }
-    Ref<Element> protectedElement() const { return m_element.get(); }
+    Element& element() { return m_element; }
+    const Element& element() const { return m_element; }
+    Ref<Element> protectedElement() const { return m_element; }
 
     bool shouldIgnoreCandidateWhenLoadingFromArchive(const ImageCandidate&) const;
 

--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -574,12 +574,12 @@ bool NavigationScheduler::redirectScheduledDuringLoad()
 
 bool NavigationScheduler::locationChangePending()
 {
-    return m_redirect && m_redirect->isLocationChange() && m_redirect->targetIsCurrentFrame() && !m_redirect->isSameDocumentNavigation(m_frame.get());
+    return m_redirect && m_redirect->isLocationChange() && m_redirect->targetIsCurrentFrame() && !m_redirect->isSameDocumentNavigation(m_frame);
 }
 
 Ref<Frame> NavigationScheduler::protectedFrame() const
 {
-    return m_frame.get();
+    return m_frame;
 }
 
 void NavigationScheduler::clear()

--- a/Source/WebCore/loader/PolicyChecker.cpp
+++ b/Source/WebCore/loader/PolicyChecker.cpp
@@ -334,7 +334,7 @@ void PolicyChecker::checkNavigationPolicy(ResourceRequest&& request, const Resou
 
 Ref<LocalFrame> PolicyChecker::protectedFrame() const
 {
-    return m_frame.get();
+    return m_frame;
 }
 
 std::optional<HitTestResult> PolicyChecker::hitTestResult(const NavigationAction& action)

--- a/Source/WebCore/loader/ProgressTracker.cpp
+++ b/Source/WebCore/loader/ProgressTracker.cpp
@@ -106,7 +106,7 @@ void ProgressTracker::reset()
 
 Ref<Page> ProgressTracker::protectedPage() const
 {
-    return m_page.get();
+    return m_page;
 }
 
 void ProgressTracker::progressStarted(LocalFrame& frame)
@@ -121,7 +121,7 @@ void ProgressTracker::progressStarted(LocalFrame& frame)
         m_originatingProgressFrame = frame;
 
         m_progressHeartbeatTimer.startRepeating(progressHeartbeatInterval);
-        RefPtr originatingProgressFrame = m_originatingProgressFrame.get();
+        RefPtr originatingProgressFrame = m_originatingProgressFrame;
         originatingProgressFrame->loader().loadProgressingStatusChanged();
 
         bool isMainFrame = !originatingProgressFrame->tree().parent();

--- a/Source/WebCore/loader/ResourceLoadNotifier.cpp
+++ b/Source/WebCore/loader/ResourceLoadNotifier.cpp
@@ -55,7 +55,7 @@ ResourceLoadNotifier::ResourceLoadNotifier(LocalFrame& frame)
 
 Ref<LocalFrame> ResourceLoadNotifier::protectedFrame() const
 {
-    return m_frame.get();
+    return m_frame;
 }
 
 void ResourceLoadNotifier::didReceiveAuthenticationChallenge(ResourceLoaderIdentifier identifier, DocumentLoader* loader, const AuthenticationChallenge& currentWebChallenge)

--- a/Source/WebCore/loader/ResourceLoader.cpp
+++ b/Source/WebCore/loader/ResourceLoader.cpp
@@ -960,18 +960,18 @@ bool ResourceLoader::isPDFJSResourceLoad() const
 
 RefPtr<LocalFrame> ResourceLoader::protectedFrame() const
 {
-    return m_frame.get();
+    return m_frame;
 }
 
 LocalFrame* ResourceLoader::frame() const
 {
-    return m_frame.get();
+    return m_frame;
 }
 
 #if ENABLE(CONTENT_EXTENSIONS)
 ResourceMonitor* ResourceLoader::resourceMonitorIfExists()
 {
-    RefPtr frame = m_frame.get();
+    RefPtr frame = m_frame;
     if (RefPtr document = frame ? frame->document() : nullptr)
         return document->resourceMonitorIfExists();
     return nullptr;

--- a/Source/WebCore/loader/SubframeLoader.cpp
+++ b/Source/WebCore/loader/SubframeLoader.cpp
@@ -89,7 +89,7 @@ FrameLoader::SubframeLoader::SubframeLoader(LocalFrame& frame)
 
 Ref<LocalFrame> FrameLoader::SubframeLoader::protectedFrame() const
 {
-    return m_frame.get();
+    return m_frame;
 }
 
 void FrameLoader::SubframeLoader::clear()
@@ -99,7 +99,7 @@ void FrameLoader::SubframeLoader::clear()
 
 bool FrameLoader::SubframeLoader::canCreateSubFrame() const
 {
-    Ref frame = m_frame.get();
+    Ref frame = m_frame;
     if (!frame->page() || frame->protectedPage()->subframeCount() >= Page::maxNumberOfFrames)
         return false;
 
@@ -302,7 +302,7 @@ LocalFrame* FrameLoader::SubframeLoader::loadOrRedirectSubframe(HTMLFrameOwnerEl
 
 RefPtr<LocalFrame> FrameLoader::SubframeLoader::loadSubframe(HTMLFrameOwnerElement& ownerElement, const URL& url, const AtomString& name, const URL& referrer)
 {
-    Ref frame = m_frame.get();
+    Ref frame = m_frame;
     Ref document = ownerElement.document();
 
     if (!document->protectedSecurityOrigin()->canDisplay(url, OriginAccessPatternsForWebProcess::singleton())) {
@@ -407,7 +407,7 @@ RefPtr<LocalFrame> FrameLoader::SubframeLoader::loadSubframe(HTMLFrameOwnerEleme
 
 bool FrameLoader::SubframeLoader::shouldUsePlugin(const URL& url, const String& mimeType, bool hasFallback, bool& useFallback)
 {
-    Ref frame = m_frame.get();
+    Ref frame = m_frame;
 
     ObjectContentType objectType = frame->loader().client().objectContentType(url, mimeType);
     // If an object's content can't be handled and it has no fallback, let

--- a/Source/WebCore/page/Chrome.cpp
+++ b/Source/WebCore/page/Chrome.cpp
@@ -92,7 +92,7 @@ Chrome::~Chrome()
 
 Ref<Page> Chrome::protectedPage() const
 {
-    return m_page.get();
+    return m_page;
 }
 
 void Chrome::invalidateRootView(const IntRect& updateRect)

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -117,7 +117,7 @@ ContextMenuController::~ContextMenuController()
 
 Page& ContextMenuController::page()
 {
-    return m_page.get();
+    return m_page;
 }
 
 void ContextMenuController::clearContextMenu()

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -5694,7 +5694,7 @@ void EventHandler::resetCapturingMouseEventsElement()
 
 Ref<LocalFrame> EventHandler::protectedFrame() const
 {
-    return m_frame.get();
+    return m_frame;
 }
 
 #if !PLATFORM(COCOA) && !PLATFORM(WIN)

--- a/Source/WebCore/page/FrameDestructionObserverInlines.h
+++ b/Source/WebCore/page/FrameDestructionObserverInlines.h
@@ -32,12 +32,12 @@ namespace WebCore {
 
 inline LocalFrame* FrameDestructionObserver::frame() const
 {
-    return m_frame.get();
+    return m_frame;
 }
 
 inline RefPtr<LocalFrame> FrameDestructionObserver::protectedFrame() const
 {
-    return m_frame.get();
+    return m_frame;
 }
 
 }

--- a/Source/WebCore/page/RemoteDOMWindow.h
+++ b/Source/WebCore/page/RemoteDOMWindow.h
@@ -55,7 +55,7 @@ public:
 
     ~RemoteDOMWindow() final;
 
-    RemoteFrame* frame() const final { return m_frame.get(); }
+    RemoteFrame* frame() const final { return m_frame; }
     ScriptExecutionContext* scriptExecutionContext() const final { return nullptr; }
 
     // DOM API exposed cross-origin.

--- a/Source/WebCore/page/UndoManager.h
+++ b/Source/WebCore/page/UndoManager.h
@@ -52,7 +52,7 @@ public:
     void removeItem(UndoItem&);
     void removeAllItems();
     ExceptionOr<void> addItem(Ref<UndoItem>&&);
-    Document& document() { return m_document.get(); }
+    Document& document() { return m_document; }
 
 private:
     UndoManager(Document&);

--- a/Source/WebCore/page/scrolling/ScrollingStateNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateNode.h
@@ -315,7 +315,7 @@ public:
 
     ScrollingNodeID scrollingNodeID() const { return m_nodeID; }
 
-    RefPtr<ScrollingStateNode> parent() const { return m_parent.get(); }
+    RefPtr<ScrollingStateNode> parent() const { return m_parent; }
     void setParent(RefPtr<ScrollingStateNode>&& parent) { m_parent = parent; }
     std::optional<ScrollingNodeID> parentNodeID() const;
 

--- a/Source/WebCore/page/scrolling/ScrollingTreeNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeNode.h
@@ -80,7 +80,7 @@ public:
     
     virtual void willBeDestroyed() { }
 
-    RefPtr<ScrollingTreeNode> parent() const { return m_parent.get(); }
+    RefPtr<ScrollingTreeNode> parent() const { return m_parent; }
     void setParent(RefPtr<ScrollingTreeNode>&& parent) { m_parent = parent; }
 
     WEBCORE_EXPORT bool isRootNode() const;
@@ -103,7 +103,7 @@ public:
 
 protected:
     ScrollingTreeNode(ScrollingTree&, ScrollingNodeType, ScrollingNodeID);
-    RefPtr<ScrollingTree> scrollingTree() const { return m_scrollingTree.get(); }
+    RefPtr<ScrollingTree> scrollingTree() const { return m_scrollingTree; }
 
     virtual void applyLayerPositions() = 0;
 

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h
@@ -39,8 +39,8 @@ public:
     WEBCORE_EXPORT explicit ScrollingTreeScrollingNodeDelegate(ScrollingTreeScrollingNode&);
     WEBCORE_EXPORT virtual ~ScrollingTreeScrollingNodeDelegate();
 
-    Ref<ScrollingTreeScrollingNode> scrollingNode() { return m_scrollingNode.get(); }
-    Ref<const ScrollingTreeScrollingNode> scrollingNode() const { return m_scrollingNode.get(); }
+    Ref<ScrollingTreeScrollingNode> scrollingNode() { return m_scrollingNode; }
+    Ref<const ScrollingTreeScrollingNode> scrollingNode() const { return m_scrollingNode; }
 
     virtual bool startAnimatedScrollToPosition(FloatPoint) = 0;
     virtual void stopAnimatedScroll() = 0;

--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.h
@@ -58,7 +58,7 @@ public:
 
     void attach();
 
-    RefPtr<ScrollerPairMac> pair() const { return m_pair.get(); }
+    RefPtr<ScrollerPairMac> pair() const { return m_pair; }
 
     ScrollbarOrientation orientation() const { return m_orientation; }
 

--- a/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
@@ -114,7 +114,7 @@ public:
 
     NSScrollerImpPair *scrollerImpPair() const { return m_scrollerImpPair.get(); }
     void ensureOnMainThreadWithProtectedThis(Function<void(ScrollerPairMac&)>&&);
-    RefPtr<ScrollingTreeScrollingNode> protectedNode() const { return m_scrollingNode.get(); }
+    RefPtr<ScrollingTreeScrollingNode> protectedNode() const { return m_scrollingNode; }
 
     bool mouseInContentArea() const { return m_mouseInContentArea; }
 

--- a/Source/WebCore/platform/ScrollAnimator.h
+++ b/Source/WebCore/platform/ScrollAnimator.h
@@ -62,7 +62,7 @@ public:
     explicit ScrollAnimator(ScrollableArea&);
     virtual ~ScrollAnimator();
 
-    ScrollableArea& scrollableArea() const { return m_scrollableArea.get(); }
+    ScrollableArea& scrollableArea() const { return m_scrollableArea; }
     CheckedRef<ScrollableArea> checkedScrollableArea() const { return scrollableArea(); }
 
     KeyboardScrollingAnimator *keyboardScrollingAnimator() const final { return m_keyboardScrollingAnimator.ptr(); }

--- a/Source/WebCore/platform/audio/ios/MediaDeviceRouteController.h
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRouteController.h
@@ -58,7 +58,7 @@ class MediaDeviceRouteController {
 public:
     WEBCORE_EXPORT static MediaDeviceRouteController& singleton();
 
-    RefPtr<MediaDeviceRouteControllerClient> client() const { return m_client.get(); }
+    RefPtr<MediaDeviceRouteControllerClient> client() const { return m_client; }
     void setClient(MediaDeviceRouteControllerClient* client) { m_client = client; }
 
     RefPtr<MediaDeviceRoute> mostRecentActiveRoute() const;

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -148,8 +148,8 @@ public:
     virtual void setName(const String& name) { m_name = name; }
     WEBCORE_EXPORT virtual String debugName() const;
 
-    GraphicsLayer* parent() const { return m_parent.get(); }
-    RefPtr<GraphicsLayer> protectedParent() const { return m_parent.get(); }
+    GraphicsLayer* parent() const { return m_parent; }
+    RefPtr<GraphicsLayer> protectedParent() const { return m_parent; }
     void setParent(GraphicsLayer*); // Internal use only.
     
     // Returns true if the layer has the given layer as an ancestor (excluding self).

--- a/Source/WebCore/platform/graphics/ImageAdapter.h
+++ b/Source/WebCore/platform/graphics/ImageAdapter.h
@@ -97,7 +97,7 @@ public:
 #endif
 
 private:
-    Image& image() const { return m_image.get(); }
+    Image& image() const { return m_image; }
 
     RefPtr<NativeImage> nativeImageOfSize(const IntSize&);
     Vector<Ref<NativeImage>> allNativeImages();

--- a/Source/WebCore/platform/ios/LegacyTileGrid.h
+++ b/Source/WebCore/platform/ios/LegacyTileGrid.h
@@ -55,7 +55,7 @@ public:
     LegacyTileGrid(LegacyTileCache&, const IntSize&);
     ~LegacyTileGrid();
 
-    LegacyTileCache& tileCache() const { return m_tileCache.get(); }
+    LegacyTileCache& tileCache() const { return m_tileCache; }
     Ref<LegacyTileCache> protectedTileCache() const { return tileCache(); }
 
     CALayer *tileHostLayer() const;

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
@@ -153,7 +153,7 @@ public:
         bool hasVideo() const { return m_mode & (HTMLMediaElementEnums::VideoFullscreenModeStandard | HTMLMediaElementEnums::VideoFullscreenModePictureInPicture); }
     };
 
-    RefPtr<VideoPresentationModel> videoPresentationModel() const { return m_videoPresentationModel.get(); }
+    RefPtr<VideoPresentationModel> videoPresentationModel() const { return m_videoPresentationModel; }
     WEBCORE_EXPORT virtual bool shouldExitFullscreenWithReason(ExitFullScreenReason);
     HTMLMediaElementEnums::VideoFullscreenMode mode() const { return m_currentMode.mode(); }
     WEBCORE_EXPORT virtual bool mayAutomaticallyShowVideoPictureInPicture() const = 0;

--- a/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h
+++ b/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h
@@ -66,7 +66,7 @@ public:
         return adoptRef(*new VideoPresentationInterfaceMac(playbackSessionInterface));
     }
     ~VideoPresentationInterfaceMac();
-    PlaybackSessionInterfaceMac& playbackSessionInterface() const { return m_playbackSessionInterface.get(); }
+    PlaybackSessionInterfaceMac& playbackSessionInterface() const { return m_playbackSessionInterface; }
     RefPtr<VideoPresentationModel> videoPresentationModel() const { return m_videoPresentationModel.get(); }
     PlaybackSessionModel* playbackSessionModel() const { return m_playbackSessionInterface->playbackSessionModel(); }
     CheckedPtr<PlaybackSessionModel> checkedPlaybackSessionModel() const { return playbackSessionModel(); }

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -884,7 +884,7 @@ void Scope::didChangeExtensionStyleSheets()
 
 void Scope::didChangeViewportSize()
 {
-    Ref<ContainerNode> rootNode = m_document.get();
+    Ref<ContainerNode> rootNode = m_document;
     if (m_shadowRoot)
         rootNode = *m_shadowRoot;
     else {

--- a/Source/WebCore/svg/SVGTests.cpp
+++ b/Source/WebCore/svg/SVGTests.cpp
@@ -131,12 +131,12 @@ void SVGTests::addSupportedAttributes(MemoryCompactLookupOnlyRobinHoodHashSet<Qu
 
 Ref<SVGElement> SVGTests::protectedContextElement() const
 {
-    return m_contextElement.get();
+    return m_contextElement;
 }
 
 SVGConditionalProcessingAttributes& SVGTests::conditionalProcessingAttributes()
 {
-    Ref<SVGElement> contextElement = m_contextElement.get();
+    Ref contextElement = m_contextElement;
     return contextElement->conditionalProcessingAttributes();
 }
 

--- a/Source/WebCore/svg/animation/SVGSMILElement.h
+++ b/Source/WebCore/svg/animation/SVGSMILElement.h
@@ -60,8 +60,8 @@ public:
     SMILTimeContainer* timeContainer() { return m_timeContainer.get(); }
     RefPtr<SMILTimeContainer> protectedTimeContainer() const;
 
-    SVGElement* targetElement() const { return m_targetElement.get(); }
-    RefPtr<SVGElement> protectedTargetElement() const { return m_targetElement.get(); }
+    SVGElement* targetElement() const { return m_targetElement; }
+    RefPtr<SVGElement> protectedTargetElement() const { return m_targetElement; }
     const QualifiedName& attributeName() const { return m_attributeName; }
 
     void beginByLinkActivation();

--- a/Source/WebCore/workers/service/server/SWServerRegistration.h
+++ b/Source/WebCore/workers/service/server/SWServerRegistration.h
@@ -133,7 +133,7 @@ private:
     void handleClientUnload();
     void softUpdate();
 
-    RefPtr<SWServer> protectedServer() const { return m_server.get(); }
+    RefPtr<SWServer> protectedServer() const { return m_server; }
 
     ServiceWorkerRegistrationKey m_registrationKey;
     ServiceWorkerUpdateViaCache m_updateViaCache;

--- a/Source/WebCore/workers/service/server/SWServerWorker.cpp
+++ b/Source/WebCore/workers/service/server/SWServerWorker.cpp
@@ -150,7 +150,7 @@ void SWServerWorker::startTermination(CompletionHandler<void()>&& callback)
     m_terminationCallbacks.append(WTF::move(callback));
 
     constexpr Seconds terminationDelayForTesting = 1_s;
-    RefPtr<SWServer> server = m_server.get();
+    RefPtr server = m_server;
     m_terminationTimer.startOneShot(server && server->isProcessTerminationDelayEnabled() ? SWServer::defaultTerminationDelay : terminationDelayForTesting);
 
     m_terminationIfPossibleTimer.stop();
@@ -190,7 +190,7 @@ const ClientOrigin& SWServerWorker::origin() const
 
 SWServerToContextConnection* SWServerWorker::contextConnection()
 {
-    RefPtr<SWServer> server = m_server.get();
+    RefPtr server = m_server;
     return server ? server->contextConnectionForRegistrableDomain(topRegistrableDomain()) : nullptr;
 }
 

--- a/Source/WebCore/xml/DOMParser.h
+++ b/Source/WebCore/xml/DOMParser.h
@@ -40,7 +40,7 @@ public:
 private:
     explicit DOMParser(Document& contextDocument);
 
-    RefPtr<Document> protectedContextDocument() const { return m_contextDocument.get(); }
+    RefPtr<Document> protectedContextDocument() const { return m_contextDocument; }
 
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_contextDocument;
     const Ref<const Settings> m_settings;

--- a/Source/WebKitLegacy/WebCoreSupport/LegacyWebPageDebuggable.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/LegacyWebPageDebuggable.cpp
@@ -47,7 +47,7 @@ String LegacyWebPageDebuggable::name() const
 {
     String result;
     callOnMainThreadAndWait([this, protectedThis = Ref { *this }, &result] {
-        if (RefPtr page = m_page.get()) {
+        if (RefPtr page = m_page) {
             if (RefPtr document = page->localTopDocument())
                 result = document->title().isolatedCopy();
         }
@@ -59,7 +59,7 @@ String LegacyWebPageDebuggable::url() const
 {
     String result;
     callOnMainThreadAndWait([this, protectedThis = Ref { *this }, &result] {
-        RefPtr page = m_page.get();
+        RefPtr page = m_page;
         if (!page)
             return;
 
@@ -74,7 +74,7 @@ bool LegacyWebPageDebuggable::hasLocalDebugger() const
 {
     bool result;
     callOnMainThreadAndWait([this, protectedThis = Ref { *this }, &result] {
-        RefPtr controller = m_inspectorController.get();
+        RefPtr controller = m_inspectorController;
         result = controller && controller->hasLocalFrontend();
     });
     return result;
@@ -86,7 +86,7 @@ void LegacyWebPageDebuggable::connect(Inspector::FrontendChannel& frontendChanne
     UNUSED_PARAM(immediatelyPause);
 
     callOnMainThreadAndWait([this, protectedThis = Ref { *this }, &frontendChannel] {
-        if (RefPtr controller = m_inspectorController.get())
+        if (RefPtr controller = m_inspectorController)
             controller->connectFrontend(frontendChannel);
     });
 }
@@ -94,7 +94,7 @@ void LegacyWebPageDebuggable::connect(Inspector::FrontendChannel& frontendChanne
 void LegacyWebPageDebuggable::disconnect(Inspector::FrontendChannel& frontendChannel)
 {
     callOnMainThreadAndWait([this, protectedThis = Ref { *this }, &frontendChannel] {
-        if (RefPtr controller = m_inspectorController.get())
+        if (RefPtr controller = m_inspectorController)
             controller->disconnectFrontend(frontendChannel);
     });
 }
@@ -102,7 +102,7 @@ void LegacyWebPageDebuggable::disconnect(Inspector::FrontendChannel& frontendCha
 void LegacyWebPageDebuggable::dispatchMessageFromRemote(String&& message)
 {
     callOnMainThreadAndWait([this, protectedThis = Ref { *this }, message = WTF::move(message).isolatedCopy()] mutable {
-        if (RefPtr controller = m_inspectorController.get())
+        if (RefPtr controller = m_inspectorController)
             controller->dispatchMessageFromFrontend(WTF::move(message));
     });
 }
@@ -110,7 +110,7 @@ void LegacyWebPageDebuggable::dispatchMessageFromRemote(String&& message)
 void LegacyWebPageDebuggable::setIndicating(bool indicating)
 {
     callOnMainThreadAndWait([this, protectedThis = Ref { *this }, indicating] {
-        if (RefPtr page = m_page.get())
+        if (RefPtr page = m_page)
             page->protectedInspectorController()->setIndicating(indicating);
     });
 }

--- a/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp
@@ -93,7 +93,7 @@ WebSocketChannel::ConnectStatus WebSocketChannel::connect(const URL& requestedUR
     ASSERT(!m_suspended);
 
     if (validatedURL->url != requestedURL) {
-        if (RefPtr client = m_client.get())
+        if (RefPtr client = m_client)
             client->didUpgradeURL();
     }
 
@@ -124,7 +124,7 @@ WebSocketChannel::ConnectStatus WebSocketChannel::connect(const URL& requestedUR
 
 Document* WebSocketChannel::document()
 {
-    return m_document.get();
+    return m_document;
 }
 
 String WebSocketChannel::subprotocol()
@@ -226,7 +226,7 @@ void WebSocketChannel::fail(String&& reason)
     m_deflateFramer.didFail();
     m_hasContinuousFrame = false;
     m_continuousFrameData.clear();
-    if (RefPtr client = m_client.get())
+    if (RefPtr client = m_client)
         client->didReceiveMessageError(WTF::move(reason));
 
     if (m_handle && !m_closed)
@@ -298,7 +298,7 @@ void WebSocketChannel::didCloseSocketStream(SocketStreamHandle& handle)
         m_unhandledBufferedAmount = m_handle->bufferedAmount();
         if (m_suspended)
             return;
-        RefPtr client = m_client.get();
+        RefPtr client = m_client;
         m_client = nullptr;
         m_document = nullptr;
         m_handle = nullptr;
@@ -345,7 +345,7 @@ void WebSocketChannel::didFailToReceiveSocketStreamData(SocketStreamHandle& hand
 
 void WebSocketChannel::didUpdateBufferedAmount(SocketStreamHandle&, size_t bufferedAmount)
 {
-    if (RefPtr client = m_client.get())
+    if (RefPtr client = m_client)
         client->didUpdateBufferedAmount(bufferedAmount);
 }
 
@@ -368,7 +368,7 @@ void WebSocketChannel::didFailSocketStream(SocketStreamHandle& handle, const Soc
         LOG_ERROR("%s", message.utf8().data());
     }
     m_shouldDiscardReceivedData = true;
-    if (RefPtr client = m_client.get())
+    if (RefPtr client = m_client)
         client->didReceiveMessageError(WTF::move(message));
     handle.disconnect();
 }
@@ -512,7 +512,7 @@ void WebSocketChannel::startClosingHandshake(int code, const String& reason)
     }
 
     m_closing = true;
-    if (RefPtr client = m_client.get())
+    if (RefPtr client = m_client)
         client->didStartClosingHandshake();
 }
 
@@ -708,7 +708,7 @@ bool WebSocketChannel::processFrame()
 
 RefPtr<WebSocketChannelClient> WebSocketChannel::protectedClient() const
 {
-    return m_client.get();
+    return m_client;
 }
 
 void WebSocketChannel::enqueueTextFrame(CString&& string)


### PR DESCRIPTION
#### 59dd5e40089369547382c51ef7e49c5e6c3e3c41
<pre>
Reduce use for .get() for smart pointers
<a href="https://bugs.webkit.org/show_bug.cgi?id=305904">https://bugs.webkit.org/show_bug.cgi?id=305904</a>

Reviewed by Anne van Kesteren.

Reduce use for .get() for smart pointers to simplify the code a bit.

* Source/JavaScriptCore/inspector/InjectedScriptBase.h:
(Inspector::InjectedScriptBase::inspectorEnvironment const):
* Source/JavaScriptCore/inspector/InjectedScriptManager.h:
(Inspector::InjectedScriptManager::inspectorEnvironment const):
* Source/WTF/wtf/Forward.h:
* Source/WTF/wtf/Ref.h:
* Source/WTF/wtf/RefPtr.h:
* Source/WTF/wtf/ThreadSafeWeakPtr.h:
* Source/WebCore/Modules/cookie-store/CookieStore.cpp:
(WebCore::CookieStore::MainThreadBridge::protectedCookieStore const):
* Source/WebCore/Modules/mediastream/RTCIceTransport.h:
(WebCore::RTCIceTransport::connection const):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.h:
* Source/WebCore/Modules/webtransport/WebTransportReceiveStreamSource.h:
(WebCore::WebTransportReceiveStreamSource::stream const):
* Source/WebCore/Modules/webxr/WebXRSession.h:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::modalNode):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AccessibilityScrollView.h:
* Source/WebCore/bindings/js/ScriptController.cpp:
(WebCore::ScriptController::protectedFrame const):
* Source/WebCore/bindings/js/WindowProxy.cpp:
(WebCore::WindowProxy::frame const):
* Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.h:
* Source/WebCore/dom/ContainerNode.h:
(WebCore::ContainerNode::firstChild const):
(WebCore::ContainerNode::protectedFirstChild const):
(WebCore::ContainerNode::lastChild const):
(WebCore::ContainerNode::protectedLastChild const):
(WebCore::ContainerNode::hasChildNodes const):
* Source/WebCore/dom/DataTransferItemList.h:
* Source/WebCore/dom/DatasetDOMStringMap.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::sameOriginTopLevelTraversable const):
* Source/WebCore/dom/DocumentFullscreen.h:
* Source/WebCore/dom/DocumentImmersive.h:
* Source/WebCore/dom/Element.cpp:
(WebCore::listBoxElementScrollIntoView):
* Source/WebCore/dom/MutationObserverRegistration.h:
* Source/WebCore/dom/Node.h:
(WebCore::Node::nextSibling const):
(WebCore::Node::protectedNextSibling const):
* Source/WebCore/dom/RadioButtonGroups.cpp:
(WebCore::RadioButtonGroup::checkedButton const):
* Source/WebCore/dom/ScriptElement.h:
(WebCore::ScriptElement::element):
(WebCore::ScriptElement::element const):
(WebCore::ScriptElement::protectedElement const):
* Source/WebCore/dom/ShadowRoot.h:
* Source/WebCore/editing/Editor.h:
* Source/WebCore/editing/WebContentReader.h:
(WebCore::FrameWebContentReader::frame const):
(WebCore::FrameWebContentReader::protectedFrame const):
* Source/WebCore/history/BackForwardController.cpp:
(WebCore::BackForwardController::protectedPage const):
* Source/WebCore/history/CachedPage.h:
* Source/WebCore/html/FormAssociatedElement.h:
(WebCore::FormAssociatedElement::form const):
(WebCore::FormAssociatedElement::protectedForm const):
* Source/WebCore/html/InputType.h:
(WebCore::InputType::element const):
(WebCore::InputType::protectedElement const):
* Source/WebCore/html/parser/HTMLConstructionSite.h:
(WebCore::HTMLConstructionSite::document const):
* Source/WebCore/inspector/InspectorCanvas.h:
* Source/WebCore/inspector/InspectorShaderProgram.h:
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::nodeForPath):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::protectedFrame const):
(WebCore::FrameLoader::clear):
(WebCore::FrameLoader::finishedParsing):
(WebCore::FrameLoader::checkCompleted):
* Source/WebCore/loader/FrameNetworkingContext.h:
(WebCore::FrameNetworkingContext::frame const):
(WebCore::FrameNetworkingContext::protectedFrame const):
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::protectedFrame const):
* Source/WebCore/loader/ImageLoader.h:
(WebCore::ImageLoader::element):
(WebCore::ImageLoader::element const):
(WebCore::ImageLoader::protectedElement const):
* Source/WebCore/loader/NavigationScheduler.cpp:
(WebCore::NavigationScheduler::locationChangePending):
(WebCore::NavigationScheduler::protectedFrame const):
* Source/WebCore/loader/PolicyChecker.cpp:
(WebCore::PolicyChecker::protectedFrame const):
* Source/WebCore/loader/ProgressTracker.cpp:
(WebCore::ProgressTracker::protectedPage const):
(WebCore::ProgressTracker::progressStarted):
* Source/WebCore/loader/ResourceLoadNotifier.cpp:
(WebCore::ResourceLoadNotifier::protectedFrame const):
* Source/WebCore/loader/ResourceLoader.cpp:
(WebCore::ResourceLoader::protectedFrame const):
(WebCore::ResourceLoader::frame const):
(WebCore::ResourceLoader::resourceMonitorIfExists):
* Source/WebCore/loader/SubframeLoader.cpp:
(WebCore::FrameLoader::SubframeLoader::protectedFrame const):
(WebCore::FrameLoader::SubframeLoader::canCreateSubFrame const):
(WebCore::FrameLoader::SubframeLoader::loadSubframe):
(WebCore::FrameLoader::SubframeLoader::shouldUsePlugin):
* Source/WebCore/page/Chrome.cpp:
(WebCore::Chrome::protectedPage const):
* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::ContextMenuController::page):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::protectedFrame const):
* Source/WebCore/page/FrameDestructionObserverInlines.h:
(WebCore::FrameDestructionObserver::frame const):
(WebCore::FrameDestructionObserver::protectedFrame const):
* Source/WebCore/page/RemoteDOMWindow.h:
* Source/WebCore/page/UndoManager.h:
(WebCore::UndoManager::document):
* Source/WebCore/page/scrolling/ScrollingStateNode.h:
(WebCore::ScrollingStateNode::parent const):
* Source/WebCore/page/scrolling/ScrollingTreeNode.h:
(WebCore::ScrollingTreeNode::parent const):
(WebCore::ScrollingTreeNode::scrollingTree const):
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h:
(WebCore::ScrollingTreeScrollingNodeDelegate::scrollingNode):
(WebCore::ScrollingTreeScrollingNodeDelegate::scrollingNode const):
* Source/WebCore/page/scrolling/mac/ScrollerMac.h:
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.h:
(WebCore::ScrollerPairMac::protectedNode const):
* Source/WebCore/platform/ScrollAnimator.h:
(WebCore::ScrollAnimator::scrollableArea const):
* Source/WebCore/platform/audio/ios/MediaDeviceRouteController.h:
(WebCore::MediaDeviceRouteController::client const):
* Source/WebCore/platform/graphics/GraphicsLayer.h:
(WebCore::GraphicsLayer::parent const):
(WebCore::GraphicsLayer::protectedParent const):
* Source/WebCore/platform/graphics/ImageAdapter.h:
(WebCore::ImageAdapter::image const):
* Source/WebCore/platform/ios/LegacyTileGrid.h:
(WebCore::LegacyTileGrid::tileCache const):
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h:
(WebCore::VideoPresentationInterfaceIOS::videoPresentationModel const):
* Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h:
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::didChangeViewportSize):
* Source/WebCore/svg/SVGTests.cpp:
(WebCore::SVGTests::protectedContextElement const):
(WebCore::SVGTests::conditionalProcessingAttributes):
* Source/WebCore/svg/animation/SVGSMILElement.h:
(WebCore::SVGSMILElement::targetElement const):
(WebCore::SVGSMILElement::protectedTargetElement const):
* Source/WebCore/workers/service/server/SWServerRegistration.h:
(WebCore::SWServerRegistration::protectedServer const):
* Source/WebCore/workers/service/server/SWServerWorker.cpp:
(WebCore::SWServerWorker::startTermination):
(WebCore::SWServerWorker::contextConnection):
* Source/WebCore/xml/DOMParser.h:
(WebCore::DOMParser::protectedContextDocument const):
* Source/WebKitLegacy/WebCoreSupport/LegacyWebPageDebuggable.cpp:
(LegacyWebPageDebuggable::name const):
(LegacyWebPageDebuggable::url const):
(LegacyWebPageDebuggable::hasLocalDebugger const):
(LegacyWebPageDebuggable::connect):
(LegacyWebPageDebuggable::disconnect):
(LegacyWebPageDebuggable::dispatchMessageFromRemote):
(LegacyWebPageDebuggable::setIndicating):
* Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp:
(WebCore::WebSocketChannel::connect):
(WebCore::WebSocketChannel::document):
(WebCore::WebSocketChannel::fail):
(WebCore::WebSocketChannel::didCloseSocketStream):
(WebCore::WebSocketChannel::didUpdateBufferedAmount):
(WebCore::WebSocketChannel::didFailSocketStream):
(WebCore::WebSocketChannel::startClosingHandshake):
(WebCore::WebSocketChannel::protectedClient const):

Canonical link: <a href="https://commits.webkit.org/305932@main">https://commits.webkit.org/305932@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3caae36f264f521c1a48ff89276818ae10683488

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139856 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12237 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1367 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147998 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ffd199bf-85c6-4b56-a060-d15830c42d51) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141729 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12947 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12389 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107093 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6aef6412-799b-431c-b636-489dc86f3fbc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142806 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9971 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125250 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87971 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d23bef98-d734-4840-8158-8e525eb65285) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9624 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7135 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8288 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/131830 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118844 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1252 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150782 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/652 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11922 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1318 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/115507 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11934 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10213 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115821 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29424 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10601 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121730 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/66927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11964 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1205 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/171128 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11704 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75651 "Built successfully") | [⏳ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11900 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11752 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->